### PR TITLE
Refactor playground

### DIFF
--- a/packages/outline-playground/src/Editor.js
+++ b/packages/outline-playground/src/Editor.js
@@ -13,7 +13,6 @@ import useOutlineAutoFormatter from 'outline-react/useOutlineAutoFormatter';
 import useToolbar from './useToolbar';
 import useHashtags from './useHashtags';
 import BlockControls from './BlockControls';
-import useStepRecorder from './useStepRecorder';
 import CharacterLimit from './CharacterLimit';
 import {Typeahead} from './Typeahead';
 
@@ -139,46 +138,56 @@ function ContentEditable({
   );
 }
 
-export function RichTextEditor({
+export const useRichTextEditor = ({
   onChange,
   isReadOnly,
   isCharLimit,
   isAutocomplete,
-}: Props): React.MixedElement {
+}: Props): [OutlineEditor, React.MixedElement] => {
   const editorElementRef = useRef(null);
   const editor = useOutlineEditor(editorElementRef, 'Enter some rich text...');
-  const toolbar = useToolbar(editor);
   const mentionsTypeahead = useMentions(editor);
   const props = useOutlineRichText(editor, isReadOnly);
+  const toolbar = useToolbar(editor);
   useOutlineOnChange(editor, onChange);
-  const stepRecorder = useStepRecorder(editor);
   useEmojis(editor);
   useHashtags(editor);
   useOutlineAutoFormatter(editor);
 
-  return (
-    <>
-      <ContentEditable
-        props={props}
-        isReadOnly={isReadOnly}
-        editorElementRef={editorElementRef}
-      />
-      {mentionsTypeahead}
-      {toolbar}
-      {stepRecorder}
-      <BlockControls editor={editor} />
-      {isCharLimit && <CharacterLimit editor={editor} />}
-      {isAutocomplete && <Typeahead editor={editor} />}
-    </>
-  );
-}
+  const element = useMemo(() => {
+    return (
+      <>
+        <ContentEditable
+          props={props}
+          isReadOnly={isReadOnly}
+          editorElementRef={editorElementRef}
+        />
+        {mentionsTypeahead}
+        {toolbar}
+        <BlockControls editor={editor} />
+        {isCharLimit && <CharacterLimit editor={editor} />}
+        {isAutocomplete && <Typeahead editor={editor} />}
+      </>
+    );
+  }, [
+    props,
+    isReadOnly,
+    isCharLimit,
+    isAutocomplete,
+    mentionsTypeahead,
+    toolbar,
+    editor,
+  ]);
 
-export function PlainTextEditor({
+  return [editor, element];
+};
+
+export const usePlainTextEditor = ({
   onChange,
   isReadOnly,
   isCharLimit,
   isAutocomplete,
-}: Props): React$Node {
+}: Props): [OutlineEditor, React.MixedElement] => {
   const editorElementRef = useRef(null);
   const editor = useOutlineEditor(editorElementRef, 'Enter some plain text...');
   const mentionsTypeahead = useMentions(editor);
@@ -186,19 +195,22 @@ export function PlainTextEditor({
   useOutlineOnChange(editor, onChange);
   useEmojis(editor);
   useHashtags(editor);
-  const stepRecorder = useStepRecorder(editor);
 
-  return (
-    <>
-      <ContentEditable
-        props={props}
-        isReadOnly={isReadOnly}
-        editorElementRef={editorElementRef}
-      />
-      {mentionsTypeahead}
-      {stepRecorder}
-      {isCharLimit && <CharacterLimit editor={editor} />}
-      {isAutocomplete && <Typeahead editor={editor} />}
-    </>
+  const element = useMemo(
+    () => (
+      <>
+        <ContentEditable
+          props={props}
+          isReadOnly={isReadOnly}
+          editorElementRef={editorElementRef}
+        />
+        {mentionsTypeahead}
+        {isCharLimit && <CharacterLimit editor={editor} />}
+        {isAutocomplete && <Typeahead editor={editor} />}
+      </>
+    ),
+    [props, mentionsTypeahead, isReadOnly, isCharLimit, isAutocomplete, editor],
   );
-}
+
+  return [editor, element];
+};

--- a/packages/outline-playground/src/index.css
+++ b/packages/outline-playground/src/index.css
@@ -74,7 +74,7 @@ header h1 {
   top: 10px;
   left: 10px;
   user-select: none;
-  white-space: 'nowrap';
+  white-space: nowrap;
   display: inline-block;
   pointer-events: none;
 }
@@ -106,7 +106,7 @@ header h1 {
 .editor-shell div.editor span.editor-text-link,
 .editor-shell div.editor strong.editor-text-link,
 .editor-shell div.editor em.editor-text-link {
-  color: rgb(33,111,219);
+  color: rgb(33, 111, 219);
 }
 
 .editor-shell div.editor blockquote {
@@ -142,44 +142,62 @@ pre {
   white-space: pre-wrap;
 }
 
-#step-recorder-button {
+.editor-dev-toolbar {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  display: flex;
+}
+
+.editor-dev-button {
   display: block;
   width: 40px;
   height: 40px;
   font-size: 12px;
-  padding: 10px 11px;
-  border-radius:  20px;
+  padding: 10px 10px;
+  border-radius: 20px;
   border: none;
   cursor: pointer;
   outline: none;
-  box-shadow:  0px 1px 10px rgba(0,0,0, 0.3);
-  position: fixed;
-  right: 20px;
-  bottom: 20px;
+  box-shadow: 0px 1px 10px rgba(0, 0, 0, 0.3);
   background-color: #444;
 }
 
-#step-recorder-button:hover {
+.editor-dev-button + .editor-dev-button {
+  margin-left: 8px;
+}
+
+.editor-dev-button::after {
+  content: "";
+  display: block;
+  width: 20px;
+  height: 20px;
+  background-repeat: no-repeat;
+  filter: invert(1);
+}
+
+.editor-dev-button:hover {
   background-color: #555;
 }
 
-#step-recorder-button.recording {
+.editor-dev-button.active {
   background-color: rgb(233, 35, 35);
 }
 
-#step-recorder-button span {
-  width: 20px;
-  height: 20px;
-  display: block;
+#options-button::after {
+  background-image: url(https://static.xx.fbcdn.net/rsrc.php/v3/y9/r/Vn1r5cFcNrX.png);
+  background-position: 0 -679px;
+}
+
+#step-recorder-button::after {
   background-image: url(https://static.xx.fbcdn.net/rsrc.php/v3/yM/r/t_wyvBug7cH.png);
   background-position: 0 -466px;
-  filter: invert(1);
 }
 
 #mentions-typeahead {
   position: fixed;
   background: #fff;
-  box-shadow:  0px 5px 10px rgba(0,0,0, 0.3);
+  box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.3);
   border-radius: 8px;
   z-index: 3;
 }
@@ -218,7 +236,7 @@ pre {
   margin-top: -6px;
   opacity: 0;
   background-color: #fff;
-  box-shadow:  0px 5px 10px rgba(0,0,0, 0.3);
+  box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.3);
   border-radius: 8px;
   transition: opacity 0.5s;
 }
@@ -228,7 +246,7 @@ pre {
   height: 20px;
   display: inline-block;
   padding: 6px;
-  border-radius:  8px;
+  border-radius: 8px;
   cursor: pointer;
   margin: 0 2px;
 }
@@ -283,10 +301,10 @@ pre {
   display: inline-block;
   margin: 0 2px;
   padding: 8px 12px;
-  border-radius:  15px;
+  border-radius: 15px;
   background-color: rgb(240, 242, 245);
   font-size: 15px;
-  color: rgb(5,5,5);
+  color: rgb(5, 5, 5);
   min-width: 200px;
   border: 0;
   outline: 0;
@@ -314,7 +332,7 @@ pre {
 }
 
 #toolbar .link-input a {
-  color: rgb(33,111,219);
+  color: rgb(33, 111, 219);
   text-decoration: none;
   display: block;
 }
@@ -335,7 +353,7 @@ pre {
   width: 62px;
   height: 32px;
   box-sizing: border-box;
-  box-shadow: rgba(0,0,0,0.1) 0px 1px 2px 0px;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px 0px;
   top: 16px;
   z-index: 10;
   border-radius: 8px;
@@ -482,7 +500,7 @@ pre {
   z-index: 5;
   display: block;
   position: absolute;
-  box-shadow: 0 12px 28px 0 rgba(0,0,0,0.2),0 2px 4px 0 rgba(0,0,0,0.1),inset 0 0 0 1px rgba(255,255,255,0.5);
+  box-shadow: 0 12px 28px 0 rgba(0, 0, 0, 0.2), 0 2px 4px 0 rgba(0, 0, 0, 0.1), inset 0 0 0 1px rgba(255, 255, 255, 0.5);
   border-radius: 8px;
   min-width: 100px;
   min-height: 40px;
@@ -573,33 +591,6 @@ pre {
   background-position: 0 -343px;
 }
 
-#options-button {
-  display: block;
-  width: 40px;
-  height: 40px;
-  font-size: 12px;
-  padding: 10px 10px;
-  border-radius:  20px;
-  border: none;
-  cursor: pointer;
-  outline: none;
-  box-shadow:  0px 1px 10px rgba(0,0,0, 0.3);
-  position: fixed;
-  right: 70px;
-  bottom: 20px;
-  background-color: #444;
-  z-index: 1;
-}
-
-#options-button span {
-  width: 20px;
-  height: 20px;
-  display: block;
-  background-image: url(https://static.xx.fbcdn.net/rsrc.php/v3/y9/r/Vn1r5cFcNrX.png);
-  background-position: 0 -679px;
-  filter: invert(1);
-}
-
 .switches {
   z-index: 6;
   position: fixed;
@@ -610,12 +601,12 @@ pre {
 
 @keyframes slide-in {
   0% {
-      opacity: 0;
-      transform: translateX(200px);
+    opacity: 0;
+    transform: translateX(200px);
   }
   100% {
-      opacity: 1;
-      transform: translateX(0);
+    opacity: 1;
+    transform: translateX(0);
   }
 }
 
@@ -650,7 +641,6 @@ pre {
   height: 24px;
   box-sizing: border-box;
   border-radius: 12px;
-  border: 0;
   width: 44px;
   display: inline-block;
   vertical-align: middle;

--- a/packages/outline-playground/src/useOptions.js
+++ b/packages/outline-playground/src/useOptions.js
@@ -1,0 +1,89 @@
+// @flow strict-local
+
+import * as React from 'react';
+import {useState, useMemo} from 'react';
+import Switch from './Switch';
+
+export type Options = {
+  measureTypingPerf: boolean,
+  isRichText: boolean,
+  isCharLimit: boolean,
+  isAutocomplete: boolean,
+  showTreeView: boolean,
+  showOptions: boolean,
+};
+
+function useOptions(
+  initialOptions: Options,
+): [React$Node, React$Node, Options] {
+  const [showOptions, setShowOptions] = useState(initialOptions.showOptions);
+  const [measureTypingPerf, setMeasureTypingPerf] = useState(
+    initialOptions.measureTypingPerf,
+  );
+  const [isRichText, setRichText] = useState(initialOptions.isRichText);
+  const [isCharLimit, setCharLimit] = useState(initialOptions.isCharLimit);
+  const [isAutocomplete, setAutocomplete] = useState(
+    initialOptions.isAutocomplete,
+  );
+  const [showTreeView, setShowTreeView] = useState(initialOptions.showTreeView);
+
+  const button = (
+    <button
+      id="options-button"
+      className="editor-dev-button"
+      onClick={() => setShowOptions(!showOptions)}></button>
+  );
+
+  const switches = showOptions ? (
+    <div className="switches">
+      <Switch
+        onClick={() => setMeasureTypingPerf(!measureTypingPerf)}
+        checked={measureTypingPerf}
+        text="Measure Perf"
+      />
+      <Switch
+        onClick={() => setShowTreeView(!showTreeView)}
+        checked={showTreeView}
+        text="Tree View"
+      />
+      <Switch
+        onClick={() => setRichText(!isRichText)}
+        checked={isRichText}
+        text="Rich Text"
+      />
+      <Switch
+        onClick={() => setCharLimit(!isCharLimit)}
+        checked={isCharLimit}
+        text="Char Limit"
+      />
+      <Switch
+        onClick={() => setAutocomplete(!isAutocomplete)}
+        checked={isAutocomplete}
+        text="Autocomplete"
+      />
+    </div>
+  ) : null;
+
+  const options: Options = useMemo(
+    () => ({
+      measureTypingPerf,
+      isRichText,
+      isCharLimit,
+      isAutocomplete,
+      showTreeView,
+      showOptions,
+    }),
+    [
+      measureTypingPerf,
+      isRichText,
+      isCharLimit,
+      isAutocomplete,
+      showTreeView,
+      showOptions,
+    ],
+  );
+
+  return [button, switches, options];
+}
+
+export default useOptions;

--- a/packages/outline-playground/src/useStepRecorder.js
+++ b/packages/outline-playground/src/useStepRecorder.js
@@ -6,7 +6,6 @@
 import type {OutlineEditor, View} from 'outline';
 
 // $FlowFixMe
-import {createPortal} from 'react-dom';
 import {createTextNode} from 'outline';
 import {createParagraphNode} from 'outline-extensions/ParagraphNode';
 import useEvent from './useEvent';
@@ -116,7 +115,9 @@ const COALESCABLE_COMMANDS = [
   'deleteWordBackward',
 ];
 
-export default function useStepRecorder(editor: OutlineEditor): React$Node {
+export default function useStepRecorder(
+  editor: OutlineEditor,
+): [React$Node, React$Node] {
   const [steps, setSteps] = useState<Steps>([]);
   const [isRecording, setIsRecording] = useState(false);
   const [currentInnerHTML, setCurrentInnerHTML] = useState('');
@@ -340,17 +341,17 @@ export default function useStepRecorder(editor: OutlineEditor): React$Node {
     };
   }, [getCurrentEditor, toggleEditorSelection]);
 
-  return createPortal(
-    <>
-      <button
-        id="step-recorder-button"
-        className={isRecording ? 'recording' : null}
-        onClick={() => toggleEditorSelection(getCurrentEditor())}
-        title={isRecording ? 'Disable step recorder' : 'Enable step recorder'}>
-        <span></span>
-      </button>
-      {steps.length !== 0 && <pre id="step-recorder">{templatedTest}</pre>}
-    </>,
-    document.body,
+  const button = (
+    <button
+      id="step-recorder-button"
+      className={`editor-dev-button ${isRecording ? 'active' : ''}`}
+      onClick={() => toggleEditorSelection(getCurrentEditor())}
+      title={isRecording ? 'Disable step recorder' : 'Enable step recorder'}
+    />
   );
+  const output = isRecording ? (
+    <pre id="step-recorder">{templatedTest}</pre>
+  ) : null;
+
+  return [button, output];
 }

--- a/packages/outline-playground/src/useToolbar.js
+++ b/packages/outline-playground/src/useToolbar.js
@@ -3,7 +3,7 @@
 import type {OutlineEditor, Selection, TextFormatType, TextNode} from 'outline';
 
 import {isTextNode} from 'outline';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState, useMemo} from 'react';
 // $FlowFixMe
 import {unstable_batchedUpdates, createPortal} from 'react-dom';
 import {formatText} from 'outline-react/OutlineSelectionHelpers';
@@ -319,5 +319,8 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
 }
 
 export default function useToolbar(editor: OutlineEditor): React$Node {
-  return createPortal(<Toolbar editor={editor} />, document.body);
+  return useMemo(
+    () => createPortal(<Toolbar editor={editor} />, document.body),
+    [editor],
+  );
 }


### PR DESCRIPTION
This PR refactors Outline playground to make it more performant, extensible and versatile.

Changes include:
* `useStepRecorder` hook is extracted from the editor and managed by the main App
* Options popup with switches extracted into a separate hook `useOptions` and managed by the main App
* `useToolbar` popup now memorized to prevent redundant renders
* editor is no longer rendered on every keypress 
* developer tool buttons and panels are now managed by the main App via hooks
* step recorder now shows up immediately once you click the recording button
* some CSS cleanup
