### PR TITLE
Skip reconcileSelection if selection is not dirty

### DIFF
--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -542,7 +542,7 @@ export function reconcileViewModel(
   const domSelection: null | Selection = window.getSelection();
   if (
     domSelection !== null &&
-    (!needsUpdate || nextSelection === null || nextSelection.dirty)
+    (needsUpdate || nextSelection === null || nextSelection.dirty)
   ) {
     reconcileSelection(prevSelection, nextSelection, editor, domSelection);
   }


### PR DESCRIPTION
Once upon a time, we used to skip `reconcileSelection` if we could avoid it. However, on reflection we can probably skip it still if there are no dirty nodes and selection itself isn't `null` or dirty.