### PR TITLE
Revise reconcileNodeChildren logic

### DIFF
--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -362,12 +362,16 @@ function reconcileNodeChildren(
       } else {
         // Move next
         const childDOM = getElementByKeyOrThrow(activeEditor, nextKey);
-        if (siblingDOM != null) {
-          dom.insertBefore(childDOM, siblingDOM);
+        if (childDOM === siblingDOM) {
+          siblingDOM = getNextSibling(reconcileNode(nextKey, dom));
         } else {
-          dom.appendChild(childDOM);
+          if (siblingDOM != null) {
+            dom.insertBefore(childDOM, siblingDOM);
+          } else {
+            dom.appendChild(childDOM);
+          }
+          reconcileNode(nextKey, dom);
         }
-        reconcileNode(nextKey, dom);
         prevIndex++;
         nextIndex++;
       }


### PR DESCRIPTION
This applies a better (simpler) fix for our `reconcileNodeChildren` logic, to fix the issues show in https://github.com/facebookexternal/Outline/pull/523 and also other issues I found during testing.