### PR TITLE
Chrome: Add exclusion to using getTargetRanges for deleteSoftLineBackward

### DIFF
--- a/packages/outline-react/src/OutlineEnv.js
+++ b/packages/outline-react/src/OutlineEnv.js
@@ -28,6 +28,10 @@ export const IS_SAFARI: boolean =
   typeof navigator !== 'undefined' &&
   /Version\/[\d\.]+.*Safari/.test(navigator.userAgent);
 
+export const IS_CHROME: boolean =
+  typeof navigator !== 'undefined' &&
+  /^(?=.*Chrome).*/i.test(navigator.userAgent);
+
 export const CAN_USE_DOM: boolean =
   typeof window !== 'undefined' &&
   typeof window.document !== 'undefined' &&


### PR DESCRIPTION
Turns out that Chrome has a bug where the offsets from `getTargetRanges` is just completely off. So let's fall back to using the emulated version for now, which is wrong, but at least is predictable.

See: https://bugs.chromium.org/p/chromium/issues/detail?id=1043564