### PR TITLE
Prevent bad editor.update() calls

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineEditor.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor.test.js
@@ -115,6 +115,42 @@ describe('OutlineEditor tests', () => {
     );
   });
 
+  it('nested updates should fail', () => {
+    const rootElement = document.createElement('div');
+    container.appendChild(rootElement);
+
+    editor = createEditor();
+    editor.addListener('error', e => {
+      throw e;
+    });
+
+    editor.update((view) => {
+      expect(() => {
+        editor.update(() => {});
+      }).toThrow()
+    });
+
+    editor.getEditorState().read((view) => {
+      expect(() => {
+        editor.update(() => {});
+      }).toThrow()
+    });
+
+    editor.addTextNodeTransform(() => {
+      expect(() => {
+        editor.update(() => {});
+      }).toThrow()
+    });
+
+    editor.update((view) => {
+      const root = view.getRoot();
+      const paragraph = createParagraphNode();
+      const text = createTextNode('This works!');
+      root.append(paragraph);
+      paragraph.append(text);
+    });
+  });
+
   it('Should be able to update an editor state without an root element', () => {
     const ref = React.createRef();
 

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -15,7 +15,6 @@ import {
   errorOnPreparingPendingViewUpdate,
   commitPendingUpdates,
   parseEditorState,
-  errorOnProcessingTextNodeTransforms,
 } from './OutlineUpdates';
 import {isBlockNode, isTextNode, TextNode} from '.';
 import {EditorState, createEmptyEditorState} from './OutlineEditorState';
@@ -367,7 +366,6 @@ class BaseOutlineEditor {
     return parseEditorState(stringifiedEditorState, getSelf(this));
   }
   update(updateFn: (view: View) => void, callbackFn?: () => void): boolean {
-    errorOnProcessingTextNodeTransforms();
     return beginUpdate(getSelf(this), updateFn, false, callbackFn);
   }
   focus(callbackFn?: () => void): void {

--- a/packages/outline/src/core/OutlineSelection.js
+++ b/packages/outline/src/core/OutlineSelection.js
@@ -16,7 +16,7 @@ import type {EditorState} from './OutlineEditorState';
 import {
   getActiveEditor,
   getActiveEditorState,
-  isCurrentlyReadOnlyMode,
+  isReadOnlyMode,
 } from './OutlineUpdates';
 import {getNodeKeyFromDOM} from './OutlineReconciler';
 import {getIsProcesssingMutations} from './OutlineMutations';
@@ -119,7 +119,7 @@ class Point {
     this.key = key;
     this.offset = offset;
     this.type = type;
-    if (!isCurrentlyReadOnlyMode()) {
+    if (!isReadOnlyMode()) {
       if (getCompositionKey() === oldKey) {
         setCompositionKey(key);
       }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -43,5 +43,7 @@
   "41": "reconcileNode: prevNode or nextNode does not exist in nodeMap",
   "42": "reconcileNode: parentDOM is null",
   "43": "Reconciliation: could not find DOM element for node key \"${key}\"",
-  "44": "A ListItemNode must have a ListNode for a parent."
+  "44": "A ListItemNode must have a ListNode for a parent.",
+  "45": "Editor.update() cannot be used within another update or an editorState.read().",
+  "46": "Editor.update() cannot be used within another update, an editorState.read() or text transforms."
 }


### PR DESCRIPTION
The practice of calling `editor.update()` from within a read or update is a bad practice and we shouldn't allow it.