### PR TITLE
Fix keywords logic

### DIFF
--- a/packages/outline-playground/src/useKeywords.js
+++ b/packages/outline-playground/src/useKeywords.js
@@ -37,7 +37,6 @@ export default function useKeywords(editor: OutlineEditor): void {
         if (isKeywordNode(prevSibling)) {
           convertKeywordNodeToPlainTextNode(prevSibling);
         }
-        const nextSibling = node.getNextSibling();
         if (isKeywordNode(nextSibling)) {
           convertKeywordNodeToPlainTextNode(nextSibling);
         }


### PR DESCRIPTION
If the proceeding node is a text node that starts with an invalid character, do not attempt to make a keyword.