### PR TITLE
Handle mutations with text entry time stamps

### DIFF
--- a/packages/outline-react/src/useOutlinePlainText.js
+++ b/packages/outline-react/src/useOutlinePlainText.js
@@ -15,7 +15,7 @@ import {log} from 'outline';
 import useLayoutEffect from './shared/useLayoutEffect';
 import useOutlineEditorEvents from './useOutlineEditorEvents';
 import {createParagraphNode, ParagraphNode} from 'outline/ParagraphNode';
-import {CAN_USE_BEFORE_INPUT, IS_SAFARI, IS_CHROME} from 'shared/environment';
+import {CAN_USE_BEFORE_INPUT} from 'shared/environment';
 import {
   onSelectionChange,
   onKeyDownForPlainText,
@@ -29,7 +29,6 @@ import {
   onDragStartPolyfill,
   onTextMutation,
   onInput,
-  applyMutationInputWebkitWorkaround,
   onClick,
 } from 'outline/events';
 import useOutlineDragonSupport from './shared/useOutlineDragonSupport';
@@ -95,10 +94,6 @@ if (CAN_USE_BEFORE_INPUT) {
   events.push(['beforeinput', onBeforeInputForPlainText]);
 } else {
   events.push(['drop', onDropPolyfill]);
-}
-
-if (IS_SAFARI || IS_CHROME) {
-  applyMutationInputWebkitWorkaround();
 }
 
 export default function useOutlinePlainText(editor: OutlineEditor): () => void {

--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -21,7 +21,7 @@ import {CodeNode} from 'outline/CodeNode';
 import {ParagraphNode} from 'outline/ParagraphNode';
 import {ListItemNode} from 'outline/ListItemNode';
 import {createParagraphNode} from 'outline/ParagraphNode';
-import {CAN_USE_BEFORE_INPUT, IS_SAFARI, IS_CHROME} from 'shared/environment';
+import {CAN_USE_BEFORE_INPUT} from 'shared/environment';
 import {
   onSelectionChange,
   onKeyDownForRichText,
@@ -35,7 +35,6 @@ import {
   onDragStartPolyfill,
   onTextMutation,
   onInput,
-  applyMutationInputWebkitWorkaround,
   onClick,
 } from 'outline/events';
 import useOutlineDragonSupport from './shared/useOutlineDragonSupport';
@@ -101,10 +100,6 @@ if (CAN_USE_BEFORE_INPUT) {
   events.push(['beforeinput', onBeforeInputForRichText]);
 } else {
   events.push(['drop', onDropPolyfill]);
-}
-
-if (IS_SAFARI || IS_CHROME) {
-  applyMutationInputWebkitWorkaround();
 }
 
 export default function useOutlineRichText(editor: OutlineEditor): () => void {

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -241,9 +241,6 @@ class BaseOutlineEditor {
     // Logging for updates
     this._log = [];
   }
-  getObserver(): null | MutationObserver {
-    return this._observer;
-  }
   isComposing(): boolean {
     return this._compositionKey != null;
   }
@@ -374,11 +371,7 @@ class BaseOutlineEditor {
         "setEditorState: the editor state is empty. Ensure the editor state's root node never becomes empty.",
       );
     }
-    const observer = this._observer;
-    if (observer !== null) {
-      const mutations = observer.takeRecords();
-      flushRootMutations(getSelf(this), mutations, observer);
-    }
+    flushRootMutations(getSelf(this));
     if (this._pendingEditorState !== null) {
       commitPendingUpdates(getSelf(this));
     }
@@ -477,7 +470,6 @@ declare export class OutlineEditor {
   _observer: null | MutationObserver;
   _log: Array<string>;
 
-  getObserver(): null | MutationObserver;
   isComposing(): boolean;
   isEmpty(trim?: boolean): boolean;
   registerNodeType(nodeType: string, klass: Class<OutlineNode>): void;
@@ -499,10 +491,4 @@ declare export class OutlineEditor {
   update(updateFn: (state: State) => void, callbackFn?: () => void): boolean;
   focus(callbackFn?: () => void): void;
   canShowPlaceholder(): boolean;
-}
-
-export function getEditorFromElement(element: Element): null | OutlineEditor {
-  // $FlowFixMe: internal field
-  const possibleEditor: void | OutlineEditor = element.__outlineEditor;
-  return possibleEditor != null ? possibleEditor : null;
 }

--- a/packages/outline/src/core/OutlineMutations.js
+++ b/packages/outline/src/core/OutlineMutations.js
@@ -20,10 +20,24 @@ import {
   pushLogEntry,
 } from './OutlineUtils';
 
+// The time between a text entry event and the mutation observer firing.
+const TEXT_MUTATION_VARIANCE = 100;
+
 let isProcessingMutations: boolean = false;
+let lastTextEntryTimeStamp = 0;
 
 export function getIsProcesssingMutations(): boolean {
   return isProcessingMutations;
+}
+
+function updateTimeStamp(event) {
+  lastTextEntryTimeStamp = event.timeStamp;
+}
+
+function initTextEntryListener(): void {
+  if (lastTextEntryTimeStamp === 0) {
+    window.addEventListener('textInput', updateTimeStamp, true);
+  }
 }
 
 function isManagedLineBreak(dom: Node, target: Node): boolean {
@@ -40,11 +54,11 @@ function getLastSelection(editor: OutlineEditor): null | Selection {
   });
 }
 
-function flushTextMutation(
+function handleTextMutation(
   target: Text,
   node: TextNode,
   editor: OutlineEditor,
-) {
+): void {
   const domSelection = window.getSelection();
   let anchorOffset = null;
   let focusOffset = null;
@@ -63,133 +77,145 @@ export function flushMutations(
   mutations: Array<MutationRecord>,
   observer: MutationObserver,
 ): void {
-  let shouldRevertSelection = false;
-  for (let i = 0; i < mutations.length; i++) {
-    const mutation = mutations[i];
-    const type = mutation.type;
-    const target = mutation.target;
-    const targetNode = getNearestNodeFromDOMNode(target);
-
-    if (isDecoratorNode(targetNode)) {
-      continue;
-    }
-    if (type === 'characterData') {
-      // Text mutations are deferred and passed to mutation listeners to be
-      // processed outside of the Outline engine.
-      if (
-        target.nodeType === 3 &&
-        isTextNode(targetNode) &&
-        targetNode.isAttached()
-      ) {
-        // $FlowFixMe: nodeType === 3 is a Text DOM node
-        flushTextMutation(((target: any): Text), targetNode, editor);
-      }
-    } else if (type === 'childList') {
-      shouldRevertSelection = true;
-      // We attempt to "undo" any changes that have occured outside
-      // of Outline. We want Outline's editor state to be source of truth.
-      // To the user, these will look like no-ops.
-      const addedDOMs = mutation.addedNodes;
-      const removedDOMs = mutation.removedNodes;
-      const siblingDOM = mutation.nextSibling;
-
-      for (let s = 0; s < removedDOMs.length; s++) {
-        const removedDOM = removedDOMs[s];
-        const node = getNodeFromDOMNode(removedDOM);
-        let placementDOM = siblingDOM;
-
-        if (node !== null && node.isAttached()) {
-          const nextSibling = node.getNextSibling();
-          if (nextSibling !== null) {
-            const key = nextSibling.getKey();
-            const nextSiblingDOM = editor.getElementByKey(key);
-            if (nextSiblingDOM !== null && nextSiblingDOM.parentNode !== null) {
-              placementDOM = nextSiblingDOM;
-            }
-          }
-        }
-        if (placementDOM != null) {
-          while (placementDOM != null) {
-            const parentDOM = placementDOM.parentNode;
-            if (parentDOM === target) {
-              target.insertBefore(removedDOM, placementDOM);
-              break;
-            }
-            placementDOM = parentDOM;
-          }
-        } else {
-          target.appendChild(removedDOM);
-        }
-      }
-      for (let s = 0; s < addedDOMs.length; s++) {
-        const addedDOM = addedDOMs[s];
-        const node = getNodeFromDOMNode(addedDOM);
-        const parentDOM = addedDOM.parentNode;
-        if (parentDOM != null && node === null) {
-          parentDOM.removeChild(addedDOM);
-        }
-      }
-    }
-  }
-
-  // Capture all the mutations made during this function. This
-  // also prevents us having to process them on the next cycle
-  // of onMutation, as these mutations were made by us.
-  const records = observer.takeRecords();
-
-  // Check for any random auto-added <br> elements, and remove them.
-  // These get added by the browser when we undo the above mutations
-  // and this can lead to a broken UI.
-  if (records.length > 0) {
-    for (let i = 0; i < records.length; i++) {
-      const record = records[i];
-      const addedNodes = record.addedNodes;
-      const target = record.target;
-
-      for (let s = 0; s < addedNodes.length; s++) {
-        const addedDOM = addedNodes[s];
-        const parentDOM = addedDOM.parentNode;
-        if (
-          parentDOM != null &&
-          addedDOM.nodeName === 'BR' &&
-          !isManagedLineBreak(addedDOM, target)
-        ) {
-          parentDOM.removeChild(addedDOM);
-        }
-      }
-    }
-    // Clear any of those removal mutations
-    observer.takeRecords();
-  }
-  if (shouldRevertSelection) {
-    const selection = state.getSelection() || getLastSelection(editor);
-    if (selection !== null) {
-      selection.dirty = true;
-      state.setSelection(selection);
-    }
-  }
-}
-
-export function flushRootMutations(
-  editor: OutlineEditor,
-  mutations: Array<MutationRecord>,
-  observer: MutationObserver,
-): void {
   isProcessingMutations = true;
+  const shouldFlushTextMutations =
+    performance.now() - lastTextEntryTimeStamp > TEXT_MUTATION_VARIANCE;
   try {
     editor.update(() => {
       pushLogEntry('onMutation');
-      flushMutations(editor, mutations, observer);
+      let shouldRevertSelection = false;
+
+      for (let i = 0; i < mutations.length; i++) {
+        const mutation = mutations[i];
+        const type = mutation.type;
+        const target = mutation.target;
+        const targetNode = getNearestNodeFromDOMNode(target);
+
+        if (isDecoratorNode(targetNode)) {
+          continue;
+        }
+        if (type === 'characterData') {
+          // Text mutations are deferred and passed to mutation listeners to be
+          // processed outside of the Outline engine.
+          if (
+            shouldFlushTextMutations &&
+            target.nodeType === 3 &&
+            isTextNode(targetNode) &&
+            targetNode.isAttached()
+          ) {
+            handleTextMutation(
+              // $FlowFixMe: nodeType === 3 is a Text DOM node
+              ((target: any): Text),
+              targetNode,
+              editor,
+            );
+          }
+        } else if (type === 'childList') {
+          shouldRevertSelection = true;
+          // We attempt to "undo" any changes that have occured outside
+          // of Outline. We want Outline's editor state to be source of truth.
+          // To the user, these will look like no-ops.
+          const addedDOMs = mutation.addedNodes;
+          const removedDOMs = mutation.removedNodes;
+          const siblingDOM = mutation.nextSibling;
+
+          for (let s = 0; s < removedDOMs.length; s++) {
+            const removedDOM = removedDOMs[s];
+            const node = getNodeFromDOMNode(removedDOM);
+            let placementDOM = siblingDOM;
+
+            if (node !== null && node.isAttached()) {
+              const nextSibling = node.getNextSibling();
+              if (nextSibling !== null) {
+                const key = nextSibling.getKey();
+                const nextSiblingDOM = editor.getElementByKey(key);
+                if (
+                  nextSiblingDOM !== null &&
+                  nextSiblingDOM.parentNode !== null
+                ) {
+                  placementDOM = nextSiblingDOM;
+                }
+              }
+            }
+            if (placementDOM != null) {
+              while (placementDOM != null) {
+                const parentDOM = placementDOM.parentNode;
+                if (parentDOM === target) {
+                  target.insertBefore(removedDOM, placementDOM);
+                  break;
+                }
+                placementDOM = parentDOM;
+              }
+            } else {
+              target.appendChild(removedDOM);
+            }
+          }
+          for (let s = 0; s < addedDOMs.length; s++) {
+            const addedDOM = addedDOMs[s];
+            const node = getNodeFromDOMNode(addedDOM);
+            const parentDOM = addedDOM.parentNode;
+            if (parentDOM != null && node === null) {
+              parentDOM.removeChild(addedDOM);
+            }
+          }
+        }
+      }
+
+      // Capture all the mutations made during this function. This
+      // also prevents us having to process them on the next cycle
+      // of onMutation, as these mutations were made by us.
+      const records = observer.takeRecords();
+
+      // Check for any random auto-added <br> elements, and remove them.
+      // These get added by the browser when we undo the above mutations
+      // and this can lead to a broken UI.
+      if (records.length > 0) {
+        for (let i = 0; i < records.length; i++) {
+          const record = records[i];
+          const addedNodes = record.addedNodes;
+          const target = record.target;
+
+          for (let s = 0; s < addedNodes.length; s++) {
+            const addedDOM = addedNodes[s];
+            const parentDOM = addedDOM.parentNode;
+            if (
+              parentDOM != null &&
+              addedDOM.nodeName === 'BR' &&
+              !isManagedLineBreak(addedDOM, target)
+            ) {
+              parentDOM.removeChild(addedDOM);
+            }
+          }
+        }
+        // Clear any of those removal mutations
+        observer.takeRecords();
+      }
+      if (shouldRevertSelection) {
+        const selection = state.getSelection() || getLastSelection(editor);
+        if (selection !== null) {
+          selection.dirty = true;
+          state.setSelection(selection);
+        }
+      }
     });
   } finally {
     isProcessingMutations = false;
   }
 }
 
+export function flushRootMutations(editor: OutlineEditor): void {
+  const observer = editor._observer;
+  if (observer !== null) {
+    const mutations = observer.takeRecords();
+    flushMutations(editor, mutations, observer);
+  }
+}
+
 export function initMutationObserver(editor: OutlineEditor): void {
+  initTextEntryListener();
   editor._observer = new MutationObserver(
     (mutations: Array<MutationRecord>, observer: MutationObserver) => {
-      flushRootMutations(editor, mutations, observer);
+      flushMutations(editor, mutations, observer);
     },
   );
 }

--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -22,7 +22,7 @@ import {
 } from './OutlineSelection';
 import {FULL_RECONCILE, NO_DIRTY_NODES} from './OutlineConstants';
 import {resetEditor} from './OutlineEditor';
-import {initMutationObserver, flushMutations} from './OutlineMutations';
+import {initMutationObserver, flushRootMutations} from './OutlineMutations';
 import {
   EditorState,
   editorStateHasDirtySelection,
@@ -60,7 +60,7 @@ export type State = {
   setCompositionKey: (compositionKey: NodeKey | null) => void,
   getCompositionKey: () => null | NodeKey,
   getNearestNodeFromDOMNode: (dom: Node) => null | OutlineNode,
-  flushMutations: (mutations: Array<MutationRecord>) => void,
+  flushMutations: () => void,
 };
 
 export const state: State = {
@@ -84,13 +84,10 @@ export const state: State = {
   },
   getCompositionKey,
   getNearestNodeFromDOMNode,
-  flushMutations(mutations: Array<MutationRecord>): void {
+  flushMutations(): void {
     errorOnReadOnly();
     const editor = getActiveEditor();
-    const observer = editor._observer;
-    if (observer !== null) {
-      flushMutations(editor, mutations, observer);
-    }
+    flushRootMutations(editor);
   },
 };
 

--- a/packages/outline/src/core/index.js
+++ b/packages/outline/src/core/index.js
@@ -26,7 +26,7 @@ export type {
 export type {TextFormatType} from './OutlineTextNode';
 export type {LineBreakNode} from './OutlineLineBreakNode';
 
-import {createEditor, getEditorFromElement} from './OutlineEditor';
+import {createEditor} from './OutlineEditor';
 import {createTextNode, isTextNode, TextNode} from './OutlineTextNode';
 import {isBlockNode, BlockNode} from './OutlineBlockNode';
 import {createRootNode, isRootNode, RootNode} from './OutlineRootNode';
@@ -39,7 +39,6 @@ import {createNodeFromParse} from './OutlineParsing';
 export {
   createSelection,
   createEditor,
-  getEditorFromElement,
   // Node factories
   createLineBreakNode,
   createRootNode,


### PR DESCRIPTION
It turns out that our previous heuristic of capturing mutations during the capture phase of the `input` event does not suffice. On Safari, if you open dev tools, mutation observers always happen before even a capture `input`. Instead we now use the `textInput` time stamp to give signal to when we're typing and thus can ignore some text mutations entirely.