### PR TITLE
initEditor invariant when no ParagraphNode

### DIFF
--- a/packages/outline-react/src/useOutlinePlainText.js
+++ b/packages/outline-react/src/useOutlinePlainText.js
@@ -19,6 +19,7 @@ import {
   isParagraphNode,
 } from 'outline/ParagraphNode';
 import {CAN_USE_BEFORE_INPUT} from 'shared/environment';
+import invariant from 'shared/invariant';
 import {
   onSelectionChange,
   onKeyDownForPlainText,
@@ -39,8 +40,15 @@ import useOutlineHistory from './shared/useOutlineHistory';
 function initEditor(editor: OutlineEditor): void {
   editor.update((view) => {
     const root = view.getRoot();
-
-    if (root.getFirstChild() === null) {
+    const firstChild = root.getFirstChild();
+    if (firstChild !== null) {
+      if (!isParagraphNode(firstChild)) {
+        invariant(
+          'false',
+          'Expected plain text root first child to be a ParagraphNode',
+        );
+      }
+    } else {
       const paragraph = createParagraphNode();
       root.append(paragraph);
       if (view.getSelection() !== null) {

--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -17,10 +17,11 @@ import {HeadingNode} from 'outline/HeadingNode';
 import {ListNode} from 'outline/ListNode';
 import {QuoteNode} from 'outline/QuoteNode';
 import {CodeNode} from 'outline/CodeNode';
-import {ParagraphNode} from 'outline/ParagraphNode';
+import {ParagraphNode, isParagraphNode} from 'outline/ParagraphNode';
 import {ListItemNode} from 'outline/ListItemNode';
 import {createParagraphNode} from 'outline/ParagraphNode';
 import {CAN_USE_BEFORE_INPUT} from 'shared/environment';
+import invariant from 'shared/invariant';
 import {
   onSelectionChange,
   onKeyDownForRichText,
@@ -41,8 +42,15 @@ import useOutlineHistory from './shared/useOutlineHistory';
 function initEditor(editor: OutlineEditor): void {
   editor.update((view) => {
     const root = view.getRoot();
-
-    if (root.getFirstChild() === null) {
+    const firstChild = root.getFirstChild();
+    if (firstChild !== null) {
+      if (!isParagraphNode(firstChild)) {
+        invariant(
+          'false',
+          'Expected rich text root first child to be a ParagraphNode',
+        );
+      }
+    } else {
       const paragraph = createParagraphNode();
       root.append(paragraph);
       if (view.getSelection() !== null) {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -41,5 +41,9 @@
   "39": "getNodesInRange: no common ancestor",
   "40": "getNodesInRange: excludeFromCopy node does not have non-excluded parent",
   "41": "createOffsetModel: could not find node by key",
-  "42": "rootNode.append: Only block nodes can be appended to the root node"
+  "42": "Expect root first child to be a ParagraphNode",
+  "44": "Expected root first child to be a ParagraphNode",
+  "45": "rootNode.append: Only block nodes can be appended to the root node",
+  "46": "Expected rich text root first child to be a ParagraphNode",
+  "47": "Expected plain text root first child to be a ParagraphNode"
 }


### PR DESCRIPTION
Make sure that the first node for plain text and rich text is a ParagraphNode