### PR TITLE
Fix setEditorElement bug

### DIFF
--- a/packages/outline/src/OutlineEditor.js
+++ b/packages/outline/src/OutlineEditor.js
@@ -295,7 +295,7 @@ export class OutlineEditor {
       if (prevEditorElement !== null) {
         prevEditorElement.textContent = '';
       }
-      this._keyToDOMMap.delete('root');
+      resetEditor(this);
     } else {
       if (
         nextEditorElement !== prevEditorElement &&


### PR DESCRIPTION
Fixes a bug with `editor.setEditorElement` where the element wasn't being reset when switched.