### PR TITLE
Add basic test for OutlineTextNode.getTextNodeFormatFlags()

### DIFF
--- a/packages/outline/src/OutlineTextNode.js
+++ b/packages/outline/src/OutlineTextNode.js
@@ -16,23 +16,23 @@ import {getSelection, makeSelection} from './OutlineSelection';
 import {invariant} from './OutlineUtils';
 import {shouldErrorOnReadOnly} from './OutlineView';
 
-const IS_BOLD = 1 << 3;
-const IS_ITALIC = 1 << 4;
-const IS_STRIKETHROUGH = 1 << 5;
-const IS_UNDERLINE = 1 << 6;
-const IS_CODE = 1 << 7;
-const IS_LINK = 1 << 8;
-const IS_HASHTAG = 1 << 9;
+export const IS_BOLD = 1 << 3;
+export const IS_ITALIC = 1 << 4;
+export const IS_STRIKETHROUGH = 1 << 5;
+export const IS_UNDERLINE = 1 << 6;
+export const IS_CODE = 1 << 7;
+export const IS_LINK = 1 << 8;
+export const IS_HASHTAG = 1 << 9;
 
 // Do not import these from shared, otherwise we will bundle
 // all of shared too.
-const FORMAT_BOLD = 0;
-const FORMAT_ITALIC = 1;
-const FORMAT_STRIKETHROUGH = 2;
-const FORMAT_UNDERLINE = 3;
-const FORMAT_CODE = 4;
-const FORMAT_LINK = 5;
-const FORMAT_HASHTAG = 6;
+export const FORMAT_BOLD = 0;
+export const FORMAT_ITALIC = 1;
+export const FORMAT_STRIKETHROUGH = 2;
+export const FORMAT_UNDERLINE = 3;
+export const FORMAT_CODE = 4;
+export const FORMAT_LINK = 5;
+export const FORMAT_HASHTAG = 6;
 
 const zeroWidthString = '\uFEFF';
 

--- a/packages/outline/src/__tests__/OutlineTextNode-test.js
+++ b/packages/outline/src/__tests__/OutlineTextNode-test.js
@@ -1,0 +1,108 @@
+import {createTextNode} from '..';
+import {
+  IS_BOLD,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_UNDERLINE,
+  IS_CODE,
+  IS_LINK,
+  IS_HASHTAG,
+  FORMAT_BOLD,
+  FORMAT_ITALIC,
+  FORMAT_STRIKETHROUGH,
+  FORMAT_UNDERLINE,
+  FORMAT_CODE,
+  FORMAT_LINK,
+  FORMAT_HASHTAG,
+} from '../OutlineTextNode';
+import {HAS_DIRECTION} from '../OutlineNode';
+
+let container = null;
+let React;
+let ReactDOM;
+let ReactTestUtils;
+let Outline;
+let ParagraphNode;
+
+describe('OutlineTextNode tests', () => {
+  beforeEach(() => {
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactTestUtils = require('react-dom/test-utils');
+    Outline = require('outline');
+    ParagraphNode = require('outline-extensions/ParagraphNode');
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    init();
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  function update(callback) {
+    editor.update(callback, undefined, true);
+  }
+
+  function useOutlineEditor(editorElementRef) {
+    const editor = React.useMemo(() => Outline.createEditor(), []);
+
+    React.useEffect(() => {
+      const editorElement = editorElementRef.current;
+
+      editor.setEditorElement(editorElement);
+    }, [editorElementRef, editor]);
+
+    return editor;
+  }
+
+  let editor = null;
+
+  function init() {
+    const ref = React.createRef();
+
+    function TestBase() {
+      editor = useOutlineEditor(ref);
+      return <div ref={ref} contentEditable={true} />;
+    }
+
+    ReactTestUtils.act(() => {
+      ReactDOM.render(<TestBase />, container);
+    });
+
+    // Insert initial block
+    update((view) => {
+      const paragraph = ParagraphNode.createParagraphNode();
+      const text = Outline.createTextNode();
+      paragraph.append(text);
+      view.getRoot().append(paragraph);
+    });
+  }
+
+  describe.each([
+    [FORMAT_BOLD, IS_BOLD],
+    [FORMAT_ITALIC, IS_ITALIC],
+    [FORMAT_STRIKETHROUGH, IS_STRIKETHROUGH],
+    [FORMAT_UNDERLINE, IS_UNDERLINE],
+    [FORMAT_CODE, IS_CODE],
+    [FORMAT_LINK, IS_LINK],
+    [FORMAT_HASHTAG, IS_HASHTAG],
+  ])('getTextNodeFormatFlags(%i)', (formatFlag, stateFlag) => {
+    test(`getTextNodeFormatFlags(${formatFlag})`, () => {
+      update((view) => {
+        const root = view.getRoot();
+        const paragraphNode = root.getFirstChild();
+        const textNode = paragraphNode.getFirstChild();
+
+        const newFlags = textNode.getTextNodeFormatFlags(formatFlag, null);
+        expect(newFlags).toBe(stateFlag | HAS_DIRECTION);
+
+        textNode.setFlags(newFlags);
+        const newFlags2 = textNode.getTextNodeFormatFlags(formatFlag, null);
+        expect(newFlags2).toBe(HAS_DIRECTION);
+      });
+    });
+  });
+});


### PR DESCRIPTION
I want to help to refactor `OutlineTextNode.getTextNodeFormatFlags()` to be less repetitive as mentioned in the TODO. Adding a basic test first before proceeding with the refactor.