### PR TITLE
Fix various hashtag bugs

### DIFF
--- a/packages/outline-react/src/OutlineSelectionHelpers.js
+++ b/packages/outline-react/src/OutlineSelectionHelpers.js
@@ -487,7 +487,7 @@ export function updateCaretSelectionForRange(
     return;
   }
   const currentBlock = anchorNode.getParentBlockOrThrow();
-  const textContent = anchorNode.getTextContent();
+  let textContent = anchorNode.getTextContent();
   const textContentLength = textContent.length;
   const sibling = isBackward
     ? anchorNode.getPreviousSibling()
@@ -519,6 +519,7 @@ export function updateCaretSelectionForRange(
     if (granularity === 'character') {
       let characterNode = anchorNode;
       let characterOffset = anchorOffset;
+      let key = characterNode.getKey();
       if (isOffsetAtBoundary) {
         if (sibling === null) {
           return;
@@ -531,20 +532,22 @@ export function updateCaretSelectionForRange(
           return;
         }
         characterNode = sibling;
-        characterOffset = isBackward ? sibling.getTextContent().length : 0;
+        textContent = sibling.getTextContent();
+        key = sibling.getKey();
+        textContent = sibling.getTextContent();
+        characterOffset = isBackward ? textContent.length : 0;
       }
       let offset = 1;
       if (CAN_USE_INTL_SEGMENTER) {
         const textSlice = isBackward
-          ? textContent.slice(0, anchorOffset)
-          : textContent.slice(anchorOffset);
+          ? textContent.slice(0, characterOffset)
+          : textContent.slice(characterOffset);
         const segments = getSegmentsFromString(textSlice, 'grapheme');
         const segment = isBackward
           ? segments[segments.length - 1]
           : segments[0];
         offset = segment.segment.length;
       }
-      const key = characterNode.getKey();
       setSelectionFocus(
         selection,
         key,

--- a/packages/outline/src/OutlineTextNode.js
+++ b/packages/outline/src/OutlineTextNode.js
@@ -548,19 +548,35 @@ export class TextNode extends OutlineNode {
     let skipSelectionRestoration = false;
     let handledText = newText;
     // Handle hashtag containing whitespace
-    if (isHashtag) {
+    if (isHashtag && newText !== '') {
+      const parent = this.getParentOrThrow();
+      if (offset === 0) {
+        const textNode = createTextNode(newText);
+        this.insertBefore(textNode);
+        if (restoreSelection) {
+          textNode.select();
+        }
+        parent.normalizeTextNodes(true);
+        return this;
+      }
       const whiteSpaceIndex = handledText.search(/\s/);
 
       if (whiteSpaceIndex !== -1) {
+        const currentText = this.getTextContent();
         handledText = newText.slice(0, whiteSpaceIndex);
         const splitTextStr = newText.slice(whiteSpaceIndex);
         const textNode = createTextNode(splitTextStr);
-        this.insertAfter(textNode);
+        if (offset === currentText.length) {
+          this.insertAfter(textNode);
+        } else {
+          const [, targetNode] = this.splitText(offset);
+          targetNode.insertBefore(textNode);
+          targetNode.toggleHashtag();
+        }
         if (restoreSelection) {
           textNode.select();
           skipSelectionRestoration = true;
         }
-        const parent = this.getParentOrThrow();
         parent.normalizeTextNodes(true);
       }
     }


### PR DESCRIPTION
This PR tackles three bugs I found with hashtags:

- When trying to backspace into a hashtag, it would cause a fatal.
- When trying to add a space inside a hashtag, it would not do anything, instead moving selection to after the hashtag
  - Note: it should be possible to add a space at the start, at the end and part way through. It should also be possible to paste in a string part way through a hashtag that contains spaces too.
- When trying to use the delete key (to delete forwards), the editor would crash