### PR TITLE
Remove placeholder from DOM rather than display: none

### DIFF
--- a/packages/outline/src/OutlineReconciler.js
+++ b/packages/outline/src/OutlineReconciler.js
@@ -410,10 +410,15 @@ export function reconcilePlaceholder(
   if (editorElement === null) {
     return;
   }
-  const noPlaceholderText = placeholderText === '';
+  const noPlaceholder =
+    placeholderText === '' ||
+    editor._textContent !== '' ||
+    editor._isComposing ||
+    !isEditorEmpty(editor, nextViewModel);
+
   let placeholderElement = editor._placeholderElement;
   if (placeholderElement === null) {
-    if (noPlaceholderText) {
+    if (noPlaceholder) {
       return;
     }
     placeholderElement = document.createElement('div');
@@ -422,16 +427,9 @@ export function reconcilePlaceholder(
     placeholderElement.appendChild(document.createTextNode(placeholderText));
     editorElement.appendChild(placeholderElement);
     editor._placeholderElement = placeholderElement;
-  }
-  if (
-    editor._textContent !== '' ||
-    noPlaceholderText ||
-    editor._isComposing ||
-    !isEditorEmpty(editor, nextViewModel)
-  ) {
-    placeholderElement.style.display = 'none';
-  } else {
-    placeholderElement.style.display = 'block';
+  } else if (noPlaceholder) {
+    editorElement.removeChild(placeholderElement);
+    editor._placeholderElement = null;
   }
 }
 

--- a/packages/outline/src/__tests__/OutlineEditor-test.js
+++ b/packages/outline/src/__tests__/OutlineEditor-test.js
@@ -111,7 +111,7 @@ describe('OutlineEditor tests', () => {
       }, true);
 
       expect(sanitizeHTML(container.innerHTML)).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><div class="placeholder" style="display: block;">' +
+        '<div contenteditable="true" data-outline-editor="true"><div class="placeholder">' +
           'Placeholder text</div><p><span data-text="true"><br></span></p></div>',
       );
     });
@@ -127,8 +127,7 @@ describe('OutlineEditor tests', () => {
       }, true);
 
       expect(sanitizeHTML(container.innerHTML)).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><div class="placeholder" style="display: none;">' +
-          'Placeholder text</div><p dir="ltr"><span data-text="true">Some text</span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p dir="ltr"><span data-text="true">Some text</span></p></div>',
       );
     });
 
@@ -147,8 +146,7 @@ describe('OutlineEditor tests', () => {
       }, true);
 
       expect(sanitizeHTML(container.innerHTML)).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><div class="placeholder" style="display: none;">' +
-          'Placeholder text</div><p><span data-text="true"><br></span></p><p>' +
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-text="true"><br></span></p><p>' +
           '<span data-text="true"><br></span></p></div>',
       );
     });


### PR DESCRIPTION
This PR adjusts the logic so that we remove the placeholder element, rather than hide it via CSS.