### PR TITLE
Fix FF text replacement bug

### DIFF
--- a/packages/outline-playground/__tests__/e2e/TextEntry-test.js
+++ b/packages/outline-playground/__tests__/e2e/TextEntry-test.js
@@ -43,6 +43,32 @@ describe('TextEntry', () => {
         });
       });
 
+      it(`Can type 'Hello Outline' in the editor and replace it with foo`, async () => {
+        const {page} = e2e;
+
+        const targetText = 'Hello Outline';
+        await page.focus('div.editor');
+        await page.keyboard.type(targetText);
+
+        // Select all the text
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('a');
+        await keyUpCtrlOrMeta(page);
+
+        await page.keyboard.type('Foo');
+
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Foo</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 3,
+          focusPath: [0, 0, 0],
+          focusOffset: 3,
+        });
+      });
+
       it('Paragraphed text entry and selection', async () => {
         const {isRichText, page} = e2e;
 

--- a/packages/outline-react/src/useOutlinePlainText.js
+++ b/packages/outline-react/src/useOutlinePlainText.js
@@ -31,6 +31,7 @@ import {
   onDropPolyfill,
   onDragStartPolyfill,
   onMutation,
+  onInput,
 } from './shared/EventHandlers';
 import useOutlineDragonSupport from './shared/useOutlineDragonSupport';
 import useOutlineHistory from './shared/useOutlineHistory';
@@ -80,6 +81,7 @@ const events: InputEvents = [
   ['copy', onCopyForPlainText],
   ['dragstart', onDragStartPolyfill],
   ['paste', onPasteForPlainText],
+  ['input', onInput],
 ];
 
 if (CAN_USE_BEFORE_INPUT) {

--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -33,6 +33,7 @@ import {
   onDropPolyfill,
   onDragStartPolyfill,
   onMutation,
+  onInput,
 } from './shared/EventHandlers';
 import useOutlineDragonSupport from './shared/useOutlineDragonSupport';
 import useOutlineHistory from './shared/useOutlineHistory';
@@ -76,6 +77,7 @@ const events: InputEvents = [
   ['copy', onCopyForRichText],
   ['dragstart', onDragStartPolyfill],
   ['paste', onPasteForRichText],
+  ['input', onInput],
 ];
 
 if (CAN_USE_BEFORE_INPUT) {


### PR DESCRIPTION
Turns out that we need to keep `onInput` in Outline, otherwise we get a nasty FF text replacement issue for when you select a range that is of all the text and type some content. Added regression test.