### PR TITLE
Add controller shared context

### DIFF
--- a/packages/outline-playground/src/controllers/PlaygroundController.js
+++ b/packages/outline-playground/src/controllers/PlaygroundController.js
@@ -22,6 +22,8 @@ export type PlaygroundContext = {
   triggerListeners(type: 'readonly' | 'clear', value: ListenerValue): void,
 };
 
+export type PlaygroundSharedContext = {};
+
 const config = {
   theme: {
     paragraph: 'editor-paragraph',
@@ -90,7 +92,17 @@ function createPlaygroundContext(): PlaygroundContext {
   };
 }
 
-const PlaygroundController: Controller<PlaygroundContext> =
-  createController<PlaygroundContext>(createPlaygroundContext, config);
+function createPlaygroundSharedContext(): PlaygroundSharedContext {
+  return {};
+}
+
+const PlaygroundController: Controller<
+  PlaygroundContext,
+  PlaygroundSharedContext,
+> = createController<PlaygroundContext, PlaygroundSharedContext>(
+  createPlaygroundContext,
+  createPlaygroundSharedContext,
+  config,
+);
 
 export default PlaygroundController;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -43,5 +43,6 @@
   "41": "createNode: node does not exist in nodeMap",
   "42": "reconcileNode: prevNode or nextNode does not exist in nodeMap",
   "43": "reconcileNode: parentDOM is null",
-  "44": "Reconciliation: could not find DOM element for node key \"${key}\""
+  "44": "Reconciliation: could not find DOM element for node key \"${key}\"",
+  "45": "OutlineCotext.useOutlineContext: cannot find matching OutlineContext"
 }


### PR DESCRIPTION
When nesting editors, it would be good to have a shared consistent context between all in scope.