### PR TITLE
Guard against no range count

### DIFF
--- a/packages/outline-react/src/OutlineSelectionHelpers.js
+++ b/packages/outline-react/src/OutlineSelectionHelpers.js
@@ -588,9 +588,12 @@ export function updateCaretSelectionForRange(
   if (isAtBoundary && granularity === 'character') {
     moveSelection(domSelection, collapse, isBackward, granularity);
   }
-  const range = domSelection.getRangeAt(0);
-  // Apply the DOM selection to our Outline selection.
-  selection.applyDOMRange(range);
+  // Guard against no ranges
+  if (domSelection.rangeCount > 0) {
+    const range = domSelection.getRangeAt(0);
+    // Apply the DOM selection to our Outline selection.
+    selection.applyDOMRange(range);
+  }
 }
 
 export function removeText(selection: Selection): void {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -42,7 +42,12 @@
   "40": "reconcileNode: parentDOM is null",
   "41": "Expected node %s to have a top parent block.",
   "42": "Expected node %s to have a parent block.",
-  "43": "onNativeInput: cannot find DOM text node for anchor node",
-  "44": "resolveNonLineBreakOrInertNode: resolved node not a text node",
-  "45": "Reconciliation: could not find DOM element for node key \"${key}\""
+  "43": "onNativeInput: cannot find DOM element for anchor node",
+  "44": "onNativeInput: cannot find DOM element and its text node for anchor node",
+  "45": "updateTextNodeContentFromDOM: cannot find DOM element and its text node for node",
+  "46": "onNativeInput: cannot find DOM text node for anchor node",
+  "47": "resolveNonLineBreakOrInertNode: resolved node not a text node",
+  "48": "getStartNode: startNode not a text node",
+  "49": "getEndNode: endNode not a text node",
+  "50": "Reconciliation: could not find DOM element for node key \"${key}\""
 }


### PR DESCRIPTION
If there are no ranges, don't try and get a range. This was coming up in our internal error metrics.