### PR TITLE
Ensure we use returned node from normalizeTextNodes

### DIFF
--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -45,6 +45,9 @@ function initEditor(editor: OutlineEditor): void {
     if (root.getFirstChild() === null) {
       const paragraph = createParagraphNode();
       root.append(paragraph);
+      if (view.getSelection() !== null) {
+        paragraph.select();
+      }
     }
   }, 'initEditor');
 }


### PR DESCRIPTION
This ensures consistency and fixes a bug with normalization during node creation.