### PR TITLE
Make outline-react event handlers an Outline Helpers module

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -31,6 +31,7 @@ module.name_mapper='^outline/SelectionHelpers' -> '<PROJECT_ROOT>/packages/outli
 module.name_mapper='^outline/TextHelpers' -> '<PROJECT_ROOT>/packages/outline/src/helpers/OutlineTextHelpers.js'
 module.name_mapper='^outline/KeyHelpers' -> '<PROJECT_ROOT>/packages/outline/src/helpers/OutlineKeyHelpers.js'
 module.name_mapper='^outline/NodeHelpers' -> '<PROJECT_ROOT>/packages/outline/src/helpers/OutlineNodeHelpers.js'
+module.name_mapper='^outline/EventHelpers' -> '<PROJECT_ROOT>/packages/outline/src/helpers/OutlineEventHelpers.js'
 
 module.name_mapper='^outline-react/OutlineTreeView' -> '<PROJECT_ROOT>/packages/outline-react/src/OutlineTreeView.js'
 module.name_mapper='^outline-react/useOutlineEditor' -> '<PROJECT_ROOT>/packages/outline-react/src/useOutlineEditor.js'

--- a/jest.config.js
+++ b/jest.config.js
@@ -47,6 +47,8 @@ module.exports = {
           '<rootDir>/packages/outline/src/helpers/OutlineKeyHelpers.js',
         '^outline/NodeHelpers$':
           '<rootDir>/packages/outline/src/helpers/OutlineNodeHelpers.js',
+        '^outline/EventHelpers$':
+          '<rootDir>/packages/outline/src/helpers/OutlineEventHelpers.js',
         '^shared/getDOMTextNodeFromElement$':
           '<rootDir>/packages/shared/src/getDOMTextNodeFromElement.js',
         '^shared/isImmutableOrInert$':

--- a/packages/outline-playground/craco.config.js
+++ b/packages/outline-playground/craco.config.js
@@ -16,6 +16,7 @@ module.exports = {
       'outline/HistoryHelpers': 'outline/dist/OutlineHistoryHelpers',
       'outline/KeyHelpers': 'outline/dist/OutlineKeyHelpers',
       'outline/NodeHelpers': 'outline/dist/OutlineNodeHelpers',
+      'outline/EventHelpers': 'outline/dist/OutlineEventHelpers',
       // Outline React
       'outline-react/OutlineTreeView': 'outline-react/dist/OutlineTreeView',
       'outline-react/useOutlineEditor': 'outline-react/dist/useOutlineEditor',

--- a/packages/outline-react/src/useOutlineEditorEvents.js
+++ b/packages/outline-react/src/useOutlineEditorEvents.js
@@ -8,7 +8,7 @@
  */
 
 import type {OutlineEditor} from 'outline';
-import type {EventHandler} from './shared/EventHandlers';
+import type {EventHandler} from 'outline/EventHelpers';
 
 import useLayoutEffect from './shared/useLayoutEffect';
 

--- a/packages/outline-react/src/useOutlinePlainText.js
+++ b/packages/outline-react/src/useOutlinePlainText.js
@@ -32,7 +32,7 @@ import {
   onDragStartPolyfill,
   onMutation,
   onInput,
-} from './shared/EventHandlers';
+} from 'outline/EventHelpers';
 import useOutlineDragonSupport from './shared/useOutlineDragonSupport';
 import useOutlineHistory from './shared/useOutlineHistory';
 

--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -34,7 +34,7 @@ import {
   onDragStartPolyfill,
   onMutation,
   onInput,
-} from './shared/EventHandlers';
+} from 'outline/EventHelpers';
 import useOutlineDragonSupport from './shared/useOutlineDragonSupport';
 import useOutlineHistory from './shared/useOutlineHistory';
 

--- a/packages/outline/src/helpers/OutlineEventHelpers.js
+++ b/packages/outline/src/helpers/OutlineEventHelpers.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import type {
+ import type {
   OutlineEditor,
   Selection,
   OutlineNode,

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -85,8 +85,6 @@ const externals = [
   'outline',
   'Outline',
   'outline-react',
-  'outline/HistoryHelpers',
-  'Outline/HistoryHelpers',
   'react-dom',
   'ReactDOMComet',
   'react',
@@ -153,6 +151,18 @@ async function build(name, inputFile, outputFile) {
             find: isWWW ? 'Outline/TextHelpers' : 'outline/TextHelpers',
             replacement: path.resolve(
               'packages/outline/src/helpers/OutlineTextHelpers',
+            ),
+          },
+          {
+            find: isWWW ? 'Outline/HistoryHelpers' : 'outline/HistoryHelpers',
+            replacement: path.resolve(
+              'packages/outline/src/helpers/OutlineHistoryHelpers',
+            ),
+          },
+          {
+            find: isWWW ? 'Outline/EventHelpers' : 'outline/EventHelpers',
+            replacement: path.resolve(
+              'packages/outline/src/helpers/OutlineEventHelpers',
             ),
           },
         ],


### PR DESCRIPTION
It makes sense to make the event logic sharable and re-usable by others, especially as it's not React specific at all.