### PR TITLE
RootHelpers based on State

### DIFF
--- a/packages/outline-react/src/useOutlineEditor.js
+++ b/packages/outline-react/src/useOutlineEditor.js
@@ -10,7 +10,7 @@
 import type {OutlineEditor, EditorThemeClasses, EditorState} from 'outline';
 
 import {createEditor} from 'outline';
-import {canShowPlaceholder} from 'outline/root';
+import {canShowPlaceholder2} from 'outline/root';
 
 import {useCallback, useMemo, useRef, useState} from 'react';
 import useLayoutEffect from './shared/useLayoutEffect';
@@ -42,9 +42,8 @@ export default function useOutlineEditor<EditorContext>(editorConfig?: {
   }, [editor, onError]);
   useLayoutEffect(() => {
     return editor.addListener('update', ({editorState}) => {
-      const currentCanShowPlaceholder = canShowPlaceholder(
-        editorState,
-        editor.isComposing(),
+      const currentCanShowPlaceholder = editorState.read((state) =>
+        canShowPlaceholder2(state, editor.isComposing()),
       );
       if (showPlaceholderRef.current !== currentCanShowPlaceholder) {
         showPlaceholderRef.current = currentCanShowPlaceholder;

--- a/packages/outline-react/src/useOutlineIsBlank.js
+++ b/packages/outline-react/src/useOutlineIsBlank.js
@@ -11,7 +11,7 @@ import type {OutlineEditor} from 'outline';
 
 import useLayoutEffect from './shared/useLayoutEffect';
 import {useState} from 'react';
-import {isBlank} from 'outline/root';
+import {isBlank2} from 'outline/root';
 
 /**
  * DEPRECATED. Use useOutlineIsBlank
@@ -22,7 +22,8 @@ export default function useCometOutlineIsBlank(editor: OutlineEditor): boolean {
   useLayoutEffect(() => {
     return editor.addListener('update', ({editorState}) => {
       const isComposing = editor.isComposing();
-      setIsBlank(isBlank(editorState, isComposing));
+      const isBlank = editorState.read((state) => isBlank2(state, isComposing));
+      setIsBlank(isBlank);
     });
   }, [editor]);
   return isCurrentlyBlank;

--- a/packages/outline-react/src/useOutlineIsEmpty.js
+++ b/packages/outline-react/src/useOutlineIsEmpty.js
@@ -11,7 +11,7 @@ import type {OutlineEditor} from 'outline';
 
 import useLayoutEffect from './shared/useLayoutEffect';
 import {useState} from 'react';
-import {isBlank} from 'outline/root';
+import {isBlank2} from 'outline/root';
 
 /**
  * DEPRECATED. Use useOutlineIsBlank
@@ -22,7 +22,8 @@ export default function useCometOutlineIsEmpty(editor: OutlineEditor): boolean {
   useLayoutEffect(() => {
     return editor.addListener('update', ({editorState}) => {
       const isComposing = editor.isComposing();
-      setIsEmpty(isBlank(editorState, isComposing));
+      const isEmpty = editorState.read((state) => isBlank2(state, isComposing));
+      setIsEmpty(isEmpty);
     });
   }, [editor]);
   return isCurrentlyEmpty;

--- a/packages/outline/src/helpers/OutlineRootHelpers.js
+++ b/packages/outline/src/helpers/OutlineRootHelpers.js
@@ -7,15 +7,70 @@
  * @flow strict
  */
 
-import type {EditorState} from 'outline';
+import type {EditorState, State} from 'outline';
 
 import {getEditorStateTextContent} from '../core/OutlineUtils';
 import {isBlockNode, isTextNode} from 'outline';
 
+export function textContent2(state: State): string {
+  const root = state.getRoot();
+  return root.getTextContent();
+}
+
+export function isBlank2(
+  state: State,
+  isEditorComposing: boolean,
+  trim?: boolean = true,
+): boolean {
+  if (isEditorComposing) {
+    return false;
+  }
+  let text = textContent2(state);
+  if (trim) {
+    text = text.trim();
+  }
+  return text === '';
+}
+
+export function canShowPlaceholder2(
+  state: State,
+  isComposing: boolean,
+): boolean {
+  if (!isBlank2(state, isComposing, false)) {
+    return false;
+  }
+  const root = state.getRoot();
+  const children = root.getChildren();
+  const childrenLength = children.length;
+  if (childrenLength > 1) {
+    return false;
+  }
+  for (let i = 0; i < childrenLength; i++) {
+    const topBlock = children[i];
+
+    if (isBlockNode(topBlock)) {
+      if (topBlock.__type !== 'paragraph') {
+        return false;
+      }
+      const topBlockChildren = topBlock.getChildren();
+      const topBlockChildrenLength = topBlockChildren.length;
+      for (let s = 0; s < topBlockChildrenLength; s++) {
+        const child = topBlockChildren[i];
+        if (!isTextNode(child)) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+// Deprecated
 export function textContent(editorState: EditorState): string {
   return getEditorStateTextContent(editorState);
 }
 
+// Deprecated
 export function isBlank(
   editorState: EditorState,
   isEditorComposing: boolean,
@@ -31,6 +86,7 @@ export function isBlank(
   return text === '';
 }
 
+// Deprecated
 export function canShowPlaceholder(
   editorState: EditorState,
   isComposing: boolean,

--- a/packages/outline/src/helpers/__tests__/unit/OutlineRootHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineRootHelpers.test.js
@@ -11,24 +11,45 @@ import type {State} from 'outline';
 
 import {createTextNode} from 'outline';
 import {createParagraphNode} from 'outline/ParagraphNode';
-import {isBlank} from 'outline/root';
+import {isBlank2, textContent2} from 'outline/root';
 import {initializeUnitTest} from '../../../__tests__/utils';
 
 describe('OutlineRootHelpers tests', () => {
   initializeUnitTest((testEnv) => {
-    it('isBlank', async () => {
+    it('textContent', async () => {
       const editor = testEnv.editor;
-      expect(isBlank(editor.getEditorState(), editor.isComposing())).toBe(true);
+      expect(editor.getEditorState().read(textContent2)).toBe('');
       await editor.update((state: State) => {
         const root = state.getRoot();
         const paragraph = createParagraphNode();
         const text = createTextNode('foo');
         root.append(paragraph);
         paragraph.append(text);
+        expect(textContent2(state)).toBe('foo');
       });
-      expect(isBlank(editor.getEditorState(), editor.isComposing())).toBe(
-        false,
-      );
+      expect(editor.getEditorState().read(textContent2)).toBe('foo');
+    });
+
+    it('isBlank', async () => {
+      const editor = testEnv.editor;
+      expect(
+        editor
+          .getEditorState()
+          .read((state) => isBlank2(state, editor.isComposing())),
+      ).toBe(true);
+      await editor.update((state: State) => {
+        const root = state.getRoot();
+        const paragraph = createParagraphNode();
+        const text = createTextNode('foo');
+        root.append(paragraph);
+        paragraph.append(text);
+        expect(isBlank2(state, editor.isComposing())).toBe(false);
+      });
+      expect(
+        editor
+          .getEditorState()
+          .read((state) => isBlank2(state, editor.isComposing())),
+      ).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Rather than having helpers based on EditorState, let's first-hand support the `editor.update` ones which is the preferred user flow.

```
const text = editorState.read(textContent);
```

```
editor.update(state => {
  const text = textContent(state);
});
```