### PR TITLE
Fix inert node leaking content to parent after reconciliation

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
@@ -100,6 +100,52 @@ describe('OutlineTextNode tests', () => {
     });
   }
 
+  describe('getTextContent()', () => {
+    test('writable nodes', async () => {
+      let nodeKey;
+
+      await update((view) => {
+        const textNode = createTextNode('Text');
+        nodeKey = textNode.getKey();
+        expect(textNode.getTextContent()).toBe('Text');
+        expect(textNode.getTextContent(true)).toBe('Text');
+        expect(textNode.__text).toBe('Text');
+
+        view.getRoot().getFirstChild().append(textNode);
+      });
+
+      expect(editor.getTextContent()).toBe('Text');
+
+      // Make sure that the editor content is still set after further reconciliations
+      await update((view) => {
+        view.markNodeAsDirty(view.getNodeByKey(nodeKey));
+      });
+      expect(editor.getTextContent()).toBe('Text');
+    });
+
+    test('inert nodes', async () => {
+      let nodeKey;
+
+      await update((view) => {
+        const textNode = createTextNode('Inert text').makeInert();
+        nodeKey = textNode.getKey();
+        expect(textNode.getTextContent()).toBe('');
+        expect(textNode.getTextContent(true)).toBe('Inert text');
+        expect(textNode.__text).toBe('Inert text');
+
+        view.getRoot().getFirstChild().append(textNode);
+      });
+
+      expect(editor.getTextContent()).toBe('');
+
+      // Make sure that the editor content is still empty after further reconciliations
+      await update((view) => {
+        view.markNodeAsDirty(view.getNodeByKey(nodeKey));
+      });
+      expect(editor.getTextContent()).toBe('');
+    });
+  });
+
   describe('setTextContent()', () => {
     test('writable nodes', async () => {
       await update(() => {

--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -99,11 +99,9 @@ function createNode(
   }
 
   if (isTextNode(node)) {
-    if (!isInert) {
-      const text = node.__text;
+      const text = node.getTextContent();
       subTreeTextContent += text;
       editorTextContent += text;
-    }
   } else if (isBlockNode(node)) {
     if (flags & IS_LTR) {
       dom.dir = 'ltr';
@@ -232,7 +230,7 @@ function reconcileNode(key: NodeKey, parentDOM: HTMLElement | null): void {
 
   if ((prevNode === nextNode && !isDirty) || isComposingNode) {
     if (isTextNode(prevNode)) {
-      const text = prevNode.__text;
+      const text = prevNode.getTextContent();
       editorTextContent += text;
       subTreeTextContent += text;
     } else {
@@ -271,7 +269,7 @@ function reconcileNode(key: NodeKey, parentDOM: HTMLElement | null): void {
   }
   // Handle text content, for LTR, LTR cases.
   if (isTextNode(nextNode)) {
-    const text = nextNode.__text;
+    const text = nextNode.getTextContent();
     subTreeTextContent += text;
     editorTextContent += text;
     return;


### PR DESCRIPTION
Part of the reconciliation logic is missing the inert node checks. We can leverage the `getTextContent` in the node to have this done for us.

This bug meant inert nodes were working fine on node creation but after further typing text that triggered reconciliation on inert nodes the content would be appended to parent nodes and editor.