### PR TITLE
Remove text node wrapping logic

### DIFF
--- a/packages/outline-playground/__tests__/e2e/Emoticons-test.js
+++ b/packages/outline-playground/__tests__/e2e/Emoticons-test.js
@@ -7,6 +7,7 @@
  */
 
 import {initializeE2E, assertHTML, assertSelection, repeat} from '../utils';
+import {moveToLineBeginning, moveToLineEnd} from '../keyboardShortcuts';
 
 describe('Emoticons', () => {
   initializeE2E((e2e) => {
@@ -17,7 +18,7 @@ describe('Emoticons', () => {
       await page.keyboard.type('This is an emoji :)');
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">This is an emoji </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">This is an emoji </span><span class="emoji happysmile" data-outline-text="true">🙂</span></p>',
       );
       await assertSelection(page, {
         anchorPath: [0, 1, 0],
@@ -76,12 +77,12 @@ describe('Emoticons', () => {
       await page.keyboard.type(':) :) <3 :(');
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph"><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 7, 0],
+        anchorPath: [0, 6, 0],
         anchorOffset: 2,
-        focusPath: [0, 7, 0],
+        focusPath: [0, 6, 0],
         focusOffset: 2,
       });
 
@@ -90,24 +91,24 @@ describe('Emoticons', () => {
       await page.keyboard.up('Shift');
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true"></span><br><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph"><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><br><br></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 10, 0],
-        anchorOffset: 0,
-        focusPath: [0, 10, 0],
-        focusOffset: 0,
+        anchorPath: [0],
+        anchorOffset: 8,
+        focusPath: [0],
+        focusOffset: 8,
       });
 
       await page.keyboard.type(':) :) <3 :(');
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true"></span><br><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph"><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><br><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 17, 0],
+        anchorPath: [0, 14, 0],
         anchorOffset: 2,
-        focusPath: [0, 17, 0],
+        focusPath: [0, 14, 0],
         focusOffset: 2,
       });
 
@@ -115,24 +116,24 @@ describe('Emoticons', () => {
       if (isRichText) {
         await assertHTML(
           page,
-          '<p class="editor-paragraph"><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true"></span><br><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true"></span></p><p class="editor-paragraph"><span data-outline-text="true"></span></p>',
+          '<p class="editor-paragraph"><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><br><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span></p><p class="editor-paragraph"><br></p>',
         );
         await assertSelection(page, {
-          anchorPath: [1, 0, 0],
+          anchorPath: [1],
           anchorOffset: 0,
-          focusPath: [1, 0, 0],
+          focusPath: [1],
           focusOffset: 0,
         });
       } else {
         await assertHTML(
           page,
-          '<p class="editor-paragraph"><span data-outline-text="true">​</span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​ </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​ </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true">​ </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true">​</span><br><span data-outline-text="true">​</span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​ </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​ </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true">​ </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true">​</span><br><span data-outline-text="true">​</span></p>',
+          '<p class="editor-paragraph"><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><br><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><br><br></p>',
         );
         await assertSelection(page, {
-          anchorPath: [0, 20, 0],
-          anchorOffset: 0,
-          focusPath: [0, 20, 0],
-          focusOffset: 0,
+          anchorPath: [0],
+          anchorOffset: 16,
+          focusPath: [0],
+          focusOffset: 16,
         });
       }
 
@@ -140,31 +141,36 @@ describe('Emoticons', () => {
       if (isRichText) {
         await assertHTML(
           page,
-          '<p class="editor-paragraph"><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true"></span><br><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true"></span></p><p class="editor-paragraph"><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true"></span></p>',
+          '<p class="editor-paragraph"><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><br><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span></p><p class="editor-paragraph"><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span></p>',
         );
         await assertSelection(page, {
-          anchorPath: [1, 7, 0],
+          anchorPath: [1, 6, 0],
           anchorOffset: 2,
-          focusPath: [1, 7, 0],
+          focusPath: [1, 6, 0],
           focusOffset: 2,
         });
       } else {
         await assertHTML(
           page,
-          '<p class="editor-paragraph"><span data-outline-text="true">​</span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​ </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​ </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true">​ </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true">​</span><br><span data-outline-text="true">​</span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​ </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​ </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true">​ </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true">​</span><br><span data-outline-text="true">​</span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​ </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​ </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true">​ </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true">​</span></p>',
+          '<p class="editor-paragraph"><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><br><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><br><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> </span><span class="emoji heart" data-outline-text="true">❤</span><span data-outline-text="true"> </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span></p>',
         );
         await assertSelection(page, {
-          anchorPath: [0, 27, 0],
+          anchorPath: [0, 22, 0],
           anchorOffset: 2,
-          focusPath: [0, 27, 0],
+          focusPath: [0, 22, 0],
           focusOffset: 2,
         });
       }
 
-      await repeat(23, async () => await page.keyboard.press('Backspace'));
+      await moveToLineBeginning(page);
+      // This should not crash on a deletion on an immutable node
+      await page.keyboard.press('Backspace');
+      await moveToLineEnd(page);
+
+      await repeat(22, async () => await page.keyboard.press('Backspace'));
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p><div class="editor-placeholder">Enter some rich text...</div>',
+        '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p>',
       );
       await assertSelection(page, {
         anchorPath: [0, 0, 0],
@@ -176,34 +182,34 @@ describe('Emoticons', () => {
       await page.keyboard.type(':):):):):)');
       await page.keyboard.press('ArrowLeft');
       await assertSelection(page, {
-        anchorPath: [0, 8, 0],
-        anchorOffset: 0,
-        focusPath: [0, 8, 0],
-        focusOffset: 0,
-      });
-
-      await page.keyboard.press('ArrowLeft');
-      await assertSelection(page, {
-        anchorPath: [0, 6, 0],
-        anchorOffset: 0,
-        focusPath: [0, 6, 0],
-        focusOffset: 0,
-      });
-
-      await page.keyboard.press('ArrowLeft');
-      await assertSelection(page, {
-        anchorPath: [0, 4, 0],
-        anchorOffset: 0,
-        focusPath: [0, 4, 0],
-        focusOffset: 0,
+        anchorPath: [0, 3, 0],
+        anchorOffset: 2,
+        focusPath: [0, 3, 0],
+        focusOffset: 2,
       });
 
       await page.keyboard.press('ArrowLeft');
       await assertSelection(page, {
         anchorPath: [0, 2, 0],
-        anchorOffset: 0,
+        anchorOffset: 2,
         focusPath: [0, 2, 0],
-        focusOffset: 0,
+        focusOffset: 2,
+      });
+
+      await page.keyboard.press('ArrowLeft');
+      await assertSelection(page, {
+        anchorPath: [0, 1, 0],
+        anchorOffset: 2,
+        focusPath: [0, 1, 0],
+        focusOffset: 2,
+      });
+
+      await page.keyboard.press('ArrowLeft');
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 2,
+        focusPath: [0, 0, 0],
+        focusOffset: 2,
       });
 
       await page.keyboard.press('ArrowLeft');

--- a/packages/outline-playground/__tests__/e2e/Images-test.js
+++ b/packages/outline-playground/__tests__/e2e/Images-test.js
@@ -6,115 +6,117 @@
  *
  */
 
-import {initializeE2E, assertHTML, assertSelection} from '../utils';
+ import {initializeE2E, assertHTML, assertSelection} from '../utils';
 
-describe('Images', () => {
-  initializeE2E((e2e) => {
-    it(`Can create a decorator and move selection around it`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await page.focus('div.editor');
-
-      await page.waitForSelector('.action-button.insert-image');
-
-      await page.click('.action-button.insert-image');
-
-      await page.waitForSelector('.editor-image img');
-
-      await assertHTML(
-        page,
-        '<p class="editor-paragraph"><span data-outline-text="true">⁠</span><span class="editor-image" data-outline-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit;"></span><span data-outline-text="true">⁠</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 0,
-      });
-
-      await page.keyboard.press('ArrowLeft');
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 0,
-        focusPath: [0, 0, 0],
-        focusOffset: 0,
-      });
-
-      await page.keyboard.press('ArrowRight');
-      await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 0,
-      });
-
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.press('Backspace');
-
-      await assertHTML(
-        page,
-        '<p class="editor-paragraph"><span data-outline-text="true">⁠<br></span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 0,
-        focusPath: [0, 0, 0],
-        focusOffset: 0,
-      });
-
-      await page.click('.action-button.insert-image');
-
-      await page.waitForSelector('.editor-image img');
-
-      await page.click('.editor-image img');
-
-      await assertHTML(
-        page,
-        '<p class="editor-paragraph"><span data-outline-text="true">⁠</span><span class="editor-image" data-outline-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit;" class="focused"><div class="image-resizer-s"></div><div class="image-resizer-e"></div><div class="image-resizer-se"></div></span><span data-outline-text="true">⁠</span></p>',
-      );
-
-      await page.keyboard.press('Backspace');
-
-      await assertHTML(
-        page,
-        '<p class="editor-paragraph"><span data-outline-text="true">⁠<br></span></p>',
-      );
-
-      await page.click('.action-button.insert-image');
-
-      await page.waitForSelector('.editor-image img');
-
-      await page.keyboard.press('ArrowLeft');
-
-      await assertHTML(
-        page,
-        '<p class="editor-paragraph"><span data-outline-text="true">⁠</span><span class="editor-image" data-outline-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit;"></span><span data-outline-text="true">⁠</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 0,
-        focusPath: [0, 0, 0],
-        focusOffset: 0,
-      });
-
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('Delete');
-
-      await assertHTML(
-        page,
-        '<p class="editor-paragraph"><span data-outline-text="true">⁠<br></span></p>',
-      );
-
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 0,
-        focusPath: [0, 0, 0],
-        focusOffset: 0,
-      });
-    });
-  });
-});
+ describe('Images', () => {
+   initializeE2E((e2e) => {
+     it(`Can create a decorator and move selection around it`, async () => {
+       const {isRichText, page} = e2e;
+ 
+       if (!isRichText) {
+         return;
+       }
+ 
+       await page.focus('div.editor');
+ 
+       await page.waitForSelector('.action-button.insert-image');
+ 
+       await page.click('.action-button.insert-image');
+ 
+       await page.waitForSelector('.editor-image img');
+ 
+       await assertHTML(
+         page,
+         '<p class="editor-paragraph"><span data-outline-text="true">⁠</span><span class="editor-image" data-outline-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit;"></span><br></p>',
+       );
+       await assertSelection(page, {
+         anchorPath: [0],
+         anchorOffset: 1,
+         focusPath: [0],
+         focusOffset: 1,
+       });
+ 
+       await page.focus('div.editor');
+       await page.keyboard.press('ArrowLeft');
+       await assertSelection(page, {
+         anchorPath: [0, 0, 0],
+         anchorOffset: 0,
+         focusPath: [0, 0, 0],
+         focusOffset: 0,
+       });
+ 
+       await page.keyboard.press('ArrowRight');
+       await assertSelection(page, {
+         anchorPath: [0],
+         anchorOffset: 1,
+         focusPath: [0],
+         focusOffset: 1,
+       });
+ 
+       await page.keyboard.press('ArrowRight');
+       await page.keyboard.press('Backspace');
+ 
+       await assertHTML(
+         page,
+         '<p class="editor-paragraph"><span data-outline-text="true">⁠<br></span></p>',
+       );
+       await assertSelection(page, {
+         anchorPath: [0, 0, 0],
+         anchorOffset: 0,
+         focusPath: [0, 0, 0],
+         focusOffset: 0,
+       });
+ 
+       await page.click('.action-button.insert-image');
+ 
+       await page.waitForSelector('.editor-image img');
+ 
+       await page.click('.editor-image img');
+ 
+       await assertHTML(
+         page,
+         '<p class="editor-paragraph"><span data-outline-text="true"></span><span class="editor-image" data-outline-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit;" class="focused"><div class="image-resizer-ne"></div><div class="image-resizer-se"></div><div class="image-resizer-sw"></div><div class="image-resizer-nw"></div></span><br></p>',
+       );
+ 
+       await page.keyboard.press('Backspace');
+ 
+       await assertHTML(
+         page,
+         '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p>',
+       );
+ 
+       await page.click('.action-button.insert-image');
+ 
+       await page.waitForSelector('.editor-image img');
+ 
+       await page.focus('div.editor');
+ 
+       await assertHTML(
+         page,
+         '<p class="editor-paragraph"><span data-outline-text="true">⁠</span><span class="editor-image" data-outline-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit;"></span><br></p>',
+       );
+       await assertSelection(page, {
+         anchorPath: [0],
+         anchorOffset: 1,
+         focusPath: [0],
+         focusOffset: 1,
+       });
+ 
+       await page.keyboard.press('ArrowLeft');
+       await page.keyboard.press('Delete');
+ 
+       await assertHTML(
+         page,
+         '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p>',
+       );
+ 
+       await assertSelection(page, {
+         anchorPath: [0, 0, 0],
+         anchorOffset: 0,
+         focusPath: [0, 0, 0],
+         focusOffset: 0,
+       });
+     });
+   });
+ });
+ 

