### PR TITLE
Resolve selection after selection mutates from reconcilation

### DIFF
--- a/packages/outline-playground/src/index.css
+++ b/packages/outline-playground/src/index.css
@@ -56,7 +56,7 @@ header h1 {
   position: relative;
 }
 
-.editor-shell div.editor div[data-placeholder=] {
+.editor-shell div.editor div.placeholder {
   color: #999;
   overflow: hidden;
   position: absolute;


### PR DESCRIPTION
Sometimes, when a DOM node that has selection is moved or mutated, it can cause selection offsets to reset. We can detect this and attempt to resolve it so that we recover from these cases.