### PR TITLE
Refactor OutlineSelection tests

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -53,7 +53,8 @@ const outlineExtensionsExternals = outlineExtensions.map((node) => {
 
 const outlineReactModules = fs
   .readdirSync(path.resolve('./packages/outline-react/src'))
-  .map((str) => path.basename(str, '.js'));
+  .map((str) => path.basename(str, '.js'))
+  .filter((str) => !str.includes('__tests__'));
 const outlineReactModuleExternals = outlineReactModules.map((module) => {
   const external = `outline-react/${module}`;
   wwwMappings[external] = module;


### PR DESCRIPTION
This PR moves OutlineSelection tests to the `outline-react` package, as it's using the APIs from that package. It also moves to use the event handlers from that package so we get better coverage. Lastly, I added an additional test that covers moving selection between blocks.