### PR TITLE
Clean up event handling logic + re-add skipping of composing text transforms

### DIFF
--- a/packages/outline-react/src/shared/EventHandlers.js
+++ b/packages/outline-react/src/shared/EventHandlers.js
@@ -791,10 +791,27 @@ export function onBeforeInputForPlainText(
         if (data) {
           // This is the end of composition
           editor._compositionKey = null;
+          // This fixes a Safari issue when composition starts
+          // in another node and gets moved to the next sibling.
+          // The offset is always off.
+          if (compositonStartKey !== null) {
+            if (compositonStartKey !== anchorNode.getKey()) {
+              const prevSibling = anchorNode.getPreviousSibling();
+              if (
+                isTextNode(prevSibling) &&
+                prevSibling.getKey() === compositonStartKey &&
+                compositonStartOffset === prevSibling.getTextContentSize()
+              ) {
+                anchorNode.select(0, 0);
+              }
+            }
+            compositonStartKey = null;
+          }
           insertText(selection, data);
         }
         break;
       }
+      case 'insertLineBreak':
       case 'insertParagraph': {
         // Used for Android
         editor.setCompositionKey(null);
@@ -950,6 +967,12 @@ export function onBeforeInputForRichText(
           }
           insertText(selection, data);
         }
+        break;
+      }
+      case 'insertLineBreak': {
+        // Used for Android
+        editor.setCompositionKey(null);
+        insertLineBreak(selection);
         break;
       }
       case 'insertParagraph': {

--- a/packages/outline/src/core/OutlineView.js
+++ b/packages/outline/src/core/OutlineView.js
@@ -169,6 +169,7 @@ function triggerTextMutationListeners(
   dirtyNodes: Array<NodeKey>,
   transforms: Array<TextNodeTransform>,
 ): void {
+  const compositionKey = getActiveEditor()._compositionKey;
   for (let s = 0; s < dirtyNodes.length; s++) {
     const nodeKey = dirtyNodes[s];
 
@@ -177,6 +178,8 @@ function triggerTextMutationListeners(
     if (
       node !== undefined &&
       isTextNode(node) &&
+      // We don't want to transform nodes being composed
+      node.__key !== compositionKey &&
       !isLineBreakNode(node) &&
       node.isAttached() &&
       // You shouldn't be able to transform these types of


### PR DESCRIPTION
We have some event handling logic that doesn't match between plan vs rich text. Also, it turns out that mutating composing text nodes is far too much hassle, so let's reinstate that we skip composing nodes.