### PR TITLE
Fix node key rendering in outline debug tree view

### DIFF
--- a/packages/outline-react/src/OutlineTreeView.js
+++ b/packages/outline-react/src/OutlineTreeView.js
@@ -83,7 +83,7 @@ function generateContent(viewModel: ViewModel): string {
 
     visitTree(view, view.getRoot(), (node, indent) => {
       const nodeKey = node.getKey();
-      const nodeKeyDisplay = `(${nodeKey.slice(1)})`;
+      const nodeKeyDisplay = `(${nodeKey})`;
       const typeDisplay = node.getType() || '';
       const isSelected = selectedNodes !== null && selectedNodes.has(nodeKey);
 


### PR DESCRIPTION
This fixes rendering node keys in the outline debug tree view as we no longer prefix node keys with `_`