### PR TITLE
insertNode handle ParagraphNode and variable parent

### DIFF
--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
@@ -20,6 +20,7 @@ import {
   getNodesInRange,
 } from 'outline/SelectionHelpers';
 import {createTestBlockNode} from '../../../__tests__/utils';
+import {createListNode} from '../../../extensions/OutlineListNode';
 
 export class ExcludeFromCopyBlockNode extends BlockNode {
   static clone(node: BlockNode) {
@@ -965,6 +966,24 @@ describe('OutlineSelectionHelpers tests', () => {
           offset: 3,
           key: block.getFirstChild().getKey(),
         });
+      });
+
+      setupTestCase((selection, view, block) => {
+        insertNodes(selection, [
+          createParagraphNode(),
+          createTextNode('1'),
+          createTextNode('2').toggleBold(),
+          createListNode(),
+          createParagraphNode(),
+          createTextNode('3'),
+        ]);
+        const firstParagraph = view.getRoot().getFirstChild();
+        const secondParagraph = firstParagraph.getNextSibling();
+        const thirdParagraph = secondParagraph.getNextSibling();
+        expect(secondParagraph.__children.length).toBe(3);
+        expect(secondParagraph.getTextContent()).toBe('12');
+        expect(thirdParagraph.__children.length).toBe(1);
+        expect(thirdParagraph.getTextContent()).toBe('3');
       });
 
       // insertParagraph


### PR DESCRIPTION
This PR might be a complete misunderstanding but it's worth a discussion..

It attempts to address the following two things:
1. All BlockNodes are treated the same way and that's quite unsafe. We understand how ParagraphNode works but other custom nodes or even the latest ListNode have different children rules.
2. The parent is a constant, always fixed the top most block. The parent should be the closest block and iterate from here, i.e. in case of an addition ParagraphNode it makes sense to append a new block just next to it given how we've been handling ParagraphNode so far in browser events. 