### PR TITLE
LinkNode - propagate needsReplace

### DIFF
--- a/packages/outline/src/extensions/OutlineLinkNode.js
+++ b/packages/outline/src/extensions/OutlineLinkNode.js
@@ -45,7 +45,7 @@ export class LinkNode extends TextNode {
       const replacementText = super.createDOM(editorThemeClasses);
       dom.replaceChild(replacementText, text);
     }
-    return false;
+    return needsReplace;
   }
   getURL(): string {
     return this.getLatest().__url;


### PR DESCRIPTION
If the child text needs replacing, so does the parent, doesn't it? Everyone extending LinkNode should take this into account. Am I correct?