### PR TITLE
Register LinkNode on useOutlineRichText

### DIFF
--- a/packages/outline-playground/src/plugins/FloatingToolbarPlugin.js
+++ b/packages/outline-playground/src/plugins/FloatingToolbarPlugin.js
@@ -32,7 +32,7 @@ import {
   isAtNodeEnd,
 } from 'outline/selection';
 import {log, getSelection, setSelection} from 'outline';
-import {createLinkNode, isLinkNode, LinkNode} from 'outline/LinkNode';
+import {createLinkNode, isLinkNode} from 'outline/LinkNode';
 
 function positionToolbar(toolbar, rect) {
   if (rect === null) {
@@ -519,9 +519,6 @@ function Toolbar({editor}: {editor: OutlineEditor}): React$Node {
 }
 
 function useFloatingToolbar(editor: OutlineEditor): React$Node {
-  useEffect(() => {
-    editor.registerNode(LinkNode);
-  }, [editor]);
   return useMemo(
     () => createPortal(<Toolbar editor={editor} />, document.body),
     [editor],

--- a/packages/outline-react/src/shared/useRichTextSetup.js
+++ b/packages/outline-react/src/shared/useRichTextSetup.js
@@ -19,6 +19,7 @@ import {QuoteNode} from 'outline/QuoteNode';
 import {CodeNode} from 'outline/CodeNode';
 import {ParagraphNode} from 'outline/ParagraphNode';
 import {ListItemNode} from 'outline/ListItemNode';
+import {LinkNode} from 'outline/LinkNode';
 import {createParagraphNode} from 'outline/ParagraphNode';
 import {CAN_USE_BEFORE_INPUT} from 'shared/environment';
 import useOutlineDragonSupport from './useOutlineDragonSupport';
@@ -110,6 +111,7 @@ export function useRichTextSetup(
     editor.registerNode(CodeNode);
     editor.registerNode(ParagraphNode);
     editor.registerNode(ListItemNode);
+    editor.registerNode(LinkNode);
     if (init) {
       initEditor(editor);
     }


### PR DESCRIPTION
Since LinkNode is part of the copy-pasting default logic, we want to include it on our `useOutlineRichText` module

Closes #915