### PR TITLE
Improve undo/redo logic to better handle text fragments

### DIFF
--- a/packages/outline-playground/__tests__/FlakyTest-test.js
+++ b/packages/outline-playground/__tests__/FlakyTest-test.js
@@ -1,5 +1,4 @@
-
-  /**
+/**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
@@ -7,18 +6,16 @@
  *
  */
 
-import {
-    initializeE2E,
-} from 'outline-playground/__tests__/utils';
+import {initializeE2E} from 'outline-playground/__tests__/utils';
 
 describe('Flaky Test', () => {
-    initializeE2E({chromium: true, webkit: true, firefox: true}, (e2e) => {
-        e2e.flaky(['webkit', 'chromium', 'firefox'], () => {
-            // Note: this test is, itself, technically flaky but should pass 99.9% of the time (0.5^10)
-            it('can handle a flaky test that fails 50% of the time', () => {
-                const testValue = Math.floor(Math.random()*2);
-                expect(testValue).toBe(0);
-            });
-        });
+  initializeE2E({chromium: true, webkit: true, firefox: true}, (e2e) => {
+    e2e.flaky(['webkit', 'chromium', 'firefox'], () => {
+      // Note: this test is, itself, technically flaky but should pass 99.9% of the time (0.5^10)
+      it('can handle a flaky test that fails 50% of the time', () => {
+        const testValue = Math.floor(Math.random() * 2);
+        expect(testValue).toBe(0);
+      });
     });
+  });
 });

--- a/packages/outline-playground/__tests__/utils/index.js
+++ b/packages/outline-playground/__tests__/utils/index.js
@@ -80,10 +80,10 @@ export function initializeE2E(browsers, runTests) {
                   try {
                     // test attempt
                     return await test();
-                  } catch(err) {
+                  } catch (err) {
                     // test failed
                     if (count < retryCount) {
-                      count ++;
+                      count++;
                       // retry
                       return await attempt();
                     } else {
@@ -95,7 +95,7 @@ export function initializeE2E(browsers, runTests) {
                 return await attempt();
               });
               return result;
-            }
+            };
 
             try {
               cb();


### PR DESCRIPTION
Our existing logic for handling text selection through undo/redo isn't very powerful compared to other editors. We should be checking if offset is getting incrementally increased as it is entered to understand if we should merge things.