### PR TITLE
Add selectionTransform method to TextNode

### DIFF
--- a/packages/outline/src/OutlineEditor.js
+++ b/packages/outline/src/OutlineEditor.js
@@ -24,6 +24,7 @@ import {
   triggerErrorListeners,
   parseViewModel,
   errorOnProcessingTextNodeTransforms,
+  applySelectionTransforms,
 } from './OutlineView';
 import {createSelection} from './OutlineSelection';
 import {
@@ -141,6 +142,7 @@ function updateEditor(
             }
           }
         }
+        applySelectionTransforms(currentPendingViewModel, editor);
         if (currentPendingViewModel.hasDirtyNodes()) {
           applyTextTransforms(currentPendingViewModel, editor);
           garbageCollectDetachedNodes(currentPendingViewModel, editor);

--- a/packages/outline/src/OutlineNode.js
+++ b/packages/outline/src/OutlineNode.js
@@ -256,10 +256,10 @@ export class OutlineNode {
   getParentBlockOrThrow(): BlockNode {
     let node = this;
     while (node !== null) {
-      node = node.getParent();
       if (isBlockNode(node)) {
         return node;
       }
+      node = node.getParent();
     }
     invariant(false, 'Expected node %s to have a parent block.', this.__key);
   }

--- a/packages/outline/src/OutlineTextNode.js
+++ b/packages/outline/src/OutlineTextNode.js
@@ -350,6 +350,10 @@ export class TextNode extends OutlineNode {
     }
     return false;
   }
+  selectionTransform(
+    prevSelection: null | Selection,
+    nextSelection: Selection,
+  ): void {}
 
   // Mutators
   toggleOverflowed(): TextNode {

--- a/packages/outline/src/OutlineView.js
+++ b/packages/outline/src/OutlineView.js
@@ -196,6 +196,23 @@ function triggerTextMutationListeners(
   }
 }
 
+export function applySelectionTransforms(
+  nextViewModel: ViewModel,
+  editor: OutlineEditor,
+): void {
+  const prevViewModel = editor.getViewModel();
+  const prevSelection = prevViewModel._selection;
+  const nextSelection = nextViewModel._selection;
+  if (nextSelection !== null) {
+    const anchorNode = nextSelection.getAnchorNode();
+    const focusNode = nextSelection.getFocusNode();
+    anchorNode.selectionTransform(prevSelection, nextSelection);
+    if (anchorNode !== focusNode) {
+      focusNode.selectionTransform(prevSelection, nextSelection);
+    }
+  }
+}
+
 export function applyTextTransforms(
   viewModel: ViewModel,
   editor: OutlineEditor,


### PR DESCRIPTION
This adds a new methods that can be extended from TextNode, to allow for powerful ways to control the selection of a focused node. This can be done via the `selectionTransform` method, which works in a similar way to other view level methods on TextNodes.