### PR TITLE
Add support to word break polyfill for Japanese punctuation

### DIFF
--- a/packages/outline-react/src/OutlineTextHelpers.js
+++ b/packages/outline-react/src/OutlineTextHelpers.js
@@ -12,6 +12,9 @@ import type {RootNode, TextNode} from 'outline';
 import {isTextNode, isBlockNode} from 'outline';
 import {IS_SAFARI} from './OutlineEnv';
 
+const wordBreakPolyfillRegex =
+  /[\s.,\\\/#!$%\^&\*;:{}=\-`~()\uD800-\uDBFF\uDC00-\uDFFF\u3000-\u303F]/;
+
 export function findTextIntersectionFromCharacters(
   root: RootNode,
   targetCharacters: number,
@@ -118,7 +121,7 @@ export function getWordsFromString(string: string): Array<Segment> {
   for (i = 0; i < string.length; i++) {
     const char = string[i];
 
-    if (/[\s.,\\\/#!$%\^&\*;:{}=\-`~()\uD800-\uDBFF\uDC00-\uDFFF]/.test(char)) {
+    if (wordBreakPolyfillRegex.test(char)) {
       if (wordString !== '') {
         pushSegment(segments, i, wordString, true);
         wordString = '';


### PR DESCRIPTION
I used this resource, which was awesome:

https://www.localizingjapan.com/blog/2012/01/20/regular-expressions-for-japanese-text/

This makes our polyfill work better with Japanese. We should add some tests around this using text from:

https://generator.lorem-ipsum.info/_japanese