### PR TITLE
Normalize text nodes prior transform

### DIFF
--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -17,7 +17,7 @@ import type {ParsedNode, NodeParserState} from './OutlineParsing';
 import type {TextNode} from './OutlineTextNode';
 import type {DecoratorNode} from './OutlineDecoratorNode';
 
-import {updateEditorState} from './OutlineReconciler';
+import {normalizeTextNode, updateEditorState} from './OutlineReconciler';
 import {
   createSelection,
   getSelection,
@@ -160,7 +160,7 @@ function applyAllTransforms(
   editorState: EditorState,
   editor: OutlineEditor,
 ): void {
-  // const selection = editorState._selection;
+  const selection = editorState._selection;
   const dirtyLeaves = editor._dirtyLeaves;
   const dirtyBlocks = editor._dirtyBlocks;
   const transforms = editor._transforms;
@@ -198,8 +198,7 @@ function applyAllTransforms(
         if (isTextNode(node)) {
           const parent = node.getParent();
           if (parent !== null) {
-            // TODO
-            // normalizeTextNodes(parent, selection);
+            normalizeTextNode(node, selection);
           }
         }
         if (isNodeValidForTransform(node, compositionKey)) {

--- a/packages/outline/src/core/OutlineUtils.js
+++ b/packages/outline/src/core/OutlineUtils.js
@@ -278,30 +278,34 @@ export function markAllNodesAsDirty(
   type: 'text' | 'decorator' | 'block' | 'root',
 ): void {
   // Mark all existing text nodes as dirty
-  updateEditor(editor, () => {
-    const editorState = getActiveEditorState();
-    if (editorState.isEmpty()) {
-      return;
-    }
-    if (type === 'root') {
-      getRoot().markDirty();
-      return;
-    }
-    const nodeMap = editorState._nodeMap;
-    const nodeMapEntries = Array.from(nodeMap);
-    // For...of would be faster here, but this will get
-    // compiled away to a slow-path with Babel.
-    for (let i = 0; i < nodeMapEntries.length; i++) {
-      const node = nodeMapEntries[i][1];
-      if (
-        (type === 'text' && isTextNode(node)) ||
-        (type === 'decorator' && isDecoratorNode(node)) ||
-        (type === 'block' && isBlockNode(node))
-      ) {
-        node.markDirty();
+  updateEditor(
+    editor,
+    () => {
+      const editorState = getActiveEditorState();
+      if (editorState.isEmpty()) {
+        return;
       }
-    }
-  }, true);
+      if (type === 'root') {
+        getRoot().markDirty();
+        return;
+      }
+      const nodeMap = editorState._nodeMap;
+      const nodeMapEntries = Array.from(nodeMap);
+      // For...of would be faster here, but this will get
+      // compiled away to a slow-path with Babel.
+      for (let i = 0; i < nodeMapEntries.length; i++) {
+        const node = nodeMapEntries[i][1];
+        if (
+          (type === 'text' && isTextNode(node)) ||
+          (type === 'decorator' && isDecoratorNode(node)) ||
+          (type === 'block' && isBlockNode(node))
+        ) {
+          node.markDirty();
+        }
+      }
+    },
+    true,
+  );
 }
 
 export function getRoot(): RootNode {

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
@@ -227,6 +227,115 @@ describe('OutlineSelectionHelpers tests', () => {
       });
     });
 
+    test('Has correct text point after removal after merge', async () => {
+      const editor = createEditor({});
+
+      editor.addListener('error', (error) => {
+        throw error;
+      });
+
+      const element = document.createElement('div');
+      let block;
+
+      editor.setRootElement(element);
+
+      editor.update((state) => {
+        const root = state.getRoot();
+        block = createParagraphWithNodes(
+          editor,
+          [
+            {text: 'a', key: 'a', mergeable: true},
+            {text: 'bb', key: 'bb', mergeable: true},
+            {text: '', key: 'empty', mergeable: true},
+            {text: 'cc', key: 'cc', mergeable: true},
+            {text: 'd', key: 'd', mergeable: true},
+          ],
+          true,
+        );
+        root.append(block);
+        setAnchorPoint(state, {
+          type: 'text',
+          key: 'bb',
+          offset: 1,
+        });
+        setFocusPoint(state, {
+          type: 'text',
+          key: 'cc',
+          offset: 1,
+        });
+      });
+
+      await Promise.resolve().then();
+
+      editor.getEditorState().read((state) => {
+        const selection = getSelection();
+        expect(selection.anchor).toEqual({
+          type: 'text',
+          key: 'a',
+          offset: 2,
+        });
+        expect(selection.focus).toEqual({
+          type: 'text',
+          key: 'a',
+          offset: 4,
+        });
+      });
+    });
+
+    test('Has correct text point after removal after merge (2)', async () => {
+      const editor = createEditor({});
+
+      editor.addListener('error', (error) => {
+        throw error;
+      });
+
+      const element = document.createElement('div');
+      let block;
+
+      editor.setRootElement(element);
+
+      editor.update((state) => {
+        const root = state.getRoot();
+        block = createParagraphWithNodes(
+          editor,
+          [
+            {text: 'a', key: 'a', mergeable: true},
+            {text: '', key: 'empty', mergeable: true},
+            {text: 'b', key: 'b', mergeable: true},
+            {text: 'c', key: 'c', mergeable: true},
+          ],
+          true,
+        );
+        root.append(block);
+        setAnchorPoint(state, {
+          type: 'text',
+          key: 'a',
+          offset: 0,
+        });
+        setFocusPoint(state, {
+          type: 'text',
+          key: 'c',
+          offset: 1,
+        });
+      });
+
+      await Promise.resolve().then();
+
+      editor.getEditorState().read((state) => {
+        const selection = getSelection();
+        expect(selection.anchor).toEqual({
+          type: 'text',
+          key: 'a',
+          offset: 0,
+        });
+        expect(selection.focus).toEqual({
+          type: 'text',
+          key: 'a',
+          offset: 3,
+        });
+      });
+    });
+
     test('Has correct text point adjust to block point after removal of a single empty text node', async () => {
       const editor = createEditor({});
 


### PR DESCRIPTION
This PR brings node normalization on transforms.

**Why is this important?**

We want transforms to be self-sufficient, the only required mechanism to react to modifications. Currently, the listener -> update pattern still has advantage because adjacent nodes aren't merged/removed (aka normalization) until reconciliation, which happens after the transforms.

To make this possible, we're introducing normalization between transforms. **The chosen heuristic is to normalize the current leaf node prior running the transforms on that leaf**. This ensures that this particular node is always normalized and transforms will at least see the normalized node at least once.

Alternatively, we could've merged after each transform but unless we do so for each of the dirty nodes generated by each transform (pretty costly) we would not be able to ensure that each transform sees normalized nodes.

**Side note**

The selection part of the diff isn't neat but there's further work we have to iterate on because right now it's split in two different places (the nodes and the reconciler) which also prevents us from removing the previous normalization logic.