### PR TITLE
Rename OutlineProcess to OutlineUpdates

### DIFF
--- a/packages/outline/src/core/OutlineBlockNode.js
+++ b/packages/outline/src/core/OutlineBlockNode.js
@@ -13,7 +13,7 @@ import type {Selection} from './OutlineSelection';
 import {isTextNode, TextNode} from '.';
 import {OutlineNode, updateDirectionIfNeeded} from './OutlineNode';
 import {makeSelection, getSelection, setPointValues} from './OutlineSelection';
-import {errorOnReadOnly} from './OutlineProcess';
+import {errorOnReadOnly} from './OutlineUpdates';
 import {IS_DIRECTIONLESS, IS_LTR, IS_RTL} from './OutlineConstants';
 import {getNodeByKey} from './OutlineUtils';
 

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -9,14 +9,14 @@
 
 import type {OutlineNode, NodeKey} from './OutlineNode';
 import type {Node as ReactNode} from 'react';
-import type {View} from './OutlineProcess';
+import type {View} from './OutlineUpdates';
 
 import {
-  asyncErrorOnPreparingPendingViewUpdate,
+  errorOnPreparingPendingViewUpdate,
   commitPendingUpdates,
   parseViewModel,
   errorOnProcessingTextNodeTransforms,
-} from './OutlineProcess';
+} from './OutlineUpdates';
 import {isBlockNode, isTextNode, TextNode} from '.';
 import {ViewModel, createEmptyViewModel} from './OutlineViewModel';
 import {emptyFunction} from './OutlineUtils';
@@ -25,7 +25,7 @@ import {RootNode} from './OutlineRootNode';
 import {NO_DIRTY_NODES, FULL_RECONCILE} from './OutlineConstants';
 import {flushRootMutations, initMutationObserver} from './OutlineMutations';
 import {triggerListeners} from './OutlineListeners';
-import {processUpdate} from './OutlineProcess';
+import {beginUpdate} from './OutlineUpdates';
 import invariant from 'shared/invariant';
 
 export type EditorThemeClassName = string;
