### PR TITLE
Add isInline to BlockNode.

### DIFF
--- a/packages/outline/src/core/OutlineBlockNode.js
+++ b/packages/outline/src/core/OutlineBlockNode.js
@@ -330,6 +330,9 @@ export class BlockNode extends OutlineNode {
   canInsertTextAtBoundary(): boolean {
     return true;
   }
+  isInline(): boolean {
+    return false;
+  }
 }
 
 export function isBlockNode(node: ?OutlineNode): boolean %checks {


### PR DESCRIPTION
This might have been an omission. In any case, I think it should be on BlockNode and overridden on LinkNode (and wherever else).