--- a/packages/outline-playground/__tests__/e2e/Keywords-test.js
+++ b/packages/outline-playground/__tests__/e2e/Keywords-test.js
@@ -20,13 +20,13 @@ describe('Keywords', () => {
 
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠</span><span class="keyword" data-outline-text="true" style="cursor: default;">congrats</span><span data-outline-text="true">⁠</span></p>',
+        '<p class="editor-paragraph" dir="ltr"><span class="keyword" data-outline-text="true" style="cursor: default;">congrats</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 0,
+        anchorPath: [0, 0, 0],
+        anchorOffset: 8,
+        focusPath: [0, 0, 0],
+        focusOffset: 8,
       });
 
       await page.keyboard.type('c');
@@ -47,12 +47,12 @@ describe('Keywords', () => {
 
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠</span><span class="keyword" data-outline-text="true" style="cursor: default;">congrats</span><span data-outline-text="true"> c</span></p>',
+        '<p class="editor-paragraph" dir="ltr"><span class="keyword" data-outline-text="true" style="cursor: default;">congrats</span><span data-outline-text="true"> c</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 2, 0],
+        anchorPath: [0, 1, 0],
         anchorOffset: 1,
-        focusPath: [0, 2, 0],
+        focusPath: [0, 1, 0],
         focusOffset: 1,
       });
 
@@ -61,22 +61,22 @@ describe('Keywords', () => {
 
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠</span><span class="keyword" data-outline-text="true" style="cursor: default;">congrats</span><span data-outline-text="true"> </span><span class="keyword" data-outline-text="true" style="cursor: default;">congrats</span><span data-outline-text="true">⁠</span></p>',
+        '<p class="editor-paragraph" dir="ltr"><span class="keyword" data-outline-text="true" style="cursor: default;">congrats</span><span data-outline-text="true"> </span><span class="keyword" data-outline-text="true" style="cursor: default;">congrats</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 4, 0],
-        anchorOffset: 0,
-        focusPath: [0, 4, 0],
-        focusOffset: 0,
+        anchorPath: [0, 2, 0],
+        anchorOffset: 8,
+        focusPath: [0, 2, 0],
+        focusOffset: 8,
       });
 
       await repeat(8, async () => {
         await page.keyboard.press('ArrowLeft');
       });
       await assertSelection(page, {
-        anchorPath: [0, 2, 0],
+        anchorPath: [0, 1, 0],
         anchorOffset: 1,
-        focusPath: [0, 2, 0],
+        focusPath: [0, 1, 0],
         focusOffset: 1,
       });
 
@@ -97,12 +97,12 @@ describe('Keywords', () => {
 
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠</span><span class="keyword" data-outline-text="true" style="cursor: default;">congrats</span><span data-outline-text="true"> </span><span class="keyword" data-outline-text="true" style="cursor: default;">congrats</span><span data-outline-text="true">⁠</span></p>',
+        '<p class="editor-paragraph" dir="ltr"><span class="keyword" data-outline-text="true" style="cursor: default;">congrats</span><span data-outline-text="true"> </span><span class="keyword" data-outline-text="true" style="cursor: default;">congrats</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 2, 0],
+        anchorPath: [0, 1, 0],
         anchorOffset: 1,
-        focusPath: [0, 2, 0],
+        focusPath: [0, 1, 0],
         focusOffset: 1,
       });
     });

--- a/packages/outline-playground/__tests__/e2e/Mentions-test.js
+++ b/packages/outline-playground/__tests__/e2e/Mentions-test.js
@@ -38,39 +38,39 @@ describe('Mentions', () => {
       await page.keyboard.press('Enter');
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span data-outline-text="true"></span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph"><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 0,
+        anchorPath: [0, 0, 0],
+        anchorOffset: 14,
+        focusPath: [0, 0, 0],
+        focusOffset: 14,
       });
 
       await page.waitForSelector('.mention');
 
       await page.keyboard.press('ArrowLeft');
       await assertSelection(page, {
-        anchorPath: [0, 1, 0],
+        anchorPath: [0, 0, 0],
         anchorOffset: 13,
-        focusPath: [0, 1, 0],
+        focusPath: [0, 0, 0],
         focusOffset: 13,
       });
 
       await page.keyboard.press('ArrowRight');
       await assertSelection(page, {
-        anchorPath: [0, 1, 0],
+        anchorPath: [0, 0, 0],
         anchorOffset: 14,
-        focusPath: [0, 1, 0],
+        focusPath: [0, 0, 0],
         focusOffset: 14,
       });
 
       await page.keyboard.press('ArrowRight');
       await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 0,
+        anchorPath: [0, 0, 0],
+        anchorOffset: 14,
+        focusPath: [0, 0, 0],
+        focusOffset: 14,
       });
     });
 
@@ -95,29 +95,29 @@ describe('Mentions', () => {
       await page.keyboard.press('Enter');
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span data-outline-text="true"></span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph"><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 0,
+        anchorPath: [0, 0, 0],
+        anchorOffset: 14,
+        focusPath: [0, 0, 0],
+        focusOffset: 14,
       });
 
       await page.waitForSelector('.mention');
 
       await page.keyboard.press('ArrowLeft');
       await assertSelection(page, {
-        anchorPath: [0, 1, 0],
+        anchorPath: [0, 0, 0],
         anchorOffset: 13,
-        focusPath: [0, 1, 0],
+        focusPath: [0, 0, 0],
         focusOffset: 13,
       });
 
       await page.keyboard.press('Delete');
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"></span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Skywalker</span><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph" dir="ltr"><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Skywalker</span></p>',
       );
       await assertSelection(page, {
         anchorPath: [0, 0, 0],
@@ -129,12 +129,12 @@ describe('Mentions', () => {
       await page.keyboard.press('Delete');
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"><br></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
+        '<p class="editor-paragraph" dir="ltr"><br></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 0, 0],
+        anchorPath: [0],
         anchorOffset: 0,
-        focusPath: [0, 0, 0],
+        focusPath: [0],
         focusOffset: 0,
       });
     });
@@ -160,13 +160,13 @@ describe('Mentions', () => {
       await page.keyboard.press('Enter');
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span data-outline-text="true"></span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph"><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 0,
+        anchorPath: [0, 0, 0],
+        anchorOffset: 14,
+        focusPath: [0, 0, 0],
+        focusOffset: 14,
       });
 
       await page.waitForSelector('.mention');
@@ -174,24 +174,24 @@ describe('Mentions', () => {
       await page.keyboard.press('Backspace');
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"></span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke</span><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph" dir="ltr"><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 1, 0],
+        anchorPath: [0, 0, 0],
         anchorOffset: 4,
-        focusPath: [0, 1, 0],
+        focusPath: [0, 0, 0],
         focusOffset: 4,
       });
 
       await page.keyboard.press('Backspace');
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"><br></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
+        '<p class="editor-paragraph" dir="ltr"><br></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 0, 0],
+        anchorPath: [0],
         anchorOffset: 0,
-        focusPath: [0, 0, 0],
+        focusPath: [0],
         focusOffset: 0,
       });
 
