### PR TITLE
Do not apply text transforms on invalid nodes

### DIFF
--- a/packages/outline-playground/src/useMentions.js
+++ b/packages/outline-playground/src/useMentions.js
@@ -751,7 +751,7 @@ const dummyMentionsData = [
   'Lor San Tekka',
   'Lorth Needa',
   'Lott Dod',
-  'Luke Dickmood',
+  'Luke Skywalker',
   'Lumat',
   'Luminara Unduli',
   'Lux Bonteri',


### PR DESCRIPTION
We shouldn't be applying text transform nodes that are immutable or segmented.