### PR TITLE
isSelectionWithinEditor: guard against bad nodes

### DIFF
--- a/packages/outline/src/core/OutlineUtils.js
+++ b/packages/outline/src/core/OutlineUtils.js
@@ -55,11 +55,15 @@ export function isSelectionWithinEditor(
   focusDOM: null | Node,
 ): boolean {
   const editorElement = editor.getEditorElement();
-  return (
-    editorElement !== null &&
-    editorElement.contains(anchorDOM) &&
-    editorElement.contains(focusDOM)
-  );
+  try {
+    return (
+      editorElement !== null &&
+      editorElement.contains(anchorDOM) &&
+      editorElement.contains(focusDOM)
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function getTextDirection(text: string): 'ltr' | 'rtl' | null {


### PR DESCRIPTION
We are seeing errors throwing in prod, because anchorDOM/focusDOM are not valid DOM nodes (odd?).