### PR TITLE
Remove IS_OVERFLOWED flag from Outline

### DIFF
--- a/packages/outline-playground/__tests__/e2e/TextEntry-test.js
+++ b/packages/outline-playground/__tests__/e2e/TextEntry-test.js
@@ -815,7 +815,10 @@ describe('TextEntry', () => {
 
       await page.keyboard.press('Delete');
       if (isRichText) {
-        await assertHTML(page, '<p class="editor-paragraph" dir="ltr"><br></p>');
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><br></p>',
+        );
       } else {
         await assertHTML(page, '<p class="editor-paragraph"><br></p>');
       }

--- a/packages/outline-playground/src/Editor.js
+++ b/packages/outline-playground/src/Editor.js
@@ -69,7 +69,6 @@ const editorConfig = {
       bold: 'editor-text-bold',
       link: 'editor-text-link',
       italic: 'editor-text-italic',
-      overflowed: 'editor-text-overflowed',
       underline: 'editor-text-underline',
       strikethrough: 'editor-text-strikethrough',
       underlineStrikethrough: 'editor-text-underlineStrikethrough',

--- a/packages/outline-playground/src/index.css
+++ b/packages/outline-playground/src/index.css
@@ -512,12 +512,6 @@ pre :not(.tree-view-output) {
   color: red;
 }
 
-.editor-shell div.editor span.editor-text-overflowed,
-.editor-shell div.editor strong.editor-text-overflowed,
-.editor-shell div.editor em.editor-text-overflowed {
-  color: red;
-}
-
 .editor-shell div.editor span.editor-text-bold,
 .editor-shell div.editor strong.editor-text-bold,
 .editor-shell div.editor em.editor-text-bold {

--- a/packages/outline-react/src/OutlineTreeView.js
+++ b/packages/outline-react/src/OutlineTreeView.js
@@ -187,7 +187,6 @@ const LABEL_PREDICATES = [
   (node) => node.isSegmented() && 'Segmented',
   (node) => node.isStrikethrough() && 'Strikethrough',
   (node) => node.isUnderline() && 'Underline',
-  (node) => node.isOverflowed() && 'Overflowed',
   (node) => node.isInert() && 'Inert',
   (node) => node.isDirectionless() && 'Directionless',
   (node) => node.isUnmergeable() && 'Unmergeable',

--- a/packages/outline/src/__tests__/unit/OutlineLinkNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineLinkNode.test.js
@@ -19,7 +19,6 @@ const editorConfig = Object.freeze({
       italic: 'my-italic-class',
       code: 'my-code-class',
       hashtag: 'my-hashtag-class',
-      overflowed: 'my-overflowed-class',
     },
     link: 'my-link-class',
   },

--- a/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
@@ -12,7 +12,6 @@ import {
   IS_STRIKETHROUGH,
   IS_UNDERLINE,
   IS_CODE,
-  IS_OVERFLOWED,
 } from '../../core/OutlineConstants';
 
 import React from 'react';
@@ -33,7 +32,6 @@ const editorConfig = Object.freeze({
       underlineStrikethrough: 'my-underline-strikethrough-class',
       italic: 'my-italic-class',
       code: 'my-code-class',
-      overflowed: 'my-overflowed-class',
     },
   },
 });
@@ -576,12 +574,6 @@ describe('OutlineTextNode tests', () => {
         IS_CODE,
         'My text node',
         '<code><span class="my-code-class">My text node</span></code>',
-      ],
-      [
-        'overflowed',
-        IS_OVERFLOWED,
-        'My text node',
-        '<span class="my-overflowed-class">My text node</span>',
       ],
       [
         'underline + strikethrough',

--- a/packages/outline/src/core/OutlineConstants.js
+++ b/packages/outline/src/core/OutlineConstants.js
@@ -30,7 +30,6 @@ export const IS_UNDERLINE = 1 << 3;
 export const IS_CODE = 1 << 4;
 export const IS_SUBSCRIPT = 1 << 5;
 export const IS_SUPERSCRIPT = 1 << 6;
-export const IS_OVERFLOWED = 1 << 7; // This is going soon
 
 // Reconciliation
 
@@ -51,5 +50,4 @@ export const TEXT_TYPE_TO_FORMAT: {[TextFormatType]: number} = {
   strikethrough: IS_STRIKETHROUGH,
   italic: IS_ITALIC,
   code: IS_CODE,
-  overflowed: IS_OVERFLOWED,
 };

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -43,7 +43,6 @@ export type TextNodeThemeClasses = {
   underlineStrikethrough?: EditorThemeClassName,
   italic?: EditorThemeClassName,
   code?: EditorThemeClassName,
-  overflowed?: EditorThemeClassName,
 };
 
 export type EditorThemeClasses = {
@@ -357,7 +356,10 @@ class BaseOutlineEditor {
   }
   setViewModel(viewModel: ViewModel): void {
     if (viewModel.isEmpty()) {
-      invariant(false, 'setViewModel: the view model is empty. Ensure the view model\'s root node never becomes empty.')
+      invariant(
+        false,
+        "setViewModel: the view model is empty. Ensure the view model's root node never becomes empty.",
+      );
     }
     if (this._pendingViewModel !== null) {
       commitPendingUpdates(getSelf(this), 'setViewModel #1');

--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -29,7 +29,6 @@ import {
   IS_DIRECTIONLESS,
   IS_IMMUTABLE,
   IS_INERT,
-  IS_OVERFLOWED,
   IS_SEGMENTED,
 } from './OutlineConstants';
 import {getSelection} from './OutlineSelection';
@@ -879,9 +878,6 @@ export function createNodeFromParse(
     viewModel._nodeMap.set('root', node);
   }
   node.__flags = parsedNode.__flags;
-  if (node.__flags & IS_OVERFLOWED) {
-    node.__flags ^= IS_OVERFLOWED;
-  }
   node.__parent = parentKey;
   // We will need to recursively handle the children in the case
   // of a BlockNode.

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -22,7 +22,6 @@ import {
   IS_ITALIC,
   IS_STRIKETHROUGH,
   IS_UNDERLINE,
-  IS_OVERFLOWED,
   IS_UNMERGEABLE,
   NO_BREAK_SPACE_CHAR,
   TEXT_TYPE_TO_FORMAT,
@@ -38,8 +37,7 @@ export type TextFormatType =
   | 'underline'
   | 'strikethrough'
   | 'italic'
-  | 'code'
-  | 'overflowed';
+  | 'code';
 
 function getElementOuterTag(node: TextNode, format: number): string | null {
   if (format & IS_CODE) {
@@ -221,9 +219,6 @@ export class TextNode extends OutlineNode {
   isCode(): boolean {
     return (this.getFormat() & IS_CODE) !== 0;
   }
-  isOverflowed(): boolean {
-    return (this.getFormat() & IS_OVERFLOWED) !== 0;
-  }
   isUnmergeable(): boolean {
     return (this.getFlags() & IS_UNMERGEABLE) !== 0;
   }
@@ -384,9 +379,6 @@ export class TextNode extends OutlineNode {
   }
   toggleCode(): TextNode {
     return this.setFormat(this.getFormat() ^ IS_CODE);
-  }
-  toggleOverflowed(): TextNode {
-    return this.setFormat(this.getFormat() ^ IS_OVERFLOWED);
   }
   toggleUnmergeable(): TextNode {
     return this.setFlags(this.getFlags() ^ IS_UNMERGEABLE);

--- a/packages/outline/src/core/OutlineView.js
+++ b/packages/outline/src/core/OutlineView.js
@@ -201,7 +201,10 @@ export function preparePendingViewUpdate(
     const dirtyNodes = editor._dirtyNodes;
     if (dirtyNodes !== null && dirtyNodes.size > 0) {
       if (pendingViewModel.isEmpty()) {
-        invariant(false, 'updateEditor: the pending view model is empty. Ensure the root not never becomes empty from an update.')
+        invariant(
+          false,
+          'updateEditor: the pending view model is empty. Ensure the root not never becomes empty from an update.',
+        );
       }
       applyTextTransforms(pendingViewModel, dirtyNodes, editor);
       garbageCollectDetachedNodes(pendingViewModel, dirtyNodes, editor);

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelection.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelection.test.js
@@ -88,7 +88,6 @@ describe('OutlineSelection tests', () => {
               bold: 'editor-text-bold',
               link: 'editor-text-link',
               italic: 'editor-text-italic',
-              overflowed: 'editor-text-overflowed',
               hashtag: 'editor-text-hashtag',
               underline: 'editor-text-underline',
               strikethrough: 'editor-text-strikethrough',


### PR DESCRIPTION
We no longer need this flag or the respective methods that use it.