### PR TITLE
Remove DOM selection on null nextSelection

### DIFF
--- a/packages/outline/src/OutlineReconciler.js
+++ b/packages/outline/src/OutlineReconciler.js
@@ -14,7 +14,11 @@ import type {Selection} from './OutlineSelection';
 import type {Node as ReactNode} from 'react';
 
 import {isTextNode, isBlockNode} from '.';
-import {invariant, getAdjustedSelectionOffset} from './OutlineUtils';
+import {
+  invariant,
+  getAdjustedSelectionOffset,
+  isSelectionWithinEditor,
+} from './OutlineUtils';
 import {
   IS_IMMUTABLE,
   IS_SEGMENTED,
@@ -620,7 +624,15 @@ function reconcileSelection(
 ): void {
   const domSelection = window.getSelection();
   if (nextSelection === null) {
-    domSelection.removeAllRanges();
+    if (
+      isSelectionWithinEditor(
+        editor,
+        domSelection.anchorNode,
+        domSelection.focusNode,
+      )
+    ) {
+      domSelection.removeAllRanges();
+    }
     return;
   }
   const anchorKey = nextSelection.anchorKey;

--- a/packages/outline/src/OutlineSelection.js
+++ b/packages/outline/src/OutlineSelection.js
@@ -14,7 +14,11 @@ import {getActiveViewModel} from './OutlineView';
 import {getNodeKeyFromDOM} from './OutlineReconciler';
 import {getNodeByKey} from './OutlineNode';
 import {isTextNode, isBlockNode, isLineBreakNode, TextNode} from '.';
-import {invariant, getAdjustedSelectionOffset} from './OutlineUtils';
+import {
+  invariant,
+  getAdjustedSelectionOffset,
+  isSelectionWithinEditor,
+} from './OutlineUtils';
 import {OutlineEditor} from './OutlineEditor';
 import {LineBreakNode} from './OutlineLineBreakNode';
 
@@ -251,13 +255,10 @@ function resolveSelectionNodesAndOffsets(
   focusOffset: number,
   editor: OutlineEditor,
 ): null | [TextNode, TextNode, number, number, boolean] {
-  const editorElement = editor.getEditorElement();
   if (
-    editorElement === null ||
     anchorDOM === null ||
     focusDOM === null ||
-    !editorElement.contains(anchorDOM) ||
-    !editorElement.contains(focusDOM)
+    !isSelectionWithinEditor(editor, anchorDOM, focusDOM)
   ) {
     return null;
   }

--- a/packages/outline/src/OutlineUtils.js
+++ b/packages/outline/src/OutlineUtils.js
@@ -7,6 +7,8 @@
  * @flow strict
  */
 
+import type {OutlineEditor} from './OutlineEditor';
+
 export const emptyFunction = () => {};
 
 let keyCounter = 0;
@@ -51,3 +53,16 @@ export const scheduleMicroTask: (fn: () => void) => void =
   typeof queueMicrotask === 'function'
     ? queueMicrotask
     : (fn) => NativePromise.resolve().then(fn);
+
+export function isSelectionWithinEditor(
+  editor: OutlineEditor,
+  anchorDOM: Node,
+  focusDOM: Node,
+): boolean {
+  const editorElement = editor.getEditorElement();
+  return (
+    editorElement !== null &&
+    editorElement.contains(anchorDOM) &&
+    editorElement.contains(focusDOM)
+  );
+}


### PR DESCRIPTION
When we do `view.clearSelection()` would should probably also update the DOM selection too.