### PR TITLE
Fix selection bug on insertLineBreak

### DIFF
--- a/packages/outline-react/src/OutlineSelectionHelpers.js
+++ b/packages/outline-react/src/OutlineSelectionHelpers.js
@@ -590,6 +590,7 @@ export function removeText(selection: Selection): void {
 export function insertLineBreak(selection: Selection): void {
   const lineBreakNode = createLineBreakNode();
   insertNodes(selection, [lineBreakNode]);
+  lineBreakNode.selectNext(0, 0);
 }
 
 export function insertNodes(


### PR DESCRIPTION
We should be selecting the beginning of the next node after a line break, not the end.