### PR TITLE
Make editor.update() calls sync instead of async

### DIFF
--- a/packages/outline/src/OutlineEditor.js
+++ b/packages/outline/src/OutlineEditor.js
@@ -28,7 +28,6 @@ import {
   generateRandomKey,
   emptyFunction,
   invariant,
-  scheduleMicroTask,
 } from './OutlineUtils';
 import {getWritableNode} from './OutlineNode';
 import {createRootNode as createRoot} from './OutlineRootNode';
@@ -153,12 +152,10 @@ function updateEditor(
     return false;
   }
   if (viewModelWasCloned) {
-    scheduleMicroTask(() => {
-      commitPendingUpdates(editor);
-      if (callbackFn) {
-        callbackFn();
-      }
-    });
+    commitPendingUpdates(editor);
+    if (callbackFn) {
+      callbackFn();
+    }
   }
   return true;
 }

--- a/packages/outline/src/OutlineUtils.js
+++ b/packages/outline/src/OutlineUtils.js
@@ -44,10 +44,3 @@ export function getAdjustedSelectionAnchor(anchorDOM: Node): number {
 }
 
 export const isArray = Array.isArray;
-
-const NativePromise = window.Promise;
-
-export const scheduleMicroTask: (fn: () => void) => void =
-  typeof queueMicrotask === 'function'
-    ? queueMicrotask
-    : (fn) => NativePromise.resolve().then(fn);


### PR DESCRIPTION
I don't expect to land this PR, more to see what effect it has on the e2e testing stability.