@@ -269,7 +269,7 @@ describe('Mentions', () => {
       await page.waitForSelector('#mentions-typeahead ul li');
       await page.keyboard.press('Enter');
 
-      await page.waitForSelector('.mention:nth-child(2)');
+      await page.waitForSelector('.mention:nth-child(1)');
 
       await page.keyboard.type(' ');
 
@@ -278,7 +278,7 @@ describe('Mentions', () => {
       await page.waitForSelector('#mentions-typeahead ul li');
       await page.keyboard.press('Enter');
 
-      await page.waitForSelector('.mention:nth-child(3n)');
+      await page.waitForSelector('.mention:nth-child(3)');
 
       await page.keyboard.type(' ');
 
@@ -287,17 +287,17 @@ describe('Mentions', () => {
       await page.waitForSelector('#mentions-typeahead ul li');
       await page.keyboard.press('Enter');
 
-      await page.waitForSelector('.mention:nth-child(1n + 7)');
+      await page.waitForSelector('.mention:nth-child(5)');
 
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span data-outline-text="true">⁠</span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true">⁠</span></p>',
+        '<p class="editor-paragraph"><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 8, 0],
-        anchorOffset: 0,
-        focusPath: [0, 8, 0],
-        focusOffset: 0,
+        anchorPath: [0, 6, 0],
+        anchorOffset: 14,
+        focusPath: [0, 6, 0],
+        focusOffset: 14,
       });
 
       await moveToEditorBeginning(page);
@@ -314,12 +314,12 @@ describe('Mentions', () => {
       if (IS_WINDOWS && E2E_BROWSER === 'chromium') {
         await assertHTML(
           page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Skywalker </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true">⁠</span></p>',
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Skywalker </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span></p>',
         );
       } else {
         await assertHTML(
           page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"> Skywalker </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true">⁠</span></p>',
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"> Skywalker </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span></p>',
         );
       }
       await assertSelection(page, {
@@ -333,12 +333,12 @@ describe('Mentions', () => {
       if (IS_WINDOWS && E2E_BROWSER === 'chromium') {
         await assertHTML(
           page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠</span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true">⁠</span></p>',
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠</span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span></p>',
         );
       } else {
         await assertHTML(
           page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true">⁠</span></p>',
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span></p>',
         );
       }
       await assertSelection(page, {
@@ -352,12 +352,12 @@ describe('Mentions', () => {
       if (IS_WINDOWS && E2E_BROWSER === 'chromium') {
         await assertHTML(
           page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Skywalker </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true">⁠</span></p>',
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Skywalker </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span></p>',
         );
       } else {
         await assertHTML(
           page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"> Skywalker </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true">⁠</span></p>',
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"> Skywalker </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"> </span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span></p>',
         );
       }
       await assertSelection(page, {

--- a/packages/outline-playground/__tests__/e2e/Navigation-test.js
+++ b/packages/outline-playground/__tests__/e2e/Navigation-test.js
@@ -825,18 +825,18 @@ describe('Keyboard Navigation', () => {
       // type sample text
       await page.keyboard.type('123:)456 abc:):)de fg');
       await assertSelection(page, {
-        anchorPath: [0, 6, 0],
+        anchorPath: [0, 5, 0],
         anchorOffset: 5,
-        focusPath: [0, 6, 0],
+        focusPath: [0, 5, 0],
         focusOffset: 5,
       });
       // navigate through the text
       // 1 left
       await moveToPrevWord(page);
       await assertSelection(page, {
-        anchorPath: [0, 6, 0],
+        anchorPath: [0, 5, 0],
         anchorOffset: 3,
-        focusPath: [0, 6, 0],
+        focusPath: [0, 5, 0],
         focusOffset: 3,
       });
       // 2 left
@@ -850,16 +850,16 @@ describe('Keyboard Navigation', () => {
         });
       } else if (E2E_BROWSER === 'webkit') {
         await assertSelection(page, {
-          anchorPath: [0, 5, 0],
+          anchorPath: [0, 4, 0],
           anchorOffset: 2,
-          focusPath: [0, 5, 0],
+          focusPath: [0, 4, 0],
           focusOffset: 2,
         });
       } else {
         await assertSelection(page, {
-          anchorPath: [0, 5, 0],
+          anchorPath: [0, 4, 0],
           anchorOffset: 2,
-          focusPath: [0, 5, 0],
+          focusPath: [0, 4, 0],
           focusOffset: 2,
         });
       }
@@ -1020,16 +1020,16 @@ describe('Keyboard Navigation', () => {
       } else if (E2E_BROWSER === 'firefox') {
         if (IS_WINDOWS) {
           await assertSelection(page, {
-            anchorPath: [0, 6, 0],
+            anchorPath: [0, 5, 0],
             anchorOffset: 3,
-            focusPath: [0, 6, 0],
+            focusPath: [0, 5, 0],
             focusOffset: 3,
           });
         } else {
           await assertSelection(page, {
-            anchorPath: [0, 6, 0],
+            anchorPath: [0, 5, 0],
             anchorOffset: 2,
-            focusPath: [0, 6, 0],
+            focusPath: [0, 5, 0],
             focusOffset: 2,
           });
         }
@@ -1061,9 +1061,9 @@ describe('Keyboard Navigation', () => {
         });
       } else if (E2E_BROWSER === 'firefox') {
         await assertSelection(page, {
-          anchorPath: [0, 6, 0],
+          anchorPath: [0, 5, 0],
           anchorOffset: 5,
-          focusPath: [0, 6, 0],
+          focusPath: [0, 5, 0],
           focusOffset: 5,
         });
       } else if (IS_WINDOWS) {
@@ -1085,9 +1085,9 @@ describe('Keyboard Navigation', () => {
       await moveToNextWord(page);
       if (E2E_BROWSER === 'firefox') {
         await assertSelection(page, {
-          anchorPath: [0, 6, 0],
+          anchorPath: [0, 5, 0],
           anchorOffset: 5,
-          focusPath: [0, 6, 0],
+          focusPath: [0, 5, 0],
           focusOffset: 5,
         });
       } else {
@@ -1095,37 +1095,46 @@ describe('Keyboard Navigation', () => {
         await moveToNextWord(page);
         if (E2E_BROWSER === 'webkit') {
           await assertSelection(page, {
-            anchorPath: [0, 4, 0],
-            anchorOffset: 0,
-            focusPath: [0, 4, 0],
-            focusOffset: 0,
+            anchorPath: [0, 3, 0],
+            anchorOffset: 2,
+            focusPath: [0, 3, 0],
+            focusOffset: 2,
           });
         } else if (IS_WINDOWS) {
           await assertSelection(page, {
-            anchorPath: [0, 5, 0],
+            anchorPath: [0, 4, 0],
             anchorOffset: 2,
-            focusPath: [0, 5, 0],
+            focusPath: [0, 4, 0],
             focusOffset: 2,
           });
 
           // 6 right
           await moveToNextWord(page);
           await assertSelection(page, {
-            anchorPath: [0, 6, 0],
+            anchorPath: [0, 5, 0],
             anchorOffset: 3,
-            focusPath: [0, 6, 0],
+            focusPath: [0, 5, 0],
             focusOffset: 3,
           });
 
           // 7 right
           await moveToNextWord(page);
           await assertSelection(page, {
-            anchorPath: [0, 6, 0],
+            anchorPath: [0, 5, 0],
             anchorOffset: 5,
-            focusPath: [0, 6, 0],
+            focusPath: [0, 5, 0],
             focusOffset: 5,
           });
         } else {
+          await assertSelection(page, {
+            anchorPath: [0, 4, 0],
+            anchorOffset: 2,
+            focusPath: [0, 4, 0],
+            focusOffset: 2,
+          });
+
+          // 6 right
+          await moveToNextWord(page);
           await assertSelection(page, {
             anchorPath: [0, 5, 0],
             anchorOffset: 2,
@@ -1133,13 +1142,13 @@ describe('Keyboard Navigation', () => {
             focusOffset: 2,
           });
 
-          // 6 right
+          // 7 right
           await moveToNextWord(page);
           await assertSelection(page, {
-            anchorPath: [0, 6, 0],
-            anchorOffset: 2,
-            focusPath: [0, 6, 0],
-            focusOffset: 2,
+            anchorPath: [0, 5, 0],
+            anchorOffset: 5,
+            focusPath: [0, 5, 0],
+            focusOffset: 5,
           });
         }
 
@@ -1147,27 +1156,36 @@ describe('Keyboard Navigation', () => {
           // 6 right
           await moveToNextWord(page);
           await assertSelection(page, {
-            anchorPath: [0, 5, 0],
+            anchorPath: [0, 4, 0],
             anchorOffset: 2,
-            focusPath: [0, 5, 0],
+            focusPath: [0, 4, 0],
             focusOffset: 2,
           });
 
           // 7 right
           await moveToNextWord(page);
           await assertSelection(page, {
-            anchorPath: [0, 6, 0],
+            anchorPath: [0, 5, 0],
             anchorOffset: 2,
-            focusPath: [0, 6, 0],
+            focusPath: [0, 5, 0],
             focusOffset: 2,
           });
 
           // 8 right
           await moveToNextWord(page);
           await assertSelection(page, {
-            anchorPath: [0, 6, 0],
+            anchorPath: [0, 5, 0],
             anchorOffset: 5,
-            focusPath: [0, 6, 0],
+            focusPath: [0, 5, 0],
+            focusOffset: 5,
+          });
+
+          // 9 right
+          await moveToNextWord(page);
+          await assertSelection(page, {
+            anchorPath: [0, 5, 0],
+            anchorOffset: 5,
+            focusPath: [0, 5, 0],
             focusOffset: 5,
           });
         }

--- a/packages/outline-playground/__tests__/e2e/Placeholder-test.js
+++ b/packages/outline-playground/__tests__/e2e/Placeholder-test.js
@@ -23,7 +23,7 @@ describe('Placeholder', () => {
 
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p><div contenteditable="false" class="editor-placeholder">Enter some rich text...</div>',
+        '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p>',
       );
       await assertSelection(page, {
         anchorPath: [0, 0, 0],

--- a/packages/outline-playground/__tests__/e2e/TextEntry-test.js
+++ b/packages/outline-playground/__tests__/e2e/TextEntry-test.js
@@ -24,723 +24,721 @@ import {
 
 describe('TextEntry', () => {
   initializeE2E((e2e) => {
-    describe(`Rich text`, () => {
-      it(`Can type 'Hello Outline' in the editor`, async () => {
-        const {page} = e2e;
+    it(`Can type 'Hello Outline' in the editor`, async () => {
+      const {page} = e2e;
 
-        const targetText = 'Hello Outline';
-        await page.focus('div.editor');
-        await page.keyboard.type(targetText);
-        await assertHTML(
-          page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello Outline</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: targetText.length,
-          focusPath: [0, 0, 0],
-          focusOffset: targetText.length,
-        });
+      const targetText = 'Hello Outline';
+      await page.focus('div.editor');
+      await page.keyboard.type(targetText);
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello Outline</span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: targetText.length,
+        focusPath: [0, 0, 0],
+        focusOffset: targetText.length,
       });
+    });
 
-      it(`Can type 'Hello Outline' in the editor and replace it with foo`, async () => {
-        const {page} = e2e;
+    it(`Can type 'Hello Outline' in the editor and replace it with foo`, async () => {
+      const {page} = e2e;
 
-        const targetText = 'Hello Outline';
-        await page.focus('div.editor');
-        await page.keyboard.type(targetText);
+      const targetText = 'Hello Outline';
+      await page.focus('div.editor');
+      await page.keyboard.type(targetText);
 
-        // Select all the text
-        await keyDownCtrlOrMeta(page);
-        await page.keyboard.press('a');
-        await keyUpCtrlOrMeta(page);
+      // Select all the text
+      await keyDownCtrlOrMeta(page);
+      await page.keyboard.press('a');
+      await keyUpCtrlOrMeta(page);
 
-        await page.keyboard.type('Foo');
+      await page.keyboard.type('Foo');
 
-        await assertHTML(
-          page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Foo</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: 3,
-          focusPath: [0, 0, 0],
-          focusOffset: 3,
-        });
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Foo</span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 3,
+        focusPath: [0, 0, 0],
+        focusOffset: 3,
       });
+    });
 
-      it('Paragraphed text entry and selection', async () => {
-        const {isRichText, page} = e2e;
+    it('Paragraphed text entry and selection', async () => {
+      const {isRichText, page} = e2e;
 
-        await page.focus('div.editor');
-        await page.keyboard.type('Hello World.');
-        await page.keyboard.press('Enter');
-        await page.keyboard.type('This is another block.');
-        await page.keyboard.down('Shift');
-        await repeat(6, async () => await page.keyboard.down('ArrowLeft'));
-        if (isRichText) {
-          await assertSelection(page, {
-            anchorPath: [1, 0, 0],
-            anchorOffset: 22,
-            focusPath: [1, 0, 0],
-            focusOffset: 16,
-          });
-        } else {
-          await assertSelection(page, {
-            anchorPath: [0, 2, 0],
-            anchorOffset: 22,
-            focusPath: [0, 2, 0],
-            focusOffset: 16,
-          });
-        }
-
-        await page.keyboard.up('Shift');
-        await page.keyboard.type('paragraph.');
-        await page.keyboard.type(' :)');
-
-        if (isRichText) {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello World.</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">This is another paragraph. </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"></span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [1, 1, 0],
-            anchorOffset: 2,
-            focusPath: [1, 1, 0],
-            focusOffset: 2,
-          });
-        } else {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠Hello World.</span><br><span data-outline-text="true">⁠This is another paragraph. </span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [0, 3, 0],
-            anchorOffset: 2,
-            focusPath: [0, 3, 0],
-            focusOffset: 2,
-          });
-        }
-      });
-
-      it(`Can delete characters after they're typed`, async () => {
-        const {page} = e2e;
-
-        await page.focus('div.editor');
-        const text = 'Delete some of these characters.';
-        const backspacedText = 'Delete some of these characte';
-        await page.keyboard.type(text);
-        await page.keyboard.press('Backspace');
-        await page.keyboard.press('Backspace');
-        await page.keyboard.press('Backspace');
-
-        await assertHTML(
-          page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Delete some of these characte</span></p>',
-        );
+      await page.focus('div.editor');
+      await page.keyboard.type('Hello World.');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('This is another block.');
+      await page.keyboard.down('Shift');
+      await repeat(6, async () => await page.keyboard.down('ArrowLeft'));
+      if (isRichText) {
         await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: backspacedText.length,
-          focusPath: [0, 0, 0],
-          focusOffset: backspacedText.length,
+          anchorPath: [1, 0, 0],
+          anchorOffset: 22,
+          focusPath: [1, 0, 0],
+          focusOffset: 16,
         });
-      });
-
-      it(`Can type characters, and select and replace a part`, async () => {
-        const {page} = e2e;
-
-        await page.focus('div.editor');
-        const text = 'Hello foobar.';
-        await page.keyboard.type(text);
-        await repeat(7, async () => await page.keyboard.down('ArrowLeft'));
-        await page.keyboard.down('Shift');
-        await repeat(3, async () => await page.keyboard.down('ArrowRight'));
-        await page.keyboard.up('Shift');
-        await page.keyboard.type('lol');
-
-        await assertHTML(
-          page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello lolbar.</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: 9,
-          focusPath: [0, 0, 0],
-          focusOffset: 9,
-        });
-      });
-
-      it(`Can select and delete a word`, async () => {
-        const {page} = e2e;
-
-        await page.focus('div.editor');
-        const text = 'Delete some of these characters.';
-        const backspacedText = 'Delete some of these ';
-        await page.keyboard.type(text);
-        await keyDownCtrlOrAlt(page);
-        await page.keyboard.down('Shift');
-        await page.keyboard.press('ArrowLeft');
-        // Chrome stops words on punctuation, so we need to trigger
-        // the left arrow key one more time.
-        if (E2E_BROWSER === 'chromium') {
-          await page.keyboard.press('ArrowLeft');
-        }
-        await page.keyboard.up('Shift');
-        await keyUpCtrlOrAlt(page);
-        // Ensure the selection is now covering the whole word and period.
-        await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: text.length,
-          focusPath: [0, 0, 0],
-          focusOffset: backspacedText.length,
-        });
-
-        await page.keyboard.press('Backspace');
-
-        await assertHTML(
-          page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Delete some of these </span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: backspacedText.length,
-          focusPath: [0, 0, 0],
-          focusOffset: backspacedText.length,
-        });
-      });
-
-      it('First paragraph backspace handling', async () => {
-        const {isRichText, page} = e2e;
-
-        await page.focus('div.editor');
-
-        // Add some trimmable text
-        await page.keyboard.type('  ');
-
-        // Add paragraph
-        await page.keyboard.press('Enter');
-
-        if (isRichText) {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph"><span data-outline-text="true">  </span></p><p class="editor-paragraph"><span data-outline-text="true"><br></span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [1],
-            anchorOffset: 0,
-            focusPath: [1],
-            focusOffset: 0,
-          });
-        } else {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph"><span data-outline-text="true">  </span><br><span data-outline-text="true"></span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [0, 2, 0],
-            anchorOffset: 0,
-            focusPath: [0, 2, 0],
-            focusOffset: 0,
-          });
-        }
-
-        // Move to previous paragraph and press backspace
-        await page.keyboard.press('ArrowUp');
-        await page.keyboard.press('Backspace');
-
-        if (isRichText) {
-          await assertHTML(page, '<p class="editor-paragraph"><br></p>');
-          await assertSelection(page, {
-            anchorPath: [0],
-            anchorOffset: 0,
-            focusPath: [0],
-            focusOffset: 0,
-          });
-        } else {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph"><span data-outline-text="true">  </span><br><span data-outline-text="true"></span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [0, 0, 0],
-            anchorOffset: 0,
-            focusPath: [0, 0, 0],
-            focusOffset: 0,
-          });
-        }
-      });
-
-      it('Empty paragraph and new line node selection', async () => {
-        const {isRichText, page} = e2e;
-
-        await page.focus('div.editor');
-
-        // Add paragraph
-        await page.keyboard.press('Enter');
-        if (isRichText) {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p><p class="editor-paragraph"><span data-outline-text="true"><br></span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [1, 0, 0],
-            anchorOffset: 0,
-            focusPath: [1, 0, 0],
-            focusOffset: 0,
-          });
-        } else {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph"><span data-outline-text="true">​</span><br><span data-outline-text="true">​</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [0, 2, 0],
-            anchorOffset: 0,
-            focusPath: [0, 2, 0],
-            focusOffset: 0,
-          });
-        }
-
-        await page.keyboard.press('ArrowLeft');
-        await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: 0,
-          focusPath: [0, 0, 0],
-          focusOffset: 0,
-        });
-
-        await page.keyboard.press('ArrowRight');
-        if (isRichText) {
-          await assertSelection(page, {
-            anchorPath: [1, 0, 0],
-            anchorOffset: 0,
-            focusPath: [1, 0, 0],
-            focusOffset: 0,
-          });
-        } else {
-          await assertSelection(page, {
-            anchorPath: [0, 2, 0],
-            anchorOffset: 0,
-            focusPath: [0, 2, 0],
-            focusOffset: 0,
-          });
-        }
-
-        await page.keyboard.press('ArrowLeft');
-        await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: 0,
-          focusPath: [0, 0, 0],
-          focusOffset: 0,
-        });
-
-        // Remove paragraph
-        await page.keyboard.press('Delete');
-        await assertHTML(
-          page,
-          '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p><div contenteditable="false" data-outline-text="true" class="editor-placeholder">Enter some rich text...</div>',
-        );
-        await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: 0,
-          focusPath: [0, 0, 0],
-          focusOffset: 0,
-        });
-
-        // Add line break
-        await page.keyboard.down('Shift');
-        await page.keyboard.press('Enter');
-        await page.keyboard.up('Shift');
-        await assertHTML(
-          page,
-          '<p class="editor-paragraph"><span data-outline-text="true"></span><br><span data-outline-text="true"></span></p>',
-        );
+      } else {
         await assertSelection(page, {
           anchorPath: [0, 2, 0],
-          anchorOffset: 0,
+          anchorOffset: 22,
           focusPath: [0, 2, 0],
-          focusOffset: 0,
+          focusOffset: 16,
         });
+      }
 
+      await page.keyboard.up('Shift');
+      await page.keyboard.type('paragraph.');
+      await page.keyboard.type(' :)');
+
+      if (isRichText) {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello World.</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">This is another paragraph. </span><span class="emoji happysmile" data-outline-text="true">🙂</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [1, 1, 0],
+          anchorOffset: 2,
+          focusPath: [1, 1, 0],
+          focusOffset: 2,
+        });
+      } else {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠Hello World.</span><br><span data-outline-text="true">⁠This is another paragraph. </span><span class="emoji happysmile" data-outline-text="true">🙂</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 3, 0],
+          anchorOffset: 2,
+          focusPath: [0, 3, 0],
+          focusOffset: 2,
+        });
+      }
+    });
+
+    it(`Can delete characters after they're typed`, async () => {
+      const {page} = e2e;
+
+      await page.focus('div.editor');
+      const text = 'Delete some of these characters.';
+      const backspacedText = 'Delete some of these characte';
+      await page.keyboard.type(text);
+      await page.keyboard.press('Backspace');
+      await page.keyboard.press('Backspace');
+      await page.keyboard.press('Backspace');
+
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Delete some of these characte</span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: backspacedText.length,
+        focusPath: [0, 0, 0],
+        focusOffset: backspacedText.length,
+      });
+    });
+
+    it(`Can type characters, and select and replace a part`, async () => {
+      const {page} = e2e;
+
+      await page.focus('div.editor');
+      const text = 'Hello foobar.';
+      await page.keyboard.type(text);
+      await repeat(7, async () => await page.keyboard.down('ArrowLeft'));
+      await page.keyboard.down('Shift');
+      await repeat(3, async () => await page.keyboard.down('ArrowRight'));
+      await page.keyboard.up('Shift');
+      await page.keyboard.type('lol');
+
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello lolbar.</span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 9,
+        focusPath: [0, 0, 0],
+        focusOffset: 9,
+      });
+    });
+
+    it(`Can select and delete a word`, async () => {
+      const {page} = e2e;
+
+      await page.focus('div.editor');
+      const text = 'Delete some of these characters.';
+      const backspacedText = 'Delete some of these ';
+      await page.keyboard.type(text);
+      await keyDownCtrlOrAlt(page);
+      await page.keyboard.down('Shift');
+      await page.keyboard.press('ArrowLeft');
+      // Chrome stops words on punctuation, so we need to trigger
+      // the left arrow key one more time.
+      if (E2E_BROWSER === 'chromium') {
         await page.keyboard.press('ArrowLeft');
-        await assertHTML(
-          page,
-          '<p class="editor-paragraph"><span data-outline-text="true"></span><br><span data-outline-text="true"></span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: 0,
-          focusPath: [0, 0, 0],
-          focusOffset: 0,
-        });
-
-        // Remove line break
-        await page.keyboard.press('Delete');
-        await assertHTML(
-          page,
-          '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p><div contenteditable="false" data-outline-text="true" class="editor-placeholder">Enter some rich text...</div>',
-        );
-        await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: 0,
-          focusPath: [0, 0, 0],
-          focusOffset: 0,
-        });
+      }
+      await page.keyboard.up('Shift');
+      await keyUpCtrlOrAlt(page);
+      // Ensure the selection is now covering the whole word and period.
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: text.length,
+        focusPath: [0, 0, 0],
+        focusOffset: backspacedText.length,
       });
 
