### PR TITLE
Clear old editor element in setEditorElement

### DIFF
--- a/packages/outline/src/OutlineEditor.js
+++ b/packages/outline/src/OutlineEditor.js
@@ -290,6 +290,9 @@ export class OutlineEditor {
     const prevEditorElement = this._editorElement;
     this._editorElement = nextEditorElement;
     if (nextEditorElement === null) {
+      if (prevEditorElement !== null) {
+        prevEditorElement.textContent = '';
+      }
       this._keyToDOMMap.delete('root');
     } else {
       if (nextEditorElement !== prevEditorElement) {


### PR DESCRIPTION
Fixes a bug where content might look duplicated, even though the view model doesn't represent this.