### PR TITLE
Fix insertText bug with last node parent blocks

### DIFF
--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -1248,7 +1248,7 @@ export function insertText(selection: Selection, text: string): void {
         const childrenLength = children.length;
         if (
           childrenLength === 0 ||
-          (childrenLength === 1 && children[0].is(lastRemovedParent))
+          children[childrenLength - 1].is(lastRemovedParent)
         ) {
           markedNodeKeysForKeep.delete(parent.getKey());
           lastRemovedParent = parent;


### PR DESCRIPTION
This PR fixes an issue where if you had many list item nodes in the last block, then the top level block would never be removed – plus added regression test.