### PR TITLE
BlockNode append multiple nodes at once

### DIFF
--- a/packages/outline-playground/__tests__/unit/CharacterLimit.test.js
+++ b/packages/outline-playground/__tests__/unit/CharacterLimit.test.js
@@ -53,8 +53,7 @@ describe('OutlineNodeHelpers tests', () => {
           const overflowRight = view.getNodeByKey(overflowRightKey);
           const text1 = createTextNode('1');
           const text2 = createTextNode('2');
-          overflowRight.append(text1);
-          overflowRight.append(text2);
+          overflowRight.append(text1, text2);
           text2.toggleBold(); // Prevent merging with text1
 
           overflowLeft.select();
@@ -89,11 +88,9 @@ describe('OutlineNodeHelpers tests', () => {
           const text3 = createTextNode('3');
           const text4 = createTextNode('4');
           text2Key = text2.getKey();
-          overflowLeft.append(text1);
-          overflowLeft.append(text2);
+          overflowLeft.append(text1, text2);
           text2.toggleBold(); // Prevent merging with text1
-          overflowRight.append(text3);
-          overflowRight.append(text4);
+          overflowRight.append(text3, text4);
           text4.toggleBold(); // Prevent merging with text3
 
           overflowLeft.select(1, 1);

--- a/packages/outline-playground/src/BlockControls.js
+++ b/packages/outline-playground/src/BlockControls.js
@@ -193,7 +193,7 @@ function DropdownList({
               : anchor.getNode();
           const children = block.getChildren();
           const paragraph = createHeadingNode('h2');
-          children.forEach((child) => paragraph.append(child));
+          paragraph.append(...children);
           block.replace(paragraph);
         }
       }, 'formatSmallHeading');

--- a/packages/outline-playground/src/CharacterLimit.js
+++ b/packages/outline-playground/src/CharacterLimit.js
@@ -218,9 +218,7 @@ export function mergePrevious(overflowNode: OverflowNode, view: View) {
   const previousNodeChildren = previousNode.getChildren();
   const previousNodeChildrenLength = previousNodeChildren.length;
   if (firstChild === null) {
-    for (let i = 0; i < previousNodeChildrenLength; i++) {
-      overflowNode.append(previousNodeChildren[i]);
-    }
+    overflowNode.append(...previousNodeChildren);
   } else {
     for (let i = 0; i < previousNodeChildrenLength; i++) {
       firstChild.insertBefore(previousNodeChildren[i]);

--- a/packages/outline-react/src/useOutlineAutoFormatter.js
+++ b/packages/outline-react/src/useOutlineAutoFormatter.js
@@ -43,20 +43,20 @@ function textNodeTransform(node: TextNode, view: View): void {
         updateTextNode(node, 2);
         const heading = createHeadingNode('h1');
         const children = block.getChildren();
-        children.forEach((child) => heading.append(child));
+        heading.append(...children);
         block.replace(heading);
       } else if (firstChar === '>') {
         updateTextNode(node, 2);
         const quote = createQuoteNode();
         const children = block.getChildren();
-        children.forEach((child) => quote.append(child));
+        quote.append(...children);
         block.replace(quote);
       } else if (firstChar === '-' || firstChar === '*') {
         updateTextNode(node, 2);
         const list = createListNode('ul');
         const listItem = createListItemNode();
         const children = block.getChildren();
-        children.forEach((child) => listItem.append(child));
+        listItem.append(...children);
         list.append(listItem);
         block.replace(list);
       }
@@ -65,14 +65,14 @@ function textNodeTransform(node: TextNode, view: View): void {
         updateTextNode(node, 3);
         const heading = createHeadingNode('h2');
         const children = block.getChildren();
-        children.forEach((child) => heading.append(child));
+        heading.append(...children);
         block.replace(heading);
       } else if (firstChar === '1' && secondChar === '.') {
         updateTextNode(node, 3);
         const list = createListNode('ol');
         const listItem = createListItemNode();
         const children = block.getChildren();
-        children.forEach((child) => listItem.append(child));
+        listItem.append(...children);
         list.append(listItem);
         block.replace(list);
       }

--- a/packages/outline-react/src/useOutlineNestedList.js
+++ b/packages/outline-react/src/useOutlineNestedList.js
@@ -156,9 +156,7 @@ function handleOutdent(listItemNodes: Array<ListItemNode>): void {
         const nextSiblingsListItem = createListItemNode();
         const nextSiblingsList = createListNode(tag);
         nextSiblingsListItem.append(nextSiblingsList);
-        listItemNode
-          .getNextSiblings()
-          .forEach((sibling) => nextSiblingsList.append(sibling));
+        nextSiblingsList.append(...listItemNode.getNextSiblings());
         // put the sibling nested lists on either side of the grandparent list item in the great grandparent.
         grandparentListItem.insertBefore(previousSiblingsListItem);
         grandparentListItem.insertAfter(nextSiblingsListItem);

--- a/packages/outline/src/__tests__/unit/OutlineBlockNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineBlockNode.test.js
@@ -75,9 +75,7 @@ describe('OutlineBlockNode tests', () => {
       // Some operations require a selection to exist, hence
       // we make a selection in the setup code.
       text.select(0, 0);
-      block.append(text);
-      block.append(text2);
-      block.append(text3);
+      block.append(text, text2, text3);
       view.getRoot().append(block);
     });
   }
@@ -118,12 +116,8 @@ describe('OutlineBlockNode tests', () => {
         const text3 = createTextNode('Baz');
         const text4 = createTextNode('Qux');
 
-        block.append(text);
-        block.append(innerBlock);
-        block.append(text4);
-
-        innerBlock.append(text2);
-        innerBlock.append(text3);
+        block.append(text, innerBlock, text4);
+        innerBlock.append(text2, text3);
 
         const children = block.getAllTextNodes();
         expect(children).toHaveLength(4);
@@ -132,8 +126,7 @@ describe('OutlineBlockNode tests', () => {
         const innerInnerBlock = createTestBlockNode();
         const text5 = createTextNode('More');
         const text6 = createTextNode('Stuff');
-        innerInnerBlock.append(text5);
-        innerInnerBlock.append(text6);
+        innerInnerBlock.append(text5, text6);
         innerBlock.append(innerInnerBlock);
 
         const children2 = block.getAllTextNodes();
@@ -207,12 +200,8 @@ describe('OutlineBlockNode tests', () => {
         text3.makeInert();
         const text4 = createTextNode('Qux');
 
-        block.append(text);
-        block.append(innerBlock);
-        block.append(text4);
-
-        innerBlock.append(text2);
-        innerBlock.append(text3);
+        block.append(text, innerBlock, text4);
+        innerBlock.append(text2, text3);
 
         expect(block.getTextContent()).toEqual('FooBar\n\nQux');
         expect(block.getTextContent(true)).toEqual('FooBarBaz\n\nQux');
@@ -221,8 +210,7 @@ describe('OutlineBlockNode tests', () => {
         const text5 = createTextNode('More');
         text5.makeInert();
         const text6 = createTextNode('Stuff');
-        innerInnerBlock.append(text5);
-        innerInnerBlock.append(text6);
+        innerInnerBlock.append(text5, text6);
         innerBlock.append(innerInnerBlock);
 
         expect(block.getTextContent()).toEqual('FooBarStuff\n\nQux');

--- a/packages/outline/src/__tests__/unit/OutlineEditor.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor.test.js
@@ -674,8 +674,7 @@ describe('OutlineEditor tests', () => {
         blockNode2Key = blockNode2.getKey();
         textNode2Key = textNode2.getKey();
 
-        paragraph.append(blockNode1);
-        paragraph.append(blockNode2);
+        paragraph.append(blockNode1, blockNode2);
       });
       await update((view: View) => {
         const blockNode1: BlockNode = getNodeByKey(blockNode1Key);
@@ -719,8 +718,7 @@ describe('OutlineEditor tests', () => {
         const blockNode2 = createBlockNodeWithText('B');
         blockNode2Key = blockNode2.getKey();
 
-        paragraph.append(blockNode1);
-        paragraph.append(blockNode2);
+        paragraph.append(blockNode1, blockNode2);
       });
       await update((view: View) => {
         const blockNode1: BlockNode = getNodeByKey(blockNode1Key);
@@ -755,9 +753,7 @@ describe('OutlineEditor tests', () => {
         const blockNode3 = createBlockNodeWithText('C');
         blockNode3Key = blockNode3.getKey();
 
-        paragraph.append(blockNode1);
-        paragraph.append(blockNode2);
-        paragraph.append(blockNode3);
+        paragraph.append(blockNode1, blockNode2, blockNode3);
       });
       await update((view: View) => {
         const blockNode1: BlockNode = getNodeByKey(blockNode1Key);

--- a/packages/outline/src/__tests__/unit/OutlineListItemNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineListItemNode.test.js
@@ -109,14 +109,12 @@ describe('OutlineListItemNode tests', () => {
           listNode = new ListNode('ul');
           listItemNode1 = new ListItemNode();
           listItemNode1.append(new TextNode('one'));
-          listNode.append(listItemNode1);
           listItemNode2 = new ListItemNode();
           listItemNode2.append(new TextNode('two'));
-          listNode.append(listItemNode2);
           listItemNode3 = new ListItemNode();
           listItemNode3.append(new TextNode('three'));
-          listNode.append(listItemNode3);
           root.append(listNode);
+          listNode.append(listItemNode1, listItemNode2, listItemNode3);
         });
         expect(testEnv.outerHTML).toBe(
           '<div contenteditable="true" data-outline-editor="true"><ul><li><span data-outline-text="true">one</span></li><li><span data-outline-text="true">two</span></li><li><span data-outline-text="true">three</span></li></ul></div>',
@@ -229,15 +227,13 @@ describe('OutlineListItemNode tests', () => {
           const root = view.getRoot();
           listNode = new ListNode('ul');
           listItemNode1 = new ListItemNode();
-          listItemNode1.append(new TextNode('one'));
-          listNode.append(listItemNode1);
           listItemNode2 = new ListItemNode();
-          listItemNode2.append(new TextNode('two'));
-          listNode.append(listItemNode2);
           listItemNode3 = new ListItemNode();
-          listItemNode3.append(new TextNode('three'));
-          listNode.append(listItemNode3);
           root.append(listNode);
+          listNode.append(listItemNode1, listItemNode2, listItemNode3);
+          listItemNode1.append(new TextNode('one'));
+          listItemNode2.append(new TextNode('two'));
+          listItemNode3.append(new TextNode('three'));
         });
         expect(testEnv.outerHTML).toBe(
           '<div contenteditable="true" data-outline-editor="true"><ul><li><span data-outline-text="true">one</span></li><li><span data-outline-text="true">two</span></li><li><span data-outline-text="true">three</span></li></ul></div>',
@@ -304,12 +300,10 @@ describe('OutlineListItemNode tests', () => {
           const root = view.getRoot();
           listNode = new ListNode('ul');
           listItemNode1 = new ListItemNode();
-          listNode.append(listItemNode1);
           listItemNode2 = new ListItemNode();
-          listNode.append(listItemNode2);
           listItemNode3 = new ListItemNode();
-          listNode.append(listItemNode3);
           root.append(listNode);
+          listNode.append(listItemNode1, listItemNode2, listItemNode3);
         });
         expect(testEnv.outerHTML).toBe(
           '<div contenteditable="true" data-outline-editor="true"><ul><li><br></li><li><br></li><li><br></li></ul></div>',

--- a/packages/outline/src/__tests__/unit/OutlineNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineNode.test.js
@@ -222,10 +222,9 @@ describe('OutlineNode tests', () => {
       await editor.update(() => {
         barTextNode = new TextNode('bar');
         barTextNode.toggleUnmergeable();
-        paragraphNode.append(barTextNode);
         bazTextNode = new TextNode('baz');
         bazTextNode.toggleUnmergeable();
-        paragraphNode.append(bazTextNode);
+        paragraphNode.append(barTextNode, bazTextNode);
       });
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">bar</span><span data-outline-text="true">baz</span></p></div>',
@@ -266,10 +265,9 @@ describe('OutlineNode tests', () => {
       await editor.update(() => {
         barTextNode = new TextNode('bar');
         barTextNode.toggleUnmergeable();
-        paragraphNode.append(barTextNode);
         bazTextNode = new TextNode('baz');
         bazTextNode.toggleUnmergeable();
-        paragraphNode.append(bazTextNode);
+        paragraphNode.append(barTextNode, bazTextNode);
       });
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">bar</span><span data-outline-text="true">baz</span></p></div>',
@@ -304,8 +302,7 @@ describe('OutlineNode tests', () => {
         barParagraphNode.append(barTextNode);
         bazParagraphNode.append(bazTextNode);
         expect(barTextNode.getCommonAncestor(bazTextNode)).toBe(null);
-        rootNode.append(barParagraphNode);
-        rootNode.append(bazParagraphNode);
+        rootNode.append(barParagraphNode, bazParagraphNode);
       });
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">qux</span></p><p><span data-outline-text="true">bar</span></p><p><span data-outline-text="true">baz</span></p></div>',
@@ -332,10 +329,9 @@ describe('OutlineNode tests', () => {
       await editor.update(() => {
         barTextNode = new TextNode('bar');
         barTextNode.toggleUnmergeable();
-        paragraphNode.append(barTextNode);
         bazTextNode = new TextNode('baz');
         bazTextNode.toggleUnmergeable();
-        paragraphNode.append(bazTextNode);
+        paragraphNode.append(barTextNode, bazTextNode);
       });
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">bar</span><span data-outline-text="true">baz</span></p></div>',
@@ -375,15 +371,14 @@ describe('OutlineNode tests', () => {
         const rootNode = view.getRoot();
         barTextNode = new TextNode('bar');
         barTextNode.toggleUnmergeable();
-        paragraphNode.append(barTextNode);
         bazTextNode = new TextNode('baz');
         bazTextNode.toggleUnmergeable();
-        paragraphNode.append(bazTextNode);
         newParagraphNode = new ParagraphNode();
         quxTextNode = new TextNode('qux');
         quxTextNode.toggleUnmergeable();
-        newParagraphNode.append(quxTextNode);
         rootNode.append(newParagraphNode);
+        paragraphNode.append(barTextNode, bazTextNode);
+        newParagraphNode.append(quxTextNode);
       });
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">bar</span><span data-outline-text="true">baz</span></p><p><span data-outline-text="true">qux</span></p></div>',
@@ -833,9 +828,7 @@ describe('OutlineNode tests', () => {
         block1.append(text1);
         block2.append(text2);
         block3.append(text3);
-        root.append(block1);
-        root.append(block2);
-        root.append(block3);
+        root.append(block1, block2, block3);
       });
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">A</span></p><p><span data-outline-text="true">B</span></p><p><span data-outline-text="true">C</span></p></div>',

--- a/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
@@ -278,8 +278,7 @@ describe('OutlineTextNode tests', () => {
       const textNode = createTextNode('Hello World');
       const textNode2 = createTextNode('Goodbye Earth');
 
-      paragraphNode.append(textNode);
-      paragraphNode.append(textNode2);
+      paragraphNode.append(textNode, textNode2);
       view.getRoot().append(paragraphNode);
 
       let selection = textNode2.selectPrevious();
@@ -301,8 +300,7 @@ describe('OutlineTextNode tests', () => {
       const textNode = createTextNode('Hello World');
       const textNode2 = createTextNode('Goodbye Earth');
 
-      paragraphNode.append(textNode);
-      paragraphNode.append(textNode2);
+      paragraphNode.append(textNode, textNode2);
       view.getRoot().append(paragraphNode);
 
       let selection = textNode.selectNext(1, 3);

--- a/packages/outline/src/core/OutlineBlockNode.js
+++ b/packages/outline/src/core/OutlineBlockNode.js
@@ -202,32 +202,36 @@ export class BlockNode extends OutlineNode {
     children.forEach((child) => child.remove());
     return writableSelf;
   }
-  // TODO add support for appending multiple nodes?
-  append(nodeToAppend: OutlineNode): BlockNode {
+  append(...nodesToAppend: OutlineNode[]): BlockNode {
     errorOnReadOnly();
     const writableSelf = this.getWritable();
-    const writableNodeToAppend = nodeToAppend.getWritable();
+    const writableSelfKey = writableSelf.__key;
+    const writableSelfChildren = writableSelf.__children;
+    const nodesToAppendLength = nodesToAppend.length;
+    for (let i = 0; i < nodesToAppendLength; i++) {
+      const nodeToAppend = nodesToAppend[i];
+      const writableNodeToAppend = nodeToAppend.getWritable();
 
-    // Remove node from previous parent
-    const oldParent = writableNodeToAppend.getParent();
-    if (oldParent !== null) {
-      const writableParent = oldParent.getWritable();
-      const children = writableParent.__children;
-      const index = children.indexOf(writableNodeToAppend.__key);
-      if (index > -1) {
-        children.splice(index, 1);
+      // Remove node from previous parent
+      const oldParent = writableNodeToAppend.getParent();
+      if (oldParent !== null) {
+        const writableParent = oldParent.getWritable();
+        const children = writableParent.__children;
+        const index = children.indexOf(writableNodeToAppend.__key);
+        if (index > -1) {
+          children.splice(index, 1);
+        }
       }
-    }
-    // Set child parent to self
-    writableNodeToAppend.__parent = writableSelf.__key;
-    const children = writableSelf.__children;
-    // Append children.
-    const newKey = writableNodeToAppend.__key;
-    children.push(newKey);
-    const flags = writableNodeToAppend.__flags;
-    // Handle direction if node is directionless
-    if (flags & IS_DIRECTIONLESS) {
-      updateDirectionIfNeeded(writableNodeToAppend);
+      // Set child parent to self
+      writableNodeToAppend.__parent = writableSelfKey;
+      // Append children.
+      const newKey = writableNodeToAppend.__key;
+      writableSelfChildren.push(newKey);
+      const flags = writableNodeToAppend.__flags;
+      // Handle direction if node is directionless
+      if (flags & IS_DIRECTIONLESS) {
+        updateDirectionIfNeeded(writableNodeToAppend);
+      }
     }
     return writableSelf;
   }

--- a/packages/outline/src/helpers/__tests__/unit/OutlineNodeHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineNodeHelpers.test.js
@@ -43,17 +43,13 @@ describe('OutlineNodeHelpers tests', () => {
         const text4 = createTextNode('text4');
         const text5 = createTextNode('text5');
         const text6 = createTextNode('text6');
-        root.append(paragraph1);
-        root.append(paragraph2);
-        paragraph1.append(block1);
-        paragraph1.append(block2);
-        paragraph2.append(text4);
-        paragraph2.append(text5);
+        root.append(paragraph1, paragraph2);
+        paragraph1.append(block1, block2);
+        paragraph2.append(text4, text5);
         text5.toggleBold(); // Prevent from merging with text 4
         paragraph2.append(block3);
         block1.append(text1);
-        block2.append(text2);
-        block2.append(text3);
+        block2.append(text2, text3);
         text3.toggleBold(); // Prevent from merging with text2
         block3.append(text6);
 
@@ -94,9 +90,7 @@ describe('OutlineNodeHelpers tests', () => {
         const block2 = createTestBlockNode();
         const block3 = createTestBlockNode();
         root.append(paragraph1);
-        paragraph1.append(block1);
-        paragraph1.append(block2);
-        paragraph1.append(block3);
+        paragraph1.append(block1, block2, block3);
 
         expectedKeys = [root.getKey(), paragraph1.getKey(), block3.getKey()];
       });

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
@@ -1199,9 +1199,7 @@ describe('OutlineSelectionHelpers tests', () => {
       const text1 = createTextNode('First');
       const text2 = createTextNode('Second');
       const text3 = createTextNode('Third');
-      root.append(paragraph1);
-      root.append(paragraph2);
-      root.append(paragraph3);
+      root.append(paragraph1, paragraph2, paragraph3);
       paragraph1.append(text1);
       paragraph2.append(text2);
       paragraph3.append(text3);


### PR DESCRIPTION
Widely used use case, in both tests and client code. I believe that's similar to `array.push`. Implementation wise, the spread operator [caniuse](https://caniuse.com/mdn-javascript_operators_spread_spread_in_function_calls) seems good