### PR TITLE
Prevent merging/removing custom TextNodes

### DIFF
--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -954,7 +954,12 @@ function normalizeTextNodes(block: BlockNode): BlockNode {
     const child = children[i];
     const index = i - removedNodes;
 
-    if (isTextNode(child) && child.isSimpleText() && !child.isUnmergeable()) {
+    if (
+      child.__type === 'text' &&
+      isTextNode(child) &&
+      child.isSimpleText() &&
+      !child.isUnmergeable()
+    ) {
       const flags = child.__flags;
       const format = child.__format;
       const style = child.__style;


### PR DESCRIPTION
Ideally, we support merging custom TextNodes with their own merging strategy but since I'm redoing part of this logic in #853 I'm just preventing this unsupported thing for now