### PR TITLE
Recreate TextNode on splitText when TextNode is segmented

### DIFF
--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -541,12 +541,23 @@ export class TextNode extends OutlineNode {
     } else if (parts[0] === textContent) {
       return [this];
     }
-    // For the first part, update the existing node
-    const writableNode = this.getWritable();
-    const parentKey = writableNode.__parent;
     const firstPart = parts[0];
-    const flags = writableNode.__flags;
-    writableNode.__text = firstPart;
+    const parent = this.getParentOrThrow();
+    const parentKey = parent.__key;
+    let writableNode;
+    let flags;
+    if (this.isSegmented()) {
+      // Create a new TextNode
+      writableNode = createTextNode(firstPart);
+      writableNode.__parent = parentKey;
+      flags = writableNode.__flags;
+      this.remove();
+    } else {
+      // For the first part, update the existing node
+      writableNode = this.getWritable();
+      writableNode.__text = firstPart;
+      flags = writableNode.__flags;
+    }
 
     // Handle selection
     const selection = getSelection();
@@ -591,7 +602,6 @@ export class TextNode extends OutlineNode {
     }
 
     // Insert the nodes into the parent's children
-    const parent = this.getParentOrThrow();
     const writableParent = parent.getWritable();
     const writableParentChildren = writableParent.__children;
     const insertionIndex = writableParentChildren.indexOf(key);

--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -699,6 +699,11 @@ export function insertNodes(
   const siblings = [];
   let target;
 
+  // Get all remaining text node siblings in this block so we can
+  // append them after the last node we're inserting.
+  const nextSiblings = anchorNode.getNextSiblings();
+  const topLevelBlock = anchorNode.getTopParentBlockOrThrow();
+
   if (anchorOffset === 0) {
     // Insert an empty text node to wrap whatever is being inserted
     // in case it's immutable
@@ -720,11 +725,7 @@ export function insertNodes(
   }
   const startingNode = target;
 
-  // Finally, get all remaining text node siblings in this block so we can
-  // append them after the last node we're inserting.
-  const nextSiblings = anchorNode.getNextSiblings();
   siblings.push(...nextSiblings);
-  const topLevelBlock = anchorNode.getTopParentBlockOrThrow();
 
   // Time to insert the nodes!
   for (let i = 0; i < nodes.length; i++) {


### PR DESCRIPTION
This is a followup of #467. When using `node.splitText()`, the segmented node should go away. What's more, not blocking so allows splitting the segmented node is forbidden ways (i.e. Luke Skywalker like Lu <--> ke Skywalker where Lu is a segmented ActorNode)