### PR TITLE
Fix bug where normalizeTextNodes would break during hashtags

### DIFF
--- a/packages/outline/src/OutlineNode.js
+++ b/packages/outline/src/OutlineNode.js
@@ -209,11 +209,11 @@ export class OutlineNode {
     return getNodeByKey<BlockNode>(parent);
   }
   getParentOrThrow(): BlockNode {
-    const parent = this.getLatest().__parent;
+    const parent = this.getParent();
     if (parent === null) {
       invariant(false, 'Expected node %s to have a parent.', this.__key);
     }
-    return getNodeByKeyOrThrow<BlockNode>(parent);
+    return parent;
   }
   getParentBlockOrThrow(): BlockNode {
     let node = this;
@@ -223,7 +223,7 @@ export class OutlineNode {
       }
       node = node.getParent();
     }
-    invariant(false, 'Expected node %s to have a parent.', this.__key);
+    invariant(false, 'Expected node %s to have a parent block.', this.__key);
   }
   getTopParentBlockOrThrow(): BlockNode {
     let node = this;
@@ -234,7 +234,11 @@ export class OutlineNode {
       }
       node = parent;
     }
-    invariant(false, 'Expected node %s to have a top parent.', this.__key);
+    invariant(
+      false,
+      'Expected node %s to have a top parent block.',
+      this.__key,
+    );
   }
   getParents(): Array<BlockNode> {
     const parents = [];

--- a/packages/outline/src/OutlineTextNode.js
+++ b/packages/outline/src/OutlineTextNode.js
@@ -416,6 +416,7 @@ export class TextNode extends OutlineNode {
     }
     const isHashtag = this.isHashtag();
     let skipSelectionRestoration = false;
+    let shouldNormalizeTextNodes = false;
     let handledText = newText;
     // Handle hashtag containing whitespace
     if (isHashtag && newText !== '') {
@@ -438,6 +439,7 @@ export class TextNode extends OutlineNode {
         handledText = newText.slice(0, breakCharacterIndex);
         const splitTextStr = newText.slice(breakCharacterIndex);
         const textNode = createTextNode(splitTextStr);
+        shouldNormalizeTextNodes = true;
         if (offset === currentText.length) {
           this.insertAfter(textNode);
         } else if (offset === 0) {
@@ -450,7 +452,6 @@ export class TextNode extends OutlineNode {
           textNode.select();
           skipSelectionRestoration = true;
         }
-        parent.normalizeTextNodes(true);
       }
     }
     const writableSelf = getWritableNode(this);
@@ -501,6 +502,9 @@ export class TextNode extends OutlineNode {
       }
       const newOffset = offset + handledTextLength;
       selection.setRange(key, newOffset, key, newOffset);
+    }
+    if (shouldNormalizeTextNodes) {
+      this.getParentBlockOrThrow().normalizeTextNodes(true);
     }
     return writableSelf;
   }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -39,5 +39,7 @@
   "37": "getDOMTextNodeFromElement: text node not found",
   "38": "storeDOMWithNodeKey: key was null",
   "39": "Reconcilation: could not find DOM element for node key \"${key}\"",
-  "40": "reconcileNode: parentDOM is null"
+  "40": "reconcileNode: parentDOM is null",
+  "41": "Expected node %s to have a top parent block.",
+  "42": "Expected node %s to have a parent block."
 }


### PR DESCRIPTION
Calling normalizeTextNodes during spliceText is a bad idea, we should wait to do it at the end. This fixes a bug where:

- Type `#foo`
- Move selection before hash, and type `bar`
- Move selection to after hash, and type `!`
- Hashtag should go away, and display `bar#!foo` as plain text

@prontiol Would be good for a e2e test for this, as this caused a bunch of fatals internally.