### PR TITLE
Refactor cloneContents and insertNodes

### DIFF
--- a/packages/outline-playground/__tests__/e2e/CopyAndPaste-test.js
+++ b/packages/outline-playground/__tests__/e2e/CopyAndPaste-test.js
@@ -6,7 +6,12 @@
  *
  */
 
-import {moveToPrevWord, selectAll} from '../keyboardShortcuts';
+import {
+  moveToPrevWord,
+  selectAll,
+  moveToLineBeginning,
+  moveToLineEnd,
+} from '../keyboardShortcuts';
 import {
   initializeE2E,
   assertSelection,
@@ -296,77 +301,151 @@ describe('CopyAndPaste', () => {
       });
     });
 
-    // it('Copy and paste of partial list items', async () => {
-    //   const {isRichText, page} = e2e;
+    it('Copy and paste of partial list items', async () => {
+      const {isRichText, page} = e2e;
 
-    //   // 
-    //   if (!isRichText) {
-    //     return;
-    //   }
+      if (!isRichText) {
+        return;
+      }
 
-    //   await page.focus('div.editor');
+      await page.focus('div.editor');
 
-    //   // Add three list items
-    //   await page.keyboard.type('- One');
-    //   await page.keyboard.press('Enter');
-    //   await page.keyboard.type('Two');
-    //   await page.keyboard.press('Enter');
-    //   await page.keyboard.type('Three');
+      // Add three list items
+      await page.keyboard.type('- One');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Two');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Three');
 
-    //   await page.keyboard.press('Enter');
-    //   await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
 
-    //   // Add a paragraph
-    //   await page.keyboard.type('Some text.');
+      // Add a paragraph
+      await page.keyboard.type('Some text.');
 
-    //   await assertHTML(
-    //     page,
-    //     '<ul class="editor-list-ul" dir="ltr"><li class="editor-listitem"><span data-outline-text="true">One</span></li><li class="editor-listitem"><span data-outline-text="true">Two</span></li><li class="editor-listitem"><span data-outline-text="true">Three</span></li></ul><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Some text.</span></p>',
-    //   );
-    //   await assertSelection(page, {
-    //     anchorPath: [1, 0, 0],
-    //     anchorOffset: 10,
-    //     focusPath: [1, 0, 0],
-    //     focusOffset: 10,
-    //   });
+      await assertHTML(
+        page,
+        '<ul class="editor-list-ul" dir="ltr"><li class="editor-listitem"><span data-outline-text="true">One</span></li><li class="editor-listitem"><span data-outline-text="true">Two</span></li><li class="editor-listitem"><span data-outline-text="true">Three</span></li></ul><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Some text.</span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [1, 0, 0],
+        anchorOffset: 10,
+        focusPath: [1, 0, 0],
+        focusOffset: 10,
+      });
 
-    //   await page.keyboard.down('Shift');
-    //   await moveToLineBeginning(page);
-    //   await page.keyboard.press('ArrowLeft');
-    //   await page.keyboard.press('ArrowLeft');
-    //   await page.keyboard.press('ArrowLeft');
-    //   await page.keyboard.up('Shift');
+      await page.keyboard.down('Shift');
+      await moveToLineBeginning(page);
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.up('Shift');
 
-    //   await assertSelection(page, {
-    //     anchorPath: [1, 0, 0],
-    //     anchorOffset: 10,
-    //     focusPath: [0, 2, 0, 0],
-    //     focusOffset: 3,
-    //   });
+      await assertSelection(page, {
+        anchorPath: [1, 0, 0],
+        anchorOffset: 10,
+        focusPath: [0, 2, 0, 0],
+        focusOffset: 3,
+      });
 
-    //   // Copy the partial list item and paragraph
-    //   const clipboard = await copyToClipboard(page);
+      // Copy the partial list item and paragraph
+      const clipboard = await copyToClipboard(page);
 
-    //   // Select all and remove content
-    //   await selectAll(page);
-    //   await page.keyboard.press('Backspace');
-    //   await page.keyboard.press('Backspace');
+      // Select all and remove content
+      await selectAll(page);
+      await page.keyboard.press('Backspace');
+      await page.keyboard.press('Backspace');
 
