### PR TITLE
Improve hashtag handling around composition

### DIFF
--- a/packages/outline-playground/src/useHashtags.js
+++ b/packages/outline-playground/src/useHashtags.js
@@ -284,7 +284,7 @@ export default function useHashtags(editor: OutlineEditor): void {
     const removeUpdateListener = editor.addListener('update', () => {
       editor.update((view) => {
         const selection = view.getSelection();
-        if (selection !== null) {
+        if (selection !== null && !editor.isComposing()) {
           const anchorNode = selection.getAnchorNode();
           textNodeTransform(anchorNode, view);
         }

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -392,7 +392,7 @@ export class TextNode extends OutlineNode {
   toggleUnmergeable(): TextNode {
     return this.setFlags(this.getFlags() ^ IS_UNMERGEABLE);
   }
-  setTextContent(text: string): boolean {
+  setTextContent(text: string): void {
     errorOnReadOnly();
     if (this.isImmutable()) {
       invariant(
@@ -425,8 +425,6 @@ export class TextNode extends OutlineNode {
     } else {
       writableSelf.__text = text;
     }
-
-    return false;
   }
   select(_anchorOffset?: number, _focusOffset?: number): Selection {
     errorOnReadOnly();

--- a/packages/outline/src/extensions/OutlineHashtagNode.js
+++ b/packages/outline/src/extensions/OutlineHashtagNode.js
@@ -33,20 +33,18 @@ export class HashtagNode extends TextNode {
     return element;
   }
 
-  setTextContent(text: string): boolean {
-    let requireNormalize = super.setTextContent(text);
+  setTextContent(text: string): void {
+    super.setTextContent(text);
     const isHashtag = isHashtagNode(this);
     // Handle hashtags
-    if (isHashtag && this.getParent() !== null) {
+    if (isHashtag && this.getParent() !== null && !this.isComposing()) {
       const indexOfHash = text.indexOf('#');
       let targetNode = this;
-      if (indexOfHash === -1) {
+      if (indexOfHash === -1 || targetNode.getTextContent() === '#') {
         toggleHashtag(targetNode);
-        requireNormalize = true;
       } else if (indexOfHash > 0) {
         [targetNode] = this.splitText(indexOfHash);
         toggleHashtag(targetNode);
-        requireNormalize = true;
       }
       // Check for invalid characters
       const targetTextContent = targetNode.getTextContent().slice(1);
@@ -55,14 +53,11 @@ export class HashtagNode extends TextNode {
       );
       if (indexOfInvalidChar === 0) {
         toggleHashtag(targetNode);
-        requireNormalize = true;
       } else if (indexOfInvalidChar > 0) {
         [targetNode] = targetNode.splitText(indexOfInvalidChar + 1);
         toggleHashtag(targetNode);
-        requireNormalize = true;
       }
     }
-    return requireNormalize;
   }
 }
 


### PR DESCRIPTION
We shouldn't be splitting and changing the DOM on a hashtag during composition or it will break composition in many places.