### PR TITLE
Remove onInput

### DIFF
--- a/packages/outline-react/src/useOutlinePlainText.js
+++ b/packages/outline-react/src/useOutlinePlainText.js
@@ -30,7 +30,6 @@ import {
   onPasteForPlainText,
   onDropPolyfill,
   onDragStartPolyfill,
-  onInput,
   onMutation,
 } from './shared/EventHandlers';
 import useOutlineDragonSupport from './shared/useOutlineDragonSupport';
@@ -81,7 +80,6 @@ const events: InputEvents = [
   ['copy', onCopyForPlainText],
   ['dragstart', onDragStartPolyfill],
   ['paste', onPasteForPlainText],
-  ['input', onInput],
 ];
 
 if (CAN_USE_BEFORE_INPUT) {

--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -32,7 +32,6 @@ import {
   onPasteForRichText,
   onDropPolyfill,
   onDragStartPolyfill,
-  onInput,
   onMutation,
 } from './shared/EventHandlers';
 import useOutlineDragonSupport from './shared/useOutlineDragonSupport';
@@ -77,7 +76,6 @@ const events: InputEvents = [
   ['copy', onCopyForRichText],
   ['dragstart', onDragStartPolyfill],
   ['paste', onPasteForRichText],
-  ['input', onInput],
 ];
 
 if (CAN_USE_BEFORE_INPUT) {


### PR DESCRIPTION
We no longer need to listen to `input`, avoiding extra overhead.