### PR TITLE
Added TextNode.selectEnd / Renamed TextNode.selectAfter to .selectNext

### DIFF
--- a/packages/outline-playground/src/useEmojis.js
+++ b/packages/outline-playground/src/useEmojis.js
@@ -57,7 +57,7 @@ function textNodeTransform(node: TextNode, view: View): void {
       }
       const emojiNode = createEmojiNode(emojiStyle, emojiText);
       targetNode.replace(emojiNode);
-      emojiNode.selectAfter(0, 0);
+      emojiNode.selectNext(0, 0);
       emojiNode.getParentOrThrow().normalizeTextNodes(true);
       break;
     }

--- a/packages/outline-playground/src/useMentions.js
+++ b/packages/outline-playground/src/useMentions.js
@@ -193,7 +193,7 @@ function MentionsTypeahead({
 
       // $FlowFixMe
       targetNode.replace(mentionNode);
-      mentionNode.selectAfter(0, 0);
+      mentionNode.selectNext(0, 0);
       mentionNode.getParentOrThrow().normalizeTextNodes(true);
     });
   }, [close, editor, nodeKey, results, selectedIndex]);

--- a/packages/outline-react/src/OutlineSelectionHelpers.js
+++ b/packages/outline-react/src/OutlineSelectionHelpers.js
@@ -898,3 +898,12 @@ export function insertText(selection: Selection, text: string): void {
     currentBlock.normalizeTextNodes(true);
   }
 }
+
+export function moveEnd(selection: Selection): void {
+  const anchorNode = selection.getAnchorNode();
+  if (anchorNode === null) {
+    return;
+  }
+
+  anchorNode.selectEnd();
+}

--- a/packages/outline-react/src/__tests__/OutlineSelection-test.js
+++ b/packages/outline-react/src/__tests__/OutlineSelection-test.js
@@ -18,6 +18,7 @@ import {
   convertToSegmentedNode,
   moveBackward,
   moveForward,
+  moveEnd,
   deleteWordBackward,
   deleteWordForward,
   printWhitespace,
@@ -751,6 +752,29 @@ describe('OutlineSelection tests', () => {
           anchorOffset: 0,
           focusPath: [0, 0, 0],
           focusOffset: 0,
+        },
+      },
+      {
+        name:
+          'Type a text and an immutable text, move the caret to the end of the first text',
+        inputs: [
+          insertText('Hello '),
+          insertImmutableNode('Bob'),
+          moveBackward(),
+          moveBackward(),
+          moveEnd(),
+        ],
+        expectedHTML:
+          '<div contenteditable="true" data-outline-editor="true"><p dir="ltr">' +
+          '<span>Hello </span>' +
+          '<span>Bob</span>' +
+          '<span></span>' +
+          '</p></div>',
+        expectedSelection: {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 6,
+          focusPath: [0, 0, 0],
+          focusOffset: 6,
         },
       },
     ]),

--- a/packages/outline-react/src/test-utils/index.js
+++ b/packages/outline-react/src/test-utils/index.js
@@ -93,6 +93,12 @@ export function moveForward(n: ?number) {
   };
 }
 
+export function moveEnd() {
+  return {
+    type: 'move_end',
+  }
+}
+
 export function deleteBackward(n: ?number) {
   return {
     type: 'delete_backward',
@@ -395,6 +401,10 @@ export async function applySelectionInputs(inputs, update, editor) {
             moveNativeSelectionForward();
             break;
           }
+          case 'move_end': {
+            SelectionHelpers.moveEnd(selection);
+            break;
+          }
           case 'delete_backward': {
             SelectionHelpers.deleteBackward(selection);
             break;
@@ -429,28 +439,28 @@ export async function applySelectionInputs(inputs, update, editor) {
             const text = createTextNode(input.text);
             text.makeImmutable();
             SelectionHelpers.insertNodes(selection, [text]);
-            text.selectAfter();
+            text.selectNext();
             break;
           }
           case 'insert_segmented_node': {
             const text = createTextNode(input.text);
             text.makeSegmented();
             SelectionHelpers.insertNodes(selection, [text]);
-            text.selectAfter();
+            text.selectNext();
             break;
           }
           case 'covert_to_immutable_node': {
             const text = createTextNode(selection.getTextContent());
             text.makeImmutable();
             SelectionHelpers.insertNodes(selection, [text]);
-            text.selectAfter();
+            text.selectNext();
             break;
           }
           case 'covert_to_segmented_node': {
             const text = createTextNode(selection.getTextContent());
             text.makeSegmented();
             SelectionHelpers.insertNodes(selection, [text]);
-            text.selectAfter();
+            text.selectNext();
             break;
           }
           case 'undo': {

--- a/packages/outline/src/OutlineTextNode.js
+++ b/packages/outline/src/OutlineTextNode.js
@@ -424,7 +424,12 @@ export class TextNode extends OutlineNode {
     writableSelf.__text = text;
     return writableSelf;
   }
-  selectAfter(anchorOffset?: number, focusOffset?: number): Selection {
+  selectEnd(): Selection {
+    shouldErrorOnReadOnly();
+    const text = this.getTextContent();
+    return this.select(text.length, text.length);
+  }
+  selectNext(anchorOffset?: number, focusOffset?: number): Selection {
     shouldErrorOnReadOnly();
     const nextSibling = this.getNextSibling();
     if (


### PR DESCRIPTION
`selectAfter` works well most of the times. But there's some cases when the next Node is immutable that you either want to move the cursor before or after, not to the immutable node. 

For reference:
```
if (nextSibling === null || !(nextSibling instanceof TextNode) || nextSibling.isImmutable() || nextSibling.isSegmented()) {
  throw new Error('This needs to be fixed');
}
```

This diff doesn't implement a recursive solution to the immutable nodes to follow, but the introduction of `selectEnd` should fix the first, move the cursor just at the end of the node you're working with.

That said, this diff is very opinionated so I'm happy to drop it entirely.