### PR TITLE
Fix isEnter to be isReturn

### DIFF
--- a/packages/outline-playground/src/App.js
+++ b/packages/outline-playground/src/App.js
@@ -37,7 +37,9 @@ function RichTextEditor({options, onOptionsChange}): React$Node {
   return (
     <>
       <div className="editor-shell">{editorComponent}</div>
-      {showTreeView && <OutlineTreeView className="tree-view-output" editor={editor} />}
+      {showTreeView && (
+        <OutlineTreeView className="tree-view-output" editor={editor} />
+      )}
       {stepRecorderOutput}
       {testRecorderOutput}
       <div className="editor-dev-toolbar">
@@ -70,7 +72,9 @@ function PlainTextEditor({options, onOptionsChange}): React$Node {
   return (
     <>
       <div className="editor-shell">{editorComponent}</div>
-      {showTreeView && <OutlineTreeView className="tree-view-output" editor={editor} />}
+      {showTreeView && (
+        <OutlineTreeView className="tree-view-output" editor={editor} />
+      )}
       {stepRecorderOutput}
       <div className="editor-dev-toolbar">
         {optionsSwitches}

--- a/packages/outline-react/src/shared/EventHandlers.js
+++ b/packages/outline-react/src/shared/EventHandlers.js
@@ -64,9 +64,7 @@ import {isTextNode} from 'outline';
 
 // Safari triggers composition before keydown, meaning
 // we need to account for this when handling key events.
-let wasRecentlyComposing = false;
 let lastKeyWasMaybeAndroidSoftKey = false;
-const RESOLVE_DELAY = 20;
 const ZERO_WIDTH_SPACE_CHAR = '\u200B';
 const ZERO_WIDTH_JOINER_CHAR = '\u2060';
 
@@ -163,7 +161,7 @@ export function onKeyDownForPlainText(
   state: EventHandlerState,
 ): void {
   updateAndroidSoftKeyFlagIfAny(event);
-  if (editor.isComposing() || wasRecentlyComposing) {
+  if (editor.isComposing()) {
     return;
   }
   editor.update((view) => {
@@ -234,7 +232,7 @@ export function onKeyDownForRichText(
   state: EventHandlerState,
 ): void {
   updateAndroidSoftKeyFlagIfAny(event);
-  if (editor.isComposing() || wasRecentlyComposing) {
+  if (editor.isComposing()) {
     return;
   }
   editor.update((view) => {
@@ -472,10 +470,6 @@ export function onCompositionEnd(
   state: EventHandlerState,
 ): void {
   editor.setCompositionKey(null);
-  wasRecentlyComposing = true;
-  setTimeout(() => {
-    wasRecentlyComposing = false;
-  }, RESOLVE_DELAY);
 }
 
 export function onSelectionChange(

--- a/packages/outline/src/helpers/OutlineKeyHelpers.js
+++ b/packages/outline/src/helpers/OutlineKeyHelpers.js
@@ -16,8 +16,8 @@ function controlOrMeta(event: KeyboardEvent): boolean {
   return event.ctrlKey;
 }
 
-function isEnter(event: KeyboardEvent): boolean {
-  return event.key === 'Enter' || event.keyCode === 13;
+function isReturn(event: KeyboardEvent): boolean {
+  return event.keyCode === 13;
 }
 
 function isBackspace(event: KeyboardEvent): boolean {
@@ -49,11 +49,11 @@ export function isUnderline(event: KeyboardEvent): boolean {
 }
 
 export function isParagraph(event: KeyboardEvent): boolean {
-  return isEnter(event) && !event.shiftKey;
+  return isReturn(event) && !event.shiftKey;
 }
 
 export function isLineBreak(event: KeyboardEvent): boolean {
-  return isEnter(event) && event.shiftKey;
+  return isReturn(event) && event.shiftKey;
 }
 
 export function isDeleteWordBackward(event: KeyboardEvent): boolean {


### PR DESCRIPTION
This logic is not right. We should only be checking for RETURN and not Enter. This also means we can skip adding a setTimeout and checking for the resolution of composition.