### PR TITLE
Infinite loop to throw on the transform itself

### DIFF
--- a/packages/outline/src/core/OutlineUtils.js
+++ b/packages/outline/src/core/OutlineUtils.js
@@ -32,6 +32,7 @@ import {
   RootNode,
 } from '.';
 import {
+  errorOnInfiniteTransforms,
   errorOnReadOnly,
   getActiveEditor,
   getActiveEditorState,
@@ -162,6 +163,7 @@ export function isLeafNode(node: ?OutlineNode): boolean %checks {
 
 export function generateKey(node: OutlineNode): NodeKey {
   errorOnReadOnly();
+  errorOnInfiniteTransforms();
   const editor = getActiveEditor();
   const editorState = getActiveEditorState();
   const key = generateRandomKey();
@@ -199,6 +201,7 @@ export function markParentBlocksAsDirty(
 // Never use this function directly! It will break
 // the cloning heuristic. Instead use node.getWritable().
 export function internallyMarkNodeAsDirty(node: OutlineNode): void {
+  errorOnInfiniteTransforms();
   const latest = node.getLatest();
   const parent = latest.__parent;
   const editorState = getActiveEditorState();


### PR DESCRIPTION
The infinite loop is currently great at preventing the page getting frozen but it doesn't give any clues on what's breaking. This PR will make it throw on the transform itself so that we can easily tell one of the transforms that's causing this loop. I believe we could also track the last X somehow but definitely won't be as cheap as this throws solution.

I.e. It's telling me there's something wrong in my ActionsPlugin at line 71, which is correct



![Screen Shot 2021-11-30 at 4 12 22 pm](https://user-images.githubusercontent.com/193447/144085751-541c642d-a13d-4fd8-aac8-6b9fd1235498.png)


