### PR TITLE
Do not normalize empty text nodes that have selection

### DIFF
--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -711,13 +711,18 @@ function normalizeTextNodes(block: BlockNode): void {
   let lastTextNodeFlags: number | null = null;
   for (let i = 0; i < children.length; i++) {
     const child = children[i];
+    const childKey = child.__key;
 
     if (
       isTextNode(child) &&
       child.__type === 'text' &&
       !child.isImmutable() &&
       !child.isSegmented() &&
-      !child.isUnmergeable()
+      !child.isUnmergeable() &&
+      (child.__text !== '' ||
+        activeSelection === null ||
+        (activeSelection.anchorKey !== childKey &&
+          activeSelection.focusKey !== childKey))
     ) {
       const flags = child.__flags;
       if (lastTextNodeFlags === null || flags === lastTextNodeFlags) {

--- a/packages/outline/src/core/OutlineView.js
+++ b/packages/outline/src/core/OutlineView.js
@@ -313,7 +313,9 @@ export function commitPendingUpdates(editor: OutlineEditor): void {
   editor._pendingViewModel = null;
   editor._viewModel = pendingViewModel;
   const previousActiveViewModel = activeViewModel;
+  const previousReadOnlyMode = isReadOnlyMode;
   activeViewModel = pendingViewModel;
+  isReadOnlyMode = false;
   try {
     reconcileViewModel(rootElement, currentViewModel, pendingViewModel, editor);
   } catch (error) {
@@ -331,6 +333,7 @@ export function commitPendingUpdates(editor: OutlineEditor): void {
     return;
   } finally {
     activeViewModel = previousActiveViewModel;
+    isReadOnlyMode = previousReadOnlyMode;
   }
   garbageCollectDetachedDecorators(editor, pendingViewModel);
   const pendingDecorators = editor._pendingDecorators;


### PR DESCRIPTION
Otherwise, this can break some tooling and expectations around text formatting. Once we remove empty text nodes, this can go away.