### PR TITLE
Fix unit tests

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineBlockNode-test.js
+++ b/packages/outline/src/__tests__/unit/OutlineBlockNode-test.js
@@ -68,6 +68,9 @@ describe('OutlineBlockNode tests', () => {
 
     function TestBase() {
       editor = useOutlineEditor(ref);
+      editor.addErrorListener(error => {
+        throw error
+      })
       return <div ref={ref} contentEditable={true} />;
     }
 

--- a/packages/outline/src/__tests__/unit/OutlineEditor-test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor-test.js
@@ -50,6 +50,9 @@ describe('OutlineEditor tests', () => {
 
     function TestBase() {
       editor = useOutlineEditor(ref);
+      editor.addErrorListener(error => {
+        throw error
+      })
       return <div ref={ref} contentEditable={true} />;
     }
 

--- a/packages/outline/src/__tests__/unit/OutlineLineBreakNode-test.js
+++ b/packages/outline/src/__tests__/unit/OutlineLineBreakNode-test.js
@@ -50,6 +50,9 @@ describe('OutlineLineBreakNode tests', () => {
 
     function TestBase() {
       editor = useOutlineEditor(ref);
+      editor.addErrorListener(error => {
+        throw error
+      })
       return <div ref={ref} contentEditable={true} />;
     }
 

--- a/packages/outline/src/__tests__/unit/OutlineNode-test.js
+++ b/packages/outline/src/__tests__/unit/OutlineNode-test.js
@@ -56,6 +56,9 @@ describe('OutlineNode tests', () => {
 
     function TestBase() {
       editor = useOutlineEditor(ref);
+      editor.addErrorListener(error => {
+        throw error
+      })
       return <div ref={ref} contentEditable={true} />;
     }
 

--- a/packages/outline/src/__tests__/unit/OutlineTextNode-test.js
+++ b/packages/outline/src/__tests__/unit/OutlineTextNode-test.js
@@ -77,6 +77,9 @@ describe('OutlineTextNode tests', () => {
 
     function TestBase() {
       editor = useOutlineEditor(ref);
+      editor.addErrorListener(error => {
+        throw error
+      })
       return <div ref={ref} contentEditable={true} />;
     }
 

--- a/packages/outline/src/__tests__/unit/OutlineViewModel-test.js
+++ b/packages/outline/src/__tests__/unit/OutlineViewModel-test.js
@@ -51,6 +51,9 @@ describe('OutlineViewModel tests', () => {
 
     function TestBase() {
       editor = useOutlineEditor(ref);
+      editor.addErrorListener(error => {
+        throw error
+      })
       return <div ref={ref} contentEditable={true} />;
     }
 


### PR DESCRIPTION
Our unit tests do not really work at the moment as `editor.update()` executes the passed function within try-catch block so assertions thrown by expect never reach the test runner.
This PR fixes that by adding an error listener which throws any errors caught by the editor.