### PR TITLE
Handle bad paste clipboard on Rich Text

### DIFF
--- a/packages/outline/src/helpers/OutlineEventHelpers.js
+++ b/packages/outline/src/helpers/OutlineEventHelpers.js
@@ -112,10 +112,14 @@ function insertDataTransferForRichText(
   );
 
   if (outlineNodesString) {
-    const nodeRange = JSON.parse(outlineNodesString);
-    const nodes = generateNodes(nodeRange, state);
-    insertNodes(selection, nodes);
-    return;
+    try {
+      const nodeRange = JSON.parse(outlineNodesString);
+      const nodes = generateNodes(nodeRange, state);
+      insertNodes(selection, nodes);
+      return;
+    } catch (e) {
+      // Malformed, missing nodes..
+    }
   }
   insertDataTransferForPlainText(dataTransfer, selection, state);
 }


### PR DESCRIPTION
Right now a Rich Text editor can crash when
1. Clipboard is malformed (unlikely)
2. Copy paste from another text editor which has more features/nodes (the current editor is not able to interpret them)

I believe that a better long term solution would be to either grab the HTML from paste or try to parse as many nodes as we can and grab the text (inc. children text) from the ones we don't recognized (mimicking a plain text copy / `getTextContent` for a part of the tree)