### PR TITLE
Bring back selectionTransform API

### DIFF
--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -349,6 +349,10 @@ export class TextNode extends OutlineNode {
   }
 
   // Mutators
+  selectionTransform(
+    prevSelection: null | Selection,
+    nextSelection: Selection,
+  ): void {}
   setFormat(format: number): this {
     errorOnReadOnly();
     if (this.isImmutable()) {

--- a/packages/outline/src/core/OutlineView.js
+++ b/packages/outline/src/core/OutlineView.js
@@ -200,6 +200,7 @@ export function preparePendingViewUpdate(
         }
       }
     }
+    applySelectionTransforms(pendingViewModel, editor);
     if (pendingViewModel.hasDirtyNodes()) {
       applyTextTransforms(pendingViewModel, editor);
       garbageCollectDetachedNodes(pendingViewModel, editor);
@@ -263,6 +264,31 @@ function triggerTextMutationListeners(
         if (!node.isAttached()) {
           break;
         }
+      }
+    }
+  }
+}
+
+export function applySelectionTransforms(
+  nextViewModel: ViewModel,
+  editor: OutlineEditor,
+): void {
+  const prevViewModel = editor.getViewModel();
+  const prevSelection = prevViewModel._selection;
+  const nextSelection = nextViewModel._selection;
+  if (nextSelection !== null) {
+    const anchor = nextSelection.anchor;
+    const focus = nextSelection.focus;
+    let anchorNode;
+
+    if (anchor.type === 'character') {
+      anchorNode = anchor.getNode();
+      anchorNode.selectionTransform(prevSelection, nextSelection);
+    }
+    if (focus.type === 'character') {
+      const focusNode = focus.getNode();
+      if (anchorNode !== focusNode) {
+        focusNode.selectionTransform(prevSelection, nextSelection);
       }
     }
   }


### PR DESCRIPTION
Now that we have immutable nodes that are now selectable again, we need to bring back this API to handle emoticons and other emojis internally.