### PR TITLE
Add Windows e2e support for Chromium/FF

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,6 +166,28 @@ jobs:
     - run: npm run build
     - run: npm run test-e2e-ci:firefox
 
+  e2e-firefox-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    env:
+      CI: true
+      PLAYWRIGHT_BROWSERS_PATH: 0
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - uses: actions/cache@v2
+      with:
+        path: '**/node_modules'
+        key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+    - run: npm install --legacy-peer-deps
+    - run: npm run build
+    - run: npm run test-e2e-ci:firefox
+
   e2e-webkit-mac:
     runs-on: macos-latest
     strategy:


### PR DESCRIPTION
Let's add Windows support to our e2e tests, specifically Chromium and Firefox.