### PR TITLE
Improve text content updates

### DIFF
--- a/packages/outline-react/src/__tests__/OutlineSelection-test.js
+++ b/packages/outline-react/src/__tests__/OutlineSelection-test.js
@@ -99,7 +99,7 @@ describe('OutlineSelection tests', () => {
 
   test('Expect initial output to be a block with some text', () => {
     expect(sanitizeHTML(container.innerHTML)).toBe(
-      '<div contenteditable="true" data-outline-editor="true"><p><span><br></span></p></div>',
+      '<div contenteditable="true" data-outline-editor="true"><p><span></span></p></div>',
     );
   });
 
@@ -305,7 +305,7 @@ describe('OutlineSelection tests', () => {
       name: 'Deletion of an immutable node',
       inputs: [insertImmutableNode('Dominic Gannaway'), deleteBackward()],
       expectedHTML:
-        '<div contenteditable="true" data-outline-editor="true"><p><span><br></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span></span></p></div>',
       expectedSelection: {
         anchorPath: [0, 0, 0],
         anchorOffset: 0,
@@ -364,7 +364,7 @@ describe('OutlineSelection tests', () => {
         'Should correctly handle empty paragraph blocks when moving backward',
       inputs: [insertParagraph(), moveBackward()],
       expectedHTML:
-        '<div contenteditable="true" data-outline-editor="true"><p><span><br></span></p><p><span><br></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span></span></p><p><span></span></p></div>',
       expectedSelection: {
         anchorPath: [0, 0, 0],
         anchorOffset: 0,
@@ -381,7 +381,7 @@ describe('OutlineSelection tests', () => {
         moveForward(),
       ],
       expectedHTML:
-        '<div contenteditable="true" data-outline-editor="true"><p><span><br></span></p><p><span><br></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span></span></p><p><span></span></p></div>',
       expectedSelection: {
         anchorPath: [1, 0, 0],
         anchorOffset: 0,
@@ -577,8 +577,8 @@ describe('OutlineSelection tests', () => {
       name: 'Inserting a paragraph',
       inputs: [insertParagraph()],
       expectedHTML:
-        '<div contenteditable="true" data-outline-editor="true"><p><span><br></span></p>' +
-        '<p><span><br></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span></span></p>' +
+        '<p><span></span></p></div>',
       expectedSelection: {
         anchorPath: [1, 0, 0],
         anchorOffset: 0,
@@ -590,7 +590,7 @@ describe('OutlineSelection tests', () => {
       name: 'Inserting a paragraph and then removing it',
       inputs: [insertParagraph(), deleteBackward()],
       expectedHTML:
-        '<div contenteditable="true" data-outline-editor="true"><p><span><br></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span></span></p></div>',
       expectedSelection: {
         anchorPath: [0, 0, 0],
         anchorOffset: 0,
@@ -625,7 +625,7 @@ describe('OutlineSelection tests', () => {
         deleteBackward(),
       ],
       expectedHTML:
-        '<div contenteditable="true" data-outline-editor="true"><p><span><br></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span></span></p></div>',
       expectedSelection: {
         anchorPath: [0, 0, 0],
         anchorOffset: 0,

--- a/packages/outline/src/OutlineTextNode.js
+++ b/packages/outline/src/OutlineTextNode.js
@@ -234,33 +234,12 @@ function setTextContent(
 ): void {
   let nextText = _nextText;
   const firstChild = dom.firstChild;
-  const hasBreakNode = firstChild && firstChild.nextSibling;
-  const parent = node.getParent();
-  // Check if we are on an empty line
-  if (parent !== null && parent.__children.length === 1) {
-    if (nextText === '') {
-      if (firstChild == null) {
-        // We use a zero width string so that the browser moves
-        // the cursor into the text node. It won't move the cursor
-        // in if it's empty. This trick makes it seem empty, so
-        // the browser plays along nicely. We use the <br>
-        // to ensure we take up a full line, as we don't have any
-        // characters taking up the full height yet.
-        dom.appendChild(document.createTextNode(BYTE_ORDER_MARK));
-        dom.appendChild(document.createElement('br'));
-      } else if (!hasBreakNode) {
-        firstChild.nodeValue = BYTE_ORDER_MARK;
-        dom.appendChild(document.createElement('br'));
-      }
-      return;
-    }
-  }
   if (nextText === '') {
     nextText = BYTE_ORDER_MARK;
   }
-  if (firstChild == null || hasBreakNode) {
+  if (firstChild == null) {
     dom.textContent = nextText;
-  } else if (prevText !== nextText) {
+  } else if (prevText !== nextText && firstChild.nodeValue !== nextText) {
     firstChild.nodeValue = nextText;
   }
 }

--- a/packages/outline/src/__tests__/OutlineEditor-test.js
+++ b/packages/outline/src/__tests__/OutlineEditor-test.js
@@ -234,7 +234,7 @@ describe('OutlineEditor tests', () => {
 
         expect(sanitizeHTML(container.innerHTML)).toBe(
           '<div contenteditable="true" data-outline-editor="true"><div>' +
-            'Placeholder text</div><p><span><br></span></p></div>',
+            'Placeholder text</div><p><span></span></p></div>',
         );
       });
 
@@ -268,8 +268,8 @@ describe('OutlineEditor tests', () => {
         });
 
         expect(sanitizeHTML(container.innerHTML)).toBe(
-          '<div contenteditable="true" data-outline-editor="true"><p><span><br></span></p><p>' +
-            '<span><br></span></p></div>',
+          '<div contenteditable="true" data-outline-editor="true"><p><span></span></p><p>' +
+            '<span></span></p></div>',
         );
       });
     });

--- a/packages/outline/src/__tests__/OutlineTextNode-test.js
+++ b/packages/outline/src/__tests__/OutlineTextNode-test.js
@@ -599,7 +599,7 @@ describe('OutlineTextNode tests', () => {
           'no formatting + empty string',
           null,
           '',
-          `<span>${BYTE_ORDER_MARK}<br></span>`,
+          `<span>${BYTE_ORDER_MARK}</span>`,
         ],
       ])('%s text format type', async (_type, flag, contents, expectedHTML) => {
         await update(() => {


### PR DESCRIPTION
This PR significantly improves text content updates in a bunch of cases. Specifically, the logic for adding and removing <br> nodes is no longer needed, as new line breaks are now handled differently. This improves initial text input from 100-900ms to 0.2ms.