### PR TITLE
Fix bug in finding boundaries in resolveSelectionNodes

### DIFF
--- a/packages/outline/src/OutlineSelection.js
+++ b/packages/outline/src/OutlineSelection.js
@@ -177,7 +177,6 @@ function resolveSelectionNodes(
     anchorNode instanceof TextNode && focusNode instanceof TextNode,
     'Should never happen',
   );
-  console.log(anchorOffset);
   return [anchorNode, focusNode, resolvedAnchorOffset, resolvedFocusOffset];
 }
 


### PR DESCRIPTION
This fixes a bug where we weren't properly correcting the resolve offsets when determining the nodes when the anchor/focus DOM selection nodes are the editor element itself.