### PR TITLE
Fix reconciler bug with moving around nodes between blocks

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineNode.test.js
@@ -816,6 +816,70 @@ describe('OutlineNode tests', () => {
       // TODO: add text direction validations
     });
 
+    test('OutlineNode.insertAfter() move blocks around', async () => {
+      const {editor} = testEnv;
+      let block1, block2, block3, text1, text2, text3;
+      await editor.update((view) => {
+        const root = view.getRoot();
+        root.clear();
+        block1 = new ParagraphNode();
+        block2 = new ParagraphNode();
+        block3 = new ParagraphNode();
+        text1 = new TextNode('A');
+        text2 = new TextNode('B');
+        text3 = new TextNode('C');
+        block1.append(text1);
+        block2.append(text2);
+        block3.append(text3);
+        root.append(block1);
+        root.append(block2);
+        root.append(block3);
+      });
+      expect(testEnv.outerHTML).toBe(
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">A</span></p><p><span data-outline-text="true">B</span></p><p><span data-outline-text="true">C</span></p></div>',
+      );
+      await editor.update((view) => {
+        text1.insertAfter(block2);
+      });
+      expect(testEnv.outerHTML).toBe(
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">A</span><p><span data-outline-text="true">B</span></p></p><p><span data-outline-text="true">C</span></p></div>',
+      );
+    });
+
+    test('OutlineNode.insertAfter() move blocks around #2', async () => {
+      const {editor} = testEnv;
+      let block1, block2, block3, text1, text2, text3;
+      await editor.update((view) => {
+        const root = view.getRoot();
+        root.clear();
+        block1 = new ParagraphNode();
+        block2 = new ParagraphNode();
+        block3 = new ParagraphNode();
+        text1 = new TextNode('A');
+        text1.toggleUnmergeable();
+        text2 = new TextNode('B');
+        text2.toggleUnmergeable();
+        text3 = new TextNode('C');
+        text3.toggleUnmergeable();
+        block1.append(text1);
+        block2.append(text2);
+        block3.append(text3);
+        root.append(block1);
+        root.append(block2);
+        root.append(block3);
+      });
+      expect(testEnv.outerHTML).toBe(
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">A</span></p><p><span data-outline-text="true">B</span></p><p><span data-outline-text="true">C</span></p></div>',
+      );
+      await editor.update((view) => {
+        text3.insertAfter(text1);
+        text3.insertAfter(text2);
+      });
+      expect(testEnv.outerHTML).toBe(
+        '<div contenteditable="true" data-outline-editor="true"><p></p><p></p><p><span data-outline-text="true">C</span><span data-outline-text="true">B</span><span data-outline-text="true">A</span></p></div>',
+      );
+    });
+
     test('OutlineNode.insertBefore()', async () => {
       const {editor} = testEnv;
       await editor.getViewModel().read(() => {

--- a/packages/outline/src/core/OutlineBlockNode.js
+++ b/packages/outline/src/core/OutlineBlockNode.js
@@ -16,6 +16,7 @@ import {
   getNodeByKey,
   wrapInTextNodes,
   updateDirectionIfNeeded,
+  reparentNode,
 } from './OutlineNode';
 import {makeSelection, getSelection, setPointValues} from './OutlineSelection';
 import {errorOnReadOnly} from './OutlineView';
@@ -164,23 +165,24 @@ export class BlockNode extends OutlineNode {
     errorOnReadOnly();
     const writableSelf = this.getWritable();
     const writableNodeToAppend = nodeToAppend.getWritable();
+    let key = writableNodeToAppend.__key;
 
     // Remove node from previous parent
     const oldParent = writableNodeToAppend.getParent();
     if (oldParent !== null) {
       const writableParent = oldParent.getWritable();
       const children = writableParent.__children;
-      const index = children.indexOf(writableNodeToAppend.__key);
+      const index = children.indexOf(key);
       if (index > -1) {
         children.splice(index, 1);
       }
+      key = reparentNode(writableNodeToAppend);
     }
     // Set child parent to self
     writableNodeToAppend.__parent = writableSelf.__key;
     const children = writableSelf.__children;
     // Append children.
-    const newKey = writableNodeToAppend.__key;
-    children.push(newKey);
+    children.push(key);
     const flags = writableNodeToAppend.__flags;
     // Handle direction if node is directionless
     if (flags & IS_DIRECTIONLESS) {


### PR DESCRIPTION
This should fix a bug where moving around nodes between parents (re-parenting) can causes bugs with the reconcilers handling of DOM nodes. When we move an existing node into another parent, we now create a new key for the same node and update the references accordingly. This ensures we don't clash on a key inside a parent from the previous reconciliation.