### PR TITLE
Unify selection logic for applyDOMRange

### DIFF
--- a/packages/outline-react/src/useOutlineInputEvents.js
+++ b/packages/outline-react/src/useOutlineInputEvents.js
@@ -454,9 +454,10 @@ function onNativeBeforeInput(
   if (inputType !== 'deleteSoftLineBackward' || !IS_CHROME) {
       // $FlowFixMe: Flow doesn't know of getTargetRanges
     const targetRange = event.getTargetRanges()[0];
+    const editorElement = editor.getEditorElement();
 
-    if (targetRange != null) {
-      selection.applyDOMRange(targetRange);
+    if (targetRange != null && editorElement !== null) {
+      selection.applyDOMRange(targetRange, editorElement);
     }
   }
 


### PR DESCRIPTION
When calling `selection.applyDOMRange` we should take into account the editor element being the selected node. For this case, we should reuse the existing logic to ensure we find the right corresponding text nodes. This also provides an opportunity to clean up some Flow related nonsense.