-      it('Handles Arabic characters with diacritics', async () => {
-        const {page} = e2e;
+      await page.keyboard.press('Backspace');
 
-        await page.focus('div.editor');
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Delete some of these </span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: backspacedText.length,
+        focusPath: [0, 0, 0],
+        focusOffset: backspacedText.length,
+      });
+    });
 
-        await page.keyboard.type('هَ');
+    it('First paragraph backspace handling', async () => {
+      const {isRichText, page} = e2e;
+
+      await page.focus('div.editor');
+
+      // Add some trimmable text
+      await page.keyboard.type('  ');
+
+      // Add paragraph
+      await page.keyboard.press('Enter');
+
+      if (isRichText) {
         await assertHTML(
           page,
-          '<p class="editor-paragraph" dir="rtl"><span data-outline-text="true">هَ</span></p>',
+          '<p class="editor-paragraph"><span data-outline-text="true">  </span></p><p class="editor-paragraph"><br></p>',
         );
         await assertSelection(page, {
-          anchorPath: [0, 0, 0],
+          anchorPath: [1],
+          anchorOffset: 0,
+          focusPath: [1],
+          focusOffset: 0,
+        });
+      } else {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph"><span data-outline-text="true">  </span><br><br></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0],
           anchorOffset: 2,
-          focusPath: [0, 0, 0],
+          focusPath: [0],
           focusOffset: 2,
         });
+      }
 
