### PR TITLE
Enforce package manager version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,10 @@
         "serve": "^11.3.2",
         "start-server-and-test": "^1.12.1",
         "tmp": "^0.2.1"
+      },
+      "engines": {
+        "npm": ">=7",
+        "yarn": ">=1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
   "workspaces": [
     "packages/*"
   ],
+  "engines": {
+    "npm": ">=7",
+    "yarn": ">=1"
+  },
+  "engineStrict": true,
   "scripts": {
     "start": "npm run build && npm run start --prefix packages/outline-playground",
     "dev": "concurrently \"npm:watch\" \"npm run start --prefix packages/outline-playground\"",


### PR DESCRIPTION
This PR tries to make sure users use correct package managers (npm@7+ or yarn@1+) which can handle workspaces used in this repo.