### PR TITLE
Add <br> on empty line with empty text

### DIFF
--- a/packages/outline-playground/__tests__/e2e/Emoticons-test.js
+++ b/packages/outline-playground/__tests__/e2e/Emoticons-test.js
@@ -146,7 +146,7 @@ describe('Emoticons', () => {
       await repeat(23, async () => await page.keyboard.press('Backspace'));
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span></span></p><div class="editor-placeholder">Enter some rich text...</div>',
+        '<p class="editor-paragraph"><span><br></span></p><div class="editor-placeholder">Enter some rich text...</div>',
       );
       await assertSelection(page, {
         anchorPath: [0, 0, 0],

--- a/packages/outline-playground/__tests__/e2e/Mentions-test.js
+++ b/packages/outline-playground/__tests__/e2e/Mentions-test.js
@@ -122,7 +122,7 @@ describe('Mentions', () => {
       await page.keyboard.press('Delete');
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
+        '<p class="editor-paragraph" dir="ltr"><span><br></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
       );
       await assertSelection(page, {
         anchorPath: [0, 0, 0],
@@ -179,7 +179,7 @@ describe('Mentions', () => {
       await page.keyboard.press('Backspace');
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
+        '<p class="editor-paragraph" dir="ltr"><span><br></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
       );
       await assertSelection(page, {
         anchorPath: [0, 0, 0],

--- a/packages/outline-playground/__tests__/e2e/Placeholder-test.js
+++ b/packages/outline-playground/__tests__/e2e/Placeholder-test.js
@@ -19,7 +19,7 @@ describe('Placeholder', () => {
 
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
+        '<p class="editor-paragraph"><span><br></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
       );
       await assertSelection(page, {
         anchorPath: [0, 0, 0],

--- a/packages/outline-playground/__tests__/e2e/TextEntry-test.js
+++ b/packages/outline-playground/__tests__/e2e/TextEntry-test.js
@@ -168,7 +168,7 @@ describe('TextEntry', () => {
         await page.keyboard.press('Enter');
         await assertHTML(
           page,
-          '<p class="editor-paragraph"><span></span></p><p class="editor-paragraph"><span></span></p>',
+          '<p class="editor-paragraph"><span><br></span></p><p class="editor-paragraph"><span><br></span></p>',
         );
         await assertSelection(page, {
           anchorPath: [1, 0, 0],
@@ -205,7 +205,7 @@ describe('TextEntry', () => {
         await page.keyboard.press('Delete');
         await assertHTML(
           page,
-          '<p class="editor-paragraph"><span></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
+          '<p class="editor-paragraph"><span><br></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
         );
         await assertSelection(page, {
           anchorPath: [0, 0, 0],
@@ -245,7 +245,7 @@ describe('TextEntry', () => {
         await page.keyboard.press('Delete');
         await assertHTML(
           page,
-          '<p class="editor-paragraph"><span></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
+          '<p class="editor-paragraph"><span><br></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
         );
         await assertSelection(page, {
           anchorPath: [0, 0, 0],
@@ -286,7 +286,10 @@ describe('TextEntry', () => {
 
         await page.keyboard.press('Backspace');
 
-        await assertHTML(page, '<p class="editor-paragraph"><span></span></p>');
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph"><span><br></span></p>',
+        );
 
         await page.keyboard.type('هَ');
         await assertHTML(

--- a/packages/outline-playground/__tests__/regression/231-empty-text-nodes.js
+++ b/packages/outline-playground/__tests__/regression/231-empty-text-nodes.js
@@ -28,7 +28,7 @@ describe('Regression test #231', () => {
       });
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span class=""></span></p>',
+        '<p class="editor-paragraph"><span class=""><br></span></p>',
       );
       await assertSelection(page, {
         anchorPath: [0, 0, 0],

--- a/packages/outline/src/__tests__/unit/OutlineEditor.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor.test.js
@@ -398,7 +398,7 @@ describe('OutlineEditor tests', () => {
         });
 
         expect(sanitizeHTML(container.innerHTML)).toBe(
-          '<div contenteditable="true" data-outline-editor="true"><p><span></span></p>' +
+          '<div contenteditable="true" data-outline-editor="true"><p><span><br></span></p>' +
             '<div>Placeholder text</div></div>',
         );
       });
@@ -433,8 +433,8 @@ describe('OutlineEditor tests', () => {
         });
 
         expect(sanitizeHTML(container.innerHTML)).toBe(
-          '<div contenteditable="true" data-outline-editor="true"><p><span></span></p><p>' +
-            '<span></span></p></div>',
+          '<div contenteditable="true" data-outline-editor="true"><p><span><br></span></p><p>' +
+            '<span><br></span></p></div>',
         );
       });
 

--- a/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
@@ -574,7 +574,7 @@ describe('OutlineTextNode tests', () => {
     describe('has parent node', () => {
       test.each([
         ['no formatting', null, 'My text node', '<span>My text node</span>'],
-        ['no formatting + empty string', null, '', `<span></span>`],
+        ['no formatting + empty string', null, '', `<span><br></span>`],
       ])('%s text format type', async (_type, flag, contents, expectedHTML) => {
         await update(() => {
           const paragraphNode = createParagraphNode();

--- a/packages/outline/src/__tests__/utils/index.js
+++ b/packages/outline/src/__tests__/utils/index.js
@@ -26,7 +26,10 @@ export const initializeUnitTest = (runTests: (testEnv: TestEnv) => void) => {
     editor: null,
     container: null,
     get outerHTML() {
-      return this.container.innerHTML.replace(/[\u200B-\u200D\u2060\uFEFF]/g, '');
+      return this.container.innerHTML.replace(
+        /[\u200B-\u200D\u2060\uFEFF]/g,
+        '',
+      );
     },
   };
 

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -171,8 +171,9 @@ function setTextContent(
   }
   let possibleLineBreak = dom.lastChild;
   if (possibleLineBreak != null) {
+    const parent = node.getParent();
     const needsLineBreak =
-      nextText === '' && node.getParentOrThrow().__children.length === 1;
+      nextText === '' && parent !== null && parent.__children.length === 1;
     if (needsLineBreak && possibleLineBreak.nodeType === 3) {
       possibleLineBreak = document.createElement('br');
       dom.appendChild(possibleLineBreak);

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelection.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelection.test.js
@@ -130,7 +130,7 @@ describe('OutlineSelection tests', () => {
 
   test('Expect initial output to be a block with some text', () => {
     expect(sanitizeHTML(container.innerHTML)).toBe(
-      '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span></span></p></div>',
+      '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span><br></span></p></div>',
     );
   });
 
@@ -378,7 +378,7 @@ describe('OutlineSelection tests', () => {
       name: 'Deletion of an immutable node',
       inputs: [insertImmutableNode('Dominic Gannaway'), deleteBackward()],
       expectedHTML:
-        '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span><br></span></p></div>',
       expectedSelection: {
         anchorPath: [0, 0, 0],
         anchorOffset: 0,
@@ -436,8 +436,8 @@ describe('OutlineSelection tests', () => {
       name: 'Should correctly handle empty paragraph blocks when moving backward',
       inputs: [insertParagraph(), moveBackward()],
       expectedHTML:
-        '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span></span></p>' +
-        '<p class="editor-paragraph"><span></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span><br></span></p>' +
+        '<p class="editor-paragraph"><span><br></span></p></div>',
       expectedSelection: {
         anchorPath: [0, 0, 0],
         anchorOffset: 0,
@@ -453,8 +453,8 @@ describe('OutlineSelection tests', () => {
         moveForward(),
       ],
       expectedHTML:
-        '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span></span></p>' +
-        '<p class="editor-paragraph"><span></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span><br></span></p>' +
+        '<p class="editor-paragraph"><span><br></span></p></div>',
       expectedSelection: {
         anchorPath: [1, 0, 0],
         anchorOffset: 0,
@@ -702,8 +702,8 @@ describe('OutlineSelection tests', () => {
       name: 'Inserting a paragraph',
       inputs: [insertParagraph()],
       expectedHTML:
-        '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span></span></p>' +
-        '<p class="editor-paragraph"><span></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span><br></span></p>' +
+        '<p class="editor-paragraph"><span><br></span></p></div>',
       expectedSelection: {
         anchorPath: [1, 0, 0],
         anchorOffset: 0,
@@ -715,7 +715,7 @@ describe('OutlineSelection tests', () => {
       name: 'Inserting a paragraph and then removing it',
       inputs: [insertParagraph(), deleteBackward()],
       expectedHTML:
-        '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span><br></span></p></div>',
       expectedSelection: {
         anchorPath: [0, 0, 0],
         anchorOffset: 0,
@@ -750,7 +750,7 @@ describe('OutlineSelection tests', () => {
         deleteBackward(),
       ],
       expectedHTML:
-        '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span><br></span></p></div>',
       expectedSelection: {
         anchorPath: [0, 0, 0],
         anchorOffset: 0,


### PR DESCRIPTION
When we have an empty text node, as the only child in a block. It should probably have a `<br>` after it.