### PR TITLE
Refine onInput to accept only text DOM nodes

### DIFF
--- a/packages/outline-react/src/shared/EventHandlers.js
+++ b/packages/outline-react/src/shared/EventHandlers.js
@@ -615,7 +615,9 @@ export function onInput(
     editor.update((view) => {
       const domSelection = window.getSelection();
       const anchorDOM = domSelection.anchorNode;
-      updateTextNodeFromDOMContent(anchorDOM, view, editor);
+      if (anchorDOM.nodeType === 3) {
+        updateTextNodeFromDOMContent(anchorDOM, view, editor);
+      }
     });
   }
 }


### PR DESCRIPTION
We should only be passing around text nodes.