### PR TITLE
Fix deleting segmented mentions

### DIFF
--- a/packages/outline-example/src/useMentions.js
+++ b/packages/outline-example/src/useMentions.js
@@ -474,15 +474,15 @@ function createMention(mentionName) {
 
 class MentionNode extends TextNode {
   mention: string;
-  constructor(mentionName: string, key?: NodeKey) {
-    super(mentionName, key);
+  constructor(mentionName: string, key?: NodeKey, text?: string) {
+    super(text ?? mentionName, key);
     this.mention = mentionName;
     // $FlowFixMe: TODO
     this.type = 'mention';
   }
 
   clone() {
-    const clone = new MentionNode(this.mention, this.key);
+    const clone = new MentionNode(this.mention, this.key, this.text);
     clone.parent = this.parent;
     clone.flags = this.flags;
     return clone;


### PR DESCRIPTION
Deleting a mention is failing when there are 3 segments or more in it, because cloning a `MentionNode` resets the text property in the node.

Issue before:
https://user-images.githubusercontent.com/2316643/106030109-b6679e80-60c5-11eb-9308-16397e90760e.mov

