### PR TITLE
Revert "Conditionally move focus to rootElement in editor.focus()"

### DIFF
--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -387,9 +387,6 @@ class BaseOutlineEditor {
           }
         },
         () => {
-          if (document.activeElement !== rootElement) {
-            rootElement.focus({preventScroll: true});
-          }
           rootElement.removeAttribute('autocapitalize');
           if (callbackFn) {
             callbackFn();


### PR DESCRIPTION
Reverts facebookexternal/outline#774

This was a guestimate and it turned out to be not useful.