### PR TITLE
Revise DOM clearing logic in setEditorElement

### DIFF
--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -334,7 +334,9 @@ export class OutlineEditor {
     const prevEditorElement = this._editorElement;
     if (nextEditorElement !== prevEditorElement) {
       this._editorElement = nextEditorElement;
-      resetEditor(this);
+      if (nextEditorElement === null || prevEditorElement !== null) {
+        resetEditor(this);
+      }
       if (nextEditorElement !== null) {
         nextEditorElement.setAttribute('data-outline-editor', 'true');
         this._keyToDOMMap.set('root', nextEditorElement);


### PR DESCRIPTION
We should be careful clearing the editor element, as it might contain an element maintained outside of Outline (SSR placeholders for example).