### PR TITLE
Isolate outline-playground eslint rules

### DIFF
--- a/packages/outline-playground/.eslintrc.js
+++ b/packages/outline-playground/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  "extends": "react-app",
+  "root": true
+}


### PR DESCRIPTION
`outline-playground` should use the CRA eslint rules, rather than that of the project itself.