### PR TITLE
Check for valid window selection in reconciler

### DIFF
--- a/packages/outline/src/core/OutlineUtils.js
+++ b/packages/outline/src/core/OutlineUtils.js
@@ -50,8 +50,8 @@ export const scheduleMicroTask: (fn: () => void) => void =
 
 export function isSelectionWithinEditor(
   editor: OutlineEditor,
-  anchorDOM: ?Node,
-  focusDOM: ?Node,
+  anchorDOM: null | Node,
+  focusDOM: null | Node,
 ): boolean {
   const rootElement = editor.getRootElement();
   try {


### PR DESCRIPTION
Sometimes `window.getSelection()` can result in a nullish value in Firefox. We should check for this during reconciliation, as this can occur out of the normal event input cycle.