### PR TITLE
Add isSimpleText

### DIFF
--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -227,6 +227,14 @@ export class TextNode extends OutlineNode {
   isUnmergeable(): boolean {
     return (this.getFlags() & IS_UNMERGEABLE) !== 0;
   }
+  isSimpleText(): boolean {
+    return (
+      this.__type === 'text' &&
+      !this.isImmutable() &&
+      !this.isInert() &&
+      !this.isSegmented()
+    );
+  }
   getTextContent(includeInert?: boolean, includeDirectionless?: false): string {
     if (
       (!includeInert && this.isInert()) ||


### PR DESCRIPTION
A helper utility to check if text is "simple", i.e. is not immutable, segmented or inert and is the base text node rather than a custom node.