### PR TITLE
Add canRemoveText helper function

### DIFF
--- a/packages/outline-react/src/OutlineEventHandlers.js
+++ b/packages/outline-react/src/OutlineEventHandlers.js
@@ -651,7 +651,7 @@ function applyTargetRange(selection: Selection, event: InputEvent): void {
   }
 }
 
-export function canRemoveText(anchorNode: TextNode, focusNode: TextNode): boolean {
+function canRemoveText(anchorNode: TextNode, focusNode: TextNode): boolean {
   return (
     anchorNode !== focusNode ||
     !isImmutableOrInertOrSegmented(anchorNode) ||


### PR DESCRIPTION
We have a specific heuristic for knowing when can apply `removeText` in the event handlers. Instead of repeating this everywhere, we should break it out into a helper function.