### PR TITLE
You can now customize the placeholder class name

### DIFF
--- a/packages/outline/src/OutlineEditor.js
+++ b/packages/outline/src/OutlineEditor.js
@@ -38,6 +38,8 @@ export type UpdateListener = (viewModel: ViewModel) => void;
 
 export type DecoratorListener = (decorator: {[NodeKey]: ReactNode}) => void;
 
+type PlaceholderConfig = $ReadOnly<{className?: null | string}>;
+
 const NativePromise = window.Promise;
 
 function updateEditor(
@@ -128,6 +130,7 @@ export class OutlineEditor {
   _needsReconcile: boolean;
   _nodeDecorators: {[NodeKey]: ReactNode};
   _pendingNodeDecorators: null | {[NodeKey]: ReactNode};
+  _placeholderClassName: null | string;
   _placeholderText: string;
   _placeholderElement: null | HTMLElement;
   _textContent: string;
@@ -164,6 +167,7 @@ export class OutlineEditor {
     // is complete.
     this._pendingNodeDecorators = null;
     // Used for rendering placeholder text
+    this._placeholderClassName = 'placeholder';
     this._placeholderText = '';
     this._placeholderElement = null;
     // Editor fast-path for text content
@@ -267,7 +271,11 @@ export class OutlineEditor {
   update(callbackFn: (view: View) => void, sync?: boolean): boolean {
     return updateEditor(this, callbackFn, false, sync);
   }
-  setPlaceholder(placeholderText: string): void {
+  setPlaceholder(placeholderText: string, config?: PlaceholderConfig): void {
+    const className = config && config.className;
+    if (className !== undefined) {
+      this._placeholderClassName = className;
+    }
     const placeholderElement = this._placeholderElement;
     if (placeholderElement !== null) {
       // $FlowFixMe: placeholder elements always have a text node

--- a/packages/outline/src/OutlineReconciler.js
+++ b/packages/outline/src/OutlineReconciler.js
@@ -417,11 +417,15 @@ export function reconcilePlaceholder(
       return;
     }
     placeholderElement = document.createElement('div');
-    placeholderElement.className = 'placeholder';
     placeholderElement.contentEditable = 'false';
     placeholderElement.appendChild(document.createTextNode(placeholderText));
     editorElement.appendChild(placeholderElement);
     editor._placeholderElement = placeholderElement;
+  }
+  if (editor._placeholderClassName == null) {
+    placeholderElement.removeAttribute('class');
+  } else {
+    placeholderElement.className = editor._placeholderClassName;
   }
   if (
     editor._textContent !== '' ||

--- a/packages/outline/src/__tests__/OutlineEditor-test.js
+++ b/packages/outline/src/__tests__/OutlineEditor-test.js
@@ -100,6 +100,46 @@ describe('OutlineEditor tests', () => {
   });
 
   describe('Placeholder', () => {
+    it('Placeholder uses a default class name when no config is specified', () => {
+      editor.setPlaceholder('Placeholder text');
+      expect(sanitizeHTML(container.innerHTML)).toBe(
+        '<div contenteditable="true" data-outline-editor="true">' +
+          '<div class="placeholder" style="display: block;">Placeholder text</div>' +
+          '</div>',
+      );
+    });
+
+    it('Placeholder uses a default class name when config contains no custom classname', () => {
+      editor.setPlaceholder('Placeholder text', {});
+      expect(sanitizeHTML(container.innerHTML)).toBe(
+        '<div contenteditable="true" data-outline-editor="true">' +
+          '<div class="placeholder" style="display: block;">Placeholder text</div>' +
+          '</div>',
+      );
+    });
+
+    it('Placeholder uses a custom class name when specified', () => {
+      editor.setPlaceholder('Placeholder text', {
+        className: 'superPlaceholder',
+      });
+      expect(sanitizeHTML(container.innerHTML)).toBe(
+        '<div contenteditable="true" data-outline-editor="true">' +
+          '<div class="superPlaceholder" style="display: block;">Placeholder text</div>' +
+          '</div>',
+      );
+    });
+
+    it('Placeholder uses no class name when null class name is specified', () => {
+      editor.setPlaceholder('Placeholder text', {
+        className: null,
+      });
+      expect(sanitizeHTML(container.innerHTML)).toBe(
+        '<div contenteditable="true" data-outline-editor="true">' +
+          '<div style="display: block;">Placeholder text</div>' +
+          '</div>',
+      );
+    });
+
     it('Placeholder shows when there is no content', () => {
       editor.setPlaceholder('Placeholder text');
 


### PR DESCRIPTION
This is helpful for folks who can't craft descendent selectors because they use a particular CSS-in-JS implementation.

This is largely an RFC, in particular because this PR doesn't solve the larger problem of being able to style all of the _other_ kinds of nodes in the editor without relying on an actual stylesheet.