### PR TITLE
Refactor MutationObserver logic to work around Webkit bug

### DIFF
--- a/packages/outline-playground/__tests__/e2e/Composition-test.js
+++ b/packages/outline-playground/__tests__/e2e/Composition-test.js
@@ -429,6 +429,27 @@ describe('Composition', () => {
           focusPath: [0],
           focusOffset: 0,
         });
+
+        await page.keyboard.type(' ');
+        await page.keyboard.press('ArrowLeft');
+
+        await page.keyboard.imeSetComposition('ｓ', 1, 1);
+        await page.keyboard.imeSetComposition('す', 1, 1);
+        await page.keyboard.imeSetComposition('すｓ', 2, 2);
+        await page.keyboard.imeSetComposition('すｓｈ', 3, 3);
+        await page.keyboard.imeSetComposition('すし', 2, 2);
+        await page.keyboard.imeSetComposition('す', 1, 1);
+        await page.keyboard.imeSetComposition('', 0, 0);
+        // Escape would fire here
+        await page.keyboard.insertText('');
+
+        await assertHTML(page, '<p class="editor-paragraph" dir="ltr"><span data-outline-text="true"> </span></p>');
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 0,
+          focusPath: [0, 0, 0],
+          focusOffset: 0,
+        });
       });
     });
   });

--- a/packages/outline-react/src/useOutlinePlainText.js
+++ b/packages/outline-react/src/useOutlinePlainText.js
@@ -18,7 +18,7 @@ import {
   ParagraphNode,
   isParagraphNode,
 } from 'outline/ParagraphNode';
