### PR TITLE
Fix try-catch for old browsers

### DIFF
--- a/packages/outline-playground/src/useMentions.js
+++ b/packages/outline-playground/src/useMentions.js
@@ -417,7 +417,7 @@ function tryToPositionRange(match: MentionMatch, range: Range): boolean {
   try {
     range.setStart(anchorNode, startOffset);
     range.setEnd(anchorNode, endOffset);
-  } catch {
+  } catch (error) {
     return false;
   }
 

--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -560,7 +560,7 @@ function reconcileSelection(
       nextFocusNode,
       nextFocusOffset,
     );
-  } catch {
+  } catch (error) {
     // If we encounter an error, continue. This can sometimes
     // occur with FF and there's no good reason as to why it
     // should happen.

--- a/packages/outline/src/core/OutlineUtils.js
+++ b/packages/outline/src/core/OutlineUtils.js
@@ -61,7 +61,7 @@ export function isSelectionWithinEditor(
       rootElement.contains(anchorDOM) &&
       rootElement.contains(focusDOM)
     );
-  } catch {
+  } catch (error) {
     return false;
   }
 }


### PR DESCRIPTION
`catch` needs brackets on old browser (i.e. FF 55) even when we're not using the variable