### PR TITLE
triggerTextContentListeners to rely on pendingEditorState param

### DIFF
--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -343,11 +343,7 @@ function triggerTextContentListeners(
   pendingEditorState: EditorState,
 ): void {
   const currentTextContent = getEditorStateTextContent(currentEditorState);
-  const latestPendingState = editor._pendingEditorState;
-  const latestTextContent =
-    latestPendingState !== null
-      ? getEditorStateTextContent(latestPendingState)
-      : getEditorStateTextContent(pendingEditorState);
+  const latestTextContent = getEditorStateTextContent(pendingEditorState);
   if (currentTextContent !== latestTextContent) {
     triggerListeners('textcontent', editor, true, latestTextContent);
   }


### PR DESCRIPTION
There's a chance this is intentional but it's worth the shot for the sake of readability.