### PR TITLE
setTextContent: ensure we always check the DOM text value

### DIFF
--- a/packages/outline/src/OutlineTextNode.js
+++ b/packages/outline/src/OutlineTextNode.js
@@ -239,7 +239,7 @@ function setTextContent(
   }
   if (firstChild == null) {
     dom.textContent = nextText;
-  } else if (prevText !== nextText && firstChild.nodeValue !== nextText) {
+  } else if (prevText !== nextText || firstChild.nodeValue !== nextText) {
     firstChild.nodeValue = nextText;
   }
 }


### PR DESCRIPTION
Given that we now let text updates from the DOM occur through, it means that our model might not represent the last DOM value. To ensure text updates correctly reconcile, we should always check the DOM text node against the model in case we need to update it.