### PR TITLE
Ensure we apply empty text node heuristic on selection ranges

### DIFF
--- a/packages/outline/src/OutlineReconciler.js
+++ b/packages/outline/src/OutlineReconciler.js
@@ -14,7 +14,7 @@ import type {Selection} from './OutlineSelection';
 import type {Node as ReactNode} from 'react';
 
 import {isTextNode, isBlockNode} from '.';
-import {invariant, getAdjustedSelectionAnchor} from './OutlineUtils';
+import {invariant, getAdjustedSelectionOffset} from './OutlineUtils';
 import {
   IS_IMMUTABLE,
   IS_SEGMENTED,
@@ -622,6 +622,7 @@ function reconcileSelection(
   const anchorDOM = editor.getElementByKey(anchorKey);
   const focusDOM = editor.getElementByKey(focusKey);
   const anchorTextIsEmpty = anchorNode.__text === '';
+  const focusTextIsEmpty = focusNode.__text === '';
   let anchorOffset = nextSelection.anchorOffset;
   let focusOffset = nextSelection.focusOffset;
 
@@ -629,10 +630,11 @@ function reconcileSelection(
   // selection and text entry works as expected, it also
   // means we need to adjust the offset to ensure native
   // selection works correctly and doesn't act buggy.
-  if (anchorNode === focusNode && anchorTextIsEmpty) {
-    const offset = getAdjustedSelectionAnchor(anchorDOM);
-    anchorOffset = offset;
-    focusOffset = offset;
+  if (anchorTextIsEmpty) {
+    anchorOffset = getAdjustedSelectionOffset(anchorDOM);
+  }
+  if (focusTextIsEmpty) {
+    focusOffset = getAdjustedSelectionOffset(focusDOM);
   }
   // Get the underlying DOM text nodes from the representive
   // Outline text nodes (we use elements for text nodes).
@@ -644,6 +646,7 @@ function reconcileSelection(
   const domSelection = window.getSelection();
   if (
     !anchorTextIsEmpty &&
+    !focusTextIsEmpty &&
     domSelection.anchorOffset === anchorOffset &&
     domSelection.focusOffset === focusOffset &&
     domSelection.anchorNode === anchorDOMTarget &&

--- a/packages/outline/src/OutlineUtils.js
+++ b/packages/outline/src/OutlineUtils.js
@@ -38,7 +38,7 @@ export function generateRandomKey(): string {
 // We let the browser natively insert text, but this can cause issues on a new block
 // with things like autocorrect and the software keyboard suggestions. Conversely,
 // IME input can break if the anchor is not at 1 in other cases.
-export function getAdjustedSelectionAnchor(anchorDOM: Node): number {
+export function getAdjustedSelectionOffset(anchorDOM: Node): number {
   const previousSibling = anchorDOM.previousSibling;
   return previousSibling == null || previousSibling.nodeName === 'BR' ? 0 : 1;
 }


### PR DESCRIPTION
We only apply this heuristic to caret selections – we should also be applying it to ranges too.