### PR TITLE
Clear deferred callbacks before executing them

### DIFF
--- a/packages/outline/src/core/OutlineView.js
+++ b/packages/outline/src/core/OutlineView.js
@@ -428,11 +428,11 @@ export function commitPendingUpdates(
   }
   triggerListeners('update', editor, pendingViewModel, dirtyNodes);
   const deferred = editor._deferred;
+  editor._deferred = [];
   if (deferred.length !== 0) {
     for (let i = 0; i < deferred.length; i++) {
       deferred[i]();
     }
-    editor._deferred = [];
   }
 }
 


### PR DESCRIPTION
This should fix an issue for when we flush sync and re-invoke the same deferred callbacks by mistake.