### PR TITLE
Fix crash in BlockControlsPlugin.

### DIFF
--- a/packages/outline-playground/__tests__/e2e/NestedList-test.js
+++ b/packages/outline-playground/__tests__/e2e/NestedList-test.js
@@ -89,5 +89,46 @@ describe('Nested List', () => {
         '<ul class="editor-list-ul" dir="ltr"><li class="editor-listitem"><span data-outline-text="true">Hello</span></li><li class="editor-listitem"><span data-outline-text="true">from</span></li><li class="editor-listitem"><span data-outline-text="true">the</span></li><li class="editor-listitem"><span data-outline-text="true">other</span></li><li class="editor-listitem"><span data-outline-text="true">side</span></li></ul>',
       );
     });
+
+    it(`Can create an unordered list and convert it to an ordered list `, async () => {
+      const {isRichText, page} = e2e;
+
+      if (!isRichText) {
+        return;
+      }
+
+      await page.focus('div.editor');
+
+      await page.waitForSelector('#block-controls button');
+
+      await page.click('#block-controls button');
+      await page.waitForSelector('.dropdown .icon.bullet-list');
+      await page.click('.dropdown .icon.bullet-list');
+
+      await assertHTML(
+        page,
+        '<ul class="editor-list-ul"><li class="editor-listitem"><br></li></ul>',
+      );
+
+      await page.click('#block-controls button');
+      await page.waitForSelector('.dropdown .icon.numbered-list');
+      await page.click('.dropdown .icon.numbered-list');
+
+      await assertHTML(
+        page,
+        '<ol class="editor-list-ol"><li class="editor-listitem"><br></li></ol>',
+      );
+
+      // Issue #904 Converting back to a ul from ol doesn't work properly.
+
+      // await page.click('#block-controls button');
+      // await page.waitForSelector('.dropdown .icon.bullet-list');
+      // await page.click('.dropdown .icon.bullet-list');
+
+      // await assertHTML(
+      //   page,
+      //   '<ul class="editor-list-ul"><li class="editor-listitem"><br></li></ul>',
+      // );
+    });
   });
 });

--- a/packages/outline-playground/src/plugins/BlockControlsPlugin.js
+++ b/packages/outline-playground/src/plugins/BlockControlsPlugin.js
@@ -233,7 +233,10 @@ export default function BlockControlsPlugin(): React$Node {
         const selection = getSelection();
         if (selection !== null) {
           const anchorNode = selection.anchor.getNode();
-          const block = anchorNode.getTopParentBlockOrThrow();
+          const block =
+            anchorNode.getKey() === 'root'
+              ? anchorNode
+              : anchorNode.getTopParentBlockOrThrow();
           const blockKey = block.getKey();
           if (blockKey !== selectedBlockKey) {
             const blockDOM = editor.getElementByKey(blockKey);


### PR DESCRIPTION
What's actually happening here is this call is throwing because the anchor node is the root node:

https://github.com/facebookexternal/outline/blob/main/packages/outline-playground/src/plugins/BlockControlsPlugin.js#L236

When we run the list insertion logic, this listener triggers twice. On the first trigger, for some reason the Selection is on the RootNode. On the second trigger, it's on the newly inserted ListItemNode, where it should be.

This should fix the crash, but there might be a deeper problem with that Selection being on the Root - not sure why that happens.