### PR TITLE
Deleting a word backward from the end of trailing whitespace no longer deletes the entire line

### DIFF
--- a/packages/outline/src/OutlineSelection.js
+++ b/packages/outline/src/OutlineSelection.js
@@ -551,7 +551,10 @@ export class Selection {
 
         for (let s = endIndex - 1; s >= 0; s--) {
           const char = textContent[s];
-          if (char === ' ') {
+          if (s === 0) {
+            node.spliceText(s, endIndex - s, '', true);
+            return;
+          } else if (char === ' ') {
             if (foundNonWhitespace) {
               node.spliceText(s + 1, endIndex - s, '', true);
               return;

--- a/packages/outline/src/__tests__/OutlineSelection-test.js
+++ b/packages/outline/src/__tests__/OutlineSelection-test.js
@@ -680,6 +680,42 @@ describe('OutlineSelection tests', () => {
       },
       setup: emptySetup,
     },
+    {
+      name:
+        'Type two words, delete word forward from beginning of preceding whitespace',
+      inputs: [
+        insertText('Hello world'),
+        moveNativeSelection([0, 0, 0], 5, [0, 0, 0], 5),
+        deleteWordForward(),
+      ],
+      expectedHTML:
+        '<div contenteditable=\"true\"><p dir=\"ltr\"><span data-text=\"true\">Hello</span></p></div>',
+      expectedSelection: {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 5,
+        focusPath: [0, 0, 0],
+        focusOffset: 5,
+      },
+      setup: emptySetup,
+    },
+    {
+      name:
+        'Type two words, delete word backward from end of trailing whitespace',
+      inputs: [
+        insertText('Hello world'),
+        moveNativeSelection([0, 0, 0], 6, [0, 0, 0], 6),
+        deleteWordBackward(),
+      ],
+      expectedHTML:
+        '<div contenteditable=\"true\"><p dir=\"ltr\"><span data-text=\"true\">world</span></p></div>',
+      expectedSelection: {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 0,
+        focusPath: [0, 0, 0],
+        focusOffset: 0,
+      },
+      setup: emptySetup,
+    },
   ];
 
   suite.forEach((testUnit, i) => {


### PR DESCRIPTION
Fixes #10.

Before:

https://user-images.githubusercontent.com/13243/105116992-95c59600-5a80-11eb-9c63-09ea83060c50.mov

After:

https://user-images.githubusercontent.com/13243/105116942-7e86a880-5a80-11eb-96d5-9bc07cc567ff.mov

