### PR TITLE
Ensure we restore insertText selection during onNativeInput

### DIFF
--- a/packages/outline-react/src/OutlineEventHandlers.js
+++ b/packages/outline-react/src/OutlineEventHandlers.js
@@ -553,8 +553,16 @@ export function onNativeInput(
     }
     const data = event.data;
     if (data) {
+      const anchorTextBeforeInsertion = selection
+        .getAnchorNode()
+        .getTextContent();
       insertText(selection, data);
-      if (isInsertText && anchorKey === selection.focusKey) {
+      if (
+        isInsertText &&
+        anchorKey === selection.focusKey &&
+        // If we're dealing with empty text node heuristics, skip this logic
+        anchorTextBeforeInsertion !== ''
+      ) {
         const {anchorOffset, focusOffset} = window.getSelection();
         // Re-adjust the selection to what the browser thinks it should be
         if (


### PR DESCRIPTION
After we insert text into our view model from `insertText`, we should also adjust the selection to match what the browser has to ensure we're in sync.