### PR TITLE
step-recorder: fix selection

### DIFF
--- a/packages/outline-playground/src/useStepRecorder.js
+++ b/packages/outline-playground/src/useStepRecorder.js
@@ -186,7 +186,9 @@ export default function useStepRecorder(editor: OutlineEditor): React$Node {
       editorElement == null ||
       browserSelection == null ||
       browserSelection.anchorNode == null ||
-      browserSelection.focusNode == null
+      browserSelection.focusNode == null ||
+      !editorElement.contains(browserSelection.anchorNode) ||
+      !editorElement.contains(browserSelection.focusNode)
     ) {
       return null;
     }


### PR DESCRIPTION
I was not checking that the element focus was within the editor, so if you clicked outside and then tried to record, the path generation went on forever