### PR TITLE
Ban listener - update pattern

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineEditor.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor.test.js
@@ -555,6 +555,18 @@ describe('OutlineEditor tests', () => {
     );
   });
 
+  it('Throws on forbidden addListener + update pattern', async () => {
+    init();
+
+    const removeListener = editor.addListener('update', () => {
+      expect(() => editor.update(() => {})).toThrow();
+    });
+    await editor.update(() => {
+      getRoot().append(createParagraphNode());
+    });
+    removeListener();
+  });
+
   it('Should be able to handle a change in root element', async () => {
     const rootListener = jest.fn();
     const updateListener = jest.fn();

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -370,13 +370,7 @@ class BaseOutlineEditor {
         // $FlowFixMe: internal field
         nextRootElement.__outlineEditor = this;
       }
-      triggerListeners(
-        'root',
-        getSelf(this),
-        false,
-        nextRootElement,
-        prevRootElement,
-      );
+      triggerListeners('root', getSelf(this), nextRootElement, prevRootElement);
     }
   }
   getElementByKey(key: NodeKey): HTMLElement | null {

--- a/packages/outline/src/core/OutlineMutations.js
+++ b/packages/outline/src/core/OutlineMutations.js
@@ -68,7 +68,7 @@ function handleTextMutation(
 
   const text = target.nodeValue;
   const textMutation = {node, anchorOffset, focusOffset, text};
-  triggerListeners('textmutation', editor, false, textMutation);
+  triggerListeners('textmutation', editor, textMutation);
 }
 
 export function flushMutations(

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -58,5 +58,6 @@
   "57": "Create node: Attempted to create node %s that was not previously registered on the editor. You can use editor.registerNode to register your custom nodes.",
   "58": "Node %s has not been registered. Run editor.registerNode to register your own nodes.",
   "59": "registeredNode: Type %s not found",
-  "60": "One or more transforms are endlessly triggering additional transforms. May have encountered infinite recursion caused by transforms that have their preconditions too lose and/or conflict with each other."
+  "60": "One or more transforms are endlessly triggering additional transforms. May have encountered infinite recursion caused by transforms that have their preconditions too lose and/or conflict with each other.",
+  "61": "Attempted to run an update inside addListener (a forbidden pattern). You probably want to use a transform (addTransform) instead."
 }


### PR DESCRIPTION
Updates inside listeners are a bad pattern. You always want to use a transform instead in this case. Let's ban this pattern. Alternatively, we can show a warning instead.