### PR TITLE
Add shared history context for playground

### DIFF
--- a/packages/outline-playground/src/App.js
+++ b/packages/outline-playground/src/App.js
@@ -18,6 +18,7 @@ import PlaygroundEditorContext from './context/PlaygroundEditorContext';
 import TreeViewPlugin from './plugins/TreeViewPlugin';
 import TestRecorderPlugin from './plugins/TestRecorderPlugin';
 import TypingPerfPlugin from './plugins/TypingPerfPlugin';
+import {SharedHistoryContext} from './context/SharedHistoryContext';
 
 function setURLParam(param: SettingName, value: null | boolean) {
   const url = new URL(window.location.href);
@@ -63,23 +64,25 @@ function App(): React$Node {
 
   return (
     <PlaygroundEditorContext>
-      <header>
-        <img src="logo.svg" alt="Outline Logo" />
-      </header>
-      <div className="editor-shell">
-        <Editor
-          isCharLimit={isCharLimit}
-          isCharLimitUtf8={isCharLimitUtf8}
-          isAutocomplete={isAutocomplete}
-          isRichText={isRichText}
-          isCollab={isCollab}
-        />
-      </div>
-      {showTreeView && <TreeViewPlugin />}
-      {settingsSwitches}
-      {settingsButton}
-      <TestRecorderPlugin />
-      {measureTypingPerf && <TypingPerfPlugin />}
+      <SharedHistoryContext>
+        <header>
+          <img src="logo.svg" alt="Outline Logo" />
+        </header>
+        <div className="editor-shell">
+          <Editor
+            isCharLimit={isCharLimit}
+            isCharLimitUtf8={isCharLimitUtf8}
+            isAutocomplete={isAutocomplete}
+            isRichText={isRichText}
+            isCollab={isCollab}
+          />
+        </div>
+        {showTreeView && <TreeViewPlugin />}
+        {settingsSwitches}
+        {settingsButton}
+        <TestRecorderPlugin />
+        {measureTypingPerf && <TypingPerfPlugin />}
+      </SharedHistoryContext>
     </PlaygroundEditorContext>
   );
 }

--- a/packages/outline-playground/src/context/SharedHistoryContext.js
+++ b/packages/outline-playground/src/context/SharedHistoryContext.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {HistoryState} from 'outline-react/useOutlineHistory';
+
+import {createEmptyHistoryState} from 'outline-react/useOutlineHistory';
+import * as React from 'react';
+import {createContext, useContext, useMemo} from 'react';
+
+type ContextShape = {
+  historyState?: HistoryState,
+};
+
+const Context: React$Context<ContextShape> = createContext({});
+
+export const SharedHistoryContext = ({
+  children,
+}: {
+  children: React$Node,
+}): React$Node => {
+  const historyContext = useMemo(
+    () => ({historyState: createEmptyHistoryState()}),
+    [],
+  );
+  return <Context.Provider value={historyContext}>{children}</Context.Provider>;
+};
+
+export const useSharedHistoryContext = (): ContextShape => {
+  return useContext(Context);
+};

--- a/packages/outline-playground/src/plugins/PlainTextPlugin.js
+++ b/packages/outline-playground/src/plugins/PlainTextPlugin.js
@@ -16,6 +16,7 @@ import useOutlineDecorators from 'outline-react/useOutlineDecorators';
 import ContentEditable from '../ui/ContentEditable';
 import Placeholder from '../ui/Placeholder';
 import useEditorListeners from '../hooks/useEditorListeners';
+import {useSharedHistoryContext} from '../context/SharedHistoryContext';
 
 function onError(e: Error): void {
   throw e;
@@ -28,7 +29,8 @@ export default function PlainTextPlugin({
 }): React$Node {
   const [editor, state] = useEditorContext(PlaygroundEditorContext);
   const [rootElementRef, showPlaceholder] = useOutlineEditor(editor, onError);
-  const clear = useOutlinePlainText(editor);
+  const {historyState} = useSharedHistoryContext();
+  const clear = useOutlinePlainText(editor, historyState);
   const decorators = useOutlineDecorators(editor);
   const isReadOnly = useEditorListeners(state, clear);
 

--- a/packages/outline-playground/src/plugins/RichTextPlugin.js
+++ b/packages/outline-playground/src/plugins/RichTextPlugin.js
@@ -16,6 +16,7 @@ import useOutlineDecorators from 'outline-react/useOutlineDecorators';
 import ContentEditable from '../ui/ContentEditable';
 import Placeholder from '../ui/Placeholder';
 import useEditorListeners from '../hooks/useEditorListeners';
+import {useSharedHistoryContext} from '../context/SharedHistoryContext';
 
 function onError(e: Error): void {
   throw e;
@@ -28,7 +29,8 @@ export default function RichTextPlugin({
 }): React$Node {
   const [editor, state] = useEditorContext(PlaygroundEditorContext);
   const [rootElementRef, showPlaceholder] = useOutlineEditor(editor, onError);
-  const clear = useOutlineRichText(editor);
+  const {historyState} = useSharedHistoryContext();
+  const clear = useOutlineRichText(editor, historyState);
   const decorators = useOutlineDecorators(editor);
   const isReadOnly = useEditorListeners(state, clear);
 


### PR DESCRIPTION
Adding shared history context so that undo/redo states for nested editors (e.g. images captions) could be stored in the same stack