### PR TITLE
Add space to stringify

### DIFF
--- a/packages/outline/src/OutlineView.js
+++ b/packages/outline/src/OutlineView.js
@@ -399,20 +399,24 @@ export class ViewModel {
   read<V>(callbackFn: (view: View) => V): V {
     return enterViewModelScope(callbackFn, this, null, true);
   }
-  stringify(): string {
+  stringify(space?: string | number): string {
     const selection = this._selection;
-    return JSON.stringify({
-      _nodeMap: this._nodeMap,
-      _selection:
-        selection === null
-          ? null
-          : {
-              anchorKey: selection.anchorKey,
-              anchorOffset: selection.anchorOffset,
-              focusKey: selection.focusKey,
-              focusOffset: selection.focusOffset,
-            },
-    });
+    return JSON.stringify(
+      {
+        _nodeMap: this._nodeMap,
+        _selection:
+          selection === null
+            ? null
+            : {
+                anchorKey: selection.anchorKey,
+                anchorOffset: selection.anchorOffset,
+                focusKey: selection.focusKey,
+                focusOffset: selection.focusOffset,
+              },
+      },
+      null,
+      space,
+    );
   }
 }
 

--- a/packages/outline/src/__tests__/unit/OutlineViewModel-test.js
+++ b/packages/outline/src/__tests__/unit/OutlineViewModel-test.js
@@ -123,6 +123,19 @@ describe('OutlineViewModel tests', () => {
     );
   });
 
+  test('stringify(2)', async () => {
+    await update((view) => {
+      const paragraph = ParagraphNodeModule.createParagraphNode();
+      const text = Outline.createTextNode('Hello world');
+      text.select(6, 11);
+      paragraph.append(text);
+      view.getRoot().append(paragraph);
+    });
+    const string = editor.getViewModel().stringify(2);
+
+    expect(string).toMatchSnapshot();
+  });
+
   test('ensure garbage collection works as expected', async () => {
     await update((view) => {
       const paragraph = ParagraphNodeModule.createParagraphNode();

--- a/packages/outline/src/__tests__/unit/__snapshots__/OutlineViewModel-test.js.snap
+++ b/packages/outline/src/__tests__/unit/__snapshots__/OutlineViewModel-test.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OutlineViewModel tests stringify(2) 1`] = `
+"{
+  \\"_nodeMap\\": {
+    \\"root\\": {
+      \\"__type\\": \\"root\\",
+      \\"__flags\\": 0,
+      \\"__key\\": \\"root\\",
+      \\"__parent\\": null,
+      \\"__children\\": [
+        \\"_7\\"
+      ]
+    },
+    \\"_7\\": {
+      \\"__type\\": \\"paragraph\\",
+      \\"__flags\\": 0,
+      \\"__key\\": \\"_7\\",
+      \\"__parent\\": \\"root\\",
+      \\"__children\\": [
+        \\"_8\\"
+      ]
+    },
+    \\"_8\\": {
+      \\"__type\\": \\"text\\",
+      \\"__flags\\": 0,
+      \\"__key\\": \\"_8\\",
+      \\"__parent\\": \\"_7\\",
+      \\"__text\\": \\"Hello world\\",
+      \\"__url\\": null
+    }
+  },
+  \\"_selection\\": {
+    \\"anchorKey\\": \\"_8\\",
+    \\"anchorOffset\\": 6,
+    \\"focusKey\\": \\"_8\\",
+    \\"focusOffset\\": 11
+  }
+}"
+`;


### PR DESCRIPTION
Allows to add a `space` argument to the `JSON.stringify` function for formatting.