### PR TITLE
Improve example debug TreeView

### DIFF
--- a/packages/outline-example/src/TreeView.js
+++ b/packages/outline-example/src/TreeView.js
@@ -59,11 +59,16 @@ export default function TreeView({
 
     viewModel.read((view: View) => {
       const selection = view.getSelection();
-      const anchorKey = selection?.getAnchorNode()?.key;
+      let selectedNodes = null;
+      if (selection !== null) {
+        selectedNodes = new Set(
+          selection.getNodes().map((node) => node.getKey()),
+        );
+      }
 
       visitTree(view, view.getRoot(), (node, indent) => {
         const nodeKey = node.getKey();
-        const isSelected = anchorKey === nodeKey;
+        const isSelected = selectedNodes !== null && selectedNodes.has(nodeKey);
         res += `${isSelected ? '>' : ' '} ${indent.join(' ')} (${nodeKey.slice(
           1,
         )}) ${node?.getType() ?? ''} ${printNode(node)}\n`;
@@ -79,7 +84,8 @@ export default function TreeView({
 function printNode(node) {
   if (node instanceof TextNode) {
     const text = node.getTextContent();
-    return text.length === 0 ? '(empty)' : `"${node.text}"`;
+    const title = text.length === 0 ? '(empty)' : `"${node.text}"`;
+    return `${title} flags: ${node.getFlags()}`;
   }
   return '';
 }


### PR DESCRIPTION
This improves the debug view in the Outline example app. Specifically:
- range selection is now properly shown on the relevant nodes
- the flags property on text nodes is now shown after the title

![Screenshot 2021-02-08 at 15 49 51](https://user-images.githubusercontent.com/1519870/107243957-6e317000-6a25-11eb-806d-26ccc2255890.png)
