### PR TITLE
Resolve text nodes selection on ranges when nodes are added/deleted

### DIFF
--- a/packages/outline/src/core/OutlineSelection.js
+++ b/packages/outline/src/core/OutlineSelection.js
@@ -729,30 +729,56 @@ export function updateBlockSelectionOnCreateDeleteNode(
 
 function updateSelectionResolveTextNodes(selection: Selection) {
   const anchor = selection.anchor;
+  const anchorOffset = anchor.offset;
   const focus = selection.focus;
+  const focusOffset = focus.offset;
   const anchorNode = anchor.getNode();
   const focusNode = focus.getNode();
   if (selection.isCollapsed()) {
     if (!isBlockNode(anchorNode)) {
       return;
     }
-    const child = anchorNode.getChildAtIndex(anchor.offset);
+    const childSize = anchorNode.getChildrenSize();
+    const anchorOffsetAtEnd = anchorOffset >= childSize;
+    const child = anchorOffsetAtEnd
+      ? anchorNode.getChildAtIndex(childSize - 1)
+      : anchorNode.getChildAtIndex(anchorOffset);
     if (isTextNode(child)) {
-      anchor.set(child.getKey(), 0, 'text');
-      focus.set(child.getKey(), 0, 'text');
+      let newOffset = 0;
+      if (anchorOffsetAtEnd) {
+        newOffset = child.getTextContentSize();
+      }
+      anchor.set(child.getKey(), newOffset, 'text');
+      focus.set(child.getKey(), newOffset, 'text');
     }
     return;
   }
   if (isBlockNode(anchorNode)) {
-    const child = anchorNode.getChildAtIndex(anchor.offset);
+    const childSize = anchorNode.getChildrenSize();
+    const anchorOffsetAtEnd = anchorOffset >= childSize;
+    const child = anchorOffsetAtEnd
+      ? anchorNode.getChildAtIndex(childSize - 1)
+      : anchorNode.getChildAtIndex(anchorOffset);
     if (isTextNode(child)) {
-      anchor.set(child.getKey(), 0, 'text');
+      let newOffset = 0;
+      if (anchorOffsetAtEnd) {
+        newOffset = child.getTextContentSize();
+      }
+      anchor.set(child.getKey(), newOffset, 'text');
     }
   }
   if (isBlockNode(focusNode)) {
-    const child = focusNode.getChildAtIndex(focus.offset);
+    const childSize = focusNode.getChildrenSize();
+    const focusOffsetAtEnd = focusOffset >= childSize;
+    const child = focusOffsetAtEnd
+      ? focusNode.getChildAtIndex(childSize - 1)
+      : focusNode.getChildAtIndex(focusOffset);
     if (isTextNode(child)) {
-      focus.set(child.getKey(), 0, 'text');
+      let newOffset = 0;
+      if (focusOffsetAtEnd) {
+        newOffset = child.getTextContentSize();
+      }
+      focus.set(child.getKey(), newOffset, 'text');
     }
   }
 }

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelection.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelection.test.js
@@ -1348,6 +1348,49 @@ describe('OutlineSelection tests', () => {
           };
         },
       },
+      // Edge cases
+      {
+        name: "Selection resolves to the end of text node when it's at the end (1)",
+        anchorOffset: 3,
+        focusOffset: 3,
+        fnBefore: (paragraph, originalText1) => {
+          const originalText2 = createTextNode('bar');
+          paragraph.append(originalText2);
+        },
+        fn: (paragraph, originalText1) => {
+          const originalText2 = paragraph.getLastChild();
+          const newText = createTextNode('new');
+          originalText1.insertBefore(newText);
+
+          return {
+            expectedAnchor: originalText2,
+            expectedAnchorOffset: 'bar'.length,
+            expectedFocus: originalText2,
+            expectedFocusOffset: 'bar'.length,
+          };
+        },
+      },
+      {
+        name: "Selection resolves to the end of text node when it's at the end (2)",
+        anchorOffset: 0,
+        focusOffset: 3,
+        fnBefore: (paragraph, originalText1) => {
+          const originalText2 = createTextNode('bar');
+          paragraph.append(originalText2);
+        },
+        fn: (paragraph, originalText1) => {
+          const originalText2 = paragraph.getLastChild();
+          const newText = createTextNode('new');
+          originalText1.insertBefore(newText);
+
+          return {
+            expectedAnchor: originalText1,
+            expectedAnchorOffset: 0,
+            expectedFocus: originalText2,
+            expectedFocusOffset: 'bar'.length,
+          };
+        },
+      },
     ]
       .reduce((testSuite, testCase) => {
         // Test inverse selection

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
@@ -308,13 +308,13 @@ describe('OutlineSelectionHelpers tests', () => {
       editor.getViewModel().read((view) => {
         const selection = view.getSelection();
         expect(selection.anchor).toEqual({
-          type: 'block',
-          key: block.getKey(),
+          type: 'text',
+          key: 'b',
           offset: 1,
         });
         expect(selection.focus).toEqual({
-          type: 'block',
-          key: block.getKey(),
+          type: 'text',
+          key: 'b',
           offset: 1,
         });
       });
@@ -362,13 +362,13 @@ describe('OutlineSelectionHelpers tests', () => {
       editor.getViewModel().read((view) => {
         const selection = view.getSelection();
         expect(selection.anchor).toEqual({
-          type: 'block',
-          key: block.getKey(),
+          type: 'text',
+          key: 'c',
           offset: 2,
         });
         expect(selection.focus).toEqual({
-          type: 'block',
-          key: block.getKey(),
+          type: 'text',
+          key: 'c',
           offset: 2,
         });
       });
@@ -883,14 +883,14 @@ describe('OutlineSelectionHelpers tests', () => {
       editor.getViewModel().read((view) => {
         const selection = view.getSelection();
         expect(selection.anchor).toEqual({
-          type: 'block',
-          key: block.getKey(),
-          offset: 1,
+          type: 'text',
+          key: 'a',
+          offset: 3,
         });
         expect(selection.focus).toEqual({
-          type: 'block',
-          key: block.getKey(),
-          offset: 1,
+          type: 'text',
+          key: 'a',
+          offset: 3,
         });
       });
     });


### PR DESCRIPTION
In `updateBlockSelectionOnCreateDeleteNode `, we were already resolving the TextNode selection (when possible) when the selection is collapsed but the same should be done on ranges.