### PR TITLE
Fix bug with Intl.Segmenter words

### DIFF
--- a/packages/outline-react/src/OutlineSelectionHelpers.js
+++ b/packages/outline-react/src/OutlineSelectionHelpers.js
@@ -726,6 +726,11 @@ export function updateCaretSelectionForRange(
             const nextIndex = segment.index;
 
             if (isSegmentWordLike(segment)) {
+              // If we already found a word on the same node,
+              // use that instead.
+              if (node === foundWordNode) {
+                break;
+              }
               index = nextIndex;
               foundWordNode = node;
             } else if (foundWordNode !== null) {


### PR DESCRIPTION
Some languages may not contain non-words between words (non-Roman languages). So we should properly account for this.