### PR TITLE
Report typing perf to screen

### DIFF
--- a/packages/outline-playground/src/index.css
+++ b/packages/outline-playground/src/index.css
@@ -703,3 +703,14 @@ pre {
   margin: 8px 0;
   tab-size: 2;
 }
+
+div.report {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50px);
+  font-size: 32px;
+  background: rgba(255, 255, 255, 0.4);
+  border-radius: 20px;
+  padding: 20px;
+}

--- a/packages/outline-playground/src/useTypingPerfTracker.js
+++ b/packages/outline-playground/src/useTypingPerfTracker.js
@@ -10,7 +10,20 @@ export default function useTypingPerfTracker(measureTypingPerf: boolean): void {
       let log = [];
       const report = () => {
         const total = log.reduce((a, b) => a + b, 0);
-        console.log('Average Typing Perf:', total / log.length + 'ms');
+        const reportedText =
+          'Typing Perf: ' + Math.round((total / log.length) * 100) / 100 + 'ms';
+        console.log(reportedText);
+        // Show an element on the screen too :)
+        const element = document.createElement('div');
+        element.className = 'report';
+        element.textContent = reportedText;
+        const body = document.body;
+        if (body !== null) {
+          body.appendChild(element);
+          setTimeout(() => {
+            body.removeChild(element);
+          }, 1000);
+        }
         log = [];
       };
       const handleBeforeInput = (event) => {


### PR DESCRIPTION
This makes it easier to see perf without needing dev tools open (good for iOS/Android testing).