### PR TITLE
core: update OutlineTextNode flag tests

### DIFF
--- a/packages/outline/src/__tests__/OutlineTextNode-test.js
+++ b/packages/outline/src/__tests__/OutlineTextNode-test.js
@@ -170,7 +170,7 @@ describe('OutlineTextNode tests', () => {
 
     test(`toggling for ${formatFlag}`, async () => {
       // Toggle method hasn't been implemented for this flag.
-      if (flagToggle == null) {
+      if (flagToggle === null) {
         return;
       }
 


### PR DESCRIPTION
## Summary

Update the `OutlineTextNode` flag tests:

- Added tests for `IS_OVERFLOWED` flag
- Fixed a bug where the `getTextNodeFormatFlags` test didn't use `await`
- Added tests for flag predicate methods 
- Added tests for flag toggling mutators where available

## Test Plan

Unit tests