@@ -288,7 +288,7 @@ class BaseOutlineEditor {
   }
   addTextNodeTransform(listener: TextNodeTransform): () => void {
     this._textNodeTransforms.add(listener);
-    processUpdate(getSelf(this), emptyFunction, true);
+    beginUpdate(getSelf(this), emptyFunction, true);
     return () => {
       this._textNodeTransforms.delete(listener);
     };
@@ -303,7 +303,7 @@ class BaseOutlineEditor {
     return this._textContent;
   }
   getLatestTextContent(callback: (text: string) => void): void {
-    asyncErrorOnPreparingPendingViewUpdate('Editor.getLatestTextContent()');
+    errorOnPreparingPendingViewUpdate('Editor.getLatestTextContent()');
     if (this._pendingViewModel === null) {
       callback(this._textContent);
       return;
@@ -368,7 +368,7 @@ class BaseOutlineEditor {
   }
   update(updateFn: (view: View) => void, callbackFn?: () => void): boolean {
     errorOnProcessingTextNodeTransforms();
-    return processUpdate(getSelf(this), updateFn, false, callbackFn);
+    return beginUpdate(getSelf(this), updateFn, false, callbackFn);
   }
   focus(callbackFn?: () => void): void {
     const rootElement = this._rootElement;

--- a/packages/outline/src/core/OutlineListeners.js
+++ b/packages/outline/src/core/OutlineListeners.js
@@ -14,7 +14,7 @@ import type {
 } from './OutlineEditor';
 import type {NodeKey, NodeMap} from './OutlineNode';
 import {getCompositionKey} from './OutlineUtils';
-import {view} from './OutlineProcess';
+import {view} from './OutlineUpdates';
 import {isTextNode, isLineBreakNode} from '.';
 
 export function triggerTextMutationListeners(

--- a/packages/outline/src/core/OutlineMutations.js
+++ b/packages/outline/src/core/OutlineMutations.js
@@ -12,7 +12,7 @@ import type {Selection} from './OutlineSelection';
 import type {TextNode} from './OutlineTextNode';
 
 import {isTextNode, isDecoratorNode} from '.';
-import {view} from './OutlineProcess';
+import {view} from './OutlineUpdates';
 import {triggerListeners} from './OutlineListeners';
 import {getNearestNodeFromDOMNode, getNodeFromDOMNode} from './OutlineUtils';
 

--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -15,7 +15,7 @@ import {
   getActiveViewModel,
   errorOnReadOnly,
   getActiveEditor,
-} from './OutlineProcess';
+} from './OutlineUpdates';
 import {
   generateKey,
   getCompositionKey,

--- a/packages/outline/src/core/OutlineParsing.js
+++ b/packages/outline/src/core/OutlineParsing.js
@@ -10,7 +10,7 @@
 import type {OutlineEditor} from './OutlineEditor';
 import type {NodeKey, OutlineNode} from './OutlineNode';
 
-import {getActiveViewModel} from './OutlineProcess';
+import {getActiveViewModel} from './OutlineUpdates';
 import {isRootNode, isBlockNode, isTextNode} from '.';
 import invariant from 'shared/invariant';
 

--- a/packages/outline/src/core/OutlineSelection.js
+++ b/packages/outline/src/core/OutlineSelection.js
@@ -18,7 +18,7 @@ import {
   getActiveEditor,
   getActiveViewModel,
   isViewReadOnlyMode,
-} from './OutlineProcess';
+} from './OutlineUpdates';
 import {getNodeKeyFromDOM} from './OutlineReconciler';
 import {getIsProcesssingMutations} from './OutlineMutations';
 import {

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -24,7 +24,7 @@ import {
   toggleTextFormatType,
 } from './OutlineUtils';
 import invariant from 'shared/invariant';
-import {errorOnReadOnly} from './OutlineProcess';
+import {errorOnReadOnly} from './OutlineUpdates';
 import {
   IS_CODE,
   IS_BOLD,

--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -150,6 +150,20 @@ export function errorOnReadOnly(): void {
   }
 }
 
+export function errorOnPreparingPendingViewUpdate(
+  fnName: 'Editor.getLatestTextContent()',
+): void {
+  if (
+    isPreparingPendingViewUpdate &&
+    fnName === 'Editor.getLatestTextContent()'
+  ) {
+    invariant(
+      false,
+      'Editor.getLatestTextContent() can be asynchronous and cannot be used within Editor.update()',
+    );
+  }
+}
+
 export function getActiveViewModel(): ViewModel {
   if (activeViewModel === null) {
     invariant(
@@ -234,20 +248,9 @@ export function parseViewModel(
   return viewModel;
 }
 
-export function asyncErrorOnPreparingPendingViewUpdate(
-  fnName: 'Editor.getLatestTextContent()',
-): void {
-  if (
-    isPreparingPendingViewUpdate &&
-    fnName === 'Editor.getLatestTextContent()'
-  ) {
-    invariant(
-      false,
-      'Editor.getLatestTextContent() can be asynchronous and cannot be used within Editor.update()',
-    );
-  }
-}
-
+// This technically isn't an update but given we need
+// exposure to the module's active bindings, we have this
+// function here
 export function readViewModel<V>(
   viewModel: ViewModel,
   callbackFn: (view: View) => V,
@@ -369,7 +372,7 @@ export function commitPendingUpdates(editor: OutlineEditor): void {
   }
 }
 
-export function processUpdate(
+export function beginUpdate(
   editor: OutlineEditor,
   updateFn: (view: View) => void,
   markAllTextNodesAsDirty: boolean,

--- a/packages/outline/src/core/OutlineUtils.js
+++ b/packages/outline/src/core/OutlineUtils.js
@@ -23,7 +23,7 @@ import {
   errorOnReadOnly,
   getActiveEditor,
   getActiveViewModel,
-} from './OutlineProcess';
+} from './OutlineUpdates';
 
 export const emptyFunction = () => {};
 

--- a/packages/outline/src/core/OutlineViewModel.js
+++ b/packages/outline/src/core/OutlineViewModel.js
@@ -10,11 +10,11 @@
 import type {OutlineEditor} from './OutlineEditor';
 import type {NodeKey, NodeMap} from './OutlineNode';
 import type {Selection} from './OutlineSelection';
-import type {View} from './OutlineProcess';
+import type {View} from './OutlineUpdates';
 import type {ParsedNode} from './OutlineParsing';
 
 import {createRootNode} from './OutlineRootNode';
-import {readViewModel} from './OutlineProcess';
+import {readViewModel} from './OutlineUpdates';
 
 export type ParsedViewModel = {
   _selection: null | {

--- a/packages/outline/src/core/index.js
+++ b/packages/outline/src/core/index.js
@@ -14,7 +14,7 @@ export type {
   TextMutation,
 } from './OutlineEditor';
 export type {ViewModel, ParsedViewModel} from './OutlineViewModel';
-export type {View} from './OutlineProcess';
+export type {View} from './OutlineUpdates';
 export type {
   NodeKey,
   OutlineNode,


### PR DESCRIPTION
This is a follow up to https://github.com/facebookexternal/outline/pull/766. Essentially, this renames the confusingly named `OutlineProcess` module to `OutlineUpdates`. Why? This module handles all the updating logic within Outline (with the exception of one exported function that does reads, but has a comment to explain why).