### PR TITLE
Invariant when node.__parent !== parent.__children

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineEditor.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor.test.js
@@ -957,7 +957,7 @@ describe('OutlineEditor tests', () => {
           const writableParagraph: ParagraphNode = getRoot()
             .getFirstChild()
             .getWritable();
-          // Remove prev that are not in next
+          // Remove previous that are not in next
           for (let i = 0; i < previous.length; i++) {
             const previousText = previous[i];
             if (!nextSet.has(previousText)) {
@@ -972,14 +972,14 @@ describe('OutlineEditor tests', () => {
             const nextKey = textToKey.get(nextText);
             let textNode;
             if (nextKey === undefined) {
-              // New node; append at the end
+              // New node; append to the end
               textNode = new TextNode(nextText).toggleUnmergeable();
               textNode.__parent = writableParagraph.__key;
               expect(getNodeByKey(nextKey)).toBe(null);
               textToKey.set(nextText, textNode.__key);
               writableParagraph.__children.push(textNode.__key);
             } else {
-              // Node exists in prev; reorder it
+              // Node exists in previous; reorder it
               textNode = getNodeByKey(nextKey);
               expect(textNode.__text).toBe(nextText);
               writableParagraph.__children.splice(

--- a/packages/outline/src/core/OutlineElementNode.js
+++ b/packages/outline/src/core/OutlineElementNode.js
@@ -274,9 +274,10 @@ export class ElementNode extends OutlineNode {
         const writableParent = oldParent.getWritable();
         const children = writableParent.__children;
         const index = children.indexOf(writableNodeToAppend.__key);
-        if (index > -1) {
-          children.splice(index, 1);
+        if (index === -1) {
+          invariant(false, 'Node is not a child of its parent');
         }
+        children.splice(index, 1);
       }
       // Set child parent to self
       writableNodeToAppend.__parent = writableSelfKey;

--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -75,10 +75,10 @@ export function removeNode(
   const writableParent = parent.getWritable();
   const parentChildren = writableParent.__children;
   const index = parentChildren.indexOf(key);
-  // TODO: we probably need an invariant here
-  if (index > -1) {
-    parentChildren.splice(index, 1);
+  if (index === -1) {
+    invariant(false, 'Node is not a child of its parent');
   }
+  parentChildren.splice(index, 1);
   const writableNodeToRemove = nodeToRemove.getWritable();
   writableNodeToRemove.__parent = null;
 
@@ -607,18 +607,20 @@ export class OutlineNode {
       const writableParent = oldParent.getWritable();
       const children = writableParent.__children;
       const index = children.indexOf(writableReplaceWith.__key);
-      if (index > -1) {
-        children.splice(index, 1);
+      if (index === -1) {
+        invariant(false, 'Node is not a child of its parent');
       }
+      children.splice(index, 1);
     }
     const newParent = this.getParentOrThrow();
     const writableParent = newParent.getWritable();
     const children = writableParent.__children;
     const index = children.indexOf(this.__key);
     const newKey = writableReplaceWith.__key;
-    if (index > -1) {
-      children.splice(index, 0, newKey);
+    if (index === -1) {
+      invariant(false, 'Node is not a child of its parent');
     }
+    children.splice(index, 0, newKey);
     writableReplaceWith.__parent = newParent.__key;
     removeNode(this, false);
     const flags = writableReplaceWith.__flags;
@@ -655,20 +657,20 @@ export class OutlineNode {
       const writableParent = oldParent.getWritable();
       const children = writableParent.__children;
       const index = children.indexOf(writableNodeToInsert.__key);
-      if (index > -1) {
-        children.splice(index, 1);
+      if (index === -1) {
+        invariant(false, 'Node is not a child of its parent');
       }
+      children.splice(index, 1);
     }
     const writableParent = this.getParentOrThrow().getWritable();
     const insertKey = writableNodeToInsert.__key;
     writableNodeToInsert.__parent = writableSelf.__parent;
     const children = writableParent.__children;
     const index = children.indexOf(writableSelf.__key);
-    if (index > -1) {
-      children.splice(index + 1, 0, insertKey);
-    } else {
-      children.push(insertKey);
+    if (index === -1) {
+      invariant(false, 'Node is not a child of its parent');
     }
+    children.splice(index + 1, 0, insertKey);
     const flags = writableNodeToInsert.__flags;
     // Handle direction if node is directionless
     if (flags & IS_DIRECTIONLESS) {
@@ -693,20 +695,20 @@ export class OutlineNode {
       const writableParent = oldParent.getWritable();
       const children = writableParent.__children;
       const index = children.indexOf(writableNodeToInsert.__key);
-      if (index > -1) {
-        children.splice(index, 1);
+      if (index === -1) {
+        invariant(false, 'Node is not a child of its parent');
       }
+      children.splice(index, 1);
     }
     const writableParent = this.getParentOrThrow().getWritable();
     const insertKey = writableNodeToInsert.__key;
     writableNodeToInsert.__parent = writableSelf.__parent;
     const children = writableParent.__children;
     const index = children.indexOf(writableSelf.__key);
-    if (index > -1) {
-      children.splice(index, 0, insertKey);
-    } else {
-      children.push(insertKey);
+    if (index === -1) {
+      invariant(false, 'Node is not a child of its parent');
     }
+    children.splice(index, 0, insertKey);
     const flags = writableNodeToInsert.__flags;
     // Handle direction if node is directionless
     if (flags & IS_DIRECTIONLESS) {

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -585,10 +585,11 @@ export class TextNode extends OutlineNode {
     const writableParentChildren = writableParent.__children;
     const insertionIndex = writableParentChildren.indexOf(key);
     const splitNodesKeys = splitNodes.map((splitNode) => splitNode.__key);
-    writableParentChildren.splice(insertionIndex, 1, ...splitNodesKeys);
-
     if (hasReplacedSelf) {
+      writableParentChildren.splice(insertionIndex, 0, ...splitNodesKeys);
       this.remove();
+    } else {
+      writableParentChildren.splice(insertionIndex, 1, ...splitNodesKeys);
     }
 
     if (selection !== null) {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -55,5 +55,9 @@
   "53": "insertNodes: cloned parent clone is not an element",
   "54": "rootNode.append: Only element nodes can be appended to the root node",
   "55": "Expected node %s to have a parent element.",
-  "56": "Expected node %s to have a top parent element."
+  "56": "Expected node %s to have a top parent element.",
+  "57": "OutlineComposerContext.useOutlineComposerContext: cannot find a OutlineComposerContext",
+  "58": "mergeWithSibling: sibling must be a previous or next sibling",
+  "59": "Expected node %s to have a first child.",
+  "60": "Node is not a child of its parent"
 }


### PR DESCRIPTION
When doing the basic operations add/remove/replace/insertBefore/insertAfter these are prerequisites that should be taken for granted