### PR TITLE
Update list of built-in nodes for the dev-only contract check

### DIFF
--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -243,9 +243,22 @@ export class OutlineNode {
     if (__DEV__) {
       // don't check built-in nodes
       if (
-        !['RootNode', 'BlockNode', 'TextNode', 'ParagraphNode'].includes(
-          this.constructor.name,
-        )
+        ![
+          'RootNode',
+          'BlockNode',
+          'TextNode',
+          'LineBreakNode',
+          'CodeNode',
+          'HashtagNode',
+          'HeadingNode',
+          'ImageNode',
+          'LinkNode',
+          'ListNode',
+          'ListItemNode',
+          'ParagraphNode',
+          'QuoteNode',
+          'OverflowedTextNode',
+        ].includes(this.constructor.name)
       ) {
         const proto = Object.getPrototypeOf(this);
         ['clone', 'createDOM', 'serialize', 'deserialize'].forEach((method) => {


### PR DESCRIPTION
We don't need dev-only warnings for built-in nodes so we skip the check for them.
This PR updates the list.