### PR TITLE
Trigger textcontent mutation on add

### DIFF
--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -275,10 +275,16 @@ class BaseOutlineEditor {
     listenerSet.add(listener);
 
     const isRootType = type === 'root';
+    const isTextContentType = type === 'textcontent';
     if (isRootType) {
       // $FlowFixMe: TODO refine
-      const rootListener: RootListener = (listener: any);
+      const rootListener: RootListener = listener;
       rootListener(this._rootElement, null);
+    } else if (isTextContentType) {
+      const textContent = getEditorStateTextContent(this._editorState);
+      // $FlowFixMe: TODO refine
+      const textContentListener: TextContentListener = listener;
+      textContentListener(textContent);
     }
     return () => {
       // $FlowFixMe: TODO refine this from the above types


### PR DESCRIPTION
The common textcontent pattern is to read the text content on load and keep up with updates. That's because by the time the plugin loads the content might have been populated.

There's two ways around that:
1. Provide a shortcut for end users like the one we have in OutlineUtils: getEditorStateTextContent
2. Trigger the `textcontent` listener when it's registered (just like `root`)

This PR proposes the second one.