### PR TITLE
Preceding whitespace is now preserved when deleting words backward

### DIFF
--- a/packages/outline/src/OutlineSelection.js
+++ b/packages/outline/src/OutlineSelection.js
@@ -553,7 +553,7 @@ export class Selection {
           const char = textContent[s];
           if (char === ' ') {
             if (foundNonWhitespace) {
-              node.spliceText(s, endIndex - s, '', true);
+              node.spliceText(s + 1, endIndex - s, '', true);
               return;
             }
           } else if (char === '\n') {

--- a/packages/outline/src/__tests__/OutlineSelection-test.js
+++ b/packages/outline/src/__tests__/OutlineSelection-test.js
@@ -647,15 +647,31 @@ describe('OutlineSelection tests', () => {
     },
     {
       name:
-        'Type text, move word backward, delete forward a word, delete backward',
+        'Type two words, delete word backward from end',
       inputs: [
         insertText('Hello world'),
-        moveWordBackward(),
-        deleteWordForward(),
         deleteWordBackward(),
       ],
       expectedHTML:
-        '<div contenteditable="true"><p><span data-text="true"><br></span></p></div>',
+        '<div contenteditable=\"true\"><p dir=\"ltr\"><span data-text=\"true\">Hello </span></p></div>',
+      expectedSelection: {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 6,
+        focusPath: [0, 0, 0],
+        focusOffset: 6,
+      },
+      setup: emptySetup,
+    },
+    {
+      name:
+        'Type two words, delete word forward from beginning',
+      inputs: [
+        insertText('Hello world'),
+        moveNativeSelection([0, 0, 0], 0, [0, 0, 0], 0),
+        deleteWordForward(),
+      ],
+      expectedHTML:
+        '<div contenteditable=\"true\"><p dir=\"ltr\"><span data-text=\"true\"> world</span></p></div>',
       expectedSelection: {
         anchorPath: [0, 0, 0],
         anchorOffset: 0,


### PR DESCRIPTION
Related to #9.

Before:

https://user-images.githubusercontent.com/13243/105115844-70d02380-5a7e-11eb-9417-f19ffdc08c8c.mov

After:

https://user-images.githubusercontent.com/13243/105115836-6e6dc980-5a7e-11eb-8751-a932ec0104be.mov

