### PR TITLE
core: add OutlineTextNode splitText test

### DIFF
--- a/packages/outline/src/__tests__/OutlineTextNode-test.js
+++ b/packages/outline/src/__tests__/OutlineTextNode-test.js
@@ -195,7 +195,7 @@ describe('OutlineTextNode tests', () => {
         textNode.makeImmutable();
 
         expect(() => {
-          textNode.split(3);
+          textNode.splitText(3);
         }).toThrow();
       });
     });


### PR DESCRIPTION
## Summary

Add tests for `OutlineTextNode.splitText()`. Some things to note:

- I didn't add tests for changes to `getSelection()`. Will it be good to test them? If so I'll add them later on
- `Outline.createTextNode('').splitText()` gives `[]`. Is this intended? Given that empty node is still a node maybe it's better to return the empty node instead