### PR TITLE
playground: show selected characters in TreeView

### DIFF
--- a/packages/outline-playground/src/TreeView.js
+++ b/packages/outline-playground/src/TreeView.js
@@ -9,7 +9,9 @@ import {BlockNode, TextNode} from 'outline';
 
 import React from 'react';
 
-const NON_SINGLE_WIDTH_CHARS_REPLACEMENT = Object.freeze({
+const NON_SINGLE_WIDTH_CHARS_REPLACEMENT: $ReadOnly<{
+  [string]: string,
+}> = Object.freeze({
   '\n': '\\n',
   '\t': '\\t',
 });
@@ -105,7 +107,7 @@ export default function TreeView({
 
 function normalize(text) {
   return Object.entries(NON_SINGLE_WIDTH_CHARS_REPLACEMENT).reduce(
-    (acc, [key, value]) => acc.replaceAll(key, value),
+    (acc, [key, value]) => acc.replace(new RegExp(key, 'g'), String(value)),
     text,
   );
 }
@@ -202,7 +204,7 @@ function printSelectedCharsLine({
   );
 }
 
-function getSelectionStartEnd(node, selection) {
+function getSelectionStartEnd(node, selection): [number, number] {
   const anchorNode = selection.getAnchorNode();
   const focusNode = selection.getFocusNode();
   const textContent = node.getTextContent(true);


### PR DESCRIPTION
## Summary

In the playground's tree view, show which characters are being selected.

This took way longer than I thought it would and the value of this might not be worth the effort considering the implementation is a bit complex (maintenance burden) and doesn't work well with unicode.

Feel free to close this if you don't find it helpful.

## Test Plan

### Select within a single line
![image](https://user-images.githubusercontent.com/1315101/108624289-08aa9e00-747f-11eb-927a-ae4c4b77287c.png)

### Select across multiple lines
![image](https://user-images.githubusercontent.com/1315101/108624300-15c78d00-747f-11eb-95ca-bb4c6d55c829.png)

### Lines contains newlines
![image](https://user-images.githubusercontent.com/1315101/108624337-4d363980-747f-11eb-8e69-7b8ceb46c052.png)

### Works for mentions

![image](https://user-images.githubusercontent.com/1315101/108624470-24fb0a80-7480-11eb-8386-13b8ac5479c2.png)


## ⚠️⚠️Note ⚠️⚠️

Because emojis don't take up the same width as the other characters, the carets don't appear nicely under them. Suggestions welcome.

![image](https://user-images.githubusercontent.com/1315101/108624375-99817980-747f-11eb-8bf3-44a7d16eb560.png)
