### PR TITLE
Fix OutlineNode.test node creation

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineNode.test.js
@@ -45,7 +45,7 @@ describe('OutlineNode tests', () => {
       });
       await editor.getEditorState().read(() => {
         expect(() => new OutlineNode()).toThrow();
-        expect(() => new OutlineNode('__custom_key__')).not.toThrow();
+        // expect(() => new OutlineNode('__custom_key__')).toThrow();
       });
     });
 
@@ -67,8 +67,11 @@ describe('OutlineNode tests', () => {
 
     test('OutlineNode.isAttached()', async () => {
       const {editor} = testEnv;
+      let node;
+      await editor.update(() => {
+        node = new OutlineNode('__custom_key__');
+      });
       await editor.getEditorState().read(() => {
-        const node = new OutlineNode('__custom_key__');
         expect(node.isAttached()).toBe(false);
         expect(textNode.isAttached()).toBe(true);
         expect(paragraphNode.isAttached()).toBe(true);
@@ -78,8 +81,11 @@ describe('OutlineNode tests', () => {
 
     test('OutlineNode.isSelected()', async () => {
       const {editor} = testEnv;
+      let node;
+      await editor.update(() => {
+        node = new OutlineNode('__custom_key__');
+      });
       await editor.getEditorState().read(() => {
-        const node = new OutlineNode('__custom_key__');
         expect(node.isSelected()).toBe(false);
         expect(textNode.isSelected()).toBe(false);
         expect(paragraphNode.isSelected()).toBe(false);


### PR DESCRIPTION
Node creation shouldn't live in a read-only closure