### PR TITLE
Restore original RootHelpers names

### DIFF
--- a/packages/outline-react/src/useOutlineEditor.js
+++ b/packages/outline-react/src/useOutlineEditor.js
@@ -10,7 +10,7 @@
 import type {OutlineEditor, EditorThemeClasses, EditorState} from 'outline';
 
 import {createEditor} from 'outline';
-import {canShowPlaceholder2} from 'outline/root';
+import {canShowPlaceholder} from 'outline/root';
 
 import {useCallback, useMemo, useRef, useState} from 'react';
 import useLayoutEffect from './shared/useLayoutEffect';
@@ -43,7 +43,7 @@ export default function useOutlineEditor<EditorContext>(editorConfig?: {
   useLayoutEffect(() => {
     return editor.addListener('update', ({editorState}) => {
       const currentCanShowPlaceholder = editorState.read((state) =>
-        canShowPlaceholder2(state, editor.isComposing()),
+        canShowPlaceholder(state, editor.isComposing()),
       );
       if (showPlaceholderRef.current !== currentCanShowPlaceholder) {
         showPlaceholderRef.current = currentCanShowPlaceholder;

--- a/packages/outline-react/src/useOutlineIsBlank.js
+++ b/packages/outline-react/src/useOutlineIsBlank.js
@@ -11,20 +11,22 @@ import type {OutlineEditor} from 'outline';
 
 import useLayoutEffect from './shared/useLayoutEffect';
 import {useState} from 'react';
-import {isBlank2} from 'outline/root';
+import {isBlank} from 'outline/root';
 
 export default function useOutlineIsBlank(editor: OutlineEditor): boolean {
   const [isCurrentlyBlank, setIsBlank] = useState(
     editor
       .getEditorState()
-      .read((state) => isBlank2(state, editor.isComposing())),
+      .read((state) => isBlank(state, editor.isComposing())),
   );
 
   useLayoutEffect(() => {
     return editor.addListener('update', ({editorState}) => {
       const isComposing = editor.isComposing();
-      const isBlank = editorState.read((state) => isBlank2(state, isComposing));
-      setIsBlank(isBlank);
+      const currentIsBlank = editorState.read((state) =>
+        isBlank(state, isComposing),
+      );
+      setIsBlank(currentIsBlank);
     });
   }, [editor]);
   return isCurrentlyBlank;

--- a/packages/outline/src/helpers/OutlineRootHelpers.js
+++ b/packages/outline/src/helpers/OutlineRootHelpers.js
@@ -7,17 +7,18 @@
  * @flow strict
  */
 
-import type {EditorState, State} from 'outline';
+import type {State} from 'outline';
 
-import {getEditorStateTextContent} from '../core/OutlineUtils';
 import {isBlockNode, isTextNode} from 'outline';
 
-export function textContent2(state: State): string {
+export function textContent(state: State): string {
   const root = state.getRoot();
   return root.getTextContent();
 }
 
-export function isBlank2(
+export const textContent2 = textContent;
+
+export function isBlank(
   state: State,
   isEditorComposing: boolean,
   trim?: boolean = true,
@@ -25,18 +26,20 @@ export function isBlank2(
   if (isEditorComposing) {
     return false;
   }
-  let text = textContent2(state);
+  let text = textContent(state);
   if (trim) {
     text = text.trim();
   }
   return text === '';
 }
 
-export function canShowPlaceholder2(
+export const isBlank2 = isBlank;
+
+export function canShowPlaceholder(
   state: State,
   isComposing: boolean,
 ): boolean {
-  if (!isBlank2(state, isComposing, false)) {
+  if (!isBlank(state, isComposing, false)) {
     return false;
   }
   const root = state.getRoot();
@@ -68,58 +71,4 @@ export function canShowPlaceholder2(
   return true;
 }
 
-// Deprecated
-export function textContent(editorState: EditorState): string {
-  return getEditorStateTextContent(editorState);
-}
-
-// Deprecated
-export function isBlank(
-  editorState: EditorState,
-  isEditorComposing: boolean,
-  trim?: boolean = true,
-): boolean {
-  if (isEditorComposing) {
-    return false;
-  }
-  let text = getEditorStateTextContent(editorState);
-  if (trim) {
-    text = text.trim();
-  }
-  return text === '';
-}
-
-// Deprecated
-export function canShowPlaceholder(
-  editorState: EditorState,
-  isComposing: boolean,
-): boolean {
-  if (!isBlank(editorState, isComposing, false)) {
-    return false;
-  }
-  const nodeMap = editorState._nodeMap;
-  // $FlowFixMe: root is always in the Map
-  const root = ((nodeMap.get('root'): any): RootNode);
-  const topBlockIDs = root.__children;
-  const topBlockIDsLength = topBlockIDs.length;
-  if (topBlockIDsLength > 1) {
-    return false;
-  }
-  for (let i = 0; i < topBlockIDsLength; i++) {
-    const topBlock = nodeMap.get(topBlockIDs[i]);
-
-    if (isBlockNode(topBlock)) {
-      if (topBlock.__type !== 'paragraph') {
-        return false;
-      }
-      const children = topBlock.__children;
-      for (let s = 0; s < children.length; s++) {
-        const child = nodeMap.get(children[s]);
-        if (!isTextNode(child)) {
-          return false;
-        }
-      }
-    }
-  }
-  return true;
-}
+export const canShowPlaceholder2 = canShowPlaceholder;


### PR DESCRIPTION
Having deprecated the old methods, we can now safely put the good names back