### PR TITLE
Fix isDirty selection regression

### DIFF
--- a/packages/outline/src/OutlineSelection.js
+++ b/packages/outline/src/OutlineSelection.js
@@ -191,12 +191,16 @@ function resolveSelectionNodeAndOffset(
   let resolvedDOM = dom;
   let resolvedOffset = offset;
   let resolvedNode;
+  let isDirty = _isDirty;
   // If we have selection on an element, we will
   // need to figure out (using the offset) what text
   // node should be selected.
 
   if (domIsElement(resolvedDOM) && resolvedDOM.nodeName !== 'BR') {
     let moveSelectionToEnd = false;
+    // Given we're moving selection to another node, selection is
+    // definitely dirty.
+    isDirty = true;
     // We use the anchor to find which child node to select
     const childNodes = resolvedDOM.childNodes;
     const childNodesLength = childNodes.length;
@@ -230,7 +234,6 @@ function resolveSelectionNodeAndOffset(
     return null;
   }
   const resolvedTextNode = resolvedNode;
-  let isDirty = _isDirty;
   // Because we use a special character for whitespace,
   // we need to adjust offsets to 0 when the text is
   // really empty.


### PR DESCRIPTION
When we have selection that changes nodes from the original selection, we should be marking that as dirty.

We previously were:

https://github.com/facebookexternal/Outline/commit/031016945a3277544aae25bc9fbc83b53df6017a#diff-86c7e2b9990831a776302548b260246149c99339ad40a981f900d71bff563e8dL259

So this was a recent regression.