### PR TITLE
Revert "Trigger update callbacks on setRootElement unmount"

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineEditor.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor.test.js
@@ -242,8 +242,7 @@ describe('OutlineEditor tests', () => {
   });
 
   it('Should be able to handle a change in root element', async () => {
-    const rootListener = jest.fn();
-    const updateListener = jest.fn();
+    const listener = jest.fn();
 
     function TestBase({changeElement}) {
       editor = React.useMemo(() => createEditor(), []);
@@ -266,11 +265,7 @@ describe('OutlineEditor tests', () => {
       }, [changeElement]);
 
       React.useEffect(() => {
-        return editor.addListener('root', rootListener);
-      }, []);
-
-      React.useEffect(() => {
-        return editor.addListener('update', updateListener);
+        editor.addListener('root', listener);
       }, []);
 
       const ref = React.useCallback((node) => {
@@ -296,8 +291,7 @@ describe('OutlineEditor tests', () => {
       reactRoot.render(<TestBase changeElement={true} />);
     });
 
-    expect(rootListener).toHaveBeenCalledTimes(3);
-    expect(updateListener).toHaveBeenCalledTimes(4);
+    expect(listener).toHaveBeenCalledTimes(3);
     expect(sanitizeHTML(container.innerHTML)).toBe(
       '<span contenteditable="true" data-outline-editor="true"><p dir="ltr"><span data-outline-text="true">Change successful</span></p></span>',
     );

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -341,9 +341,7 @@ class BaseOutlineEditor {
         nextRootElement,
         pendingViewModel,
       );
-      if (nextRootElement === null) {
-        triggerListeners('update', getSelf(this), this._viewModel, null);
-      } else {
+      if (nextRootElement !== null) {
         nextRootElement.setAttribute('data-outline-editor', 'true');
         commitPendingUpdates(getSelf(this), 'setRootElement');
       }


### PR DESCRIPTION
Reverts facebookexternal/outline#635

The reason we trigger this update was because of a strange bug internally, but after addressing the internal bug correctly it makes no sense to trigger updates when we have an empty view model, so this code is redundant.