### PR TITLE
Export LinkNode and fix issues around text insertion

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -24,6 +24,7 @@ module.name_mapper='^outline/ImageNode' -> '<PROJECT_ROOT>/packages/outline/src/
 module.name_mapper='^outline/QuoteNode' -> '<PROJECT_ROOT>/packages/outline/src/extensions/OutlineQuoteNode.js'
 module.name_mapper='^outline/ParagraphNode' -> '<PROJECT_ROOT>/packages/outline/src/extensions/OutlineParagraphNode.js'
 module.name_mapper='^outline/CodeNode' -> '<PROJECT_ROOT>/packages/outline/src/extensions/OutlineCodeNode.js'
+module.name_mapper='^outline/LinkNode' -> '<PROJECT_ROOT>/packages/outline/src/extensions/OutlineLinkNode.js'
 
 module.name_mapper='^outline/HistoryHelpers' -> '<PROJECT_ROOT>/packages/outline/src/helpers/OutlineHistoryHelpers.js'
 module.name_mapper='^outline/SelectionHelpers' -> '<PROJECT_ROOT>/packages/outline/src/helpers/OutlineSelectionHelpers.js'

--- a/packages/outline-playground/craco.config.js
+++ b/packages/outline-playground/craco.config.js
@@ -9,6 +9,7 @@ module.exports = {
       'outline/QuoteNode': 'outline/dist/OutlineQuoteNode',
       'outline/ParagraphNode': 'outline/dist/OutlineParagraphNode',
       'outline/CodeNode': 'outline/dist/OutlineCodeNode',
+      'outline/LinkNode': 'outline/dist/OutlineLinkNode',
       // Outline Helpers
       'outline/SelectionHelpers': 'outline/dist/OutlineSelectionHelpers',
       'outline/TextHelpers': 'outline/dist/OutlineTextHelpers',

--- a/packages/outline-playground/src/Editor.js
+++ b/packages/outline-playground/src/Editor.js
@@ -69,6 +69,7 @@ const editorThemeClasses = {
     code: 'editor-text-code',
   },
   code: 'editor-code',
+  link: 'editor-text-link',
 };
 
 function ContentEditable({

--- a/packages/outline-playground/src/useToolbar.js
+++ b/packages/outline-playground/src/useToolbar.js
@@ -7,19 +7,14 @@
  * @flow strict-local
  */
 
-import type {
-  OutlineEditor,
-  Selection,
-  TextFormatType,
-  NodeKey,
-  EditorThemeClasses,
-} from 'outline';
+import type {OutlineEditor, Selection, TextFormatType, TextNode} from 'outline';
 
-import {createTextNode, isTextNode, TextNode} from 'outline';
+import {createTextNode, isTextNode} from 'outline';
 import React, {useCallback, useEffect, useRef, useState, useMemo} from 'react';
 // $FlowFixMe
 import {unstable_batchedUpdates, createPortal} from 'react-dom';
 import {formatText} from 'outline/SelectionHelpers';
+import {createLinkNode, isLinkNode, LinkNode} from 'outline/LinkNode';
 
 function positionToolbar(toolbar, rect) {
   if (rect === null) {
@@ -345,62 +340,6 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
       ) : null}
     </div>
   );
-}
-
-class LinkNode extends TextNode {
-  __url: string;
-
-  constructor(text: string, url: string, key?: NodeKey) {
-    super(text, key);
-    this.__url = url;
-    this.__type = 'link';
-  }
-  clone(): LinkNode {
-    return new LinkNode(this.__text, this.__url, this.__key);
-  }
-  createDOM(editorThemeClasses: EditorThemeClasses): HTMLElement {
-    const text = super.createDOM(editorThemeClasses);
-    const link = document.createElement('a');
-    link.href = this.__url;
-    link.appendChild(text);
-    return link;
-  }
-  updateDOM(
-    // $FlowFixMe: not sure how to fix this
-    prevNode: LinkNode,
-    dom: HTMLElement,
-    editorThemeClasses: EditorThemeClasses,
-  ): boolean {
-    // $FlowFixMe: this is always the case here.
-    const textNode: null | HTMLElement = dom.firstChild;
-    if (textNode != null) {
-      const textUpdate = super.updateDOM(
-        prevNode,
-        textNode,
-        editorThemeClasses,
-      );
-      if (prevNode.__url !== this.__url) {
-        dom.setAttribute('href', this.__url);
-      }
-      return textUpdate;
-    }
-    return true;
-  }
-  getURL(): string {
-    return this.getLatest().__url;
-  }
-  setURL(url: string): void {
-    const writable = this.getWritable<LinkNode>();
-    writable.__url = url;
-  }
-}
-
-function createLinkNode(text: string, url: string): LinkNode {
-  return new LinkNode(text, url);
-}
-
-function isLinkNode(node: TextNode): boolean %checks {
-  return node instanceof LinkNode;
 }
 
 export default function useToolbar(editor: OutlineEditor): React$Node {

--- a/packages/outline-react/src/shared/EventHandlers.js
+++ b/packages/outline-react/src/shared/EventHandlers.js
@@ -60,7 +60,7 @@ import {
   moveForward,
   moveWordForward,
 } from 'outline/SelectionHelpers';
-import {isTextNode} from 'outline';
+import {createTextNode, isTextNode} from 'outline';
 
 // Safari triggers composition before keydown, meaning
 // we need to account for this when handling key events.
@@ -749,12 +749,18 @@ export function onNativeBeforeInputForPlainText(
       if (
         isInputText &&
         selection.isCaret() &&
-        isImmutableOrInertOrSegmented(anchorNode)
+        selection.anchorOffset === anchorNode.getTextContentSize() &&
+        (isImmutableOrInertOrSegmented(anchorNode) ||
+          !anchorNode.canInsertTextAtEnd())
       ) {
         event.preventDefault();
-        if (selection.anchorOffset === anchorNode.getTextContentSize()) {
+        if (data != null) {
           const nextSibling = anchorNode.getNextSibling();
-          if (isTextNode(nextSibling) && data != null) {
+          if (nextSibling === null) {
+            const textNode = createTextNode(data);
+            textNode.select();
+            anchorNode.insertAfter(textNode);
+          } else if (isTextNode(nextSibling)) {
             nextSibling.select(0, 0);
             insertText(selection, data);
           }
@@ -907,12 +913,18 @@ export function onNativeBeforeInputForRichText(
       if (
         isInputText &&
         selection.isCaret() &&
-        isImmutableOrInertOrSegmented(anchorNode)
+        selection.anchorOffset === anchorNode.getTextContentSize() &&
+        (isImmutableOrInertOrSegmented(anchorNode) ||
+          !anchorNode.canInsertTextAtEnd())
       ) {
         event.preventDefault();
-        if (selection.anchorOffset === anchorNode.getTextContentSize()) {
+        if (data != null) {
           const nextSibling = anchorNode.getNextSibling();
-          if (isTextNode(nextSibling) && data != null) {
+          if (nextSibling === null) {
+            const textNode = createTextNode(data);
+            textNode.select();
+            anchorNode.insertAfter(textNode);
+          } else if (isTextNode(nextSibling)) {
             nextSibling.select(0, 0);
             insertText(selection, data);
           }

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -57,6 +57,7 @@ export type EditorThemeClasses = {
     ul?: EditorThemeClassName,
     ol?: EditorThemeClassName,
   },
+  link?: EditorThemeClassName,
   listitem?: EditorThemeClassName,
   quote?: EditorThemeClassName,
   code?: EditorThemeClassName,

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -530,6 +530,9 @@ export class TextNode extends OutlineNode {
 
     return writableSelf;
   }
+  canInsertTextAtEnd(): boolean {
+    return true;
+  }
   splitText(...splitOffsets: Array<number>): Array<TextNode> {
     errorOnReadOnly();
     if (this.isImmutable()) {

--- a/packages/outline/src/extensions/OutlineLinkNode.js
+++ b/packages/outline/src/extensions/OutlineLinkNode.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {NodeKey, EditorThemeClasses} from 'outline';
+
+import {TextNode} from 'outline';
+
+export class LinkNode extends TextNode {
+  __url: string;
+
+  constructor(text: string, url: string, key?: NodeKey) {
+    super(text, key);
+    this.__url = url;
+    this.__type = 'link';
+  }
+  clone(): LinkNode {
+    return new LinkNode(this.__text, this.__url, this.__key);
+  }
+  createDOM(editorThemeClasses: EditorThemeClasses): HTMLElement {
+    const element = super.createDOM(editorThemeClasses);
+    const className = editorThemeClasses.link;
+    if (className !== undefined) {
+      element.className = className;
+    }
+    return element;
+  }
+  updateDOM(
+    // $FlowFixMe: not sure how to fix this
+    prevNode: LinkNode,
+    dom: HTMLElement,
+    editorThemeClasses: EditorThemeClasses,
+  ): boolean {
+    const textUpdate = super.updateDOM(prevNode, dom, editorThemeClasses);
+    return textUpdate;
+  }
+  getURL(): string {
+    return this.getLatest().__url;
+  }
+  setURL(url: string): void {
+    const writable = this.getWritable<LinkNode>();
+    writable.__url = url;
+  }
+  canInsertTextAtEnd(): false {
+    return false;
+  }
+}
+
+export function createLinkNode(text: string, url: string): LinkNode {
+  return new LinkNode(text, url);
+}
+
+export function isLinkNode(node: TextNode): boolean %checks {
+  return node instanceof LinkNode;
+}


### PR DESCRIPTION
This PR does three things:

- Exposes LinkNode so it can be consumed externally
- Adds a `canInsertTextAtEnd` method to give signal as to what to do with text insertion
- Moves from an `<a>` to a normal node, otherwise this causes issues with browser text insertion.