### PR TITLE
Use carriage return for Windows new line breaks

### DIFF
--- a/packages/outline-react/src/OutlineEnv.js
+++ b/packages/outline-react/src/OutlineEnv.js
@@ -11,6 +11,9 @@ export const IS_MAC: boolean =
   typeof window !== 'undefined' &&
   /Mac|iPod|iPhone|iPad/.test(window.navigator.platform);
 
+export const IS_WINDOWS: boolean =
+  typeof window !== 'undefined' && /Win/.test(window.navigator.platform);
+
 export const IS_IOS: boolean =
   typeof navigator !== 'undefined' &&
   typeof window !== 'undefined' &&
@@ -53,3 +56,5 @@ if (CAN_USE_DOM && 'InputEvent' in window && !documentMode) {
 
 export const CAN_USE_INTL_SEGMENTER: boolean =
   'Intl' in window && 'Segmenter' in window.Intl;
+
+export const NEW_LINE: string = IS_WINDOWS ? '\r\n' : '\n';

--- a/packages/outline-react/src/OutlineEventHandlers.js
+++ b/packages/outline-react/src/OutlineEventHandlers.js
@@ -22,6 +22,7 @@ import {
   IS_APPLE,
   IS_SAFARI,
   IS_CHROME,
+  NEW_LINE,
 } from './OutlineEnv';
 import {
   isDeleteBackward,
@@ -275,10 +276,10 @@ export function onKeyDownForPlainText(
         deleteWordForward(selection);
       } else if (isParagraph(event)) {
         event.preventDefault();
-        insertText(selection, '\n');
+        insertText(selection, NEW_LINE);
       } else if (isLineBreak(event)) {
         event.preventDefault();
-        insertText(selection, '\n');
+        insertText(selection, NEW_LINE);
       }
     }
     handleCustomKeyInput(event, selection, editor);
@@ -325,7 +326,7 @@ export function onKeyDownForRichText(
         insertParagraph(selection);
       } else if (isLineBreak(event)) {
         event.preventDefault();
-        insertText(selection, '\n');
+        insertText(selection, NEW_LINE);
       }
     }
     // Used for screen readers and speech tooling
@@ -609,11 +610,11 @@ export function onNativeBeforeInputForPlainText(
         break;
       }
       case 'insertLineBreak': {
-        insertText(selection, '\n');
+        insertText(selection, NEW_LINE);
         break;
       }
       case 'insertParagraph': {
-        insertText(selection, '\n');
+        insertText(selection, NEW_LINE);
         break;
       }
       case 'deleteByComposition':
@@ -733,7 +734,7 @@ export function onNativeBeforeInputForRichText(
         break;
       }
       case 'insertLineBreak': {
-        insertText(selection, '\n');
+        insertText(selection, NEW_LINE);
         break;
       }
       case 'insertParagraph': {

--- a/packages/outline-react/src/OutlineSelectionHelpers.js
+++ b/packages/outline-react/src/OutlineSelectionHelpers.js
@@ -10,7 +10,7 @@
 import type {NodeKey, OutlineNode, Selection, TextFormatType} from 'outline';
 
 import {BlockNode, RootNode, TextNode, createTextNode} from 'outline';
-import {CAN_USE_INTL_SEGMENTER} from './OutlineEnv';
+import {CAN_USE_INTL_SEGMENTER, NEW_LINE} from './OutlineEnv';
 import {invariant} from './OutlineReactUtils';
 
 const WHITESPACE_REGEX = /\s/g;
@@ -371,7 +371,7 @@ export function insertParagraph(selection: Selection): void {
   const newBlock = currentBlock.insertNewAfter(selection);
   if (newBlock === null) {
     // Handle as a line break insertion
-    insertText(selection, '\n');
+    insertText(selection, NEW_LINE);
   } else if (newBlock instanceof BlockNode) {
     const nodesToMoveLength = nodesToMove.length;
     let firstChild = null;
@@ -438,7 +438,7 @@ export function deleteLineBackward(selection: Selection): void {
     if (node instanceof TextNode) {
       const isAnchor = node === anchorNode;
       const textContent = node.getTextContent();
-      const indexOfNewLine = textContent.lastIndexOf('\n');
+      const indexOfNewLine = textContent.lastIndexOf(NEW_LINE);
 
       if (indexOfNewLine > -1) {
         let delCount;
@@ -500,7 +500,7 @@ export function deleteLineForward(selection: Selection): void {
     if (node instanceof TextNode) {
       const isAnchor = node === anchorNode;
       const textContent = node.getTextContent();
-      const indexOfNewLine = textContent.indexOf('\n', anchorOffset);
+      const indexOfNewLine = textContent.indexOf(NEW_LINE, anchorOffset);
 
       if (indexOfNewLine > -1) {
         const delCount = indexOfNewLine - anchorOffset + 1;


### PR DESCRIPTION
For Windows we should use `\r\n` rather than `\n`, otherwise it can break the logic for cursor movement, as per https://github.com/facebookexternal/Outline/issues/158