### PR TITLE
Ensure setEditorElement can bootstrap with state and no element

### DIFF
--- a/packages/outline/src/OutlineEditor.js
+++ b/packages/outline/src/OutlineEditor.js
@@ -297,7 +297,10 @@ export class OutlineEditor {
       }
       this._keyToDOMMap.delete('root');
     } else {
-      if (nextEditorElement !== prevEditorElement) {
+      if (
+        nextEditorElement !== prevEditorElement &&
+        prevEditorElement !== null
+      ) {
         resetEditor(this);
       }
       nextEditorElement.setAttribute('data-outline-editor', 'true');

--- a/packages/outline/src/__tests__/OutlineEditor-test.js
+++ b/packages/outline/src/__tests__/OutlineEditor-test.js
@@ -24,7 +24,6 @@ describe('OutlineEditor tests', () => {
   beforeEach(() => {
     container = document.createElement('div');
     document.body.appendChild(container);
-    init();
   });
 
   afterEach(() => {
@@ -64,120 +63,162 @@ describe('OutlineEditor tests', () => {
     return Promise.resolve().then();
   }
 
-  describe('parseViewModel()', () => {
-    let originalText;
-    let parsedParagraph;
-    let parsedRoot;
-    let parsedSelection;
-    let parsedText;
+  it('Should be able to update a view model without an editor element', () => {
+    const ref = React.createRef();
 
-    beforeEach(async () => {
-      await update((view) => {
-        const paragraph = ParagraphNodeModule.createParagraphNode();
-        originalText = Outline.createTextNode('Hello world');
-        originalText.select(6, 11);
-        paragraph.append(originalText);
-        view.getRoot().append(paragraph);
-      });
-      editor.addNodeType('paragraph', ParagraphNodeModule.ParagraphNode);
-      const stringifiedViewModel = editor.getViewModel().stringify();
-      const viewModel = editor.parseViewModel(stringifiedViewModel);
-      viewModel.read((view) => {
-        parsedRoot = view.getRoot();
-        parsedParagraph = parsedRoot.getFirstChild();
-        parsedText = parsedParagraph.getFirstChild();
-        parsedSelection = view.getSelection();
-      });
+    function TestBase({element}) {
+      editor = React.useMemo(() => Outline.createEditor(), []);
+
+      React.useEffect(() => {
+        editor.setEditorElement(element);
+      }, [element]);
+
+      return <div ref={ref} contentEditable={true} />;
+    }
+
+    ReactTestUtils.act(() => {
+      ReactDOM.render(<TestBase element={null} />, container);
     });
 
-    it('Parses the nodes of a stringified view model', async () => {
-      expect(parsedRoot).toEqual({
-        __children: ['_3'],
-        __flags: 0,
-        __key: 'root',
-        __parent: null,
-        __type: 'root',
-      });
-      expect(parsedParagraph).toEqual({
-        __children: ['_4'],
-        __flags: 0,
-        __key: '_3',
-        __parent: 'root',
-        __type: 'paragraph',
-      });
-      expect(parsedText).toEqual({
-        __text: 'Hello world',
-        __flags: 0,
-        __key: '_4',
-        __parent: '_3',
-        __type: 'text',
-        __url: null,
-      });
+    editor.update((view) => {
+      const root = view.getRoot();
+      const paragraph = ParagraphNodeModule.createParagraphNode();
+      const text = Outline.createTextNode('This works!');
+      root.append(paragraph);
+      paragraph.append(text);
     });
 
-    it('Parses the selection offsets of a stringified view model', async () => {
-      expect(parsedSelection.anchorOffset).toEqual(6);
-      expect(parsedSelection.focusOffset).toEqual(11);
+    expect(container.innerHTML).toBe('<div contenteditable="true"></div>');
+
+    ReactTestUtils.act(() => {
+      ReactDOM.render(<TestBase element={ref.current} />, container);
     });
 
-    it('Remaps the selection keys of a stringified view model', async () => {
-      expect(parsedSelection.anchorKey).not.toEqual(originalText.__key);
-      expect(parsedSelection.focusKey).not.toEqual(originalText.__key);
-      expect(parsedSelection.anchorKey).toEqual(parsedText.__key);
-      expect(parsedSelection.focusKey).toEqual(parsedText.__key);
-    });
+    expect(container.innerHTML).toBe(
+      '<div contenteditable="true" data-outline-editor="true"><p dir="ltr"><span>This works!</span></p></div>',
+    );
   });
 
-  describe('setPlaceholder', () => {
-    it('Placeholder shows when there is no content', async () => {
-      editor.setPlaceholder('Placeholder text');
-
-      await update((view) => {
-        const paragraph = ParagraphNodeModule.createParagraphNode();
-        const text = Outline.createTextNode();
-        paragraph.append(text);
-        view.getRoot().append(paragraph);
-      });
-
-      expect(sanitizeHTML(container.innerHTML)).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><div>' +
-          'Placeholder text</div><p><span><br></span></p></div>',
-      );
+  describe('With editor element', () => {
+    beforeEach(() => {
+      init();
     });
 
-    it('Placeholder does not should when there is content', async () => {
-      editor.setPlaceholder('Placeholder text');
+    describe('parseViewModel()', () => {
+      let originalText;
+      let parsedParagraph;
+      let parsedRoot;
+      let parsedSelection;
+      let parsedText;
 
-      await update((view) => {
-        const paragraph = ParagraphNodeModule.createParagraphNode();
-        const text = Outline.createTextNode('Some text');
-        paragraph.append(text);
-        view.getRoot().append(paragraph);
+      beforeEach(async () => {
+        await update((view) => {
+          const paragraph = ParagraphNodeModule.createParagraphNode();
+          originalText = Outline.createTextNode('Hello world');
+          originalText.select(6, 11);
+          paragraph.append(originalText);
+          view.getRoot().append(paragraph);
+        });
+        editor.addNodeType('paragraph', ParagraphNodeModule.ParagraphNode);
+        const stringifiedViewModel = editor.getViewModel().stringify();
+        const viewModel = editor.parseViewModel(stringifiedViewModel);
+        viewModel.read((view) => {
+          parsedRoot = view.getRoot();
+          parsedParagraph = parsedRoot.getFirstChild();
+          parsedText = parsedParagraph.getFirstChild();
+          parsedSelection = view.getSelection();
+        });
       });
 
-      expect(sanitizeHTML(container.innerHTML)).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p dir="ltr"><span>Some text</span></p></div>',
-      );
+      it('Parses the nodes of a stringified view model', async () => {
+        expect(parsedRoot).toEqual({
+          __children: ['_6'],
+          __flags: 0,
+          __key: 'root',
+          __parent: null,
+          __type: 'root',
+        });
+        expect(parsedParagraph).toEqual({
+          __children: ['_7'],
+          __flags: 0,
+          __key: '_6',
+          __parent: 'root',
+          __type: 'paragraph',
+        });
+        expect(parsedText).toEqual({
+          __text: 'Hello world',
+          __flags: 0,
+          __key: '_7',
+          __parent: '_6',
+          __type: 'text',
+          __url: null,
+        });
+      });
+
+      it('Parses the selection offsets of a stringified view model', async () => {
+        expect(parsedSelection.anchorOffset).toEqual(6);
+        expect(parsedSelection.focusOffset).toEqual(11);
+      });
+
+      it('Remaps the selection keys of a stringified view model', async () => {
+        expect(parsedSelection.anchorKey).not.toEqual(originalText.__key);
+        expect(parsedSelection.focusKey).not.toEqual(originalText.__key);
+        expect(parsedSelection.anchorKey).toEqual(parsedText.__key);
+        expect(parsedSelection.focusKey).toEqual(parsedText.__key);
+      });
     });
 
-    it('Placeholder does not should when there are two paragraphs', async () => {
-      editor.setPlaceholder('Placeholder text');
+    describe('setPlaceholder', () => {
+      it('Placeholder shows when there is no content', async () => {
+        editor.setPlaceholder('Placeholder text');
 
-      await update((view) => {
-        const paragraph = ParagraphNodeModule.createParagraphNode();
-        const text = Outline.createTextNode();
-        paragraph.append(text);
-        const paragraph2 = ParagraphNodeModule.createParagraphNode();
-        const text2 = Outline.createTextNode();
-        paragraph2.append(text2);
-        view.getRoot().append(paragraph);
-        view.getRoot().append(paragraph2);
+        await update((view) => {
+          const paragraph = ParagraphNodeModule.createParagraphNode();
+          const text = Outline.createTextNode();
+          paragraph.append(text);
+          view.getRoot().append(paragraph);
+        });
+
+        expect(sanitizeHTML(container.innerHTML)).toBe(
+          '<div contenteditable="true" data-outline-editor="true"><div>' +
+            'Placeholder text</div><p><span><br></span></p></div>',
+        );
       });
 
-      expect(sanitizeHTML(container.innerHTML)).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span><br></span></p><p>' +
-          '<span><br></span></p></div>',
-      );
+      it('Placeholder does not should when there is content', async () => {
+        editor.setPlaceholder('Placeholder text');
+
+        await update((view) => {
+          const paragraph = ParagraphNodeModule.createParagraphNode();
+          const text = Outline.createTextNode('Some text');
+          paragraph.append(text);
+          view.getRoot().append(paragraph);
+        });
+
+        expect(sanitizeHTML(container.innerHTML)).toBe(
+          '<div contenteditable="true" data-outline-editor="true"><p dir="ltr"><span>Some text</span></p></div>',
+        );
+      });
+
+      it('Placeholder does not should when there are two paragraphs', async () => {
+        editor.setPlaceholder('Placeholder text');
+
+        await update((view) => {
+          const paragraph = ParagraphNodeModule.createParagraphNode();
+          const text = Outline.createTextNode();
+          paragraph.append(text);
+          const paragraph2 = ParagraphNodeModule.createParagraphNode();
+          const text2 = Outline.createTextNode();
+          paragraph2.append(text2);
+          view.getRoot().append(paragraph);
+          view.getRoot().append(paragraph2);
+        });
+
+        expect(sanitizeHTML(container.innerHTML)).toBe(
+          '<div contenteditable="true" data-outline-editor="true"><p><span><br></span></p><p>' +
+            '<span><br></span></p></div>',
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
This fixes a bug @zurfyx recently found with `setEditorElement` and where we bootstrap state before knowing the editor element.