### PR TITLE
Check readonly mode during selection set

### DIFF
--- a/packages/outline/src/core/OutlineSelection.js
+++ b/packages/outline/src/core/OutlineSelection.js
@@ -12,7 +12,7 @@ import type {OutlineEditor} from './OutlineEditor';
 import type {BlockNode} from './OutlineBlockNode';
 import type {TextFormatType} from './OutlineTextNode';
 
-import {getActiveEditor, ViewModel, isReadOnly} from './OutlineView';
+import {getActiveEditor, ViewModel, isViewReadOnlyMode} from './OutlineView';
 import {getActiveViewModel} from './OutlineView';
 import {getNodeKeyFromDOM} from './OutlineReconciler';
 import {
@@ -111,7 +111,7 @@ class Point {
     this.key = key;
     this.offset = offset;
     this.type = type;
-    if (!isReadOnly() && getCompositionKey() === oldKey) {
+    if (!isViewReadOnlyMode() && getCompositionKey() === oldKey) {
       setCompositionKey(key);
     }
     if (selection !== null) {

--- a/packages/outline/src/core/OutlineView.js
+++ b/packages/outline/src/core/OutlineView.js
@@ -73,7 +73,7 @@ let isReadOnlyMode = false;
 let isProcessingTextNodeTransforms = false;
 let isAttemptingToRecoverFromReconcilerError = false;
 
-export function isReadOnly(): boolean {
+export function isViewReadOnlyMode(): boolean {
   return isReadOnlyMode;
 }
 


### PR DESCRIPTION
If we don't check, we'll actually run into an invariant for trying to access the editor.