### PR TITLE
Add utility function to get the common ancestor of a list of nodes

### DIFF
--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -1010,3 +1010,32 @@ export function selectAll(selection: Selection): void {
     );
   }
 }
+
+export function getCommonAncestorFromNodeList(
+  nodeList: Array<OutlineNode>,
+): ?OutlineNode {
+  if (nodeList.length === 0) {
+    return null;
+  }
+  if (nodeList.length === 1) {
+    return nodeList[0].getParentOrThrow();
+  }
+  // Find all unique common ancestors for each node combination
+  const ancestorSet = new Set();
+  nodeList.forEach((node, index) => {
+    for (let i = index + 1; i < nodeList.length; i++) {
+      ancestorSet.add(node.getCommonAncestor(nodeList[i]));
+    }
+  });
+  const commonAncestors = Array.from(ancestorSet.values());
+  let commonAncestor = null;
+  // Get the common ancestor that's not in the list itself.
+  for (let i = 0; i < commonAncestors.length; i++) {
+    const ancestor = commonAncestors[i];
+    if (!nodeList.includes(ancestor)) {
+      commonAncestor = ancestor;
+      break;
+    }
+  }
+  return commonAncestor;
+}

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
@@ -6,6 +6,9 @@
  *
  */
 
+import {getCommonAncestorFromNodeList} from '../../OutlineSelectionHelpers';
+import {createListItemNode} from '../../../extensions/OutlineListItemNode';
+import {createListNode} from '../../../extensions/OutlineListNode';
 import {createEditor, createTextNode, TextNode} from 'outline';
 import {createParagraphNode} from 'outline/ParagraphNode';
 import {insertText} from 'outline/SelectionHelpers';
@@ -47,6 +50,42 @@ function setFocusPoint(view, point) {
   focus.type = point.type;
   focus.offset = point.offset;
   focus.key = point.key;
+}
+
+/* root
+ *   |- ul
+ *       |- li
+ *           |- text ('hello')
+ *       |- li
+ *           |- ul
+ *              |- li
+ *                  |- text ('hi')
+ */
+function createNestedList(editor): ListNode {
+  const topLevelList = createListNode('ul');
+  const topLevelListItem = createListItemNode();
+  const topLevelListItemTwo = createListItemNode();
+  const topLevelListItemText = new TextNode('hello', 'hello');
+  const secondLevelList = createListNode('ul');
+  const secondLevelListItem = createListItemNode();
+  const secondLevelListItemText = new TextNode('hi', 'hi');
+  editor._pendingViewModel?._nodeMap.set('hello', topLevelListItemText);
+  editor._pendingViewModel?._nodeMap.set('hi', secondLevelListItemText);
+  topLevelList.append(topLevelListItem);
+  topLevelList.append(topLevelListItemTwo);
+  topLevelListItem.append(topLevelListItemText);
+  secondLevelList.append(secondLevelListItem);
+  secondLevelListItem.append(secondLevelListItemText);
+  topLevelListItemTwo.append(secondLevelList);
+  return {
+    topLevelList,
+    topLevelListItem,
+    topLevelListItemTwo,
+    topLevelListItemText,
+    secondLevelList,
+    secondLevelListItem,
+    secondLevelListItemText,
+  };
 }
 
 describe('OutlineSelectionHelpers tests', () => {
@@ -101,6 +140,62 @@ describe('OutlineSelectionHelpers tests', () => {
           offset: 4,
           key: 'a',
         });
+      });
+    });
+  });
+
+  describe('getCommonAncestorFromNodeList', () => {
+    test('Returns the correct common ancestor when selecting across levels', () => {
+      const editor = createEditor({});
+
+      editor.addListener('error', (error) => {
+        throw error;
+      });
+
+      editor.update((view) => {
+        const root = view.getRoot();
+        const {topLevelList} = createNestedList(editor);
+        root.append(topLevelList);
+        setAnchorPoint(view, {
+          type: 'character',
+          offset: 0,
+          key: 'hello',
+        });
+        setFocusPoint(view, {
+          type: 'character',
+          offset: 2,
+          key: 'hi',
+        });
+        const nodes = view.getSelection()?.getNodes();
+        const result = getCommonAncestorFromNodeList(nodes);
+        expect(result).toBe(topLevelList);
+      });
+    });
+
+    test('Returns the correct common ancestor when selecting a single node', () => {
+      const editor = createEditor({});
+
+      editor.addListener('error', (error) => {
+        throw error;
+      });
+
+      editor.update((view) => {
+        const root = view.getRoot();
+        const {topLevelList, topLevelListItem} = createNestedList(editor);
+        root.append(topLevelList);
+        setAnchorPoint(view, {
+          type: 'character',
+          offset: 0,
+          key: 'hello',
+        });
+        setFocusPoint(view, {
+          type: 'character',
+          offset: 5,
+          key: 'hello',
+        });
+        const nodes = view.getSelection()?.getNodes();
+        const result = getCommonAncestorFromNodeList(nodes);
+        expect(result).toBe(topLevelListItem);
       });
     });
   });


### PR DESCRIPTION
Primary use case for this right now is indenting/outdenting a list, where we need to find a common ancestor across indentation levels.