### PR TITLE
Revert "Debugger editor performance"

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -44,7 +44,6 @@ module.name_mapper='^outline-react/useOutlineDecorators' -> '<PROJECT_ROOT>/pack
 module.name_mapper='^outline-react/useOutlineNestedList' -> '<PROJECT_ROOT>/packages/outline-react/src/useOutlineNestedList.js'
 module.name_mapper='^outline-react/useOutlineIsEmpty' -> '<PROJECT_ROOT>/packages/outline-react/src/useOutlineIsEmpty.js'
 module.name_mapper='^outline-react/useOutlineCharacterLimit' -> '<PROJECT_ROOT>/packages/outline-react/src/useOutlineCharacterLimit.js'
-module.name_mapper='^outline-react/useOutlineTypingPerformance' -> '<PROJECT_ROOT>/packages/outline-react/src/useOutlineTypingPerformance.js'
 
 module.name_mapper='^shared/isImmutableOrInert' -> '<PROJECT_ROOT>/packages/shared/src/isImmutableOrInert.js'
 module.name_mapper='^shared/invariant' -> '<PROJECT_ROOT>/packages/shared/src/invariant.js'

--- a/packages/outline-playground/craco.config.js
+++ b/packages/outline-playground/craco.config.js
@@ -36,8 +36,6 @@ module.exports = {
       'outline-react/useOutlineIsEmpty': 'outline-react/dist/useOutlineIsEmpty',
       'outline-react/useOutlineCharacterLimit':
         'outline-react/dist/useOutlineCharacterLimit',
-      'outline-react/useOutlineTypingPerformance':
-        'outline-react/dist/useOutlineTypingPerformance',
       //Shared
       'shared/environment': 'shared/dist/environment',
     },

--- a/packages/outline-playground/src/App.js
+++ b/packages/outline-playground/src/App.js
@@ -15,6 +15,7 @@ import {useRichTextEditor, usePlainTextEditor} from './Editor';
 import OutlineTreeView from 'outline-react/OutlineTreeView';
 import useSettings from './useSettings';
 import useTestRecorder from './useTestRecorder';
+import useTypingPerfTracker from './useTypingPerfTracker';
 import {DEFAULT_SETTINGS} from './appSettings';
 
 function RichTextEditor({settings, onSettingsChange}): React$Node {
@@ -22,13 +23,20 @@ function RichTextEditor({settings, onSettingsChange}): React$Node {
     settings,
     onSettingsChange,
   );
-  const {isCharLimit, isCharLimitUtf8, isAutocomplete, showTreeView} = settings;
+  const {
+    measureTypingPerf,
+    isCharLimit,
+    isCharLimitUtf8,
+    isAutocomplete,
+    showTreeView,
+  } = settings;
   const [editor, editorComponent] = useRichTextEditor({
     isCharLimit,
     isCharLimitUtf8,
     isAutocomplete,
   });
   const [testRecorderButton, testRecorderOutput] = useTestRecorder(editor);
+  useTypingPerfTracker(measureTypingPerf);
 
   return (
     <>
@@ -40,8 +48,6 @@ function RichTextEditor({settings, onSettingsChange}): React$Node {
           timeTravelButtonClassName="debug-timetravel-button"
           timeTravelPanelSliderClassName="debug-timetravel-panel-slider"
           timeTravelPanelButtonClassName="debug-timetravel-panel-button"
-          typingPerfButtonClassName="debug-typing-perf-button"
-          typingPerfButtonActiveClassName="debug-typing-perf-button-active"
           editor={editor}
         />
       )}
@@ -60,7 +66,13 @@ function PlainTextEditor({settings, onSettingsChange}): React$Node {
     settings,
     onSettingsChange,
   );
-  const {isCharLimit, isCharLimitUtf8, isAutocomplete, showTreeView} = settings;
+  const {
+    measureTypingPerf,
+    isCharLimit,
+    isCharLimitUtf8,
+    isAutocomplete,
+    showTreeView,
+  } = settings;
   const onError = useCallback((e: Error) => {
     throw e;
   }, []);
@@ -70,6 +82,7 @@ function PlainTextEditor({settings, onSettingsChange}): React$Node {
     isCharLimitUtf8,
     isAutocomplete,
   });
+  useTypingPerfTracker(measureTypingPerf);
 
   return (
     <>
@@ -81,8 +94,6 @@ function PlainTextEditor({settings, onSettingsChange}): React$Node {
           timeTravelButtonClassName="debug-timetravel-button"
           timeTravelPanelSliderClassName="debug-timetravel-panel-slider"
           timeTravelPanelButtonClassName="debug-timetravel-panel-button"
-          typingPerfButtonClassName="debug-typing-perf-button"
-          typingPerfButtonActiveClassName="debug-typing-perf-button-active"
           editor={editor}
         />
       )}

--- a/packages/outline-playground/src/appSettings.js
+++ b/packages/outline-playground/src/appSettings.js
@@ -9,6 +9,7 @@
 
 export type SettingName =
   | 'disableBeforeInput'
+  | 'measureTypingPerf'
   | 'isRichText'
   | 'isCharLimit'
   | 'isCharLimitUtf8'
