### PR TITLE
More insertText fixes

### DIFF
--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -1013,7 +1013,7 @@ export function insertText(selection: Selection, text: string): void {
     if (
       (endPoint.type === 'text' && endOffset !== 0) ||
       (endPoint.type === 'block' &&
-        lastNode.getIndexWithinParent() <= endOffset)
+        lastNode.getIndexWithinParent() < endOffset)
     ) {
       if (
         isTextNode(lastNode) &&


### PR DESCRIPTION
When we deal with boundaries on the lastNode, we need to take into account if the selection point is a block or text point.