### PR TITLE
Normalize selection on boundary

### DIFF
--- a/packages/outline-playground/__tests__/utils/index.js
+++ b/packages/outline-playground/__tests__/utils/index.js
@@ -295,3 +295,7 @@ export async function pasteFromClipboard(page, clipboardData) {
     {clipboardData, canUseBeforeInput},
   );
 }
+
+export async function sleep(delay) {
+  await new Promise((resolve) => setTimeout(resolve, delay));
+}


### PR DESCRIPTION
This extends on https://github.com/facebookexternal/Outline/pull/246 and fixes https://github.com/facebookexternal/Outline/issues/243.

This PR intends to make backward selections on boundaries wrap to the previous sibling if the heuristics of the previous sibling should allow for this. This allows for a more consistent UX and also improves some characteristics of selection deletions too.