### PR TITLE
Remove FF forked logic in compositionend

### DIFF
--- a/packages/outline/src/core/OutlineView.js
+++ b/packages/outline/src/core/OutlineView.js
@@ -203,10 +203,7 @@ export function preparePendingViewUpdate(
       garbageCollectDetachedNodes(pendingViewModel, editor);
     }
     const endingCompositionKey = editor._compositionKey;
-    if (
-      endingCompositionKey !== null &&
-      startingCompositionKey !== endingCompositionKey
-    ) {
+    if (startingCompositionKey !== endingCompositionKey) {
       pendingViewModel._flushSync = true;
     }
     const pendingSelection = pendingViewModel._selection;


### PR DESCRIPTION
We needed to check the DOM anchor for the latest content, avoiding a setTimeout.