### PR TITLE
Revert deserialize/serialize methods

### DIFF
--- a/packages/outline-playground/src/useEmojis.js
+++ b/packages/outline-playground/src/useEmojis.js
@@ -95,18 +95,6 @@ class EmojiNode extends TextNode {
     this.__className = className;
     this.__type = 'emoji';
   }
-  serialize(): ParsedEmojiNode {
-    const {__className} = this;
-    return {
-      ...super.serialize(),
-      __className,
-    };
-  }
-  deserialize(data: $FlowFixMe) {
-    const {__className, ...rest} = data;
-    super.deserialize(rest);
-    this.__className = __className;
-  }
   clone() {
     return new EmojiNode(this.__className, this.__text, this.__key);
   }

--- a/packages/outline-playground/src/useKeywords.js
+++ b/packages/outline-playground/src/useKeywords.js
@@ -7,7 +7,7 @@
  * @flow strict-local
  */
 
-import type {OutlineEditor, ParsedNode, NodeKey, TextNode} from 'outline';
+import type {OutlineEditor, NodeKey, TextNode} from 'outline';
 
 import * as React from 'react';
 import {useEffect} from 'react';
@@ -38,11 +38,6 @@ function Keyword({children}: {children: string}): React.MixedElement {
   return <span className="keyword">{children}</span>;
 }
 
