### PR TITLE
Rename origin to tag on Autocomplete plugin

### DIFF
--- a/packages/outline-playground/src/plugins/AutocompletePlugin.js
+++ b/packages/outline-playground/src/plugins/AutocompletePlugin.js
@@ -49,82 +49,89 @@ function useTypeahead(editor: OutlineEditor): void {
   }, [editor]);
 
   const renderTypeahead = useCallback(() => {
-    editor.update(() => {
-      log('useTypeahead');
-      const currentTypeaheadNode = getTypeaheadTextNode();
+    editor.update(
+      () => {
+        log('useTypeahead');
+        const currentTypeaheadNode = getTypeaheadTextNode();
 
-      function maybeRemoveTypeahead() {
-        if (currentTypeaheadNode !== null) {
-          const selection = getSelection();
-          if (selection !== null) {
-            const anchor = selection.anchor;
-            const focus = selection.focus;
-            if (anchor.type === 'text' && focus.type === 'text') {
-              let anchorNode = anchor.getNode();
-              let anchorNodeOffset = anchor.offset;
-              if (anchorNode.getKey() === currentTypeaheadNode.getKey()) {
-                anchorNode = anchorNode.getPreviousSibling();
-                if (isTextNode(anchorNode)) {
-                  anchorNodeOffset = anchorNode.getTextContent().length;
+        function maybeRemoveTypeahead() {
+          if (currentTypeaheadNode !== null) {
+            const selection = getSelection();
+            if (selection !== null) {
+              const anchor = selection.anchor;
+              const focus = selection.focus;
+              if (anchor.type === 'text' && focus.type === 'text') {
+                let anchorNode = anchor.getNode();
+                let anchorNodeOffset = anchor.offset;
+                if (anchorNode.getKey() === currentTypeaheadNode.getKey()) {
+                  anchorNode = anchorNode.getPreviousSibling();
+                  if (isTextNode(anchorNode)) {
+                    anchorNodeOffset = anchorNode.getTextContent().length;
+                  }
                 }
-              }
-              let focusNode = focus.getNode();
-              let focusNodeOffset = focus.offset;
-              if (focusNode.getKey() === currentTypeaheadNode.getKey()) {
-                focusNode = focusNode.getPreviousSibling();
-                if (isTextNode(focusNode)) {
-                  focusNodeOffset = focusNode.getTextContent().length;
+                let focusNode = focus.getNode();
+                let focusNodeOffset = focus.offset;
+                if (focusNode.getKey() === currentTypeaheadNode.getKey()) {
+                  focusNode = focusNode.getPreviousSibling();
+                  if (isTextNode(focusNode)) {
+                    focusNodeOffset = focusNode.getTextContent().length;
+                  }
                 }
-              }
-              if (isTextNode(focusNode) && isTextNode(anchorNode)) {
-                selection.setTextNodeRange(
-                  anchorNode,
-                  anchorNodeOffset,
-                  focusNode,
-                  focusNodeOffset,
-                );
+                if (isTextNode(focusNode) && isTextNode(anchorNode)) {
+                  selection.setTextNodeRange(
+                    anchorNode,
+                    anchorNodeOffset,
+                    focusNode,
+                    focusNodeOffset,
+                  );
+                }
               }
             }
+            currentTypeaheadNode.remove();
           }
-          currentTypeaheadNode.remove();
+          typeaheadNodeKey.current = null;
         }
-        typeaheadNodeKey.current = null;
-      }
 
-      function maybeAddOrEditTypeahead() {
-        if (currentTypeaheadNode !== null) {
-          // Edit
-          if (currentTypeaheadNode.getTextContent(true) !== suggestion) {
-            currentTypeaheadNode.setTextContent(suggestion ?? '');
+        function maybeAddOrEditTypeahead() {
+          if (currentTypeaheadNode !== null) {
+            // Edit
+            if (currentTypeaheadNode.getTextContent(true) !== suggestion) {
+              currentTypeaheadNode.setTextContent(suggestion ?? '');
+            }
+            return;
           }
-          return;
-        }
-        // Add
-        const lastParagraph = getRoot().getLastChild();
-        if (isBlockNode(lastParagraph)) {
-          const lastTextNode = lastParagraph.getLastChild();
-          if (isTextNode(lastTextNode)) {
-            const newTypeaheadNode = createTypeaheadNode(suggestion ?? '');
-            lastTextNode.insertAfter(newTypeaheadNode);
-            typeaheadNodeKey.current = newTypeaheadNode.getKey();
+          // Add
+          const lastParagraph = getRoot().getLastChild();
+          if (isBlockNode(lastParagraph)) {
+            const lastTextNode = lastParagraph.getLastChild();
+            if (isTextNode(lastTextNode)) {
+              const newTypeaheadNode = createTypeaheadNode(suggestion ?? '');
+              lastTextNode.insertAfter(newTypeaheadNode);
+              typeaheadNodeKey.current = newTypeaheadNode.getKey();
+            }
           }
         }
-      }
 
-      const selection = getSelection();
-      const anchorNode = selection?.anchor.getNode();
-      const anchorOffset = selection?.anchor.offset;
-      const anchorLength = anchorNode?.getTextContentSize();
-      const isCaretPositionAtEnd =
-        anchorLength != null && anchorOffset === anchorLength;
-      if (suggestion === null || !selectionCollapsed || !isCaretPositionAtEnd) {
-        maybeRemoveTypeahead();
-      } else {
-        maybeAddOrEditTypeahead();
-      }
-    }, {
-      origin: 'without-history'
-    });
+        const selection = getSelection();
+        const anchorNode = selection?.anchor.getNode();
+        const anchorOffset = selection?.anchor.offset;
+        const anchorLength = anchorNode?.getTextContentSize();
+        const isCaretPositionAtEnd =
+          anchorLength != null && anchorOffset === anchorLength;
+        if (
+          suggestion === null ||
+          !selectionCollapsed ||
+          !isCaretPositionAtEnd
+        ) {
+          maybeRemoveTypeahead();
+        } else {
+          maybeAddOrEditTypeahead();
+        }
+      },
+      {
+        tag: 'without-history',
+      },
+    );
   }, [editor, getTypeaheadTextNode, selectionCollapsed, suggestion]);
 
   // Rerender on suggestion change

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -48,7 +48,6 @@ export type EditorUpdateOptions = {
   onUpdate?: () => void,
   tag?: string,
   skipTransforms?: true,
-  origin?: string,
 };
 
 export type EditorThemeClasses = {


### PR DESCRIPTION
I'm confused why Flow didn't throw (and surprisingly it does on WWW)

We need origin for the previously `updateWithoutHistory`