@@ -19,6 +20,7 @@ export type Settings = {[SettingName]: boolean};
 
 export const DEFAULT_SETTINGS: Settings = {
   disableBeforeInput: false,
+  measureTypingPerf: false,
   isRichText: true,
   isCharLimit: false,
   isCharLimitUtf8: false,

--- a/packages/outline-playground/src/index.css
+++ b/packages/outline-playground/src/index.css
@@ -927,30 +927,17 @@ pre::-webkit-scrollbar-thumb {
   text-decoration: underline;
 }
 
-.debug-timetravel-button, .debug-typing-perf-button {
-  cursor: pointer;
+.debug-timetravel-button {
   border: 0;
   padding: 0;
   font-size: 12px;
   top: 10px;
+  right: 15px;
   position: absolute;
   background: none;
   color: #fff;
 }
 
-.debug-timetravel-button:hover, .debug-typing-perf-button:hover {
+.debug-timetravel-button:hover {
   text-decoration: underline;
-}
-
-.debug-timetravel-button {
-  right: 100px;
-}
-
-.debug-typing-perf-button {
-  right: 15px;
-}
-
-.debug-typing-perf-button-active {
-  background-color: #fff;
-  color: #000;
 }

--- a/packages/outline-playground/src/useSettings.js
+++ b/packages/outline-playground/src/useSettings.js
@@ -18,6 +18,7 @@ function useSettings(
   onChange: (setting: SettingName, value: boolean) => void = () => {},
 ): [React$Node, React$Node] {
   const {
+    measureTypingPerf,
     isRichText,
     isCharLimit,
     isCharLimitUtf8,
@@ -36,6 +37,11 @@ function useSettings(
 
   const switches = showSettings ? (
     <div className="switches">
+      <Switch
+        onClick={() => onChange('measureTypingPerf', !measureTypingPerf)}
+        checked={measureTypingPerf}
+        text="Measure Perf"
+      />
       <Switch
         onClick={() => onChange('showTreeView', !showTreeView)}
         checked={showTreeView}

--- a/packages/outline-playground/src/useTypingPerfTracker.js
+++ b/packages/outline-playground/src/useTypingPerfTracker.js
@@ -4,14 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict
+ * @flow strict-local
  */
 
 import {useEffect} from 'react';
 
-export default function useOutlineTypingPerfTracker(
-  measureTypingPerf: boolean,
-): void {
+export default function useTypingPerfTracker(measureTypingPerf: boolean): void {
   useEffect(() => {
     if (measureTypingPerf) {
       let start = 0;
@@ -21,7 +19,6 @@ export default function useOutlineTypingPerfTracker(
         const total = log.reduce((a, b) => a + b, 0);
         const reportedText =
           'Typing Perf: ' + Math.round((total / log.length) * 100) / 100 + 'ms';
-        // eslint-disable-next-line no-console
         console.log(reportedText);
         // Show an element on the screen too :)
         const element = document.createElement('div');

--- a/packages/outline-react/src/OutlineTreeView.js
+++ b/packages/outline-react/src/OutlineTreeView.js
@@ -19,7 +19,6 @@ import {isBlockNode, isTextNode} from 'outline';
 
 import * as React from 'react';
 import {useState, useEffect, useRef} from 'react';
-import useTypingPerfTracker from './useOutlineTypingPerformance';
 
 const NON_SINGLE_WIDTH_CHARS_REPLACEMENT: $ReadOnly<{
   [string]: string,
@@ -44,18 +43,14 @@ export default function TreeView({
   timeTravelButtonClassName,
   timeTravelPanelSliderClassName,
   timeTravelPanelButtonClassName,
-  timeTravelPanelClassName,
-  typingPerfButtonClassName,
-  typingPerfButtonActiveClassName,
   viewClassName,
+  timeTravelPanelClassName,
   editor,
 }: {
   timeTravelPanelClassName: string,
   timeTravelPanelSliderClassName: string,
   timeTravelPanelButtonClassName: string,
   timeTravelButtonClassName: string,
-  typingPerfButtonClassName: string,
-  typingPerfButtonActiveClassName: string,
   viewClassName: string,
   editor: OutlineEditor,
 }): React$Node {
@@ -65,9 +60,6 @@ export default function TreeView({
   const playingIndexRef = useRef(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [typingPerformanceEnabled, setTypingPerformanceEnabled] =
-    useState(false);
-  useTypingPerfTracker(typingPerformanceEnabled);
   useEffect(() => {
     setContent(generateContent(editor.getEditorState()));
     return editor.addListener('update', ({editorState}) => {
@@ -135,15 +127,6 @@ export default function TreeView({
           Time Travel
         </button>
       )}
-      <button
-        onClick={() => {
-          setTypingPerformanceEnabled((state) => !state);
-        }}
-        className={`${typingPerfButtonClassName} ${
-          typingPerformanceEnabled ? typingPerfButtonActiveClassName : ''
-        }`}>
-        Performance
-      </button>
       <pre>{content}</pre>
       {timeTravelEnabled && (
         <div className={timeTravelPanelClassName}>


### PR DESCRIPTION
Reverts facebookexternal/outline#780

I don't think the performance monitoring tool should be in the debugger for two reasons:

- Performance monitoring is per the entire page, not just for a single text editor field. The performance tool actually checks the performance of all typing instrumentation, including non-Outline surfaces.
- The debugger component adds 80% more overhead for me on the Playground and about 30% overhead internally. It doesn't make sense from a UX perspective to somehow disable the debugger when using the performance tracking tool either.