### PR TITLE
Add view.log(text), remove update name

### DIFF
--- a/packages/outline-playground/src/BlockControls.js
+++ b/packages/outline-playground/src/BlockControls.js
@@ -141,6 +141,7 @@ function DropdownList({
   const formatParagraph = () => {
     if (blockType !== 'paragraph') {
       editor.update((view) => {
+        view.log('formatParagraph');
         const selection = view.getSelection();
 
         if (selection !== null) {
@@ -154,7 +155,7 @@ function DropdownList({
           children.forEach((child) => paragraph.append(child));
           block.replace(paragraph);
         }
-      }, 'formatParagraph');
+      });
     }
     setShowDropDown(false);
   };
@@ -162,6 +163,7 @@ function DropdownList({
   const formatLargeHeading = () => {
     if (blockType !== 'h1') {
       editor.update((view) => {
+        view.log('formatLargeHeading');
         const selection = view.getSelection();
 
         if (selection !== null) {
@@ -175,7 +177,7 @@ function DropdownList({
           children.forEach((child) => paragraph.append(child));
           block.replace(paragraph);
         }
-      }, 'formatLargeHeading');
+      });
     }
     setShowDropDown(false);
   };
@@ -183,6 +185,7 @@ function DropdownList({
   const formatSmallHeading = () => {
     if (blockType !== 'h2') {
       editor.update((view) => {
+        view.log('formatSmallHeading');
         const selection = view.getSelection();
 
         if (selection !== null) {
@@ -196,7 +199,7 @@ function DropdownList({
           paragraph.append(...children);
           block.replace(paragraph);
         }
-      }, 'formatSmallHeading');
+      });
     }
     setShowDropDown(false);
   };
@@ -204,6 +207,7 @@ function DropdownList({
   const formatBulletList = () => {
     if (blockType !== 'ul') {
       editor.update((view) => {
+        view.log('formatBulletList');
         const selection = view.getSelection();
 
         if (selection !== null) {
@@ -219,7 +223,7 @@ function DropdownList({
           children.forEach((child) => listItem.append(child));
           block.replace(list);
         }
-      }, 'formatBulletList');
+      });
     }
     setShowDropDown(false);
   };
@@ -227,6 +231,7 @@ function DropdownList({
   const formatNumberedList = () => {
     if (blockType !== 'ol') {
       editor.update((view) => {
+        view.log('formatNumberedList');
         const selection = view.getSelection();
 
         if (selection !== null) {
@@ -242,7 +247,7 @@ function DropdownList({
           children.forEach((child) => listItem.append(child));
           block.replace(list);
         }
-      }, 'formatNumberedList');
+      });
     }
     setShowDropDown(false);
   };
@@ -250,6 +255,7 @@ function DropdownList({
   const formatQuote = () => {
     if (blockType !== 'quote') {
       editor.update((view) => {
+        view.log('formatQuote');
         const selection = view.getSelection();
 
         if (selection !== null) {
@@ -263,7 +269,7 @@ function DropdownList({
           children.forEach((child) => quoteNode.append(child));
           block.replace(quoteNode);
         }
-      }, 'formatQuote');
+      });
     }
     setShowDropDown(false);
   };
@@ -271,6 +277,7 @@ function DropdownList({
   const formatCode = () => {
     if (blockType !== 'code') {
       editor.update((view) => {
+        view.log('formatCode')
         const selection = view.getSelection();
 
         if (selection !== null) {
@@ -284,7 +291,7 @@ function DropdownList({
           children.forEach((child) => codeNode.append(child));
           block.replace(codeNode);
         }
-      }, 'formatCode');
+      });
     }
     setShowDropDown(false);
   };

--- a/packages/outline-playground/src/Editor.js
+++ b/packages/outline-playground/src/Editor.js
@@ -123,6 +123,7 @@ export const useRichTextEditor = ({
   const element = useMemo(() => {
     const handleAddImage = () => {
       editor.update((view) => {
+        view.log('handleAddImage')
         const selection = view.getSelection();
         if (selection !== null) {
           const imageNode = createImageNode(
@@ -131,7 +132,7 @@ export const useRichTextEditor = ({
           );
           insertNodes(selection, [imageNode]);
         }
-      }, 'handleAddImage');
+      });
     };
 
     return (

--- a/packages/outline-playground/src/ImageNode.js
+++ b/packages/outline-playground/src/ImageNode.js
@@ -257,13 +257,14 @@ function ImageComponent({
   const handleKeyDown = (event) => {
     if ((hasFocus && event.key === 'Backspace') || event.key === 'Delete') {
       editor.update((view) => {
+        view.log('Image.keyDown')
         const node = view.getNodeByKey(nodeKey);
         if (node !== null) {
           node.remove();
           event.stopPropagation();
           event.preventDefault();
         }
-      }, 'Image.keyDown');
+      });
     }
   };
 
@@ -303,11 +304,12 @@ function ImageComponent({
               }
               setIsResizing(false);
               editor.update((view) => {
+                view.log('ImageNode.resize')
                 const node = view.getNodeByKey(nodeKey);
                 if (isImageNode(node)) {
                   node.setWidthAndHeight(nextWidth, nextHeight);
                 }
-              }, 'ImageNode.resize');
+              });
             }}
           />
         )}

--- a/packages/outline-playground/src/useEvent.js
+++ b/packages/outline-playground/src/useEvent.js
@@ -25,7 +25,10 @@ function useWrapper<E: Event>(
           return;
         }
       }
-      editor.update((view) => handler(event, view, editor), event.type);
+      editor.update((view) => {
+        view.log(event.type);
+        handler(event, view, editor);
+      });
     },
     [editor, handler],
   );

--- a/packages/outline-playground/src/useFloatingToolbar.js
+++ b/packages/outline-playground/src/useFloatingToolbar.js
@@ -298,6 +298,7 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
   const updateSelectedLinks = useCallback(
     (url: null | string, selection: null | Selection) => {
       editor.update((view) => {
+        view.log('useToolbar')
         if (selection !== null) {
           view.setSelection(selection);
         }
@@ -334,7 +335,7 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
             }
           });
         }
-      }, 'useToolbar');
+      });
     },
     [editor],
   );
@@ -342,11 +343,12 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
   const applyFormatText = useCallback(
     (formatType: TextFormatType) => {
       editor.update((view) => {
+        view.log('applyFormatText')
         const selection = view.getSelection();
         if (selection !== null) {
           formatText(selection, formatType);
         }
-      }, 'applyFormatText');
+      });
     },
     [editor],
   );
@@ -354,11 +356,12 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
   const applyStyleText = useCallback(
     (styles: {[string]: string}) => {
       editor.update((view) => {
+        view.log('applyStyleText')
         const selection = view.getSelection();
         if (selection !== null) {
           patchStyleText(selection, styles);
         }
-      }, 'applyStyleText');
+      });
     },
     [editor],
   );

--- a/packages/outline-playground/src/useHashtags.js
+++ b/packages/outline-playground/src/useHashtags.js
@@ -284,6 +284,7 @@ export default function useHashtags(editor: OutlineEditor): void {
       editor.addTextNodeTransform(textNodeTransform);
     const removeUpdateListener = editor.addListener('update', () => {
       editor.update((view) => {
+        view.log('useHashtags')
         const selection = view.getSelection();
         if (selection !== null && !editor.isComposing()) {
           const anchorNode = selection.anchor.getNode();
@@ -291,7 +292,7 @@ export default function useHashtags(editor: OutlineEditor): void {
             textNodeTransform(anchorNode, view);
           }
         }
-      }, 'useHashtags');
+      });
     });
 
     return () => {

--- a/packages/outline-playground/src/useKeywords.js
+++ b/packages/outline-playground/src/useKeywords.js
@@ -143,9 +143,10 @@ export default function useKeywords(editor: OutlineEditor): void {
 
     const updateListener = () => {
       editor.update((view) => {
+        view.log('useKeywords')
         const root = view.getRoot();
         traverseNodes(root);
-      }, 'useKeywords');
+      });
     };
 
     const removeTextTransform =