-        await page.keyboard.press('Backspace');
-        await assertHTML(
-          page,
-          '<p class="editor-paragraph" dir="rtl"><span data-outline-text="true">ه</span></p>',
-        );
+      // Move to previous paragraph and press backspace
+      await page.keyboard.press('ArrowUp');
+      await page.keyboard.press('Backspace');
+
+      if (isRichText) {
+        await assertHTML(page, '<p class="editor-paragraph"><br></p>');
         await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: 1,
-          focusPath: [0, 0, 0],
-          focusOffset: 1,
+          anchorPath: [0],
+          anchorOffset: 0,
+          focusPath: [0],
+          focusOffset: 0,
         });
-
-        await page.keyboard.press('Backspace');
-
+      } else {
         await assertHTML(
           page,
-          '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p>',
+          '<p class="editor-paragraph"><span data-outline-text="true">  </span><br><br></p>',
         );
-
-        await page.keyboard.type('هَ');
-        await assertHTML(
-          page,
-          '<p class="editor-paragraph" dir="rtl"><span data-outline-text="true">هَ</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: 2,
-          focusPath: [0, 0, 0],
-          focusOffset: 2,
-        });
-
-        await page.keyboard.press('ArrowRight');
         await assertSelection(page, {
           anchorPath: [0, 0, 0],
           anchorOffset: 0,
           focusPath: [0, 0, 0],
           focusOffset: 0,
         });
+      }
+    });
 
-        await page.keyboard.press('Delete');
+    it('Empty paragraph and new line node selection', async () => {
+      const {isRichText, page} = e2e;
+
+      await page.focus('div.editor');
+
+      // Add paragraph
+      await page.keyboard.press('Enter');
+      if (isRichText) {
         await assertHTML(
           page,
-          '<p class="editor-paragraph" dir="rtl"><span data-outline-text="true">ه</span></p>',
+          '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p><p class="editor-paragraph"><span data-outline-text="true"><br></span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [1, 0, 0],
+          anchorOffset: 0,
+          focusPath: [1, 0, 0],
+          focusOffset: 0,
+        });
+      } else {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph"><span data-outline-text="true">​</span><br><br></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 1,
+          focusPath: [0],
+          focusOffset: 1,
+        });
+      }
+
+      await page.keyboard.press('ArrowLeft');
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 0,
+        focusPath: [0, 0, 0],
+        focusOffset: 0,
+      });
+
+      await page.keyboard.press('ArrowRight');
+      if (isRichText) {
+        await assertSelection(page, {
+          anchorPath: [1, 0, 0],
+          anchorOffset: 0,
+          focusPath: [1, 0, 0],
+          focusOffset: 0,
+        });
+      } else {
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 1,
+          focusPath: [0],
+          focusOffset: 1,
+        });
+      }
+
+      await page.keyboard.press('ArrowLeft');
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 0,
+        focusPath: [0, 0, 0],
+        focusOffset: 0,
+      });
+
+      // Remove paragraph
+      await page.keyboard.press('Delete');
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 0,
+        focusPath: [0, 0, 0],
+        focusOffset: 0,
+      });
+
+      // Add line break
+      await page.keyboard.down('Shift');
+      await page.keyboard.press('Enter');
+      await page.keyboard.up('Shift');
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph"><span data-outline-text="true"></span><br><br></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0],
+        anchorOffset: 1,
+        focusPath: [0],
+        focusOffset: 1,
+      });
+
+      await page.keyboard.press('ArrowLeft');
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph"><span data-outline-text="true"></span><br><br></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 0,
+        focusPath: [0, 0, 0],
+        focusOffset: 0,
+      });
+
+      // Remove line break
+      await page.keyboard.press('Delete');
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 0,
+        focusPath: [0, 0, 0],
+        focusOffset: 0,
+      });
+    });
+
+    it('Handles Arabic characters with diacritics', async () => {
+      const {page} = e2e;
+
+      await page.focus('div.editor');
+
+      await page.keyboard.type('هَ');
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="rtl"><span data-outline-text="true">هَ</span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 2,
+        focusPath: [0, 0, 0],
+        focusOffset: 2,
+      });
+
+      await page.keyboard.press('Backspace');
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="rtl"><span data-outline-text="true">ه</span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 1,
+        focusPath: [0, 0, 0],
+        focusOffset: 1,
+      });
+
+      await page.keyboard.press('Backspace');
+
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph"><span data-outline-text="true"><br></span></p>',
+      );
+
+      await page.keyboard.type('هَ');
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="rtl"><span data-outline-text="true">هَ</span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 2,
+        focusPath: [0, 0, 0],
+        focusOffset: 2,
+      });
+
+      await page.keyboard.press('ArrowRight');
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 0,
+        focusPath: [0, 0, 0],
+        focusOffset: 0,
+      });
+
+      await page.keyboard.press('Delete');
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="rtl"><span data-outline-text="true">ه</span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 1,
+        focusPath: [0, 0, 0],
+        focusOffset: 1,
+      });
+    });
+
+    it('Basic copy + paste', async () => {
+      const {isRichText, page} = e2e;
+
+      await page.focus('div.editor');
+
+      // Add paragraph
+      await page.keyboard.type('Copy + pasting?');
+      await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Sounds good!');
+      if (isRichText) {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Copy + pasting?</span></p><p class="editor-paragraph" dir="ltr"><br></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Sounds good!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [2, 0, 0],
+          anchorOffset: 12,
+          focusPath: [2, 0, 0],
+          focusOffset: 12,
+        });
+      } else {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠Copy + pasting?</span><br><br><span data-outline-text="true">⁠Sounds good!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 3, 0],
+          anchorOffset: 12,
+          focusPath: [0, 3, 0],
+          focusOffset: 12,
+        });
+      }
+
+      // Select all the text
+      await keyDownCtrlOrMeta(page);
+      await page.keyboard.press('a');
+      await keyUpCtrlOrMeta(page);
+      if (isRichText) {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Copy + pasting?</span></p><p class="editor-paragraph" dir="ltr"><br></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Sounds good!</span></p>',
         );
         await assertSelection(page, {
           anchorPath: [0, 0, 0],
-          anchorOffset: 1,
-          focusPath: [0, 0, 0],
-          focusOffset: 1,
+          anchorOffset: 0,
+          focusPath: [2, 0, 0],
+          focusOffset: 12,
         });
