### PR TITLE
Add @generated header to wwww builds

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -118,6 +118,7 @@ ${license}
   * @nolint
   * @preventMunge
   * @preserve-invariant-messages
+  * @generated
   */
 
 ${source}`;


### PR DESCRIPTION
We don't want our internal tools to modify the generated www builds that we sync to www, so let's the header that defines this behavior.