### PR TITLE
Remove RootHelpers based on State

### DIFF
--- a/packages/outline-react/src/useOutlineEditor.js
+++ b/packages/outline-react/src/useOutlineEditor.js
@@ -10,7 +10,7 @@
 import type {OutlineEditor, EditorThemeClasses, EditorState} from 'outline';
 
 import {createEditor} from 'outline';
-import {canShowPlaceholderFromEditorState} from 'outline/root';
+import {canShowPlaceholder} from 'outline/root';
 
 import {useCallback, useMemo, useRef, useState} from 'react';
 import useLayoutEffect from './shared/useLayoutEffect';
@@ -42,7 +42,7 @@ export default function useOutlineEditor<EditorContext>(editorConfig?: {
   }, [editor, onError]);
   useLayoutEffect(() => {
     return editor.addListener('update', ({editorState}) => {
-      const currentCanShowPlaceholder = canShowPlaceholderFromEditorState(
+      const currentCanShowPlaceholder = canShowPlaceholder(
         editorState,
         editor.isComposing(),
       );

--- a/packages/outline-react/src/useOutlineIsBlank.js
+++ b/packages/outline-react/src/useOutlineIsBlank.js
@@ -11,7 +11,7 @@ import type {OutlineEditor} from 'outline';
 
 import useLayoutEffect from './shared/useLayoutEffect';
 import {useState} from 'react';
-import {isBlankFromEditorState} from 'outline/root';
+import {isBlank} from 'outline/root';
 
 /**
  * DEPRECATED. Use useOutlineIsBlank
@@ -22,7 +22,7 @@ export default function useCometOutlineIsBlank(editor: OutlineEditor): boolean {
   useLayoutEffect(() => {
     return editor.addListener('update', ({editorState}) => {
       const isComposing = editor.isComposing();
-      setIsBlank(isBlankFromEditorState(editorState, isComposing));
+      setIsBlank(isBlank(editorState, isComposing));
     });
   }, [editor]);
   return isCurrentlyBlank;

--- a/packages/outline-react/src/useOutlineIsEmpty.js
+++ b/packages/outline-react/src/useOutlineIsEmpty.js
@@ -11,7 +11,7 @@ import type {OutlineEditor} from 'outline';
 
 import useLayoutEffect from './shared/useLayoutEffect';
 import {useState} from 'react';
-import {isBlankFromEditorState} from 'outline/root';
+import {isBlank} from 'outline/root';
 
 /**
  * DEPRECATED. Use useOutlineIsBlank
@@ -22,7 +22,7 @@ export default function useCometOutlineIsEmpty(editor: OutlineEditor): boolean {
   useLayoutEffect(() => {
     return editor.addListener('update', ({editorState}) => {
       const isComposing = editor.isComposing();
-      setIsEmpty(isBlankFromEditorState(editorState, isComposing));
+      setIsEmpty(isBlank(editorState, isComposing));
     });
   }, [editor]);
   return isCurrentlyEmpty;

--- a/packages/outline/src/helpers/OutlineRootHelpers.js
+++ b/packages/outline/src/helpers/OutlineRootHelpers.js
@@ -7,31 +7,16 @@
  * @flow strict
  */
 
-import type {State, EditorState} from 'outline';
+import type {EditorState} from 'outline';
 
 import {getEditorStateTextContent} from '../core/OutlineUtils';
-import {getActiveEditorState} from '../core/OutlineUpdates';
 import {isBlockNode, isTextNode} from 'outline';
 
-export function textContent(state: State): string {
-  const editorState = getActiveEditorState();
-  return textContentFromEditorState(editorState);
-}
-
-export function textContentFromEditorState(editorState: EditorState): string {
+export function textContent(editorState: EditorState): string {
   return getEditorStateTextContent(editorState);
 }
 
 export function isBlank(
-  state: State,
-  isEditorComposing: boolean,
-  trim?: boolean = true,
-): boolean {
-  const editorState = getActiveEditorState();
-  return isBlankFromEditorState(editorState, isEditorComposing, trim);
-}
-
-export function isBlankFromEditorState(
   editorState: EditorState,
   isEditorComposing: boolean,
   trim?: boolean = true,
@@ -47,18 +32,10 @@ export function isBlankFromEditorState(
 }
 
 export function canShowPlaceholder(
-  state: State,
-  isComposing: boolean,
-): boolean {
-  const editorState = getActiveEditorState();
-  return isBlankFromEditorState(editorState, isComposing);
-}
-
-export function canShowPlaceholderFromEditorState(
   editorState: EditorState,
   isComposing: boolean,
 ): boolean {
-  if (!isBlankFromEditorState(editorState, isComposing, false)) {
+  if (!isBlank(editorState, isComposing, false)) {
     return false;
   }
   const nodeMap = editorState._nodeMap;

--- a/packages/outline/src/helpers/__tests__/unit/OutlineRootHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineRootHelpers.test.js
@@ -11,28 +11,24 @@ import type {State} from 'outline';
 
 import {createTextNode} from 'outline';
 import {createParagraphNode} from 'outline/ParagraphNode';
-import {isBlank, isBlankFromEditorState} from 'outline/root';
+import {isBlank} from 'outline/root';
 import {initializeUnitTest} from '../../../__tests__/utils';
 
-describe('OutlineNodeHelpers tests', () => {
+describe('OutlineRootHelpers tests', () => {
   initializeUnitTest((testEnv) => {
     it('isBlank', async () => {
       const editor = testEnv.editor;
-      expect(
-        isBlankFromEditorState(editor.getEditorState(), editor.isComposing()),
-      ).toBe(true);
+      expect(isBlank(editor.getEditorState(), editor.isComposing())).toBe(true);
       await editor.update((state: State) => {
-        expect(isBlank(state, editor.isComposing())).toBe(true);
         const root = state.getRoot();
         const paragraph = createParagraphNode();
         const text = createTextNode('foo');
         root.append(paragraph);
         paragraph.append(text);
-        expect(isBlank(state, editor.isComposing())).toBe(false);
       });
-      expect(
-        isBlankFromEditorState(editor.getEditorState(), editor.isComposing()),
-      ).toBe(false);
+      expect(isBlank(editor.getEditorState(), editor.isComposing())).toBe(
+        false,
+      );
     });
   });
 });


### PR DESCRIPTION
`getActiveEditorState` compiles to 

```
let activeEditorState = null;
function getActiveEditorState() {
  {
    {
      throw Error(`Unable to find an active editor state. State helpers or node methods can only be used synchronously during the callback of editor.update() or editorState.read().`);
    }
  }
}
```

Possibly because of how helpers are configured. Removing these methods for now since this is really bad.