### PR TITLE
Refactor setting editor NodeTypes

### DIFF
--- a/packages/outline-playground/src/useEmojis.js
+++ b/packages/outline-playground/src/useEmojis.js
@@ -67,10 +67,9 @@ function textNodeTransform(node: TextNode, view: View): void {
 export default function useEmojis(editor: null | OutlineEditor): void {
   useEffect(() => {
     if (editor !== null) {
-      const removeNodeType = editor.addNodeType('emoji', EmojiNode);
+      editor.setNodeType('emoji', EmojiNode);
       const removeTransform = editor.addTextNodeTransform(textNodeTransform);
       return () => {
-        removeNodeType();
         removeTransform();
       };
     }

--- a/packages/outline-playground/src/useMentions.js
+++ b/packages/outline-playground/src/useMentions.js
@@ -416,7 +416,7 @@ export default function useMentions(editor: OutlineEditor): React$Node {
   );
 
   useEffect(() => {
-    return editor.addNodeType('mention', MentionNode);
+    editor.setNodeType('mention', MentionNode);
   }, [editor]);
 
   useEffect(() => {

--- a/packages/outline-react/src/useOutlinePlainText.js
+++ b/packages/outline-react/src/useOutlinePlainText.js
@@ -98,7 +98,7 @@ export default function useOutlinePlainText(
   useEffect(() => {
     if (editor !== null) {
       initEditor(editor);
-      return editor.addNodeType('paragraph', ParagraphNode);
+      editor.setNodeType('paragraph', ParagraphNode);
     }
   }, [editor]);
 

--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -101,25 +101,13 @@ export default function useOutlineRichText(
 
   useEffect(() => {
     if (editor !== null) {
-      const removeHeadingType = editor.addNodeType('heading', HeadingNode);
-      const removeListType = editor.addNodeType('list', ListNode);
-      const removeQuoteType = editor.addNodeType('quote', QuoteNode);
-      const removeCodeType = editor.addNodeType('code', CodeNode);
-      const removeParagraphType = editor.addNodeType(
-        'paragraph',
-        ParagraphNode,
-      );
-      const removeListItemType = editor.addNodeType('listitem', ListItemNode);
+      editor.setNodeType('heading', HeadingNode);
+      editor.setNodeType('list', ListNode);
+      editor.setNodeType('quote', QuoteNode);
+      editor.setNodeType('code', CodeNode);
+      editor.setNodeType('paragraph', ParagraphNode);
+      editor.setNodeType('listitem', ListItemNode);
       initEditor(editor);
-
-      return () => {
-        removeHeadingType();
-        removeListType();
-        removeQuoteType();
-        removeParagraphType();
-        removeListItemType();
-        removeCodeType();
-      };
     }
   }, [editor]);
 

--- a/packages/outline/src/OutlineNode.js
+++ b/packages/outline/src/OutlineNode.js
@@ -676,8 +676,8 @@ export function createNodeFromParse(
   state: NodeParserState = {},
 ): OutlineNode {
   const nodeType = parsedNode.__type;
-  const NodeTypeCount = editor._registeredNodeTypes.get(nodeType);
-  if (NodeTypeCount === undefined) {
+  const NodeType = editor._nodeTypes.get(nodeType);
+  if (NodeType === undefined) {
     if (__DEV__) {
       invariant(
         false,
@@ -687,7 +687,7 @@ export function createNodeFromParse(
       invariant();
     }
   }
-  const node = new NodeTypeCount.class();
+  const node = new NodeType();
   const key = node.__key;
   if (isRootNode(node)) {
     const viewModel = getActiveViewModel();

--- a/packages/outline/src/__tests__/OutlineEditor-test.js
+++ b/packages/outline/src/__tests__/OutlineEditor-test.js
@@ -249,7 +249,7 @@ describe('OutlineEditor tests', () => {
           paragraph.append(originalText);
           view.getRoot().append(paragraph);
         });
-        editor.addNodeType('paragraph', ParagraphNodeModule.ParagraphNode);
+        editor.setNodeType('paragraph', ParagraphNodeModule.ParagraphNode);
         const stringifiedViewModel = editor.getViewModel().stringify();
         const viewModel = editor.parseViewModel(stringifiedViewModel);
         viewModel.read((view) => {
@@ -350,29 +350,6 @@ describe('OutlineEditor tests', () => {
           '<div contenteditable="true" data-outline-editor="true"><p><span></span></p><p>' +
             '<span></span></p></div>',
         );
-      });
-    });
-
-    describe('addNodeType()', () => {
-      it('Supports adding and removing the same node type', async () => {
-        await update((view) => {
-          const paragraph = ParagraphNodeModule.createParagraphNode();
-          const text = Outline.createTextNode('Hello world');
-          text.select(6, 11);
-          paragraph.append(text);
-          view.getRoot().append(paragraph);
-        });
-
-        const remove = editor.addNodeType(
-          'paragraph',
-          ParagraphNodeModule.ParagraphNode,
-        );
-        editor.addNodeType('paragraph', ParagraphNodeModule.ParagraphNode);
-        // Remove the first added node type
-        remove();
-        // Parse the view model
-        const stringifiedViewModel = editor.getViewModel().stringify();
-        editor.parseViewModel(stringifiedViewModel);
       });
     });
   });


### PR DESCRIPTION
This greatly simplifies the NodeType logic for editors, so it works much more like a Map. Setting `null` removes a node type.