### PR TITLE
Fix selection.getTextContent()

### DIFF
--- a/packages/outline-playground/src/Editor.js
+++ b/packages/outline-playground/src/Editor.js
@@ -106,7 +106,7 @@ function useOutlineOnChange(
   // Subscribe to errors
   useEffect(() => {
     if (outlineEditor !== null) {
-      return outlineEditor.addErrorListener(e => {
+      return outlineEditor.addErrorListener((e) => {
         throw e;
       });
     }

--- a/packages/outline/src/OutlineSelection.js
+++ b/packages/outline/src/OutlineSelection.js
@@ -91,10 +91,34 @@ export class Selection {
   }
   getTextContent(): string {
     const nodes = this.getNodes();
+    if (nodes.length === 0) {
+      return '';
+    }
+    const firstNode = nodes[0];
+    const lastNode = nodes[nodes.length - 1];
+    const isBefore = firstNode === this.getAnchorNode();
+    const anchorOffset = this.anchorOffset;
+    const focusOffset = this.focusOffset;
     let textContent = '';
     nodes.forEach((node) => {
       if (isTextNode(node)) {
-        textContent += node.getTextContent();
+        let text = node.getTextContent();
+        if (node === firstNode) {
+          if (node === lastNode) {
+            text = text.slice(anchorOffset, focusOffset);
+          } else {
+            text = isBefore
+              ? text.slice(anchorOffset)
+              : text.slice(focusOffset);
+          }
+        } else if (node === lastNode) {
+          text = isBefore
+            ? text.slice(0, focusOffset)
+            : text.slice(0, anchorOffset);
+        }
+        textContent += text;
+      } else if (isBlockNode(node)) {
+        textContent += '\n';
       }
     });
     return textContent;


### PR DESCRIPTION
The logic before did not properly take into account the offsets from selection, nor line breaks of block nodes. They do now!