### PR TITLE
Expose useOutlineHistory in sync + allow external state

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -48,6 +48,7 @@ module.name_mapper='^outline-react/useOutlineIsBlank' -> '<PROJECT_ROOT>/package
 module.name_mapper='^outline-react/useOutlineIsTextContentEmpty' -> '<PROJECT_ROOT>/packages/outline-react/src/useOutlineIsTextContentEmpty.js'
 module.name_mapper='^outline-react/useOutlineCanShowPlaceholder' -> '<PROJECT_ROOT>/packages/outline-react/src/useOutlineCanShowPlaceholder.js'
 module.name_mapper='^outline-react/useOutlineCharacterLimit' -> '<PROJECT_ROOT>/packages/outline-react/src/useOutlineCharacterLimit.js'
+module.name_mapper='^outline-react/useOutlineHistory' -> '<PROJECT_ROOT>/packages/outline-react/src/useOutlineHistory.js'
 
 module.name_mapper='^outline-yjs$' -> '<PROJECT_ROOT>/packages/outline-yjs/src/index.js'
 

--- a/packages/outline-playground/craco.config.js
+++ b/packages/outline-playground/craco.config.js
@@ -44,6 +44,7 @@ module.exports = {
         'outline-react/dist/useOutlineCanShowPlaceholder',
       'outline-react/useOutlineCharacterLimit':
         'outline-react/dist/useOutlineCharacterLimit',
+      'outline-react/useOutlineHistory': 'outline-react/dist/useOutlineHistory',
       //Shared
       'shared/environment': 'shared/dist/environment',
       'shared/useLayoutEffect': 'shared/dist/useLayoutEffect',

--- a/packages/outline-react/src/useOutlinePlainText.js
+++ b/packages/outline-react/src/useOutlinePlainText.js
@@ -8,15 +8,19 @@
  */
 
 import type {OutlineEditor} from 'outline';
+import type {HistoryState} from './useOutlineHistory';
 
 import {useCallback} from 'react';
 
 import usePlainTextSetup from './shared/usePlainTextSetup';
-import useOutlineHistory from './shared/useOutlineHistory';
+import {useOutlineHistory} from './useOutlineHistory';
 
-export default function useOutlinePlainText(editor: OutlineEditor): () => void {
+export default function useOutlinePlainText(
+  editor: OutlineEditor,
+  externalHistoryState?: HistoryState,
+): () => void {
   const clearEditor = usePlainTextSetup(editor, true);
-  const clearHistory = useOutlineHistory(editor);
+  const clearHistory = useOutlineHistory(editor, externalHistoryState);
 
   return useCallback(
     (callbackFn?: () => void) => {

--- a/packages/outline-react/src/useOutlineRichText.js
+++ b/packages/outline-react/src/useOutlineRichText.js
@@ -8,15 +8,19 @@
  */
 
 import type {OutlineEditor} from 'outline';
+import type {HistoryState} from './useOutlineHistory';
 
 import {useCallback} from 'react';
 
 import {useRichTextSetup} from './shared/useRichTextSetup';
-import useOutlineHistory from './shared/useOutlineHistory';
+import {useOutlineHistory} from './useOutlineHistory';
 
-export default function useOutlineRichText(editor: OutlineEditor): () => void {
+export default function useOutlineRichText(
+  editor: OutlineEditor,
+  externalHistoryState?: HistoryState,
+): () => void {
   const clearEditor = useRichTextSetup(editor, true);
-  const clearHistory = useOutlineHistory(editor);
+  const clearHistory = useOutlineHistory(editor, externalHistoryState);
 
   return useCallback(
     (callbackFn?: () => void) => {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -310,8 +310,10 @@ outlineReactModules.forEach((outlineReactModule) => {
   // modules already.
   if (
     outlineReactModule === 'OutlineEnv' ||
-    outlineReactModule === 'useOutlineHistory' ||
     outlineReactModule === 'useOutlineDragonSupport' ||
+    outlineReactModule === 'usePlainTextSetup' ||
+    outlineReactModule === 'useRichTextSetup' ||
+    outlineReactModule === 'useYjsCollaboration' ||
     outlineReactModule === 'OutlineReactUtils'
   ) {
     return;


### PR DESCRIPTION
It's desirable for others to use `useOutlineHistory` in their custom hooks – so this PR exposes it in the build so it can be included in our www sync. The hook also allows for an external history state to be passed in, rather than the hook using its own.