### PR TITLE
Fixes to CharacterLimit

### DIFF
--- a/packages/outline-playground/src/CharacterLimit.js
+++ b/packages/outline-playground/src/CharacterLimit.js
@@ -78,6 +78,16 @@ export default function CharacterLimit({
                     nodeKey: nextOverflowNode.getKey(),
                     offset: 0,
                   };
+                } else {
+                  // Handle next sibling blocks
+                  const parent = node.getTopParentBlockOrThrow();
+                  const parentBlock = parent.getParentBlockOrThrow();
+                  const parentBlockSiblings = parentBlock.getNextSiblings();
+                  recursivelySetBlockOverflowedNodes(
+                    parentBlock,
+                    parentBlockSiblings,
+                    true,
+                  );
                 }
                 return;
               } else {


### PR DESCRIPTION
This applies a few more fixes to CharacterLimit, where next siblings were not properly being marked as overflowed.