-      });
-
-      it('Basic copy + paste', async () => {
-        const {isRichText, page} = e2e;
-
-        await page.focus('div.editor');
-
-        // Add paragraph
-        await page.keyboard.type('Copy + pasting?');
-        await page.keyboard.press('Enter');
-        await page.keyboard.press('Enter');
-        await page.keyboard.type('Sounds good!');
-        if (isRichText) {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Copy + pasting?</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true"></span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Sounds good!</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [2, 0, 0],
-            anchorOffset: 12,
-            focusPath: [2, 0, 0],
-            focusOffset: 12,
-          });
-        } else {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠Copy + pasting?</span><br><span data-outline-text="true">​</span><br><span data-outline-text="true">⁠Sounds good!</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [0, 4, 0],
-            anchorOffset: 12,
-            focusPath: [0, 4, 0],
-            focusOffset: 12,
-          });
-        }
-
-        // Select all the text
-        await keyDownCtrlOrMeta(page);
-        await page.keyboard.press('a');
-        await keyUpCtrlOrMeta(page);
-        if (isRichText) {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Copy + pasting?</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true"></span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Sounds good!</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [0, 0, 0],
-            anchorOffset: 0,
-            focusPath: [2, 0, 0],
-            focusOffset: 12,
-          });
-        } else {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠Copy + pasting?</span><br><span data-outline-text="true">​</span><br><span data-outline-text="true">⁠Sounds good!</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [0, 0, 0],
-            anchorOffset: 0,
-            focusPath: [0, 4, 0],
-            focusOffset: 12,
-          });
-        }
-
-        // Copy all the text
-        const clipboard = await copyToClipboard(page);
-        if (isRichText) {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Copy + pasting?</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true"></span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Sounds good!</span></p>',
-          );
-        } else {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠Copy + pasting?</span><br><span data-outline-text="true">​</span><br><span data-outline-text="true">⁠Sounds good!</span></p>',
-          );
-        }
-
-        // Paste after
-        await page.keyboard.press('ArrowRight');
-        await pasteFromClipboard(page, clipboard);
-        if (isRichText) {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Copy + pasting?</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true"></span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Sounds good!</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [4, 0, 0],
-            anchorOffset: 12,
-            focusPath: [4, 0, 0],
-            focusOffset: 12,
-          });
-        } else {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠Copy + pasting?</span><br><span data-outline-text="true">​</span><br><span data-outline-text="true">⁠Sounds good!Copy + pasting?</span><br><span data-outline-text="true">​</span><br><span data-outline-text="true">⁠Sounds good!</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [0, 8, 0],
-            anchorOffset: 12,
-            focusPath: [0, 8, 0],
-            focusOffset: 12,
-          });
-        }
-      });
-
-      it(`Copy and paste between sections`, async () => {
-        const {isRichText, page} = e2e;
-
-        await page.focus('div.editor');
-        await page.keyboard.type('Hello world #foobar test #foobar2 when #not');
-
-        await page.keyboard.press('Enter');
-        await page.keyboard.type('Next #line of #text test #foo');
-
-        if (isRichText) {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello world </span><span class="editor-text-hashtag" data-outline-text="true">#foobar</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foobar2</span><span data-outline-text="true"> when </span><span class="editor-text-hashtag" data-outline-text="true">#not</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Next </span><span class="editor-text-hashtag" data-outline-text="true">#line</span><span data-outline-text="true"> of </span><span class="editor-text-hashtag" data-outline-text="true">#text</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foo</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [1, 5, 0],
-            anchorOffset: 4,
-            focusPath: [1, 5, 0],
-            focusOffset: 4,
-          });
-        } else {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello world </span><span class="editor-text-hashtag" data-outline-text="true">#foobar</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foobar2</span><span data-outline-text="true"> when </span><span class="editor-text-hashtag" data-outline-text="true">#not</span><br><span data-outline-text="true">Next </span><span class="editor-text-hashtag" data-outline-text="true">#line</span><span data-outline-text="true"> of </span><span class="editor-text-hashtag" data-outline-text="true">#text</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foo</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [0, 12, 0],
-            anchorOffset: 4,
-            focusPath: [0, 12, 0],
-            focusOffset: 4,
-          });
-        }
-
-        // Select all the content
-        await keyDownCtrlOrMeta(page);
-        await page.keyboard.press('a');
-        await keyUpCtrlOrMeta(page);
-
-        if (isRichText) {
-          await assertSelection(page, {
-            anchorPath: [0, 0, 0],
-            anchorOffset: 0,
-            focusPath: [1, 5, 0],
-            focusOffset: 4,
-          });
-        } else {
-          await assertSelection(page, {
-            anchorPath: [0, 0, 0],
-            anchorOffset: 0,
-            focusPath: [0, 12, 0],
-            focusOffset: 4,
-          });
-        }
-
-        // Copy all the text
-        let clipboard = await copyToClipboard(page);
-        await page.keyboard.press('Delete');
-        // Paste the content
-        await pasteFromClipboard(page, clipboard);
-
-        if (isRichText) {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello world </span><span class="editor-text-hashtag" data-outline-text="true">#foobar</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foobar2</span><span data-outline-text="true"> when </span><span class="editor-text-hashtag" data-outline-text="true">#not</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Next </span><span class="editor-text-hashtag" data-outline-text="true">#line</span><span data-outline-text="true"> of </span><span class="editor-text-hashtag" data-outline-text="true">#text</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foo</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [1, 5, 0],
-            anchorOffset: 4,
-            focusPath: [1, 5, 0],
-            focusOffset: 4,
-          });
-        } else {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello world </span><span class="editor-text-hashtag" data-outline-text="true">#foobar</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foobar2</span><span data-outline-text="true"> when </span><span class="editor-text-hashtag" data-outline-text="true">#not</span><br><span data-outline-text="true">Next </span><span class="editor-text-hashtag" data-outline-text="true">#line</span><span data-outline-text="true"> of </span><span class="editor-text-hashtag" data-outline-text="true">#text</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foo</span><span data-outline-text="true">⁠</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [0, 12, 0],
-            anchorOffset: 4,
-            focusPath: [0, 12, 0],
-            focusOffset: 4,
-          });
-        }
-
-        await moveToPrevWord(page);
-        await page.keyboard.down('Shift');
-        await page.keyboard.press('ArrowUp');
-        await moveToPrevWord(page);
-        // Once more for linux on Chromium
-        if (IS_LINUX && E2E_BROWSER === 'chromium') {
-          await moveToPrevWord(page);
-        }
-        await page.keyboard.up('Shift');
-
-        if (isRichText) {
-          await assertSelection(page, {
-            anchorPath: [1, 5, 0],
-            anchorOffset: 1,
-            focusPath: [0, 2, 0],
-            focusOffset: 1,
-          });
-        } else {
-          await assertSelection(page, {
-            anchorPath: [0, 12, 0],
-            anchorOffset: 1,
-            focusPath: [0, 2, 0],
-            focusOffset: 1,
-          });
-        }
-
-        // Copy selected text
-        clipboard = await copyToClipboard(page);
-        await page.keyboard.press('Delete');
-        // Paste the content
-        await pasteFromClipboard(page, clipboard);
-
-        if (isRichText) {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello world </span><span class="editor-text-hashtag" data-outline-text="true">#foobar</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foobar2</span><span data-outline-text="true"> when </span><span class="editor-text-hashtag" data-outline-text="true">#not</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Next </span><span class="editor-text-hashtag" data-outline-text="true">#line</span><span data-outline-text="true"> of </span><span class="editor-text-hashtag" data-outline-text="true">#text</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foo</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [1, 5, 0],
-            anchorOffset: 1,
-            focusPath: [1, 5, 0],
-            focusOffset: 1,
-          });
-        } else {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello world </span><span class="editor-text-hashtag" data-outline-text="true">#foobar</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foobar2</span><span data-outline-text="true"> when </span><span class="editor-text-hashtag" data-outline-text="true">#not</span><br><span data-outline-text="true">Next </span><span class="editor-text-hashtag" data-outline-text="true">#line</span><span data-outline-text="true"> of </span><span class="editor-text-hashtag" data-outline-text="true">#text</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foo</span></p>',
-          );
-          await assertSelection(page, {
-            anchorPath: [0, 12, 0],
-            anchorOffset: 1,
-            focusPath: [0, 12, 0],
-            focusOffset: 1,
-          });
-        }
-
-        // Select all the content
-        await keyDownCtrlOrMeta(page);
-        await page.keyboard.press('a');
-        await keyUpCtrlOrMeta(page);
-
-        if (isRichText) {
-          await assertSelection(page, {
-            anchorPath: [0, 0, 0],
-            anchorOffset: 0,
-            focusPath: [1, 6, 0],
-            focusOffset: 3,
-          });
-        } else {
-          await assertSelection(page, {
-            anchorPath: [0, 0, 0],
-            anchorOffset: 0,
-            focusPath: [0, 12, 0],
-            focusOffset: 4,
-          });
-        }
-
-        await page.keyboard.press('Delete');
-
-        if (isRichText) {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠<br></span></p>',
-          );
-        } else {
-          await assertHTML(
-            page,
-            '<p class="editor-paragraph"><span data-outline-text="true">⁠<br></span></p>',
-          );
-        }
+      } else {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠Copy + pasting?</span><br><br><span data-outline-text="true">⁠Sounds good!</span></p>',
+        );
         await assertSelection(page, {
           anchorPath: [0, 0, 0],
           anchorOffset: 0,
-          focusPath: [0, 0, 0],
-          focusOffset: 0,
+          focusPath: [0, 3, 0],
+          focusOffset: 12,
         });
+      }
+
+      // Copy all the text
+      const clipboard = await copyToClipboard(page);
+      if (isRichText) {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Copy + pasting?</span></p><p class="editor-paragraph" dir="ltr"><br></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Sounds good!</span></p>',
+        );
+      } else {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠Copy + pasting?</span><br><br><span data-outline-text="true">⁠Sounds good!</span></p>',
+        );
+      }
+
+      // Paste after
+      await page.keyboard.press('ArrowRight');
+      await pasteFromClipboard(page, clipboard);
+      if (isRichText) {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Copy + pasting?</span></p><p class="editor-paragraph" dir="ltr"><br></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Sounds good!Copy + pasting?</span></p><p class="editor-paragraph" dir="ltr"><br></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Sounds good!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [4, 0, 0],
+          anchorOffset: 12,
+          focusPath: [4, 0, 0],
+          focusOffset: 12,
+        });
+      } else {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠Copy + pasting?</span><br><br><span data-outline-text="true">⁠Sounds good!Copy + pasting?</span><br><span data-outline-text="true">​</span><br><span data-outline-text="true">⁠Sounds good!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 7, 0],
+          anchorOffset: 12,
+          focusPath: [0, 7, 0],
+          focusOffset: 12,
+        });
+      }
+    });
+
+    it(`Copy and paste between sections`, async () => {
+      const {isRichText, page} = e2e;
+
+      await page.focus('div.editor');
+      await page.keyboard.type('Hello world #foobar test #foobar2 when #not');
+
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Next #line of #text test #foo');
+
+      if (isRichText) {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello world </span><span class="editor-text-hashtag" data-outline-text="true">#foobar</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foobar2</span><span data-outline-text="true"> when </span><span class="editor-text-hashtag" data-outline-text="true">#not</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Next </span><span class="editor-text-hashtag" data-outline-text="true">#line</span><span data-outline-text="true"> of </span><span class="editor-text-hashtag" data-outline-text="true">#text</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foo</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [1, 5, 0],
+          anchorOffset: 4,
+          focusPath: [1, 5, 0],
+          focusOffset: 4,
+        });
+      } else {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello world </span><span class="editor-text-hashtag" data-outline-text="true">#foobar</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foobar2</span><span data-outline-text="true"> when </span><span class="editor-text-hashtag" data-outline-text="true">#not</span><br><span data-outline-text="true">Next </span><span class="editor-text-hashtag" data-outline-text="true">#line</span><span data-outline-text="true"> of </span><span class="editor-text-hashtag" data-outline-text="true">#text</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foo</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 12, 0],
+          anchorOffset: 4,
+          focusPath: [0, 12, 0],
+          focusOffset: 4,
+        });
+      }
+
+      // Select all the content
+      await keyDownCtrlOrMeta(page);
+      await page.keyboard.press('a');
+      await keyUpCtrlOrMeta(page);
+
+      if (isRichText) {
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 0,
+          focusPath: [1, 5, 0],
+          focusOffset: 4,
+        });
+      } else {
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 0,
+          focusPath: [0, 12, 0],
+          focusOffset: 4,
+        });
+      }
+
+      // Copy all the text
+      let clipboard = await copyToClipboard(page);
+      await page.keyboard.press('Delete');
+      // Paste the content
+      await pasteFromClipboard(page, clipboard);
+
+      if (isRichText) {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello world </span><span class="editor-text-hashtag" data-outline-text="true">#foobar</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foobar2</span><span data-outline-text="true"> when </span><span class="editor-text-hashtag" data-outline-text="true">#not</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Next </span><span class="editor-text-hashtag" data-outline-text="true">#line</span><span data-outline-text="true"> of </span><span class="editor-text-hashtag" data-outline-text="true">#text</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foo</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [1, 5, 0],
+          anchorOffset: 4,
+          focusPath: [1, 5, 0],
+          focusOffset: 4,
+        });
+      } else {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello world </span><span class="editor-text-hashtag" data-outline-text="true">#foobar</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foobar2</span><span data-outline-text="true"> when </span><span class="editor-text-hashtag" data-outline-text="true">#not</span><br><span data-outline-text="true">Next </span><span class="editor-text-hashtag" data-outline-text="true">#line</span><span data-outline-text="true"> of </span><span class="editor-text-hashtag" data-outline-text="true">#text</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foo</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 12, 0],
+          anchorOffset: 4,
+          focusPath: [0, 12, 0],
+          focusOffset: 4,
+        });
+      }
+
+      await moveToPrevWord(page);
+      await page.keyboard.down('Shift');
+      await page.keyboard.press('ArrowUp');
+      await moveToPrevWord(page);
+      // Once more for linux on Chromium
+      if (IS_LINUX && E2E_BROWSER === 'chromium') {
+        await moveToPrevWord(page);
+      }
+      await page.keyboard.up('Shift');
+
+      if (isRichText) {
+        await assertSelection(page, {
+          anchorPath: [1, 5, 0],
+          anchorOffset: 1,
+          focusPath: [0, 2, 0],
+          focusOffset: 1,
+        });
+      } else {
+        await assertSelection(page, {
+          anchorPath: [0, 12, 0],
+          anchorOffset: 1,
+          focusPath: [0, 2, 0],
+          focusOffset: 1,
+        });
+      }
+
+      // Copy selected text
+      clipboard = await copyToClipboard(page);
+      await page.keyboard.press('Delete');
+      // Paste the content
+      await pasteFromClipboard(page, clipboard);
+
+      if (isRichText) {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello world </span><span class="editor-text-hashtag" data-outline-text="true">#foobar</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foobar2</span><span data-outline-text="true"> when </span><span class="editor-text-hashtag" data-outline-text="true">#not</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Next </span><span class="editor-text-hashtag" data-outline-text="true">#line</span><span data-outline-text="true"> of </span><span class="editor-text-hashtag" data-outline-text="true">#text</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#</span><span data-outline-text="true">foo</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [1, 5, 0],
+          anchorOffset: 1,
+          focusPath: [1, 5, 0],
+          focusOffset: 1,
+        });
+      } else {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Hello world </span><span class="editor-text-hashtag" data-outline-text="true">#foobar</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foobar2</span><span data-outline-text="true"> when </span><span class="editor-text-hashtag" data-outline-text="true">#not</span><br><span data-outline-text="true">Next </span><span class="editor-text-hashtag" data-outline-text="true">#line</span><span data-outline-text="true"> of </span><span class="editor-text-hashtag" data-outline-text="true">#text</span><span data-outline-text="true"> test </span><span class="editor-text-hashtag" data-outline-text="true">#foo</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 12, 0],
+          anchorOffset: 1,
+          focusPath: [0, 12, 0],
+          focusOffset: 1,
+        });
+      }
+
+      // Select all the content
+      await keyDownCtrlOrMeta(page);
+      await page.keyboard.press('a');
+      await keyUpCtrlOrMeta(page);
+
+      if (isRichText) {
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 0,
+          focusPath: [1, 6, 0],
+          focusOffset: 3,
+        });
+      } else {
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 0,
+          focusPath: [0, 12, 0],
+          focusOffset: 4,
+        });
+      }
+
+      await page.keyboard.press('Delete');
+
+      if (isRichText) {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠<br></span></p>',
+        );
+      } else {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph"><span data-outline-text="true">⁠<br></span></p>',
+        );
+      }
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 0,
+        focusPath: [0, 0, 0],
+        focusOffset: 0,
       });
     });
   });

