### PR TITLE
Fix addEditorElementListener destroy bug

### DIFF
--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -287,6 +287,7 @@ export class OutlineEditor {
 
     return () => {
       this._elementListeners.delete(listener);
+      listener(null);
     };
   }
   addDecoratorListener(listener: DecoratorListener): () => void {


### PR DESCRIPTION
Ensure we listener again on the destruction of a listener via `addEditorElementListener`.