### PR TITLE
Expose state methods on Outline export

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -51,17 +51,18 @@ helper selection functions provided by the Outline pacakge:
 import type {State, OutlineEditor, Selection} from 'outline';
 
 import {insertText} from 'outline/SelectionHlpers'
+import {getSelection} from 'outline';
 
 function listenToTextInsertion(editor: OutlineEditor) {
 
   // The "input" event fires when a user types in some text
   const onInput = (event: InputEvent) => {
-    editor.update((state: State) => {
+    editor.update(() => {
       // Note: this is not a browser selection, but rather an Outline
       // selection. Outline always tries to ensure selection matches up
       // with an Outline TextNode, to simplify its usage and avoid common
       // edge-cases.
-      const selection: Selection = state.getSelection();
+      const selection: Selection = getSelection();
       // Get the text from this input event.
       const text = event.data;
 

--- a/packages/outline-playground/src/nodes/ImageNode.js
+++ b/packages/outline-playground/src/nodes/ImageNode.js
@@ -9,7 +9,7 @@
 
 import type {EditorConfig, NodeKey, OutlineNode, OutlineEditor} from 'outline';
 
-import {DecoratorNode, log} from 'outline';
+import {DecoratorNode, log, getNodeByKey} from 'outline';
 
 import * as React from 'react';
 
@@ -250,9 +250,9 @@ function ImageComponent({
 
   const handleKeyDown = (event) => {
     if ((hasFocus && event.key === 'Backspace') || event.key === 'Delete') {
-      editor.update((state) => {
+      editor.update(() => {
         log('Image.keyDown');
-        const node = state.getNodeByKey(nodeKey);
+        const node = getNodeByKey(nodeKey);
         if (node !== null) {
           node.remove();
           event.stopPropagation();
@@ -297,9 +297,9 @@ function ImageComponent({
                 rootElement.style.setProperty('cursor', 'default');
               }
               setIsResizing(false);
-              editor.update((state) => {
+              editor.update(() => {
                 log('ImageNode.resize');
-                const node = state.getNodeByKey(nodeKey);
+                const node = getNodeByKey(nodeKey);
                 if (isImageNode(node)) {
                   node.setWidthAndHeight(nextWidth, nextHeight);
                 }

--- a/packages/outline-playground/src/plugins/ActionsPlugin.js
+++ b/packages/outline-playground/src/plugins/ActionsPlugin.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import PlaygroundController from '../controllers/PlaygroundController';
 import {useController} from 'outline-react/OutlineController';
 import {useEffect, useState} from 'react';
-import {log, isBlockNode} from 'outline';
+import {log, isBlockNode, getSelection} from 'outline';
 import {isListItemNode} from 'outline/ListItemNode';
 import {ImageNode, createImageNode} from '../nodes/ImageNode';
 import {insertNodes} from 'outline/selection';
@@ -36,9 +36,9 @@ export default function ActionsPlugins({
   }, [addListener, editor]);
 
   const handleAddImage = () => {
-    editor.update((state) => {
+    editor.update(() => {
       log('handleAddImage');
-      const selection = state.getSelection();
+      const selection = getSelection();
       if (selection !== null) {
         const imageNode = createImageNode(
           yellowFlowerImage,
@@ -50,8 +50,8 @@ export default function ActionsPlugins({
   };
 
   const setAlignment = (alignment: 'left' | 'right' | 'center' | 'justify') => {
-    editor.update((state) => {
-      const selection = state.getSelection();
+    editor.update(() => {
+      const selection = getSelection();
       if (selection !== null) {
         const node = selection.anchor.getNode();
         const block = isBlockNode(node) ? node : node.getParentOrThrow();
@@ -77,8 +77,8 @@ export default function ActionsPlugins({
   };
 
   const applyOutdent = () => {
-    editor.update((state) => {
-      const selection = state.getSelection();
+    editor.update(() => {
+      const selection = getSelection();
       if (selection !== null) {
         const node = selection.anchor.getNode();
         const block = isBlockNode(node) ? node : node.getParentOrThrow();
@@ -94,8 +94,8 @@ export default function ActionsPlugins({
   };
 
   const applyIndent = () => {
-    editor.update((state) => {
-      const selection = state.getSelection();
+    editor.update(() => {
+      const selection = getSelection();
       if (selection !== null) {
         const node = selection.anchor.getNode();
         const block = isBlockNode(node) ? node : node.getParentOrThrow();

--- a/packages/outline-playground/src/plugins/BlockControlsPlugin.js
+++ b/packages/outline-playground/src/plugins/BlockControlsPlugin.js
@@ -23,7 +23,7 @@ import {wrapLeafNodesInBlocks} from 'outline/selection';
 import {useEffect, useRef, useState} from 'react';
 // $FlowFixMe
 import {createPortal} from 'react-dom';
-import {log} from 'outline';
+import {log, getSelection} from 'outline';
 
 function DropdownList({
   editor,
@@ -73,9 +73,9 @@ function DropdownList({
 
   const formatParagraph = () => {
     if (blockType !== 'paragraph') {
-      editor.update((state) => {
+      editor.update(() => {
         log('formatParagraph');
-        const selection = state.getSelection();
+        const selection = getSelection();
 
         if (selection !== null) {
           wrapLeafNodesInBlocks(selection, () => createParagraphNode());
@@ -87,9 +87,9 @@ function DropdownList({
 
   const formatLargeHeading = () => {
     if (blockType !== 'h1') {
-      editor.update((state) => {
+      editor.update(() => {
         log('formatLargeHeading');
-        const selection = state.getSelection();
+        const selection = getSelection();
 
         if (selection !== null) {
           wrapLeafNodesInBlocks(selection, () => createHeadingNode('h1'));
@@ -103,7 +103,7 @@ function DropdownList({
     if (blockType !== 'h2') {
       editor.update((state) => {
         log('formatSmallHeading');
-        const selection = state.getSelection();
+        const selection = getSelection();
 
         if (selection !== null) {
           wrapLeafNodesInBlocks(selection, () => createHeadingNode('h2'));
@@ -117,7 +117,7 @@ function DropdownList({
     if (blockType !== 'ul') {
       editor.update((state) => {
         log('formatBulletList');
-        const selection = state.getSelection();
+        const selection = getSelection();
 
         if (selection !== null) {
           wrapLeafNodesInBlocks(
@@ -135,7 +135,7 @@ function DropdownList({
     if (blockType !== 'ol') {
       editor.update((state) => {
         log('formatNumberedList');
-        const selection = state.getSelection();
+        const selection = getSelection();
 
         if (selection !== null) {
           wrapLeafNodesInBlocks(
@@ -153,7 +153,7 @@ function DropdownList({
     if (blockType !== 'quote') {
       editor.update((state) => {
         log('formatQuote');
-        const selection = state.getSelection();
+        const selection = getSelection();
 
         if (selection !== null) {
           wrapLeafNodesInBlocks(selection, () => createQuoteNode());
@@ -167,7 +167,7 @@ function DropdownList({
     if (blockType !== 'code') {
       editor.update((state) => {
         log('formatCode');
-        const selection = state.getSelection();
+        const selection = getSelection();
 
         if (selection !== null) {
           wrapLeafNodesInBlocks(selection, () => createCodeNode());
@@ -229,8 +229,8 @@ export default function BlockControlsPlugin(): React$Node {
 
   useEffect(() => {
     return editor.addListener('update', ({editorState}) => {
-      editorState.read((state) => {
-        const selection = state.getSelection();
+      editorState.read(() => {
+        const selection = getSelection();
         if (selection !== null) {
           const anchorNode = selection.anchor.getNode();
           const block = anchorNode.getTopParentBlockOrThrow();

--- a/packages/outline-playground/src/plugins/EmojisPlugin.js
+++ b/packages/outline-playground/src/plugins/EmojisPlugin.js
@@ -7,12 +7,13 @@
  * @flow strict-local
  */
 
-import type {TextNode, State, OutlineEditor, Selection} from 'outline';
+import type {TextNode, OutlineEditor, Selection} from 'outline';
 
 import PlaygroundController from '../controllers/PlaygroundController';
 import {useController} from 'outline-react/OutlineController';
 import {createEmojiNode, EmojiNode} from '../nodes/EmojiNode';
 import {useEffect} from 'react';
+import {getSelection} from 'outline';
 
 const emojis: Map<string, [string, string]> = new Map([
   [':)', ['emoji happysmile', '🙂']],
@@ -49,8 +50,8 @@ function findAndTransformEmoji(
   return null;
 }
 
-function textNodeTransform(node: TextNode, state: State): void {
-  const selection = state.getSelection();
+function textNodeTransform(node: TextNode): void {
+  const selection = getSelection();
   let targetNode = node;
 
   while (targetNode !== null) {

--- a/packages/outline-playground/src/plugins/FloatingToolbarPlugin.js
+++ b/packages/outline-playground/src/plugins/FloatingToolbarPlugin.js
@@ -30,7 +30,7 @@ import {
   getSelectionStyleValueForProperty,
   patchStyleText,
 } from 'outline/selection';
-import {log} from 'outline';
+import {log, getSelection, setSelection} from 'outline';
 import {createLinkNode, isLinkNode, LinkNode} from 'outline/LinkNode';
 
 function positionToolbar(toolbar, rect) {
@@ -216,8 +216,8 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
   );
 
   useEffect(() => {
-    editor.getEditorState().read((state) => {
-      const selection = state.getSelection();
+    editor.getEditorState().read(() => {
+      const selection = getSelection();
       moveToolbar(selection);
     });
   });
@@ -261,15 +261,15 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
       };
 
       const selectionChangeHandler = () => {
-        editor.getEditorState().read((state) => {
-          const selection = state.getSelection();
+        editor.getEditorState().read(() => {
+          const selection = getSelection();
           updateButtonStates(selection);
           moveToolbar(selection);
         });
       };
       const checkForChanges = () => {
-        editor.getEditorState().read((state) => {
-          const selection = state.getSelection();
+        editor.getEditorState().read(() => {
+          const selection = getSelection();
           updateButtonStates(selection);
           moveToolbar(selection);
         });
@@ -279,8 +279,8 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
       };
       const mouseUpHandler = () => {
         mouseDownRef.current = false;
-        editor.getEditorState().read((state) => {
-          const selection = state.getSelection();
+        editor.getEditorState().read(() => {
+          const selection = getSelection();
           moveToolbar(selection);
         });
       };
@@ -303,12 +303,12 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
 
   const updateSelectedLinks = useCallback(
     (url: null | string, selection: null | Selection) => {
-      editor.update((state) => {
+      editor.update(() => {
         log('useToolbar');
         if (selection !== null) {
-          state.setSelection(selection);
+          setSelection(selection);
         }
-        const sel = state.getSelection();
+        const sel = getSelection();
         if (sel !== null) {
           const nodes = extractSelection(sel);
           nodes.forEach((node) => {
@@ -348,9 +348,9 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
 
   const applyFormatText = useCallback(
     (formatType: TextFormatType) => {
-      editor.update((state) => {
+      editor.update(() => {
         log('applyFormatText');
-        const selection = state.getSelection();
+        const selection = getSelection();
         if (selection !== null) {
           formatText(selection, formatType);
         }
@@ -361,9 +361,9 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
 
   const applyStyleText = useCallback(
     (styles: {[string]: string}) => {
-      editor.update((state) => {
+      editor.update(() => {
         log('applyStyleText');
-        const selection = state.getSelection();
+        const selection = getSelection();
         if (selection !== null) {
           patchStyleText(selection, styles);
         }

--- a/packages/outline-playground/src/plugins/KeywordsPlugin.js
+++ b/packages/outline-playground/src/plugins/KeywordsPlugin.js
@@ -11,7 +11,13 @@ import PlaygroundController from '../controllers/PlaygroundController';
 import {useController} from 'outline-react/OutlineController';
 import type {OutlineEditor, State, BlockNode} from 'outline';
 import {useEffect} from 'react';
-import {createTextNode, isTextNode, TextNode, isBlockNode} from 'outline';
+import {
+  createTextNode,
+  isTextNode,
+  TextNode,
+  isBlockNode,
+  getSelection,
+} from 'outline';
 import {
   KeywordNode,
   isKeywordNode,
@@ -39,7 +45,7 @@ function textTransform(node: TextNode, state: State): void {
     }
     adjacentTextNode = adjacentTextNode.getNextSibling();
   }
-  const selection = state.getSelection();
+  const selection = getSelection();
 
   if (!isCharacterBetweenValid(text[0])) {
     // Handle when a text node occurs after a keyword, but doesn't include a space.

--- a/packages/outline-playground/src/plugins/MentionsPlugin.js
+++ b/packages/outline-playground/src/plugins/MentionsPlugin.js
@@ -7,13 +7,13 @@
  * @flow strict-local
  */
 
-import type {OutlineEditor, State, Selection} from 'outline';
+import type {OutlineEditor, Selection} from 'outline';
 
 import PlaygroundController from '../controllers/PlaygroundController';
 import {useController} from 'outline-react/OutlineController';
 // $FlowFixMe
 import {createPortal} from 'react-dom';
-import {log} from 'outline';
+import {log, getSelection} from 'outline';
 import React, {useCallback, useLayoutEffect, useMemo, useRef} from 'react';
 import {startTransition, useEffect, useState} from 'react';
 import {MentionNode, createMentionNode} from '../nodes/MentionNode';
@@ -844,8 +844,8 @@ function tryToPositionRange(match: MentionMatch, range: Range): boolean {
 
 function getMentionsTextToSearch(editor: OutlineEditor): string | null {
   let text = null;
-  editor.getEditorState().read((state: State) => {
-    const selection = state.getSelection();
+  editor.getEditorState().read(() => {
+    const selection = getSelection();
     if (selection == null) {
       return;
     }
@@ -886,9 +886,9 @@ function createMentionNodeFromSearchResult(
   entryText: string,
   match: MentionMatch,
 ): void {
-  editor.update((state: State) => {
+  editor.update(() => {
     log('createMentionNodeFromSearchResult');
-    const selection = state.getSelection();
+    const selection = getSelection();
     if (selection == null || !selection.isCollapsed()) {
       return;
     }

--- a/packages/outline-playground/src/plugins/TestRecorderPlugin.js
+++ b/packages/outline-playground/src/plugins/TestRecorderPlugin.js
@@ -7,12 +7,12 @@
  * @flow strict-local
  */
 
-import type {OutlineEditor, State} from 'outline';
+import type {OutlineEditor} from 'outline';
 
 import * as React from 'react';
 import PlaygroundController from '../controllers/PlaygroundController';
 import {useController} from 'outline-react/OutlineController';
-import {createTextNode, log} from 'outline';
+import {createTextNode, log, getRoot} from 'outline';
 import {createParagraphNode} from 'outline/ParagraphNode';
 import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {IS_APPLE} from 'shared/environment';
@@ -337,9 +337,9 @@ ${steps.map(formatStep).join(`\n`)}
   const toggleEditorSelection = useCallback(
     (currentEditor) => {
       if (!isRecording) {
-        currentEditor.update((state: State) => {
+        currentEditor.update(() => {
           log('useStepRecorder');
-          const root = state.getRoot();
+          const root = getRoot();
           root.clear();
           const text = createTextNode();
           root.append(createParagraphNode().append(text));

--- a/packages/outline-react/src/OutlineTreeView.js
+++ b/packages/outline-react/src/OutlineTreeView.js
@@ -7,15 +7,9 @@
  * @flow strict
  */
 
-import type {
-  BlockNode,
-  EditorState,
-  State,
-  OutlineEditor,
-  Selection,
-} from 'outline';
+import type {BlockNode, EditorState, OutlineEditor, Selection} from 'outline';
 
-import {isBlockNode, isTextNode} from 'outline';
+import {isBlockNode, isTextNode, getRoot, getSelection} from 'outline';
 
 import * as React from 'react';
 import {useState, useEffect, useRef} from 'react';
@@ -123,8 +117,7 @@ export default function TreeView({
               setTimeTravelEnabled(true);
             }
           }}
-          className={timeTravelButtonClassName}
-        >
+          className={timeTravelButtonClassName}>
           Time Travel
         </button>
       )}
@@ -135,8 +128,7 @@ export default function TreeView({
             className={timeTravelPanelButtonClassName}
             onClick={() => {
               setIsPlaying(!isPlaying);
-            }}
-          >
+            }}>
             {isPlaying ? 'Pause' : 'Play'}
           </button>
           <input
@@ -171,8 +163,7 @@ export default function TreeView({
                 setTimeTravelEnabled(false);
                 setIsPlaying(false);
               }
-            }}
-          >
+            }}>
             Exit
           </button>
         </div>
@@ -200,10 +191,10 @@ function printSelection(selection: Selection): string {
 function generateContent(editorState: EditorState): string {
   let res = ' root\n';
 
-  const selectionString = editorState.read((state: State) => {
-    const selection = state.getSelection();
+  const selectionString = editorState.read(() => {
+    const selection = getSelection();
 
-    visitTree(state, state.getRoot(), (node, indent) => {
+    visitTree(getRoot(), (node, indent) => {
       const nodeKey = node.getKey();
       const nodeKeyDisplay = `(${nodeKey})`;
       const typeDisplay = node.getType() || '';
@@ -229,7 +220,7 @@ function generateContent(editorState: EditorState): string {
   return res + '\n selection' + selectionString;
 }
 
-function visitTree(state: State, currentNode: BlockNode, visitor, indent = []) {
+function visitTree(currentNode: BlockNode, visitor, indent = []) {
   const childNodes = currentNode.getChildren();
   const childNodesLength = childNodes.length;
 
@@ -245,7 +236,6 @@ function visitTree(state: State, currentNode: BlockNode, visitor, indent = []) {
 
     if (isBlockNode(childNode)) {
       visitTree(
-        state,
         childNode,
         visitor,
         indent.concat(

--- a/packages/outline-react/src/__tests__/unit/useOutlineCharacterLimit.test.js
+++ b/packages/outline-react/src/__tests__/unit/useOutlineCharacterLimit.test.js
@@ -7,10 +7,10 @@
  * @flow strict
  */
 
-import type {OutlineEditor, State, NodeKey} from 'outline';
+import type {OutlineEditor, NodeKey} from 'outline';
 
 import {initializeUnitTest} from '../../../../outline/src/__tests__/utils';
-import {createTextNode} from 'outline';
+import {createTextNode, getSelection, getNodeByKey, getRoot} from 'outline';
 import {createParagraphNode} from 'outline/ParagraphNode';
 import {
   createOverflowNode,
@@ -29,8 +29,8 @@ describe('OutlineNodeHelpers tests', () => {
         const editor: OutlineEditor = testEnv.editor;
         let overflowLeftKey;
         let overflowRightKey;
-        await editor.update((state: State) => {
-          const root = state.getRoot();
+        await editor.update(() => {
+          const root = getRoot();
           const paragraph = createParagraphNode();
           const overflowLeft = createOverflowNode();
           const overflowRight = createOverflowNode();
@@ -48,9 +48,9 @@ describe('OutlineNodeHelpers tests', () => {
         const editor: OutlineEditor = testEnv.editor;
         const [overflowLeftKey, overflowRightKey] =
           await initializeEditorWithLeftRightOverflowNodes();
-        await editor.update((state: State) => {
-          const overflowLeft = state.getNodeByKey(overflowLeftKey);
-          const overflowRight = state.getNodeByKey(overflowRightKey);
+        await editor.update(() => {
+          const overflowLeft = getNodeByKey(overflowLeftKey);
+          const overflowRight = getNodeByKey(overflowRightKey);
           const text1 = createTextNode('1');
           const text2 = createTextNode('2');
           overflowRight.append(text1, text2);
@@ -58,13 +58,13 @@ describe('OutlineNodeHelpers tests', () => {
 
           overflowLeft.select();
         });
-        await editor.update((state: State) => {
-          const paragraph: ParagraphNode = state.getRoot().getFirstChild();
-          const overflowRight = state.getNodeByKey(overflowRightKey);
-          mergePrevious(overflowRight, state);
+        await editor.update(() => {
+          const paragraph: ParagraphNode = getRoot().getFirstChild();
+          const overflowRight = getNodeByKey(overflowRightKey);
+          mergePrevious(overflowRight);
           expect(paragraph.getChildrenSize()).toBe(1);
           expect(isOverflowNode(paragraph.getFirstChild())).toBe(true);
-          const selection = state.getSelection();
+          const selection = getSelection();
           if (selection === null) {
             throw new Error('Lost selection');
           }
@@ -80,9 +80,9 @@ describe('OutlineNodeHelpers tests', () => {
         const [overflowLeftKey, overflowRightKey] =
           await initializeEditorWithLeftRightOverflowNodes();
         let text2Key: NodeKey;
-        await editor.update((state: State) => {
-          const overflowLeft = state.getNodeByKey(overflowLeftKey);
-          const overflowRight = state.getNodeByKey(overflowRightKey);
+        await editor.update(() => {
+          const overflowLeft = getNodeByKey(overflowLeftKey);
+          const overflowRight = getNodeByKey(overflowRightKey);
           const text1 = createTextNode('1');
           const text2 = createTextNode('2');
           const text3 = createTextNode('3');
@@ -95,13 +95,13 @@ describe('OutlineNodeHelpers tests', () => {
 
           overflowLeft.select(1, 1);
         });
-        await editor.update((state: State) => {
-          const paragraph: ParagraphNode = state.getRoot().getFirstChild();
-          const overflowRight = state.getNodeByKey(overflowRightKey);
-          mergePrevious(overflowRight, state);
+        await editor.update(() => {
+          const paragraph: ParagraphNode = getRoot().getFirstChild();
+          const overflowRight = getNodeByKey(overflowRightKey);
+          mergePrevious(overflowRight);
           expect(paragraph.getChildrenSize()).toBe(1);
           expect(isOverflowNode(paragraph.getFirstChild())).toBe(true);
-          const selection = state.getSelection();
+          const selection = getSelection();
           if (selection === null) {
             throw new Error('Lost selection');
           }
@@ -118,9 +118,9 @@ describe('OutlineNodeHelpers tests', () => {
           await initializeEditorWithLeftRightOverflowNodes();
         let text2Key: NodeKey;
         let text4Key: NodeKey;
-        await editor.update((state: State) => {
-          const overflowLeft = state.getNodeByKey(overflowLeftKey);
-          const overflowRight = state.getNodeByKey(overflowRightKey);
+        await editor.update(() => {
+          const overflowLeft = getNodeByKey(overflowLeftKey);
+          const overflowRight = getNodeByKey(overflowRightKey);
           const text1 = createTextNode('1');
           const text2 = createTextNode('2');
           const text3 = createTextNode('3');
@@ -135,16 +135,16 @@ describe('OutlineNodeHelpers tests', () => {
           text4.toggleFormat('bold'); // Prevent merging with text3
 
           overflowLeft.select(1, 1);
-          const selection = state.getSelection();
+          const selection = getSelection();
           selection.focus.set(overflowRightKey, 1, 'block');
         });
-        await editor.update((state: State) => {
-          const paragraph: ParagraphNode = state.getRoot().getFirstChild();
-          const overflowRight = state.getNodeByKey(overflowRightKey);
-          mergePrevious(overflowRight, state);
+        await editor.update(() => {
+          const paragraph: ParagraphNode = getRoot().getFirstChild();
+          const overflowRight = getNodeByKey(overflowRightKey);
+          mergePrevious(overflowRight);
           expect(paragraph.getChildrenSize()).toBe(1);
           expect(isOverflowNode(paragraph.getFirstChild())).toBe(true);
-          const selection = state.getSelection();
+          const selection = getSelection();
           if (selection === null) {
             throw new Error('Lost selection');
           }

--- a/packages/outline-react/src/shared/useOutlineDragonSupport.js
+++ b/packages/outline-react/src/shared/useOutlineDragonSupport.js
@@ -12,7 +12,7 @@ import type {OutlineEditor} from 'outline';
 import {insertRichText} from 'outline/selection';
 
 import {useEffect} from 'react';
-import {isTextNode, log} from 'outline';
+import {isTextNode, log, getSelection} from 'outline';
 
 export default function useOutlineDragonSupport(editor: OutlineEditor) {
   useEffect(() => {
@@ -49,9 +49,9 @@ export default function useOutlineDragonSupport(editor: OutlineEditor) {
               // TODO: we should probably handle formatCommand somehow?
               // eslint-disable-next-line no-unused-expressions
               formatCommand;
-              editor.update((state) => {
+              editor.update(() => {
                 log('useOutlineDragonSupport');
-                const selection = state.getSelection();
+                const selection = getSelection();
                 if (selection !== null) {
                   const anchor = selection.anchor;
                   let anchorNode = anchor.getNode();

--- a/packages/outline-react/src/shared/usePlainTextSetup.js
+++ b/packages/outline-react/src/shared/usePlainTextSetup.js
@@ -8,9 +8,9 @@
  */
 
 import type {InputEvents} from 'outline-react/useOutlineEditorEvents';
-import type {OutlineEditor, State, RootNode} from 'outline';
+import type {OutlineEditor, RootNode} from 'outline';
 
-import {log} from 'outline';
+import {log, getRoot, getSelection} from 'outline';
 import useLayoutEffect from './useLayoutEffect';
 import useOutlineEditorEvents from '../useOutlineEditorEvents';
 import {createParagraphNode, ParagraphNode} from 'outline/ParagraphNode';
@@ -51,33 +51,29 @@ if (CAN_USE_BEFORE_INPUT) {
   events.push(['drop', onDropPolyfill]);
 }
 
-function shouldSelectParagraph(state: State, editor: OutlineEditor): boolean {
+function shouldSelectParagraph(editor: OutlineEditor): boolean {
   const activeElement = document.activeElement;
   return (
-    state.getSelection() !== null ||
+    getSelection() !== null ||
     (activeElement !== null && activeElement === editor.getRootElement())
   );
 }
 
-function initParagraph(
-  state: State,
-  root: RootNode,
-  editor: OutlineEditor,
-): void {
+function initParagraph(root: RootNode, editor: OutlineEditor): void {
   const paragraph = createParagraphNode();
   root.append(paragraph);
-  if (shouldSelectParagraph(state, editor)) {
+  if (shouldSelectParagraph(editor)) {
     paragraph.select();
   }
 }
 
 function initEditor(editor: OutlineEditor): void {
-  editor.update((state) => {
+  editor.update(() => {
     log('initEditor');
-    const root = state.getRoot();
+    const root = getRoot();
     const firstChild = root.getFirstChild();
     if (firstChild === null) {
-      initParagraph(state, root, editor);
+      initParagraph(root, editor);
     }
   });
 }
@@ -86,11 +82,11 @@ function clearEditor(
   editor: OutlineEditor,
   callbackFn?: (callbackFn?: () => void) => void,
 ): void {
-  editor.update((state) => {
+  editor.update(() => {
     log('clearEditor');
-    const root = state.getRoot();
+    const root = getRoot();
     root.clear();
-    initParagraph(state, root, editor);
+    initParagraph(root, editor);
   }, callbackFn);
 }
 

--- a/packages/outline-react/src/shared/useRichTextSetup.js
+++ b/packages/outline-react/src/shared/useRichTextSetup.js
@@ -7,10 +7,10 @@
  * @flow strict
  */
 
-import type {OutlineEditor, State, RootNode} from 'outline';
+import type {OutlineEditor, RootNode} from 'outline';
 import type {InputEvents} from 'outline-react/useOutlineEditorEvents';
 
-import {log} from 'outline';
+import {log, getSelection, getRoot} from 'outline';
 import useLayoutEffect from './useLayoutEffect';
 import useOutlineEditorEvents from '../useOutlineEditorEvents';
 import {HeadingNode} from 'outline/HeadingNode';
@@ -57,33 +57,29 @@ if (CAN_USE_BEFORE_INPUT) {
   events.push(['drop', onDropPolyfill]);
 }
 
-function shouldSelectParagraph(state: State, editor: OutlineEditor): boolean {
+function shouldSelectParagraph(editor: OutlineEditor): boolean {
   const activeElement = document.activeElement;
   return (
-    state.getSelection() !== null ||
+    getSelection() !== null ||
     (activeElement !== null && activeElement === editor.getRootElement())
   );
 }
 
-function initParagraph(
-  state: State,
-  root: RootNode,
-  editor: OutlineEditor,
-): void {
+function initParagraph(root: RootNode, editor: OutlineEditor): void {
   const paragraph = createParagraphNode();
   root.append(paragraph);
-  if (shouldSelectParagraph(state, editor)) {
+  if (shouldSelectParagraph(editor)) {
     paragraph.select();
   }
 }
 
 export function initEditor(editor: OutlineEditor): void {
-  editor.update((state: State) => {
+  editor.update(() => {
     log('initEditor');
-    const root = state.getRoot();
+    const root = getRoot();
     const firstChild = root.getFirstChild();
     if (firstChild === null) {
-      initParagraph(state, root, editor);
+      initParagraph(root, editor);
     }
   });
 }
@@ -92,11 +88,11 @@ function clearEditor(
   editor: OutlineEditor,
   callbackFn?: (callbackFn?: () => void) => void,
 ): void {
-  editor.update((state) => {
+  editor.update(() => {
     log('clearEditor');
-    const root = state.getRoot();
+    const root = getRoot();
     root.clear();
-    initParagraph(state, root, editor);
+    initParagraph(root, editor);
   }, callbackFn);
 }
 

--- a/packages/outline-react/src/useOutlineNestedList.js
+++ b/packages/outline-react/src/useOutlineNestedList.js
@@ -7,11 +7,11 @@
  * @flow
  */
 
-import type {OutlineEditor, OutlineNode, State} from 'outline';
+import type {OutlineEditor, OutlineNode} from 'outline';
 import type {ListItemNode} from 'outline/ListItemNode';
 
 import {useCallback, useEffect, useMemo} from 'react';
-import {log} from 'outline';
+import {log, getSelection} from 'outline';
 import {createListItemNode, isListItemNode} from 'outline/ListItemNode';
 import {createListNode, isListNode} from 'outline/ListNode';
 
@@ -20,9 +20,9 @@ function maybeIndentOrOutdent(
   direction: 'indent' | 'outdent',
 ): boolean {
   let hasHandledIndention = false;
-  editor.update((state: State) => {
+  editor.update(() => {
     log('useNestedList.maybeIndent');
-    const selection = state.getSelection();
+    const selection = getSelection();
     if (selection === null) {
       return;
     }

--- a/packages/outline/src/__tests__/unit/OutlineBlockNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineBlockNode.test.js
@@ -12,7 +12,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import {createEditor, createTextNode} from 'outline';
+import {createEditor, createTextNode, getRoot} from 'outline';
 import {createTestBlockNode} from '../utils';
 
 describe('OutlineBlockNode tests', () => {
@@ -64,7 +64,7 @@ describe('OutlineBlockNode tests', () => {
     });
 
     // Insert initial block
-    await update((state) => {
+    await update(() => {
       const block = createTestBlockNode();
       const text = createTextNode('Foo');
       const text2 = createTextNode('Bar');
@@ -76,7 +76,7 @@ describe('OutlineBlockNode tests', () => {
       // we make a selection in the setup code.
       text.select(0, 0);
       block.append(text, text2, text3);
-      state.getRoot().append(block);
+      getRoot().append(block);
     });
   }
 
@@ -91,8 +91,8 @@ describe('OutlineBlockNode tests', () => {
     });
 
     test('some children', async () => {
-      await update((state) => {
-        const children = state.getRoot().getFirstChild().getChildren();
+      await update(() => {
+        const children = getRoot().getFirstChild().getChildren();
         expect(children).toHaveLength(3);
       });
     });
@@ -100,14 +100,14 @@ describe('OutlineBlockNode tests', () => {
 
   describe('getAllTextNodes()', () => {
     test('basic', async () => {
-      await update((state) => {
-        const textNodes = state.getRoot().getFirstChild().getAllTextNodes();
+      await update(() => {
+        const textNodes = getRoot().getFirstChild().getAllTextNodes();
         expect(textNodes).toHaveLength(3);
       });
     });
 
     test('nested', async () => {
-      await update((state) => {
+      await update(() => {
         const block = createTestBlockNode();
         const innerBlock = createTestBlockNode();
         const text = createTextNode('Foo');
@@ -132,7 +132,7 @@ describe('OutlineBlockNode tests', () => {
         const children2 = block.getAllTextNodes();
         expect(children2).toHaveLength(6);
         expect(children2).toEqual([text, text2, text3, text5, text6, text4]);
-        state.getRoot().append(block);
+        getRoot().append(block);
       });
     });
 
@@ -141,10 +141,10 @@ describe('OutlineBlockNode tests', () => {
 
   describe('getFirstChild()', () => {
     test('basic', async () => {
-      await update((state) => {
-        expect(
-          state.getRoot().getFirstChild().getFirstChild().getTextContent(),
-        ).toBe('Foo');
+      await update(() => {
+        expect(getRoot().getFirstChild().getFirstChild().getTextContent()).toBe(
+          'Foo',
+        );
       });
     });
 
@@ -158,10 +158,10 @@ describe('OutlineBlockNode tests', () => {
 
   describe('getLastChild()', () => {
     test('basic', async () => {
-      await update((state) => {
-        expect(
-          state.getRoot().getFirstChild().getLastChild().getTextContent(),
-        ).toBe('Baz');
+      await update(() => {
+        expect(getRoot().getFirstChild().getLastChild().getTextContent()).toBe(
+          'Baz',
+        );
       });
     });
 
@@ -175,10 +175,8 @@ describe('OutlineBlockNode tests', () => {
 
   describe('getTextContent()', () => {
     test('basic', async () => {
-      await update((state) => {
-        expect(state.getRoot().getFirstChild().getTextContent()).toBe(
-          'FooBarBaz',
-        );
+      await update(() => {
+        expect(getRoot().getFirstChild().getTextContent()).toBe('FooBarBaz');
       });
     });
 
@@ -190,7 +188,7 @@ describe('OutlineBlockNode tests', () => {
     });
 
     test('nested', async () => {
-      await update((state) => {
+      await update(() => {
         const block = createTestBlockNode();
         const innerBlock = createTestBlockNode();
         const text = createTextNode('Foo');
@@ -215,7 +213,7 @@ describe('OutlineBlockNode tests', () => {
 
         expect(block.getTextContent()).toEqual('FooBarStuff\n\nQux');
         expect(block.getTextContent(true)).toEqual('FooBarBazMoreStuff\n\nQux');
-        state.getRoot().append(block);
+        getRoot().append(block);
       });
     });
   });

--- a/packages/outline/src/__tests__/unit/OutlineCodeNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineCodeNode.test.js
@@ -8,7 +8,7 @@
 
 import {createCodeNode, CodeNode} from 'outline/CodeNode';
 import {createParagraphNode} from 'outline/ParagraphNode';
-import {createTextNode} from 'outline';
+import {createTextNode, getRoot, getSelection} from 'outline';
 import {initializeUnitTest} from '../utils';
 
 const editorConfig = Object.freeze({
@@ -58,14 +58,14 @@ describe('OutlineCodeNode tests', () => {
 
     test.skip('CodeNode.insertNewAfter()', async () => {
       const {editor} = testEnv;
-      await editor.update((state) => {
-        const root = state.getRoot();
+      await editor.update(() => {
+        const root = getRoot();
         const paragraphNode = createParagraphNode();
         const textNode = createTextNode('foo');
         paragraphNode.append(textNode);
         root.append(paragraphNode);
         textNode.select(0, 0);
-        const selection = state.getSelection();
+        const selection = getSelection();
         expect(selection).toEqual({
           anchorKey: '_2',
           anchorOffset: 0,
@@ -78,9 +78,9 @@ describe('OutlineCodeNode tests', () => {
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" data-outline-editor="true"><p><span>foo</span></p></div>',
       );
-      await editor.update((state) => {
+      await editor.update(() => {
         const codeNode = new CodeNode();
-        const selection = state.getSelection();
+        const selection = getSelection();
         codeNode.insertNewAfter(selection);
       });
     });

--- a/packages/outline/src/__tests__/unit/OutlineEditor.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor.test.js
@@ -6,7 +6,7 @@
  *
  */
 
-import type {OutlineEditor, State} from 'outline';
+import type {OutlineEditor} from 'outline';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -18,10 +18,14 @@ import {
   TextNode,
   DecoratorNode,
   BlockNode,
+  getRoot,
+  setCompositionKey,
+  getSelection,
+  getNodeByKey,
 } from 'outline';
 import {createParagraphNode, ParagraphNode} from 'outline/ParagraphNode';
 import useOutlineRichText from 'outline-react/useOutlineRichText';
-import {getEditorStateTextContent, getNodeByKey} from '../../core/OutlineUtils';
+import {getEditorStateTextContent} from '../../core/OutlineUtils';
 import {createTestBlockNode} from '../utils';
 
 describe('OutlineEditor tests', () => {
@@ -82,8 +86,8 @@ describe('OutlineEditor tests', () => {
 
     const initialEditor = createEditor();
 
-    initialEditor.update((state) => {
-      const root = state.getRoot();
+    initialEditor.update(() => {
+      const root = getRoot();
       const paragraph = createParagraphNode();
       const text = createTextNode('This works!');
       root.append(paragraph);
@@ -127,8 +131,8 @@ describe('OutlineEditor tests', () => {
 
     editor.setRootElement(rootElement);
 
-    editor.update((state) => {
-      const root = state.getRoot();
+    editor.update(() => {
+      const root = getRoot();
       const paragraph = createParagraphNode();
       const text = createTextNode('This works!');
       root.append(paragraph);
@@ -136,10 +140,10 @@ describe('OutlineEditor tests', () => {
     });
 
     editor.update(
-      (state) => {
+      () => {
         log.push('A1');
         // To enforce the update
-        state.getRoot().markDirty();
+        getRoot().markDirty();
         editor.update(
           () => {
             log.push('B1');
@@ -169,17 +173,17 @@ describe('OutlineEditor tests', () => {
     log = [];
 
     editor.update(
-      (state) => {
+      () => {
         log.push('A2');
         // To enforce the update
-        state.getRoot().markDirty();
+        getRoot().markDirty();
       },
       () => {
         log.push('B2');
         editor.update(
-          (state) => {
+          () => {
             // force flush sync
-            state.setCompositionKey('root');
+            setCompositionKey('root');
             log.push('D2');
           },
           () => {
@@ -227,9 +231,9 @@ describe('OutlineEditor tests', () => {
     log = [];
 
     editor.update(
-      (state) => {
+      () => {
         log.push('A3');
-        state.getRoot().getLastDescendant().markDirty();
+        getRoot().getLastDescendant().markDirty();
       },
       () => {
         log.push('B3');
@@ -265,8 +269,8 @@ describe('OutlineEditor tests', () => {
       reactRoot.render(<TestBase element={null} />);
     });
 
-    editor.update((state) => {
-      const root = state.getRoot();
+    editor.update(() => {
+      const root = getRoot();
       const paragraph = createParagraphNode();
       const text = createTextNode('This works!');
       root.append(paragraph);
@@ -299,8 +303,8 @@ describe('OutlineEditor tests', () => {
       reactRoot.render(<TestBase element={null} />);
     });
 
-    editor.update((state) => {
-      const root = state.getRoot();
+    editor.update(() => {
+      const root = getRoot();
       if (root.getFirstChild() === null) {
         const paragraph = createParagraphNode();
         const text = createTextNode('This works!');
@@ -321,8 +325,8 @@ describe('OutlineEditor tests', () => {
 
     expect(listener).toHaveBeenCalledTimes(0);
 
-    editor.update((state) => {
-      const root = state.getRoot();
+    editor.update(() => {
+      const root = getRoot();
       root
         .getFirstChild()
         .getFirstChild()
@@ -352,8 +356,8 @@ describe('OutlineEditor tests', () => {
       reactRoot.render(<TestBase element={null} />);
     });
 
-    editor.update((state) => {
-      const root = state.getRoot();
+    editor.update(() => {
+      const root = getRoot();
       if (root.getFirstChild() === null) {
         const paragraph = createParagraphNode();
         const text = createTextNode('This works!');
@@ -374,8 +378,8 @@ describe('OutlineEditor tests', () => {
 
     expect(listener).toHaveBeenCalledTimes(0);
 
-    editor.update((state) => {
-      const root = state.getRoot();
+    editor.update(() => {
+      const root = getRoot();
       root.getFirstChild().getFirstChild().setTextContent('Foo');
     });
 
@@ -402,8 +406,8 @@ describe('OutlineEditor tests', () => {
       editor = React.useMemo(() => createEditor(), []);
 
       React.useEffect(() => {
-        editor.update((state) => {
-          const root = state.getRoot();
+        editor.update(() => {
+          const root = getRoot();
           const firstChild = root.getFirstChild();
           const text = changeElement ? 'Change successful' : 'Not changed';
           if (firstChild === null) {
@@ -527,11 +531,11 @@ describe('OutlineEditor tests', () => {
             return <Decorator text={'Hello world'} />;
           }
         }
-        await editor.update((state) => {
+        await editor.update(() => {
           const paragraph = createParagraphNode();
           const test = new TestNode();
           paragraph.append(test);
-          state.getRoot().append(paragraph);
+          getRoot().append(paragraph);
         });
       });
 
@@ -585,8 +589,8 @@ describe('OutlineEditor tests', () => {
       // Wait for update to complete
       await Promise.resolve().then();
 
-      editor.getEditorState().read((state) => {
-        const root = state.getRoot();
+      editor.getEditorState().read(() => {
+        const root = getRoot();
         const paragraph = root.getFirstChild();
 
         expect(root).toEqual({
@@ -633,18 +637,18 @@ describe('OutlineEditor tests', () => {
           originalText = createTextNode('Hello world');
           originalText.select(6, 11);
           paragraph.append(originalText);
-          state.getRoot().append(paragraph);
+          getRoot().append(paragraph);
         });
         editor.registerNodeType('paragraph', ParagraphNode);
         const stringifiedEditorState = editor.getEditorState().stringify();
         parsedEditorState = editor.parseEditorState(stringifiedEditorState);
-        parsedEditorState.read((state) => {
-          parsedRoot = state.getRoot();
+        parsedEditorState.read(() => {
+          parsedRoot = getRoot();
           parsedParagraph = parsedRoot.getFirstChild();
           paragraphKey = parsedParagraph.getKey();
           parsedText = parsedParagraph.getFirstChild();
           textKey = parsedText.getKey();
-          parsedSelection = state.getSelection();
+          parsedSelection = getSelection();
         });
       });
 
@@ -680,12 +684,10 @@ describe('OutlineEditor tests', () => {
       });
 
       it('Parses the text content of the editor state', async () => {
-        expect(
-          parsedEditorState.read((state) => state.getRoot().__cachedText),
-        ).toBe(null);
-        expect(
-          parsedEditorState.read((state) => state.getRoot().getTextContent()),
-        ).toBe('Hello world');
+        expect(parsedEditorState.read(() => getRoot().__cachedText)).toBe(null);
+        expect(parsedEditorState.read(() => getRoot().getTextContent())).toBe(
+          'Hello world',
+        );
       });
 
       it('Parses the selection offsets of a stringified editor state', async () => {
@@ -710,8 +712,8 @@ describe('OutlineEditor tests', () => {
 
     async function reset() {
       init();
-      await update((state) => {
-        const root = state.getRoot();
+      await update(() => {
+        const root = getRoot();
         const paragraph = createParagraphNode();
         root.append(paragraph);
       });
@@ -774,9 +776,8 @@ describe('OutlineEditor tests', () => {
 
         // Next editor state
         const previousSet = new Set(previous);
-        await update((state: State) => {
-          const writableParagraph: ParagraphNode = state
-            .getRoot()
+        await update(() => {
+          const writableParagraph: ParagraphNode = getRoot()
             .getFirstChild()
             .getWritable();
           writableParagraph.__children = [];
@@ -787,10 +788,10 @@ describe('OutlineEditor tests', () => {
             if (nextKey === undefined) {
               textNode = new TextNode(nextText).toggleUnmergeable();
               textNode.__parent = writableParagraph.__key;
-              expect(state.getNodeByKey(nextKey)).toBe(null);
+              expect(getNodeByKey(nextKey)).toBe(null);
               textToKey.set(nextText, textNode.__key);
             } else {
-              textNode = state.getNodeByKey(nextKey);
+              textNode = getNodeByKey(nextKey);
               expect(textNode.__text).toBe(nextText);
             }
             writableParagraph.__children.push(textNode.__key);
@@ -798,7 +799,7 @@ describe('OutlineEditor tests', () => {
           }
           previousSet.forEach((previousText) => {
             const previousKey = textToKey.get(previousText);
-            const textNode = state.getNodeByKey(previousKey);
+            const textNode = getNodeByKey(previousKey);
             expect(textNode.__text).toBe(previousText);
             textNode.remove();
           });
@@ -819,15 +820,15 @@ describe('OutlineEditor tests', () => {
           }</p></div>`,
         );
         // Expect editorState to have the correct latest nodes
-        editor.getEditorState().read((state: State) => {
+        editor.getEditorState().read(() => {
           for (let i = 0; i < next.length; i++) {
             const nextText = next[i];
             const nextKey = textToKey.get(nextText);
-            expect(state.getNodeByKey(nextKey)).not.toBe(null);
+            expect(getNodeByKey(nextKey)).not.toBe(null);
           }
           previousSet.forEach((previousText) => {
             const previousKey = textToKey.get(previousText);
-            expect(state.getNodeByKey(previousKey)).toBe(null);
+            expect(getNodeByKey(previousKey)).toBe(null);
           });
         });
       }
@@ -854,8 +855,8 @@ describe('OutlineEditor tests', () => {
       let textNode1Key;
       let blockNode2Key;
       let textNode2Key;
-      await update((state: State) => {
-        const paragraph: ParagraphNode = state.getRoot().getFirstChild();
+      await update(() => {
+        const paragraph: ParagraphNode = getRoot().getFirstChild();
         paragraphNodeKey = paragraph.getKey();
 
         const [blockNode1, textNode1] = createBlockNodeWithText('A');
@@ -868,7 +869,7 @@ describe('OutlineEditor tests', () => {
 
         paragraph.append(blockNode1, blockNode2);
       });
-      await update((state: State) => {
+      await update(() => {
         const blockNode1: BlockNode = getNodeByKey(blockNode1Key);
         const blockNode2: TextNode = getNodeByKey(blockNode2Key);
         blockNode1.append(blockNode2);
@@ -901,8 +902,8 @@ describe('OutlineEditor tests', () => {
 
       let blockNode1Key;
       let blockNode2Key;
-      await update((state: State) => {
-        const paragraph: ParagraphNode = state.getRoot().getFirstChild();
+      await update(() => {
+        const paragraph: ParagraphNode = getRoot().getFirstChild();
 
         const blockNode1 = createBlockNodeWithText('A');
         blockNode1Key = blockNode1.getKey();
@@ -933,8 +934,8 @@ describe('OutlineEditor tests', () => {
       let blockNode1Key;
       let blockNode2Key;
       let blockNode3Key;
-      await update((state: State) => {
-        const paragraph: ParagraphNode = state.getRoot().getFirstChild();
+      await update(() => {
+        const paragraph: ParagraphNode = getRoot().getFirstChild();
 
         const blockNode1 = createBlockNodeWithText('A');
         blockNode1Key = blockNode1.getKey();

--- a/packages/outline/src/__tests__/unit/OutlineEditorState.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditorState.test.js
@@ -6,7 +6,7 @@
  *
  */
 
-import {createRootNode, createTextNode} from 'outline';
+import {createRootNode, createTextNode, getRoot} from 'outline';
 import {createParagraphNode} from 'outline/ParagraphNode';
 import {EditorState} from '../../core/OutlineEditorState';
 import {initializeUnitTest} from '../utils';
@@ -24,18 +24,18 @@ describe('OutlineEditorState tests', () => {
     test('read()', async () => {
       const {editor} = testEnv;
 
-      await editor.update((state) => {
+      await editor.update(() => {
         const paragraph = createParagraphNode();
         const text = createTextNode('foo');
         paragraph.append(text);
-        state.getRoot().append(paragraph);
+        getRoot().append(paragraph);
       });
 
       let root = null;
       let paragraph = null;
       let text = null;
-      editor.getEditorState().read((state) => {
-        root = state.getRoot();
+      editor.getEditorState().read(() => {
+        root = getRoot();
         paragraph = root.getFirstChild();
         text = paragraph.getFirstChild();
       });
@@ -72,12 +72,12 @@ describe('OutlineEditorState tests', () => {
 
     test('stringify()', async () => {
       const {editor} = testEnv;
-      await editor.update((state) => {
+      await editor.update(() => {
         const paragraph = createParagraphNode();
         const text = createTextNode('Hello world');
         text.select(6, 11);
         paragraph.append(text);
-        state.getRoot().append(paragraph);
+        getRoot().append(paragraph);
       });
       expect(editor.getEditorState().stringify()).toEqual(
         `{\"_nodeMap\":[[\"root\",{\"__type\":\"root\",\"__flags\":0,\"__key\":\"root\",\"__parent\":null,\"__children\":[\"0\"],\"__format\":0,\"__indent\":0,\"__cachedText\":\"Hello world\"}],[\"0\",{\"__type\":\"paragraph\",\"__flags\":0,\"__key\":\"0\",\"__parent\":\"root\",\"__children\":[\"1\"],\"__format\":0,\"__indent\":0}],[\"1\",{\"__type\":\"text\",\"__flags\":0,\"__key\":\"1\",\"__parent\":\"0\",\"__text\":\"Hello world\",\"__format\":0,\"__style\":\"\"}]],\"_selection\":{\"anchor\":{\"key\":\"1\",\"offset\":6,\"type\":\"text\"},\"focus\":{\"key\":\"1\",\"offset\":11,\"type\":\"text\"}}}`,
@@ -145,16 +145,16 @@ describe('OutlineEditorState tests', () => {
 
     test('ensure garbage collection works as expected', async () => {
       const {editor} = testEnv;
-      await editor.update((state) => {
+      await editor.update(() => {
         const paragraph = createParagraphNode();
         const text = createTextNode('foo');
         paragraph.append(text);
-        state.getRoot().append(paragraph);
+        getRoot().append(paragraph);
       });
 
       // Remove the first node, which should cause a GC for everything
-      await editor.update((state) => {
-        state.getRoot().getFirstChild().remove();
+      await editor.update(() => {
+        getRoot().getFirstChild().remove();
       });
 
       expect(editor.getEditorState()._nodeMap).toEqual(

--- a/packages/outline/src/__tests__/unit/OutlineHeadingNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineHeadingNode.test.js
@@ -13,6 +13,7 @@ import {
 } from 'outline/HeadingNode';
 import {ParagraphNode} from 'outline/ParagraphNode';
 import {initializeUnitTest} from '../utils';
+import {getRoot} from 'outline';
 
 const editorConfig = Object.freeze({
   theme: {
@@ -70,8 +71,8 @@ describe('OutlineHeadingNode tests', () => {
     test('HeadingNode.insertNewAfter()', async () => {
       const {editor} = testEnv;
       let headingNode;
-      await editor.update((state) => {
-        const root = state.getRoot();
+      await editor.update(() => {
+        const root = getRoot();
         headingNode = new HeadingNode('h1');
         root.append(headingNode);
       });

--- a/packages/outline/src/__tests__/unit/OutlineListItemNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineListItemNode.test.js
@@ -12,7 +12,7 @@ import {
   createListItemNode,
   isListItemNode,
 } from 'outline/ListItemNode';
-import {TextNode} from 'outline';
+import {TextNode, getRoot} from 'outline';
 import {initializeUnitTest} from '../utils';
 
 const editorConfig = Object.freeze({
@@ -105,7 +105,7 @@ describe('OutlineListItemNode tests', () => {
       beforeEach(async () => {
         const {editor} = testEnv;
         await editor.update((state) => {
-          const root = state.getRoot();
+          const root = getRoot();
           listNode = new ListNode('ul', 1);
           listItemNode1 = new ListItemNode();
           listItemNode1.append(new TextNode('one'));
@@ -130,8 +130,8 @@ describe('OutlineListItemNode tests', () => {
         expect(testEnv.outerHTML).toBe(
           '<div contenteditable="true" data-outline-editor="true"></div>',
         );
-        await editor.update((state) => {
-          const root = state.getRoot();
+        await editor.update(() => {
+          const root = getRoot();
           listItemNode = new ListItemNode();
           root.append(listItemNode);
         });
@@ -223,8 +223,8 @@ describe('OutlineListItemNode tests', () => {
 
       beforeEach(async () => {
         const {editor} = testEnv;
-        await editor.update((state) => {
-          const root = state.getRoot();
+        await editor.update(() => {
+          const root = getRoot();
           listNode = new ListNode('ul', 1);
           listItemNode1 = new ListItemNode();
           listItemNode2 = new ListItemNode();
@@ -296,8 +296,8 @@ describe('OutlineListItemNode tests', () => {
 
       beforeEach(async () => {
         const {editor} = testEnv;
-        await editor.update((state) => {
-          const root = state.getRoot();
+        await editor.update(() => {
+          const root = getRoot();
           listNode = new ListNode('ul', 1);
           listItemNode1 = new ListItemNode();
           listItemNode2 = new ListItemNode();

--- a/packages/outline/src/__tests__/unit/OutlineNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineNode.test.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {TextNode} from 'outline';
+import {TextNode, getRoot, getSelection} from 'outline';
 import {ParagraphNode} from 'outline/ParagraphNode';
 import {OutlineNode} from '../../core/OutlineNode';
 
@@ -25,8 +25,8 @@ describe('OutlineNode tests', () => {
 
     beforeEach(async () => {
       const {editor} = testEnv;
-      await editor.update((state) => {
-        const rootNode = state.getRoot();
+      await editor.update(() => {
+        const rootNode = getRoot();
         paragraphNode = new ParagraphNode();
         textNode = new TextNode('foo');
         paragraphNode.append(textNode);
@@ -128,10 +128,10 @@ describe('OutlineNode tests', () => {
         expect(newTextNode.isSelected()).toBe(false);
       });
 
-      await editor.update((state) => {
+      await editor.update(() => {
         textNode.select(0, 0);
 
-        const selection = state.getSelection();
+        const selection = getSelection();
         expect(selection).not.toBe(null);
 
         selection.anchor.type = 'text';
@@ -145,8 +145,8 @@ describe('OutlineNode tests', () => {
 
       await Promise.resolve().then();
 
-      await editor.update((state) => {
-        const selection = state.getSelection();
+      await editor.update(() => {
+        const selection = getSelection();
 
         expect(selection.anchor.key).toBe(textNode.getKey());
         expect(selection.focus.key).toBe(newTextNode.getKey());
@@ -175,8 +175,8 @@ describe('OutlineNode tests', () => {
         const node = new OutlineNode();
         expect(node.getParent()).toBe(null);
       });
-      await editor.getEditorState().read((state) => {
-        const rootNode = state.getRoot();
+      await editor.getEditorState().read(() => {
+        const rootNode = getRoot();
         expect(textNode.getParent()).toBe(paragraphNode);
         expect(paragraphNode.getParent()).toBe(rootNode);
       });
@@ -189,8 +189,8 @@ describe('OutlineNode tests', () => {
         const node = new OutlineNode();
         expect(() => node.getParentOrThrow()).toThrow();
       });
-      await editor.getEditorState().read((state) => {
-        const rootNode = state.getRoot();
+      await editor.getEditorState().read(() => {
+        const rootNode = getRoot();
         expect(textNode.getParent()).toBe(paragraphNode);
         expect(paragraphNode.getParent()).toBe(rootNode);
       });
@@ -211,8 +211,8 @@ describe('OutlineNode tests', () => {
 
     test('OutlineNode.getParentBlockOrThrow()', async () => {
       const {editor} = testEnv;
-      await editor.getEditorState().read((state) => {
-        const rootNode = state.getRoot();
+      await editor.getEditorState().read(() => {
+        const rootNode = getRoot();
         expect(paragraphNode.getParentBlockOrThrow()).not.toBe(paragraphNode);
         expect(paragraphNode.getParentBlockOrThrow()).toBe(rootNode);
       });
@@ -253,8 +253,8 @@ describe('OutlineNode tests', () => {
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span></p></div>',
       );
-      await editor.getEditorState().read((state) => {
-        const rootNode = state.getRoot();
+      await editor.getEditorState().read(() => {
+        const rootNode = getRoot();
         expect(textNode.getParents()).toEqual([paragraphNode, rootNode]);
         expect(paragraphNode.getParents()).toEqual([rootNode]);
       });
@@ -351,8 +351,8 @@ describe('OutlineNode tests', () => {
       let barTextNode;
       let bazParagraphNode;
       let bazTextNode;
-      await editor.update((state) => {
-        const rootNode = state.getRoot();
+      await editor.update(() => {
+        const rootNode = getRoot();
         barParagraphNode = new ParagraphNode();
         barTextNode = new TextNode('bar');
         barTextNode.toggleUnmergeable();
@@ -371,8 +371,8 @@ describe('OutlineNode tests', () => {
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span><span data-outline-text="true">qux</span></p><p><span data-outline-text="true">bar</span></p><p><span data-outline-text="true">baz</span></p></div>',
       );
-      await editor.getEditorState().read((state) => {
-        const rootNode = state.getRoot();
+      await editor.getEditorState().read(() => {
+        const rootNode = getRoot();
         expect(textNode.getCommonAncestor(rootNode)).toBe(rootNode);
         expect(quxTextNode.getCommonAncestor(rootNode)).toBe(rootNode);
         expect(barTextNode.getCommonAncestor(rootNode)).toBe(rootNode);
@@ -413,8 +413,8 @@ describe('OutlineNode tests', () => {
 
     test('OutlineNode.isParentOf()', async () => {
       const {editor} = testEnv;
-      await editor.getEditorState().read((state) => {
-        const rootNode = state.getRoot();
+      await editor.getEditorState().read(() => {
+        const rootNode = getRoot();
         expect(rootNode.isParentOf(textNode)).toBe(true);
         expect(rootNode.isParentOf(paragraphNode)).toBe(true);
         expect(paragraphNode.isParentOf(textNode)).toBe(true);
@@ -431,8 +431,8 @@ describe('OutlineNode tests', () => {
       let bazTextNode;
       let newParagraphNode;
       let quxTextNode;
-      await editor.update((state) => {
-        const rootNode = state.getRoot();
+      await editor.update(() => {
+        const rootNode = getRoot();
         barTextNode = new TextNode('bar');
         barTextNode.toggleUnmergeable();
         bazTextNode = new TextNode('baz');
@@ -709,8 +709,8 @@ describe('OutlineNode tests', () => {
         '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">foo</span></p></div>',
       );
       let barTextNode;
-      await editor.update((state) => {
-        const rootNode = state.getRoot();
+      await editor.update(() => {
+        const rootNode = getRoot();
         const barParagraphNode = new ParagraphNode();
         barTextNode = new TextNode('bar');
         barParagraphNode.append(barTextNode);
@@ -880,8 +880,8 @@ describe('OutlineNode tests', () => {
     test('OutlineNode.insertAfter() move blocks around', async () => {
       const {editor} = testEnv;
       let block1, block2, block3, text1, text2, text3;
-      await editor.update((state) => {
-        const root = state.getRoot();
+      await editor.update(() => {
+        const root = getRoot();
         root.clear();
         block1 = new ParagraphNode();
         block2 = new ParagraphNode();
@@ -908,8 +908,8 @@ describe('OutlineNode tests', () => {
     test('OutlineNode.insertAfter() move blocks around #2', async () => {
       const {editor} = testEnv;
       let block1, block2, block3, text1, text2, text3;
-      await editor.update((state) => {
-        const root = state.getRoot();
+      await editor.update(() => {
+        const root = getRoot();
         root.clear();
         block1 = new ParagraphNode();
         block2 = new ParagraphNode();
@@ -930,7 +930,7 @@ describe('OutlineNode tests', () => {
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" data-outline-editor="true"><p><span data-outline-text="true">A</span></p><p><span data-outline-text="true">B</span></p><p><span data-outline-text="true">C</span></p></div>',
       );
-      await editor.update((state) => {
+      await editor.update(() => {
         text3.insertAfter(text1);
         text3.insertAfter(text2);
       });
@@ -955,8 +955,8 @@ describe('OutlineNode tests', () => {
       );
 
       let barTextNode;
-      await editor.update((state) => {
-        const rootNode = state.getRoot();
+      await editor.update(() => {
+        const rootNode = getRoot();
         const barParagraphNode = new ParagraphNode();
         barTextNode = new TextNode('bar');
         barParagraphNode.append(barTextNode);

--- a/packages/outline/src/__tests__/unit/OutlineParagraphNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineParagraphNode.test.js
@@ -12,6 +12,7 @@ import {
   isParagraphNode,
 } from 'outline/ParagraphNode';
 import {initializeUnitTest} from '../utils';
+import {getRoot} from 'outline';
 
 const editorConfig = Object.freeze({
   theme: {
@@ -59,8 +60,8 @@ describe('OutlineParagraphNode tests', () => {
     test('ParagraphNode.insertNewAfter()', async () => {
       const {editor} = testEnv;
       let paragraphNode;
-      await editor.update((state) => {
-        const root = state.getRoot();
+      await editor.update(() => {
+        const root = getRoot();
         paragraphNode = new ParagraphNode();
         root.append(paragraphNode);
       });

--- a/packages/outline/src/__tests__/unit/OutlineQuoteNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineQuoteNode.test.js
@@ -8,6 +8,7 @@
 
 import {QuoteNode, createQuoteNode} from 'outline/QuoteNode';
 import {ParagraphNode} from 'outline/ParagraphNode';
+import {getRoot} from 'outline';
 import {initializeUnitTest} from '../utils';
 
 const editorConfig = Object.freeze({
@@ -62,8 +63,8 @@ describe('OutlineQuoteNode tests', () => {
     test('QuoteNode.insertNewAfter()', async () => {
       const {editor} = testEnv;
       let quoteNode;
-      await editor.update((state) => {
-        const root = state.getRoot();
+      await editor.update(() => {
+        const root = getRoot();
         quoteNode = new QuoteNode();
         root.append(quoteNode);
       });

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -19,7 +19,7 @@ import {
   parseEditorState,
   shouldEnqueueUpdates,
 } from './OutlineUpdates';
-import {TextNode} from '.';
+import {TextNode, getSelection, getRoot} from '.';
 import {createEmptyEditorState} from './OutlineEditorState';
 import {LineBreakNode} from './OutlineLineBreakNode';
 import {RootNode} from './OutlineRootNode';
@@ -88,10 +88,7 @@ export type RootListener = (
   element: null | HTMLElement,
   element: null | HTMLElement,
 ) => void;
-export type TextMutationListener = (
-  state: State,
-  mutation: TextMutation,
-) => void;
+export type TextMutationListener = (mutation: TextMutation) => void;
 export type TextContentListener = (text: string) => void;
 
 export type TextTransform = (node: TextNode, state: State) => void;
@@ -391,9 +388,9 @@ class BaseOutlineEditor {
       // This ensures that iOS does not trigger caps lock upon focus
       rootElement.setAttribute('autocapitalize', 'off');
       this.update(
-        (state: State) => {
-          const selection = state.getSelection();
-          const root = state.getRoot();
+        () => {
+          const selection = getSelection();
+          const root = getRoot();
           if (selection !== null) {
             // Marking the selection dirty will force the selection back to it
             selection.dirty = true;

--- a/packages/outline/src/core/OutlineMutations.js
+++ b/packages/outline/src/core/OutlineMutations.js
@@ -10,10 +10,9 @@
 import type {OutlineEditor} from './OutlineEditor';
 import type {Selection} from './OutlineSelection';
 import type {TextNode} from './OutlineTextNode';
-import type {State} from './OutlineUpdates';
 
-import {isTextNode, isDecoratorNode} from '.';
-import {state, triggerListeners} from './OutlineUpdates';
+import {isTextNode, isDecoratorNode, getSelection, setSelection} from '.';
+import {triggerListeners} from './OutlineUpdates';
 import {
   getNearestNodeFromDOMNode,
   getNodeFromDOMNode,
@@ -48,8 +47,8 @@ function isManagedLineBreak(dom: Node, target: Node): boolean {
 }
 
 function getLastSelection(editor: OutlineEditor): null | Selection {
-  return editor.getEditorState().read((lastState: State) => {
-    const selection = lastState.getSelection();
+  return editor.getEditorState().read(() => {
+    const selection = getSelection();
     return selection !== null ? selection.clone() : null;
   });
 }
@@ -69,7 +68,7 @@ function handleTextMutation(
 
   const text = target.nodeValue;
   const textMutation = {node, anchorOffset, focusOffset, text};
-  triggerListeners('textmutation', editor, false, state, textMutation);
+  triggerListeners('textmutation', editor, false, textMutation);
 }
 
 export function flushMutations(
@@ -191,10 +190,10 @@ export function flushMutations(
         observer.takeRecords();
       }
       if (shouldRevertSelection) {
-        const selection = state.getSelection() || getLastSelection(editor);
+        const selection = getSelection() || getLastSelection(editor);
         if (selection !== null) {
           selection.dirty = true;
-          state.setSelection(selection);
+          setSelection(selection);
         }
       }
     });

--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -25,7 +25,7 @@ import {
 } from './OutlineSelection';
 import {FULL_RECONCILE, NO_DIRTY_NODES} from './OutlineConstants';
 import {resetEditor} from './OutlineEditor';
-import {initMutationObserver, flushRootMutations} from './OutlineMutations';
+import {initMutationObserver} from './OutlineMutations';
 import {
   EditorState,
   editorStateHasDirtySelection,
@@ -38,6 +38,10 @@ import {
   setCompositionKey,
   getNearestNodeFromDOMNode,
   getEditorStateTextContent,
+  flushMutations,
+  setSelection,
+  clearSelection,
+  getRoot,
 } from './OutlineUtils';
 import {
   garbageCollectDetachedDecorators,
@@ -67,31 +71,15 @@ export type State = {
 };
 
 export const state: State = {
-  getRoot() {
-    // $FlowFixMe: root is always in our Map
-    return ((getActiveEditorState()._nodeMap.get('root'): any): RootNode);
-  },
+  getRoot,
   getNodeByKey,
   getSelection,
-  clearSelection(): void {
-    const editorState = getActiveEditorState();
-    editorState._selection = null;
-  },
-  setSelection(selection: Selection): void {
-    const editorState = getActiveEditorState();
-    editorState._selection = selection;
-  },
-  setCompositionKey(compositionKey: null | NodeKey): void {
-    errorOnReadOnly();
-    setCompositionKey(compositionKey);
-  },
+  clearSelection,
+  setSelection,
+  setCompositionKey,
   getCompositionKey,
   getNearestNodeFromDOMNode,
-  flushMutations(): void {
-    errorOnReadOnly();
-    const editor = getActiveEditor();
-    flushRootMutations(editor);
-  },
+  flushMutations,
 };
 
 export function isCurrentlyReadOnlyMode(): boolean {

--- a/packages/outline/src/core/OutlineUtils.js
+++ b/packages/outline/src/core/OutlineUtils.js
@@ -12,6 +12,8 @@ import type {OutlineNode, NodeKey, NodeMap} from './OutlineNode';
 import type {TextFormatType} from './OutlineTextNode';
 import type {Node as ReactNode} from 'react';
 import type {EditorState} from './OutlineEditorState';
+import type {Selection} from './OutlineSelection';
+import type {RootNode} from './OutlineRootNode';
 
 import {
   RTL_REGEX,
@@ -25,6 +27,7 @@ import {
   getActiveEditor,
   getActiveEditorState,
 } from './OutlineUpdates';
+import {flushRootMutations} from './OutlineMutations';
 
 export const emptyFunction = () => {};
 
@@ -183,6 +186,7 @@ export function internallyMarkNodeAsDirty(node: OutlineNode): void {
 }
 
 export function setCompositionKey(compositionKey: null | NodeKey): void {
+  errorOnReadOnly();
   const editor = getActiveEditor();
   const previousCompositionKey = editor._compositionKey;
   editor._compositionKey = compositionKey;
@@ -268,9 +272,9 @@ export function markAllNodesAsDirty(
   type: 'text' | 'decorator' | 'block' | 'root',
 ): void {
   // Mark all existing text nodes as dirty
-  editor.update((state) => {
+  editor.update(() => {
     if (type === 'root') {
-      state.getRoot().markDirty();
+      getRoot().markDirty();
       return;
     }
     const editorState = getActiveEditorState();
@@ -289,4 +293,25 @@ export function markAllNodesAsDirty(
       }
     }
   });
+}
+
+export function getRoot(): RootNode {
+  // $FlowFixMe: root is always in our Map
+  return ((getActiveEditorState()._nodeMap.get('root'): any): RootNode);
+}
+
+export function clearSelection(): void {
+  const editorState = getActiveEditorState();
+  editorState._selection = null;
+}
+
+export function setSelection(selection: Selection): void {
+  const editorState = getActiveEditorState();
+  editorState._selection = selection;
+}
+
+export function flushMutations(): void {
+  errorOnReadOnly();
+  const editor = getActiveEditor();
+  flushRootMutations(editor);
 }

--- a/packages/outline/src/core/index.js
+++ b/packages/outline/src/core/index.js
@@ -33,18 +33,30 @@ import {isBlockNode, BlockNode} from './OutlineBlockNode';
 import {createRootNode, isRootNode, RootNode} from './OutlineRootNode';
 import {createLineBreakNode, isLineBreakNode} from './OutlineLineBreakNode';
 import {DecoratorNode, isDecoratorNode} from './OutlineDecoratorNode';
-import {isLeafNode, pushLogEntry as log} from './OutlineUtils';
-import {createEmptySelection as createSelection} from './OutlineSelection';
+import {
+  isLeafNode,
+  pushLogEntry as log,
+  getRoot,
+  getNodeByKey,
+  clearSelection,
+  getNearestNodeFromDOMNode,
+  flushMutations,
+  setSelection,
+  setCompositionKey,
+  getCompositionKey,
+} from './OutlineUtils';
+import {
+  createEmptySelection as createSelection,
+  getSelection,
+} from './OutlineSelection';
 import {createNodeFromParse} from './OutlineParsing';
 
 export {
-  createSelection,
   createEditor,
-  // Node factories
-  createLineBreakNode,
-  createRootNode,
-  createTextNode,
-  createNodeFromParse,
+  BlockNode,
+  DecoratorNode,
+  RootNode,
+  TextNode,
   // Node validation
   isLeafNode,
   isBlockNode,
@@ -52,11 +64,20 @@ export {
   isLineBreakNode,
   isRootNode,
   isTextNode,
-  // Extensible nodes
-  BlockNode,
-  DecoratorNode,
-  RootNode,
-  TextNode,
-  // Logging
+  // Used during read/update/transform
+  createLineBreakNode,
+  createRootNode,
+  createTextNode,
+  createNodeFromParse,
+  createSelection,
+  getRoot,
+  getNodeByKey,
+  getSelection,
+  clearSelection,
+  setSelection,
+  setCompositionKey,
+  getCompositionKey,
+  getNearestNodeFromDOMNode,
+  flushMutations,
   log,
 };

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelection.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelection.test.js
@@ -11,6 +11,8 @@ import {
   createLineBreakNode,
   createTextNode,
   Selection,
+  getSelection,
+  getRoot,
 } from 'outline';
 
 import React from 'react';
@@ -898,15 +900,15 @@ describe('OutlineSelection tests', () => {
   });
 
   test('getNodes resolves nested block nodes', async () => {
-    await editor.update((state) => {
-      const root = state.getRoot();
+    await editor.update(() => {
+      const root = getRoot();
       const paragraph = root.getFirstChild();
       const blockNode = createTestBlockNode();
       const text = createTextNode();
       paragraph.append(blockNode);
       blockNode.append(text);
 
-      const selectedNodes = state.getSelection().getNodes();
+      const selectedNodes = getSelection().getNodes();
       expect(selectedNodes.length).toBe(1);
       expect(selectedNodes[0].getKey()).toBe(text.getKey());
     });
@@ -1416,13 +1418,13 @@ describe('OutlineSelection tests', () => {
           // eslint-disable-next-line no-only-tests/no-only-tests
           const test_ = only === true ? test.only : test;
           test_(name, async () => {
-            await editor.update((state) => {
-              const root = state.getRoot();
+            await editor.update(() => {
+              const root = getRoot();
               const paragraph = root.getFirstChild();
               const textNode = createTextNode('foo');
               // Note: line break can't be selected by the DOM
               const linebreak = createLineBreakNode();
-              const selection: Selection = state.getSelection();
+              const selection: Selection = getSelection();
               const anchor = selection.anchor;
               const focus = selection.focus;
 
@@ -1458,15 +1460,15 @@ describe('OutlineSelection tests', () => {
   });
 
   test('isBackward', async () => {
-    await editor.update((state) => {
-      const root = state.getRoot();
+    await editor.update(() => {
+      const root = getRoot();
       const paragraph = root.getFirstChild();
       const paragraphKey = paragraph.getKey();
       const textNode = createTextNode('foo');
       const textNodeKey = textNode.getKey();
       // Note: line break can't be selected by the DOM
       const linebreak = createLineBreakNode();
-      const selection: Selection = state.getSelection();
+      const selection: Selection = getSelection();
       const anchor = selection.anchor;
       const focus = selection.focus;
 

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
@@ -8,7 +8,13 @@
 
 import type {State} from 'outline';
 
-import {createEditor, createTextNode, TextNode, BlockNode} from 'outline';
+import {
+  createEditor,
+  createTextNode,
+  TextNode,
+  BlockNode,
+  getSelection,
+} from 'outline';
 import {createParagraphNode} from 'outline/ParagraphNode';
 import {
   insertText,
@@ -57,11 +63,11 @@ function createParagraphWithNodes(editor, nodes) {
 }
 
 function setAnchorPoint(state, point) {
-  let selection = state.getSelection();
+  let selection = getSelection();
   if (selection === null) {
     const dummyTextNode = createTextNode();
     dummyTextNode.select();
-    selection = state.getSelection();
+    selection = getSelection();
   }
   const anchor = selection.anchor;
   anchor.type = point.type;
@@ -70,11 +76,11 @@ function setAnchorPoint(state, point) {
 }
 
 function setFocusPoint(state, point) {
-  let selection = state.getSelection();
+  let selection = getSelection();
   if (selection === null) {
     const dummyTextNode = createTextNode();
     dummyTextNode.select();
-    selection = state.getSelection();
+    selection = getSelection();
   }
   const focus = selection.focus;
   focus.type = point.type;
@@ -111,7 +117,7 @@ describe('OutlineSelectionHelpers tests', () => {
             key: 'a',
           });
 
-          const selection = state.getSelection();
+          const selection = getSelection();
           cb(selection, state, block);
         });
       };
@@ -256,7 +262,7 @@ describe('OutlineSelectionHelpers tests', () => {
       await Promise.resolve().then();
 
       editor.getEditorState().read((state) => {
-        const selection = state.getSelection();
+        const selection = getSelection();
         expect(selection.anchor).toEqual({
           type: 'block',
           key: block.getKey(),
@@ -308,7 +314,7 @@ describe('OutlineSelectionHelpers tests', () => {
       await Promise.resolve().then();
 
       editor.getEditorState().read((state) => {
-        const selection = state.getSelection();
+        const selection = getSelection();
         expect(selection.anchor).toEqual({
           type: 'text',
           key: 'b',
@@ -362,7 +368,7 @@ describe('OutlineSelectionHelpers tests', () => {
       await Promise.resolve().then();
 
       editor.getEditorState().read((state) => {
-        const selection = state.getSelection();
+        const selection = getSelection();
         expect(selection.anchor).toEqual({
           type: 'text',
           key: 'c',
@@ -416,7 +422,7 @@ describe('OutlineSelectionHelpers tests', () => {
       await Promise.resolve().then();
 
       editor.getEditorState().read((state) => {
-        const selection = state.getSelection();
+        const selection = getSelection();
         expect(selection.anchor).toEqual({
           type: 'text',
           key: 'c',
@@ -453,7 +459,7 @@ describe('OutlineSelectionHelpers tests', () => {
             key: block.getKey(),
           });
 
-          const selection = state.getSelection();
+          const selection = getSelection();
           cb(selection, state, block);
         });
       };
@@ -575,7 +581,7 @@ describe('OutlineSelectionHelpers tests', () => {
             key: block.getKey(),
           });
 
-          const selection = state.getSelection();
+          const selection = getSelection();
           cb(selection, state, block);
         });
       };
@@ -700,7 +706,7 @@ describe('OutlineSelectionHelpers tests', () => {
             key: block.getKey(),
           });
 
-          const selection = state.getSelection();
+          const selection = getSelection();
           cb(selection, state, block);
         });
       };
@@ -834,7 +840,7 @@ describe('OutlineSelectionHelpers tests', () => {
       await Promise.resolve().then();
 
       editor.getEditorState().read((state) => {
-        const selection = state.getSelection();
+        const selection = getSelection();
         expect(selection.anchor).toEqual({
           type: 'text',
           key: 'a',
@@ -883,7 +889,7 @@ describe('OutlineSelectionHelpers tests', () => {
       await Promise.resolve().then();
 
       editor.getEditorState().read((state) => {
-        const selection = state.getSelection();
+        const selection = getSelection();
         expect(selection.anchor).toEqual({
           type: 'text',
           key: 'a',
@@ -926,7 +932,7 @@ describe('OutlineSelectionHelpers tests', () => {
             key: 'b',
           });
 
-          const selection = state.getSelection();
+          const selection = getSelection();
           cb(selection, state, block);
         });
       };
@@ -1070,7 +1076,7 @@ describe('OutlineSelectionHelpers tests', () => {
             key: block.getKey(),
           });
 
-          const selection = state.getSelection();
+          const selection = getSelection();
           cb(selection, state, block);
         });
       };
@@ -1203,7 +1209,7 @@ describe('OutlineSelectionHelpers tests', () => {
             key: 'c',
           });
 
-          const selection = state.getSelection();
+          const selection = getSelection();
           cb(selection, state, block);
         });
       };
@@ -1339,9 +1345,9 @@ describe('OutlineSelectionHelpers tests', () => {
       paragraph3.append(text3);
 
       text1.select(0, 0);
-      const selection1 = state.getSelection();
+      const selection1 = getSelection();
       selection1.focus.set(text3.getKey(), 1, 'text');
-      const selectedNodes1 = cloneContents(state.getSelection());
+      const selectedNodes1 = cloneContents(getSelection());
       expect(selectedNodes1.range).toEqual([
         paragraph1.getKey(),
         paragraph2.getKey(),
@@ -1357,9 +1363,9 @@ describe('OutlineSelectionHelpers tests', () => {
       expect(selectedNodes1.nodeMap[5][1].getTextContent()).toBe('Third');
 
       text1.select(1, 1);
-      const selection2 = state.getSelection();
+      const selection2 = getSelection();
       selection2.focus.set(text3.getKey(), 4, 'text');
-      const selectedNodes2 = cloneContents(state.getSelection());
+      const selectedNodes2 = cloneContents(getSelection());
       expect(selectedNodes2.range).toEqual([
         paragraph1.getKey(),
         paragraph2.getKey(),
@@ -1392,23 +1398,23 @@ describe('OutlineSelectionHelpers tests', () => {
       const excludeBlockNode1 = createExcludeFromCopyBlockNode();
       paragraph.append(excludeBlockNode1);
       paragraph.select(0, 0);
-      const selectedNodes1 = cloneContents(state.getSelection());
+      const selectedNodes1 = cloneContents(getSelection());
       expect(selectedNodes1.range).toEqual([]);
 
       const text1 = createTextNode('1');
       excludeBlockNode1.append(text1);
       excludeBlockNode1.select(0, 0);
-      const selectedNodes2 = cloneContents(state.getSelection());
+      const selectedNodes2 = cloneContents(getSelection());
       expect(selectedNodes2.range).toEqual([paragraph.getKey()]);
 
       paragraph.select(0, 0);
-      const selectedNodes3 = cloneContents(state.getSelection());
+      const selectedNodes3 = cloneContents(getSelection());
       expect(selectedNodes3.range).toEqual([paragraph.getKey()]);
 
       const text2 = createTextNode('2');
       excludeBlockNode1.insertAfter(text2);
       paragraph.select(0, 2);
-      const selectedNodes4 = cloneContents(state.getSelection());
+      const selectedNodes4 = cloneContents(getSelection());
       expect(selectedNodes4.range).toEqual([paragraph.getKey()]);
       expect(selectedNodes4.nodeMap[0][0]).toEqual(text1.getKey());
       expect(selectedNodes4.nodeMap[1][0]).toEqual(paragraph.getKey());
@@ -1417,7 +1423,7 @@ describe('OutlineSelectionHelpers tests', () => {
       const text3 = createTextNode('3');
       excludeBlockNode1.append(text3);
       paragraph.select(0, 2);
-      const selectedNodes5 = cloneContents(state.getSelection());
+      const selectedNodes5 = cloneContents(getSelection());
       expect(selectedNodes5.range).toEqual([paragraph.getKey()]);
       expect(selectedNodes5.nodeMap[0][0]).toEqual(text1.getKey());
       expect(selectedNodes5.nodeMap[1][0]).toEqual(paragraph.getKey());
@@ -1431,7 +1437,7 @@ describe('OutlineSelectionHelpers tests', () => {
       testBlockNode.append(excludeBlockNode2);
       excludeBlockNode2.append(text4);
       paragraph.select(0, 3);
-      const selectedNodes6 = cloneContents(state.getSelection());
+      const selectedNodes6 = cloneContents(getSelection());
       expect(selectedNodes6.range).toEqual([paragraph.getKey()]);
       expect(selectedNodes6.nodeMap[0][0]).toEqual(text4.getKey());
       expect(selectedNodes6.nodeMap[1][0]).toEqual(testBlockNode.getKey());
@@ -1442,7 +1448,7 @@ describe('OutlineSelectionHelpers tests', () => {
 
       text4.remove();
       paragraph.select(0, 3);
-      const selectedNodes7 = cloneContents(state.getSelection());
+      const selectedNodes7 = cloneContents(getSelection());
       expect(selectedNodes7.range).toEqual([paragraph.getKey()]);
       expect(selectedNodes7.nodeMap[0][0]).toEqual(testBlockNode.getKey());
       expect(selectedNodes7.nodeMap[1][0]).toEqual(paragraph.getKey());
@@ -1477,7 +1483,7 @@ describe('OutlineSelectionHelpers tests', () => {
             offset: 0,
             key: paragraph.getKey(),
           });
-          const selection = state.getSelection();
+          const selection = getSelection();
 
           insertNodes(selection, [createTextNode('foo')]);
         });
@@ -1510,7 +1516,7 @@ describe('OutlineSelectionHelpers tests', () => {
             offset: 0,
             key: paragraph.getKey(),
           });
-          const selection = state.getSelection();
+          const selection = getSelection();
 
           insertNodes(selection, [
             createTextNode('foo'),
@@ -1546,7 +1552,7 @@ describe('OutlineSelectionHelpers tests', () => {
             offset: 0,
             key: paragraph.getKey(),
           });
-          const selection = state.getSelection();
+          const selection = getSelection();
           const heading = createHeadingNode('h1');
           const child = createTextNode('foo');
           heading.append(child);
@@ -1582,7 +1588,7 @@ describe('OutlineSelectionHelpers tests', () => {
             offset: 0,
             key: paragraph.getKey(),
           });
-          const selection = state.getSelection();
+          const selection = getSelection();
           const heading = createHeadingNode('h1');
           const child = createTextNode('foo');
           heading.append(child);
@@ -1624,7 +1630,7 @@ describe('OutlineSelectionHelpers tests', () => {
             offset: 16,
             key: text.getKey(),
           });
-          const selection = state.getSelection();
+          const selection = getSelection();
 
           insertNodes(selection, [createTextNode('foo')]);
         });
@@ -1659,7 +1665,7 @@ describe('OutlineSelectionHelpers tests', () => {
             offset: 16,
             key: text.getKey(),
           });
-          const selection = state.getSelection();
+          const selection = getSelection();
 
           insertNodes(selection, [
             createTextNode('foo'),
@@ -1697,7 +1703,7 @@ describe('OutlineSelectionHelpers tests', () => {
             offset: 16,
             key: text.getKey(),
           });
-          const selection = state.getSelection();
+          const selection = getSelection();
           const heading = createHeadingNode('h1');
           const child = createTextNode('foo');
           heading.append(child);
@@ -1735,7 +1741,7 @@ describe('OutlineSelectionHelpers tests', () => {
             offset: 16,
             key: text.getKey(),
           });
-          const selection = state.getSelection();
+          const selection = getSelection();
           const heading = createHeadingNode('h1');
           const child = createTextNode('foo');
           heading.append(child);

--- a/packages/outline/src/helpers/__tests__/utils/index.js
+++ b/packages/outline/src/helpers/__tests__/utils/index.js
@@ -7,7 +7,7 @@
  */
 
 import * as SelectionHelpers from 'outline/selection';
-import {createTextNode, isTextNode} from 'outline';
+import {createTextNode, isTextNode, getSelection} from 'outline';
 
 Object.defineProperty(HTMLElement.prototype, 'contentEditable', {
   get() {
@@ -582,8 +582,8 @@ export async function applySelectionInputs(inputs, update, editor) {
     const times = input?.times ?? 1;
 
     for (let j = 0; j < times; j++) {
-      await update((state) => {
-        const selection = state.getSelection();
+      await update(() => {
+        const selection = getSelection();
 
         switch (input.type) {
           case 'insert_text': {


### PR DESCRIPTION
This exposes the Outline state methods on the package export, so you can load them without needing to do `state.getRoot()` etc. This might be somewhat controversial but in making the changes internally, it did feel "cleaner" and I got rid of a ton of code doing so as we no longer need to pass `state` everywhere, which is somewhat empowering.