### PR TITLE
Flush sync init editor

### DIFF
--- a/packages/outline-react/src/useOutlinePlainText.js
+++ b/packages/outline-react/src/useOutlinePlainText.js
@@ -55,26 +55,34 @@ function initParagraph(
 }
 
 function initEditor(editor: OutlineEditor): void {
-  editor.update((state) => {
-    log('initEditor');
-    const root = state.getRoot();
-    const firstChild = root.getFirstChild();
-    if (firstChild === null) {
-      initParagraph(state, root, editor);
-    }
-  });
+  editor.update(
+    (state: State) => {
+      log('initEditor');
+      const root = state.getRoot();
+      const firstChild = root.getFirstChild();
+      if (firstChild === null) {
+        initParagraph(state, root, editor);
+      }
+    },
+    undefined,
+    true,
+  );
 }
 
 function clearEditor(
   editor: OutlineEditor,
   callbackFn?: (callbackFn?: () => void) => void,
 ): void {
-  editor.update((state) => {
-    log('clearEditor');
-    const root = state.getRoot();
-    root.clear();
-    initParagraph(state, root, editor);
-  }, callbackFn);
+  editor.update(
+    (state) => {
+      log('clearEditor');
+      const root = state.getRoot();
+      root.clear();
+      initParagraph(state, root, editor);
+    },
+    callbackFn,
+    true,
+  );
 }
 
 const events: InputEvents = [

--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -61,26 +61,34 @@ function initParagraph(
 }
 
 function initEditor(editor: OutlineEditor): void {
-  editor.update((state: State) => {
-    log('initEditor');
-    const root = state.getRoot();
-    const firstChild = root.getFirstChild();
-    if (firstChild === null) {
-      initParagraph(state, root, editor);
-    }
-  });
+  editor.update(
+    (state: State) => {
+      log('initEditor');
+      const root = state.getRoot();
+      const firstChild = root.getFirstChild();
+      if (firstChild === null) {
+        initParagraph(state, root, editor);
+      }
+    },
+    undefined,
+    true,
+  );
 }
 
 function clearEditor(
   editor: OutlineEditor,
   callbackFn?: (callbackFn?: () => void) => void,
 ): void {
-  editor.update((state) => {
-    log('clearEditor');
-    const root = state.getRoot();
-    root.clear();
-    initParagraph(state, root, editor);
-  }, callbackFn);
+  editor.update(
+    (state) => {
+      log('clearEditor');
+      const root = state.getRoot();
+      root.clear();
+      initParagraph(state, root, editor);
+    },
+    callbackFn,
+    true,
+  );
 }
 
 const events: InputEvents = [

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -386,11 +386,15 @@ class BaseOutlineEditor {
   parseEditorState(stringifiedEditorState: string): EditorState {
     return parseEditorState(stringifiedEditorState, getSelf(this));
   }
-  update(updateFn: (state: State) => void, callbackFn?: () => void): void {
+  update(
+    updateFn: (state: State) => void,
+    callbackFn?: () => void,
+    flushSync = false,
+  ): void {
     if (shouldEnqueueUpdates()) {
-      getSelf(this)._updates.push([updateFn, callbackFn]);
+      getSelf(this)._updates.push([updateFn, callbackFn, flushSync]);
     } else {
-      beginUpdate(getSelf(this), updateFn, callbackFn);
+      beginUpdate(getSelf(this), updateFn, callbackFn, flushSync);
     }
   }
   focus(callbackFn?: () => void): void {
@@ -462,7 +466,7 @@ declare export class OutlineEditor {
   _pendingEditorState: null | EditorState;
   _compositionKey: null | NodeKey;
   _deferred: Array<() => void>;
-  _updates: Array<[(state: State) => void, void | (() => void)]>;
+  _updates: Array<[(state: State) => void, void | (() => void), boolean]>;
   _keyToDOMMap: Map<NodeKey, HTMLElement>;
   _listeners: Listeners;
   _textNodeTransforms: Set<TextNodeTransform>;
@@ -494,7 +498,11 @@ declare export class OutlineEditor {
   getEditorState(): EditorState;
   setEditorState(editorState: EditorState): void;
   parseEditorState(stringifiedEditorState: string): EditorState;
-  update(updateFn: (state: State) => void, callbackFn?: () => void): boolean;
+  update(
+    updateFn: (state: State) => void,
+    callbackFn?: () => void,
+    flushSync?: boolean,
+  ): boolean;
   focus(callbackFn?: () => void): void;
   // canShowPlaceholder(): boolean;
 }

--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -375,8 +375,8 @@ export function triggerListeners(
 function triggerEnqueuedUpdates(editor: OutlineEditor): void {
   const queuedUpdates = editor._updates;
   if (queuedUpdates.length !== 0) {
-    const [updateFn, callbackFn] = queuedUpdates.shift();
-    beginUpdate(editor, updateFn, callbackFn);
+    const [updateFn, callbackFn, flushSync] = queuedUpdates.shift();
+    beginUpdate(editor, updateFn, callbackFn, flushSync);
   }
 }
 
@@ -417,6 +417,7 @@ export function beginUpdate(
   editor: OutlineEditor,
   updateFn: (state: State) => void,
   callbackFn?: () => void,
+  flushSync: boolean,
 ): void {
   const deferred = editor._deferred;
   if (callbackFn) {
@@ -430,6 +431,9 @@ export function beginUpdate(
     pendingEditorState = editor._pendingEditorState =
       cloneEditorState(currentEditorState);
     editorStateWasCloned = true;
+  }
+  if (flushSync) {
+    pendingEditorState._flushSync = true;
   }
 
   const previousActiveEditorState = activeEditorState;


### PR DESCRIPTION
Batching updates is fine most of the times, but there's cases when we want to play it as safe as possible. For example, editor load.

If two updates are batched and one of them is the editor update and the second one crashes the editor is left uninitialized. Hence, unusable. That's I propose to `flushSync` these critical updates.

Additionally, you may argue that text transforms can still break it. This is true, but for the most part (including the two provided hooks to initialize rich and plain text) the text will be empty so no text transforms will be triggered.