### PR TITLE
textcontent listener not to trigger immediately upon registration

### DIFF
--- a/packages/outline-playground/src/plugins/AutocompletePlugin.js
+++ b/packages/outline-playground/src/plugins/AutocompletePlugin.js
@@ -22,10 +22,13 @@ import {
   getRoot,
 } from 'outline';
 import {useEffect, useRef, useState, useCallback, useMemo} from 'react';
+import {textContentCurry} from 'outline/root';
 
 function useTypeahead(editor: OutlineEditor): void {
   const typeaheadNodeKey = useRef<NodeKey | null>(null);
-  const [text, setText] = useState<string>('');
+  const [text, setText] = useState<string>(
+    editor.getEditorState().read(textContentCurry),
+  );
   const [selectionCollapsed, setSelectionCollapsed] = useState<boolean>(false);
   const server = useMemo(() => new TypeaheadServer(), []);
   const suggestion = useTypeaheadSuggestion(text, server.query);

--- a/packages/outline-react/src/useOutlineCharacterLimit.js
+++ b/packages/outline-react/src/useOutlineCharacterLimit.js
@@ -25,6 +25,7 @@ import {
   setSelection,
 } from 'outline';
 import {dfs} from 'outline/nodes';
+import {textContentCurry} from 'outline/root';
 import {useEffect} from 'react';
 
 type OptionalProps = {
@@ -47,7 +48,7 @@ export function useCharacterLimit(
   }, [editor]);
 
   useEffect(() => {
-    let text = '';
+    let text = editor.getEditorState().read(textContentCurry);
     let lastComputedTextLength = 0;
     const textContentListener = editor.addListener(
       'textcontent',

--- a/packages/outline/src/__tests__/unit/OutlineEditor.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor.test.js
@@ -31,7 +31,7 @@ import {
   createTestEditor,
 } from '../utils';
 import {LineBreakNode} from '../../core/OutlineLineBreakNode';
-import {RootNode} from '../../core/OutlineRootNode'; 
+import {RootNode} from '../../core/OutlineRootNode';
 
 describe('OutlineEditor tests', () => {
   let container = null;
@@ -1256,5 +1256,28 @@ describe('OutlineEditor tests', () => {
       // eslint-disable-next-line no-new
       new CustomSecondTextNode();
     });
+  });
+
+  it('textcontent listener', async () => {
+    init();
+    const fn = jest.fn();
+    editor.update(() => {
+      const root = getRoot();
+      const paragraph = createParagraphNode();
+      const textNode = createTextNode('foo');
+      root.append(paragraph);
+      paragraph.append(textNode);
+    });
+
+    editor.addListener('textcontent', (text) => {
+      fn(text);
+    });
+    await editor.update(() => {
+      const root = getRoot();
+      const child = root.getLastDescendant();
+      child.insertAfter(createTextNode('bar'));
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('foobar');
   });
 });

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -24,11 +24,7 @@ import {LineBreakNode} from './OutlineLineBreakNode';
 import {NO_DIRTY_NODES, FULL_RECONCILE} from './OutlineConstants';
 import {flushRootMutations, initMutationObserver} from './OutlineMutations';
 import {RootNode} from './OutlineRootNode';
-import {
-  generateRandomKey,
-  getEditorStateTextContent,
-  markAllNodesAsDirty,
-} from './OutlineUtils';
+import {generateRandomKey, markAllNodesAsDirty} from './OutlineUtils';
 import invariant from 'shared/invariant';
 import type {DOMTransformerMap} from '../helpers/OutlineEventHelpers';
 
@@ -347,16 +343,10 @@ class BaseOutlineEditor {
     listenerSet.add(listener);
 
     const isRootType = type === 'root';
-    const isTextContentType = type === 'textcontent';
     if (isRootType) {
       // $FlowFixMe: TODO refine
       const rootListener: RootListener = listener;
       rootListener(this._rootElement, null);
-    } else if (isTextContentType) {
-      const textContent = getEditorStateTextContent(this._editorState);
-      // $FlowFixMe: TODO refine
-      const textContentListener: TextContentListener = listener;
-      textContentListener(textContent);
     }
     return () => {
       // $FlowFixMe: TODO refine this from the above types


### PR DESCRIPTION
We introduced the `addListener('textcontent', text => {..})` to offer a handy shortcut to subscribe to updates that cause text changes. Alternatively, a combination of update + read EditorState would (potentially - see below) have the exact result `editor.addListener('update', ({editorState}) => editorState.read(textContent)`

However, there’s currently one big difference between these two. The `textcontent` listener triggers upon registration whereas `update` only triggers on updates that happen after the registration. This means that you will always get the current textcontent.

## Why we did this

We wanted to make it as easy to possible to listen to text changes (a common use case) - a one-liner that works for all.

Instead of

```
let content = editor.getEditorState().read(textContent);
editor.addListener('textcontent', text => { content = text });
```

You’d instead just have

```
let content;
editor.addListener('textcontent', text => { content = text });
```

## Problem

This works well with standalone code or code that lives inside effects. However, half of the current use cases on WWW mix React lifecycle with React :

```
function Foo() {
  const [text, setText] = useState('');
  useEffect(() => {
    return editor.addListener('textcontent', text => {
      setState(text);
    });
  }, [editor]);
}
```

This is bad because the text is not guaranteed to be `''` when the component is rendered. And when it’s not `''` the **initial rendered text will be incorrect and will cause the component to be rendered twice immediately**.

The correct version in this case is:

```
function Foo() {
  const [text, setText] = useState(editor.getEditorState().read(textContent));
  useEffect(() => {
    return editor.addListener('textcontent', text => {
      setState(text);
    });
  }, [editor]);
}
```

## Proposal

Given the number of React lifecycle use case I propose dropping `textcontent` to trigger upon registration.

## Trade-offs

(+) It’s easier to fall into the pit of success when mixing `useState` with the `textcontent` listener
(-) It’s more verbose for standalone use cases