### PR TITLE
Handle compound classNames in ListItemNode

### DIFF
--- a/packages/outline/src/extensions/OutlineListItemNode.js
+++ b/packages/outline/src/extensions/OutlineListItemNode.js
@@ -130,7 +130,6 @@ function setListItemThemeClassNames(
   }
 
   if (nestedListClassName !== undefined) {
-    // handle compound classNames
     const nestedListClasses = nestedListClassName.split(' ');
     if (node.getChildren().some((child) => isListNode(child))) {
       classesToAdd.push(...nestedListClasses);


### PR DESCRIPTION
This handles the case where someone sets the value of an EditorThemeClass as a space separate string of class names (like stylex). Ultimately might make sense to expose a getter method on EditorThemeClasses that handles this so we don't have to remember to do it everytime we use classList.add (which is what chokes on this, since DOMTokenList.add can't handle spaces in the string you pass to it).