--- a/packages/outline-playground/src/useMentions.js
+++ b/packages/outline-playground/src/useMentions.js
@@ -469,6 +469,7 @@ function createMentionNodeFromSearchResult(
   match: MentionMatch,
 ): void {
   editor.update((view: View) => {
+    view.log('createMentionNodeFromSearchResult')
     const selection = view.getSelection();
     if (selection == null || !selection.isCollapsed()) {
       return;
@@ -510,7 +511,7 @@ function createMentionNodeFromSearchResult(
     const mentionNode = createMentionNode(entryText);
     nodeToReplace.replace(mentionNode);
     mentionNode.select();
-  }, 'createMentionNodeFromSearchResult');
+  });
 }
 
 export default function useMentions(editor: OutlineEditor): React$Node {

--- a/packages/outline-playground/src/useTestRecorder.js
+++ b/packages/outline-playground/src/useTestRecorder.js
@@ -343,12 +343,13 @@ ${steps.map(formatStep).join(`\n`)}
     (currentEditor) => {
       if (!isRecording) {
         currentEditor.update((view: View) => {
+          view.log('useStepRecorder')
           const root = view.getRoot();
           root.clear();
           const text = createTextNode();
           root.append(createParagraphNode().append(text));
           text.select();
-        }, 'useStepRecorder');
+        });
         setSteps([]);
       }
       setIsRecording((currentIsRecording) => !currentIsRecording);

