### PR TITLE
Transform invariants in unit tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -13,4 +13,10 @@ module.exports = {
     '@babel/preset-react',
     '@babel/preset-flow',
   ],
+  plugins: [
+    [
+      require('./scripts/error-codes/transform-error-messages'),
+      {noMinify: true},
+    ],
+  ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -65,6 +65,8 @@ module.exports = {
           '<rootDir>/packages/shared/src/useLayoutEffect.js',
         '^outline-yjs$': '<rootDir>/packages/outline-yjs/src/index.js',
         '^./dist/(.+)': './src/$1',
+        formatProdErrorMessage:
+          '<rootDir>/scripts/error-codes/formatProdErrorMessage.js',
       },
       globals: {
         __DEV__: true,


### PR DESCRIPTION
Not sure if this babel config is used for anything except Jest. If so, we probably need a separate babel.config.test.js or something.

Closes #903 