### PR TITLE
Further revisions to text node offsets + selection

### DIFF
--- a/packages/outline-react/src/useOutlineInputEvents.js
+++ b/packages/outline-react/src/useOutlineInputEvents.js
@@ -272,48 +272,72 @@ function onKeyDown(
     if (isLeftArrow || isRightArrow || isDelete || isBackspace) {
       const anchorNode = selection.getAnchorNode();
       const offset = selection.anchorOffset;
+      const textContent = anchorNode.getTextContent();
 
       if (isLeftArrow || isBackspace) {
-        const prevSibling = anchorNode.getPreviousSibling();
-        if (prevSibling !== null) {
-          if (
-            offset === 0 &&
-            (prevSibling.isImmutable() || prevSibling.isSegmented())
-          ) {
-            if (isLeftArrow) {
-              announceNode(prevSibling);
-            } else if (!isModifierActive(event)) {
-              deleteBackward(selection);
+        const selectionAtStart = offset === 0;
+
+        if (selectionAtStart) {
+          const prevSibling = anchorNode.getPreviousSibling();
+
+          if (prevSibling === null) {
+            // On empty text nodes, we always move native DOM selection
+            // to offset 1. Although it's at 1, we really mean that it
+            // is at 0 in our model. So when we encounter a left arrow
+            // we need to move selection to the previous block if
+            // we have no previous sibling.
+            if (isLeftArrow && textContent === '') {
+              const parent = anchorNode.getParentOrThrow();
+              const parentSibling = parent.getPreviousSibling();
+
+              if (parentSibling instanceof BlockNode) {
+                const lastChild = parentSibling.getLastChild();
+                if (lastChild instanceof TextNode) {
+                  lastChild.select();
+                  shouldPreventDefault = true;
+                }
+              }
+            }
+          } else {
+            let targetPrevSibling = prevSibling;
+            if (prevSibling.isImmutable() || prevSibling.isSegmented()) {
+              if (isLeftArrow) {
+                announceNode(prevSibling);
+                targetPrevSibling = prevSibling.getPreviousSibling();
+              } else if (!isModifierActive(event)) {
+                deleteBackward(selection);
+                shouldPreventDefault = true;
+              }
+            }
+            // Due to empty text nodes having an offset of 1, we need to
+            // account for this and move selection accordingly when right
+            // arrow is pressed.
+            if (isLeftArrow && targetPrevSibling instanceof TextNode) {
               shouldPreventDefault = true;
+              if (targetPrevSibling === prevSibling) {
+                const prevSibliongTextContent = targetPrevSibling.getTextContent();
+                // We adjust the offset by 1, as we will have have moved between
+                // two adjacent nodes.
+                const endOffset = prevSibliongTextContent.length - 1;
+                targetPrevSibling.select(endOffset, endOffset);
+              } else {
+                // We don't adjust offset as the nodes are not adjacent (the target
+                // isn't the same as the prevSibling).
+                targetPrevSibling.select();
+              }
             }
           }
         }
       } else {
-        const nextSibling = anchorNode.getNextSibling();
-        const textContent = anchorNode.getTextContent();
-        const selectionAtEnd = textContent.length === offset;
-        const selectionJustBeforeEnd = textContent.length === offset + 1;
+        const textContentLength = textContent.length;
+        const selectionAtEnd = textContentLength === offset;
+        const selectionJustBeforeEnd = textContentLength === offset + 1;
 
-        if (nextSibling === null) {
-          // When we are on an empty text node, native right arrow
-          // doesn't work correctly in some browsers. So to ensure it
-          // does work correctly, we can force it and prevent the native
-          // event so that our fix is always used.
-          if (isRightArrow && textContent === '' && selectionAtEnd) {
-            const parent = anchorNode.getParentOrThrow();
-            const parentSibling = parent.getNextSibling();
+        if (selectionAtEnd || selectionJustBeforeEnd) {
+          const nextSibling = anchorNode.getNextSibling();
 
-            if (parentSibling instanceof BlockNode) {
-              const firstChild = parentSibling.getFirstChild();
-              if (firstChild instanceof TextNode) {
-                firstChild.select(0, 0);
-                shouldPreventDefault = true;
-              }
-            }
-          }
-        } else {
           if (
-            (selectionAtEnd || selectionJustBeforeEnd) &&
+            nextSibling !== null &&
             (nextSibling.isImmutable() || nextSibling.isSegmented())
           ) {
             if (isRightArrow) {

--- a/packages/outline/src/OutlineReconciler.js
+++ b/packages/outline/src/OutlineReconciler.js
@@ -536,13 +536,8 @@ function reconcileSelection(selection: Selection, editor: OutlineEditor): void {
     // selection and text entry works as expected, it also
     // means we need to adjust the offset to ensure native
     // selection works correctly and doesn't act buggy.
-    if (anchorDOM.previousSibling === null) {
-      anchorOffset = 1;
-      focusOffset = 1;
-    } else if (anchorDOM.nextSibling === null) {
-      anchorOffset = 0;
-      focusOffset = 0;
-    }
+    anchorOffset = 1;
+    focusOffset = 1;
   }
   domSelection.setBaseAndExtent(
     getTextNodeFromElement(anchorDOM),

--- a/packages/outline/src/OutlineSelection.js
+++ b/packages/outline/src/OutlineSelection.js
@@ -288,20 +288,17 @@ export function createSelection(
   // we need to adjust offsets to 0 when the text is
   // really empty.
   if (anchorNode.text === '') {
-    if (!editor.isComposing() && !editor.isPointerDown()) {
-      const anchorElement = editor.getElementByKey(anchorKey);
-      const focusElement = editor.getElementByKey(focusKey);
-      if (anchorNode === focusNode) {
-        if (anchorElement.previousSibling === null) {
-          if (anchorOffset !== 1) {
-            isDirty = true;
-          }
-        } else if (focusElement.nextSibling === null) {
-          if (anchorOffset !== 0) {
-            isDirty = true;
-          }
-        }
-      }
+    // When dealing with empty text nodes, we always
+    // render a special empty space character, and set
+    // the native DOM selection to offset 1 so that
+    // text entry works as expected.
+    if (
+      anchorNode === focusNode &&
+      anchorOffset !== 1 &&
+      !editor.isComposing() &&
+      !editor.isPointerDown()
+    ) {
+      isDirty = true;
     }
     anchorOffset = 0;
   }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -36,6 +36,8 @@ const closureOptions = {
 
 if (isClean) {
   fs.removeSync(path.resolve('./packages/outline/dist'));
+  fs.removeSync(path.resolve('./packages/outline-react/dist'));
+  fs.removeSync(path.resolve('./packages/outline-extensions/dist'));
 }
 
 const wwwMappings = {


### PR DESCRIPTION
This was a fun rabbit hole that is linked to https://github.com/facebookexternal/Outline/issues/60 and likely also https://github.com/facebookexternal/Outline/issues/59. Specifically it's about empty text nodes again.

Beforehand, we used to adjust the native DOM selection offset when we have empty text nodes. That's because they aren't "really" empty, we insert a zero width character so that browsers properly let them get selected and move the cursor to the right place without us having to hijack and patch native selection like other editors do (which means that composition usually ends up blowing up).

As part of this, we had a relatively straightforward heuristic for how we setup the native DOM selection with empty text nodes. If the text node had no previously sibling, it's offset would be 1 and if it had no next sibling, it would be 0.

This was important for cases like this:

`<empty text node /><entity>Luke Skywalker</entity><empty text node />`

- When I select the left side of the entity, I expect a single RightArrow to move to the right side of the entity.
- When I select the right side of the entity, I expect a single LeftArrow to move to the left side of the entity.

We were able to make this work natively by making the left side have offset 1, and the right side offset 0, meaning there was no need to duplicate key presses and everything just worked. Or so I thought...

It turns out that if an empty text node is selected and the native DOM offset is 0, then `getTargetRanges` bizarrely ignores the node and finds the previous text node instead. This doesn't occur with `getTargetRanges` in FF, but does in Chrome and Safari. However, if we set the DOM offset to 1, then `getTargetRanges` just works. All fun and games aside, it seems that we need to just live with the fact that when dealing with empty text nodes, we only set the DOM offset to 1.

This PR makes that change and fixes up some logic that expected the previous heuristic to match the new one. I also updated some tests to cover this problem in the future.