### PR TITLE
Further fixes to selection block termination

### DIFF
--- a/packages/outline/src/core/OutlineSelection.js
+++ b/packages/outline/src/core/OutlineSelection.js
@@ -361,10 +361,14 @@ function resolveSelectionPoint(
       if (isBlockNode(resolvedBlock)) {
         let child = resolvedBlock.getChildAtIndex(resolvedOffset);
         if (isBlockNode(child)) {
-          child = moveSelectionToEnd
+          const descendant = moveSelectionToEnd
             ? child.getLastDescendant()
             : child.getFirstDescendant();
-          if (child !== null) {
+          if (descendant === null) {
+            resolvedBlock = child;
+            resolvedOffset = 0;
+          } else {
+            child = descendant;
             resolvedBlock = child.getParentOrThrow();
           }
         }
@@ -372,7 +376,7 @@ function resolveSelectionPoint(
           resolvedNode = child;
           resolvedBlock = null;
           resolvedOffset = getTextNodeOffset(resolvedNode, moveSelectionToEnd);
-        } else if (moveSelectionToEnd) {
+        } else if (child !== resolvedBlock && moveSelectionToEnd) {
           resolvedOffset++;
         }
       } else {


### PR DESCRIPTION
If selection ends on an empty block, we should select that block.