### PR TITLE
Fix selection boundary to empty text node

### DIFF
--- a/packages/outline-react/src/OutlineSelectionHelpers.js
+++ b/packages/outline-react/src/OutlineSelectionHelpers.js
@@ -741,6 +741,13 @@ export function updateCaretSelectionForRange(
         node = siblingAfter;
       }
 
+      if (
+        index === null &&
+        node !== anchorNode &&
+        node.getTextContent() === ''
+      ) {
+        index = 0;
+      }
       if (node.isImmutable() || node.isInert()) {
         updateSelectionForNextSiblingRange(selection, isBackward, node);
       } else if (node.isSegmented()) {

--- a/packages/outline/src/OutlineTextNode.js
+++ b/packages/outline/src/OutlineTextNode.js
@@ -324,8 +324,8 @@ export class TextNode extends OutlineNode {
     const self = this.getLatest();
     return self.__text;
   }
-  getTextContentSize(): number {
-    return this.getTextContent().length;
+  getTextContentSize(includeInert?: boolean): number {
+    return this.getTextContent(includeInert).length;
   }
   getTextNodeFormatFlags(
     type: TextFormatType,


### PR DESCRIPTION
If we have a text node that is empty on a boundary, we should be able to move to it.