### PR TITLE
Fixing bugs in wrapLeafNodesInBlocks

### DIFF
--- a/packages/outline/src/extensions/OutlineListItemNode.js
+++ b/packages/outline/src/extensions/OutlineListItemNode.js
@@ -87,8 +87,17 @@ export class ListItemNode extends BlockNode {
     if (isListItemNode(node)) {
       return super.insertAfter(node);
     }
-    if (isListNode(node)) {
-      // Attempt to merge tables
+
+    const listNode = this.getParentOrThrow();
+    if (!isListNode(listNode)) {
+      invariant(
+        false,
+        'insertAfter: list node is not parent of list item node',
+      );
+    }
+
+    // Attempt to merge tables if the list is of the same type.
+    if (isListNode(node) && node.getTag() === listNode.getTag()) {
       let child = node;
       const children = node.getChildren();
       for (let i = children.length - 1; i >= 0; i--) {
@@ -97,14 +106,8 @@ export class ListItemNode extends BlockNode {
       }
       return child;
     }
+
     // Otherwise, split the list
-    const listNode = this.getParentOrThrow();
-    if (!isListNode(listNode)) {
-      invariant(
-        false,
-        'insertAfter: list node is not parent of list item node',
-      );
-    }
     // Split the lists and insert the node in between them
     const siblings = this.getNextSiblings();
     listNode.insertAfter(node);


### PR DESCRIPTION
With multiple text nodes in a block, all should be moved to the new block type and not just the text node in selection.


https://user-images.githubusercontent.com/1712525/142349556-ec8cd73e-78c4-4ef9-9cb4-14e927eed9e9.mov

`listItem.insertAfter(node)` checks if `node` is a list and tries to merge it's items into its parent list. This should be done only if `node` list is of the same type as `listItem.getParent()`.  This was manifesting in the floating dropdown such that selecting some unordered list items and making them ordered was doing nothing since they were being merged back into their parent.


https://user-images.githubusercontent.com/1712525/142349969-4471ccf9-1da0-47b0-8978-a0647b4f243f.mov



