### PR TITLE
Fix removeNode()

### DIFF
--- a/packages/outline/src/OutlineNode.js
+++ b/packages/outline/src/OutlineNode.js
@@ -104,7 +104,6 @@ function removeNode(nodeToRemove: OutlineNode): void {
   }
   const writableNodeToRemove = getWritableNode(nodeToRemove);
   writableNodeToRemove.__parent = null;
-  markNodeAsDirty(writableNodeToRemove);
 }
 
 function replaceNode<N: OutlineNode>(


### PR DESCRIPTION
As `getWritableNode()` returns a dirty node by default, explicit call to `markNodeAsDirty()` is redundant.
This PR removes it.