### PR TITLE
Normalize start and end blocks when inserting block nodes

### DIFF
--- a/packages/outline-playground/__tests__/__snapshots__/TextEntry-test.js.snap
+++ b/packages/outline-playground/__tests__/__snapshots__/TextEntry-test.js.snap
@@ -6,7 +6,7 @@ exports[`TextEntry Chromium Rich text Basic copy + paste 2`] = `"<p class=\\"edi
 
 exports[`TextEntry Chromium Rich text Basic copy + paste 3`] = `"<p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!</span></p>"`;
 
-exports[`TextEntry Chromium Rich text Basic copy + paste 4`] = `"<p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!</span><span>Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!</span></p>"`;
+exports[`TextEntry Chromium Rich text Basic copy + paste 4`] = `"<p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!</span></p>"`;
 
 exports[`TextEntry Chromium Rich text Can delete characters after they're typed 1`] = `"<p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Delete some of these characte</span></p>"`;
 
@@ -36,7 +36,7 @@ exports[`TextEntry Firefox Rich text Basic copy + paste 2`] = `"<p class=\\"edit
 
 exports[`TextEntry Firefox Rich text Basic copy + paste 3`] = `"<p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!</span></p>"`;
 
-exports[`TextEntry Firefox Rich text Basic copy + paste 4`] = `"<p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!</span><span>Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!</span></p>"`;
+exports[`TextEntry Firefox Rich text Basic copy + paste 4`] = `"<p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!</span></p>"`;
 
 exports[`TextEntry Firefox Rich text Can delete characters after they're typed 1`] = `"<p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Delete some of these characte</span></p>"`;
 
@@ -66,7 +66,7 @@ exports[`TextEntry Webkit Rich text Basic copy + paste 2`] = `"<p class=\\"edito
 
 exports[`TextEntry Webkit Rich text Basic copy + paste 3`] = `"<p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!</span></p>"`;
 
-exports[`TextEntry Webkit Rich text Basic copy + paste 4`] = `"<p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!</span><span>Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!</span></p>"`;
+exports[`TextEntry Webkit Rich text Basic copy + paste 4`] = `"<p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!Copy + pasting?</span></p><p class=\\"editor-paragraph\\"><span>﻿</span></p><p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Sounds good!</span></p>"`;
 
 exports[`TextEntry Webkit Rich text Can delete characters after they're typed 1`] = `"<p class=\\"editor-paragraph\\" dir=\\"ltr\\"><span>Delete some of these characte</span></p>"`;
 

--- a/packages/outline-playground/src/App.js
+++ b/packages/outline-playground/src/App.js
@@ -18,7 +18,7 @@ function App(): React$Node {
   const handleOnChange = useCallback(
     (newViewModel) => {
       if (showTreeView) {
-        requestAnimationFrame(() => setViewModel(newViewModel));
+        setViewModel(newViewModel)
       }
     },
     [showTreeView],

--- a/packages/outline-react/src/OutlineSelectionHelpers.js
+++ b/packages/outline-react/src/OutlineSelectionHelpers.js
@@ -969,7 +969,9 @@ export function insertNodes(
     // Normalize the block where we started the insertion
     topLevelBlock.normalizeTextNodes(true);
     // Normalize the block where we ended the insertion
-    target.normalizeTextNodes(true);
+    if (isBlockNode(target)) {
+      target.normalizeTextNodes(true);
+    }
   } else if (isTextNode(target)) {
     // We've only inserted text nodes, so we only need to normalize this block.
     target.select();


### PR DESCRIPTION
We don't currently do any normalization when inserting block nodes, only text nodes. When inserting block nodes there's the possibility for unnecessary/empty text nodes in the starting and ending blocks. This PR fixes that and adds comments to document what's going on in `insertNodes`.

fixes #146