### PR TITLE
Add serialize and deserialize methods

### DIFF
--- a/packages/outline-playground/src/useEmojis.js
+++ b/packages/outline-playground/src/useEmojis.js
@@ -13,6 +13,7 @@ import type {
   NodeKey,
   EditorThemeClasses,
   Selection,
+  ParsedTextNode,
 } from 'outline';
 
 import {useEffect} from 'react';
@@ -88,6 +89,11 @@ export default function useEmojis(editor: OutlineEditor): void {
   }, [editor]);
 }
 
+export type ParsedEmojiNode = {
+  ...ParsedTextNode,
+  __className: string,
+};
+
 class EmojiNode extends TextNode {
   __className: string;
 
@@ -96,7 +102,18 @@ class EmojiNode extends TextNode {
     this.__className = className;
     this.__type = 'emoji';
   }
-
+  serialize(): ParsedEmojiNode {
+    const {__className} = this;
+    return {
+      ...super.serialize(),
+      __className,
+    };
+  }
+  deserialize(data: $FlowFixMe) {
+    const {__className, ...rest} = data;
+    super.deserialize(rest);
+    this.__className = __className;
+  }
   clone() {
     return new EmojiNode(this.__className, this.__text, this.__key);
   }

--- a/packages/outline-playground/src/useKeywords.js
+++ b/packages/outline-playground/src/useKeywords.js
@@ -7,7 +7,7 @@
  * @flow strict-local
  */
 
-import type {OutlineEditor, NodeKey, TextNode} from 'outline';
+import type {OutlineEditor, ParsedNode, NodeKey, TextNode} from 'outline';
 
 import * as React from 'react';
 import {useEffect} from 'react';
@@ -38,6 +38,11 @@ function Keyword({children}: {children: string}): React.MixedElement {
   return <span className="keyword">{children}</span>;
 }
 
+type ParsedKeywordNode = {
+  ...ParsedNode,
+  __keyword: string,
+};
+
 class KeywordNode extends DecoratorNode {
   __keyword: string;
 
@@ -45,6 +50,18 @@ class KeywordNode extends DecoratorNode {
     super(key);
     this.__type = 'keyword';
     this.__keyword = keyword;
+  }
+  serialize(): ParsedKeywordNode {
+    const {__keyword} = this;
+    return {
+      ...super.serialize(),
+      __keyword,
+    };
+  }
+  deserialize(data: $FlowFixMe) {
+    const {__keyword, ...rest} = data;
+    super.deserialize(rest);
+    this.__keyword = __keyword;
   }
   clone(): KeywordNode {
     return new KeywordNode(this.__keyword, this.__key);

--- a/packages/outline-playground/src/useMentions.js
+++ b/packages/outline-playground/src/useMentions.js
@@ -7,7 +7,12 @@
  * @flow
  */
 
-import type {OutlineEditor, NodeKey, EditorThemeClasses} from 'outline';
+import type {
+  OutlineEditor,
+  ParsedTextNode,
+  NodeKey,
+  EditorThemeClasses,
+} from 'outline';
 
 import React, {useCallback, useLayoutEffect, useMemo, useRef} from 'react';
 import {useEffect, useState} from 'react';
@@ -500,6 +505,11 @@ export default function useMentions(editor: OutlineEditor): React$Node {
       );
 }
 
+type ParsedMentionNode = {
+  ...ParsedTextNode,
+  __mention: string,
+};
+
 class MentionNode extends TextNode {
   __mention: string;
 
@@ -508,7 +518,18 @@ class MentionNode extends TextNode {
     this.__mention = mentionName;
     this.__type = 'mention';
   }
-
+  serialize(): ParsedMentionNode {
+    const {__mention} = this;
+    return {
+      ...super.serialize(),
+      __mention,
+    };
+  }
+  deserialize(data: $FlowFixMe) {
+    const {__mention, ...rest} = data;
+    super.deserialize(rest);
+    this.__mention = __mention;
+  }
   clone() {
     return new MentionNode(this.__mention, this.__key, this.__text);
   }

--- a/packages/outline/src/core/OutlineBlockNode.js
+++ b/packages/outline/src/core/OutlineBlockNode.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import type {NodeKey} from './OutlineNode';
+import type {NodeKey, ParsedNode} from './OutlineNode';
 
 import {isTextNode, TextNode, isLineBreakNode} from '.';
 import {
@@ -74,12 +74,29 @@ function combineAdjacentTextNodes(
   }
 }
 
+export type ParsedBlockNode = {
+  ...ParsedNode,
+  __children: Array<NodeKey>,
+};
+
 export class BlockNode extends OutlineNode {
   __children: Array<NodeKey>;
 
   constructor(key?: string) {
     super(key);
     this.__children = [];
+  }
+  serialize(): ParsedBlockNode {
+    const {__children} = this;
+    return {
+      ...super.serialize(),
+      __children,
+    };
+  }
+  deserialize(data: $FlowFixMe) {
+    const {__children, ...rest} = data;
+    super.deserialize(rest);
+    this.__children = __children;
   }
   getChildren(): Array<OutlineNode> {
     const self = this.getLatest();

--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -46,7 +46,7 @@ export type ParsedNode = {
   __key: string,
   __type: string,
   __flags: number,
-  __children: Array<NodeKey>,
+  __parent: null | NodeKey,
   ...
 };
 export type ParsedNodeMap = Map<NodeKey, ParsedNode>;
@@ -258,7 +258,29 @@ export class OutlineNode {
       }
     }
   }
-
+  serialize(): ParsedNode {
+    const {__type, __flags, __key, __parent} = this;
+    return {
+      __type,
+      __flags,
+      __key,
+      __parent,
+    };
+  }
+  deserialize({__type, __flags, __key, __parent, ...rest}: ParsedNode) {
+    Object.assign(this, {
+      __type,
+      __flags,
+      __key,
+      __parent,
+    });
+    if (__DEV__) {
+      const keys = Object.keys(rest);
+      if (keys.length > 0) {
+        invariant(false, 'Extraneous keys in serialized node data: %s', keys);
+      }
+    }
+  }
   // Getters and Traversers
 
   getType(): string {
@@ -753,7 +775,7 @@ function getNodeByKeyOrThrow<N: OutlineNode>(key: NodeKey): N {
 }
 
 export function createNodeFromParse(
-  parsedNode: ParsedNode,
+  parsedNode: $FlowFixMe,
   parsedNodeMap: ParsedNodeMap,
   editor: OutlineEditor,
   parentKey: null | NodeKey,

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -8,7 +8,7 @@
  */
 
 import type {Selection} from './OutlineSelection';
-import type {NodeKey} from './OutlineNode';
+import type {NodeKey, ParsedNode} from './OutlineNode';
 import type {EditorThemeClasses} from './OutlineEditor';
 
 import {OutlineNode} from './OutlineNode';
@@ -191,6 +191,11 @@ function createTextInnerDOM(
   }
 }
 
+export type ParsedTextNode = {
+  ...ParsedNode,
+  __text: string,
+};
+
 export class TextNode extends OutlineNode {
   __text: string;
 
@@ -199,7 +204,18 @@ export class TextNode extends OutlineNode {
     this.__text = text;
     this.__type = 'text';
   }
-
+  serialize(): ParsedTextNode {
+    const {__text} = this;
+    return {
+      ...super.serialize(),
+      __text,
+    };
+  }
+  deserialize(data: $FlowFixMe) {
+    const {__text, ...rest} = data;
+    super.deserialize(rest);
+    this.__text = __text;
+  }
   clone(): TextNode {
     return new TextNode(this.__text, this.__key);
   }

--- a/packages/outline/src/core/index.js
+++ b/packages/outline/src/core/index.js
@@ -15,6 +15,8 @@ export type {
   ParsedNodeMap,
   OutlineNode,
 } from './OutlineNode';
+export type {ParsedBlockNode} from './OutlineBlockNode';
+export type {ParsedTextNode} from './OutlineTextNode';
 export type {Selection} from './OutlineSelection';
 export type {TextFormatType} from './OutlineTextNode';
 

--- a/packages/outline/src/extensions/OutlineHeadingNode.js
+++ b/packages/outline/src/extensions/OutlineHeadingNode.js
@@ -7,13 +7,23 @@
  * @flow strict
  */
 
-import type {OutlineNode, NodeKey, EditorThemeClasses} from 'outline';
+import type {
+  OutlineNode,
+  NodeKey,
+  ParsedBlockNode,
+  EditorThemeClasses,
+} from 'outline';
 import type {ParagraphNode} from 'outline/ParagraphNode';
 
 import {BlockNode} from 'outline';
 import {createParagraphNode} from 'outline/ParagraphNode';
 
 type HeadingTagType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
+
+export type ParsedHeadingNode = {
+  ...ParsedBlockNode,
+  __tag: HeadingTagType,
+};
 
 export class HeadingNode extends BlockNode {
   __tag: HeadingTagType;
@@ -23,7 +33,18 @@ export class HeadingNode extends BlockNode {
     this.__tag = tag;
     this.__type = 'heading';
   }
-
+  serialize(): ParsedHeadingNode {
+    const {__tag} = this;
+    return {
+      ...super.serialize(),
+      __tag,
+    };
+  }
+  deserialize(data: $FlowFixMe) {
+    const {__tag, ...rest} = data;
+    super.deserialize(rest);
+    this.__tag = __tag;
+  }
   clone(): HeadingNode {
     return new HeadingNode(this.__tag, this.__key);
   }

--- a/packages/outline/src/extensions/OutlineImageNode.js
+++ b/packages/outline/src/extensions/OutlineImageNode.js
@@ -12,6 +12,7 @@ import type {
   NodeKey,
   OutlineNode,
   OutlineEditor,
+  ParsedNode,
 } from 'outline';
 
 import {DecoratorNode} from 'outline';
@@ -61,6 +62,12 @@ function Image({
   );
 }
 
+export type ParsedImageNode = {
+  ...ParsedNode,
+  __src: string,
+  __altText: string,
+};
+
 export class ImageNode extends DecoratorNode {
   __src: string;
   __altText: string;
@@ -70,6 +77,20 @@ export class ImageNode extends DecoratorNode {
     this.__type = 'image';
     this.__src = src;
     this.__altText = altText;
+  }
+  serialize(): ParsedImageNode {
+    const {__src, __altText} = this;
+    return {
+      ...super.serialize(),
+      __src,
+      __altText,
+    };
+  }
+  deserialize(data: $FlowFixMe) {
+    const {__src, __altText, ...rest} = data;
+    super.deserialize(rest);
+    this.__src = __src;
+    this.__altText = __altText;
   }
   getTextContent(): string {
     return this.__altText;

--- a/packages/outline/src/extensions/OutlineLinkNode.js
+++ b/packages/outline/src/extensions/OutlineLinkNode.js
@@ -7,9 +7,14 @@
  * @flow strict
  */
 
-import type {NodeKey, EditorThemeClasses} from 'outline';
+import type {NodeKey, ParsedTextNode, EditorThemeClasses} from 'outline';
 
 import {TextNode} from 'outline';
+
+export type ParsedLinkNode = {
+  ...ParsedTextNode,
+  __text: string,
+};
 
 export class LinkNode extends TextNode {
   __url: string;
@@ -18,6 +23,18 @@ export class LinkNode extends TextNode {
     super(text, key);
     this.__url = url;
     this.__type = 'link';
+  }
+  serialize(): ParsedLinkNode {
+    const {__url} = this;
+    return {
+      ...super.serialize(),
+      __url,
+    };
+  }
+  deserialize(data: $FlowFixMe) {
+    const {__url, ...rest} = data;
+    super.deserialize(rest);
+    this.__url = __url;
   }
   clone(): LinkNode {
     return new LinkNode(this.__text, this.__url, this.__key);

--- a/packages/outline/src/extensions/OutlineListNode.js
+++ b/packages/outline/src/extensions/OutlineListNode.js
@@ -7,11 +7,21 @@
  * @flow strict
  */
 
-import type {OutlineNode, NodeKey, EditorThemeClasses} from 'outline';
+import type {
+  OutlineNode,
+  NodeKey,
+  ParsedBlockNode,
+  EditorThemeClasses,
+} from 'outline';
 
 import {BlockNode} from 'outline';
 
 type ListNodeTagType = 'ul' | 'ol';
+
+export type ParsedListNode = {
+  ...ParsedBlockNode,
+  __tag: ListNodeTagType,
+};
 
 export class ListNode extends BlockNode {
   __tag: ListNodeTagType;
@@ -21,7 +31,18 @@ export class ListNode extends BlockNode {
     this.__tag = tag;
     this.__type = 'list';
   }
-
+  serialize(): ParsedListNode {
+    const {__tag} = this;
+    return {
+      ...super.serialize(),
+      __tag,
+    };
+  }
+  deserialize(data: $FlowFixMe) {
+    const {__tag, ...rest} = data;
+    super.deserialize(rest);
+    this.__tag = __tag;
+  }
   clone(): ListNode {
     return new ListNode(this.__tag, this.__key);
   }

--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -13,6 +13,7 @@ import type {
   Selection,
   TextFormatType,
   TextNode,
+  ParsedNode,
 } from 'outline';
 
 import {
@@ -42,7 +43,7 @@ function cloneWithProperties<T: OutlineNode>(node: T): T {
 
 export function getNodesInRange(selection: Selection): {
   range: Array<NodeKey>,
-  nodeMap: Array<[NodeKey, OutlineNode]>,
+  nodeMap: Array<[NodeKey, ParsedNode]>,
 } {
   const anchorNode = selection.getAnchorNode();
   const focusNode = selection.getFocusNode();
@@ -61,7 +62,7 @@ export function getNodesInRange(selection: Selection): {
     endOffset = isBefore ? focusOffset : anchorOffset;
     firstNode.__text = firstNode.__text.slice(startOffset, endOffset);
     const key = firstNode.getKey();
-    return {range: [key], nodeMap: [[key, firstNode]]};
+    return {range: [key], nodeMap: [[key, firstNode.serialize()]]};
   }
   const nodes = selection.getNodes();
   const firstNode = nodes[0];
@@ -97,7 +98,7 @@ export function getNodesInRange(selection: Selection): {
     }
 
     if (!nodeMap.has(nodeKey)) {
-      nodeMap.set(nodeKey, node);
+      nodeMap.set(nodeKey, node.serialize());
     }
 
     if (parent === sourceParent && parent !== null) {
@@ -131,7 +132,7 @@ export function getNodesInRange(selection: Selection): {
             includeTopLevelBlock = true;
           }
           if (!nodeMap.has(currKey)) {
-            nodeMap.set(currKey, node);
+            nodeMap.set(currKey, node.serialize());
           }
 
           const nextParent = node.getParent();

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -42,5 +42,6 @@
   "40": "reconcileNodeChildren: keyToMove to was not nextStartKey",
   "41": "storeDOMWithNodeKey: key was null",
   "42": "Reconciliation: could not find DOM element for node key \"${key}\"",
-  "43": "resolveNonLineBreakOrInertNode: resolved node not a text node"
+  "43": "resolveNonLineBreakOrInertNode: resolved node not a text node",
+  "44": "Extraneous keys in serialized node data: %s"
 }


### PR DESCRIPTION
This PR adds `serialize` and `deserialize` methods to outline node classes, replacing blind `JSON.stringify` to give developers better control on the custom node serialization. We expect every extension node to properly implement these methods and this will be enforced in dev mode (coming in the next PR).