### PR TITLE
Fix composition text entry

### DIFF
--- a/packages/outline/src/helpers/OutlineEventHelpers.js
+++ b/packages/outline/src/helpers/OutlineEventHelpers.js
@@ -444,9 +444,13 @@ export function onCompositionStart(
   editor.update((view) => {
     const selection = view.getSelection();
     if (selection !== null && !editor.isComposing()) {
-      view.setCompositionKey(selection.anchor.key);
+      const anchor = selection.anchor;
+      view.setCompositionKey(anchor.key);
       const data = event.data;
-      if (data != null && !lastKeyWasMaybeAndroidSoftKey) {
+      if (
+        data != null &&
+        (!lastKeyWasMaybeAndroidSoftKey || anchor.type === 'block' || !selection.isCollapsed())
+      ) {
         // We insert an empty space, ready for the composition
         // to get inserted into the new node we create. If
         // we don't do this, Safari will fail on us because


### PR DESCRIPTION
It was possible that when on a block selection point that text entry on Android and other composition devices would simply not work. This fixes that.