### PR TITLE
CharacterLimit graphemes

### DIFF
--- a/packages/outline-playground/__tests__/e2e/CharacterLimit-test.js
+++ b/packages/outline-playground/__tests__/e2e/CharacterLimit-test.js
@@ -7,7 +7,13 @@
  * @flow strict-local
  */
 
-import {initializeE2E, assertHTML, assertSelection, repeat} from '../utils';
+import {
+  initializeE2E,
+  assertHTML,
+  assertSelection,
+  repeat,
+  E2E_BROWSER,
+} from '../utils';
 import {moveToEditorBeginning, moveToLineBeginning} from '../keyboardShortcuts';
 
 function testSuite(e2e, charset: 'UTF-8' | 'UTF-16') {
@@ -217,6 +223,31 @@ function testSuite(e2e, charset: 'UTF-8' | 'UTF-16') {
         page,
         '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">àà</span><div class="editor-character-limit"><span data-outline-text="true">àààà</span></div></p>',
       );
+    }
+  });
+
+  it('handles graphemes', async () => {
+    const {page} = e2e;
+    await page.focus('div.editor');
+
+    await page.keyboard.type('👨‍👩‍👦‍👦');
+    if (['chromium', 'webkit'].includes(E2E_BROWSER)) {
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="ltr"><div class="editor-character-limit"><span data-outline-text="true">👨‍👩‍👦‍👦</span></div></p>',
+      );
+    } else {
+      if (charset === 'UTF-16') {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">👨‍👩</span><div class="editor-character-limit"><span data-outline-text="true">‍👦‍👦</span></div></p>',
+        );
+      } else {
+        await assertHTML(
+          page,
+          '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">👨</span><div class="editor-character-limit"><span data-outline-text="true">‍👩‍👦‍👦</span></div></p>',
+        );
+      }
     }
   });
 }

--- a/packages/outline-react/src/useOutlineCharacterLimit.js
+++ b/packages/outline-react/src/useOutlineCharacterLimit.js
@@ -38,19 +38,34 @@ export function useCharacterLimit(
   } = optional;
 
   const execute = useCallback(() => {
+    const Segmenter = Intl.Segmenter;
     let offsetUtf16 = 0;
     let offset = 0;
     const text = editor.getTextContent();
-    const codepoints = Array.from(text);
-    const codepointsLength = codepoints.length;
-    for (let i = 0; i < codepointsLength; i++) {
-      const codepoint = codepoints[i];
-      const nextOffset = offset + strlen(codepoint);
-      if (nextOffset > maxCharacters) {
-        break;
+    if (typeof Segmenter === 'function') {
+      const segmenter = new Segmenter();
+      const graphemes = segmenter.segment(text);
+      // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+      for (const {segment: grapheme} of graphemes) {
+        const nextOffset = offset + strlen(grapheme);
+        if (nextOffset > maxCharacters) {
+          break;
+        }
+        offset = nextOffset;
+        offsetUtf16 += grapheme.length;
       }
-      offset = nextOffset;
-      offsetUtf16 += codepoint.length;
+    } else {
+      const codepoints = Array.from(text);
+      const codepointsLength = codepoints.length;
+      for (let i = 0; i < codepointsLength; i++) {
+        const codepoint = codepoints[i];
+        const nextOffset = offset + strlen(codepoint);
+        if (nextOffset > maxCharacters) {
+          break;
+        }
+        offset = nextOffset;
+        offsetUtf16 += codepoint.length;
+      }
     }
     updateWithoutHistory(
       editor,


### PR DESCRIPTION
Ideally, the split is done via graphemes. However, all libraries are pretty heavy for such purpose. In this PR, we're adding Grapheme support for the built-in Intl.Segmenter (Chrome/Chromium only for now), otherwise we fallback to the previous code points approach.