-    //   await assertHTML(
-    //     page,
-    //     '<p class="editor-paragraph"><br></p>',
-    //   );
-    //   await assertSelection(page, {
-    //     anchorPath: [0],
-    //     anchorOffset: 0,
-    //     focusPath: [0],
-    //     focusOffset: 0,
-    //   });
+      await assertHTML(page, '<p class="editor-paragraph"><br></p>');
+      await assertSelection(page, {
+        anchorPath: [0],
+        anchorOffset: 0,
+        focusPath: [0],
+        focusOffset: 0,
+      });
 
-    //   // Paste
+      // Paste
 
-    //   await pasteFromClipboard(page, clipboard);
+      await pasteFromClipboard(page, clipboard);
 
-    // });
+      await assertHTML(
+        page,
+        '<ul class="editor-list-ul" dir="ltr"><li class="editor-listitem"><span data-outline-text="true">ee</span></li></ul><p class="editor-paragraph" dir="ltr"><span data-outline-text="true">Some text.</span></p>',
+      );
+      await assertSelection(page, {
+        anchorPath: [1, 0, 0],
+        anchorOffset: 10,
+        focusPath: [1, 0, 0],
+        focusOffset: 10,
+      });
+    });
+
+    it('Copy and paste of list items and paste back into list', async () => {
+      const {isRichText, page} = e2e;
+
+      if (!isRichText) {
+        return;
+      }
+
+      await page.focus('div.editor');
+
+      await page.keyboard.type('- One');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Two');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Three');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Four');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Five');
+
+      await page.keyboard.press('ArrowUp');
+      await page.keyboard.press('ArrowUp');
+
+      await moveToLineBeginning(page);
+      await page.keyboard.down('Shift');
+      await page.keyboard.press('ArrowDown');
+      await moveToLineEnd(page);
+      await page.keyboard.up('Shift');
+
+      await assertHTML(
+        page,
+        '<ul class="editor-list-ul" dir="ltr"><li class="editor-listitem"><span data-outline-text="true">One</span></li><li class="editor-listitem"><span data-outline-text="true">Two</span></li><li class="editor-listitem"><span data-outline-text="true">Three</span></li><li class="editor-listitem"><span data-outline-text="true">Four</span></li><li class="editor-listitem"><span data-outline-text="true">Five</span></li></ul>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 2, 0, 0],
+        anchorOffset: 0,
+        focusPath: [0, 3, 0, 0],
+        focusOffset: 4,
+      });
+
+      const clipboard = await copyToClipboard(page);
+
+      await page.keyboard.press('Backspace');
+
+      await assertHTML(
+        page,
+        '<ul class="editor-list-ul" dir="ltr"><li class="editor-listitem"><span data-outline-text="true">One</span></li><li class="editor-listitem"><span data-outline-text="true">Two</span></li><li class="editor-listitem"><br></li><li class="editor-listitem"><span data-outline-text="true">Five</span></li></ul>',
+      );
+      await assertSelection(page, {
+        anchorPath: [0, 2],
+        anchorOffset: 0,
+        focusPath: [0, 2],
+        focusOffset: 0,
+      });
+
+      await pasteFromClipboard(page, clipboard);
+
+      await assertHTML(
+        page,
+        '<ul class="editor-list-ul" dir="ltr"><li class="editor-listitem"><span data-outline-text="true">One</span></li><li class="editor-listitem"><span data-outline-text="true">Two</span></li></ul><ul class="editor-list-ul" dir="ltr"><li class="editor-listitem"><span data-outline-text="true">Three</span></li><li class="editor-listitem"><span data-outline-text="true">Four</span></li><li class="editor-listitem"><span data-outline-text="true">Five</span></li></ul><ul class="editor-list-ul"><br></ul>',
+      );
+      await assertSelection(page, {
+        anchorPath: [1, 1, 0, 0],
+        anchorOffset: 4,
+        focusPath: [1, 1, 0, 0],
+        focusOffset: 4,
+      });
+    });
   });
 });