-type ParsedKeywordNode = {
-  ...ParsedNode,
-  __keyword: string,
-};
-
 class KeywordNode extends DecoratorNode {
   __keyword: string;
 
@@ -50,18 +45,6 @@ class KeywordNode extends DecoratorNode {
     super(key);
     this.__type = 'keyword';
     this.__keyword = keyword;
-  }
-  serialize(): ParsedKeywordNode {
-    const {__keyword} = this;
-    return {
-      ...super.serialize(),
-      __keyword,
-    };
-  }
-  deserialize(data: $FlowFixMe) {
-    const {__keyword, ...rest} = data;
-    super.deserialize(rest);
-    this.__keyword = __keyword;
   }
   clone(): KeywordNode {
     return new KeywordNode(this.__keyword, this.__key);

--- a/packages/outline-playground/src/useMentions.js
+++ b/packages/outline-playground/src/useMentions.js
@@ -7,12 +7,7 @@
  * @flow
  */
 
-import type {
-  OutlineEditor,
-  ParsedTextNode,
-  NodeKey,
-  EditorThemeClasses,
-} from 'outline';
+import type {OutlineEditor, NodeKey, EditorThemeClasses} from 'outline';
 
 import React, {useCallback, useLayoutEffect, useMemo, useRef} from 'react';
 import {useEffect, useState} from 'react';
@@ -504,11 +499,6 @@ export default function useMentions(editor: OutlineEditor): React$Node {
       );
 }
 
-type ParsedMentionNode = {
-  ...ParsedTextNode,
-  __mention: string,
-};
-
 class MentionNode extends TextNode {
   __mention: string;
 
@@ -516,18 +506,6 @@ class MentionNode extends TextNode {
     super(text ?? mentionName, key);
     this.__mention = mentionName;
     this.__type = 'mention';
-  }
-  serialize(): ParsedMentionNode {
-    const {__mention} = this;
-    return {
-      ...super.serialize(),
-      __mention,
-    };
-  }
-  deserialize(data: $FlowFixMe) {
-    const {__mention, ...rest} = data;
-    super.deserialize(rest);
-    this.__mention = __mention;
   }
   clone() {
     return new MentionNode(this.__mention, this.__key, this.__text);

--- a/packages/outline/src/core/OutlineBlockNode.js
+++ b/packages/outline/src/core/OutlineBlockNode.js
@@ -39,18 +39,6 @@ export class BlockNode extends OutlineNode {
     super(key);
     this.__children = [];
   }
-  serialize(): ParsedBlockNode {
-    const {__children} = this;
-    return {
-      ...super.serialize(),
-      __children,
-    };
-  }
-  deserialize(data: $FlowFixMe) {
-    const {__children, ...rest} = data;
-    super.deserialize(rest);
-    this.__children = __children;
-  }
   getChildren(): Array<OutlineNode> {
     const self = this.getLatest();
     const children = self.__children;

--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -239,59 +239,16 @@ export class OutlineNode {
     this.__key = key || generateKey(this);
     this.__parent = null;
 
-    // ensure custom nodes implement required methods
+    // Ensure custom nodes implement required methods.
     if (__DEV__) {
-      // don't check built-in nodes
-      if (
-        ![
-          'RootNode',
-          'BlockNode',
-          'TextNode',
-          'LineBreakNode',
-          'CodeNode',
-          'HashtagNode',
-          'HeadingNode',
-          'ImageNode',
-          'LinkNode',
-          'ListNode',
-          'ListItemNode',
-          'ParagraphNode',
-          'QuoteNode',
-          'OverflowedTextNode',
-        ].includes(this.constructor.name)
-      ) {
-        const proto = Object.getPrototypeOf(this);
-        ['clone', 'createDOM', 'serialize', 'deserialize'].forEach((method) => {
-          if (!proto.hasOwnProperty(method)) {
-            console.warn(
-              `${this.constructor.name} must implement "${method}" method`,
-            );
-          }
-        });
-      }
-    }
-  }
-  serialize(): ParsedNode {
-    const {__type, __flags, __key, __parent} = this;
-    return {
-      __type,
-      __flags,
-      __key,
-      __parent,
-    };
-  }
-  deserialize({__type, __flags, __key, __parent, ...rest}: ParsedNode) {
-    Object.assign(this, {
-      __type,
-      __flags,
-      __key,
-      __parent,
-    });
-    if (__DEV__) {
-      const keys = Object.keys(rest);
-      if (keys.length > 0) {
-        invariant(false, 'Extraneous keys in serialized node data: %s', keys);
-      }
+      const proto = Object.getPrototypeOf(this);
+      ['clone'].forEach((method) => {
+        if (!proto.hasOwnProperty(method)) {
+          console.warn(
+            `${this.constructor.name} must implement "${method}" method`,
+          );
+        }
+      });
     }
   }
   // Getters and Traversers

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -204,18 +204,6 @@ export class TextNode extends OutlineNode {
     this.__text = text;
     this.__type = 'text';
   }
-  serialize(): ParsedTextNode {
-    const {__text} = this;
-    return {
-      ...super.serialize(),
-      __text,
-    };
-  }
-  deserialize(data: $FlowFixMe) {
-    const {__text, ...rest} = data;
-    super.deserialize(rest);
-    this.__text = __text;
-  }
   clone(): TextNode {
     return new TextNode(this.__text, this.__key);
   }

--- a/packages/outline/src/extensions/OutlineHeadingNode.js
+++ b/packages/outline/src/extensions/OutlineHeadingNode.js
@@ -33,18 +33,6 @@ export class HeadingNode extends BlockNode {
     this.__tag = tag;
     this.__type = 'heading';
   }
-  serialize(): ParsedHeadingNode {
-    const {__tag} = this;
-    return {
-      ...super.serialize(),
-      __tag,
-    };
-  }
-  deserialize(data: $FlowFixMe) {
-    const {__tag, ...rest} = data;
-    super.deserialize(rest);
-    this.__tag = __tag;
-  }
   clone(): HeadingNode {
     return new HeadingNode(this.__tag, this.__key);
   }

--- a/packages/outline/src/extensions/OutlineImageNode.js
+++ b/packages/outline/src/extensions/OutlineImageNode.js
@@ -78,20 +78,6 @@ export class ImageNode extends DecoratorNode {
     this.__src = src;
     this.__altText = altText;
   }
-  serialize(): ParsedImageNode {
-    const {__src, __altText} = this;
-    return {
-      ...super.serialize(),
-      __src,
-      __altText,
-    };
-  }
-  deserialize(data: $FlowFixMe) {
-    const {__src, __altText, ...rest} = data;
-    super.deserialize(rest);
-    this.__src = __src;
-    this.__altText = __altText;
-  }
   getTextContent(): string {
     return this.__altText;
   }

--- a/packages/outline/src/extensions/OutlineLinkNode.js
+++ b/packages/outline/src/extensions/OutlineLinkNode.js
@@ -24,18 +24,6 @@ export class LinkNode extends TextNode {
     this.__url = url;
     this.__type = 'link';
   }
-  serialize(): ParsedLinkNode {
-    const {__url} = this;
-    return {
-      ...super.serialize(),
-      __url,
-    };
-  }
-  deserialize(data: $FlowFixMe) {
-    const {__url, ...rest} = data;
-    super.deserialize(rest);
-    this.__url = __url;
-  }
   clone(): LinkNode {
     return new LinkNode(this.__text, this.__url, this.__key);
   }

--- a/packages/outline/src/extensions/OutlineListNode.js
+++ b/packages/outline/src/extensions/OutlineListNode.js
@@ -31,18 +31,6 @@ export class ListNode extends BlockNode {
     this.__tag = tag;
     this.__type = 'list';
   }
-  serialize(): ParsedListNode {
-    const {__tag} = this;
-    return {
-      ...super.serialize(),
-      __tag,
-    };
-  }
-  deserialize(data: $FlowFixMe) {
-    const {__tag, ...rest} = data;
-    super.deserialize(rest);
-    this.__tag = __tag;
-  }
   clone(): ListNode {
     return new ListNode(this.__tag, this.__key);
   }

--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -13,7 +13,6 @@ import type {
   Selection,
   TextFormatType,
   TextNode,
-  ParsedNode,
 } from 'outline';
 
 import {
@@ -43,7 +42,7 @@ function cloneWithProperties<T: OutlineNode>(node: T): T {
 
 export function getNodesInRange(selection: Selection): {
   range: Array<NodeKey>,
-  nodeMap: Array<[NodeKey, ParsedNode]>,
+  nodeMap: Array<[NodeKey, OutlineNode]>,
 } {
   const anchorNode = selection.getAnchorNode();
   const focusNode = selection.getFocusNode();
@@ -62,7 +61,7 @@ export function getNodesInRange(selection: Selection): {
     endOffset = isBefore ? focusOffset : anchorOffset;
     firstNode.__text = firstNode.__text.slice(startOffset, endOffset);
     const key = firstNode.getKey();
-    return {range: [key], nodeMap: [[key, firstNode.serialize()]]};
+    return {range: [key], nodeMap: [[key, firstNode]]};
   }
   const nodes = selection.getNodes();
   const firstNode = nodes[0];
@@ -98,7 +97,7 @@ export function getNodesInRange(selection: Selection): {
     }
 
     if (!nodeMap.has(nodeKey)) {
-      nodeMap.set(nodeKey, node.serialize());
+      nodeMap.set(nodeKey, node);
     }
 
     if (parent === sourceParent && parent !== null) {
@@ -132,7 +131,7 @@ export function getNodesInRange(selection: Selection): {
             includeTopLevelBlock = true;
           }
           if (!nodeMap.has(currKey)) {
-            nodeMap.set(currKey, node.serialize());
+            nodeMap.set(currKey, node);
           }
 
           const nextParent = node.getParent();


### PR DESCRIPTION
We are going to take another strategy in tackling serialized nodes, so we are reverting this for now. I had to manually do this by hand as Github auto unmerge failed because of subsequent changes to main.