### PR TITLE
Remove TextNode.selectEnd

### DIFF
--- a/packages/outline-playground/src/useTypeahead.js
+++ b/packages/outline-playground/src/useTypeahead.js
@@ -119,7 +119,7 @@ export default function useTypeahead(editor: OutlineEditor): void {
                 prevTextNode.getTextContent() +
                   typeaheadTextNode.getTextContent(true),
               );
-              prevTextNode.selectEnd();
+              prevTextNode.select();
             }
             typeaheadTextNode?.remove();
             typeaheadNodeKey.current = null;

--- a/packages/outline-react/src/OutlineSelectionHelpers.js
+++ b/packages/outline-react/src/OutlineSelectionHelpers.js
@@ -1051,7 +1051,7 @@ export function moveEnd(selection: Selection): void {
     return;
   }
 
-  anchorNode.selectEnd();
+  anchorNode.select();
 }
 
 export function selectAll(selection: Selection): void {

--- a/packages/outline/src/OutlineTextNode.js
+++ b/packages/outline/src/OutlineTextNode.js
@@ -388,11 +388,6 @@ export class TextNode extends OutlineNode {
     writableSelf.__text = text;
     return writableSelf;
   }
-  selectEnd(): Selection {
-    errorOnReadOnly();
-    const text = this.getTextContent();
-    return this.select(text.length, text.length);
-  }
   select(_anchorOffset?: number, _focusOffset?: number): Selection {
     errorOnReadOnly();
     let anchorOffset = _anchorOffset;

--- a/packages/outline/src/__tests__/unit/OutlineTextNode-test.js
+++ b/packages/outline/src/__tests__/unit/OutlineTextNode-test.js
@@ -251,22 +251,6 @@ describe('OutlineTextNode tests', () => {
     });
   });
 
-  test('selectEnd()', async () => {
-    await update((view) => {
-      const paragraphNode = ParagraphNodeModule.createParagraphNode();
-      const textNode = Outline.createTextNode('Hello World');
-      paragraphNode.append(textNode);
-      view.getRoot().append(paragraphNode);
-
-      const selection = textNode.selectEnd();
-
-      expect(selection.getAnchorNode()).toBe(textNode);
-      expect(selection.anchorOffset).toBe(11);
-      expect(selection.getFocusNode()).toBe(textNode);
-      expect(selection.focusOffset).toBe(11);
-    });
-  });
-
   test('selectNext()', async () => {
     await update((view) => {
       const paragraphNode = ParagraphNodeModule.createParagraphNode();
@@ -308,6 +292,10 @@ describe('OutlineTextNode tests', () => {
         [2, undefined],
         [2, 11],
       ],
+      [
+        [undefined, undefined],
+        [11, 11],
+      ]
     ])(
       'select(...%p)',
       async (


### PR DESCRIPTION
It works the same way as `select()` so it's redundant.

For reference, `select`:
```
if (typeof text === 'string') {
      const lastOffset = text.length;
      if (anchorOffset === undefined) {
        anchorOffset = lastOffset;
      }
      if (focusOffset === undefined) {
        focusOffset = lastOffset;
      }
    } else {
      anchorOffset = 0;
      focusOffset = 0;
    }
```

Added an extra test for select to ensure that `select(undefined, undefined)` works just like the previous `selectEnd()`