### PR TITLE
Fix OutlineTreeView styling

### DIFF
--- a/packages/outline-playground/src/App.js
+++ b/packages/outline-playground/src/App.js
@@ -46,6 +46,8 @@ function RichTextEditor({settings, onSettingsChange}): React$Node {
           viewClassName="tree-view-output"
           timeTravelPanelClassName="debug-timetravel-panel"
           timeTravelButtonClassName="debug-timetravel-button"
+          timeTravelPanelSliderClassName="debug-timetravel-panel-slider"
+          timeTravelPanelButtonClassName="debug-timetravel-panel-button"
           editor={editor}
         />
       )}
@@ -90,6 +92,8 @@ function PlainTextEditor({settings, onSettingsChange}): React$Node {
           viewClassName="tree-view-output"
           timeTravelPanelClassName="debug-timetravel-panel"
           timeTravelButtonClassName="debug-timetravel-button"
+          timeTravelPanelSliderClassName="debug-timetravel-panel-slider"
+          timeTravelPanelButtonClassName="debug-timetravel-panel-button"
           editor={editor}
         />
       )}

--- a/packages/outline-playground/src/index.css
+++ b/packages/outline-playground/src/index.css
@@ -901,6 +901,23 @@ pre :not(.tree-view-output, .debug-timetravel-button) {
   display: flex;
 }
 
+.debug-timetravel-panel-slider {
+  padding: 0;
+  flex: 8;
+}
+
+.debug-timetravel-panel-button {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: #444;
+  flex: 1;
+}
+
+.debug-timetravel-panel-button:hover {
+  text-decoration: underline;
+}
+
 .debug-timetravel-button {
   border: 0;
   padding: 0;

--- a/packages/outline-react/src/OutlineTreeView.js
+++ b/packages/outline-react/src/OutlineTreeView.js
@@ -41,11 +41,15 @@ const SYMBOLS = Object.freeze({
 
 export default function TreeView({
   timeTravelButtonClassName,
+  timeTravelPanelSliderClassName,
+  timeTravelPanelButtonClassName,
   viewClassName,
   timeTravelPanelClassName,
   editor,
 }: {
   timeTravelPanelClassName: string,
+  timeTravelPanelSliderClassName: string,
+  timeTravelPanelButtonClassName: string,
   timeTravelButtonClassName: string,
   viewClassName: string,
   editor: OutlineEditor,
@@ -125,13 +129,14 @@ export default function TreeView({
       {timeTravelEnabled && (
         <div className={timeTravelPanelClassName}>
           <button
-            style={{border: 0, flex: 1}}
+            className={timeTravelPanelButtonClassName}
             onClick={() => {
               setIsPlaying(!isPlaying);
             }}>
             {isPlaying ? 'Pause' : 'Play'}
           </button>
           <input
+            className={timeTravelPanelSliderClassName}
             ref={inputRef}
             onChange={(event) => {
               const viewModelIndex = Number(event.target.value);
@@ -145,10 +150,9 @@ export default function TreeView({
             type="range"
             min="1"
             max={totalViewModels - 1}
-            style={{padding: 0, flex: 8}}
           />
           <button
-            style={{border: 0, flex: 1}}
+            className={timeTravelPanelButtonClassName}
             onClick={() => {
               const rootElement = editor.getRootElement();
               if (rootElement !== null) {


### PR DESCRIPTION
This gets rid of all the inline JS styles from OutlineTreeView and makes them all required props.