### PR TITLE
Ensure paste events are attached on the root

### DIFF
--- a/packages/outline-react/src/OutlineEventHandlers.js
+++ b/packages/outline-react/src/OutlineEventHandlers.js
@@ -80,6 +80,13 @@ export type EventHandlerState = {
   isHandlingPointer: boolean,
 };
 
+function isWithinEditor(editor: OutlineEditor, target: EventTarget): boolean {
+  const editorElement = editor.getEditorElement();
+  // $FlowFixMe: target should always be a node or null
+  const node: null | Node = target;
+  return editorElement !== null && editorElement.contains(node);
+}
+
 function generateNodes(
   nodeRange: {range: Array<NodeKey>, nodeMap: ParsedNodeMap},
   view: View,
@@ -306,6 +313,9 @@ export function onPastePolyfillForPlainText(
   editor: OutlineEditor,
   state: EventHandlerState,
 ): void {
+  if (!isWithinEditor(editor, event.target)) {
+    return;
+  }
   event.preventDefault();
   editor.update((view) => {
     const selection = view.getSelection();
@@ -321,6 +331,9 @@ export function onPastePolyfillForRichText(
   editor: OutlineEditor,
   state: EventHandlerState,
 ): void {
+  if (!isWithinEditor(editor, event.target)) {
+    return;
+  }
   event.preventDefault();
   editor.update((view) => {
     const selection = view.getSelection();
@@ -442,10 +455,9 @@ export function onSelectionChange(
   state: EventHandlerState,
 ): void {
   const domSelection = window.getSelection();
-  const editorElement = editor.getEditorElement();
   // This is a hot-path, so let's avoid doing an update when
   // the anchorNode is not actually inside the editor.
-  if (editorElement && !editorElement.contains(domSelection.anchorNode)) {
+  if (!isWithinEditor(editor, domSelection.anchorNode)) {
     return;
   }
   // This update also functions as a way of reconciling a bad selection

--- a/packages/outline-react/src/useOutlineEditorEvents.js
+++ b/packages/outline-react/src/useOutlineEditorEvents.js
@@ -33,7 +33,10 @@ export default function useOutlineEditorEvents(
             eventName === 'selectionchange' ||
             eventName === 'keyup' ||
             eventName === 'pointerup' ||
-            eventName === 'pointercancel'
+            eventName === 'pointercancel' ||
+            // Paste needs to be on the document/window for Safari
+            // to properly support pasting things like img alt text.
+            eventName === 'paste'
           ) {
             eventTarget = target.ownerDocument;
           }


### PR DESCRIPTION
Interestingly, in some browsers (Safari) if the `paste` event is not delegated high enough up the DOM tree, then parts of the paste get stripped out.