### PR TITLE
Revise isAttached

### DIFF
--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -224,7 +224,7 @@ export class OutlineNode {
   }
   isAttached(): boolean {
     const parentKey = this.__parent;
-    if (parentKey === null) {
+    if (parentKey === null || getNodeByKey(this.__key) === null) {
       return false;
     }
     const parent = getNodeByKey<BlockNode>(parentKey);

--- a/packages/outline/src/core/OutlineView.js
+++ b/packages/outline/src/core/OutlineView.js
@@ -351,11 +351,9 @@ function garbageCollectDetachedDeepChildNodes(
     const childKey = children[i];
     const child = nodeMap.get(childKey);
     if (child !== undefined && child.__parent === parentKey) {
-      const writableChild = child.getWritable();
       if (isBlockNode(child)) {
-        garbageCollectDetachedDeepChildNodes(writableChild, childKey, nodeMap);
+        garbageCollectDetachedDeepChildNodes(child, childKey, nodeMap);
       }
-      writableChild.__parent = null;
     }
     nodeMap.delete(childKey);
   }
@@ -376,11 +374,9 @@ export function garbageCollectDetachedNodes(
     if (node !== undefined) {
       // Garbage collect node and its children if they exist
       if (!node.isAttached()) {
-        const writableNode = node.getWritable();
         if (isBlockNode(node)) {
-          garbageCollectDetachedDeepChildNodes(writableNode, nodeKey, nodeMap);
+          garbageCollectDetachedDeepChildNodes(node, nodeKey, nodeMap);
         }
-        writableNode.__parent = null;
         nodeMap.delete(nodeKey);
       }
     }


### PR DESCRIPTION
Turns out the change in https://github.com/facebookexternal/outline/pull/727 causes more overhead. Let's avoid that overhead with an alternative approach.