--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -180,7 +180,7 @@ function moveSelectionPointToSibling(
   }
 }
 
-export function isLeafNode(node: OutlineNode): boolean %checks {
+export function isLeafNode(node: ?OutlineNode): boolean %checks {
   return isTextNode(node) || isLineBreakNode(node) || isDecoratorNode(node);
 }
 

--- a/packages/outline/src/helpers/OutlineEventHelpers.js
+++ b/packages/outline/src/helpers/OutlineEventHelpers.js
@@ -50,7 +50,7 @@ import {
   formatText,
   insertText,
   removeText,
-  getNodesInRange,
+  cloneContents,
   insertNodes,
   insertLineBreak,
   insertRichText,
@@ -422,7 +422,7 @@ export function onCopyForRichText(
         clipboardData.setData('text/plain', selection.getTextContent());
         clipboardData.setData(
           'application/x-outline-nodes',
-          JSON.stringify(getNodesInRange(selection)),
+          JSON.stringify(cloneContents(selection)),
         );
       }
     }

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
@@ -17,7 +17,7 @@ import {
   insertLineBreak,
   formatText,
   extractSelection,
-  getNodesInRange,
+  cloneContents,
 } from 'outline/SelectionHelpers';
 import {createTestBlockNode} from '../../../__tests__/utils';
 
@@ -210,9 +210,9 @@ describe('OutlineSelectionHelpers tests', () => {
         expect(extractSelection(selection)).toEqual([view.getNodeByKey('a')]);
       });
 
-      // getNodesInRange
+      // cloneContents
       setupTestCase((selection, view, block) => {
-        expect(getNodesInRange(selection)).toEqual({
+        expect(cloneContents(selection)).toEqual({
           range: ['a'],
           nodeMap: [['a', {...view.getNodeByKey('a'), __text: ''}]],
         });
@@ -537,9 +537,9 @@ describe('OutlineSelectionHelpers tests', () => {
         expect(extractSelection(selection)).toEqual([]);
       });
 
-      // getNodesInRange
+      // cloneContents
       setupTestCase((selection, view, block) => {
-        expect(getNodesInRange(selection)).toEqual({
+        expect(cloneContents(selection)).toEqual({
           range: [],
           nodeMap: [],
         });
@@ -659,11 +659,14 @@ describe('OutlineSelectionHelpers tests', () => {
         expect(extractSelection(selection)).toEqual([view.getNodeByKey('a')]);
       });
 
-      // getNodesInRange
+      // cloneContents
       setupTestCase((selection, view, block) => {
-        expect(getNodesInRange(selection)).toEqual({
-          range: ['a'],
-          nodeMap: [['a', {...view.getNodeByKey('a'), __text: ''}]],
+        expect(cloneContents(selection)).toEqual({
+          range: [block.getKey()],
+          nodeMap: [
+            ['a', {...view.getNodeByKey('a'), __text: ''}],
+            [block.getKey(), {...block, __children: ['a']}],
+          ],
         });
       });
     });
@@ -782,11 +785,14 @@ describe('OutlineSelectionHelpers tests', () => {
         expect(extractSelection(selection)).toEqual([view.getNodeByKey('c')]);
       });
 
-      // getNodesInRange
+      // cloneContents
       setupTestCase((selection, view, block) => {
-        expect(getNodesInRange(selection)).toEqual({
-          range: ['c'],
-          nodeMap: [['c', {...view.getNodeByKey('c'), __text: ''}]],
+        expect(cloneContents(selection)).toEqual({
+          range: [block.getKey()],
+          nodeMap: [
+            ['c', {...view.getNodeByKey('c'), __text: ''}],
+            [block.getKey(), {...block, __children: ['c']}],
+          ],
         });
       });
     });
@@ -1022,12 +1028,13 @@ describe('OutlineSelectionHelpers tests', () => {
         ]);
       });
 
-      // getNodesInRange
+      // cloneContents
       setupTestCase((selection, view, block) => {
-        expect(getNodesInRange(selection)).toEqual({
-          range: ['a', 'b'],
+        expect(cloneContents(selection)).toEqual({
+          range: [block.getKey()],
           nodeMap: [
             ['a', view.getNodeByKey('a')],
+            [block.getKey(), {...block, __children: ['a', 'b']}],
             ['b', {...view.getNodeByKey('b'), __text: ''}],
           ],
         });
@@ -1154,12 +1161,13 @@ describe('OutlineSelectionHelpers tests', () => {
         ]);
       });
 
-      // getNodesInRange
+      // cloneContents
       setupTestCase((selection, view, block) => {
-        expect(getNodesInRange(selection)).toEqual({
-          range: ['a', 'b'],
+        expect(cloneContents(selection)).toEqual({
+          range: [block.getKey()],
           nodeMap: [
             ['a', view.getNodeByKey('a')],
+            [block.getKey(), {...block, __children: ['a', 'b']}],
             ['b', {...view.getNodeByKey('b'), __text: ''}],
           ],
         });
@@ -1292,12 +1300,13 @@ describe('OutlineSelectionHelpers tests', () => {
         ]);
       });
 
-      // getNodesInRange
+      // cloneContents
       setupTestCase((selection, view, block) => {
-        expect(getNodesInRange(selection)).toEqual({
-          range: ['a', 'b', 'c'],
+        expect(cloneContents(selection)).toEqual({
+          range: [block.getKey()],
           nodeMap: [
             ['a', view.getNodeByKey('a')],
+            [block.getKey(), block],
             ['b', view.getNodeByKey('b')],
             ['c', view.getNodeByKey('c')],
           ],
@@ -1330,36 +1339,38 @@ describe('OutlineSelectionHelpers tests', () => {
       text1.select(0, 0);
       const selection1 = view.getSelection();
       selection1.focus.set(text3.getKey(), 1, 'text');
-      const selectedNodes1 = getNodesInRange(view.getSelection());
+      const selectedNodes1 = cloneContents(view.getSelection());
       expect(selectedNodes1.range).toEqual([
-        text1.getKey(),
+        paragraph1.getKey(),
         paragraph2.getKey(),
         paragraph3.getKey(),
       ]);
       expect(selectedNodes1.nodeMap[0][0]).toEqual(text1.getKey());
       expect(selectedNodes1.nodeMap[0][1].getTextContent()).toBe('First');
-      expect(selectedNodes1.nodeMap[1][0]).toEqual(paragraph2.getKey());
-      expect(selectedNodes1.nodeMap[2][0]).toEqual(text2.getKey());
-      expect(selectedNodes1.nodeMap[3][0]).toEqual(paragraph3.getKey());
-      expect(selectedNodes1.nodeMap[4][0]).toEqual(text3.getKey());
-      expect(selectedNodes1.nodeMap[4][1].getTextContent()).toBe('Third');
+      expect(selectedNodes1.nodeMap[1][0]).toEqual(paragraph1.getKey());
+      expect(selectedNodes1.nodeMap[2][0]).toEqual(paragraph2.getKey());
+      expect(selectedNodes1.nodeMap[3][0]).toEqual(text2.getKey());
+      expect(selectedNodes1.nodeMap[4][0]).toEqual(paragraph3.getKey());
+      expect(selectedNodes1.nodeMap[5][0]).toEqual(text3.getKey());
+      expect(selectedNodes1.nodeMap[5][1].getTextContent()).toBe('Third');
 
       text1.select(1, 1);
       const selection2 = view.getSelection();
       selection2.focus.set(text3.getKey(), 4, 'text');
-      const selectedNodes2 = getNodesInRange(view.getSelection());
+      const selectedNodes2 = cloneContents(view.getSelection());
       expect(selectedNodes2.range).toEqual([
-        text1.getKey(),
+        paragraph1.getKey(),
         paragraph2.getKey(),
         paragraph3.getKey(),
       ]);
       expect(selectedNodes2.nodeMap[0][0]).toEqual(text1.getKey());
       expect(selectedNodes2.nodeMap[0][1].__text).toBe('irst');
-      expect(selectedNodes2.nodeMap[1][0]).toEqual(paragraph2.getKey());
-      expect(selectedNodes2.nodeMap[2][0]).toEqual(text2.getKey());
-      expect(selectedNodes2.nodeMap[3][0]).toEqual(paragraph3.getKey());
-      expect(selectedNodes2.nodeMap[4][0]).toEqual(text3.getKey());
-      expect(selectedNodes2.nodeMap[4][1].__text).toBe('Thir');
+      expect(selectedNodes2.nodeMap[1][0]).toEqual(paragraph1.getKey());
+      expect(selectedNodes2.nodeMap[2][0]).toEqual(paragraph2.getKey());
+      expect(selectedNodes2.nodeMap[3][0]).toEqual(text2.getKey());
+      expect(selectedNodes2.nodeMap[4][0]).toEqual(paragraph3.getKey());
+      expect(selectedNodes2.nodeMap[5][0]).toEqual(text3.getKey());
+      expect(selectedNodes2.nodeMap[5][1].__text).toBe('Thir');
     });
   });
 
@@ -1379,39 +1390,37 @@ describe('OutlineSelectionHelpers tests', () => {
       const excludeBlockNode1 = createExcludeFromCopyBlockNode();
       paragraph.append(excludeBlockNode1);
       paragraph.select(0, 0);
-      const selectedNodes1 = getNodesInRange(view.getSelection());
+      const selectedNodes1 = cloneContents(view.getSelection());
       expect(selectedNodes1.range).toEqual([]);
 
       const text1 = createTextNode('1');
       excludeBlockNode1.append(text1);
       excludeBlockNode1.select(0, 0);
-      const selectedNodes2 = getNodesInRange(view.getSelection());
-      expect(selectedNodes2.range).toEqual([text1.getKey()]);
+      const selectedNodes2 = cloneContents(view.getSelection());
+      expect(selectedNodes2.range).toEqual([paragraph.getKey()]);
 
       paragraph.select(0, 0);
-      const selectedNodes3 = getNodesInRange(view.getSelection());
-      expect(selectedNodes3.range).toEqual([text1.getKey()]);
+      const selectedNodes3 = cloneContents(view.getSelection());
+      expect(selectedNodes3.range).toEqual([paragraph.getKey()]);
 
       const text2 = createTextNode('2');
       excludeBlockNode1.insertAfter(text2);
       paragraph.select(0, 2);
-      const selectedNodes4 = getNodesInRange(view.getSelection());
-      expect(selectedNodes4.range).toEqual([text1.getKey(), text2.getKey()]);
+      const selectedNodes4 = cloneContents(view.getSelection());
+      expect(selectedNodes4.range).toEqual([paragraph.getKey()]);
       expect(selectedNodes4.nodeMap[0][0]).toEqual(text1.getKey());
-      expect(selectedNodes4.nodeMap[1][0]).toEqual(text2.getKey());
+      expect(selectedNodes4.nodeMap[1][0]).toEqual(paragraph.getKey());
+      expect(selectedNodes4.nodeMap[2][0]).toEqual(text2.getKey());
 
       const text3 = createTextNode('3');
       excludeBlockNode1.append(text3);
       paragraph.select(0, 2);
-      const selectedNodes5 = getNodesInRange(view.getSelection());
-      expect(selectedNodes5.range).toEqual([
-        text1.getKey(),
-        text3.getKey(),
-        text2.getKey(),
-      ]);
+      const selectedNodes5 = cloneContents(view.getSelection());
+      expect(selectedNodes5.range).toEqual([paragraph.getKey()]);
       expect(selectedNodes5.nodeMap[0][0]).toEqual(text1.getKey());
-      expect(selectedNodes5.nodeMap[1][0]).toEqual(text3.getKey());
-      expect(selectedNodes5.nodeMap[2][0]).toEqual(text2.getKey());
+      expect(selectedNodes5.nodeMap[1][0]).toEqual(paragraph.getKey());
+      expect(selectedNodes5.nodeMap[2][0]).toEqual(text3.getKey());
+      expect(selectedNodes5.nodeMap[3][0]).toEqual(text2.getKey());
 
       const testBlockNode = createTestBlockNode();
       const excludeBlockNode2 = createExcludeFromCopyBlockNode();
@@ -1420,29 +1429,24 @@ describe('OutlineSelectionHelpers tests', () => {
       testBlockNode.append(excludeBlockNode2);
       excludeBlockNode2.append(text4);
       paragraph.select(0, 3);
-      const selectedNodes6 = getNodesInRange(view.getSelection());
-      expect(selectedNodes6.range).toEqual([
-        text4.getKey(),
-        text1.getKey(),
-        text3.getKey(),
-        text2.getKey(),
-      ]);
+      const selectedNodes6 = cloneContents(view.getSelection());
+      expect(selectedNodes6.range).toEqual([paragraph.getKey()]);
       expect(selectedNodes6.nodeMap[0][0]).toEqual(text4.getKey());
-      expect(selectedNodes6.nodeMap[1][0]).toEqual(text1.getKey());
-      expect(selectedNodes6.nodeMap[2][0]).toEqual(text3.getKey());
-      expect(selectedNodes6.nodeMap[3][0]).toEqual(text2.getKey());
+      expect(selectedNodes6.nodeMap[1][0]).toEqual(testBlockNode.getKey());
+      expect(selectedNodes6.nodeMap[2][0]).toEqual(paragraph.getKey());
+      expect(selectedNodes6.nodeMap[3][0]).toEqual(text1.getKey());
+      expect(selectedNodes6.nodeMap[4][0]).toEqual(text3.getKey());
+      expect(selectedNodes6.nodeMap[5][0]).toEqual(text2.getKey());
 
       text4.remove();
       paragraph.select(0, 3);
-      const selectedNodes7 = getNodesInRange(view.getSelection());
-      expect(selectedNodes7.range).toEqual([
-        text1.getKey(),
-        text3.getKey(),
-        text2.getKey(),
-      ]);
-      expect(selectedNodes7.nodeMap[0][0]).toEqual(text1.getKey());
-      expect(selectedNodes7.nodeMap[1][0]).toEqual(text3.getKey());
-      expect(selectedNodes7.nodeMap[2][0]).toEqual(text2.getKey());
+      const selectedNodes7 = cloneContents(view.getSelection());
+      expect(selectedNodes7.range).toEqual([paragraph.getKey()]);
+      expect(selectedNodes7.nodeMap[0][0]).toEqual(testBlockNode.getKey());
+      expect(selectedNodes7.nodeMap[1][0]).toEqual(paragraph.getKey());
+      expect(selectedNodes7.nodeMap[2][0]).toEqual(text1.getKey());
+      expect(selectedNodes7.nodeMap[3][0]).toEqual(text3.getKey());
+      expect(selectedNodes7.nodeMap[4][0]).toEqual(text2.getKey());
     });
   });
 });


### PR DESCRIPTION
We've recently found a bunch of issues around `getNodesInRange` and `insertNodes`. I think part of the reason we have bugs is because of `getNodesInRange`. It was meant to work like `range.cloneContents` from the Selection API:

https://developer.mozilla.org/en-US/docs/Web/API/Range/cloneContents

So instead, I've renamed it to `cloneContents` and made it work the same way almost exactly as the browser version. This affords us an important benefit, we know the parents of the first node and last nodes! Previously, we didn't, so if the first node or last node started in a complex node hierarchy (i.e. not a paragraph or heading), then we'd just insert garbage into the view model. This allowed me to completely refactor that function and make a lot of improvements along the way, including fixing several smaller issues.

Another issue was that `insertNodes` was no longer compatible with this change, and also, it was quite buggy before anyway. So this PR involves some additional refactors to the logic. I opted to make it work more like Microsoft Word and Google Docs instead of Quip and Gmail, which is plain broken in many respects to this. To make this work effectively, I've introduced two new block methods, `canReplaceWith` and `canInsertAfter` which allow us to navigate around tricky nodes like list nodes.