### PR TITLE
Ensure we move offset to start/end of resolve selection node

### DIFF
--- a/packages/outline-playground/__tests__/utils/index.js
+++ b/packages/outline-playground/__tests__/utils/index.js
@@ -132,12 +132,8 @@ export async function assertSelection(page, expected) {
       return path.reverse();
     };
 
-    const {
-      anchorNode,
-      anchorOffset,
-      focusNode,
-      focusOffset,
-    } = window.getSelection();
+    const {anchorNode, anchorOffset, focusNode, focusOffset} =
+      window.getSelection();
 
     return {
       anchorPath: getPathFromNode(anchorNode),

--- a/packages/outline-playground/src/CharacterLimit.js
+++ b/packages/outline-playground/src/CharacterLimit.js
@@ -67,10 +67,8 @@ export default function CharacterLimit({
               if (existingOverflowNodeKey === node.getKey()) {
                 if (startOffset > existingOffset) {
                   const offset = startOffset - existingOffset;
-                  const [
-                    targetNode,
-                    nextOverflowNode,
-                  ] = existingOverflowNode.splitText(offset);
+                  const [targetNode, nextOverflowNode] =
+                    existingOverflowNode.splitText(offset);
                   targetNode.toggleOverflowed();
                   const parent = targetNode.getTopParentBlockOrThrow();
                   parent.normalizeTextNodes(true);

--- a/packages/outline-playground/src/useStepRecorder.js
+++ b/packages/outline-playground/src/useStepRecorder.js
@@ -148,12 +148,8 @@ export default function useStepRecorder(editor: OutlineEditor): React$Node {
       return null;
     }
 
-    const {
-      anchorNode,
-      anchorOffset,
-      focusNode,
-      focusOffset,
-    } = sanitizeSelectionWithEmptyTextNodes(browserSelection);
+    const {anchorNode, anchorOffset, focusNode, focusOffset} =
+      sanitizeSelectionWithEmptyTextNodes(browserSelection);
     return `
 {
   name: '<YOUR TEST NAME>',
@@ -282,12 +278,8 @@ export default function useStepRecorder(editor: OutlineEditor): React$Node {
           ) {
             return;
           }
-          const {
-            anchorNode,
-            anchorOffset,
-            focusNode,
-            focusOffset,
-          } = sanitizeSelectionWithEmptyTextNodes(browserSelection);
+          const {anchorNode, anchorOffset, focusNode, focusOffset} =
+            sanitizeSelectionWithEmptyTextNodes(browserSelection);
           pushStep('moveNativeSelection', [
             `[${getPathFromNodeToEditor(
               anchorNode,

--- a/packages/outline-playground/src/useToolbar.js
+++ b/packages/outline-playground/src/useToolbar.js
@@ -273,13 +273,15 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
   );
 
   const bold = useCallback(() => applyFormatText('bold'), [applyFormatText]);
-  const italic = useCallback(() => applyFormatText('italic'), [
-    applyFormatText,
-  ]);
+  const italic = useCallback(
+    () => applyFormatText('italic'),
+    [applyFormatText],
+  );
   const code = useCallback(() => applyFormatText('code'), [applyFormatText]);
-  const strikethrough = useCallback(() => applyFormatText('strikethrough'), [
-    applyFormatText,
-  ]);
+  const strikethrough = useCallback(
+    () => applyFormatText('strikethrough'),
+    [applyFormatText],
+  );
   const link = useCallback(() => {
     if (!isLink) {
       setEditMode(true);

--- a/packages/outline-playground/src/useTypeahead.js
+++ b/packages/outline-playground/src/useTypeahead.js
@@ -173,9 +173,10 @@ function createTypeaheadNode(text: string): TextNode {
 
 function useTypeaheadSuggestion(
   text: string,
-  query: (
-    text: string,
-  ) => {promise: () => Promise<string | null>, cancel: () => void},
+  query: (text: string) => {
+    promise: () => Promise<string | null>,
+    cancel: () => void,
+  },
 ) {
   const cancelRequest = useRef<() => void>(() => {});
   const requestTime = useRef<number>(0);

--- a/packages/outline-react/src/OutlineSelectionHelpers.js
+++ b/packages/outline-react/src/OutlineSelectionHelpers.js
@@ -41,9 +41,10 @@ function isSegmentedOrImmutableOrInert(node: OutlineNode): boolean {
   return node.isSegmented() || isImmutableOrInert(node);
 }
 
-export function getNodesInRange(
-  selection: Selection,
-): {range: Array<NodeKey>, nodeMap: {[NodeKey]: Node}} {
+export function getNodesInRange(selection: Selection): {
+  range: Array<NodeKey>,
+  nodeMap: {[NodeKey]: Node},
+} {
   const anchorNode = selection.getAnchorNode();
   const focusNode = selection.getFocusNode();
   const anchorOffset = selection.anchorOffset;

--- a/packages/outline-react/src/__tests__/unit/OutlineSelection-test.js
+++ b/packages/outline-react/src/__tests__/unit/OutlineSelection-test.js
@@ -435,8 +435,7 @@ describe('OutlineSelection tests', () => {
       },
     },
     {
-      name:
-        'Should correctly handle empty paragraph blocks when moving backward',
+      name: 'Should correctly handle empty paragraph blocks when moving backward',
       inputs: [insertParagraph(), moveBackward()],
       expectedHTML:
         '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span></span></p>' +
@@ -449,8 +448,7 @@ describe('OutlineSelection tests', () => {
       },
     },
     {
-      name:
-        'Should correctly handle empty paragraph blocks when moving forward',
+      name: 'Should correctly handle empty paragraph blocks when moving forward',
       inputs: [
         insertParagraph(),
         moveNativeSelection([0, 0, 0], 0, [0, 0, 0], 0),
@@ -872,8 +870,7 @@ describe('OutlineSelection tests', () => {
         },
       },
       {
-        name:
-          'Type a sentence, move the caret to the middle and move with the arrows to the start',
+        name: 'Type a sentence, move the caret to the middle and move with the arrows to the start',
         inputs: [
           insertText('this is weird test'),
           moveNativeSelection([0, 0, 0], 14, [0, 0, 0], 14),
@@ -890,8 +887,7 @@ describe('OutlineSelection tests', () => {
         },
       },
       {
-        name:
-          'Type a text and an immutable text, move the caret to the end of the first text',
+        name: 'Type a text and an immutable text, move the caret to the end of the first text',
         inputs: [
           insertText('Hello '),
           insertImmutableNode('Bob'),

--- a/packages/outline/src/OutlineEditor.js
+++ b/packages/outline/src/OutlineEditor.js
@@ -114,9 +114,8 @@ function updateEditor(
 
   if (pendingViewModel === null) {
     const currentViewModel = editor._viewModel;
-    pendingViewModel = editor._pendingViewModel = cloneViewModel(
-      currentViewModel,
-    );
+    pendingViewModel = editor._pendingViewModel =
+      cloneViewModel(currentViewModel);
     viewModelWasCloned = true;
   }
   const currentPendingViewModel = pendingViewModel;

--- a/packages/outline/src/OutlineSelection.js
+++ b/packages/outline/src/OutlineSelection.js
@@ -142,12 +142,8 @@ export class Selection {
     if (resolvedSelectionNodesAndOffsets === null) {
       return;
     }
-    const [
-      anchorNode,
-      focusNode,
-      anchorOffset,
-      focusOffset,
-    ] = resolvedSelectionNodesAndOffsets;
+    const [anchorNode, focusNode, anchorOffset, focusOffset] =
+      resolvedSelectionNodesAndOffsets;
     this.anchorKey = anchorNode.__key;
     this.focusKey = focusNode.__key;
     this.anchorOffset = anchorOffset;
@@ -221,6 +217,12 @@ function resolveSelectionNodeAndOffset(
         resolvedOffset = resolvedNode.getTextContentSize();
       } else {
         resolvedNode = resolvedNode.getFirstTextNode();
+        resolvedOffset = 0;
+      }
+    } else if (isTextNode(resolvedNode)) {
+      if (moveSelectionToEnd) {
+        resolvedOffset = resolvedNode.getTextContentSize();
+      } else {
         resolvedOffset = 0;
       }
     }


### PR DESCRIPTION
As per the title, this fixes a case where we weren't correctly moving the offset to the start/end when resolving a text node from selection. Plus I ran prettier now it's been updated.