### PR TITLE
Move compositionKey on splitText

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
@@ -22,6 +22,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {createEditor, createTextNode, TextNode} from 'outline';
 
 import {createParagraphNode} from 'outline/ParagraphNode';
+import {getCompositionKey, setCompositionKey} from '../../core/OutlineNode';
 
 const editorConfig = Object.freeze({
   theme: {
@@ -417,6 +418,18 @@ describe('OutlineTextNode tests', () => {
         });
       },
     );
+
+    test('splitText moves composition key to last node', async () => {
+      await update((view) => {
+        const paragraphNode = createParagraphNode();
+        const textNode = createTextNode('12345');
+        paragraphNode.append(textNode);
+        setCompositionKey(textNode.getKey());
+
+        const [, splitNode2] = textNode.splitText(1);
+        expect(getCompositionKey()).toBe(splitNode2.getKey());
+      });
+    });
 
     test.each([
       [

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -536,6 +536,7 @@ export class TextNode extends OutlineNode {
     }
     const textContent = this.getTextContent();
     const key = this.__key;
+    const compositionKey = getCompositionKey();
     const offsetsSet = new Set(splitOffsets);
     const parts = [];
     const textLength = textContent.length;
@@ -616,6 +617,9 @@ export class TextNode extends OutlineNode {
           focus.offset -= textSize;
           selection.isDirty = true;
         }
+      }
+      if (compositionKey === key) {
+        setCompositionKey(siblingKey);
       }
       textSize = nextTextSize;
       sibling.__parent = parentKey;


### PR DESCRIPTION
When splitting a  text in composition the composition key should be moved to the last node instead of being left behind. This fixes a FF issue when E2E tests with accented characters and splitText updates would fail: the composition was left behind on the previous node.

Either way, we should probably always handle the composition state in our client code.

Kudos to @trueadm 