### PR TITLE
Flaky test support

### DIFF
--- a/packages/outline-playground/__tests__/FlakyTest-test.js
+++ b/packages/outline-playground/__tests__/FlakyTest-test.js
@@ -1,0 +1,24 @@
+
+  /**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+    initializeE2E,
+} from 'outline-playground/__tests__/utils';
+
+describe('Flaky Test', () => {
+    initializeE2E({chromium: true, webkit: true, firefox: true}, (e2e) => {
+        e2e.flaky(['webkit', 'chromium', 'firefox'], () => {
+            // Note: this test is, itself, technically flaky but should pass 99.9% of the time (0.5^10)
+            it('can handle a flaky test that fails 50% of the time', () => {
+                const testValue = Math.floor(Math.random()*2);
+                expect(testValue).toBe(0);
+            });
+        });
+    });
+});

--- a/packages/outline-playground/__tests__/TextFormatting-test.js
+++ b/packages/outline-playground/__tests__/TextFormatting-test.js
@@ -18,257 +18,259 @@ import {
 
 describe('TextFormatting', () => {
   initializeE2E({chromium: true, webkit: true, firefox: true}, (e2e) => {
-    it(`Can create bold text using the shortcut`, async () => {
-      const {page} = e2e;
+    e2e.flaky(['webkit'], () => {
+      it(`Can create bold text using the shortcut`, async () => {
+        const {page} = e2e;
 
-      await focusEditor(page);
-      await page.keyboard.type('Hello');
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await page.keyboard.type(' World');
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 6,
-        focusPath: [0, 1, 0],
-        focusOffset: 6,
+        await focusEditor(page);
+        await page.keyboard.type('Hello');
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await page.keyboard.type(' World');
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 6,
+          focusPath: [0, 1, 0],
+          focusOffset: 6,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await page.keyboard.type('!');
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 2, 0],
+          anchorOffset: 1,
+          focusPath: [0, 2, 0],
+          focusOffset: 1,
+        });
       });
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await page.keyboard.type('!');
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 1,
-        focusPath: [0, 2, 0],
-        focusOffset: 1,
+      it(`Can create italic text using the shortcut`, async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+        await page.keyboard.type('Hello');
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await page.keyboard.type(' World');
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 6,
+          focusPath: [0, 1, 0],
+          focusOffset: 6,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await page.keyboard.type('!');
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 2, 0],
+          anchorOffset: 1,
+          focusPath: [0, 2, 0],
+          focusOffset: 1,
+        });
       });
-    });
 
-    it(`Can create italic text using the shortcut`, async () => {
-      const {page} = e2e;
+      it(`Can select text and boldify it with the shortcut`, async () => {
+        const {page} = e2e;
 
-      await focusEditor(page);
-      await page.keyboard.type('Hello');
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await page.keyboard.type(' World');
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 6,
-        focusPath: [0, 1, 0],
-        focusOffset: 6,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await page.keyboard.type('!');
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 1,
-        focusPath: [0, 2, 0],
-        focusOffset: 1,
-      });
-    });
-
-    it(`Can select text and boldify it with the shortcut`, async () => {
-      const {page} = e2e;
-
-      await focusEditor(page);
-      await page.keyboard.type('Hello world!');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.down('Shift');
-      await repeat(5, async () => {
+        await focusEditor(page);
+        await page.keyboard.type('Hello world!');
         await page.keyboard.press('ArrowLeft');
-      });
-      await page.keyboard.up('Shift');
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 11,
-        focusPath: [0, 0, 0],
-        focusOffset: 6,
+        await page.keyboard.down('Shift');
+        await repeat(5, async () => {
+          await page.keyboard.press('ArrowLeft');
+        });
+        await page.keyboard.up('Shift');
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 11,
+          focusPath: [0, 0, 0],
+          focusOffset: 6,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 1, 0],
+          focusOffset: 5,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 6,
+          focusPath: [0, 0, 0],
+          focusOffset: 11,
+        });
       });
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
+      it(`Can select text and italicify it with the shortcut`, async () => {
+        const {page} = e2e;
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 6,
-        focusPath: [0, 0, 0],
-        focusOffset: 11,
-      });
-    });
-
-    it(`Can select text and italicify it with the shortcut`, async () => {
-      const {page} = e2e;
-
-      await focusEditor(page);
-      await page.keyboard.type('Hello world!');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.down('Shift');
-      await repeat(5, async () => {
+        await focusEditor(page);
+        await page.keyboard.type('Hello world!');
         await page.keyboard.press('ArrowLeft');
-      });
-      await page.keyboard.up('Shift');
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 11,
-        focusPath: [0, 0, 0],
-        focusOffset: 6,
+        await page.keyboard.down('Shift');
+        await repeat(5, async () => {
+          await page.keyboard.press('ArrowLeft');
+        });
+        await page.keyboard.up('Shift');
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 11,
+          focusPath: [0, 0, 0],
+          focusOffset: 6,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 1, 0],
+          focusOffset: 5,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 6,
+          focusPath: [0, 0, 0],
+          focusOffset: 11,
+        });
       });
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
+      it(`Can select multiple text parts and format them with shortcuts`, async () => {
+        const {page} = e2e;
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 6,
-        focusPath: [0, 0, 0],
-        focusOffset: 11,
-      });
-    });
-
-    it(`Can select multiple text parts and format them with shortcuts`, async () => {
-      const {page} = e2e;
-
-      await focusEditor(page);
-      await page.keyboard.type('Hello world!');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.down('Shift');
-      await repeat(5, async () => {
+        await focusEditor(page);
+        await page.keyboard.type('Hello world!');
         await page.keyboard.press('ArrowLeft');
-      });
-      await page.keyboard.up('Shift');
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 11,
-        focusPath: [0, 0, 0],
-        focusOffset: 6,
-      });
+        await page.keyboard.down('Shift');
+        await repeat(5, async () => {
+          await page.keyboard.press('ArrowLeft');
+        });
+        await page.keyboard.up('Shift');
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 11,
+          focusPath: [0, 0, 0],
+          focusOffset: 6,
+        });
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 1, 0],
+          focusOffset: 5,
+        });
 
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.down('Shift');
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.up('Shift');
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 1,
-        focusPath: [0, 1, 0],
-        focusOffset: 3,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 2,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 2,
-      });
-
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.down('Shift');
-      await repeat(5, async () => {
+        await page.keyboard.press('ArrowLeft');
         await page.keyboard.press('ArrowRight');
-      });
-      await page.keyboard.up('Shift');
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 3, 0],
-        focusOffset: 2,
-      });
+        await page.keyboard.down('Shift');
+        await page.keyboard.press('ArrowRight');
+        await page.keyboard.press('ArrowRight');
+        await page.keyboard.up('Shift');
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 1,
+          focusPath: [0, 1, 0],
+          focusOffset: 3,
+        });
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 6,
-        focusPath: [0, 2, 0],
-        focusOffset: 2,
-      });
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 2, 0],
+          anchorOffset: 0,
+          focusPath: [0, 2, 0],
+          focusOffset: 2,
+        });
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 2, 0],
+          anchorOffset: 0,
+          focusPath: [0, 2, 0],
+          focusOffset: 2,
+        });
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await assertHTMLSnapshot(page);
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 6,
-        focusPath: [0, 0, 0],
-        focusOffset: 11,
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.down('Shift');
+        await repeat(5, async () => {
+          await page.keyboard.press('ArrowRight');
+        });
+        await page.keyboard.up('Shift');
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 3, 0],
+          focusOffset: 2,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 6,
+          focusPath: [0, 2, 0],
+          focusOffset: 2,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 1, 0],
+          focusOffset: 5,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await assertHTMLSnapshot(page);
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 6,
+          focusPath: [0, 0, 0],
+          focusOffset: 11,
+        });
       });
     });
   });

--- a/packages/outline-playground/__tests__/utils/index.js
+++ b/packages/outline-playground/__tests__/utils/index.js
@@ -54,6 +54,58 @@ export function initializeE2E(browsers, runTests) {
             cb();
           }
         },
+        flaky(flakyBrowsers, cb) {
+          const retryCount = 10;
+          const isFlaky = flakyBrowsers.find((flakyBrowser) => {
+            const [browser, option] = flakyBrowser.split('-');
+            if (browser === browserName) {
+              if (!option || (option === 'ci' && E2E_IS_CI)) {
+                return true;
+              }
+              if (!option || (option === 'mac' && IS_MAC)) {
+                return true;
+              }
+              return false;
+            }
+            return false;
+          });
+          if (isFlaky) {
+            const it = global.it;
+            // if we mark the test as flaky, overwrite the original 'it' function
+            // to attempt the test 10 times before actually failing
+            global.it = async (description, test) => {
+              const result = it(description, async () => {
+                let count = 0;
+                async function attempt() {
+                  try {
+                    // test attempt
+                    return await test();
+                  } catch(err) {
+                    // test failed
+                    if (count < retryCount) {
+                      count ++;
+                      // retry
+                      return await attempt();
+                    } else {
+                      // fail for real
+                      throw err;
+                    }
+                  }
+                }
+                return await attempt();
+              });
+              return result;
+            }
+
+            try {
+              cb();
+            } finally {
+              global.it = it;
+            }
+          } else {
+            cb();
+          }
+        },
         async saveScreenshot(print) {
           const currentTest = expect.getState().currentTestName;
           const path = currentTest.replace(/\s/g, '_') + '.png';


### PR DESCRIPTION
We've had some issues with some flaky webkit tests that make it difficult to land PRs. This PR adds a utility to mark specific tests as flaky for certain browsers, which will cause them to retry on fail up to 10 times before actually failing. Currently, the retry count is set to 10, but we could also modify this in the future if the need arises. 

Example usage:
```js
describe('TextFormatting', () => {
  initializeE2E({chromium: true, webkit: true, firefox: true}, (e2e) => {
    e2e.flaky(['webkit'], () => {
      it(`Can create bold text using the shortcut`, async () => {
        const {page} = e2e;

        await focusEditor(page);
        await page.keyboard.type('Hello');
        await keyDownCtrlOrMeta(page);
        await page.keyboard.press('b');
        await keyUpCtrlOrMeta(page);
        await page.keyboard.type(' World');
        await assertHTMLSnapshot(page);
        await assertSelection(page, {
          anchorPath: [0, 1, 0],
          anchorOffset: 6,
          focusPath: [0, 1, 0],
          focusOffset: 6,
        });

        await keyDownCtrlOrMeta(page);
        await page.keyboard.press('b');
        await keyUpCtrlOrMeta(page);
        await page.keyboard.type('!');
        await assertHTMLSnapshot(page);
        await assertSelection(page, {
          anchorPath: [0, 2, 0],
          anchorOffset: 1,
          focusPath: [0, 2, 0],
          focusOffset: 1,
        });
      });
    });
  });
});
```