### PR TITLE
Update Outline playground to use a function ref callback for editor

### DIFF
--- a/packages/outline-playground/src/Editor.js
+++ b/packages/outline-playground/src/Editor.js
@@ -76,10 +76,13 @@ function useOutlineEditor(
         editorElement.textContent = '';
       }
       editor.setEditorElement(editorElement);
-      editor.setPlaceholder(placeholder);
     },
-    [editor, placeholder],
+    [editor],
   );
+
+  useEffect(() => {
+    editor.setPlaceholder(placeholder);
+  }, [editor, placeholder]);
 
   return [editor, editorElementRef];
 }


### PR DESCRIPTION
It's just a better pattern.