### PR TITLE
Allow indenting empty list items

### DIFF
--- a/packages/outline-playground/__tests__/e2e/NestedList-test.js
+++ b/packages/outline-playground/__tests__/e2e/NestedList-test.js
@@ -33,6 +33,25 @@ describe('Nested List', () => {
         '<ul class="editor-list-ul"><li class="editor-listitem"><br></li></ul>',
       );
 
+      // Should allow indenting an empty list item
+      await page.waitForSelector('button.action-button.indent');
+      await page.click('button.action-button.indent');
+      await page.click('button.action-button.indent');
+
+      await assertHTML(
+        page,
+        '<ul class="editor-list-ul"><li class="editor-listitem editor-nested-list-listitem"><ul class="editor-list-ul"><li class="editor-listitem editor-nested-list-listitem"><ul class="editor-list-ul"><li class="editor-listitem"><br></li></ul></li></ul></li></ul>',
+      );
+
+      // Backspace should "unindent" the first list item.
+      await page.keyboard.press('Backspace');
+      await page.keyboard.press('Backspace');
+
+      await assertHTML(
+        page,
+        '<ul class="editor-list-ul"><li class="editor-listitem"><br></li></ul>',
+      );
+
       await page.keyboard.type('Hello');
       await page.keyboard.press('Enter');
       await page.keyboard.type('from');

--- a/packages/outline-react/src/useOutlineNestedList.js
+++ b/packages/outline-react/src/useOutlineNestedList.js
@@ -26,8 +26,11 @@ function maybeIndentOrOutdent(
     if (selection === null) {
       return;
     }
-    const selectedNodes = selection.getNodes() || [];
+    const selectedNodes = selection.getNodes();
     let listItemNodes = [];
+    if (selectedNodes.length === 0) {
+      selectedNodes.push(selection.anchor.getNode());
+    }
     if (selectedNodes.length === 1) {
       // Only 1 node selected. Selection may not contain the ListNodeItem so we traverse the tree to
       // find whether this is part of a ListItemNode

--- a/packages/outline/src/extensions/OutlineListItemNode.js
+++ b/packages/outline/src/extensions/OutlineListItemNode.js
@@ -155,18 +155,27 @@ export class ListItemNode extends BlockNode {
     const children = this.getChildren();
     children.forEach((child) => paragraph.append(child));
     const listNode = this.getParentOrThrow();
+    const listNodeParent = listNode.getParentOrThrow();
+    const isNested = isListItemNode(listNodeParent);
     if (listNode.getChildrenSize() === 1) {
-      listNode.replace(paragraph);
-      // If we have selection on the list item, we'll need to move it
-      // to the paragraph
-      const anchor = selection.anchor;
-      const focus = selection.focus;
-      const key = paragraph.getKey();
-      if (anchor.type === 'block' && anchor.getNode().is(this)) {
-        anchor.set(key, anchor.offset, 'block');
-      }
-      if (focus.type === 'block' && focus.getNode().is(this)) {
-        focus.set(key, focus.offset, 'block');
+      if (isNested) {
+        // if the list node is nested, we just want to remove it,
+        // effectively unindenting it.
+        listNode.remove();
+        listNodeParent.select();
+      } else {
+        listNode.replace(paragraph);
+        // If we have selection on the list item, we'll need to move it
+        // to the paragraph
+        const anchor = selection.anchor;
+        const focus = selection.focus;
+        const key = paragraph.getKey();
+        if (anchor.type === 'block' && anchor.getNode().is(this)) {
+          anchor.set(key, anchor.offset, 'block');
+        }
+        if (focus.type === 'block' && focus.getNode().is(this)) {
+          focus.set(key, focus.offset, 'block');
+        }
       }
     } else {
       listNode.insertBefore(paragraph);


### PR DESCRIPTION
This allows indenting empty list nodes. It's annoying not to be able to do this when actually compose something.

Two things to think about:

1) Adding isNested to collapseAtStart - we're not introducing the concept of a 'nested' state in ListItemNode here, but it's worth confirming that this is something we want to do. I think it makes sense, given discussions we've had about starting to think about node relationship "rules"

2) The backspace behavior is different for the top-level list item node (it outdents one level for each backspace) than for other list items (they just delete themselves and the parent list and move selection to the next list item above in the list. This is fine, since it's fairly sane behavior and it's the way it worked before apparently. However, I think ideally we would outdent like we do for the top-level one.  I traced the issue to an unexpected (to me) return value from updateCaretSelectionForRange where it's called in deleteCharacter. For some reason, it changes the selection to include the TextNode in the ListItem above. I think this is a bug, but I'm not sure so I'm leaving it alone for now.