### PR TITLE
Revise dirtyBlocks logic

### DIFF
--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -132,7 +132,7 @@ export function resetEditor(
   editor._compositionKey = null;
   editor._dirtyType = NO_DIRTY_NODES;
   editor._dirtyNodes = new Set();
-  editor._dirtySubTrees = new Set();
+  editor._dirtyBlocks = new Map();
   editor._log = [];
   editor._updates = [];
   const observer = editor._observer;
@@ -195,14 +195,11 @@ class BaseOutlineEditor {
   _config: EditorConfig<{...}>;
   _dirtyType: 0 | 1 | 2;
   _dirtyNodes: Set<NodeKey>;
-  _dirtySubTrees: Set<NodeKey>;
+  _dirtyBlocks: Map<NodeKey, Number>;
   _observer: null | MutationObserver;
   _log: Array<string>;
 
-  constructor(
-    editorState: EditorState,
-    config: EditorConfig<{...}>,
-  ) {
+  constructor(editorState: EditorState, config: EditorConfig<{...}>) {
     // The root element associated with this editor
     this._rootElement = null;
     // The current editor state
@@ -240,7 +237,7 @@ class BaseOutlineEditor {
     // Used to optimize reconcilation
     this._dirtyType = NO_DIRTY_NODES;
     this._dirtyNodes = new Set();
-    this._dirtySubTrees = new Set();
+    this._dirtyBlocks = new Map();
     // Handling of DOM mutations
     this._observer = null;
     // Logging for updates
@@ -425,7 +422,7 @@ declare export class OutlineEditor {
   _config: EditorConfig<{...}>;
   _dirtyType: 0 | 1 | 2;
   _dirtyNodes: Set<NodeKey>;
-  _dirtySubTrees: Set<NodeKey>;
+  _dirtyBlocks: Map<NodeKey, number>;
   _observer: null | MutationObserver;
   _log: Array<string>;
 

--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -22,8 +22,9 @@ import {
   getNodeByKey,
   getTextDirection,
   internallyMarkNodeAsDirty,
-  markParentsAsDirty,
+  markParentBlocksAsDirty,
   setCompositionKey,
+  getBlockDepth,
 } from './OutlineUtils';
 import invariant from 'shared/invariant';
 import {
@@ -489,12 +490,15 @@ export class OutlineNode {
     // Ensure we get the latest node from pending state
     const latestNode = this.getLatest();
     const parent = latestNode.__parent;
+    const dirtyBlocks = editor._dirtyBlocks;
     if (parent !== null) {
-      const dirtySubTrees = editor._dirtySubTrees;
-      markParentsAsDirty(parent, nodeMap, dirtySubTrees);
+      markParentBlocksAsDirty(parent, nodeMap, dirtyBlocks);
     }
     const dirtyNodes = editor._dirtyNodes;
     if (dirtyNodes.has(key)) {
+      if (isBlockNode(this)) {
+        dirtyBlocks.set(key, getBlockDepth(this));
+      }
       return latestNode;
     }
     const constructor = latestNode.constructor;

--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -46,7 +46,7 @@ let editorTextContent = '';
 let activeEditorConfig: EditorConfig<{...}>;
 let activeEditor: OutlineEditor;
 let treatAllNodesAsDirty: boolean = false;
-let activeDirtySubTrees: Set<NodeKey>;
+let activeDirtyBlocks: Map<NodeKey, number>;
 let activeDirtyNodes: Set<NodeKey>;
 let activePrevNodeMap: NodeMap;
 let activeNextNodeMap: NodeMap;
@@ -330,7 +330,7 @@ function reconcileNode(
   const isDirty =
     treatAllNodesAsDirty ||
     activeDirtyNodes.has(key) ||
-    activeDirtySubTrees.has(key);
+    activeDirtyBlocks.has(key);
   const dom = getElementByKeyOrThrow(activeEditor, key);
 
   if (prevNode === nextNode && !isDirty) {
@@ -525,7 +525,7 @@ function reconcileRoot(
   editor: OutlineEditor,
   selection: null | OutlineSelection,
   dirtyType: 0 | 1 | 2,
-  dirtySubTrees: Set<NodeKey>,
+  dirtyBlocks: Map<NodeKey, number>,
   dirtyNodes: Set<NodeKey>,
 ): void {
   subTreeTextContent = '';
@@ -535,7 +535,7 @@ function reconcileRoot(
   treatAllNodesAsDirty = dirtyType === FULL_RECONCILE;
   activeEditor = editor;
   activeEditorConfig = editor._config;
-  activeDirtySubTrees = dirtySubTrees;
+  activeDirtyBlocks = dirtyBlocks;
   activeDirtyNodes = dirtyNodes;
   activePrevNodeMap = prevEditorState._nodeMap;
   activeNextNodeMap = nextEditorState._nodeMap;
@@ -550,7 +550,7 @@ function reconcileRoot(
   // $FlowFixMe
   activeEditor = undefined;
   // $FlowFixMe
-  activeDirtySubTrees = undefined;
+  activeDirtyBlocks = undefined;
   // $FlowFixMe
   activeDirtyNodes = undefined;
   // $FlowFixMe
@@ -578,7 +578,7 @@ export function updateEditorState(
 
   if (needsUpdate && observer !== null) {
     const dirtyType = editor._dirtyType;
-    const dirtySubTrees = editor._dirtySubTrees;
+    const dirtyBlocks = editor._dirtyBlocks;
     const dirtyNodes = editor._dirtyNodes;
 
     observer.disconnect();
@@ -589,7 +589,7 @@ export function updateEditorState(
         editor,
         pendingSelection,
         dirtyType,
-        dirtySubTrees,
+        dirtyBlocks,
         dirtyNodes,
       );
     } finally {

--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -317,7 +317,7 @@ export function commitPendingUpdates(editor: OutlineEditor): void {
   if (needsUpdate) {
     editor._dirtyType = NO_DIRTY_NODES;
     editor._dirtyNodes = new Set();
-    editor._dirtySubTrees = new Set();
+    editor._dirtyBlocks = new Map();
   }
   garbageCollectDetachedDecorators(editor, pendingEditorState);
   const pendingDecorators = editor._pendingDecorators;
@@ -494,7 +494,7 @@ export function beginUpdate(
     editor._pendingEditorState = currentEditorState;
     editor._dirtyType = FULL_RECONCILE;
     editor._dirtyNodes = new Set();
-    editor._dirtySubTrees = new Set();
+    editor._dirtyBlocks = new Map();
     editor._log.push('UpdateRecover');
     commitPendingUpdates(editor);
     return;


### PR DESCRIPTION
Rather than having the naming of dirty sub-trees, which is kind of confusing, let's instead go with dirty blocks. Additionally, we store the depth of the block when adding it to the dirty blocks Map.