### PR TITLE
Clean up Selection API logic + add built-in utilities

### DIFF
--- a/packages/outline-playground/src/useMentions.js
+++ b/packages/outline-playground/src/useMentions.js
@@ -392,7 +392,7 @@ function getPossibleMentionMatch(text): MentionMatch | null {
 
 function getTextUpToAnchor(selection: Selection): string | null {
   const anchor = selection.anchor;
-  if (anchor.type !== 'character') {
+  if (anchor.type !== 'text') {
     return null;
   }
   const anchorNode = anchor.getNode();
@@ -474,7 +474,7 @@ function createMentionNodeFromSearchResult(
       return;
     }
     const anchor = selection.anchor;
-    if (anchor.type !== 'character') {
+    if (anchor.type !== 'text') {
       return;
     }
     const anchorNode = anchor.getNode();

--- a/packages/outline-playground/src/useTypeahead.js
+++ b/packages/outline-playground/src/useTypeahead.js
@@ -52,7 +52,7 @@ export default function useTypeahead(editor: OutlineEditor): void {
           if (selection !== null) {
             const anchor = selection.anchor;
             const focus = selection.focus;
-            if (anchor.type === 'character' && focus.type === 'character') {
+            if (anchor.type === 'text' && focus.type === 'text') {
               let anchorNode = anchor.getNode();
               let anchorNodeOffset = anchor.offset;
               if (anchorNode.getKey() === currentTypeaheadNode.getKey()) {

--- a/packages/outline-react/src/OutlineTreeView.js
+++ b/packages/outline-react/src/OutlineTreeView.js
@@ -268,7 +268,7 @@ function getSelectionStartEnd(node, selection): [number, number] {
   let start = -1;
   let end = -1;
   // Only one node is being selected.
-  if (anchor.type === 'character' && focus.type === 'character') {
+  if (anchor.type === 'text' && focus.type === 'text') {
     const anchorNode = anchor.getNode();
     const focusNode = focus.getNode();
     if (

--- a/packages/outline-react/src/shared/EventHandlers.js
+++ b/packages/outline-react/src/shared/EventHandlers.js
@@ -164,7 +164,7 @@ function shouldOverrideBrowserDefault(
 ): boolean {
   const anchor = selection.anchor;
   const focus = selection.focus;
-  if (anchor.type !== 'character' || focus.type !== 'character') {
+  if (anchor.type !== 'text' || focus.type !== 'text') {
     return true;
   }
   const anchorOffset = anchor.offset;
@@ -341,7 +341,7 @@ export function onKeyDownForRichText(
     } else if (isTab(event)) {
       // Handle code blocks
       const anchor = selection.anchor;
-      if (anchor.type === 'character') {
+      if (anchor.type === 'text') {
         const anchorNode = anchor.getNode();
         const parentBlock = anchorNode.getParentBlockOrThrow();
         if (parentBlock.canInsertTab()) {
@@ -541,7 +541,7 @@ export function onSelectionChange(event: Event, editor: OutlineEditor): void {
     // Update the selection textFormat
     if (selection !== null && selection.isCollapsed()) {
       const anchor = selection.anchor;
-      if (anchor.type === 'character') {
+      if (anchor.type === 'text') {
         const anchorNode = anchor.getNode();
         selection.textFormat = anchorNode.getFormat();
       }
@@ -641,8 +641,8 @@ function updateTextNodeFromDOMContent(
         const anchor = selection.anchor;
         const focus = selection.focus;
         if (
-          anchor.type === 'character' &&
-          focus.type === 'character' &&
+          anchor.type === 'text' &&
+          focus.type === 'text' &&
           anchor.key === nodeKey &&
           (node.getFormat() !== selection.textFormat ||
             shouldInsertRawTextAfterTextNode(

--- a/packages/outline-react/src/shared/useOutlineHistory.js
+++ b/packages/outline-react/src/shared/useOutlineHistory.js
@@ -70,7 +70,7 @@ function getMergeAction(
         const anchor = selection.anchor;
         const anchorKey = anchor.key;
         const prevAnchorKey = prevSelection.anchor.key;
-        if (anchorKey !== prevAnchorKey || anchor.type !== 'character') {
+        if (anchorKey !== prevAnchorKey || anchor.type !== 'text') {
           return NO_MERGE;
         }
         const anchorOffset = anchor.offset;

--- a/packages/outline/src/__tests__/unit/OutlineView.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineView.test.js
@@ -128,7 +128,7 @@ describe('OutlineView tests', () => {
         view.getRoot().append(paragraph);
       });
       expect(editor.getViewModel().stringify()).toEqual(
-        `{\"_nodeMap\":[[\"root\",{\"__type\":\"root\",\"__flags\":0,\"__key\":\"root\",\"__parent\":null,\"__children\":[\"0\"]}],[\"0\",{\"__type\":\"paragraph\",\"__flags\":0,\"__key\":\"0\",\"__parent\":\"root\",\"__children\":[\"1\"]}],[\"1\",{\"__type\":\"text\",\"__flags\":0,\"__key\":\"1\",\"__parent\":\"0\",\"__text\":\"Hello world\",\"__format\":0}]],\"_selection\":{\"anchor\":{\"key\":\"1\",\"offset\":6,"type":"character"},\"focus\":{\"key\":\"1\",\"offset\":11,"type":"character"}}}`,
+        `{\"_nodeMap\":[[\"root\",{\"__type\":\"root\",\"__flags\":0,\"__key\":\"root\",\"__parent\":null,\"__children\":[\"0\"]}],[\"0\",{\"__type\":\"paragraph\",\"__flags\":0,\"__key\":\"0\",\"__parent\":\"root\",\"__children\":[\"1\"]}],[\"1\",{\"__type\":\"text\",\"__flags\":0,\"__key\":\"1\",\"__parent\":\"0\",\"__text\":\"Hello world\",\"__format\":0}]],\"_selection\":{\"anchor\":{\"key\":\"1\",\"offset\":6,"type":"text"},\"focus\":{\"key\":\"1\",\"offset\":11,"type":"text"}}}`,
       );
       expect(editor.getViewModel().stringify(2)).toEqual(
         `{
@@ -173,12 +173,12 @@ describe('OutlineView tests', () => {
     "anchor": {
       "key": "1",
       "offset": 6,
-      "type": "character"
+      "type": "text"
     },
     "focus": {
       "key": "1",
       "offset": 11,
-      "type": "character"
+      "type": "text"
     }
   }
 }`,

--- a/packages/outline/src/core/OutlineBlockNode.js
+++ b/packages/outline/src/core/OutlineBlockNode.js
@@ -113,6 +113,15 @@ export class BlockNode extends OutlineNode {
     }
     return getNodeByKey<OutlineNode>(children[childrenLength - 1]);
   }
+  getChildAtIndex(index: number): null | OutlineNode {
+    const self = this.getLatest();
+    const children = self.__children;
+    const key = children[index];
+    if (key === undefined) {
+      return null;
+    }
+    return getNodeByKey(key);
+  }
   getTextContent(includeInert?: boolean, includeDirectionless?: false): string {
     if (
       (!includeInert && this.isInert()) ||
@@ -139,17 +148,31 @@ export class BlockNode extends OutlineNode {
 
   // Mutators
 
-  selectEnd(): Selection {
+  select(_anchorOffset?: number, _focusOffset?: number): Selection {
     errorOnReadOnly();
     const selection = getSelection();
-    const lastChild = this.getLastChild();
-    const key = lastChild === null ? this.getKey() : lastChild.getKey();
-    const type = lastChild === null ? 'start' : 'after';
+    let anchorOffset = _anchorOffset;
+    let focusOffset = _focusOffset;
+    const childrenCount = this.getChildrenSize();
+    if (anchorOffset === undefined) {
+      anchorOffset = childrenCount;
+    }
+    if (focusOffset === undefined) {
+      focusOffset = childrenCount;
+    }
+    const key = this.__key;
     if (selection === null) {
-      return makeSelection(key, null, key, null, type, type);
+      return makeSelection(
+        key,
+        anchorOffset,
+        key,
+        focusOffset,
+        'block',
+        'block',
+      );
     } else {
-      setPointValues(selection.anchor, key, null, type);
-      setPointValues(selection.focus, key, null, type);
+      setPointValues(selection.anchor, key, anchorOffset, 'block');
+      setPointValues(selection.focus, key, focusOffset, 'block');
       selection.isDirty = true;
     }
     return selection;

--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -53,13 +53,13 @@ export type ParsedNodeMap = Map<NodeKey, ParsedNode>;
 type ParsedSelection = {
   anchor: {
     key: NodeKey,
-    offset: null | number,
-    type: 'character' | 'after' | 'start',
+    offset: number,
+    type: 'text' | 'block',
   },
   focus: {
     key: NodeKey,
-    offset: null | number,
-    type: 'character' | 'after' | 'start',
+    offset: number,
+    type: 'text' | 'block',
   },
 };
 // export type NodeMapType = {root: RootNode, [key: NodeKey]: OutlineNode};
@@ -303,6 +303,14 @@ export class OutlineNode {
   getKey(): NodeKey {
     // Key is stable between copies
     return this.__key;
+  }
+  getIndexWithinParent(): number {
+    const parent = this.getLatest().__parent;
+    if (parent === null) {
+      return -1;
+    }
+    const children = parent.__children;
+    return children.indexOf(this.__key);
   }
   getParent(): BlockNode | null {
     const parent = this.getLatest().__parent;

--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -508,7 +508,7 @@ function reconcileSelection(
   let nextAnchorOffset;
   let nextFocusOffset;
 
-  if (anchor.type === 'character') {
+  if (anchor.type === 'text') {
     const nextSelectionAnchorOffset = anchor.offset;
     nextAnchorNode = getDOMTextNode(anchorDOM);
     nextAnchorOffset =
@@ -521,7 +521,7 @@ function reconcileSelection(
     // TODO
     nextAnchorOffset = 0;
   }
-  if (focus.type === 'character') {
+  if (focus.type === 'text') {
     const nextSelectionFocusOffset = focus.offset;
     nextFocusNode = getDOMTextNode(focusDOM);
     nextFocusOffset =

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -455,8 +455,8 @@ export class TextNode extends OutlineNode {
         anchorOffset,
         key,
         focusOffset,
-        'character',
-        'character',
+        'text',
+        'text',
       );
     } else {
       const compositionKey = getCompositionKey();
@@ -595,7 +595,7 @@ export class TextNode extends OutlineNode {
 
         if (
           anchor.key === key &&
-          anchor.type === 'character' &&
+          anchor.type === 'text' &&
           anchor.offset > textSize &&
           anchor.offset <= nextTextSize
         ) {
@@ -605,7 +605,7 @@ export class TextNode extends OutlineNode {
         }
         if (
           focus.key === key &&
-          focus.type === 'character' &&
+          focus.type === 'text' &&
           focus.offset > textSize &&
           focus.offset <= nextTextSize
         ) {

--- a/packages/outline/src/core/OutlineView.js
+++ b/packages/outline/src/core/OutlineView.js
@@ -56,13 +56,13 @@ export type ParsedViewModel = {
   _selection: null | {
     anchor: {
       key: string,
-      offset: null | number,
-      type: 'character' | 'after' | 'start',
+      offset: number,
+      type: 'text' | 'block',
     },
     focus: {
       key: string,
-      offset: null | number,
-      type: 'character' | 'after' | 'start',
+      offset: number,
+      type: 'text' | 'block',
     },
   },
   _nodeMap: Array<[NodeKey, ParsedNode]>,
@@ -281,11 +281,11 @@ export function applySelectionTransforms(
     const focus = nextSelection.focus;
     let anchorNode;
 
-    if (anchor.type === 'character') {
+    if (anchor.type === 'text') {
       anchorNode = anchor.getNode();
       anchorNode.selectionTransform(prevSelection, nextSelection);
     }
-    if (focus.type === 'character') {
+    if (focus.type === 'text') {
       const focusNode = focus.getNode();
       if (anchorNode !== focusNode) {
         focusNode.selectionTransform(prevSelection, nextSelection);

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
@@ -68,12 +68,12 @@ describe('OutlineSelectionHelpers tests', () => {
         const block = createParagraphWithNodes(editor, ['a', 'b', 'c']);
         root.append(block);
         setAnchorPoint(view, {
-          type: 'character',
+          type: 'text',
           offset: 0,
           key: 'a',
         });
         setFocusPoint(view, {
-          type: 'character',
+          type: 'text',
           offset: 0,
           key: 'a',
         });
@@ -97,52 +97,58 @@ describe('OutlineSelectionHelpers tests', () => {
         insertText(selection, 'Test');
         expect(view.getNodeByKey('a').getTextContent()).toBe('Testa');
         expect(selection.anchor).toEqual({
-          type: 'character',
+          type: 'text',
           offset: 4,
           key: 'a',
         });
         expect(selection.focus).toEqual({
-          type: 'character',
+          type: 'text',
           offset: 4,
           key: 'a',
         });
+
+        // insertNodes
         insertNodes(selection, [createTextNode('foo')]);
         expect(selection.anchor).toEqual({
-          type: 'character',
+          type: 'text',
           offset: 3,
           key: '2',
         });
         expect(selection.focus).toEqual({
-          type: 'character',
+          type: 'text',
           offset: 3,
           key: '2',
         });
+
+        // insertParagraph
         insertParagraph(selection);
         expect(selection.anchor).toEqual({
-          type: 'character',
+          type: 'text',
           offset: 0,
           key: '4',
         });
         expect(selection.focus).toEqual({
-          type: 'character',
+          type: 'text',
           offset: 0,
           key: '4',
         });
+
+        // insertLineBreak
         insertLineBreak(selection, true);
         expect(selection.anchor).toEqual({
-          type: 'character',
+          type: 'text',
           offset: 0,
           key: '7',
         });
         expect(selection.focus).toEqual({
-          type: 'character',
+          type: 'text',
           offset: 0,
           key: '7',
         });
       });
     });
 
-    test('Can handle a start point', () => {
+    test('Can handle a block point', () => {
       const editor = createEditor({});
 
       editor.addListener('error', (error) => {
@@ -154,13 +160,13 @@ describe('OutlineSelectionHelpers tests', () => {
         const block = createParagraphWithNodes(editor, ['a', 'b', 'c']);
         root.append(block);
         setAnchorPoint(view, {
-          type: 'start',
-          offset: null,
+          type: 'block',
+          offset: 0,
           key: block.getKey(),
         });
         setFocusPoint(view, {
-          type: 'start',
-          offset: null,
+          type: 'block',
+          offset: 0,
           key: block.getKey(),
         });
 
@@ -168,16 +174,22 @@ describe('OutlineSelectionHelpers tests', () => {
 
         // getNodes
         selection.anchor.getNode();
-        // TODO this should be an empty array
-        expect(selection.getNodes()).toEqual([
-          {
-            __children: ['a', 'b', 'c'],
-            __flags: 0,
-            __key: block.getKey(),
-            __parent: 'root',
-            __type: 'paragraph',
-          },
-        ]);
+        expect(selection.getNodes()).toEqual([block]);
+
+        // insertText
+        // insertText(selection, 'Test');
+        // const firstChild = block.getFirstChild();
+        // expect(firstChild.getTextContent()).toBe('Test');
+        // expect(selection.anchor).toEqual({
+        //   type: 'character',
+        //   offset: 4,
+        //   key: firstChild.getKey(),
+        // });
+        // expect(selection.focus).toEqual({
+        //   type: 'character',
+        //   offset: 4,
+        //   key: firstChild.getKey(),
+        // });
       });
     });
   });


### PR DESCRIPTION
This makes the Selection API work more like the DOM selection API. Plus it adds some useful methods to BlockNode and OutlineNode to make some of the handling around this simpler. Furthermore, the point type of `character` was confusing, and has now been renamed to `text` to reflect the type of node that gets returned from it.