### PR TITLE
Fix selection bug with initEditor/clearEditor

### DIFF
--- a/packages/outline-react/src/useOutlinePlainText.js
+++ b/packages/outline-react/src/useOutlinePlainText.js
@@ -44,9 +44,11 @@ function initEditor(editor: OutlineEditor): void {
 
       if (root.getFirstChild() === null) {
         const paragraph = createParagraphNode();
-        const text = createTextNode();
-        root.append(paragraph.append(text));
-        text.select();
+        const textNode = createTextNode();
+        root.append(paragraph.append(textNode));
+        if (view.getSelection() !== null) {
+          textNode.select();
+        }
       }
     },
     'initEditor',
@@ -62,6 +64,9 @@ function clearEditor(editor: OutlineEditor): void {
         const textNode = createTextNode();
         firstChild.append(textNode);
         textNode.select();
+        if (view.getSelection() !== null) {
+          textNode.select();
+        }
       }
     },
     'clearEditor',

--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -46,9 +46,11 @@ function initEditor(editor: OutlineEditor): void {
 
       if (root.getFirstChild() === null) {
         const paragraph = createParagraphNode();
-        const text = createTextNode();
-        root.append(paragraph.append(text));
-        text.select();
+        const textNode = createTextNode();
+        root.append(paragraph.append(textNode));
+        if (view.getSelection() !== null) {
+          textNode.select();
+        }
       }
     },
     'initEditor',


### PR DESCRIPTION
We should only select if we actually have selection, otherwise we will force selection into the editor.