### PR TITLE
insertNodes: fix invariant cases + add more test coverage

### DIFF
--- a/packages/outline/src/core/OutlineRootNode.js
+++ b/packages/outline/src/core/OutlineRootNode.js
@@ -36,14 +36,14 @@ export class RootNode extends BlockNode {
     // You can't select root nodes.
     invariant(false, 'remove: cannot be called on root nodes');
   }
-  replace<N: OutlineNode>(): N {
+  replace<N: OutlineNode>(node: N): N {
     // You can't select root nodes.
     invariant(false, 'replace: cannot be called on root nodes');
   }
   insertBefore() {
     invariant(false, 'insertBefore: cannot be called on root nodes');
   }
-  insertAfter() {
+  insertAfter(node: OutlineNode): OutlineNode {
     invariant(false, 'insertAfter: cannot be called on root nodes');
   }
 

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
@@ -1546,11 +1546,11 @@ describe('OutlineSelectionHelpers tests', () => {
             key: paragraph.getKey(),
           });
           const selection = view.getSelection();
+          const heading = createHeadingNode('h1');
+          const child = createTextNode('foo');
+          heading.append(child);
 
-          insertNodes(selection, [
-            createHeadingNode('h1'),
-            createTextNode('foo'),
-          ]);
+          insertNodes(selection, [heading]);
         });
 
         expect(element.innerHTML).toBe(
@@ -1558,7 +1558,7 @@ describe('OutlineSelectionHelpers tests', () => {
         );
       });
 
-      test('a heading node with a child text node and a sibling text node', async () => {
+      test('a heading node with a child text node and a disjoint sibling text node should throw', async () => {
         const editor = createEditor({});
         editor.addListener('error', (error) => {
           throw error;
@@ -1582,16 +1582,17 @@ describe('OutlineSelectionHelpers tests', () => {
             key: paragraph.getKey(),
           });
           const selection = view.getSelection();
+          const heading = createHeadingNode('h1');
+          const child = createTextNode('foo');
+          heading.append(child);
 
-          insertNodes(selection, [
-            createHeadingNode('h1'),
-            createTextNode('foo'),
-            createTextNode('bar'),
-          ]);
+          expect(() => {
+            insertNodes(selection, [heading, createTextNode('bar')]);
+          }).toThrow();
         });
 
         expect(element.innerHTML).toBe(
-          '<h1 dir="ltr"><span data-outline-text="true">foobar</span></h1>',
+          '<h1><span data-outline-text="true">foo</span></h1>',
         );
       });
     });
@@ -1696,19 +1697,19 @@ describe('OutlineSelectionHelpers tests', () => {
             key: text.getKey(),
           });
           const selection = view.getSelection();
+          const heading = createHeadingNode('h1');
+          const child = createTextNode('foo');
+          heading.append(child);
 
-          insertNodes(selection, [
-            createHeadingNode('h1'),
-            createTextNode('foo'),
-          ]);
+          insertNodes(selection, [heading]);
         });
 
         expect(element.innerHTML).toBe(
-          '<p><span data-outline-text="true">Existing text...</span></p><h1><span data-outline-text="true">foo</span></h1>',
+          '<p dir="ltr"><span data-outline-text="true">Existing text...foo</span></p>',
         );
       });
 
-      test('a heading node with a child text node and a sibling text node', async () => {
+      test('a heading node with a child text node and a disjoint sibling text node should throw', async () => {
         const editor = createEditor({});
         editor.addListener('error', (error) => {
           throw error;
@@ -1734,16 +1735,17 @@ describe('OutlineSelectionHelpers tests', () => {
             key: text.getKey(),
           });
           const selection = view.getSelection();
+          const heading = createHeadingNode('h1');
+          const child = createTextNode('foo');
+          heading.append(child);
 
-          insertNodes(selection, [
-            createHeadingNode('h1'),
-            createTextNode('foo'),
-            createTextNode('bar'),
-          ]);
+          expect(() => {
+            insertNodes(selection, [heading, createTextNode('bar')]);
+          }).toThrow();
         });
 
         expect(element.innerHTML).toBe(
-          '<p><span data-outline-text="true">Existing text...</span></p><h1 dir="ltr"><span data-outline-text="true">foobar</span></h1>',
+          '<p dir="ltr"><span data-outline-text="true">Existing text...foo</span></p>',
         );
       });
     });

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -41,5 +41,6 @@
   "39": "createNode: node does not exist in nodeMap",
   "40": "reconcileNode: prevNode or nextNode does not exist in nodeMap",
   "41": "reconcileNode: parentDOM is null",
-  "42": "Reconciliation: could not find DOM element for node key \"${key}\""
+  "42": "Reconciliation: could not find DOM element for node key \"${key}\"",
+  "43": "insertNodes: cannot insert a non-block into a root node"
 }


### PR DESCRIPTION
We were missing some test coverage over some of the `insertNodes` logic. Upon the journey to doing this, it showed up some holes in our invariants around root node insertion, which this PR also addresses.