### PR TITLE
Count addNodeType() types to ensure safe removal

### DIFF
--- a/packages/outline/src/OutlineNode.js
+++ b/packages/outline/src/OutlineNode.js
@@ -675,16 +675,19 @@ export function createNodeFromParse(
   parentKey: null | NodeKey,
   state: NodeParserState = {},
 ): OutlineNode {
-  const type = parsedNode.__type;
-  const NodeType = editor._registeredNodeTypes.get(type);
-  if (NodeType === undefined) {
+  const nodeType = parsedNode.__type;
+  const NodeTypeCount = editor._registeredNodeTypes.get(nodeType);
+  if (NodeTypeCount === undefined) {
     if (__DEV__) {
-      invariant(false, 'createNodeFromParse: type "' + type + '" + not found');
+      invariant(
+        false,
+        'createNodeFromParse: type "' + nodeType + '" + not found',
+      );
     } else {
       invariant();
     }
   }
-  const node = new NodeType();
+  const node = new NodeTypeCount.class();
   const key = node.__key;
   if (isRootNode(node)) {
     const viewModel = getActiveViewModel();

--- a/packages/outline/src/__tests__/OutlineEditor-test.js
+++ b/packages/outline/src/__tests__/OutlineEditor-test.js
@@ -344,5 +344,28 @@ describe('OutlineEditor tests', () => {
         );
       });
     });
+
+    describe('addNodeType()', () => {
+      it('Supports adding and removing the same node type', async () => {
+        await update((view) => {
+          const paragraph = ParagraphNodeModule.createParagraphNode();
+          const text = Outline.createTextNode('Hello world');
+          text.select(6, 11);
+          paragraph.append(text);
+          view.getRoot().append(paragraph);
+        });
+
+        const remove = editor.addNodeType(
+          'paragraph',
+          ParagraphNodeModule.ParagraphNode,
+        );
+        editor.addNodeType('paragraph', ParagraphNodeModule.ParagraphNode);
+        // Remove the first added node type
+        remove();
+        // Parse the view model
+        const stringifiedViewModel = editor.getViewModel().stringify();
+        editor.parseViewModel(stringifiedViewModel);
+      });
+    });
   });
 });


### PR DESCRIPTION
When using `editor.addNodeType(...)` we previously used to add and remove from the same Map. This was problematic, because if the same type was added by two separate plugins, then their removal would affect one another. Instead, we can reference count the node types and only remove when no all instances of a node type have been removed.