### PR TITLE
Revert "Prevent merging/removing custom TextNodes"

### DIFF
--- a/packages/outline/src/core/OutlineReconciler.js
+++ b/packages/outline/src/core/OutlineReconciler.js
@@ -956,12 +956,7 @@ function normalizeTextNodes(block: BlockNode): BlockNode {
     const child = children[i];
     const index = i - removedNodes;
 
-    if (
-      child.__type === 'text' &&
-      isTextNode(child) &&
-      child.isSimpleText() &&
-      !child.isUnmergeable()
-    ) {
+    if (isTextNode(child) && child.isSimpleText() && !child.isUnmergeable()) {
       const flags = child.__flags;
       const format = child.__format;
       const style = child.__style;


### PR DESCRIPTION
Reverts facebookexternal/outline#863

Turns out we have internal logic that depends on this logic now. :(