### PR TITLE
Textcontent trigger before update

### DIFF
--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -329,6 +329,7 @@ export function commitPendingUpdates(editor: OutlineEditor): void {
     editor._pendingDecorators = null;
     triggerListeners('decorator', editor, true, pendingDecorators);
   }
+  triggerTextContentListeners(editor, currentEditorState, pendingEditorState);
   triggerListeners('update', editor, true, {
     editorState: pendingEditorState,
     dirty: isEditorStateDirty,
@@ -336,7 +337,6 @@ export function commitPendingUpdates(editor: OutlineEditor): void {
     log,
   });
   triggerDeferredUpdateCallbacks(editor);
-  triggerTextContentListeners(editor, currentEditorState, pendingEditorState);
   triggerEnqueuedUpdates(editor);
 }
 


### PR DESCRIPTION
If the `textcontent` trigger happens before update we can pair these two to determine updates that modified the text (see CharacterLimit in #789). Alternatively, we can add another property to the `update` listener that includes the text or whether it has changed but I don't think we want to do this.