### PR TITLE
Enable OutlineNode.getParentBlockOrThrow() unit test

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineNode.test.js
@@ -145,7 +145,7 @@ describe('OutlineNode tests', () => {
       expect(() => textNode.getParentBlockOrThrow()).toThrow();
     });
 
-    test.skip('OutlineNode.getParentBlockOrThrow()', async () => {
+    test('OutlineNode.getParentBlockOrThrow()', async () => {
       const {editor} = testEnv;
       await editor.getViewModel().read((view) => {
         const rootNode = view.getRoot();


### PR DESCRIPTION
A follow up on #377