### PR TITLE
Non-text transforms

### DIFF
--- a/packages/outline/src/core/OutlineUtils.js
+++ b/packages/outline/src/core/OutlineUtils.js
@@ -25,6 +25,7 @@ import {
   getActiveEditor,
   getActiveEditorState,
 } from './OutlineUpdates';
+import type {State} from './OutlineUpdates';
 
 export const emptyFunction = () => {};
 
@@ -140,6 +141,23 @@ export function generateKey(node: OutlineNode): NodeKey {
   editor._dirtyNodes.add(key);
   editor._dirtyType = HAS_DIRTY_NODES;
   return key;
+}
+
+export function markNodesAsDirty(
+  state: State,
+  predicateFn: (node: OutlineNode) => boolean = () => true,
+): void {
+  const editorState = getActiveEditorState();
+  const nodeMap = editorState._nodeMap;
+  const nodeMapEntries = Array.from(nodeMap);
+  // For...of would be faster here, but this will get
+  // compiled away to a slow-path with Babel.
+  for (let i = 0; i < nodeMapEntries.length; i++) {
+    const node = nodeMapEntries[i][1];
+    if (predicateFn(node)) {
+      node.markDirty();
+    }
+  }
 }
 
 export function markParentsAsDirty(

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -43,5 +43,6 @@
   "41": "reconcileNode: prevNode or nextNode does not exist in nodeMap",
   "42": "reconcileNode: parentDOM is null",
   "43": "Reconciliation: could not find DOM element for node key \"${key}\"",
-  "44": "A ListItemNode must have a ListNode for a parent."
+  "44": "A ListItemNode must have a ListNode for a parent.",
+  "45": "Unsupported transform type"
 }


### PR DESCRIPTION
This PR enables users to transform blocks and other non-text nodes directly while we're performing the update. Not only this is faster but it will prevent loops and make it harder to misuse variables between update listeners and updates (since this will no longer be required).

```
editor.addListener('block', block => {
  // Dirty block node
});
```

```
editor.addListener('*', node => {
  // Dirty node (i.e. TextNode, Decorator, etc.)
});
```

- [ ] Unit tests

Kudos to @trueadm for the idea