### PR TITLE
Add invariant when a selection is invalid after an update

### DIFF
--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -174,16 +174,16 @@ function updateEditor(
           const pendingNodeMap = currentPendingViewModel._nodeMap;
           const anchorKey = pendingSelection.anchorKey;
           const focusKey = pendingSelection.focusKey;
-          invariant(
-            pendingNodeMap[anchorKey] !== undefined,
-            'updateEditor: selection has been lost because the previously selected anchor node has been removed and ' +
-              "selection wasn't moved to another node. Ensure selection changes after removing/replacing a selected node.",
-          );
-          invariant(
-            pendingNodeMap[focusKey] !== undefined,
-            'updateEditor: selection has been lost because the previously selected focus node has been removed and ' +
-              "selection wasn't moved to another node. Ensure selection changes after removing/replacing a selected node.",
-          );
+          if (
+            pendingNodeMap[anchorKey] === undefined ||
+            pendingNodeMap[focusKey] === undefined
+          ) {
+            invariant(
+              false,
+              'updateEditor: selection has been lost because the previously selected nodes have been removed and ' +
+                "selection wasn't moved to another node. Ensure selection changes after removing/replacing a selected node.",
+            );
+          }
         }
       },
       pendingViewModel,

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -40,6 +40,5 @@
   "38": "reconcileNodeChildren: keyToMove to was not nextStartKey",
   "39": "storeDOMWithNodeKey: key was null",
   "40": "Reconciliation: could not find DOM element for node key \"${key}\"",
-  "41": "updateEditor: selection has been lost because the previously selected anchor node has been removed and selection wasn't moved to another node. Ensure selection changes after removing/replacing a selected node.",
-  "42": "updateEditor: selection has been lost because the previously selected focus node has been removed and selection wasn't moved to another node. Ensure selection changes after removing/replacing a selected node."
+  "41": "updateEditor: selection has been lost because the previously selected nodes have been removed and selection wasn't moved to another node. Ensure selection changes after removing/replacing a selected node."
 }


### PR DESCRIPTION
Right now we have some odd invariant that fires when selection is invalid after an update. We should instead provide a much clearer error message.