### PR TITLE
Add canBeEmpty to RootNode

### DIFF
--- a/packages/outline/src/core/OutlineRootNode.js
+++ b/packages/outline/src/core/OutlineRootNode.js
@@ -66,6 +66,10 @@ export class RootNode extends BlockNode {
     }
     return super.append(...nodesToAppend);
   }
+
+  canBeEmpty(): false {
+    return false;
+  }
 }
 
 export function createRootNode(): RootNode {


### PR DESCRIPTION
Like ListNode, RootNodes can't be selected and can't be empty.