### PR TITLE
Fix insertText selection bug

### DIFF
--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -779,7 +779,6 @@ export function insertText(selection: Selection, text: string): void {
         text,
         true,
       );
-      firstNode.select(startOffset, startOffset);
     }
 
     if (!firstNodeParents.has(lastNode) && isTextNode(lastNode)) {


### PR DESCRIPTION
Not sure why this logic exists, given `spliceText` moves selection correctly.