### PR TITLE
Optimize DOM clearing

### DIFF
--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -98,20 +98,12 @@ export type ListenerType =
 export function resetEditor(editor: OutlineEditor): void {
   const root = createRoot();
   const emptyViewModel = new ViewModel({root});
-  const prevViewModel = editor._viewModel;
-  const rootChildrenKeys = prevViewModel._nodeMap.root.__children;
   const keyToDOMMap = editor._keyToDOMMap;
   const rootElement = editor._rootElement;
 
   if (rootElement !== null) {
-    // Remove all existing top level DOM elements from editor
-    for (let i = 0; i < rootChildrenKeys.length; i++) {
-      const rootChildKey = rootChildrenKeys[i];
-      const element = keyToDOMMap.get(rootChildKey);
-      if (element !== undefined && element.parentNode === rootElement) {
-        rootElement.removeChild(element);
-      }
-    }
+    // Clear all DOM content from the root element.
+    rootElement.textContent = '';
   }
   editor._viewModel = emptyViewModel;
   editor._pendingViewModel = null;

--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -161,7 +161,6 @@ function reconcileChildren(
   prevChildren: Array<NodeKey>,
   nextChildren: Array<NodeKey>,
   dom: HTMLElement,
-  isRoot: boolean,
 ): void {
   const previousSubTreeTextContent = subTreeTextContent;
   subTreeTextContent = '';
@@ -188,12 +187,10 @@ function reconcileChildren(
         prevChildren,
         0,
         prevChildrenLength - 1,
-        isRoot ? dom : null,
+        null,
       );
-      if (!isRoot) {
-        // Fast path for removing DOM nodes
-        dom.textContent = '';
-      }
+      // Fast path for removing DOM nodes
+      dom.textContent = '';
     }
   } else {
     reconcileNodeChildren(
@@ -284,8 +281,7 @@ function reconcileNode(key: NodeKey, parentDOM: HTMLElement | null): void {
     const childrenAreDifferent = prevChildren !== nextChildren;
 
     if (childrenAreDifferent || isDirty) {
-      const isRoot = key === 'root';
-      reconcileChildren(prevChildren, nextChildren, dom, isRoot);
+      reconcileChildren(prevChildren, nextChildren, dom);
     }
   }
 }


### PR DESCRIPTION
Now we don't have the placeholder in the root element, we can optimize clearing logic to use the much faster `textContent = ''`.