### PR TITLE
Ensure selection.getTextContent treats empty blocks right

### DIFF
--- a/packages/outline/src/core/OutlineSelection.js
+++ b/packages/outline/src/core/OutlineSelection.js
@@ -209,7 +209,7 @@ export class Selection {
     for (let i = 0; i < nodes.length; i++) {
       const node = nodes[i];
       if (isBlockNode(node)) {
-        if (!prevWasBlock) {
+        if (!prevWasBlock || node.getChildrenSize() === 0) {
           textContent += '\n';
         }
         prevWasBlock = true;


### PR DESCRIPTION
This bug was discovered for when we have a case like:

```
<root>
[<p></p>
<p></p>]
</root>
```

The text content should be `\n\n`.