### PR TITLE
Fix Safari Intl.Segmenter bug

### DIFF
--- a/packages/outline-react/src/OutlineSelectionHelpers.js
+++ b/packages/outline-react/src/OutlineSelectionHelpers.js
@@ -21,7 +21,11 @@ import {createParagraphNode} from 'outline-extensions/ParagraphNode';
 
 import {CAN_USE_INTL_SEGMENTER} from './OutlineEnv';
 import {invariant} from './OutlineReactUtils';
-import {getSegmentsFromString, getWordsFromString} from './OutlineTextHelpers';
+import {
+  getSegmentsFromString,
+  getWordsFromString,
+  isSegmentWordLike,
+} from './OutlineTextHelpers';
 
 export function getNodesInRange(
   selection: Selection,
@@ -654,7 +658,7 @@ export function updateCaretSelectionForRange(
             const segment = segments[i];
             const nextIndex = segment.index;
 
-            if (segment.isWordLike) {
+            if (isSegmentWordLike(segment)) {
               index = nextIndex;
               foundWordNode = node;
             } else if (foundWordNode !== null) {
@@ -669,7 +673,7 @@ export function updateCaretSelectionForRange(
             const segment = segments[i];
             const nextIndex = segment.index + segment.segment.length;
 
-            if (segment.isWordLike) {
+            if (isSegmentWordLike(segment)) {
               index = nextIndex;
               foundWordNode = node;
             } else if (foundWordNode !== null) {

--- a/packages/outline-react/src/OutlineTextHelpers.js
+++ b/packages/outline-react/src/OutlineTextHelpers.js
@@ -10,6 +10,7 @@
 import type {RootNode, TextNode} from 'outline';
 
 import {isTextNode, isBlockNode} from 'outline';
+import {IS_SAFARI} from './OutlineEnv';
 
 export function findTextIntersectionFromCharacters(
   root: RootNode,
@@ -83,6 +84,17 @@ export function getSegmentsFromString(
     granularity,
   });
   return Array.from(segmenter.segment(string));
+}
+
+export function isSegmentWordLike(segment: Segment): boolean {
+  const isWordLike = segment.isWordLike;
+  if (IS_SAFARI) {
+    // Safari treats strings with only numbers as not word like.
+    // This isn't correct, so we have to do an additional check for
+    // these cases.
+    return isWordLike || /^[0-9]*$/g.test(segment.segment);
+  }
+  return isWordLike;
 }
 
 function pushSegment(


### PR DESCRIPTION
Good news: Safari now has native support for Intl.Segmenter. Bad news: it treats strings containing only numbers as non-words. This adds a fix for this behavior.