### PR TITLE
Fix getNodesBetween bug

### DIFF
--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -503,6 +503,9 @@ export class OutlineNode {
         }
         const parent = node.getParentOrThrow();
         nodes.push(parent);
+        if (parent === targetNode) {
+          break;
+        }
         let parentSibling = null;
         let ancestor = parent;
         do {
@@ -533,6 +536,9 @@ export class OutlineNode {
         }
         const parent = node.getParentOrThrow();
         nodes.push(parent);
+        if (parent === targetNode) {
+          break;
+        }
         let parentSibling = null;
         let ancestor = parent;
         do {


### PR DESCRIPTION
When getting nodes between a child and its parent, we hit an invariant. We shouldn't.