### PR TITLE
Fix regression with selectNext/selectPrevious

### DIFF
--- a/packages/outline/src/core/OutlineBlockNode.js
+++ b/packages/outline/src/core/OutlineBlockNode.js
@@ -178,12 +178,20 @@ export class BlockNode extends OutlineNode {
     if (isBlockNode(firstNode) || isTextNode(firstNode)) {
       return firstNode.select(0, 0);
     }
+    // Decorator or LineBreak
+    if (firstNode !== null) {
+      return firstNode.selectPrevious();
+    }
     return this.select(0, 0);
   }
   selectEnd(): Selection {
     const lastNode = this.getLastDescendant();
     if (isBlockNode(lastNode) || isTextNode(lastNode)) {
       return lastNode.select();
+    }
+    // Decorator or LineBreak
+    if (lastNode !== null) {
+      return lastNode.selectNext();
     }
     return this.select();
   }


### PR DESCRIPTION
This method was incorrectly modified with: 

https://github.com/facebookexternal/Outline/commit/7e08b5f0dc1cdf43e845d4b3aff0a9d708e3c071#diff-b8e1f663b58752c86db5e55f14e162356ef14206744df610090855628cb19e5fL182

This puts it back to how it was before.