--- a/packages/outline-playground/src/useTypeahead.js
+++ b/packages/outline-playground/src/useTypeahead.js
@@ -43,87 +43,80 @@ export default function useTypeahead(editor: OutlineEditor): void {
   }, [editor]);
 
   const renderTypeahead = useCallback(() => {
-    updateWithoutHistory(
-      editor,
-      (view: View) => {
-        const currentTypeaheadNode = getTypeaheadTextNode(view);
+    updateWithoutHistory(editor, (view: View) => {
+      view.log('useTypeahead');
+      const currentTypeaheadNode = getTypeaheadTextNode(view);
 
-        function maybeRemoveTypeahead() {
-          if (currentTypeaheadNode !== null) {
-            const selection = view.getSelection();
-            if (selection !== null) {
-              const anchor = selection.anchor;
-              const focus = selection.focus;
-              if (anchor.type === 'text' && focus.type === 'text') {
-                let anchorNode = anchor.getNode();
-                let anchorNodeOffset = anchor.offset;
-                if (anchorNode.getKey() === currentTypeaheadNode.getKey()) {
-                  anchorNode = anchorNode.getPreviousSibling();
-                  if (isTextNode(anchorNode)) {
-                    anchorNodeOffset = anchorNode.getTextContent().length;
-                  }
-                }
-                let focusNode = focus.getNode();
-                let focusNodeOffset = focus.offset;
-                if (focusNode.getKey() === currentTypeaheadNode.getKey()) {
-                  focusNode = focusNode.getPreviousSibling();
-                  if (isTextNode(focusNode)) {
-                    focusNodeOffset = focusNode.getTextContent().length;
-                  }
-                }
-                if (isTextNode(focusNode) && isTextNode(anchorNode)) {
-                  selection.setTextNodeRange(
-                    anchorNode,
-                    anchorNodeOffset,
-                    focusNode,
-                    focusNodeOffset,
-                  );
+      function maybeRemoveTypeahead() {
+        if (currentTypeaheadNode !== null) {
+          const selection = view.getSelection();
+          if (selection !== null) {
+            const anchor = selection.anchor;
+            const focus = selection.focus;
+            if (anchor.type === 'text' && focus.type === 'text') {
+              let anchorNode = anchor.getNode();
+              let anchorNodeOffset = anchor.offset;
+              if (anchorNode.getKey() === currentTypeaheadNode.getKey()) {
+                anchorNode = anchorNode.getPreviousSibling();
+                if (isTextNode(anchorNode)) {
+                  anchorNodeOffset = anchorNode.getTextContent().length;
                 }
               }
+              let focusNode = focus.getNode();
+              let focusNodeOffset = focus.offset;
+              if (focusNode.getKey() === currentTypeaheadNode.getKey()) {
+                focusNode = focusNode.getPreviousSibling();
+                if (isTextNode(focusNode)) {
+                  focusNodeOffset = focusNode.getTextContent().length;
+                }
+              }
+              if (isTextNode(focusNode) && isTextNode(anchorNode)) {
+                selection.setTextNodeRange(
+                  anchorNode,
+                  anchorNodeOffset,
+                  focusNode,
+                  focusNodeOffset,
+                );
+              }
             }
-            currentTypeaheadNode.remove();
           }
-          typeaheadNodeKey.current = null;
+          currentTypeaheadNode.remove();
         }
+        typeaheadNodeKey.current = null;
+      }
 
-        function maybeAddOrEditTypeahead() {
-          if (currentTypeaheadNode !== null) {
-            // Edit
-            if (currentTypeaheadNode.getTextContent(true) !== suggestion) {
-              currentTypeaheadNode.setTextContent(suggestion ?? '');
-            }
-            return;
+      function maybeAddOrEditTypeahead() {
+        if (currentTypeaheadNode !== null) {
+          // Edit
+          if (currentTypeaheadNode.getTextContent(true) !== suggestion) {
+            currentTypeaheadNode.setTextContent(suggestion ?? '');
           }
-          // Add
-          const lastParagraph = view.getRoot().getLastChild();
-          if (isBlockNode(lastParagraph)) {
-            const lastTextNode = lastParagraph.getLastChild();
-            if (isTextNode(lastTextNode)) {
-              const newTypeaheadNode = createTypeaheadNode(suggestion ?? '');
-              lastTextNode.insertAfter(newTypeaheadNode);
-              typeaheadNodeKey.current = newTypeaheadNode.getKey();
-            }
+          return;
+        }
+        // Add
+        const lastParagraph = view.getRoot().getLastChild();
+        if (isBlockNode(lastParagraph)) {
+          const lastTextNode = lastParagraph.getLastChild();
+          if (isTextNode(lastTextNode)) {
+            const newTypeaheadNode = createTypeaheadNode(suggestion ?? '');
+            lastTextNode.insertAfter(newTypeaheadNode);
+            typeaheadNodeKey.current = newTypeaheadNode.getKey();
           }
         }
+      }
 
-        const selection = view.getSelection();
-        const anchorNode = selection?.anchor.getNode();
-        const anchorOffset = selection?.anchor.offset;
-        const anchorLength = anchorNode?.getTextContentSize();
-        const isCaretPositionAtEnd =
-          anchorLength != null && anchorOffset === anchorLength;
-        if (
-          suggestion === null ||
-          !selectionCollapsed ||
-          !isCaretPositionAtEnd
-        ) {
-          maybeRemoveTypeahead();
-        } else {
-          maybeAddOrEditTypeahead();
-        }
-      },
-      'useTypeahead',
-    );
+      const selection = view.getSelection();
+      const anchorNode = selection?.anchor.getNode();
+      const anchorOffset = selection?.anchor.offset;
+      const anchorLength = anchorNode?.getTextContentSize();
+      const isCaretPositionAtEnd =
+        anchorLength != null && anchorOffset === anchorLength;
+      if (suggestion === null || !selectionCollapsed || !isCaretPositionAtEnd) {
+        maybeRemoveTypeahead();
+      } else {
+        maybeAddOrEditTypeahead();
+      }
+    });
   }, [editor, getTypeaheadTextNode, selectionCollapsed, suggestion]);
 
   // Rerender on suggestion change
@@ -156,6 +149,7 @@ export default function useTypeahead(editor: OutlineEditor): void {
       const handleEvent = (event: KeyboardEvent) => {
         if (event.key === 'Tab' || event.key === 'ArrowRight') {
           editor.update((view: View) => {
+            view.log('useTypeahead');
             const typeaheadTextNode = getTypeaheadTextNode(view);
             const prevTextNode = typeaheadTextNode?.getPreviousSibling();
             // Make sure that the Typeahead is visible and previous child writable
@@ -170,7 +164,7 @@ export default function useTypeahead(editor: OutlineEditor): void {
             }
             typeaheadTextNode?.remove();
             typeaheadNodeKey.current = null;
-          }, 'useTypeahead');
+          });
         }
       };
 

--- a/packages/outline-react/src/shared/useOutlineDragonSupport.js
+++ b/packages/outline-react/src/shared/useOutlineDragonSupport.js
@@ -50,6 +50,7 @@ export default function useOutlineDragonSupport(editor: OutlineEditor) {
               // eslint-disable-next-line no-unused-expressions
               formatCommand;
               editor.update((view) => {
+                view.log('useOutlineDragonSupport')
                 const selection = view.getSelection();
                 if (selection !== null) {
                   const anchor = selection.anchor;
@@ -99,7 +100,7 @@ export default function useOutlineDragonSupport(editor: OutlineEditor) {
                   // block the chrome extension from handling this event
                   event.stopImmediatePropagation();
                 }
-              }, 'useOutlineDragonSupport');
+              });
             }
           }
         }

--- a/packages/outline-react/src/useOutlineCharacterLimit.js
+++ b/packages/outline-react/src/useOutlineCharacterLimit.js
@@ -66,13 +66,10 @@ export function useCharacterLimit(
         offsetUtf16 += codepoint.length;
       }
     }
-    updateWithoutHistory(
-      editor,
-      (view: View) => {
-        wrapOverflowedNodes(view, offsetUtf16);
-      },
-      'CharacterLimit',
-    );
+    updateWithoutHistory(editor, (view: View) => {
+      view.log('CharacterLimit');
+      wrapOverflowedNodes(view, offsetUtf16);
+    });
   }, [editor, maxCharacters, strlen]);
 
   useEffect(() => {

--- a/packages/outline-react/src/useOutlineEditor.js
+++ b/packages/outline-react/src/useOutlineEditor.js
@@ -19,7 +19,7 @@ function defaultOnErrorHandler(e: Error): void {
 }
 
 export default function useOutlineEditor<EditorContext>(editorConfig?: {
-  onError?: (error: Error, updateName: string) => void,
+  onError?: (error: Error, log: Array<string>) => void,
   initialViewModel?: ViewModel,
   theme?: EditorThemeClasses,
   context?: EditorContext,

--- a/packages/outline-react/src/useOutlineNestedList.js
+++ b/packages/outline-react/src/useOutlineNestedList.js
@@ -19,6 +19,7 @@ function maybeIndentOrOutdent(
 ): boolean {
   let hasHandledIndention = false;
   editor.update((view: View) => {
+    view.log('useNestedList.maybeIndent')
     const selection = view.getSelection();
     if (selection === null) {
       return;
@@ -43,7 +44,7 @@ function maybeIndentOrOutdent(
       }
       hasHandledIndention = true;
     }
-  }, 'useNestedList.maybeIndent');
+  });
   return hasHandledIndention;
 }
 

--- a/packages/outline-react/src/useOutlinePlainText.js
+++ b/packages/outline-react/src/useOutlinePlainText.js
@@ -47,12 +47,13 @@ function initParagraph(view: View, root: RootNode): void {
 
 function initEditor(editor: OutlineEditor): void {
   editor.update((view) => {
+    view.log('initEditor')
     const root = view.getRoot();
     const firstChild = root.getFirstChild();
     if (firstChild === null) {
       initParagraph(view, root);
     }
-  }, 'initEditor');
+  });
 }
 
 function clearEditor(
@@ -61,11 +62,11 @@ function clearEditor(
 ): void {
   editor.update(
     (view) => {
+      view.log('clearEditor')
       const root = view.getRoot();
       root.clear();
       initParagraph(view, root);
     },
-    'clearEditor',
     callbackFn,
   );
 }

--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -50,27 +50,25 @@ function initParagraph(view: View, root: RootNode): void {
 
 function initEditor(editor: OutlineEditor): void {
   editor.update((view: View) => {
+    view.log('initEditor');
     const root = view.getRoot();
     const firstChild = root.getFirstChild();
     if (firstChild === null) {
       initParagraph(view, root);
     }
-  }, 'initEditor');
+  });
 }
 
 function clearEditor(
   editor: OutlineEditor,
   callbackFn?: (callbackFn?: () => void) => void,
 ): void {
-  editor.update(
-    (view) => {
-      const root = view.getRoot();
-      root.clear();
-      initParagraph(view, root);
-    },
-    'clearEditor',
-    callbackFn,
-  );
+  editor.update((view) => {
+    view.log('clearEditor');
+    const root = view.getRoot();
+    root.clear();
+    initParagraph(view, root);
+  }, callbackFn);
 }
 
 const events: InputEvents = [

--- a/packages/outline/src/core/OutlineMutations.js
+++ b/packages/outline/src/core/OutlineMutations.js
@@ -173,8 +173,9 @@ export function flushRootMutations(
   isProcessingMutations = true;
   try {
     editor.update(() => {
+      view.log('onMutation');
       flushMutations(editor, mutations, observer);
-    }, 'onMutation');
+    });
   } finally {
     isProcessingMutations = false;
   }
@@ -183,7 +184,7 @@ export function flushRootMutations(
 export function initMutationObserver(editor: OutlineEditor): void {
   editor._observer = new MutationObserver(
     (mutations: Array<MutationRecord>, observer: MutationObserver) => {
-      flushRootMutations(editor, mutations, observer)
+      flushRootMutations(editor, mutations, observer);
     },
   );
 }

--- a/packages/outline/src/helpers/OutlineEventHelpers.js
+++ b/packages/outline/src/helpers/OutlineEventHelpers.js
@@ -149,6 +149,7 @@ export function onKeyDownForPlainText(
     return;
   }
   editor.update((view) => {
+    view.log('onKeyDownForPlainText');
     const selection = view.getSelection();
     if (selection === null) {
       return;
@@ -190,7 +191,7 @@ export function onKeyDownForPlainText(
       event.preventDefault();
       deleteLineForward(selection);
     }
-  }, 'onKeyDownForPlainText');
+  });
 }
 
 export function onKeyDownForRichText(
@@ -202,6 +203,7 @@ export function onKeyDownForRichText(
     return;
   }
   editor.update((view) => {
+    view.log('onKeyDownForRichText');
     const selection = view.getSelection();
     if (selection === null) {
       return;
@@ -274,7 +276,7 @@ export function onKeyDownForRichText(
         }
       }
     }
-  }, 'onKeyDownForRichText');
+  });
 }
 
 export function onPasteForPlainText(
@@ -283,12 +285,13 @@ export function onPasteForPlainText(
 ): void {
   event.preventDefault();
   editor.update((view) => {
+    view.log('onPasteForPlainText');
     const selection = view.getSelection();
     const clipboardData = event.clipboardData;
     if (clipboardData != null && selection !== null) {
       insertDataTransferForPlainText(clipboardData, selection, view);
     }
-  }, 'onPasteForPlainText');
+  });
 }
 
 export function onPasteForRichText(
@@ -297,12 +300,13 @@ export function onPasteForRichText(
 ): void {
   event.preventDefault();
   editor.update((view) => {
+    view.log('onPasteForRichText');
     const selection = view.getSelection();
     const clipboardData = event.clipboardData;
     if (clipboardData != null && selection !== null) {
       insertDataTransferForRichText(clipboardData, selection, view);
     }
-  }, 'onPasteForRichText');
+  });
 }
 
 export function onDropPolyfill(
@@ -328,11 +332,12 @@ export function onCutForPlainText(
 ): void {
   onCopyForPlainText(event, editor);
   editor.update((view) => {
+    view.log('onCutForPlainText');
     const selection = view.getSelection();
     if (selection !== null) {
       removeText(selection);
     }
-  }, 'onCutForPlainText');
+  });
 }
 
 export function onCutForRichText(
@@ -341,11 +346,12 @@ export function onCutForRichText(
 ): void {
   onCopyForRichText(event, editor);
   editor.update((view) => {
+    view.log('onCutForRichText');
     const selection = view.getSelection();
     if (selection !== null) {
       removeText(selection);
     }
-  }, 'onCutForRichText');
+  });
 }
 
 export function onCopyForPlainText(
@@ -354,6 +360,7 @@ export function onCopyForPlainText(
 ): void {
   event.preventDefault();
   editor.update((view) => {
+    view.log('onCopyForPlainText');
     const clipboardData = event.clipboardData;
     const selection = view.getSelection();
     if (selection !== null) {
@@ -373,7 +380,7 @@ export function onCopyForPlainText(
         clipboardData.setData('text/plain', selection.getTextContent());
       }
     }
-  }, 'onCopyForPlainText');
+  });
 }
 
 export function onCopyForRichText(
@@ -382,6 +389,7 @@ export function onCopyForRichText(
 ): void {
   event.preventDefault();
   editor.update((view) => {
+    view.log('onCopyForRichText');
     const clipboardData = event.clipboardData;
     const selection = view.getSelection();
     if (selection !== null) {
@@ -405,7 +413,7 @@ export function onCopyForRichText(
         );
       }
     }
-  }, 'onCopyForRichText');
+  });
 }
 
 export function onCompositionStart(
@@ -413,6 +421,7 @@ export function onCompositionStart(
   editor: OutlineEditor,
 ): void {
   editor.update((view) => {
+    view.log('onCompositionStart');
     const selection = view.getSelection();
     if (selection !== null && !editor.isComposing()) {
       const anchor = selection.anchor;
@@ -431,7 +440,7 @@ export function onCompositionStart(
         insertText(selection, ' ');
       }
     }
-  }, 'onCompositionStart');
+  });
 }
 
 function onCompositionEndInternal(
@@ -439,9 +448,10 @@ function onCompositionEndInternal(
   editor: OutlineEditor,
 ) {
   editor.update((view) => {
+    view.log('onCompositionEnd');
     view.setCompositionKey(null);
     updateSelectedTextFromDOM(editor, view, true);
-  }, 'onCompositionEnd');
+  });
 }
 
 export function onCompositionEnd(
@@ -472,6 +482,7 @@ function getLastSelection(editor: OutlineEditor): null | Selection {
 // really isn't.
 export function onClick(event: MouseEvent, editor: OutlineEditor): void {
   editor.update((view) => {
+    view.log('onClick');
     const selection = view.getSelection();
     if (selection === null) {
       return;
@@ -490,7 +501,7 @@ export function onClick(event: MouseEvent, editor: OutlineEditor): void {
         selection.dirty = true;
       }
     }
-  }, 'onClick');
+  });
 }
 
 export function onSelectionChange(event: Event, editor: OutlineEditor): void {
@@ -505,6 +516,7 @@ export function onSelectionChange(event: Event, editor: OutlineEditor): void {
   // This update functions as a way of reconciling a bad selection
   // to a good selection.
   editor.update((view) => {
+    view.log('onSelectionChange');
     const selection = view.getSelection();
     // Update the selection format
     if (selection !== null && selection.isCollapsed()) {
@@ -514,7 +526,7 @@ export function onSelectionChange(event: Event, editor: OutlineEditor): void {
         selection.format = anchorNode.getFormat();
       }
     }
-  }, 'onSelectionChange');
+  });
 }
 
 export function checkForBadInsertion(
@@ -570,20 +582,13 @@ function updateTextNodeFromDOMContent(
     }
 
     if (compositionEnd || normalizedTextContent !== node.getTextContent()) {
-      if (
-        isImmutableOrInert(node) ||
-        (editor.isComposing() && !isComposing)
-      ) {
+      if (isImmutableOrInert(node) || (editor.isComposing() && !isComposing)) {
         view.markNodeAsDirty(node);
         return;
       }
       const selection = view.getSelection();
 
-      if (
-        selection === null ||
-        anchorOffset === null ||
-        focusOffset === null
-      ) {
+      if (selection === null || anchorOffset === null || focusOffset === null) {
         node.setTextContent(normalizedTextContent);
         return;
       }
@@ -662,6 +667,7 @@ export function onBeforeInputForPlainText(
   }
 
   editor.update((view) => {
+    view.log('onBeforeInputForPlainText');
     const selection = view.getSelection();
 
     if (selection === null) {
@@ -779,7 +785,7 @@ export function onBeforeInputForPlainText(
       default:
       // NO-OP
     }
-  }, 'onBeforeInputForPlainText');
+  });
 }
 
 export function onBeforeInputForRichText(
@@ -797,6 +803,7 @@ export function onBeforeInputForRichText(
   }
 
   editor.update((view) => {
+    view.log('onBeforeInputForRichText');
     const selection = view.getSelection();
 
     if (selection === null) {
@@ -934,7 +941,7 @@ export function onBeforeInputForRichText(
       default:
       // NO-OP
     }
-  }, 'onBeforeInputForRichText');
+  });
 }
 
 function updateSelectedTextFromDOM(
@@ -976,6 +983,7 @@ export function onInput(event: InputEvent, editor: OutlineEditor): void {
   // We don't want the onInput to bubble, in the case of nested editors.
   event.stopPropagation();
   editor.update((view: View) => {
+    view.log('onInput');
     const selection = view.getSelection();
     const data = event.data;
     if (
@@ -997,7 +1005,7 @@ export function onInput(event: InputEvent, editor: OutlineEditor): void {
     if (mutations.length > 0) {
       view.flushMutations(mutations);
     }
-  }, 'onInput');
+  });
 }
 
 export function applyMutationInputWebkitWorkaround(): void {
@@ -1036,10 +1044,10 @@ export function applyMutationInputWebkitWorkaround(): void {
           }
         }
         if (otherMutations.length > 0) {
-          editor.update(
-            (view) => view.flushMutations(otherMutations),
-            'applyMutationInputWebkitWorkaround',
-          );
+          editor.update((view) => {
+            view.log('applyMutationWorkaround');
+            view.flushMutations(otherMutations);
+          });
         }
         if (textMutations.length > 0) {
           pendingOnInputTextMutations = textMutations;

--- a/packages/outline/src/helpers/OutlineHistoryHelpers.js
+++ b/packages/outline/src/helpers/OutlineHistoryHelpers.js
@@ -14,9 +14,8 @@ export const viewModelsWithoutHistory: Set<ViewModel> = new Set();
 export function updateWithoutHistory(
   editor: OutlineEditor,
   updateFn: (view: View) => void,
-  updateName: string,
 ): boolean {
-  const res = editor.update(updateFn, updateName);
+  const res = editor.update(updateFn);
   const pendingViewModel = editor._pendingViewModel;
   if (pendingViewModel !== null) {
     viewModelsWithoutHistory.add(pendingViewModel);


### PR DESCRIPTION
Right now, you always need to supply an editor update name to editor.update(). The intention here was to force engineers to give descriptive names, in case of errors.

However, this really should be optional, with the intention of this being about trust. So, instead of having an update name, I thought we could have a more robust logging system for editor updates.
So previously, you'd do this.

```js
editor.update(view => {
 // Do plugin stuff
}, 'MyPluginUpdate');
```

With this proposal, instead you'd write:

```js
editor.update(view => {
 view.log('MyPluginUpdate');
 // Do plugin stuff
});
```

You can have as many logs as you'd like:

```js
editor.update(view => {
  view.log('This will get logged');
  view.log('So will this!' + someValue);
});
```

When an error occurs, you get the log:

```js
editor.addListener('error', (error, log) => {
  console.error(…log);
  throw error;
});
```

When you get an update, you get the log:

```js
editor.addListener('update', ({log}) => {
  console.log(…log);
});
```