### PR TITLE
Remove node in updateTextNodeFromDOMContent if empty

### DIFF
--- a/packages/outline-playground/__tests__/e2e/Composition-test.js
+++ b/packages/outline-playground/__tests__/e2e/Composition-test.js
@@ -422,7 +422,7 @@ describe('Composition', () => {
         // Escape would fire here
         await page.keyboard.insertText('');
 
-        await assertHTML(page, '<p class="editor-paragraph"><br></p>');
+        await assertHTML(page, '<p class="editor-paragraph" dir="ltr"><br></p>');
         await assertSelection(page, {
           anchorPath: [0],
           anchorOffset: 0,

--- a/packages/outline/src/helpers/OutlineEventHelpers.js
+++ b/packages/outline/src/helpers/OutlineEventHelpers.js
@@ -586,7 +586,9 @@ function updateTextNodeFromDOMContent(
           state.setCompositionKey(null);
         }
         node.remove();
-      } else if (
+        return;
+      }
+      if (
         isImmutableOrInert(node) ||
         (state.getCompositionKey() !== null && !isComposing)
       ) {


### PR DESCRIPTION
A better fix than https://github.com/facebookexternal/outline/pull/795.