### PR TITLE
Expose a way to clear a plain/rich text editor

### DIFF
--- a/packages/outline-playground/src/Editor.js
+++ b/packages/outline-playground/src/Editor.js
@@ -104,7 +104,7 @@ export const useRichTextEditor = ({
     editorThemeClasses,
   );
   const mentionsTypeahead = useMentions(editor);
-  useOutlineRichText(editor, isReadOnly);
+  const clear = useOutlineRichText(editor, isReadOnly);
   const toolbar = useToolbar(editor);
   const decorators = useOutlineDecorators(editor);
   useEmojis(editor);
@@ -145,8 +145,11 @@ export const useRichTextEditor = ({
         {isCharLimit && <CharacterLimit editor={editor} />}
         {isAutocomplete && <Typeahead editor={editor} />}
         <div className="actions">
-          <button className="add-image" onClick={handleAddImage}>
+          <button className="action-button" onClick={handleAddImage}>
             Insert Image
+          </button>
+          <button className="action-button" onClick={clear}>
+            Clear
           </button>
         </div>
       </>
@@ -155,6 +158,7 @@ export const useRichTextEditor = ({
     isReadOnly,
     rootElementRef,
     showPlaceholder,
+    clear,
     decorators,
     mentionsTypeahead,
     toolbar,
@@ -181,7 +185,7 @@ export const usePlainTextEditor = ({
     editorThemeClasses,
   );
   const mentionsTypeahead = useMentions(editor);
-  usePlainText(editor, isReadOnly);
+  const clear = usePlainText(editor, isReadOnly);
   const decorators = useOutlineDecorators(editor);
   useEmojis(editor);
   useHashtags(editor);
@@ -199,12 +203,18 @@ export const usePlainTextEditor = ({
         {mentionsTypeahead}
         {isCharLimit && <CharacterLimit editor={editor} />}
         {isAutocomplete && <Typeahead editor={editor} />}
+        <div className="actions">
+          <button className="action-button" onClick={clear}>
+            Clear
+          </button>
+        </div>
       </>
     ),
     [
       isReadOnly,
       rootElementRef,
       showPlaceholder,
+      clear,
       decorators,
       mentionsTypeahead,
       isCharLimit,

--- a/packages/outline-playground/src/index.css
+++ b/packages/outline-playground/src/index.css
@@ -788,7 +788,7 @@ pre :not(.tree-view-output) {
   padding: 10px;
 }
 
-.add-image {
+.action-button {
   background-color: #eee;
   border: 0;
   padding: 8px 12px;
@@ -800,7 +800,7 @@ pre :not(.tree-view-output) {
   cursor: pointer;
 }
 
-.add-image:hover {
+.action-button:hover {
   background-color: #ddd;
   color: #000;
 }

--- a/packages/outline-react/src/useOutlinePlainText.js
+++ b/packages/outline-react/src/useOutlinePlainText.js
@@ -11,10 +11,14 @@ import type {OutlineEditor} from 'outline';
 import type {EventHandlerState} from './shared/EventHandlers';
 import type {InputEvents} from 'outline-react/useOutlineEditorEvents';
 
-import {useEffect, useMemo} from 'react';
+import {useCallback, useEffect, useMemo} from 'react';
 import {createTextNode} from 'outline';
 import useOutlineEditorEvents from './useOutlineEditorEvents';
-import {createParagraphNode, ParagraphNode} from 'outline/ParagraphNode';
+import {
+  createParagraphNode,
+  ParagraphNode,
+  isParagraphNode,
+} from 'outline/ParagraphNode';
 import {CAN_USE_BEFORE_INPUT} from 'shared/environment';
 import {
   onSelectionChange,
@@ -41,6 +45,19 @@ function initEditor(editor: OutlineEditor): void {
       const paragraph = createParagraphNode();
       const text = createTextNode();
       root.append(paragraph.append(text));
+      text.select();
+    }
+  });
+}
+
+function clearEditor(editor: OutlineEditor): void {
+  editor.update((view) => {
+    const firstChild = view.getRoot().getFirstChild();
+    if (isParagraphNode(firstChild)) {
+      firstChild.clear();
+      const textNode = createTextNode();
+      firstChild.append(textNode);
+      textNode.select();
     }
   });
 }
@@ -113,5 +130,10 @@ export default function useOutlinePlainText(
 
   useOutlineEditorEvents(events, editor, eventHandlerState);
   useOutlineDragonSupport(editor);
-  return useOutlineHistory(editor);
+  const clearHistory = useOutlineHistory(editor);
+
+  return useCallback(() => {
+    clearEditor(editor);
+    clearHistory();
+  }, [clearHistory, editor]);
 }

--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -11,7 +11,7 @@ import type {OutlineEditor} from 'outline';
 import type {EventHandlerState} from './shared/EventHandlers';
 import type {InputEvents} from 'outline-react/useOutlineEditorEvents';
 
-import {useEffect, useMemo} from 'react';
+import {useCallback, useEffect, useMemo} from 'react';
 import {createTextNode} from 'outline';
 import useOutlineEditorEvents from './useOutlineEditorEvents';
 import {HeadingNode} from 'outline/HeadingNode';
@@ -47,7 +47,16 @@ function initEditor(editor: OutlineEditor): void {
       const paragraph = createParagraphNode();
       const text = createTextNode();
       root.append(paragraph.append(text));
+      text.select();
     }
+  });
+}
+
+function clearEditor(editor: OutlineEditor): void {
+  editor.update((view) => {
+    const root = view.getRoot();
+    root.clear();
+    initEditor(editor);
   });
 }
 
@@ -128,5 +137,10 @@ export default function useOutlineRichText(
 
   useOutlineEditorEvents(events, editor, eventHandlerState);
   useOutlineDragonSupport(editor);
-  return useOutlineHistory(editor);
+  const clearHistory = useOutlineHistory(editor);
+
+  return useCallback(() => {
+    clearEditor(editor);
+    clearHistory();
+  }, [clearHistory, editor]);
 }


### PR DESCRIPTION
Currently, users have to do this manually by understanding the plain/rich text structure. Given that we built it for them in the first place, we can make provide a method to clean it. (In any case, it doesn't fix them from understanding the structure since it's a requirement for building anything on top of it)

At the same time, we can merge the `clearHistory` with `clear`, at least until there's some use case when we need to use `clearHistory` independently.

PS: Not too proud with cluttering the editor layout with another (clear) action button, we can redefine the design later