### PR TITLE
Handle execCommand gracefully

### DIFF
--- a/packages/outline-playground/__tests__/e2e/Extensions-test.js
+++ b/packages/outline-playground/__tests__/e2e/Extensions-test.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {initializeE2E, assertHTML} from '../utils';
+
+describe('Extensions', () => {
+  initializeE2E((e2e) => {
+    it(`document.execCommand("insertText")`, async () => {
+      const {page} = e2e;
+      await page.focus('div.editor');
+
+      await page.evaluate(() => {
+        document.execCommand('insertText', false, 'foo');
+      }, []);
+      await assertHTML(page, '<p class="editor-paragraph"><br /></p>');
+
+      await page.keyboard.type('f'); // A proper keyboard event creates the paragraph text node
+      await page.evaluate(() => {
+        document.execCommand('insertText', false, 'oo');
+      }, []);
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">foo</span></p>',
+      );
+    });
+
+    it(`ClipboardEvent("paste")`, async () => {
+      const {page} = e2e;
+      await page.focus('div.editor');
+
+      await page.evaluate(() => {
+        function paste() {
+          var dataTransfer = new DataTransfer();
+          function dispatchPaste(target, text) {
+            dataTransfer.setData('text/plain', text);
+            target.dispatchEvent(
+              new ClipboardEvent('paste', {
+                clipboardData: dataTransfer,
+                bubbles: true,
+                cancelable: true,
+              }),
+            );
+            dataTransfer.clearData();
+          }
+          return dispatchPaste;
+        }
+
+        const editor = document.querySelector('div.editor');
+        const dispatchPaste = paste();
+        dispatchPaste(editor, 'foo');
+      }, []);
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">foo</span></p>',
+      );
+
+      await page.evaluate(() => {
+        function paste() {
+          var dataTransfer = new DataTransfer();
+          function dispatchPaste(target, text) {
+            dataTransfer.setData('text/plain', text);
+            target.dispatchEvent(
+              new ClipboardEvent('paste', {
+                clipboardData: dataTransfer,
+                bubbles: true,
+                cancelable: true,
+              }),
+            );
+            dataTransfer.clearData();
+          }
+          return dispatchPaste;
+        }
+
+        const editor = document.querySelector('div.editor');
+        const dispatchPaste = paste();
+        dispatchPaste(editor, 'bar');
+      });
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">foobar</span></p>',
+      );
+    });
+
+    it(`ClipboardEvent("paste") + document.execCommand("insertText")`, async () => {
+      const {page} = e2e;
+      await page.focus('div.editor');
+
+      await page.evaluate(() => {
+        const editor = document.querySelector('.editor');
+        var dataTransfer = new DataTransfer();
+        dataTransfer.setData('text/plain', 'foo');
+        editor.dispatchEvent(
+          new ClipboardEvent('paste', {
+            clipboardData: dataTransfer,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+        document.execCommand('InsertText', false, 'bar');
+      });
+
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true">foobar</span></p>',
+      );
+    });
+  });
+});

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -313,10 +313,15 @@ class BaseOutlineEditor {
     listenerSet.add(listener);
 
     const isRootType = type === 'root';
+    const isMutation = type === 'mutation';
     if (isRootType) {
       // $FlowFixMe: TODO refine
       const rootListener: RootListener = (listener: any);
       rootListener(this._rootElement, null);
+    } else if (isMutation) {
+      // $FlowFixMe: TODO refine
+      const mutationListener: MutationListener = (listener: any);
+      mutationListener(this._rootElement);
     }
     return () => {
       // $FlowFixMe: TODO refine this from the above types
@@ -325,7 +330,7 @@ class BaseOutlineEditor {
         // $FlowFixMe: TODO refine
         const rootListener: RootListener = (listener: any);
         rootListener(null, this._rootElement);
-      } else if (type === 'mutation') {
+      } else if (isMutation) {
         // $FlowFixMe: TODO refine
         const mutationListener: MutationListener = (listener: any);
         mutationListener(null);

--- a/packages/outline/src/helpers/OutlineEventHelpers.js
+++ b/packages/outline/src/helpers/OutlineEventHelpers.js
@@ -295,6 +295,7 @@ export function onKeyDownForRichText(
         }
       }
     }
+    eventFlushSync(editor);
   }, 'onKeyDownForRichText');
 }
 
@@ -309,6 +310,7 @@ export function onPasteForPlainText(
     if (clipboardData != null && selection !== null) {
       insertDataTransferForPlainText(clipboardData, selection, view);
     }
+    eventFlushSync(editor);
   }, 'onPasteForPlainText');
 }
 
