### PR TITLE
BlockNode excludeFromCopy 

### DIFF
--- a/packages/outline-playground/src/CharacterLimit.js
+++ b/packages/outline-playground/src/CharacterLimit.js
@@ -173,9 +173,13 @@ export class OverflowNode extends BlockNode {
     return false;
   }
 
-  insertNewAfter(selection: Selection): BlockNode | null {
+  insertNewAfter(selection: Selection): null | BlockNode {
     const parent = this.getParentOrThrow();
     return parent.insertNewAfter(selection);
+  }
+
+  excludeFromCopy(): boolean {
+    return true;
   }
 }
 

--- a/packages/outline/src/core/OutlineBlockNode.js
+++ b/packages/outline/src/core/OutlineBlockNode.js
@@ -257,6 +257,9 @@ export class BlockNode extends OutlineNode {
   collapseAtStart(): boolean {
     return false;
   }
+  excludeFromCopy(): boolean {
+    return false;
+  }
 }
 
 export function isBlockNode(node: ?OutlineNode): boolean %checks {

--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -13,6 +13,7 @@ import type {
   Selection,
   TextFormatType,
   TextNode,
+  BlockNode,
   BlockPoint,
   Point,
 } from 'outline';
@@ -84,18 +85,25 @@ export function getNodesInRange(selection: Selection): {
   endOffset = isBefore ? focusOffset : anchorOffset;
 
   const nodesLength = nodes.length;
-  const sourceParent = isBlockNode(firstNode)
+  let sourceParent = isBlockNode(firstNode)
     ? firstNode
     : firstNode.getParentOrThrow();
+  while (sourceParent.excludeFromCopy()) {
+    sourceParent = sourceParent.getParentOrThrow();
+  }
   const sourceParentKey = sourceParent.getKey();
   const topLevelNodeKeys = new Set();
 
   for (let i = 0; i < nodesLength; i++) {
     let node = nodes[i];
-    if (node.isInert() || node.getKey() === sourceParentKey) {
+    if (
+      node.isInert() ||
+      node.getKey() === sourceParentKey ||
+      (isBlockNode(node) && node.excludeFromCopy())
+    ) {
       continue;
     }
-    const parent = node.getParent();
+    let parent = node.getParent();
     const nodeKey = node.getKey();
 
     if (isTextNode(node) && !node.isSegmented() && !node.isImmutable()) {
@@ -110,6 +118,25 @@ export function getNodesInRange(selection: Selection): {
       } else if (i === nodesLength - 1) {
         node = cloneWithProperties<TextNode>(node);
         node.__text = text.slice(0, endOffset);
+      }
+    }
+
+    if (parent !== null && isBlockNode(parent) && parent.excludeFromCopy()) {
+      const parentKey = parent.getKey();
+      const parentParent = parent.getParent();
+      if (parentParent !== null) {
+        const parentParentKey = parentParent.getKey();
+        node = cloneWithProperties<OutlineNode>(node);
+        node.__parent = parentParentKey;
+        const latestParentParent = nodeMap.get(parentParentKey);
+        if (isBlockNode(latestParentParent)) {
+          const parentParentCopy =
+            cloneWithProperties<BlockNode>(latestParentParent);
+          const parentKeyIndex = parentParentCopy.__children.indexOf(parentKey);
+          parentParentCopy.__children.splice(parentKeyIndex, 0, nodeKey);
+          nodeMap.set(parentParentKey, parentParentCopy);
+        }
+        parent = parentParent;
       }
     }
 
@@ -136,7 +163,7 @@ export function getNodesInRange(selection: Selection): {
             // We need to remove any children before out last source
             // parent key.
             const prevNode = node.getLatest();
-            node = prevNode.clone();
+            node = prevNode.constructor.clone(prevNode);
             node.__flags = prevNode.__flags;
             node.__parent = prevNode.__parent;
             if (isBlockNode(prevNode)) {
@@ -156,7 +183,11 @@ export function getNodesInRange(selection: Selection): {
             childrenKeys.splice(0, index + 1);
             includeTopLevelBlock = true;
           }
-          if (!nodeMap.has(currKey)) {
+          if (
+            !nodeMap.has(currKey) &&
+            !node.isInert() &&
+            !(isBlockNode(node) && node.excludeFromCopy())
+          ) {
             nodeMap.set(currKey, node);
           }
 

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
@@ -6,7 +6,9 @@
  *
  */
 
-import {createEditor, createTextNode, TextNode} from 'outline';
+import type {View} from 'outline';
+
+import {createEditor, createTextNode, TextNode, BlockNode} from 'outline';
 import {createParagraphNode} from 'outline/ParagraphNode';
 import {
   insertText,
@@ -17,6 +19,26 @@ import {
   extractSelection,
   getNodesInRange,
 } from 'outline/SelectionHelpers';
+// import {createTestBlockNode} from '../../../__tests__/utils';
+
+export class ExcludeFromCopyBlockNode extends BlockNode {
+  static clone(node: BlockNode) {
+    return new ExcludeFromCopyBlockNode(node.__key);
+  }
+  createDOM() {
+    return document.createElement('div');
+  }
+  updateDOM() {
+    return false;
+  }
+  excludeFromCopy() {
+    return true;
+  }
+}
+
+export function createExcludeFromCopyBlockNode(): ExcludeFromCopyBlockNode {
+  return new ExcludeFromCopyBlockNode();
+}
 
 function createParagraphWithNodes(editor, nodes) {
   const paragraph = createParagraphNode();
@@ -1024,6 +1046,86 @@ describe('OutlineSelectionHelpers tests', () => {
           ],
         });
       });
+    });
+  });
+
+  test('range with excludeFromCopy nodes', async () => {
+    const editor = createEditor({});
+
+    editor.addListener('error', (error) => {
+      throw error;
+    });
+
+    const element = document.createElement('div');
+
+    editor.setRootElement(element);
+
+    await editor.update((view: View) => {
+      const root = view.getRoot();
+      const paragraph = createParagraphNode(); // 0
+      const text1 = createTextNode('1'); // 1
+      const text2 = createTextNode('2'); // 2
+      const excludeBlockNode1 = createExcludeFromCopyBlockNode(); // 3
+      root.append(paragraph);
+      paragraph.append(text1);
+      paragraph.append(excludeBlockNode1);
+      paragraph.append(text2);
+
+      paragraph.select(0, 2);
+      const selectedNodes1 = getNodesInRange(view.getSelection());
+      expect(selectedNodes1.range).toEqual([text1.getKey(), text2.getKey()]);
+      expect(selectedNodes1.nodeMap[0][0]).toEqual(text1.getKey());
+      expect(selectedNodes1.nodeMap[1][0]).toEqual(text2.getKey());
+
+      const text3 = createTextNode('3'); // 4
+      excludeBlockNode1.append(text3);
+      paragraph.select(0, 2);
+      const selectedNodes2 = getNodesInRange(view.getSelection());
+      expect(selectedNodes2.range).toEqual([
+        text1.getKey(),
+        text3.getKey(),
+        text2.getKey(),
+      ]);
+      expect(selectedNodes2.nodeMap[0][0]).toEqual(text1.getKey());
+      expect(selectedNodes2.nodeMap[1][0]).toEqual(text3.getKey());
+      expect(selectedNodes2.nodeMap[2][0]).toEqual(text2.getKey());
+
+      // Disabled until getNodesInRange is fixed
+      // const testBlockNode = createTestBlockNode(); // 5
+      // const excludeBlockNode2 = createExcludeFromCopyBlockNode(); // 6
+      // const text4 = createTextNode('4'); // 7
+      // text1.insertBefore(testBlockNode);
+      // testBlockNode.append(excludeBlockNode2);
+      // excludeBlockNode2.append(text4);
+      // paragraph.select(0, 3);
+      // const selectedNodes3 = getNodesInRange(view.getSelection());
+      // expect(selectedNodes3.range).toEqual([
+      //   testBlockNode.getKey(),
+      //   text4.getKey(),
+      //   text1.getKey(),
+      //   text3.getKey(),
+      //   text2.getKey(),
+      // ]);
+      // expect(selectedNodes3.nodeMap[0][0]).toEqual(text4.getKey());
+      // expect(selectedNodes3.nodeMap[1][0]).toEqual(text1.getKey());
+      // expect(selectedNodes3.nodeMap[2][0]).toEqual(testBlockNode.getKey());
+      // expect(selectedNodes3.nodeMap[3][0]).toEqual(text1.getKey());
+      // expect(selectedNodes3.nodeMap[4][0]).toEqual(text2.getKey());
+
+      // text4.remove();
+      // paragraph.select(0, 3);
+      // const selectedNodes3 = getNodesInRange(view.getSelection());
+      // expect(selectedNodes3.range).toEqual([
+      //   testBlockNode.getKey(),
+      //   text4.getKey(),
+      //   text1.getKey(),
+      //   text3.getKey(),
+      //   text2.getKey(),
+      // ]);
+      // expect(selectedNodes3.nodeMap[1][0]).toEqual(text1.getKey());
+      // expect(selectedNodes3.nodeMap[2][0]).toEqual(testBlockNode.getKey());
+      // expect(selectedNodes3.nodeMap[3][0]).toEqual(text1.getKey());
+      // expect(selectedNodes3.nodeMap[4][0]).toEqual(text2.getKey());
     });
   });
 });


### PR DESCRIPTION
Adding the `excludeFromCopy` property to prevent a node from being added to the clipboard. In this case, the children will be copied as a part of the parent.

This diff revealed that the `sourceParent` does not properly handle block nodes. Since it's not a trivial fix I will iterate on this on a separate PR and I'm leaving part of the test case commented for now.