### PR TITLE
Fix selection bug when clicking editor

### DIFF
--- a/packages/outline-react/src/useOutlineInputEvents.js
+++ b/packages/outline-react/src/useOutlineInputEvents.js
@@ -16,7 +16,7 @@ import type {
 } from 'outline';
 
 import {BlockNode, TextNode} from 'outline';
-import {useCallback, useEffect} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import useOutlineEventWrapper from 'outline-react/useOutlineEventWrapper';
 import {
   CAN_USE_BEFORE_INPUT,
@@ -626,6 +626,7 @@ export default function useOutlineInputEvents<T>(
   editor: OutlineEditor,
   stateRef: RefObject<T>,
 ): {} | {onBeforeInput: (event: SyntheticInputEvent<T>) => void} {
+  const isHandlingPointerRef = useRef(false);
   const handleNativeBeforeInput = useOutlineEventWrapper(
     onNativeBeforeInput,
     editor,
@@ -641,9 +642,17 @@ export default function useOutlineInputEvents<T>(
     editor.setKeyDown(false);
   }, [editor]);
   const handlePointerDown = useCallback(() => {
-    editor.setPointerDown(true);
+    isHandlingPointerRef.current = true;
+    // Throttle setting of the flag for 50ms, as we don't want this to trigger
+    // for simple clicks.
+    setTimeout(() => {
+      if (isHandlingPointerRef.current) {
+        editor.setPointerDown(true);
+      }
+    }, 50);
   }, [editor]);
   const handlePointerUp = useCallback(() => {
+    isHandlingPointerRef.current = false;
     editor.setPointerDown(false);
   }, [editor]);
   const handlePaste = useOutlineEventWrapper(onPastePolyfill, editor, stateRef);


### PR DESCRIPTION
When we click the editor, we should ensure that our "empty" text logic for making sure selection gets updated applies. The issue is that we also want to make sure that we also don't apply selection updates to the DOM when the pointer is down for a long period – so we can solve this with a short throttle timer before setting `pointerDown` to `true`.