### PR TITLE
Revise isDirty selection recursion check

### DIFF
--- a/packages/outline/src/OutlineSelection.js
+++ b/packages/outline/src/OutlineSelection.js
@@ -432,11 +432,10 @@ export function createSelection(
     lastSelection !== null && isEqual(selection, lastSelection);
 
   if (isDirty) {
-    // If the selection hasn't changed and we're not looking at
-    // handling selection during selectionchange, then don't
-    // add the isDirty flag. This will avoid recursive updates
-    // occuring because we keep adding isDirty.
-    if (isSelectionChange || !selectionsMatch) {
+    // If the selection hasn't changed then don't add the isDirty flag.
+    // This will avoid recursive updates occuring because we keep
+    // adding isDirty.
+    if (!selectionsMatch) {
       selection.isDirty = true;
     }
   } else if (isSelectionChange && !selectionsMatch) {


### PR DESCRIPTION
We were being too conservative in https://github.com/facebookexternal/Outline/pull/348. It turns out you can get into an infinite loop during `selectionchange` too (as noted by the smart composer/autocomplete tool).