### PR TITLE
Handle "Inline Block" deletion edge case.

### DIFF
--- a/packages/outline/src/extensions/OutlineLinkNode.js
+++ b/packages/outline/src/extensions/OutlineLinkNode.js
@@ -75,6 +75,10 @@ export class LinkNode extends BlockNode {
   canBeEmpty(): false {
     return false;
   }
+
+  isInline(): true {
+    return true;
+  }
 }
 
 export function createLinkNode(url: string): LinkNode {


### PR DESCRIPTION
Links are the first example of "Inline" `BlockNode`s and need to have slightly different behavior in situations like these.

If the cursor was inside of a `ListItemNode`'s `TextNode`(s) the current behavior is perfect- the inner `TextNode`(s) are moved to into the previous `BlockNode` (effectively deleting the list item). If it's in a paragraph? Also perfect.

But for Links we want to preserve the LinkBlockNode wrapping the `TextNode`(s) and append to the previous `BlockNode` (e.g. a paragraph, list item, etc).

So for a solution I added a `isInlineBlock` function to `OutlineBlockNode` so Links and future Inline use cases can signal that they need to be handled differently.

See video below for repro instructions.
https://user-images.githubusercontent.com/13852400/142552123-89965c02-84f1-4eaa-8e42-4d5cef2d5362.mov

See video below demonstrating the fix:
https://user-images.githubusercontent.com/13852400/142552911-417df456-7797-478d-a686-9cee95b6fb7f.mov