--- a/packages/outline-playground/__tests__/regression/379-backspace-with-mentions.js
+++ b/packages/outline-playground/__tests__/regression/379-backspace-with-mentions.js
@@ -19,20 +19,20 @@ describe('Regression test #379', () => {
       await page.keyboard.press('Enter');
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span data-outline-text="true"></span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph"></span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 0,
+        anchorPath: [0, 0, 0],
+        anchorOffset: 14,
+        focusPath: [0, 0, 0],
+        focusOffset: 14,
       });
       await moveToEditorBeginning(page);
       await page.keyboard.press('Enter');
       await page.keyboard.press('Backspace');
       await assertHTML(
         page,
-        '<p class="editor-paragraph"><span data-outline-text="true"></span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph"><span data-outline-text="true"></span><span class="mention" data-outline-text="true" style="background-color: rgba(24, 119, 232, 0.2);">Luke Skywalker</span></p>',
       );
       await assertSelection(page, {
         anchorPath: [0, 0, 0],

--- a/packages/outline-playground/__tests__/regression/399-open-line.js
+++ b/packages/outline-playground/__tests__/regression/399-open-line.js
@@ -59,24 +59,24 @@ describe('Regression test #399', () => {
       if (isRichText) {
         await assertHTML(
           page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">foo</span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true"></span><br><span data-outline-text="true">bar</span></p>',
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">foo</span></p><p class="editor-paragraph" dir="ltr"><br><span data-outline-text="true">bar</span></p>',
         );
         await assertSelection(page, {
-          anchorPath: [1, 0, 0],
+          anchorPath: [1],
           anchorOffset: 0,
-          focusPath: [1, 0, 0],
+          focusPath: [1],
           focusOffset: 0,
         });
       } else {
         await assertHTML(
           page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠foo</span><br><span data-outline-text="true">​</span><br><span data-outline-text="true">⁠bar</span></p>',
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">⁠foo</span><br><br><span data-outline-text="true">⁠bar</span></p>',
         );
         await assertSelection(page, {
-          anchorPath: [0, 2, 0],
-          anchorOffset: 0,
-          focusPath: [0, 2, 0],
-          focusOffset: 0,
+          anchorPath: [0],
+          anchorOffset: 2,
+          focusPath: [0],
+          focusOffset: 2,
         });
       }
     });

--- a/packages/outline-playground/__tests__/regression/429-swapping-emoji.js
+++ b/packages/outline-playground/__tests__/regression/429-swapping-emoji.js
@@ -17,12 +17,12 @@ describe('Regression test #429', () => {
       await page.keyboard.type(':) or :(');
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> or </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph" dir="ltr"><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> or </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span></p>',
       );
       await assertSelection(page, {
-        anchorPath: [0, 3, 0],
+        anchorPath: [0, 2, 0],
         anchorOffset: 2,
-        focusPath: [0, 3, 0],
+        focusPath: [0, 2, 0],
         focusOffset: 2,
       });
 
@@ -33,7 +33,7 @@ describe('Regression test #429', () => {
       if (isRichText) {
         await assertHTML(
           page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"><br></span></p><p class="editor-paragraph" dir="ltr"><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> or </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true"></span></p>',
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"><br></span></p><p class="editor-paragraph" dir="ltr"><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> or </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span></p>',
         );
         await assertSelection(page, {
           anchorPath: [1, 0, 0],
@@ -44,12 +44,12 @@ describe('Regression test #429', () => {
       } else {
         await assertHTML(
           page,
-          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">​</span><br><span data-outline-text="true">​</span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​ or </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true">​</span></p>',
+          '<p class="editor-paragraph" dir="ltr"><br><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true">​ or </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span></p>',
         );
         await assertSelection(page, {
-          anchorPath: [0, 2, 0],
+          anchorPath: [0, 1, 0],
           anchorOffset: 0,
-          focusPath: [0, 2, 0],
+          focusPath: [0, 1, 0],
           focusOffset: 0,
         });
       }
@@ -57,7 +57,7 @@ describe('Regression test #429', () => {
       await page.keyboard.press('Backspace');
       await assertHTML(
         page,
-        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> or </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span><span data-outline-text="true"></span></p>',
+        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"></span><span class="emoji happysmile" data-outline-text="true">🙂</span><span data-outline-text="true"> or </span><span class="emoji unhappysmile" data-outline-text="true">🙁</span></p>',
       );
       await assertSelection(page, {
         anchorPath: [0, 0, 0],

--- a/packages/outline-playground/__tests__/utils/index.js
+++ b/packages/outline-playground/__tests__/utils/index.js
@@ -126,7 +126,7 @@ export async function assertHTML(page, expectedHtml) {
   actual.innerHTML = actualHtml.replace(/[\u200B-\u200D\u2060\uFEFF]/g, '');
   const expected = document.createElement('div');
   expected.innerHTML = expectedHtml.replace(/[\u200B-\u200D\u2060\uFEFF]/g, '');
-  expect(actual.firstChild).toEqual(expected.firstChild);
+  expect(actual).toEqual(expected);
 }
 
 export async function assertSelection(page, expected) {

--- a/packages/outline/src/__tests__/unit/OutlineEditor.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor.test.js
@@ -279,8 +279,8 @@ describe('OutlineEditor tests', () => {
 
       expect(listener).toHaveBeenCalledTimes(1);
       expect(sanitizeHTML(container.innerHTML)).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true"></span>' +
-          '<span data-outline-decorator="true"><span>Hello world</span></span><span data-outline-text="true"></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p>' +
+          '<span data-outline-decorator="true"><span>Hello world</span></span><br></p></div>',
       );
     });
 

--- a/packages/outline/src/__tests__/unit/OutlineNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineNode.test.js
@@ -419,7 +419,7 @@ describe('OutlineNode tests', () => {
         paragraphNode.append(immutableTextNode);
       });
       expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">immutable</span><span data-outline-text="true"></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">immutable</span></p></div>',
       );
       await editor.getViewModel().read(() => {
         expect(textNode.isImmutable(textNode)).toBe(false);
@@ -438,7 +438,7 @@ describe('OutlineNode tests', () => {
         paragraphNode.append(segmentedTextNode);
       });
       expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">segmented</span><span data-outline-text="true"></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">segmented</span></p></div>',
       );
       await editor.getViewModel().read(() => {
         expect(textNode.isSegmented(textNode)).toBe(false);
@@ -692,7 +692,7 @@ describe('OutlineNode tests', () => {
         textNode.replace(barTextNode);
       });
       expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true"></span><span data-outline-text="true">bar</span><span data-outline-text="true"></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">bar</span></p></div>',
       );
     });
 
@@ -706,7 +706,7 @@ describe('OutlineNode tests', () => {
         textNode.replace(barTextNode);
       });
       expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true"></span><span data-outline-text="true" style="pointer-events: none; user-select: none;">bar</span><span data-outline-text="true"></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true" style="pointer-events: none; user-select: none;">bar</span></p></div>',
       );
     });
 
@@ -720,7 +720,7 @@ describe('OutlineNode tests', () => {
         textNode.replace(barTextNode);
       });
       expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true"></span><span data-outline-text="true">bar</span><span data-outline-text="true"></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">bar</span></p></div>',
       );
     });
 
@@ -771,7 +771,7 @@ describe('OutlineNode tests', () => {
         textNode.insertAfter(barTextNode);
       });
       expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">bar</span><span data-outline-text="true"></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">bar</span></p></div>',
       );
     });
 
@@ -785,7 +785,7 @@ describe('OutlineNode tests', () => {
         textNode.insertAfter(barTextNode);
       });
       expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">bar</span><span data-outline-text="true"></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">bar</span></p></div>',
       );
     });
 
@@ -799,7 +799,7 @@ describe('OutlineNode tests', () => {
         textNode.insertAfter(barTextNode);
       });
       expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true" style="pointer-events: none; user-select: none;">bar</span><span data-outline-text="true"></span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true" style="pointer-events: none; user-select: none;">bar</span></p></div>',
       );
     });
 
@@ -935,7 +935,7 @@ describe('OutlineNode tests', () => {
         textNode.insertBefore(barTextNode);
       });
       expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true"></span><span data-outline-text="true">bar</span><span data-outline-text="true">foo</span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">bar</span><span data-outline-text="true">foo</span></p></div>',
       );
     });
 
