### PR TITLE
Unit test for #253

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineLineBreakNode-test.js
+++ b/packages/outline/src/__tests__/unit/OutlineLineBreakNode-test.js
@@ -65,6 +65,14 @@ describe('OutlineLineBreakNode tests', () => {
     });
   });
 
+  test('clone()', async () => {
+    await update(() => {
+      const lineBreakNode = Outline.createLineBreakNode();
+      const lineBreakNodeClone = lineBreakNode.clone()
+      expect(lineBreakNodeClone).toStrictEqual(lineBreakNode);
+    });
+  });
+
   test('createDOM()', async () => {
     await update(() => {
       const lineBreakNode = Outline.createLineBreakNode();


### PR DESCRIPTION
This PR adds a unit test for `LineBreakNode.clone()`
Fixes #253