### PR TITLE
Fixes to ParagraphNode and useHistory hook

### DIFF
--- a/packages/outline-extensions/src/OutlineParagraphNode.js
+++ b/packages/outline-extensions/src/OutlineParagraphNode.js
@@ -48,7 +48,10 @@ export class ParagraphNode extends BlockNode {
     }
     // Otherwise just reset the text node flags
     const firstChild = this.getFirstChild();
-    if (firstChild instanceof TextNode) {
+    if (
+      firstChild instanceof TextNode &&
+      firstChild.getFlags() !== HAS_DIRECTION
+    ) {
       firstChild.setFlags(HAS_DIRECTION);
     }
   }

--- a/packages/outline-react/src/useOutlineHistory.js
+++ b/packages/outline-react/src/useOutlineHistory.js
@@ -26,7 +26,7 @@ function shouldMerge(
   // If we are changing selection between view models, then merge.
   if (!hadDirtyNodes && !hasDirtyNodes) {
     return true;
-  } else if (hadDirtyNodes && hasDirtyNodes) {
+  } else if (hasDirtyNodes) {
     const dirtyNodes = viewModel.getDirtyNodes();
     if (dirtyNodes.length === 1) {
       const prevNodeMap = current.nodeMap;
@@ -46,7 +46,8 @@ function shouldMerge(
         }
         const diff = nextText.length - prevText.length;
         // Only merge if we're adding/removing a single character
-        return diff === -1 || diff === 1;
+        // or if there is not change at all.
+        return diff === -1 || diff === 1 || diff === 0;
       }
     }
   }


### PR DESCRIPTION
This fixes two issues recently found:

- When text doesn't change, we should merge the history where possible
- When merging a paragraph node, we should only set the flags if they aren't already HAS_DIRECTION