### PR TITLE
Revise textcontent trigger (params, time)

### DIFF
--- a/packages/outline-playground/src/useTypeahead.js
+++ b/packages/outline-playground/src/useTypeahead.js
@@ -36,8 +36,8 @@ export default function useTypeahead(editor: OutlineEditor): void {
 
   // Monitor entered text
   useEffect(() => {
-    return editor.addListener('textcontent', (text) => {
-      setText(text);
+    return editor.addListener('textcontent', ({textContent}) => {
+      setText(textContent);
     });
   }, [editor]);
 

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -25,7 +25,6 @@ import {RootNode} from './OutlineRootNode';
 import {NO_DIRTY_NODES, FULL_RECONCILE} from './OutlineConstants';
 import {flushRootMutations, initMutationObserver} from './OutlineMutations';
 import {beginUpdate, triggerListeners} from './OutlineUpdates';
-import {getEditorStateTextContent} from './OutlineUtils';
 import invariant from 'shared/invariant';
 
 export type EditorThemeClassName = string;
@@ -91,7 +90,13 @@ export type TextMutationListener = (
   state: State,
   mutation: TextMutation,
 ) => void;
-export type TextContentListener = (text: string) => void;
+export type TextContentListener = ({
+  textContent: string,
+  editorState: EditorState,
+  dirty: boolean,
+  dirtyNodes: Set<NodeKey>,
+  log: Array<string>,
+}) => void;
 
 export type TextMutation = {
   node: TextNode,
@@ -262,16 +267,10 @@ class BaseOutlineEditor {
     listenerSet.add(listener);
 
     const isRootType = type === 'root';
-    const isTextContentType = type === 'textcontent';
     if (isRootType) {
       // $FlowFixMe: TODO refine
       const rootListener: RootListener = listener;
       rootListener(this._rootElement, null);
-    } else if (isTextContentType) {
-      const textContent = getEditorStateTextContent(this._editorState);
-      // $FlowFixMe: TODO refine
-      const textContentListener: TextContentListener = listener;
-      textContentListener(textContent);
     }
     return () => {
       // $FlowFixMe: TODO refine this from the above types

--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -326,7 +326,13 @@ export function commitPendingUpdates(editor: OutlineEditor): void {
     editor._pendingDecorators = null;
     triggerListeners('decorator', editor, true, pendingDecorators);
   }
-  triggerTextContentListeners(editor, currentEditorState, pendingEditorState);
+  triggerTextContentListeners(editor, {
+    currentEditorState,
+    pendingEditorState,
+    dirty: isEditorStateDirty,
+    dirtyNodes,
+    log,
+  });
   triggerListeners('update', editor, true, {
     editorState: pendingEditorState,
     dirty: isEditorStateDirty,
@@ -339,13 +345,30 @@ export function commitPendingUpdates(editor: OutlineEditor): void {
 
 function triggerTextContentListeners(
   editor: OutlineEditor,
-  currentEditorState: EditorState,
-  pendingEditorState: EditorState,
+  {
+    currentEditorState,
+    pendingEditorState,
+    dirty,
+    dirtyNodes,
+    log,
+  }: {
+    currentEditorState: EditorState,
+    pendingEditorState: EditorState,
+    dirty: boolean,
+    dirtyNodes: Set<NodeKey>,
+    log: Array<string>,
+  },
 ): void {
   const currentTextContent = getEditorStateTextContent(currentEditorState);
   const latestTextContent = getEditorStateTextContent(pendingEditorState);
   if (currentTextContent !== latestTextContent) {
-    triggerListeners('textcontent', editor, true, latestTextContent);
+    triggerListeners('textcontent', editor, true, {
+      textContent: latestTextContent,
+      editorState: pendingEditorState,
+      dirty,
+      dirtyNodes,
+      log,
+    });
   }
 }
 


### PR DESCRIPTION
The `textcontent` trigger as it is is currently too basic and forces the user to have multiple listeners to solve the same use case. This shouldn't be the case because at the end of the day it's just an another update listener that triggers less often.

In this PR I propose:

1. Send the UpdateListener data to the user as well as the text. This include: `editorState`, `dirty`, `dirtyNodes` and `log`
2. Make the trigger work like `update`. Do not fire it on registration. We can still do `editor.getEditorState().read(textContent)` to get the initial content which should be pretty straightforward.