### PR TITLE
Configure flow to check only staged files

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  '*.js': ['flow', 'prettier --write'],
+  '*.js': ['flow focus-check', 'prettier --write'],
 };


### PR DESCRIPTION
By default `flow` checks all the files in the project.
By using `focus-check` argument we force `flow` to only check staged files in the `precommit` hook.