### PR TITLE
core: fix selection bug when splitting on text boundary

### DIFF
--- a/packages/outline/src/OutlineTextNode.js
+++ b/packages/outline/src/OutlineTextNode.js
@@ -128,7 +128,7 @@ function splitText(
       if (
         selection.anchorKey === key &&
         anchorOffset > textSize &&
-        anchorOffset < nextTextSize
+        anchorOffset <= nextTextSize
       ) {
         selection.anchorKey = siblingKey;
         selection.anchorOffset = anchorOffset - textSize;
@@ -137,7 +137,7 @@ function splitText(
       if (
         selection.focusKey === key &&
         focusOffset > textSize &&
-        focusOffset < nextTextSize
+        focusOffset <= nextTextSize
       ) {
         selection.focusKey = siblingKey;
         selection.focusOffset = focusOffset - textSize;

--- a/packages/outline/src/__tests__/OutlineTextNode-test.js
+++ b/packages/outline/src/__tests__/OutlineTextNode-test.js
@@ -310,6 +310,28 @@ describe('OutlineTextNode tests', () => {
 
     test.each([
       [
+        'Hello',
+        [4],
+        [3, 3],
+        {
+          anchorNodeIndex: 0,
+          anchorOffset: 3,
+          focusNodeIndex: 0,
+          focusOffset: 3,
+        },
+      ],
+      [
+        'Hello',
+        [4],
+        [5, 5],
+        {
+          anchorNodeIndex: 1,
+          anchorOffset: 1,
+          focusNodeIndex: 1,
+          focusOffset: 1,
+        },
+      ],
+      [
         'Hello World',
         [4],
         [2, 7],
@@ -362,6 +384,17 @@ describe('OutlineTextNode tests', () => {
           anchorOffset: 3,
           focusNodeIndex: 0,
           focusOffset: 2,
+        },
+      ],
+      [
+        'Hello World',
+        [4, 6],
+        [9, 9],
+        {
+          anchorNodeIndex: 2,
+          anchorOffset: 3,
+          focusNodeIndex: 2,
+          focusOffset: 3,
         },
       ],
     ])(


### PR DESCRIPTION
## Summary

Fixes #123 

## Test Plan

More unit tests. Tested that newly-added tests failed before this fix is implemented.

Playground doesn't crash when exceeding character limit

![image](https://user-images.githubusercontent.com/1315101/108728692-c8bde680-7564-11eb-82d6-a64bf51c7b77.png)
