### PR TITLE
playground: add bold formatting styles

### DIFF
--- a/packages/outline-playground/src/index.css
+++ b/packages/outline-playground/src/index.css
@@ -502,6 +502,12 @@ pre {
   color: red;
 }
 
+.editor-shell div.editor span.editor-text-bold,
+.editor-shell div.editor strong.editor-text-bold,
+.editor-shell div.editor em.editor-text-bold {
+  font-weight: bold;
+}
+
 .editor-shell div.editor span.editor-text-italic,
 .editor-shell div.editor strong.editor-text-italic,
 .editor-shell div.editor em.editor-text-italic {


### PR DESCRIPTION
## Summary

When formatting text using code -> bold, the resulting markup relies on CSS for the bold styling (class name is present), but the playground CSS doesn't contain those styling.

## Test Plan

### Before

![image](https://user-images.githubusercontent.com/1315101/109402636-526d1a00-7992-11eb-819e-caead26fec5e.png)


### After

![image](https://user-images.githubusercontent.com/1315101/109402620-3cf7f000-7992-11eb-857a-c6b17248371f.png)
