### PR TITLE
Fix FF bug in onCompositionStart

### DIFF
--- a/packages/outline-react/src/useOutlineInputEvents.js
+++ b/packages/outline-react/src/useOutlineInputEvents.js
@@ -421,14 +421,13 @@ function onCompositionStart(
   const selection = view.getSelection();
   editor.setComposing(true);
   if (selection !== null) {
-    if (selection.isCaret()) {
-      // We only have native beforeinput composition events for
-      // Safari, so we have to apply the composition selection for
-      // other browsers.
-      if (!IS_SAFARI) {
-        state.compositionSelection = selection;
-      }
-    } else {
+    // We only have native beforeinput composition events for
+    // Safari, so we have to apply the composition selection for
+    // other browsers.
+    if (!IS_SAFARI) {
+      state.compositionSelection = selection;
+    }
+    if (!selection.isCaret()) {
       removeText(selection);
     }
   }


### PR DESCRIPTION
This fixes a bug that was only observable in Firefox. Specifically, we were only storing the composition selection in state when it was a caret selection. This is not correct, as we should also be storing range selections here too.