### PR TITLE
Fix cascading updates during reconciliation

### DIFF
--- a/packages/outline/src/OutlineReconciler.js
+++ b/packages/outline/src/OutlineReconciler.js
@@ -508,10 +508,10 @@ function reconcileRoot(
 }
 
 export function reconcileViewModel(
+  prevViewModel: ViewModel,
   nextViewModel: ViewModel,
   editor: OutlineEditor,
 ): void {
-  const prevViewModel = editor.getViewModel();
   const dirtySubTrees = nextViewModel._dirtySubTrees;
   // When a view model is historic, we bail out of using dirty checks and
   // always do a full reconcilation to ensure consistency.

--- a/packages/outline/src/OutlineView.js
+++ b/packages/outline/src/OutlineView.js
@@ -201,12 +201,13 @@ export function commitPendingUpdates(editor: OutlineEditor): void {
   if (editor._editorElement === null || pendingViewModel === null) {
     return;
   }
+  const currentViewModel = editor._viewModel;
   editor._pendingViewModel = null;
+  editor._viewModel = pendingViewModel;
   const previousActiveViewModel = activeViewModel;
   activeViewModel = pendingViewModel;
-  reconcileViewModel(pendingViewModel, editor);
+  reconcileViewModel(currentViewModel, pendingViewModel, editor);
   activeViewModel = previousActiveViewModel;
-  editor._viewModel = pendingViewModel;
   const pendingNodeDecorators = editor._pendingNodeDecorators;
   if (pendingNodeDecorators !== null) {
     editor._nodeDecorators = pendingNodeDecorators;


### PR DESCRIPTION
When we trigger `setBaseAndExtent`, this can cause side effects where `focus` and others events can fire, causing cascading updates. If we apply the pending view model just before we commit it, then we can avoid this problem.