### PR TITLE
Fix resolve node on selection getNodes

### DIFF
--- a/packages/outline/src/core/OutlineSelection.js
+++ b/packages/outline/src/core/OutlineSelection.js
@@ -148,10 +148,19 @@ function resolveBlockChild(node: BlockNode, offset: number): OutlineNode {
   if (childrenLength === 0) {
     return node;
   }
+  // For non-empty block nodes, we resolve its descendant (either a leaf node or the bottom-most block)
   if (offset >= childrenLength) {
-    return children[childrenLength - 1];
+    const resolvedNode = children[childrenLength - 1];
+    return (
+      (isBlockNode(resolvedNode) && resolvedNode.getLastDescendant()) ||
+      resolvedNode
+    );
   }
-  return children[offset];
+  const resolvedNode = children[offset];
+  return (
+    (isBlockNode(resolvedNode) && resolvedNode.getFirstDescendant()) ||
+    resolvedNode
+  );
 }
 
 export class Selection {

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelection.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelection.test.js
@@ -6,13 +6,14 @@
  *
  */
 
-import {createEditor} from 'outline';
+import {createEditor, createTextNode} from 'outline';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 
 import useOutlineRichText from 'outline-react/useOutlineRichText';
+import {createTestBlockNode} from '../../../__tests__/utils';
 
 jest.mock('shared/environment', () => {
   const originalModule = jest.requireActual('shared/environment');
@@ -891,6 +892,21 @@ describe('OutlineSelection tests', () => {
       const rootElement = editor.getRootElement();
       const expectedSelection = testUnit.expectedSelection;
       assertSelection(rootElement, expectedSelection);
+    });
+  });
+
+  test('getNodes resolves nested block nodes', async () => {
+    await editor.update((view) => {
+      const root = view.getRoot();
+      const paragraph = root.getFirstChild();
+      const blockNode = createTestBlockNode();
+      const text = createTextNode();
+      paragraph.append(blockNode);
+      blockNode.append(text);
+
+      const selectedNodes = view.getSelection().getNodes();
+      expect(selectedNodes.length).toBe(1);
+      expect(selectedNodes[0].getKey()).toBe(text.getKey());
     });
   });
 });


### PR DESCRIPTION
The existing implementation was just resolving the first BlockNode level. For nested nodes it would returned the nested BlockNode instead of the leaf.

This bug meant that backspacing on the beginning of a ParagraphNode -> BlockNode -> TextNode would get rid of the rid of the TextNode.

I'll add an additional E2E test on CharacterLimit #641 

Kudos to @trueadm for the fix