-import {CAN_USE_BEFORE_INPUT} from 'shared/environment';
+import {CAN_USE_BEFORE_INPUT, IS_SAFARI, IS_CHROME} from 'shared/environment';
 import invariant from 'shared/invariant';
 import {
   onSelectionChange,
@@ -33,6 +33,7 @@ import {
   onDragStartPolyfill,
   onTextMutation,
   onInput,
+  applyMutationInputWebkitWorkaround,
   onClick,
 } from 'outline/EventHelpers';
 import useOutlineDragonSupport from './shared/useOutlineDragonSupport';
@@ -100,6 +101,10 @@ if (CAN_USE_BEFORE_INPUT) {
   events.push(['beforeinput', onBeforeInputForPlainText]);
 } else {
   events.push(['drop', onDropPolyfill]);
+}
+
+if (IS_SAFARI || IS_CHROME) {
+  applyMutationInputWebkitWorkaround();
 }
 
 export default function useOutlinePlainText(editor: OutlineEditor): () => void {

--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -20,7 +20,7 @@ import {CodeNode} from 'outline/CodeNode';
 import {ParagraphNode, isParagraphNode} from 'outline/ParagraphNode';
 import {ListItemNode} from 'outline/ListItemNode';
 import {createParagraphNode} from 'outline/ParagraphNode';
-import {CAN_USE_BEFORE_INPUT} from 'shared/environment';
+import {CAN_USE_BEFORE_INPUT, IS_SAFARI, IS_CHROME} from 'shared/environment';
 import invariant from 'shared/invariant';
 import {
   onSelectionChange,
@@ -35,6 +35,7 @@ import {
   onDragStartPolyfill,
   onTextMutation,
   onInput,
+  applyMutationInputWebkitWorkaround,
   onClick,
 } from 'outline/EventHelpers';
 import useOutlineDragonSupport from './shared/useOutlineDragonSupport';
@@ -93,6 +94,10 @@ if (CAN_USE_BEFORE_INPUT) {
   events.push(['beforeinput', onBeforeInputForRichText]);
 } else {
   events.push(['drop', onDropPolyfill]);
+}
+
+if (IS_SAFARI || IS_CHROME) {
+  applyMutationInputWebkitWorkaround();
 }
 
 export default function useOutlineRichText(editor: OutlineEditor): () => void {

--- a/packages/outline/src/core/OutlineMutations.js
+++ b/packages/outline/src/core/OutlineMutations.js
@@ -8,12 +8,11 @@
  */
 
 import type {OutlineEditor} from './OutlineEditor';
-import type {View} from './OutlineView';
 import type {Selection} from './OutlineSelection';
 import type {TextNode} from './OutlineTextNode';
 
 import {isTextNode, isDecoratorNode} from '.';
-import {triggerListeners} from './OutlineView';
+import {triggerListeners, view} from './OutlineView';
 import {getNearestNodeFromDOMNode, getNodeFromDOMNode} from './OutlineNode';
 
 let isProcessingMutations: boolean = false;
@@ -36,23 +35,11 @@ function getLastSelection(editor: OutlineEditor): null | Selection {
   });
 }
 
-function pushTextMutation(
+function flushTextMutation(
   target: Text,
   node: TextNode,
-  view: View,
   editor: OutlineEditor,
 ) {
-  // We wrap the text mutations in a rAF to ensure that
-  // the editor can control when text mutations get flushed. This
-  // is important for when we want the sequence of events to be:
-  //
-  // > onKeyDown, onBeforeInput, onInput, onTextMutation
-  //
-  // Otherwise, the problematic sequence can be:
-  //
-  // > onKeyDown, onBeforeInput, onTextMutation, onInput
-  //
-
   const domSelection = window.getSelection();
   let anchorOffset = null;
   let focusOffset = null;
@@ -60,158 +47,135 @@ function pushTextMutation(
     anchorOffset = domSelection.anchorOffset;
     focusOffset = domSelection.focusOffset;
   }
-  if (editor._mutationRAF === null) {
-    const id = window.requestAnimationFrame(() => {
-      editor.flushTextMutations();
-    });
-    editor._mutationRAF = id;
-  }
+
   const text = target.nodeValue;
-  editor._textMutations.push({node, anchorOffset, focusOffset, text});
+  const textMutation = {node, anchorOffset, focusOffset, text};
+  triggerListeners('textmutation', editor, editor, view, textMutation);
 }
 
-function handleRootMutations(
+export function flushMutations(
   editor: OutlineEditor,
   mutations: Array<MutationRecord>,
   observer: MutationObserver,
 ): void {
-  isProcessingMutations = true;
-  try {
-    editor.update((view: View) => {
-      let shouldRevertSelection = false;
-      for (let i = 0; i < mutations.length; i++) {
-        const mutation = mutations[i];
-        const type = mutation.type;
-        const target = mutation.target;
-        const targetNode = getNearestNodeFromDOMNode(target);
+  let shouldRevertSelection = false;
+  for (let i = 0; i < mutations.length; i++) {
+    const mutation = mutations[i];
+    const type = mutation.type;
+    const target = mutation.target;
+    const targetNode = getNearestNodeFromDOMNode(target);
 
-        if (isDecoratorNode(targetNode)) {
-          continue;
+    if (isDecoratorNode(targetNode)) {
+      continue;
+    }
+    if (type === 'characterData') {
+      // Text mutations are deferred and passed to mutation listeners to be
+      // processed outside of the Outline engine.
+      if (
+        target.nodeType === 3 &&
+        isTextNode(targetNode) &&
+        targetNode.isAttached()
+      ) {
+        // $FlowFixMe: nodeType === 3 is a Text DOM node
+        flushTextMutation(((target: any): Text), targetNode, editor);
+      }
+    } else if (type === 'childList') {
+      shouldRevertSelection = true;
+      // We attempt to "undo" any changes that have occured outside
+      // of Outline. We want Outline's view model to be source of truth.
+      // To the user, these will look like no-ops.
+      const addedDOMs = mutation.addedNodes;
+      const removedDOMs = mutation.removedNodes;
+      const siblingDOM = mutation.nextSibling;
+
+      for (let s = 0; s < removedDOMs.length; s++) {
+        const removedDOM = removedDOMs[s];
+        const node = getNodeFromDOMNode(removedDOM);
+        let placementDOM = siblingDOM;
+
+        if (node !== null && node.isAttached()) {
+          const nextSibling = node.getNextSibling();
+          if (nextSibling !== null) {
+            const key = nextSibling.getKey();
+            const nextSiblingDOM = editor.getElementByKey(key);
+            if (nextSiblingDOM !== null && nextSiblingDOM.parentNode !== null) {
+              placementDOM = nextSiblingDOM;
+            }
+          }
         }
-        if (type === 'characterData') {
-          // Text mutations are deferred and passed to mutation listeners to be
-          // processed outside of the Outline engine.
-          if (
-            target.nodeType === 3 &&
-            isTextNode(targetNode) &&
-            targetNode.isAttached()
-          ) {
-            // $FlowFixMe: nodeType === 3 is a Text DOM node
-            pushTextMutation(((target: any): Text), targetNode, view, editor);
-          }
-        } else if (type === 'childList') {
-          shouldRevertSelection = true;
-          // We attempt to "undo" any changes that have occured outside
-          // of Outline. We want Outline's view model to be source of truth.
-          // To the user, these will look like no-ops.
-          const addedDOMs = mutation.addedNodes;
-          const removedDOMs = mutation.removedNodes;
-          const siblingDOM = mutation.nextSibling;
-
-          for (let s = 0; s < removedDOMs.length; s++) {
-            const removedDOM = removedDOMs[s];
-            const node = getNodeFromDOMNode(removedDOM);
-            let placementDOM = siblingDOM;
-
-            if (node !== null && node.isAttached()) {
-              const nextSibling = node.getNextSibling();
-              if (nextSibling !== null) {
-                const key = nextSibling.getKey();
-                const nextSiblingDOM = editor.getElementByKey(key);
-                if (
-                  nextSiblingDOM !== null &&
-                  nextSiblingDOM.parentNode !== null
-                ) {
-                  placementDOM = nextSiblingDOM;
-                }
-              }
+        if (placementDOM != null) {
+          while (placementDOM != null) {
+            const parentDOM = placementDOM.parentNode;
+            if (parentDOM === target) {
+              target.insertBefore(removedDOM, placementDOM);
+              break;
             }
-            if (placementDOM != null) {
-              while (placementDOM != null) {
-                const parentDOM = placementDOM.parentNode;
-                if (parentDOM === target) {
-                  target.insertBefore(removedDOM, placementDOM);
-                  break;
-                }
-                placementDOM = parentDOM;
-              }
-            } else {
-              target.appendChild(removedDOM);
-            }
+            placementDOM = parentDOM;
           }
-          for (let s = 0; s < addedDOMs.length; s++) {
-            const addedDOM = addedDOMs[s];
-            const node = getNodeFromDOMNode(addedDOM);
-            const parentDOM = addedDOM.parentNode;
-            if (parentDOM != null && node === null) {
-              parentDOM.removeChild(addedDOM);
-            }
-          }
+        } else {
+          target.appendChild(removedDOM);
         }
       }
-
-      // Capture all the mutations made during this function. This
-      // also prevents us having to process them on the next cycle
-      // of onMutation, as these mutations were made by us.
-      const records = observer.takeRecords();
-
-      // Check for any random auto-added <br> elements, and remove them.
-      // These get added by the browser when we undo the above mutations
-      // and this can lead to a broken UI.
-      if (records.length > 0) {
-        for (let i = 0; i < records.length; i++) {
-          const record = records[i];
-          const addedNodes = record.addedNodes;
-          const target = record.target;
-
-          for (let s = 0; s < addedNodes.length; s++) {
-            const addedDOM = addedNodes[s];
-            const parentDOM = addedDOM.parentNode;
-            if (
-              parentDOM != null &&
-              addedDOM.nodeName === 'BR' &&
-              !isManagedLineBreak(addedDOM, target)
-            ) {
-              parentDOM.removeChild(addedDOM);
-            }
-          }
-        }
-        // Clear any of those removal mutations
-        observer.takeRecords();
-      }
-      if (shouldRevertSelection) {
-        const selection = view.getSelection() || getLastSelection(editor);
-        if (selection !== null) {
-          selection.dirty = true;
-          view.setSelection(selection);
+      for (let s = 0; s < addedDOMs.length; s++) {
+        const addedDOM = addedDOMs[s];
+        const node = getNodeFromDOMNode(addedDOM);
+        const parentDOM = addedDOM.parentNode;
+        if (parentDOM != null && node === null) {
+          parentDOM.removeChild(addedDOM);
         }
       }
-    }, 'onMutation');
-  } finally {
-    isProcessingMutations = false;
-  }
-}
-
-export function flushPendingTextMutations(editor: OutlineEditor): void {
-  const observer = editor._observer;
-  if (observer !== null) {
-    const mutations = observer.takeRecords();
-    if (mutations.length > 0) {
-      handleRootMutations(editor, mutations, observer);
     }
   }
-  const textMutations = editor._textMutations;
-  if (textMutations.length > 0) {
-    editor._textMutations = [];
-    triggerListeners('textmutation', editor, editor, textMutations);
+
+  // Capture all the mutations made during this function. This
+  // also prevents us having to process them on the next cycle
+  // of onMutation, as these mutations were made by us.
+  const records = observer.takeRecords();
+
+  // Check for any random auto-added <br> elements, and remove them.
+  // These get added by the browser when we undo the above mutations
+  // and this can lead to a broken UI.
+  if (records.length > 0) {
+    for (let i = 0; i < records.length; i++) {
+      const record = records[i];
+      const addedNodes = record.addedNodes;
+      const target = record.target;
+
+      for (let s = 0; s < addedNodes.length; s++) {
+        const addedDOM = addedNodes[s];
+        const parentDOM = addedDOM.parentNode;
+        if (
+          parentDOM != null &&
+          addedDOM.nodeName === 'BR' &&
+          !isManagedLineBreak(addedDOM, target)
+        ) {
+          parentDOM.removeChild(addedDOM);
+        }
+      }
+    }
+    // Clear any of those removal mutations
+    observer.takeRecords();
+  }
+  if (shouldRevertSelection) {
+    const selection = view.getSelection() || getLastSelection(editor);
+    if (selection !== null) {
+      selection.dirty = true;
+      view.setSelection(selection);
+    }
   }
 }
 
 export function initMutationObserver(editor: OutlineEditor): void {
   editor._observer = new MutationObserver(
     (mutations: Array<MutationRecord>, observer: MutationObserver) => {
-      handleRootMutations(editor, mutations, observer);
+      isProcessingMutations = true;
+      try {
+        editor.update(() => {
+          flushMutations(editor, mutations, observer);
+        }, 'onMutation');
+      } finally {
+        isProcessingMutations = false;
+      }
     },
   );
 }
-

--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -814,8 +814,11 @@ function removeStrandedEmptyTextNode(
   const blockKey = node.__parent;
   let selectionIsDirty = false;
 
+  // We should never try and remove a node during composition.
+  // Composed nodes are also technically not really empty, they
+  // have a no break space at the end.
   if (getCompositionKey() === key) {
-    setCompositionKey(null);
+    return;
   }
 
   if (anchor !== null && blockKey !== null) {

--- a/packages/outline/src/core/index.js
+++ b/packages/outline/src/core/index.js
@@ -30,7 +30,7 @@ export type {
 export type {TextFormatType} from './OutlineTextNode';
 export type {LineBreakNode} from './OutlineLineBreakNode';
 
-import {createEditor} from './OutlineEditor';
+import {createEditor, getEditorFromElement} from './OutlineEditor';
 import {createTextNode, isTextNode, TextNode} from './OutlineTextNode';
 import {isBlockNode, BlockNode} from './OutlineBlockNode';
 import {createRootNode, isRootNode, RootNode} from './OutlineRootNode';
@@ -51,6 +51,8 @@ export {
   isLineBreakNode,
   isRootNode,
   isTextNode,
+  // Helper
+  getEditorFromElement,
   // Extensible nodes
   BlockNode,
   DecoratorNode,


### PR DESCRIPTION
This attempts to improve the runtime performance by avoiding the need to defer text mutations with a `requestAnimationFrame`. The reason we had that before, was because of the exception around the event sequence that occured because of a heuristic in React's eager event listeners (adding an `input` capture listener to the React root), which meant that I wrongly assumed that this was always the sequence – when it's actually a bug in Chrome and Safari.