### PR TITLE
Fix bug in getSelectionStyleValueForProperty

### DIFF
--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -369,7 +369,7 @@ export function getSelectionStyleValueForProperty(
     // if no actual characters in the end node are selected, we don't
     // include it in the selection for purposes of determining style
     // value
-    if (endOffset === 0 && node.is(endNode)) {
+    if (i !== 0 && endOffset === 0 && node.is(endNode)) {
       continue;
     }
     if (isTextNode(node)) {


### PR DESCRIPTION
I'm not sure if this logic should be applied if there is only one node, so if the the first is the last node – do we want to do this? This fixes an internal e2e test that fails before this change (https://github.com/facebookexternal/outline/pull/753).