@@ -323,6 +325,7 @@ export function onPasteForRichText(
     if (clipboardData != null && selection !== null) {
       insertDataTransferForRichText(clipboardData, selection, view);
     }
+    eventFlushSync(editor);
   }, 'onPasteForRichText');
 }
 
@@ -353,6 +356,7 @@ export function onCutForPlainText(
     if (selection !== null) {
       removeText(selection);
     }
+    eventFlushSync(editor);
   }, 'onCutForPlainText');
 }
 
@@ -366,6 +370,7 @@ export function onCutForRichText(
     if (selection !== null) {
       removeText(selection);
     }
+    eventFlushSync(editor);
   }, 'onCutForRichText');
 }
 
@@ -392,6 +397,7 @@ export function onCopyForPlainText(
           clipboardData.setData('text/html', container.innerHTML);
         }
         clipboardData.setData('text/plain', selection.getTextContent());
+        eventFlushSync(editor);
       }
     }
   }, 'onCopyForPlainText');
@@ -424,6 +430,7 @@ export function onCopyForRichText(
           'application/x-outline-nodes',
           JSON.stringify(cloneContents(selection)),
         );
+        eventFlushSync(editor);
       }
     }
   }, 'onCopyForRichText');
@@ -451,6 +458,7 @@ export function onCompositionStart(
         // there is no text node matching the selection.
         insertText(selection, ' ');
       }
+      eventFlushSync(editor);
     }
   }, 'onCompositionStart');
 }
@@ -462,6 +470,7 @@ export function onCompositionEnd(
   editor.update((view) => {
     view.setCompositionKey(null);
     updateSelectedTextFromDOM(editor, view, true);
+    eventFlushSync(editor);
   }, 'onCompositionEnd');
 }
 
@@ -488,6 +497,7 @@ export function onClick(event: MouseEvent, editor: OutlineEditor): void {
       if (lastSelection !== null && selection.is(lastSelection)) {
         window.getSelection().removeAllRanges();
         selection.dirty = true;
+        eventFlushSync(editor);
       }
     }
   }, 'onClick');
@@ -512,6 +522,7 @@ export function onSelectionChange(event: Event, editor: OutlineEditor): void {
       if (anchor.type === 'text') {
         const anchorNode = anchor.getNode();
         selection.textFormat = anchorNode.getFormat();
+        eventFlushSync(editor);
       }
     }
   }, 'onSelectionChange');
@@ -755,6 +766,7 @@ export function onBeforeInputForPlainText(
         event.preventDefault();
         insertText(selection, data);
       }
+      eventFlushSync(editor);
       return;
     }
 
@@ -830,6 +842,7 @@ export function onBeforeInputForPlainText(
       default:
       // NO-OP
     }
+    eventFlushSync(editor);
   }, 'onBeforeInputForPlainText');
 }
 
@@ -858,6 +871,7 @@ export function onBeforeInputForRichText(
       view.setCompositionKey(null);
       event.preventDefault();
       deleteBackward(selection);
+      eventFlushSync(editor);
       return;
     }
     const data = event.data;
@@ -889,6 +903,7 @@ export function onBeforeInputForRichText(
         event.preventDefault();
         insertText(selection, data);
       }
+      eventFlushSync(editor);
       return;
     }
 
@@ -985,6 +1000,7 @@ export function onBeforeInputForRichText(
       default:
       // NO-OP
     }
+    eventFlushSync(editor);
   }, 'onBeforeInputForRichText');
 }
 
@@ -1016,6 +1032,7 @@ export function onInput(event: InputEvent, editor: OutlineEditor) {
       }
     }
     updateSelectedTextFromDOM(editor, view, false);
+    eventFlushSync(editor);
   }, 'onInput');
 }
 
@@ -1137,5 +1154,14 @@ export function onMutation(
         view.setSelection(selection);
       }
     }
+
+    eventFlushSync(editor);
   }, 'onMutation');
+}
+
+function eventFlushSync(editor: OutlineEditor) {
+  const pendingViewModel = editor._pendingViewModel;
+  if (pendingViewModel !== null) {
+    pendingViewModel._flushSync = true;
+  }
 }


### PR DESCRIPTION
This PR aims to address edge cases where `execCommand('insertText')` would make the editor crash or misbehave. As we discussed with @trueadm, we may not want to correct bad mutations yet we should handle them gracefully.

Cases were it fail:
1. execCommand on an empty editor would type on the paragraph and never be corrected. That is because the observer was previously not observing until the first reconciliation.
2. paste (or any event) + execCommand would crash the editor. The updates would clash. Hence, why I suggest to exempt event handlers from the Task defer and commit them synchronously.