### PR TITLE
Fix copy backward

### DIFF
--- a/packages/outline/src/OutlineSelection.js
+++ b/packages/outline/src/OutlineSelection.js
@@ -105,7 +105,10 @@ export class Selection {
         let text = node.getTextContent();
         if (node === firstNode) {
           if (node === lastNode) {
-            text = text.slice(anchorOffset, focusOffset);
+            text =
+              anchorOffset < focusOffset
+                ? text.slice(anchorOffset, focusOffset)
+                : text.slice(focusOffset, anchorOffset);
           } else {
             text = isBefore
               ? text.slice(anchorOffset)


### PR DESCRIPTION
An obvious oversight on reflection, we should be checking the offsets when slicing on the same node.