### PR TITLE
Conditionally move focus to rootElement in editor.focus()

### DIFF
--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -387,10 +387,10 @@ class BaseOutlineEditor {
           }
         },
         () => {
-          rootElement.removeAttribute('autocapitalize');
           if (document.activeElement !== rootElement) {
             rootElement.focus({preventScroll: true});
           }
+          rootElement.removeAttribute('autocapitalize');
           if (callbackFn) {
             callbackFn();
           }


### PR DESCRIPTION
It turns out that repositioning focus via the selection API isn't always reliable. So instead, let's ensure this is forced if the document activeElement is not the editor root element. 