### PR TITLE
Fix collapseAtStart bug

### DIFF
--- a/packages/outline/src/core/OutlineBlockNode.js
+++ b/packages/outline/src/core/OutlineBlockNode.js
@@ -254,7 +254,7 @@ export class BlockNode extends OutlineNode {
     }
     return self;
   }
-  collapseAtStart(): boolean {
+  collapseAtStart(selection: Selection): boolean {
     return false;
   }
 }

--- a/packages/outline/src/extensions/OutlineListItemNode.js
+++ b/packages/outline/src/extensions/OutlineListItemNode.js
@@ -12,6 +12,7 @@ import type {
   EditorConfig,
   EditorThemeClasses,
   OutlineNode,
+  Selection,
 } from 'outline';
 import type {ParagraphNode} from 'outline/ParagraphNode';
 
@@ -111,13 +112,24 @@ export class ListItemNode extends BlockNode {
     return newBlock;
   }
 
-  collapseAtStart(): true {
+  collapseAtStart(selection: Selection): true {
     const paragraph = createParagraphNode();
     const children = this.getChildren();
     children.forEach((child) => paragraph.append(child));
     const listNode = this.getParentOrThrow();
     if (listNode.getChildrenSize() === 1) {
       listNode.replace(paragraph);
+      // If we have selection on the list item, we'll need to move it
+      // to the paragraph
+      const anchor = selection.anchor;
+      const focus = selection.focus;
+      const key = paragraph.getKey();
+      if (anchor.type === 'block' && anchor.getNode().is(this)) {
+        anchor.set(key, anchor.offset, 'block');
+      }
+      if (focus.type === 'block' && focus.getNode().is(this)) {
+        focus.set(key, focus.offset, 'block');
+      }
     } else {
       listNode.insertBefore(paragraph);
       this.remove();

--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -720,15 +720,14 @@ function deleteCharacter(selection: Selection, isBackward: boolean): void {
         }
       }
       updateCaretSelectionForUnicodeCharacter(selection, isBackward);
-    } else if (isBackward) {
+    } else if (isBackward && anchor.offset === 0) {
       // Special handling around rich text nodes
-      const anchorNode = anchor.getNode();
-      const parent = anchorNode.getParentOrThrow();
-
-      if (anchor.offset === 0) {
-        if (parent.collapseAtStart()) {
-          return;
-        }
+      const block =
+        anchor.type === 'block'
+          ? anchor.getNode()
+          : anchor.getNode().getParentOrThrow();
+      if (block.collapseAtStart(selection)) {
+        return;
       }
     }
   }


### PR DESCRIPTION
Fixes a bug that preventing the removal of a block node when calling `collapseAtStart` with block selection