### PR TITLE
Rename OutlineProcess -> OutlineScope

### DIFF
--- a/packages/outline/src/core/OutlineBlockNode.js
+++ b/packages/outline/src/core/OutlineBlockNode.js
@@ -13,7 +13,7 @@ import type {Selection} from './OutlineSelection';
 import {isTextNode, TextNode} from '.';
 import {OutlineNode, updateDirectionIfNeeded} from './OutlineNode';
 import {makeSelection, getSelection, setPointValues} from './OutlineSelection';
-import {errorOnReadOnly} from './OutlineProcess';
+import {errorOnReadOnly} from './OutlineScope';
 import {IS_DIRECTIONLESS, IS_LTR, IS_RTL} from './OutlineConstants';
 import {getNodeByKey} from './OutlineUtils';
 

--- a/packages/outline/src/core/OutlineListeners.js
+++ b/packages/outline/src/core/OutlineListeners.js
@@ -14,7 +14,7 @@ import type {
 } from './OutlineEditor';
 import type {NodeKey, NodeMap} from './OutlineNode';
 import {getCompositionKey} from './OutlineUtils';
-import {view} from './OutlineProcess';
+import {view} from './OutlineScope';
 import {isTextNode, isLineBreakNode} from '.';
 
 export function triggerTextMutationListeners(

--- a/packages/outline/src/core/OutlineMutations.js
+++ b/packages/outline/src/core/OutlineMutations.js
@@ -12,7 +12,7 @@ import type {Selection} from './OutlineSelection';
 import type {TextNode} from './OutlineTextNode';
 
 import {isTextNode, isDecoratorNode} from '.';
-import {view} from './OutlineProcess';
+import {view} from './OutlineScope';
 import {triggerListeners} from './OutlineListeners';
 import {getNearestNodeFromDOMNode, getNodeFromDOMNode} from './OutlineUtils';
 

--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -12,10 +12,10 @@ import type {Selection, PointType} from './OutlineSelection';
 
 import {isBlockNode, isTextNode, isRootNode, BlockNode} from '.';
 import {
-  getActiveViewModel,
+  getActiveViewModelWithScope,
   errorOnReadOnly,
-  getActiveEditor,
-} from './OutlineProcess';
+  getActiveEditorWithScope,
+} from './OutlineScope';
 import {
   generateKey,
   getCompositionKey,
@@ -167,7 +167,7 @@ export class OutlineNode {
     return parent !== null && parent.isAttached();
   }
   isSelected(): boolean {
-    const viewModel = getActiveViewModel();
+    const viewModel = getActiveViewModelWithScope();
     const selection = viewModel._selection;
     const key = this.__key;
     return (
@@ -459,7 +459,7 @@ export class OutlineNode {
     return (this.getLatest().__flags & IS_DIRECTIONLESS) !== 0;
   }
   isDirty(): boolean {
-    const editor = getActiveEditor();
+    const editor = getActiveEditorWithScope();
     const dirtyNodes = editor._dirtyNodes;
     return dirtyNodes !== null && dirtyNodes.has(this.__key);
   }
@@ -475,8 +475,8 @@ export class OutlineNode {
   }
   getWritable<N>(): N {
     errorOnReadOnly();
-    const viewModel = getActiveViewModel();
-    const editor = getActiveEditor();
+    const viewModel = getActiveViewModelWithScope();
+    const editor = getActiveEditorWithScope();
     const nodeMap = viewModel._nodeMap;
     const key = this.__key;
     // Ensure we get the latest node from pending state

--- a/packages/outline/src/core/OutlineParsing.js
+++ b/packages/outline/src/core/OutlineParsing.js
@@ -10,7 +10,7 @@
 import type {OutlineEditor} from './OutlineEditor';
 import type {NodeKey, OutlineNode} from './OutlineNode';
 
-import {getActiveViewModel} from './OutlineProcess';
+import {getActiveViewModelWithScope} from './OutlineScope';
 import {isRootNode, isBlockNode, isTextNode} from '.';
 import invariant from 'shared/invariant';
 
@@ -72,7 +72,7 @@ export function createNodeFromParse(
   parsedNode.__key = parsedKey;
   const key = node.__key;
   if (isRootNode(node)) {
-    const viewModel = getActiveViewModel();
+    const viewModel = getActiveViewModelWithScope();
     viewModel._nodeMap.set('root', node);
   }
   node.__flags = parsedNode.__flags;

--- a/packages/outline/src/core/OutlineSelection.js
+++ b/packages/outline/src/core/OutlineSelection.js
@@ -15,10 +15,10 @@ import type {RootNode} from './OutlineRootNode';
 
 import {ViewModel} from './OutlineViewModel';
 import {
-  getActiveEditor,
-  getActiveViewModel,
+  getActiveEditorWithScope,
+  getActiveViewModelWithScope,
   isViewReadOnlyMode,
-} from './OutlineProcess';
+} from './OutlineScope';
 import {getNodeKeyFromDOM} from './OutlineReconciler';
 import {getIsProcesssingMutations} from './OutlineMutations';
 import {
@@ -29,7 +29,13 @@ import {
   isRootNode,
   TextNode,
 } from '.';
-import {getCompositionKey, getNodeByKey, isSelectionWithinEditor, setCompositionKey, toggleTextFormatType} from './OutlineUtils';
+import {
+  getCompositionKey,
+  getNodeByKey,
+  isSelectionWithinEditor,
+  setCompositionKey,
+  toggleTextFormatType,
+} from './OutlineUtils';
 import invariant from 'shared/invariant';
 import {
   IS_BOLD,
@@ -292,7 +298,7 @@ export class Selection {
     return textContent;
   }
   applyDOMRange(range: StaticRange): void {
-    const editor = getActiveEditor();
+    const editor = getActiveEditorWithScope();
     const resolvedSelectionPoints = resolveSelectionPoints(
       range.startContainer,
       range.startOffset,
@@ -360,7 +366,7 @@ export class Selection {
 function getNodeFromDOM(dom: Node): null | OutlineNode {
   const nodeKey = getNodeKeyFromDOM(dom);
   if (nodeKey === null) {
-    const editor = getActiveEditor();
+    const editor = getActiveEditorWithScope();
     const rootElement = editor.getRootElement();
     if (dom === rootElement) {
       return getNodeByKey('root');
@@ -564,7 +570,7 @@ export function makeSelection(
   anchorType: 'text' | 'block',
   focusType: 'text' | 'block',
 ): Selection {
-  const viewModel = getActiveViewModel();
+  const viewModel = getActiveViewModelWithScope();
   const selection = new Selection(
     createPoint(anchorKey, anchorOffset, anchorType),
     createPoint(focusKey, focusOffset, focusType),
@@ -662,7 +668,7 @@ export function createSelection(
 }
 
 export function getSelection(): null | Selection {
-  const viewModel = getActiveViewModel();
+  const viewModel = getActiveViewModelWithScope();
   return viewModel._selection;
 }
 

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -24,7 +24,7 @@ import {
   toggleTextFormatType,
 } from './OutlineUtils';
 import invariant from 'shared/invariant';
-import {errorOnReadOnly} from './OutlineProcess';
+import {errorOnReadOnly} from './OutlineScope';
 import {
   IS_CODE,
   IS_BOLD,

--- a/packages/outline/src/core/OutlineUtils.js
+++ b/packages/outline/src/core/OutlineUtils.js
@@ -21,9 +21,9 @@ import {
 import {isTextNode, isLineBreakNode, isDecoratorNode} from '.';
 import {
   errorOnReadOnly,
-  getActiveEditor,
-  getActiveViewModel,
-} from './OutlineProcess';
+  getActiveEditorWithScope,
+  getActiveViewModelWithScope,
+} from './OutlineScope';
 
 export const emptyFunction = () => {};
 
@@ -132,8 +132,8 @@ export function isLeafNode(node: ?OutlineNode): boolean %checks {
 
 export function generateKey(node: OutlineNode): NodeKey {
   errorOnReadOnly();
-  const editor = getActiveEditor();
-  const viewModel = getActiveViewModel();
+  const editor = getActiveEditorWithScope();
+  const viewModel = getActiveViewModelWithScope();
   const key = generateRandomKey();
   viewModel._nodeMap.set(key, node);
   editor._dirtyNodes.add(key);
@@ -165,8 +165,8 @@ export function markParentsAsDirty(
 export function internallyMarkNodeAsDirty(node: OutlineNode): void {
   const latest = node.getLatest();
   const parent = latest.__parent;
-  const viewModel = getActiveViewModel();
-  const editor = getActiveEditor();
+  const viewModel = getActiveViewModelWithScope();
+  const editor = getActiveEditorWithScope();
   const nodeMap = viewModel._nodeMap;
   if (parent !== null) {
     const dirtySubTrees = editor._dirtySubTrees;
@@ -178,7 +178,7 @@ export function internallyMarkNodeAsDirty(node: OutlineNode): void {
 }
 
 export function setCompositionKey(compositionKey: null | NodeKey): void {
-  const editor = getActiveEditor();
+  const editor = getActiveEditorWithScope();
   const previousCompositionKey = editor._compositionKey;
   editor._compositionKey = compositionKey;
   if (previousCompositionKey !== null) {
@@ -196,12 +196,12 @@ export function setCompositionKey(compositionKey: null | NodeKey): void {
 }
 
 export function getCompositionKey(): null | NodeKey {
-  const editor = getActiveEditor();
+  const editor = getActiveEditorWithScope();
   return editor._compositionKey;
 }
 
 export function getNodeByKey<N: OutlineNode>(key: NodeKey): N | null {
-  const viewModel = getActiveViewModel();
+  const viewModel = getActiveViewModelWithScope();
   const node = viewModel._nodeMap.get(key);
   if (node === undefined) {
     return null;

--- a/packages/outline/src/core/OutlineViewModel.js
+++ b/packages/outline/src/core/OutlineViewModel.js
@@ -10,11 +10,11 @@
 import type {OutlineEditor} from './OutlineEditor';
 import type {NodeKey, NodeMap} from './OutlineNode';
 import type {Selection} from './OutlineSelection';
-import type {View} from './OutlineProcess';
+import type {View} from './OutlineScope';
 import type {ParsedNode} from './OutlineParsing';
 
 import {createRootNode} from './OutlineRootNode';
-import {readViewModel} from './OutlineProcess';
+import {readViewModelWithScope} from './OutlineScope';
 
 export type ParsedViewModel = {
   _selection: null | {
@@ -72,7 +72,7 @@ export class ViewModel {
     return this._nodeMap.size === 1 && this._selection === null;
   }
   read<V>(callbackFn: (view: View) => V): V {
-    return readViewModel(this, callbackFn);
+    return readViewModelWithScope(this, callbackFn);
   }
   stringify(space?: string | number): string {
     const selection = this._selection;

--- a/packages/outline/src/core/index.js
+++ b/packages/outline/src/core/index.js
@@ -14,16 +14,9 @@ export type {
   TextMutation,
 } from './OutlineEditor';
 export type {ViewModel, ParsedViewModel} from './OutlineViewModel';
-export type {View} from './OutlineProcess';
-export type {
-  NodeKey,
-  OutlineNode,
-  NodeMap,
-} from './OutlineNode';
-export type {
-  ParsedNode,
-  ParsedNodeMap,
-} from './OutlineParsing';
+export type {View} from './OutlineScope';
+export type {NodeKey, OutlineNode, NodeMap} from './OutlineNode';
+export type {ParsedNode, ParsedNodeMap} from './OutlineParsing';
 export type {
   Selection,
   PointType as Point,


### PR DESCRIPTION
OutlineProcess is a bit confusing, so to clear things up, this PR renames the module to OutlineScope and re-labels the exported functions with `WithScope` to show that these functions are called in a given view model scope.