### PR TITLE
Fix issues with editor.parseViewModel

### DIFF
--- a/packages/outline/src/OutlineNode.js
+++ b/packages/outline/src/OutlineNode.js
@@ -580,18 +580,6 @@ function getNodeByKeyOrThrow<N: OutlineNode>(key: NodeKey): N {
   return (node: $FlowFixMe);
 }
 
-export function populateNodeMapFromParse(
-  nodeMap: NodeMapType,
-  parsedNodeMap: ParsedNodeMap,
-  editor: OutlineEditor,
-): void {
-  for (const key in parsedNodeMap) {
-    const parsedNode = parsedNodeMap[key];
-    const node = createNodeFromParse(parsedNode, parsedNodeMap, editor, null);
-    nodeMap[key] = node;
-  }
-}
-
 export function createNodeFromParse(
   parsedNode: ParsedNode,
   parsedNodeMap: ParsedNodeMap,
@@ -606,6 +594,10 @@ export function createNodeFromParse(
   );
   const node = new NodeType();
   const key = node.__key;
+  if (node instanceof RootNode) {
+    const viewModel = getActiveViewModel();
+    viewModel._nodeMap.root = node;
+  }
   // Copy over all properties, except the key and children.
   // We've already generated a unique key for this node, we
   // don't want to use an old one that might already be in use.

--- a/packages/outline/src/OutlineView.js
+++ b/packages/outline/src/OutlineView.js
@@ -21,11 +21,7 @@ import type {ParsedNodeMap} from './OutlineNode';
 
 import {reconcileViewModel} from './OutlineReconciler';
 import {getSelection, createSelectionFromParse} from './OutlineSelection';
-import {
-  getNodeByKey,
-  populateNodeMapFromParse,
-  createNodeFromParse,
-} from './OutlineNode';
+import {getNodeByKey, createNodeFromParse} from './OutlineNode';
 import {TextNode} from '.';
 import {invariant} from './OutlineUtils';
 
@@ -312,12 +308,15 @@ export function parseViewModel(
   const viewModel = new ViewModel(nodeMap);
   enterViewModelScope(
     () => {
-      populateNodeMapFromParse(nodeMap, parsedViewModel._nodeMap, editor);
+      debugger;
+      const parsedNodeMap = parsedViewModel._nodeMap;
+      createNodeFromParse(parsedNodeMap.root, parsedNodeMap, editor, null);
     },
     viewModel,
     editor,
     false,
   );
+  debugger;
   viewModel._selection = createSelectionFromParse(parsedViewModel._selection);
   viewModel._isDirty = true;
   return viewModel;


### PR DESCRIPTION
This PR fixes a few issues with the current implementation of `editor.parseViewModel()`. Notably:

- We didn't properly clone root nodes into the new view model
- We treated each node of the nodeMap as a root, rather than traversing from the single root itself