### PR TITLE
Remove dirty node key on merge

### DIFF
--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -851,7 +851,11 @@ function mergeAdjacentTextNodes(
     );
     textLength += siblingText.length;
     textNode.remove();
-    activeDirtyNodes.delete(textNodeKey);
+    // If we have created a node and it was dereferenced, then also
+    // remove it from out dirty nodes Set.
+    if (!activePrevNodeMap.has(textNodeKey)) {
+      activeDirtyNodes.delete(textNodeKey);
+    }
   }
   if (selectionIsDirty && activeSelection !== null) {
     activeSelection.dirty = true;
@@ -908,7 +912,11 @@ function removeStrandedEmptyTextNode(
     activeSelection.dirty = true;
   }
   node.remove();
-  activeDirtyNodes.delete(key);
+  // If we have created a node and it was dereferenced, then also
+  // remove it from out dirty nodes Set.
+  if (!activePrevNodeMap.has(key)) {
+    activeDirtyNodes.delete(key);
+  }
 }
 
 function normalizeTextNodes(block: BlockNode): BlockNode {


### PR DESCRIPTION
We don't want to keep around the dirty node key of a node that was merged away, if it wasn't in the previous dirty nodes map.