### PR TITLE
Fix getParentNodeOrThrow()

### DIFF
--- a/packages/outline/src/OutlineNode.js
+++ b/packages/outline/src/OutlineNode.js
@@ -257,10 +257,10 @@ export class OutlineNode {
   getParentBlockOrThrow(): BlockNode {
     let node = this;
     while (node !== null) {
+      node = node.getParent();
       if (isBlockNode(node)) {
         return node;
       }
-      node = node.getParent();
     }
     invariant(false, 'Expected node %s to have a parent block.', this.__key);
   }


### PR DESCRIPTION
`OutlineNode.getParentBlockOrThrow()` currently returns the node itself instead of the parent if it is a block node.
This PR fixes that.