### PR TITLE
Add rich text toggle to Outline Playground

### DIFF
--- a/packages/outline-playground/src/App.js
+++ b/packages/outline-playground/src/App.js
@@ -3,22 +3,38 @@
 import type {ViewModel} from 'outline';
 
 import React from 'react';
-import {useState} from 'react';
-import Editor from './Editor';
+import {useCallback, useState} from 'react';
+import {RichTextEditor, PlainTextEditor} from './Editor';
 import TreeView from './TreeView';
 
 function App(): React$Node {
   const [viewModel, setViewModel] = useState<ViewModel | null>(null);
+  const [isRichText, setRichText] = useState(true);
+  const handleOnChange = useCallback((newViewModel) => {
+    requestAnimationFrame(() => setViewModel(newViewModel));
+  }, []);
 
   return (
     <>
-      <h1>Outline Playground</h1>
+      <header>
+        <h1>Outline Playground</h1>
+        <div id="editor-rich-text-switch">
+          <label for="richTextMode">Rich Text</label>
+          <button
+            role="switch"
+            aria-checked={isRichText}
+            id="richTextMode"
+            onClick={() => setRichText(!isRichText)}>
+            <span />
+          </button>
+        </div>
+      </header>
       <div className="editor-shell">
-        <Editor
-          onChange={(newViewModel) => {
-            requestAnimationFrame(() => setViewModel(newViewModel));
-          }}
-        />
+        {isRichText ? (
+          <RichTextEditor onChange={handleOnChange} />
+        ) : (
+          <PlainTextEditor onChange={handleOnChange} />
+        )}
       </div>
       <TreeView viewModel={viewModel} />
     </>

--- a/packages/outline-playground/src/index.css
+++ b/packages/outline-playground/src/index.css
@@ -7,9 +7,17 @@ body {
   background: #eee;
 }
 
-h1 {
-  text-align: center;
+header {
+  width: 580px;
+  margin: auto;
+  position: relative;
+}
+
+header h1 {
+  text-align: left;
   color: #333;
+  display: inline-block;
+  margin: 20px 0 0 0;
 }
 
 .editor-shell {
@@ -375,4 +383,61 @@ pre {
   position: absolute;
   top: 8px;
   left: 35px;
+}
+
+#editor-rich-text-switch {
+  display: inline-block;
+  text-align: right;
+  position: absolute;
+  right: 0;
+  top: 30px;
+  width: 150px;
+  color: #444;
+}
+
+#editor-rich-text-switch label {
+  margin-right: 10px;
+  line-height: 24px;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+#editor-rich-text-switch button {
+  background-color: rgb(206, 208, 212);
+  height: 24px;
+  box-sizing: border-box;
+  border-radius: 12px;
+  border: 0;
+  width: 44px;
+  display: inline-block;
+  vertical-align: middle;
+  position: relative;
+  outline: none;
+  cursor: pointer;
+  transition: background-color 0.1s;
+  border: 2px solid transparent;
+}
+
+#editor-rich-text-switch button:focus-visible {
+  border-color: blue;
+}
+
+#editor-rich-text-switch button span {
+  top: 0px;
+  left: 0px;
+  display: block;
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 12px;
+  background-color: white;
+  transition: transform 0.2s;
+}
+
+#editor-rich-text-switch button[aria-checked="true"] {
+  background-color: rgb(24, 119, 242);
+}
+
+#editor-rich-text-switch button[aria-checked="true"] span {
+  transform: translateX(20px);
 }

--- a/packages/outline-react/useOutlinePlainText.js
+++ b/packages/outline-react/useOutlinePlainText.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./dist/useOutlinePlainText');


### PR DESCRIPTION
This adds a toggle so you can switch between rich text and plain text formatting in the Outline Playground.

![Screenshot 2021-02-10 at 18 30 20](https://user-images.githubusercontent.com/1519870/107554628-213ccd80-6bce-11eb-866c-abd290aca50c.png)
