### PR TITLE
Can register transforms before updates unit test

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineEditor.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor.test.js
@@ -604,7 +604,9 @@ describe('OutlineEditor tests', () => {
         getRoot().append(paragraph);
       });
       editor.registerNodeType('paragraph', ParagraphNode);
-      const stringifiedEditorState = JSON.stringify(editor.getEditorState().toJSON());
+      const stringifiedEditorState = JSON.stringify(
+        editor.getEditorState().toJSON(),
+      );
       parsedEditorState = editor.parseEditorState(stringifiedEditorState);
       parsedEditorState.read(() => {
         parsedRoot = getRoot();
@@ -922,5 +924,26 @@ describe('OutlineEditor tests', () => {
         '<div contenteditable="true" data-outline-editor="true"><p><div><span data-outline-text="true">A</span><div><span data-outline-text="true">C</span></div></div><div><span data-outline-text="true">B</span></div></p></div>',
       );
     });
+  });
+
+  it('can register transforms before updates', async () => {
+    init();
+    const emptyTransform = () => {};
+    const removeTextTransform = editor.addTransform('text', emptyTransform);
+    const removeDecoratorTransform = editor.addTransform(
+      'decorator',
+      emptyTransform,
+    );
+    const removeBlockTransform = editor.addTransform('block', emptyTransform);
+    const removeRootTransform = editor.addTransform('root', emptyTransform);
+    await editor.update(() => {
+      const root = getRoot();
+      const paragraph = createParagraphNode();
+      root.append(paragraph);
+    });
+    removeTextTransform();
+    removeDecoratorTransform();
+    removeBlockTransform();
+    removeRootTransform();
   });
 });


### PR DESCRIPTION
This is now fixed but the unit test should prevent a regression.

Previously, listening to block nodes before the editor had been initialized would cause this invariant in OutlineUpdates to throw:

```
if (editor._dirtyType !== NO_DIRTY_NODES) {
      const dirtyLeaves = editor._dirtyLeaves;
      const dirtyBlocks = editor._dirtyBlocks;
      if (!skipEmptyCheck && pendingEditorState.isEmpty()) {
        invariant(
          false,
          'updateEditor: the pending editor state is empty. Ensure the root not never becomes empty from an update.',
        );
      }
```

