### PR TITLE
Improve undo/redo shouldMerge heuristics

### DIFF
--- a/packages/outline-react/src/useOutlineHistory.js
+++ b/packages/outline-react/src/useOutlineHistory.js
@@ -36,10 +36,17 @@ function shouldMerge(
       if (
         prevDirtyNode !== undefined &&
         prevDirtyNode instanceof TextNode &&
-        prevDirtyNode.flags === nextDirtyNode.flags &&
-        prevDirtyNode.text !== ''
+        nextDirtyNode instanceof TextNode &&
+        prevDirtyNode.flags === nextDirtyNode.flags
       ) {
-        return true;
+        const prevText = prevDirtyNode.text;
+        const nextText = nextDirtyNode.text;
+        if (prevText === '') {
+          return false;
+        }
+        const diff = nextText.length - prevText.length;
+        // Only merge if we're adding/removing a single character
+        return diff === -1 || diff === 1;
       }
     }
   }


### PR DESCRIPTION
This improves the undo/redo heuristics for Outline. Notably, if we change a single character between updates then we merge, otherwise we do not.