### PR TITLE
Change how OutlineNode.__type is typed

### DIFF
--- a/packages/outline-extensions/src/OutlineHeadingNode.js
+++ b/packages/outline-extensions/src/OutlineHeadingNode.js
@@ -16,7 +16,6 @@ import {createParagraphNode} from 'outline-extensions/ParagraphNode';
 type HeadingTagType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
 
 export class HeadingNode extends BlockNode {
-  __type: 'heading';
   __tag: HeadingTagType;
 
   constructor(tag: HeadingTagType, key?: NodeKey) {

--- a/packages/outline-extensions/src/OutlineImageNode.js
+++ b/packages/outline-extensions/src/OutlineImageNode.js
@@ -12,7 +12,6 @@ import type {NodeKey} from 'outline';
 import {OutlineNode} from 'outline';
 
 export class ImageNode extends OutlineNode {
-  __type: 'image';
   __src: string;
   __altText: string;
 

--- a/packages/outline-extensions/src/OutlineListItemNode.js
+++ b/packages/outline-extensions/src/OutlineListItemNode.js
@@ -14,8 +14,6 @@ import {BlockNode} from 'outline';
 import {createParagraphNode} from 'outline-extensions/ParagraphNode';
 
 export class ListItemNode extends BlockNode {
-  _type: 'listitem';
-
   constructor(key?: NodeKey) {
     super(key);
     this.__type = 'listitem';

--- a/packages/outline-extensions/src/OutlineListNode.js
+++ b/packages/outline-extensions/src/OutlineListNode.js
@@ -14,7 +14,6 @@ import {BlockNode} from 'outline';
 type ListNodeTagType = 'ul' | 'ol';
 
 export class ListNode extends BlockNode {
-  __type: 'list';
   __tag: ListNodeTagType;
 
   constructor(tag: ListNodeTagType, key?: NodeKey) {

--- a/packages/outline-extensions/src/OutlineParagraphNode.js
+++ b/packages/outline-extensions/src/OutlineParagraphNode.js
@@ -14,8 +14,6 @@ import {BlockNode, TextNode} from 'outline';
 const HAS_DIRECTION = 1 << 2;
 
 export class ParagraphNode extends BlockNode {
-  __type: 'paragraph';
-
   constructor(key?: NodeKey) {
     super(key);
     this.__type = 'paragraph';

--- a/packages/outline-extensions/src/OutlineQuoteNode.js
+++ b/packages/outline-extensions/src/OutlineQuoteNode.js
@@ -14,8 +14,6 @@ import {BlockNode} from 'outline';
 import {createParagraphNode} from 'outline-extensions/ParagraphNode';
 
 export class QuoteNode extends BlockNode {
-  __type: 'quote';
-
   constructor(key?: NodeKey) {
     super(key);
     this.__type = 'quote';

--- a/packages/outline-playground/src/useEmojis.js
+++ b/packages/outline-playground/src/useEmojis.js
@@ -87,8 +87,7 @@ class EmojiNode extends TextNode {
   constructor(cssText: string, text: string, key?: NodeKey) {
     super(text, key);
     this.cssText = cssText;
-    // $FlowFixMe: TODO
-    this.type = 'emoji';
+    this.__type = 'emoji';
   }
 
   clone() {

--- a/packages/outline-playground/src/useMentions.js
+++ b/packages/outline-playground/src/useMentions.js
@@ -475,11 +475,11 @@ function createMention(mentionName) {
 
 class MentionNode extends TextNode {
   mention: string;
+
   constructor(mentionName: string, key?: NodeKey, text?: string) {
     super(text ?? mentionName, key);
     this.mention = mentionName;
-    // $FlowFixMe: TODO
-    this.type = 'mention';
+    this.__type = 'mention';
   }
 
   clone() {

--- a/packages/outline/src/OutlineNode.js
+++ b/packages/outline/src/OutlineNode.js
@@ -119,8 +119,7 @@ export function wrapInTextNodes<N: OutlineNode>(node: N): N {
 export type NodeKey = string;
 
 export class OutlineNode {
-  // $FlowFixMe: TODO
-  __type: any;
+  __type: string;
   __flags: number;
   __key: NodeKey;
   __parent: null | NodeKey;

--- a/packages/outline/src/OutlineTextNode.js
+++ b/packages/outline/src/OutlineTextNode.js
@@ -236,7 +236,6 @@ function setTextContent(
 
 export class TextNode extends OutlineNode {
   __text: string;
-  __type: 'text';
   __url: null | string;
 
   constructor(text: string, key?: NodeKey) {


### PR DESCRIPTION
## Summary

Uses `string` type for `OutlineNode.__type` instead of `any`. I get why `any` is used in the first place - it allows the inherited nodes to fix the type to a particular literal. However, this fails for inherited nodes. For example `TextNode` defines `__type: 'text'` and `EmojiNode` inherits from `TextNode` but wants to define `__type: 'emoji'`. This will require another using another `FlowFixMe`. I think it might be better to use a string type and don't enforce `__type`s within the nodes so that nodes can be inherited.

Also fixes some of the properties which missed out in https://github.com/facebookexternal/Outline/pull/62.

## Test Plan

```
yarn flow
```