### PR TITLE
Object.freeze selection in DEV are reconciliation

### DIFF
--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -589,6 +589,12 @@ function reconcileSelection(
   }
   const anchor = selection.anchor;
   const focus = selection.focus;
+  if (__DEV__) {
+    // Freeze the selection in DEV to prevent accidental mutations
+    Object.freeze(anchor);
+    Object.freeze(focus);
+    Object.freeze(selection);
+  }
   const anchorKey = anchor.key;
   const focusKey = focus.key;
   const anchorDOM = getElementByKeyOrThrow(editor, anchorKey);


### PR DESCRIPTION
We already do this for Outline nodes, let's also do it for selection.