### PR TITLE
Refactor MutationObserver logic for node envs

### DIFF
--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -521,11 +521,12 @@ export function updateViewModel(
   needsUpdate: boolean,
   editor: OutlineEditor,
 ): void {
-  if (needsUpdate) {
+  const observer = editor._observer;
+
+  if (needsUpdate && observer !== null) {
     const dirtyType = editor._dirtyType;
     const dirtySubTrees = editor._dirtySubTrees;
     const dirtyNodes = editor._dirtyNodes;
-    const observer = editor._observer;
 
     observer.disconnect();
     try {

--- a/packages/outline/src/core/OutlineView.js
+++ b/packages/outline/src/core/OutlineView.js
@@ -32,6 +32,7 @@ import {
 import {isBlockNode, isTextNode, isLineBreakNode} from '.';
 import {FULL_RECONCILE, NO_DIRTY_NODES} from './OutlineConstants';
 import {resetEditor} from './OutlineEditor';
+import {initMutationObserver} from './OutlineMutations';
 import invariant from 'shared/invariant';
 
 export type View = {
@@ -425,6 +426,7 @@ export function commitPendingUpdates(
     // Reset editor and restore incoming view model to the DOM
     if (!isAttemptingToRecoverFromReconcilerError) {
       resetEditor(editor, null, rootElement, pendingViewModel);
+      initMutationObserver(editor);
       editor._dirtyType = FULL_RECONCILE;
       isAttemptingToRecoverFromReconcilerError = true;
       commitPendingUpdates(editor, 'ReconcileRecover');


### PR DESCRIPTION
Creation of the MutationObserver during init of the editor is too soon, and thus is causing SSR to fail internally. Let's move this to logic to when we set the editor element.