### PR TITLE
Revise logic for decorators

### DIFF
--- a/packages/outline-react/src/OutlineEventHandlers.js
+++ b/packages/outline-react/src/OutlineEventHandlers.js
@@ -487,7 +487,7 @@ export function onNativeInput(
     }
     if (isInsertText) {
       const anchorKey = selection.anchorKey;
-      // Android Chrome triggers insert text during composition. 
+      // Android Chrome triggers insert text during composition.
       // If this happens, then we will need to remove the
       // composition key in order for the DOM to update in
       // accordance with what is occuring. Composition should

--- a/packages/outline/src/OutlineEditor.js
+++ b/packages/outline/src/OutlineEditor.js
@@ -193,8 +193,8 @@ export class OutlineEditor {
   _decoratorListeners: Set<DecoratorListener>;
   _textNodeTransforms: Set<TextNodeTransform>;
   _nodeTypes: Map<string, Class<OutlineNode>>;
-  _nodeDecorators: {[NodeKey]: ReactNode};
-  _pendingNodeDecorators: null | {[NodeKey]: ReactNode};
+  _decorators: {[NodeKey]: ReactNode};
+  _pendingDecorators: null | {[NodeKey]: ReactNode};
   _placeholderText: string;
   _placeholderElement: null | HTMLElement;
   _textContent: string;
@@ -233,13 +233,8 @@ export class OutlineEditor {
     ]);
     this._key = generateRandomKey();
     // React node decorators for portals
-    this._nodeDecorators = {};
-    // Outline tries to garbage collect nodes
-    // so if it garbage collects a node with
-    // a decorator, it should set the next
-    // decorators to pending until the update
-    // is complete.
-    this._pendingNodeDecorators = null;
+    this._decorators = {};
+    this._pendingDecorators = null;
     // Used for rendering placeholder text
     this._placeholderText = '';
     this._placeholderElement = null;
@@ -277,13 +272,6 @@ export class OutlineEditor {
   setPointerDown(isPointerDown: boolean): void {
     this._isPointerDown = isPointerDown;
   }
-  addNodeDecorator(key: NodeKey, decorator: ReactNode): void {
-    const pendingNodeDecorators = this._pendingNodeDecorators || {
-      ...this._nodeDecorators,
-    };
-    pendingNodeDecorators[key] = decorator;
-    this._pendingNodeDecorators = pendingNodeDecorators;
-  }
   registerNodeType(nodeType: string, klass: Class<OutlineNode>): void {
     this._nodeTypes.set(nodeType, klass);
   }
@@ -318,8 +306,8 @@ export class OutlineEditor {
       this._textNodeTransforms.delete(listener);
     };
   }
-  getNodeDecorators(): {[NodeKey]: ReactNode} {
-    return this._nodeDecorators;
+  getDecorators(): {[NodeKey]: ReactNode} {
+    return this._decorators;
   }
   getEditorKey(): string {
     return this._key;

--- a/packages/outline/src/OutlineNode.js
+++ b/packages/outline/src/OutlineNode.js
@@ -9,6 +9,7 @@
 
 import type {OutlineEditor, EditorThemeClasses} from './OutlineEditor';
 import type {Selection} from './OutlineSelection';
+import type {Node as ReactNode} from 'react';
 
 import {
   createTextNode,
@@ -466,6 +467,9 @@ export class OutlineNode {
     } else {
       invariant();
     }
+  }
+  decorate(): null | ReactNode {
+    return null;
   }
 
   // Setters and mutators

--- a/packages/outline/src/__tests__/unit/OutlineEditor-test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor-test.js
@@ -155,7 +155,7 @@ describe('OutlineEditor tests', () => {
   describe('With node decorators', () => {
     function useDecorators() {
       const [decorators, setDecorators] = React.useState(() =>
-        editor.getNodeDecorators(),
+        editor.getDecorators(),
       );
       // Subscribe to changes
       React.useEffect(() => {
@@ -206,14 +206,21 @@ describe('OutlineEditor tests', () => {
 
       // Update the editor with the decorator
       await ReactTestUtils.act(async () => {
+        class DecoratorNode extends Outline.TextNode {
+          clone() {
+            const node = new DecoratorNode(this.__text, this.__key);
+            node.__parent = this.__parent;
+            node.__flags = this.__flags;
+            return node;
+          }
+          decorate() {
+            return <Decorator text={'Hello world'} />;
+          }
+        }
         await editor.update((view) => {
           const paragraph = ParagraphNodeModule.createParagraphNode();
-          const text = Outline.createTextNode('');
+          const text = new DecoratorNode('');
           text.makeImmutable();
-          editor.addNodeDecorator(
-            text.getKey(),
-            <Decorator text={'Hello world'} />,
-          );
           paragraph.append(text);
           view.getRoot().append(paragraph);
         });


### PR DESCRIPTION
So it turns out there was a major design flaw in Outline decorators – they were coupled to the editor instance and had no real relation to the view. This meant that when you re-applied a view using `setViewModel`, and that view model had node decorators, how as the editor meant to know what React elements to decorate them with?

This PR aims to tackle this problem by bringing the relationship of a React element (a decorator) and an Outline node closer together. Now, you can add a `decorate()` method to your custom Outline node, and with this you can return your React element that you want to be used for this node. This also provides a major benefit in that Outline nodes can now dynamically update their decorators on updates – something that wasn't possible before. 