### PR TITLE
Refix focus - revert trigger deferredCallback when no dirty nodes

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineEditor.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor.test.js
@@ -297,6 +297,10 @@ describe('OutlineEditor tests', () => {
 
   it('editor.focus() callback is called', async () => {
     init();
+    await editor.update(() => {
+      const root = getRoot();
+      root.append(createParagraphNode());
+    });
 
     const fn = jest.fn();
     await editor.focus(fn);

--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -637,7 +637,6 @@ function beginUpdate(
     if (editorStateWasCloned) {
       editor._pendingEditorState = null;
     }
-    triggerDeferredUpdateCallbacks(editor);
   }
 }
 


### PR DESCRIPTION
The focus unit test was bad. Focus does nothing when the editor is empty. And we don't want to trigger deferredCallback when no dirty nodes