### PR TITLE
Create empty TextNode target when attempting to insert a DOM Text on an empty ParagraphNode

### DIFF
--- a/packages/outline/src/helpers/OutlineEventHelpers.js
+++ b/packages/outline/src/helpers/OutlineEventHelpers.js
@@ -57,6 +57,7 @@ import {
   moveCharacter,
 } from 'outline/SelectionHelpers';
 import {createTextNode, isTextNode, isDecoratorNode} from 'outline';
+import {isParagraphNode} from 'outline/ParagraphNode';
 import getPossibleDecoratorNode from 'shared/getPossibleDecoratorNode';
 
 const NO_BREAK_SPACE_CHAR = '\u00A0';
@@ -538,7 +539,14 @@ function updateTextNodeFromDOMContent(
   editor: OutlineEditor,
 ): void {
   let node = getClosestNodeFromDOMNode(view, dom);
-  if (isTextNode(node) && !node.isDirty()) {
+  let isNewNode = false;
+  if (isParagraphNode(node) && node.getChildrenSize() === 0) {
+    const emptyTextNode = createTextNode();
+    node.append(emptyTextNode);
+    node = emptyTextNode;
+    isNewNode = true;
+  }
+  if (isTextNode(node) && (!node.isDirty() || isNewNode)) {
     let textContent = dom.nodeValue;
 
     if (


### PR DESCRIPTION
Commands like `document.execCommand('insertText', ..)` are failing on empty paragraphs because they're not mutating a TextNode but rather a ParagraphNode given that the TextNode does not exist on an empty ParagraphNode.