### PR TITLE
save screenshots instead of logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ npm
 .env.development.local
 .env.test.local
 .env.production.local
+e2e-screenshots
 
 npm-debug.log*
 

--- a/packages/outline-playground/__tests__/utils/index.js
+++ b/packages/outline-playground/__tests__/utils/index.js
@@ -59,7 +59,8 @@ export function initializeE2E(runTests, config: Config = {}) {
     page: null,
     async saveScreenshot() {
       const currentTest = expect.getState().currentTestName;
-      const path = currentTest.replace(/\s/g, '_') + '.png';
+      const path =
+        'e2e-screenshots/' + currentTest.replace(/\s/g, '_') + '.png';
       await e2e.page.screenshot({path});
     },
     async logScreenshot() {
@@ -119,7 +120,7 @@ export function initializeE2E(runTests, config: Config = {}) {
             } else {
               // fail for real + log screenshot
               console.log(`Flaky Test: ${description}:`);
-              await e2e.logScreenshot();
+              await e2e.saveScreenshot();
               throw err;
             }
           }


### PR DESCRIPTION
Scrolling through 9000 lines of Base64 encoded image in the terminal isn't that fun when trying to debug a test. Let's just save the screenshots in a file. Alternatively, we can just not log them.

Not sure if there's something we're using this for in CI that I'm missing.