### PR TITLE
Patch bad compilation on OutlineSelectionHelpers

### DIFF
--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -808,13 +808,11 @@ export function updateCaretSelectionForRange(
   granularity: 'character' | 'word' | 'lineboundary',
   collapse: boolean,
 ): void {
-  const domSelection = window.getSelection();
   const focus = selection.focus;
   const anchor = selection.anchor;
 
   // Handle the selection movement around decorators.
   const possibleDecoratorNode = getPossibleDecoratorNode(focus, isBackward);
-
   if (isDecoratorNode(possibleDecoratorNode)) {
     const sibling = isBackward
       ? possibleDecoratorNode.getPreviousSibling()
@@ -832,6 +830,8 @@ export function updateCaretSelectionForRange(
       return;
     }
   }
+
+  const domSelection = window.getSelection();
   // We use the DOM selection.modify API here to "tell" us what the selection
   // will be. We then use it to update the Outline selection accordingly. This
   // is much more reliable than waiting for a beforeinput and using the ranges


### PR DESCRIPTION
`updateCaretSelectionForRange` doesn't seem to be compiling fine ([internal reference](https://fburl.com/aeo5re5q)). This issue probably requires some more in-depth research but this should patch it in the meantime

Previous (note how `window.getSelection` can get replace with `offset`)
```
function G(a, b, c, d) {
  var e = window.getSelection();
  const f = a.focus,
    l = a.anchor,
    k = E(f, b);
  if (u.isDecoratorNode(k)) {
    const g = b ? k.getPreviousSibling() : k.getNextSibling();
    if (!u.isTextNode(g)) {
      a = k.getParentOrThrow().getKey();
      e = k.getIndexWithinParent();
      b || e++;
      f.set(a, e, "block");
      d && l.set(a, e, "block");
      return;
    }
  }
  e.modify(d ? "move" : "extend", b ? "backward" : "forward", c);
}
```
After
```
function G(a, b, c, d) {
  var e = a.focus;
  const f = a.anchor,
    k = E(e, b);
  if (u.isDecoratorNode(k)) {
    const l = b ? k.getPreviousSibling() : k.getNextSibling();
    if (!u.isTextNode(l)) {
      a = k.getParentOrThrow().getKey();
      c = k.getIndexWithinParent();
      b || c++;
      e.set(a, c, "block");
      d && f.set(a, c, "block");
      return;
    }
  }
  e = window.getSelection();
  e.modify(d ? "move" : "extend", b ? "backward" : "forward", c);
  0 < e.rangeCount &&
    ((b = e.getRangeAt(0)),
    a.applyDOMRange(b),
    d ||
      (e.anchorNode === b.startContainer && e.anchorOffset === b.startOffset) ||
      a.swapPoints());
}
