### PR TITLE
playground: remove display of flags number

### DIFF
--- a/packages/outline-playground/src/TreeView.js
+++ b/packages/outline-playground/src/TreeView.js
@@ -114,11 +114,9 @@ function printNode(node) {
     const title = text.length === 0 ? '(empty)' : `"${normalize(text)}"`;
     const flags = node.getFlags();
     const flagLabels = printFlags(flags);
-    const flagLabelsFormatted =
-      flagLabels.length !== 0 ? `(${flagLabels})` : null;
-    return [title, `flags: ${flags}`, flagLabelsFormatted]
+    return [title, flagLabels.length !== 0 ? `flags: ${flagLabels}` : null]
       .filter(Boolean)
-      .join(' ')
+      .join(', ')
       .trim();
   }
 


### PR DESCRIPTION
## Summary

Follow up to #86. Since we're showing the flag labels now, there's no need to show the raw flag integers.

## Test Plan

![image](https://user-images.githubusercontent.com/1315101/107787275-d8ca0f00-6d89-11eb-81e9-fe8b7a1167c2.png)
