### PR TITLE
Prevent inserting paragraphs into unsupported nodes

### DIFF
--- a/packages/outline-react/src/OutlineSelectionHelpers.js
+++ b/packages/outline-react/src/OutlineSelectionHelpers.js
@@ -270,7 +270,7 @@ export function insertParagraph(selection: Selection): void {
     removeText(selection);
   }
   const anchorNode = selection.getAnchorNode();
-  if (anchorNode === null) {
+  if (anchorNode === null || anchorNode.isSegmented()) {
     return;
   }
   const textContent = anchorNode.getTextContent();


### PR DESCRIPTION
Inserting paragraphs should not be allowed for segmented nodes.