### PR TITLE
playground: use OutlineTextNode APIs to render flag labels

### DIFF
--- a/packages/outline/src/index.js
+++ b/packages/outline/src/index.js
@@ -19,12 +19,9 @@ import {BlockNode} from './OutlineBlockNode';
 import {RootNode} from './OutlineRootNode';
 import {OutlineNode} from './OutlineNode';
 
-import * as OutlineConstants from './OutlineConstants';
-
 export {
   createEditor,
   createTextNode,
-  OutlineConstants,
   OutlineNode,
   BlockNode,
   RootNode,


### PR DESCRIPTION
## Summary

Follow up of #86. Remove duplicated constants in playground's `TreeView.js` and use the `OutlineTextNode` APIs instead.

## Test Plan

```
flow
```

![image](https://user-images.githubusercontent.com/1315101/107793418-3ada4280-6d91-11eb-83d9-e35a4cac9c11.png)