@@ -949,7 +949,7 @@ describe('OutlineNode tests', () => {
         textNode.insertBefore(barTextNode);
       });
       expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true"></span><span data-outline-text="true">bar</span><span data-outline-text="true">foo</span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">bar</span><span data-outline-text="true">foo</span></p></div>',
       );
     });
 
@@ -963,7 +963,7 @@ describe('OutlineNode tests', () => {
         textNode.insertBefore(barTextNode);
       });
       expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true"></span><span data-outline-text="true" style="pointer-events: none; user-select: none;">bar</span><span data-outline-text="true">foo</span></p></div>',
+        '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true" style="pointer-events: none; user-select: none;">bar</span><span data-outline-text="true">foo</span></p></div>',
       );
     });
 

--- a/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
@@ -389,13 +389,9 @@ describe('OutlineTextNode tests', () => {
         const children = paragraphNode.getAllTextNodes();
         expect(paragraphNode.getTextContent()).toBe('Hello World');
         expect(children[0].isSimpleText()).toBe(true);
-        expect(children[0].getTextContent()).toBe('');
-        expect(children[1].isSimpleText()).toBe(true);
-        expect(children[1].getTextContent()).toBe('Hello');
-        expect(children[2].isSimpleText()).toBe(true);
-        expect(children[2].getTextContent()).toBe(' World');
-        expect(middle).toBe(children[1]);
-        expect(next).toBe(children[2]);
+        expect(children[0].getTextContent()).toBe('Hello');
+        expect(middle).toBe(children[0]);
+        expect(next).toBe(children[1]);
       });
     });
 

--- a/packages/outline/src/core/OutlineBlockNode.js
+++ b/packages/outline/src/core/OutlineBlockNode.js
@@ -10,23 +10,15 @@
 import type {NodeKey, ParsedNode} from './OutlineNode';
 import type {Selection} from './OutlineSelection';
 
-import {isTextNode, TextNode, isLineBreakNode} from '.';
+import {isTextNode, TextNode} from '.';
 import {
   OutlineNode,
   getNodeByKey,
-  wrapInTextNodes,
   updateDirectionIfNeeded,
 } from './OutlineNode';
 import {makeSelection, getSelection, setPointValues} from './OutlineSelection';
 import {errorOnReadOnly} from './OutlineView';
-import {
-  IS_DIRECTIONLESS,
-  IS_IMMUTABLE,
-  IS_INERT,
-  IS_LTR,
-  IS_RTL,
-  IS_SEGMENTED,
-} from './OutlineConstants';
+import {IS_DIRECTIONLESS, IS_LTR, IS_RTL} from './OutlineConstants';
 
 export type ParsedBlockNode = {
   ...ParsedNode,
@@ -210,15 +202,6 @@ export class BlockNode extends OutlineNode {
     // Handle direction if node is directionless
     if (flags & IS_DIRECTIONLESS) {
       updateDirectionIfNeeded(writableNodeToAppend);
-    }
-    // Handle immutable/segmented
-    if (
-      flags & IS_IMMUTABLE ||
-      flags & IS_SEGMENTED ||
-      flags & IS_INERT ||
-      isLineBreakNode(writableNodeToAppend)
-    ) {
-      wrapInTextNodes(writableNodeToAppend);
     }
     return writableSelf;
   }

--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -10,24 +10,13 @@
 import type {OutlineEditor, EditorConfig} from './OutlineEditor';
 import type {Selection} from './OutlineSelection';
 
-import {
-  createTextNode,
-  isBlockNode,
-  isLineBreakNode,
-  isTextNode,
-  isRootNode,
-  BlockNode,
-} from '.';
+import {isBlockNode, isTextNode, isRootNode, BlockNode} from '.';
 import {
   getActiveViewModel,
   errorOnReadOnly,
   getActiveEditor,
 } from './OutlineView';
-import {
-  generateRandomKey,
-  getTextDirection,
-  isImmutableOrInertOrSegmented,
-} from './OutlineUtils';
+import {generateRandomKey, getTextDirection} from './OutlineUtils';
 import invariant from 'shared/invariant';
 import {
   IS_DIRECTIONLESS,
@@ -187,15 +176,6 @@ function replaceNode<N: OutlineNode>(
   if (flags & IS_DIRECTIONLESS) {
     updateDirectionIfNeeded(writableReplaceWith);
   }
-  // Handle immutable/segmented
-  if (
-    flags & IS_IMMUTABLE ||
-    flags & IS_SEGMENTED ||
-    flags & IS_INERT ||
-    isLineBreakNode(writableReplaceWith)
-  ) {
-    wrapInTextNodes(writableReplaceWith);
-  }
   if (isTextNode(writableReplaceWith) && anchorOffset !== undefined) {
     writableReplaceWith.select(anchorOffset, anchorOffset);
   }
@@ -215,28 +195,6 @@ export function updateDirectionIfNeeded(node: OutlineNode): void {
       topBlock.setDirection(null);
     }
   }
-}
-
-export function wrapInTextNodes<N: OutlineNode>(node: N): N {
-  const prevSibling = node.getPreviousSibling();
-  if (
-    prevSibling === null ||
-    !isTextNode(prevSibling) ||
-    isImmutableOrInertOrSegmented(prevSibling)
-  ) {
-    const text = createTextNode('');
-    node.insertBefore(text);
-  }
-  const nextSibling = node.getNextSibling();
-  if (
-    nextSibling === null ||
-    !isTextNode(nextSibling) ||
-    isImmutableOrInertOrSegmented(nextSibling)
-  ) {
-    const text = createTextNode('');
-    node.insertAfter(text);
-  }
-  return node;
 }
 
 export type NodeKey = string;
@@ -744,15 +702,6 @@ export class OutlineNode {
     if (flags & IS_DIRECTIONLESS) {
       updateDirectionIfNeeded(writableNodeToInsert);
     }
-    // Handle immutable/segmented
-    if (
-      flags & IS_IMMUTABLE ||
-      flags & IS_SEGMENTED ||
-      flags & IS_INERT ||
-      isLineBreakNode(writableNodeToInsert)
-    ) {
-      wrapInTextNodes(writableNodeToInsert);
-    }
     return writableSelf;
   }
   // TODO add support for inserting multiple nodes?
@@ -783,15 +732,6 @@ export class OutlineNode {
     // Handle direction if node is directionless
     if (flags & IS_DIRECTIONLESS) {
       updateDirectionIfNeeded(writableNodeToInsert);
-    }
-    // Handle immutable/segmented
-    if (
-      flags & IS_IMMUTABLE ||
-      flags & IS_SEGMENTED ||
-      flags & IS_INERT ||
-      isLineBreakNode(writableNodeToInsert)
-    ) {
-      wrapInTextNodes(writableNodeToInsert);
     }
     return writableSelf;
   }

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelection.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelection.test.js
@@ -350,12 +350,12 @@ describe('OutlineSelection tests', () => {
       expectedHTML:
         '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span data-outline-text="true"></span>' +
         '<span data-outline-text="true">Dominic Gannaway</span>' +
-        '<span data-outline-text="true"></span></p></div>',
+        '</p></div>',
       expectedSelection: {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 0,
+        anchorPath: [0],
+        anchorOffset: 2,
+        focusPath: [0],
+        focusOffset: 2,
       },
     },
     {
@@ -368,12 +368,12 @@ describe('OutlineSelection tests', () => {
       expectedHTML:
         '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span data-outline-text="true"></span>' +
         '<span data-outline-text="true">Dominic Gannaway</span>' +
-        '<span data-outline-text="true"></span></p></div>',
+        '</p></div>',
       expectedSelection: {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 0,
+        anchorPath: [0],
+        anchorOffset: 2,
+        focusPath: [0],
+        focusOffset: 2,
       },
     },
     {
@@ -394,12 +394,12 @@ describe('OutlineSelection tests', () => {
       expectedHTML:
         '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span data-outline-text="true"></span>' +
         '<span data-outline-text="true">Dominic Gannaway</span>' +
-        '<span data-outline-text="true"></span></p></div>',
+        '</p></div>',
       expectedSelection: {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 0,
+        anchorPath: [0],
+        anchorOffset: 2,
+        focusPath: [0],
+        focusOffset: 2,
       },
     },
     {
@@ -412,12 +412,12 @@ describe('OutlineSelection tests', () => {
       expectedHTML:
         '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph"><span data-outline-text="true"></span>' +
         '<span data-outline-text="true">Dominic Gannaway</span>' +
-        '<span data-outline-text="true"></span></p></div>',
+        '</p></div>',
       expectedSelection: {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 0,
+        anchorPath: [0],
+        anchorOffset: 2,
+        focusPath: [0],
+        focusOffset: 2,
       },
     },
     {
@@ -426,7 +426,7 @@ describe('OutlineSelection tests', () => {
       expectedHTML:
         '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph" dir="ltr"><span data-outline-text="true"></span>' +
         '<span data-outline-text="true">Dominic</span>' +
-        '<span data-outline-text="true"></span></p></div>',
+        '</p></div>',
       expectedSelection: {
         anchorPath: [0, 1, 0],
         anchorOffset: 7,
@@ -899,7 +899,6 @@ describe('OutlineSelection tests', () => {
           '<div contenteditable="true" data-outline-editor="true"><p class="editor-paragraph" dir="ltr">' +
           '<span data-outline-text="true">Hello </span>' +
           '<span data-outline-text="true">Bob</span>' +
-          '<span data-outline-text="true"></span>' +
           '</p></div>',
         expectedSelection: {
           anchorPath: [0, 1, 0],

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
@@ -147,14 +147,14 @@ describe('OutlineSelectionHelpers tests', () => {
       setupTestCase((selection, view, block) => {
         insertLineBreak(selection, true);
         expect(selection.anchor).toEqual({
-          type: 'text',
+          type: 'block',
           offset: 0,
-          key: block.getFirstChild().getKey(),
+          key: block.getKey(),
         });
         expect(selection.focus).toEqual({
-          type: 'text',
+          type: 'block',
           offset: 0,
-          key: block.getFirstChild().getKey(),
+          key: block.getKey(),
         });
       });
 
@@ -265,16 +265,15 @@ describe('OutlineSelectionHelpers tests', () => {
       // insertLineBreak
       setupTestCase((selection, view, block) => {
         insertLineBreak(selection, true);
-        const firstChild = block.getFirstChild();
         expect(selection.anchor).toEqual({
-          type: 'text',
+          type: 'block',
           offset: 0,
-          key: firstChild.getKey(),
+          key: block.getKey(),
         });
         expect(selection.focus).toEqual({
-          type: 'text',
+          type: 'block',
           offset: 0,
-          key: firstChild.getKey(),
+          key: block.getKey(),
         });
       });
 


### PR DESCRIPTION
This PR removes the logic that wraps nodes with text nodes. This is one major step closer to our goal of removing empty text nodes.