### PR TITLE
Fix OutlineComposer to take theme from parent if not present

### DIFF
--- a/packages/outline-react/src/OutlineComposer.js
+++ b/packages/outline-react/src/OutlineComposer.js
@@ -30,10 +30,20 @@ export default function OutlineComposer({
   const parentContext = useContext(OutlineComposerContext);
   const composerContext = useMemo(
     () => {
-      const config = {theme, initialEditorState};
+      let composerTheme: EditorThemeClasses;
+      if (theme != null) {
+        composerTheme = theme;
+      } else if (parentContext != null) {
+        const parentTheme = parentContext[1].getTheme();
+        if (parentTheme != null) {
+          composerTheme = parentTheme;
+        }
+      }
+
+      const config = {initialEditorState, theme: composerTheme};
       const context: OutlineComposerContextType = createOutlineComposerContext(
         parentContext,
-        theme,
+        composerTheme,
       );
       const editor = createEditor<OutlineComposerContextType>({
         ...config,

--- a/packages/outline-react/src/OutlineComposerContext.js
+++ b/packages/outline-react/src/OutlineComposerContext.js
@@ -25,7 +25,7 @@ export const OutlineComposerContext: React$Context<?OutlineComposerContextWithEd
 
 export function createOutlineComposerContext(
   parent: ?OutlineComposerContextWithEditor,
-  theme?: EditorThemeClasses,
+  theme: ?EditorThemeClasses,
 ): OutlineComposerContextType {
   let parentContext = null;
   if (parent != null) {


### PR DESCRIPTION
Fix `OutlineComposer` so it attaches the parent theme to the editor in case missing in initialization.

![image](https://user-images.githubusercontent.com/1712525/144651658-ad54c0ab-6152-4cd2-99ca-40e1e6a64a52.png)
