### PR TITLE
Remove __flags and move properties to TextNode

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -63,7 +63,7 @@ module.name_mapper='^outline-react/HashtagsPlugin' -> '<PROJECT_ROOT>/packages/o
 
 module.name_mapper='^outline-yjs$' -> '<PROJECT_ROOT>/packages/outline-yjs/src/index.js'
 
-module.name_mapper='^shared/isImmutableOrInert' -> '<PROJECT_ROOT>/packages/shared/src/isImmutableOrInert.js'
+module.name_mapper='^shared/isTokenOrInert' -> '<PROJECT_ROOT>/packages/shared/src/isTokenOrInert.js'
 module.name_mapper='^shared/invariant' -> '<PROJECT_ROOT>/packages/shared/src/invariant.js'
 module.name_mapper='^shared/getDOMTextNodeFromElement' -> '<PROJECT_ROOT>/packages/shared/src/getDOMTextNodeFromElement.js'
 module.name_mapper='^shared/environment' -> '<PROJECT_ROOT>/packages/shared/src/environment.js'

--- a/flow-typed/yjs.js
+++ b/flow-typed/yjs.js
@@ -21,7 +21,7 @@ declare module 'yjs' {
   }
 
   declare export class XmlText {
-    doc: null | YDoc,
+    doc: null | YDoc;
     parent: null | XmlText | XmlElement;
     getAttributes(): {...};
     getAttribute(string): string | Object | void;
@@ -71,7 +71,7 @@ declare module 'yjs' {
 
   declare type Operation = {
     insert: string | {...},
-    attributes: {__type: string, __flags: number, ...},
+    attributes: {__type: string, ...},
   };
 
   declare type Delta = Array<Operation>;
@@ -672,10 +672,7 @@ declare module 'yjs' {
      * captureTimeout (defaults to 500ms). Set it to 0 to capture each change
      * individually.
      */
-    constructor(
-      scope: XmlText,
-      options?: YUndoManagerOptions,
-    ): this;
+    constructor(scope: XmlText, options?: YUndoManagerOptions): this;
 
     /**
      * Undo the last operation on the UndoManager stack. The reverse operation

--- a/jest.config.js
+++ b/jest.config.js
@@ -63,8 +63,8 @@ module.exports = {
           '<rootDir>/packages/outline/src/helpers/OutlineRootHelpers.js',
         '^shared/getDOMTextNodeFromElement$':
           '<rootDir>/packages/shared/src/getDOMTextNodeFromElement.js',
-        '^shared/isImmutableOrInert$':
-          '<rootDir>/packages/shared/src/isImmutableOrInert.js',
+        '^shared/isTokenOrInert$':
+          '<rootDir>/packages/shared/src/isTokenOrInert.js',
         '^shared/invariant$': '<rootDir>/packages/shared/src/invariant.js',
         '^shared/environment$': '<rootDir>/packages/shared/src/environment.js',
         '^shared/getPossibleDecoratorNode$':

--- a/packages/outline-playground/src/nodes/EmojiNode.js
+++ b/packages/outline-playground/src/nodes/EmojiNode.js
@@ -42,5 +42,5 @@ export function $createEmojiNode(
   className: string,
   emojiText: string,
 ): EmojiNode {
-  return new EmojiNode(className, emojiText).makeImmutable();
+  return new EmojiNode(className, emojiText).setMode('token');
 }

--- a/packages/outline-playground/src/nodes/KeywordNode.js
+++ b/packages/outline-playground/src/nodes/KeywordNode.js
@@ -29,7 +29,7 @@ export class KeywordNode extends TextNode {
 }
 
 export function $createKeywordNode(keyword: string): KeywordNode {
-  return new KeywordNode(keyword).makeSegmented();
+  return new KeywordNode(keyword).setMode('segmented');
 }
 
 export function isKeywordNode(node: null | OutlineNode): boolean %checks {

--- a/packages/outline-playground/src/nodes/MentionNode.js
+++ b/packages/outline-playground/src/nodes/MentionNode.js
@@ -38,5 +38,7 @@ export class MentionNode extends TextNode {
 }
 
 export function $createMentionNode(mentionName: string): MentionNode {
-  return new MentionNode(mentionName).makeSegmented().makeDirectionless();
+  const mentionNode = new MentionNode(mentionName);
+  mentionNode.setMode('segmented').toggleDirectionless();
+  return mentionNode;
 }

--- a/packages/outline-playground/src/plugins/AutocompletePlugin.js
+++ b/packages/outline-playground/src/plugins/AutocompletePlugin.js
@@ -219,7 +219,7 @@ class TypeaheadNode extends TextNode {
 }
 
 function createTypeaheadNode(text: string): TextNode {
-  return new TypeaheadNode(text).makeInert();
+  return new TypeaheadNode(text).setMode('inert');
 }
 
 function useTypeaheadSuggestion(

--- a/packages/outline-react/src/OutlineTreeView.js
+++ b/packages/outline-react/src/OutlineTreeView.js
@@ -272,7 +272,7 @@ function printNode(node) {
 const LABEL_PREDICATES = [
   (node) => node.hasFormat('bold') && 'Bold',
   (node) => node.hasFormat('code') && 'Code',
-  (node) => node.isImmutable() && 'Immutable',
+  (node) => node.isToken() && 'Token',
   (node) => node.hasFormat('italic') && 'Italic',
   (node) => node.isSegmented() && 'Segmented',
   (node) => node.hasFormat('strikethrough') && 'Strikethrough',

--- a/packages/outline-react/src/useOutlineHistory.js
+++ b/packages/outline-react/src/useOutlineHistory.js
@@ -107,7 +107,7 @@ function getMergeAction(
       prevDirtyNode !== undefined &&
       isTextNode(prevDirtyNode) &&
       isTextNode(nextDirtyNode) &&
-      prevDirtyNode.__flags === nextDirtyNode.__flags
+      prevDirtyNode.__mode === nextDirtyNode.__mode
     ) {
       const prevText = prevDirtyNode.__text;
       const nextText = nextDirtyNode.__text;

--- a/packages/outline-yjs/src/index.js
+++ b/packages/outline-yjs/src/index.js
@@ -43,7 +43,7 @@ declare class Provider {
 
 export type Operation = {
   insert: string | {...},
-  attributes: {__type: string, __flags: number, ...},
+  attributes: {__type: string, ...},
 };
 
 export type Delta = Array<Operation>;

--- a/packages/outline/src/__tests__/unit/OutlineCodeNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineCodeNode.test.js
@@ -23,7 +23,6 @@ describe('OutlineCodeNode tests', () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const codeNode = $createCodeNode();
-        expect(codeNode.getFlags()).toBe(0);
         expect(codeNode.getType()).toBe('code');
         expect(codeNode.getTextContent()).toBe('');
       });
@@ -99,7 +98,6 @@ describe('OutlineCodeNode tests', () => {
         const codeNode = $createCodeNode();
         const createdCodeNode = $createCodeNode();
         expect(codeNode.__type).toEqual(createdCodeNode.__type);
-        expect(codeNode.__flags).toEqual(createdCodeNode.__flags);
         expect(codeNode.__parent).toEqual(createdCodeNode.__parent);
         expect(codeNode.__src).toEqual(createdCodeNode.__src);
         expect(codeNode.__altText).toEqual(createdCodeNode.__altText);

--- a/packages/outline/src/__tests__/unit/OutlineEditor.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditor.test.js
@@ -778,7 +778,6 @@ describe('OutlineEditor tests', () => {
           __cachedText: '',
           __children: [paragraph.getKey()],
           __dir: null,
-          __flags: 0,
           __format: 0,
           __indent: 0,
           __key: 'root',
@@ -788,7 +787,6 @@ describe('OutlineEditor tests', () => {
         expect(paragraph).toEqual({
           __children: [],
           __dir: null,
-          __flags: 0,
           __format: 0,
           __indent: 0,
           __key: paragraph.getKey(),
@@ -837,7 +835,6 @@ describe('OutlineEditor tests', () => {
         __cachedText: null,
         __children: [paragraphKey],
         __dir: 'ltr',
-        __flags: 0,
         __format: 0,
         __indent: 0,
         __key: 'root',
@@ -847,7 +844,6 @@ describe('OutlineEditor tests', () => {
       expect(parsedParagraph).toEqual({
         __children: [textKey],
         __dir: 'ltr',
-        __flags: 0,
         __format: 0,
         __indent: 0,
         __key: paragraphKey,
@@ -855,8 +851,9 @@ describe('OutlineEditor tests', () => {
         __type: 'paragraph',
       });
       expect(parsedText).toEqual({
+        __mode: 0,
+        __detail: 0,
         __text: 'Hello world',
-        __flags: 0,
         __format: 0,
         __key: textKey,
         __parent: paragraphKey,

--- a/packages/outline/src/__tests__/unit/OutlineEditorState.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineEditorState.test.js
@@ -47,7 +47,6 @@ describe('OutlineEditorState tests', () => {
         __indent: 0,
         __children: ['1'],
         __dir: 'ltr',
-        __flags: 0,
         __key: 'root',
         __parent: null,
         __type: 'root',
@@ -57,15 +56,15 @@ describe('OutlineEditorState tests', () => {
         __format: 0,
         __indent: 0,
         __dir: 'ltr',
-        __flags: 0,
         __key: '1',
         __parent: 'root',
         __type: 'paragraph',
       });
       expect(text).toEqual({
+        __detail: 0,
+        __mode: 0,
         __text: 'foo',
         __format: 0,
-        __flags: 0,
         __key: '2',
         __parent: '1',
         __style: '',
@@ -83,7 +82,7 @@ describe('OutlineEditorState tests', () => {
         $getRoot().append(paragraph);
       });
       expect(JSON.stringify(editor.getEditorState().toJSON())).toEqual(
-        `{\"_nodeMap\":[[\"root\",{\"__type\":\"root\",\"__flags\":0,\"__key\":\"root\",\"__parent\":null,\"__children\":[\"1\"],\"__format\":0,\"__indent\":0,\"__dir\":\"ltr\",\"__cachedText\":\"Hello world\"}],[\"1\",{\"__type\":\"paragraph\",\"__flags\":0,\"__key\":\"1\",\"__parent\":\"root\",\"__children\":[\"2\"],\"__format\":0,\"__indent\":0,\"__dir\":\"ltr\"}],[\"2\",{\"__type\":\"text\",\"__flags\":0,\"__key\":\"2\",\"__parent\":\"1\",\"__text\":\"Hello world\",\"__format\":0,\"__style\":\"\"}]],\"_selection\":{\"anchor\":{\"key\":\"2\",\"offset\":6,\"type\":\"text\"},\"focus\":{\"key\":\"2\",\"offset\":11,\"type\":\"text\"}}}`,
+        `{\"_nodeMap\":[[\"root\",{\"__type\":\"root\",\"__key\":\"root\",\"__parent\":null,\"__children\":[\"1\"],\"__format\":0,\"__indent\":0,\"__dir\":\"ltr\",\"__cachedText\":\"Hello world\"}],[\"1\",{\"__type\":\"paragraph\",\"__key\":\"1\",\"__parent\":\"root\",\"__children\":[\"2\"],\"__format\":0,\"__indent\":0,\"__dir\":\"ltr\"}],[\"2\",{\"__type\":\"text\",\"__key\":\"2\",\"__parent\":\"1\",\"__text\":\"Hello world\",\"__format\":0,\"__style\":\"\",\"__mode\":0,\"__detail\":0}]],\"_selection\":{\"anchor\":{\"key\":\"2\",\"offset\":6,\"type\":\"text\"},\"focus\":{\"key\":\"2\",\"offset\":11,\"type\":\"text\"}}}`,
       );
     });
 
@@ -109,7 +108,6 @@ describe('OutlineEditorState tests', () => {
               __cachedText: '',
               __dir: null,
               __children: [],
-              __flags: 0,
               __format: 0,
               __indent: 0,
               __key: 'root',

--- a/packages/outline/src/__tests__/unit/OutlineElementNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineElementNode.test.js
@@ -6,8 +6,6 @@
  *
  */
 
-import {IS_BOLD} from '../../core/OutlineConstants';
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
@@ -69,7 +67,7 @@ describe('OutlineElementNode tests', () => {
       const text = $createTextNode('Foo');
       const text2 = $createTextNode('Bar');
       // Prevent text nodes from combining.
-      text2.setFlags(IS_BOLD);
+      text2.setMode('segmented');
       const text3 = $createTextNode('Baz');
 
       // Some operations require a selection to exist, hence
@@ -195,7 +193,7 @@ describe('OutlineElementNode tests', () => {
         text.select(0, 0);
         const text2 = $createTextNode('Bar');
         const text3 = $createTextNode('Baz');
-        text3.makeInert();
+        text3.setMode('inert');
         const text4 = $createTextNode('Qux');
 
         block.append(text, innerBlock, text4);
@@ -206,7 +204,7 @@ describe('OutlineElementNode tests', () => {
 
         const innerInnerBlock = $createTestElementNode();
         const text5 = $createTextNode('More');
-        text5.makeInert();
+        text5.setMode('inert');
         const text6 = $createTextNode('Stuff');
         innerInnerBlock.append(text5, text6);
         innerBlock.append(innerInnerBlock);

--- a/packages/outline/src/__tests__/unit/OutlineHeadingNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineHeadingNode.test.js
@@ -33,7 +33,6 @@ describe('OutlineHeadingNode tests', () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const headingNode = new HeadingNode('h1');
-        expect(headingNode.getFlags()).toBe(0);
         expect(headingNode.getType()).toBe('heading');
         expect(headingNode.getTag()).toBe('h1');
         expect(headingNode.getTextContent()).toBe('');
@@ -103,7 +102,6 @@ describe('OutlineHeadingNode tests', () => {
         const headingNode = new HeadingNode();
         const createdHeadingNode = $createHeadingNode();
         expect(headingNode.__type).toEqual(createdHeadingNode.__type);
-        expect(headingNode.__flags).toEqual(createdHeadingNode.__flags);
         expect(headingNode.__parent).toEqual(createdHeadingNode.__parent);
         expect(headingNode.__key).not.toEqual(createdHeadingNode.__key);
       });

--- a/packages/outline/src/__tests__/unit/OutlineLinkNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineLinkNode.test.js
@@ -30,7 +30,6 @@ describe('OutlineLinkNode tests', () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const linkNode = new LinkNode('/');
-        expect(linkNode.__flags).toBe(0);
         expect(linkNode.__type).toBe('link');
         expect(linkNode.__url).toBe('/');
       });
@@ -121,7 +120,6 @@ describe('OutlineLinkNode tests', () => {
         const linkNode = new LinkNode('https://example.com/foo');
         const createdLinkNode = $createLinkNode('https://example.com/foo');
         expect(linkNode.__type).toEqual(createdLinkNode.__type);
-        expect(linkNode.__flags).toEqual(createdLinkNode.__flags);
         expect(linkNode.__parent).toEqual(createdLinkNode.__parent);
         expect(linkNode.__url).toEqual(createdLinkNode.__url);
         expect(linkNode.__key).not.toEqual(createdLinkNode.__key);

--- a/packages/outline/src/__tests__/unit/OutlineListItemNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineListItemNode.test.js
@@ -30,7 +30,6 @@ describe('OutlineListItemNode tests', () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const listItemNode = new ListItemNode();
-        expect(listItemNode.getFlags()).toBe(0);
         expect(listItemNode.getType()).toBe('listitem');
         expect(listItemNode.getTextContent()).toBe('');
       });
@@ -364,7 +363,6 @@ describe('OutlineListItemNode tests', () => {
         const listItemNode = new ListItemNode();
         const createdListItemNode = $createListItemNode();
         expect(listItemNode.__type).toEqual(createdListItemNode.__type);
-        expect(listItemNode.__flags).toEqual(createdListItemNode.__flags);
         expect(listItemNode.__parent).toEqual(createdListItemNode.__parent);
         expect(listItemNode.__key).not.toEqual(createdListItemNode.__key);
       });

--- a/packages/outline/src/__tests__/unit/OutlineListNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineListNode.test.js
@@ -28,7 +28,6 @@ describe('OutlineListNode tests', () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const listNode = $createListNode('ul', 1);
-        expect(listNode.getFlags()).toBe(0);
         expect(listNode.getType()).toBe('list');
         expect(listNode.getTag()).toBe('ul');
         expect(listNode.getTextContent()).toBe('');
@@ -135,7 +134,6 @@ describe('OutlineListNode tests', () => {
         const listNode = $createListNode('ul', 1);
         const createdListNode = $createListNode('ul');
         expect(listNode.__type).toEqual(createdListNode.__type);
-        expect(listNode.__flags).toEqual(createdListNode.__flags);
         expect(listNode.__parent).toEqual(createdListNode.__parent);
         expect(listNode.__tag).toEqual(createdListNode.__tag);
         expect(listNode.__key).not.toEqual(createdListNode.__key);

--- a/packages/outline/src/__tests__/unit/OutlineParagraphNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineParagraphNode.test.js
@@ -26,7 +26,6 @@ describe('OutlineParagraphNode tests', () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const paragraphNode = new ParagraphNode();
-        expect(paragraphNode.getFlags()).toBe(0);
         expect(paragraphNode.getType()).toBe('paragraph');
         expect(paragraphNode.getTextContent()).toBe('');
       });
@@ -92,7 +91,6 @@ describe('OutlineParagraphNode tests', () => {
         const paragraphNode = new ParagraphNode();
         const createdParagraphNode = $createParagraphNode();
         expect(paragraphNode.__type).toEqual(createdParagraphNode.__type);
-        expect(paragraphNode.__flags).toEqual(createdParagraphNode.__flags);
         expect(paragraphNode.__parent).toEqual(createdParagraphNode.__parent);
         expect(paragraphNode.__key).not.toEqual(createdParagraphNode.__key);
       });

--- a/packages/outline/src/__tests__/unit/OutlineQuoteNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineQuoteNode.test.js
@@ -23,7 +23,6 @@ describe('OutlineQuoteNode tests', () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const quoteNode = $createQuoteNode();
-        expect(quoteNode.getFlags()).toBe(0);
         expect(quoteNode.getType()).toBe('quote');
         expect(quoteNode.getTextContent()).toBe('');
       });
@@ -95,7 +94,6 @@ describe('OutlineQuoteNode tests', () => {
         const quoteNode = $createQuoteNode();
         const createdQuoteNode = $createQuoteNode();
         expect(quoteNode.__type).toEqual(createdQuoteNode.__type);
-        expect(quoteNode.__flags).toEqual(createdQuoteNode.__flags);
         expect(quoteNode.__parent).toEqual(createdQuoteNode.__parent);
         expect(quoteNode.__key).not.toEqual(createdQuoteNode.__key);
       });

--- a/packages/outline/src/__tests__/unit/OutlineRootNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineRootNode.test.js
@@ -25,7 +25,6 @@ describe('OutlineRootNode tests', () => {
       const {editor} = testEnv;
       await editor.update(() => {
         expect(rootNode).toStrictEqual(createRootNode());
-        expect(rootNode.getFlags()).toBe(0);
         expect(rootNode.getType()).toBe('root');
         expect(rootNode.getTextContent()).toBe('');
       });

--- a/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
@@ -133,7 +133,7 @@ describe('OutlineTextNode tests', () => {
       let nodeKey;
 
       await update((state) => {
-        const textNode = $createTextNode('Inert text').makeInert();
+        const textNode = $createTextNode('Inert text').setMode('inert');
         nodeKey = textNode.getKey();
         expect(textNode.getTextContent()).toBe('');
         expect(textNode.getTextContent(true)).toBe('Inert text');
@@ -179,22 +179,10 @@ describe('OutlineTextNode tests', () => {
       });
     });
 
-    test('immutable nodes', async () => {
-      await update(() => {
-        const textNode = $createTextNode('My new text node');
-        textNode.makeImmutable();
-
-        expect(() => {
-          textNode.setTextContent('My newer text node');
-        }).toThrow();
-        expect(textNode.getTextContent()).toBe('My new text node');
-      });
-    });
-
     test('inert nodes', async () => {
       await update(() => {
         const textNode = $createTextNode('My inert text node');
-        textNode.makeInert();
+        textNode.setMode('inert');
 
         expect(textNode.getTextContent()).toBe('');
         expect(textNode.getTextContent(true)).toBe('My inert text node');
@@ -370,17 +358,6 @@ describe('OutlineTextNode tests', () => {
   });
 
   describe('splitText()', () => {
-    test('throw when immutable', async () => {
-      await update(() => {
-        const textNode = $createTextNode('Hello World');
-        textNode.makeImmutable();
-
-        expect(() => {
-          textNode.splitText(3);
-        }).toThrow();
-      });
-    });
-
     test('convert segmented node into plain text', async () => {
       await update((state) => {
         const segmentedNode = $createTestSegmentedNode('Hello World');
@@ -654,12 +631,12 @@ describe('OutlineTextNode tests', () => {
         'different tags',
         {
           text: 'My text node',
-          flags: 0,
+          mode: 'normal',
           format: IS_BOLD,
         },
         {
           text: 'My text node',
-          flags: 0,
+          mode: 'normal',
           format: IS_ITALIC,
         },
         {
@@ -671,12 +648,12 @@ describe('OutlineTextNode tests', () => {
         'no change in tags',
         {
           text: 'My text node',
-          flags: 0,
+          mode: 'normal',
           format: IS_BOLD,
         },
         {
           text: 'My text node',
-          flags: 0,
+          mode: 'normal',
           format: IS_BOLD,
         },
         {
@@ -688,12 +665,12 @@ describe('OutlineTextNode tests', () => {
         'change in text',
         {
           text: 'My text node',
-          flags: 0,
+          mode: 'normal',
           format: IS_BOLD,
         },
         {
           text: 'My new text node',
-          flags: 0,
+          mode: 'normal',
           format: IS_BOLD,
         },
         {
@@ -706,12 +683,12 @@ describe('OutlineTextNode tests', () => {
         'removing code block',
         {
           text: 'My text node',
-          flags: 0,
+          mode: 'normal',
           format: IS_CODE | IS_BOLD,
         },
         {
           text: 'My new text node',
-          flags: 0,
+          mode: 'normal',
           format: IS_BOLD,
         },
         {
@@ -723,18 +700,18 @@ describe('OutlineTextNode tests', () => {
       '%s',
       async (
         _desc,
-        {text: prevText, flags: prevFlags, format: prevFormat},
-        {text: nextText, flags: nextFlags, format: nextFormat},
+        {text: prevText, mode: prevMode, format: prevFormat},
+        {text: nextText, mode: nextMode, format: nextFormat},
         {result, expectedHTML},
       ) => {
         await update(() => {
           const prevTextNode = $createTextNode(prevText);
-          prevTextNode.setFlags(prevFlags);
+          prevTextNode.setMode(prevMode);
           prevTextNode.setFormat(prevFormat);
           const element = prevTextNode.createDOM(editorConfig);
 
           const textNode = $createTextNode(nextText);
-          textNode.setFlags(nextFlags);
+          textNode.setMode(nextMode);
           textNode.setFormat(nextFormat);
 
           expect(textNode.updateDOM(prevTextNode, element, editorConfig)).toBe(

--- a/packages/outline/src/__tests__/unit/OutlineUtils.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineUtils.test.js
@@ -15,7 +15,7 @@ import {
   isArray,
   isSelectionWithinEditor,
   getTextDirection,
-  isImmutableOrInertOrSegmented,
+  isTokenOrInertOrSegmented,
 } from '../../core/OutlineUtils';
 
 import {initializeUnitTest} from '../utils';
@@ -149,20 +149,20 @@ describe('OutlineUtils tests', () => {
       expect(getTextDirection(`\uFEFC`)).toBe('rtl');
     });
 
-    test('isImmutableOrInertOrSegmented()', async () => {
+    test('isTokenOrInertOrSegmented()', async () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const node = $createTextNode('foo');
-        expect(isImmutableOrInertOrSegmented(node)).toBe(false);
+        expect(isTokenOrInertOrSegmented(node)).toBe(false);
 
-        const immutableNode = $createTextNode().makeImmutable();
-        expect(isImmutableOrInertOrSegmented(immutableNode)).toBe(true);
+        const tokenNode = $createTextNode().setMode('token');
+        expect(isTokenOrInertOrSegmented(tokenNode)).toBe(true);
 
-        const inertNode = $createTextNode('foo').makeInert();
-        expect(isImmutableOrInertOrSegmented(inertNode)).toBe(true);
+        const inertNode = $createTextNode('foo').setMode('inert');
+        expect(isTokenOrInertOrSegmented(inertNode)).toBe(true);
 
-        const segmentedNode = $createTextNode('foo').makeSegmented();
-        expect(isImmutableOrInertOrSegmented(segmentedNode)).toBe(true);
+        const segmentedNode = $createTextNode('foo').setMode('segmented');
+        expect(isTokenOrInertOrSegmented(segmentedNode)).toBe(true);
       });
     });
 

--- a/packages/outline/src/__tests__/utils/index.js
+++ b/packages/outline/src/__tests__/utils/index.js
@@ -128,7 +128,7 @@ export class TestSegmentedNode extends TextNode {
 }
 
 export function $createTestSegmentedNode(text): TestSegmentedNode {
-  return new TestSegmentedNode(text).makeSegmented();
+  return new TestSegmentedNode(text).setMode('segmented');
 }
 
 export class TestExcludeFromCopyElementNode extends ElementNode {

--- a/packages/outline/src/core/OutlineConstants.js
+++ b/packages/outline/src/core/OutlineConstants.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import type {TextFormatType} from './OutlineTextNode';
+import type {TextFormatType, TextModeType} from './OutlineTextNode';
 import type {ElementFormatType} from './OutlineElementNode';
 
 // Reconciling
@@ -15,14 +15,11 @@ export const NO_DIRTY_NODES = 0;
 export const HAS_DIRTY_NODES = 1;
 export const FULL_RECONCILE = 2;
 
-// Nodes
-export const IS_IMMUTABLE = 1;
-export const IS_SEGMENTED = 1 << 1;
-export const IS_INERT = 1 << 2;
-export const IS_DIRECTIONLESS = 1 << 3;
-
-// Text nodes
-export const IS_UNMERGEABLE = 1 << 4;
+// Text node modes
+export const IS_NORMAL = 0;
+export const IS_TOKEN = 1;
+export const IS_SEGMENTED = 2;
+export const IS_INERT = 3;
 
 // Text node formatting
 export const IS_BOLD = 1;
@@ -32,6 +29,10 @@ export const IS_UNDERLINE = 1 << 3;
 export const IS_CODE = 1 << 4;
 export const IS_SUBSCRIPT = 1 << 5;
 export const IS_SUPERSCRIPT = 1 << 6;
+
+// Text node details
+export const IS_DIRECTIONLESS = 1;
+export const IS_UNMERGEABLE = 1 << 1;
 
 // Element node formatting
 export const IS_ALIGN_LEFT = 1;
@@ -57,6 +58,8 @@ export const TEXT_TYPE_TO_FORMAT: {[TextFormatType]: number} = {
   strikethrough: IS_STRIKETHROUGH,
   italic: IS_ITALIC,
   code: IS_CODE,
+  subscript: IS_SUBSCRIPT,
+  superscript: IS_SUPERSCRIPT,
 };
 
 export const ELEMENT_TYPE_TO_FORMAT: {[ElementFormatType]: number} = {
@@ -64,4 +67,11 @@ export const ELEMENT_TYPE_TO_FORMAT: {[ElementFormatType]: number} = {
   right: IS_ALIGN_RIGHT,
   center: IS_ALIGN_CENTER,
   justify: IS_ALIGN_JUSTIFY,
+};
+
+export const TEXT_MODE_TO_TYPE: {[TextModeType]: 0 | 1 | 2 | 3} = {
+  normal: IS_NORMAL,
+  token: IS_TOKEN,
+  segmented: IS_SEGMENTED,
+  inert: IS_INERT,
 };

--- a/packages/outline/src/core/OutlineDecoratorNode.js
+++ b/packages/outline/src/core/OutlineDecoratorNode.js
@@ -14,14 +14,12 @@ import type {OutlineRef} from './OutlineReference';
 
 import {OutlineNode} from './OutlineNode';
 import invariant from 'shared/invariant';
-import {IS_IMMUTABLE} from './OutlineConstants';
 
 export class DecoratorNode extends OutlineNode {
   __ref: null | OutlineRef;
 
   constructor(ref?: null | OutlineRef, key?: NodeKey) {
     super(key);
-    this.__flags = IS_IMMUTABLE;
     this.__ref = ref || null;
 
     // ensure custom nodes implement required methods

--- a/packages/outline/src/core/OutlineElementNode.js
+++ b/packages/outline/src/core/OutlineElementNode.js
@@ -168,12 +168,6 @@ export class ElementNode extends OutlineNode {
     return $getNodeByKey(key);
   }
   getTextContent(includeInert?: boolean, includeDirectionless?: false): string {
-    if (
-      (!includeInert && this.isInert()) ||
-      (includeDirectionless === false && this.isDirectionless())
-    ) {
-      return '';
-    }
     let textContent = '';
     const children = this.getChildren();
     const childrenLength = children.length;

--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -32,12 +32,6 @@ import {
 } from './OutlineUtils';
 import invariant from 'shared/invariant';
 import {
-  IS_DIRECTIONLESS,
-  IS_IMMUTABLE,
-  IS_INERT,
-  IS_SEGMENTED,
-} from './OutlineConstants';
-import {
   $getSelection,
   moveSelectionPointToEnd,
   updateElementSelectionOnCreateDeleteNode,
@@ -98,7 +92,6 @@ export type NodeKey = string;
 
 export class OutlineNode {
   __type: string;
-  __flags: number;
   __key: NodeKey;
   __parent: null | NodeKey;
 
@@ -124,7 +117,6 @@ export class OutlineNode {
 
   constructor(key?: NodeKey) {
     this.__type = this.constructor.getType();
-    this.__flags = 0;
     this.__key = key || generateKey(this);
     this.__parent = null;
 
@@ -189,10 +181,6 @@ export class OutlineNode {
       return false;
     }
     return isSelected;
-  }
-  getFlags(): number {
-    const self = this.getLatest();
-    return self.__flags;
   }
   getKey(): NodeKey {
     // Key is stable between copies
@@ -450,22 +438,6 @@ export class OutlineNode {
     }
     return nodes;
   }
-  // TODO remove this and move to TextNode
-  isImmutable(): boolean {
-    return (this.getLatest().__flags & IS_IMMUTABLE) !== 0;
-  }
-  // TODO remove this and move to TextNode
-  isSegmented(): boolean {
-    return (this.getLatest().__flags & IS_SEGMENTED) !== 0;
-  }
-  // TODO remove this and move to TextNode
-  isInert(): boolean {
-    return (this.getLatest().__flags & IS_INERT) !== 0;
-  }
-  // TODO remove this and move to TextNode
-  isDirectionless(): boolean {
-    return (this.getLatest().__flags & IS_DIRECTIONLESS) !== 0;
-  }
   isDirty(): boolean {
     const editor = getActiveEditor();
     const dirtyLeaves = editor._dirtyLeaves;
@@ -504,7 +476,6 @@ export class OutlineNode {
     const constructor = latestNode.constructor;
     const mutableNode = constructor.clone(latestNode);
     mutableNode.__parent = parent;
-    mutableNode.__flags = latestNode.__flags;
     if (isElementNode(mutableNode)) {
       mutableNode.__children = Array.from(latestNode.__children);
       mutableNode.__indent = latestNode.__indent;
@@ -513,6 +484,8 @@ export class OutlineNode {
     } else if (isTextNode(mutableNode)) {
       mutableNode.__format = latestNode.__format;
       mutableNode.__style = latestNode.__style;
+      mutableNode.__mode = latestNode.__mode;
+      mutableNode.__detail = latestNode.__detail;
     } else if (isDecoratorNode(mutableNode)) {
       mutableNode.__ref = latestNode.__ref;
     }
@@ -556,39 +529,6 @@ export class OutlineNode {
 
   // Setters and mutators
 
-  setFlags(flags: number): this {
-    errorOnReadOnly();
-    if (this.isImmutable()) {
-      invariant(false, 'setFlags: can only be used on non-immutable nodes');
-    }
-    const self = this.getWritable();
-    this.getWritable().__flags = flags;
-    return self;
-  }
-  makeImmutable(): this {
-    errorOnReadOnly();
-    const self = this.getWritable();
-    self.__flags |= IS_IMMUTABLE;
-    return self;
-  }
-  makeSegmented(): this {
-    errorOnReadOnly();
-    const self = this.getWritable();
-    self.__flags |= IS_SEGMENTED;
-    return self;
-  }
-  makeInert(): this {
-    errorOnReadOnly();
-    const self = this.getWritable();
-    self.__flags |= IS_INERT;
-    return self;
-  }
-  makeDirectionless(): this {
-    errorOnReadOnly();
-    const self = this.getWritable();
-    self.__flags |= IS_DIRECTIONLESS;
-    return self;
-  }
   remove(): void {
     errorOnReadOnly();
     removeNode(this, true);

--- a/packages/outline/src/core/OutlineNormalization.js
+++ b/packages/outline/src/core/OutlineNormalization.js
@@ -13,14 +13,14 @@ import {isTextNode} from './OutlineTextNode';
 import {getActiveEditor} from './OutlineUpdates';
 
 function canSimpleTextNodesBeMerged(node1: TextNode, node2: TextNode): boolean {
-  const node1Flags = node1.__flags;
+  const node1Mode = node1.__mode;
   const node1Format = node1.__format;
   const node1Style = node1.__style;
-  const node2Flags = node2.__flags;
+  const node2Mode = node2.__mode;
   const node2Format = node2.__format;
   const node2Style = node2.__style;
   return (
-    (node1Flags === null || node1Flags === node2Flags) &&
+    (node1Mode === null || node1Mode === node2Mode) &&
     (node1Format === null || node1Format === node2Format) &&
     (node1Style === null || node1Style === node2Style)
   );

--- a/packages/outline/src/core/OutlineParsing.js
+++ b/packages/outline/src/core/OutlineParsing.js
@@ -32,7 +32,6 @@ export type NodeParserState = {
 export type ParsedNode = {
   __key: NodeKey,
   __type: string,
-  __flags: number,
   __parent: null | NodeKey,
   ...
 };
@@ -40,11 +39,16 @@ export type ParsedNode = {
 export type ParsedElementNode = {
   ...ParsedNode,
   __children: Array<NodeKey>,
+  __format: number,
+  __dir: number,
+  __indent: number,
 };
 
 export type ParsedTextNode = {
   ...ParsedNode,
   __text: string,
+  __mode: number,
+  __format: number,
 };
 
 export type ParsedNodeMap = Map<NodeKey, ParsedNode>;
@@ -95,7 +99,6 @@ export function internalCreateNodeFromParse(
     const editorState = getActiveEditorState();
     editorState._nodeMap.set('root', node);
   }
-  node.__flags = parsedNode.__flags;
   node.__parent = parentKey;
   // We will need to recursively handle the children in the case
   // of a ElementNode.
@@ -122,6 +125,8 @@ export function internalCreateNodeFromParse(
   } else if (isTextNode(node)) {
     node.__format = parsedNode.__format;
     node.__style = parsedNode.__style;
+    node.__mode = parsedNode.__mode;
+    node.__detail = parsedNode.__detail;
   } else if (isDecoratorNode(node)) {
     const parsedRef = parsedNode.__ref;
     let ref = null;

--- a/packages/outline/src/core/OutlineSelection.js
+++ b/packages/outline/src/core/OutlineSelection.js
@@ -43,7 +43,7 @@ import {
 } from './OutlineUtils';
 import invariant from 'shared/invariant';
 import {TEXT_TYPE_TO_FORMAT} from './OutlineConstants';
-import isImmutableOrInert from 'shared/isImmutableOrInert';
+import isTokenOrInert from 'shared/isTokenOrInert';
 import getPossibleDecoratorNode from 'shared/getPossibleDecoratorNode';
 
 export type TextPointType = {
@@ -400,14 +400,14 @@ export class Selection {
       this.isCollapsed() &&
       startOffset === firstNodeTextLength &&
       (firstNode.isSegmented() ||
-        firstNode.isImmutable() ||
+        firstNode.isToken() ||
         !firstNode.canInsertTextAfter() ||
         !firstNodeParent.canInsertTextAfter())
     ) {
       let nextSibling = firstNode.getNextSibling();
       if (
         !isTextNode(nextSibling) ||
-        isImmutableOrInert(nextSibling) ||
+        isTokenOrInert(nextSibling) ||
         nextSibling.isSegmented()
       ) {
         nextSibling = $createTextNode();
@@ -427,14 +427,14 @@ export class Selection {
       this.isCollapsed() &&
       startOffset === 0 &&
       (firstNode.isSegmented() ||
-        firstNode.isImmutable() ||
+        firstNode.isToken() ||
         !firstNode.canInsertTextBefore() ||
         !firstNodeParent.canInsertTextBefore())
     ) {
       let prevSibling = firstNode.getPreviousSibling();
       if (
         !isTextNode(prevSibling) ||
-        isImmutableOrInert(prevSibling) ||
+        isTokenOrInert(prevSibling) ||
         prevSibling.isSegmented()
       ) {
         prevSibling = $createTextNode();
@@ -457,7 +457,7 @@ export class Selection {
     }
 
     if (selectedNodesLength === 1) {
-      if (isImmutableOrInert(firstNode)) {
+      if (isTokenOrInert(firstNode)) {
         firstNode.remove();
         return;
       }
@@ -510,7 +510,7 @@ export class Selection {
       ) {
         if (
           isTextNode(lastNode) &&
-          !isImmutableOrInert(lastNode) &&
+          !isTokenOrInert(lastNode) &&
           endOffset !== lastNode.getTextContentSize()
         ) {
           if (lastNode.isSegmented()) {
@@ -584,7 +584,7 @@ export class Selection {
 
       // Ensure we do splicing after moving of nodes, as splicing
       // can have side-effects (in the case of hashtags).
-      if (!isImmutableOrInert(firstNode)) {
+      if (!isTokenOrInert(firstNode)) {
         firstNode = firstNode.spliceText(
           startOffset,
           firstNodeTextLength - startOffset,
@@ -730,7 +730,7 @@ export class Selection {
           isTextNode(selectedNode) &&
           selectedNodeKey !== firstNode.getKey() &&
           selectedNodeKey !== lastNode.getKey() &&
-          !selectedNode.isImmutable()
+          !selectedNode.isToken()
         ) {
           const selectedNextFormat = selectedNode.getFormatFlags(
             formatType,
@@ -781,7 +781,7 @@ export class Selection {
         siblings.push(anchorNode);
       } else if (anchorOffset === textContentLength) {
         target = anchorNode;
-      } else if (isImmutableOrInert(anchorNode)) {
+      } else if (isTokenOrInert(anchorNode)) {
         // Do nothing if we're inside an immutable/inert node
         return false;
       } else {

--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -163,11 +163,7 @@ function isNodeValidForTransform(
     node !== undefined &&
     // We don't want to transform nodes being composed
     node.__key !== compositionKey &&
-    node.isAttached() &&
-    // You shouldn't be able to transform these types of
-    // nodes.
-    !node.isImmutable() &&
-    !node.isSegmented()
+    node.isAttached()
   );
 }
 

--- a/packages/outline/src/core/OutlineUtils.js
+++ b/packages/outline/src/core/OutlineUtils.js
@@ -99,8 +99,8 @@ export function getTextDirection(text: string): 'ltr' | 'rtl' | null {
   return null;
 }
 
-export function isImmutableOrInertOrSegmented(node: OutlineNode): boolean {
-  return node.isImmutable() || node.isInert() || node.isSegmented();
+export function isTokenOrInertOrSegmented(node: TextNode): boolean {
+  return node.isToken() || node.isInert() || node.isSegmented();
 }
 
 export function getDOMTextNode(element: Node | null): Text | null {

--- a/packages/outline/src/helpers/OutlineEventHelpers.js
+++ b/packages/outline/src/helpers/OutlineEventHelpers.js
@@ -15,8 +15,6 @@ import type {
   NodeKey,
   TextNode,
   ElementNode,
-  LineBreakNode,
-  DecoratorNode,
   TextMutation,
 } from 'outline';
 
@@ -39,7 +37,7 @@ import {
   isUndo,
   isRedo,
 } from 'outline/keys';
-import isImmutableOrInert from 'shared/isImmutableOrInert';
+import isTokenOrInert from 'shared/isTokenOrInert';
 import {cloneContents, insertRichText, moveCharacter} from 'outline/selection';
 import {
   $createTextNode,
@@ -662,17 +660,13 @@ function shouldInsertTextAfterOrBeforeTextNode(
   }
   const offset = selection.anchor.offset;
   const parent = node.getParentOrThrow();
-  const isImmutable = node.isImmutable();
+  const isToken = node.isToken();
   const shouldInsertTextBefore =
     offset === 0 &&
-    (!node.canInsertTextBefore() ||
-      !parent.canInsertTextBefore() ||
-      isImmutable);
+    (!node.canInsertTextBefore() || !parent.canInsertTextBefore() || isToken);
   const shouldInsertTextAfter =
     node.getTextContentSize() === offset &&
-    (!node.canInsertTextBefore() ||
-      !parent.canInsertTextBefore() ||
-      isImmutable);
+    (!node.canInsertTextBefore() || !parent.canInsertTextBefore() || isToken);
   return shouldInsertTextBefore || shouldInsertTextAfter;
 }
 
@@ -704,7 +698,7 @@ function updateTextNodeFromDOMContent(
         return;
       }
       if (
-        isImmutableOrInert(node) ||
+        isTokenOrInert(node) ||
         ($getCompositionKey() !== null && !isComposing)
       ) {
         node.markDirty();
@@ -740,13 +734,15 @@ function applyTargetRange(selection: Selection, event: InputEvent): void {
 }
 
 function canRemoveText(
-  anchorNode: TextNode | ElementNode | LineBreakNode | DecoratorNode,
-  focusNode: TextNode | ElementNode | LineBreakNode | DecoratorNode,
+  anchorNode: TextNode | ElementNode,
+  focusNode: TextNode | ElementNode,
 ): boolean {
   return (
     anchorNode !== focusNode ||
-    !isImmutableOrInert(anchorNode) ||
-    !isImmutableOrInert(focusNode)
+    isElementNode(anchorNode) ||
+    isElementNode(focusNode) ||
+    !isTokenOrInert(anchorNode) ||
+    !isTokenOrInert(focusNode)
   );
 }
 

--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -32,7 +32,6 @@ function cloneWithProperties<T: OutlineNode>(node: T): T {
   const latest = node.getLatest();
   const constructor = latest.constructor;
   const clone = constructor.clone(latest);
-  clone.__flags = latest.__flags;
   clone.__parent = latest.__parent;
   if (isElementNode(latest)) {
     clone.__children = Array.from(latest.__children);
@@ -42,6 +41,8 @@ function cloneWithProperties<T: OutlineNode>(node: T): T {
   } else if (isTextNode(latest)) {
     clone.__format = latest.__format;
     clone.__style = latest.__style;
+    clone.__mode = latest.__mode;
+    clone.__detail = latest.__detail;
   } else if (isDecoratorNode(latest)) {
     clone.__ref = latest.__ref;
   }
@@ -92,7 +93,7 @@ function copyLeafNodeBranchToRoot(
         clone = cloneWithProperties<OutlineNode>(node);
         nodeMap.set(key, clone);
       }
-      if (isTextNode(clone) && !clone.isSegmented() && !clone.isImmutable()) {
+      if (isTextNode(clone) && !clone.isSegmented() && !clone.isToken()) {
         clone.__text = clone.__text.slice(
           isLeftSide ? offset : 0,
           isLeftSide ? undefined : offset,
@@ -326,7 +327,7 @@ export function patchStyleText(
         isTextNode(selectedNode) &&
         selectedNodeKey !== firstNode.getKey() &&
         selectedNodeKey !== lastNode.getKey() &&
-        !selectedNode.isImmutable()
+        !selectedNode.isToken()
       ) {
         patchNodeStyle(selectedNode, patch);
       }

--- a/packages/outline/src/helpers/__tests__/utils/index.js
+++ b/packages/outline/src/helpers/__tests__/utils/index.js
@@ -647,27 +647,27 @@ export async function applySelectionInputs(inputs, update, editor) {
           }
           case 'insert_immutable_node': {
             const text = $createTextNode(input.text);
-            text.makeImmutable();
+            text.setMode('immutable');
             selection.insertNodes([text]);
             break;
           }
           case 'insert_segmented_node': {
             const text = $createTextNode(input.text);
-            text.makeSegmented();
+            text.setMode('segmented');
             selection.insertNodes([text]);
             text.selectNext();
             break;
           }
           case 'covert_to_immutable_node': {
             const text = $createTextNode(selection.getTextContent());
-            text.makeImmutable();
+            text.setMode('immutable');
             selection.insertNodes([text]);
             text.selectNext();
             break;
           }
           case 'covert_to_segmented_node': {
             const text = $createTextNode(selection.getTextContent());
-            text.makeSegmented();
+            text.setMode('segmented');
             selection.insertNodes([text]);
             text.selectNext();
             break;

--- a/packages/shared/src/isTokenOrInert.js
+++ b/packages/shared/src/isTokenOrInert.js
@@ -7,8 +7,8 @@
  * @flow strict
  */
 
-import type {OutlineNode} from 'outline';
+import type {TextNode} from 'outline';
 
-export default function isImmutableOrInert(node: OutlineNode): boolean {
-  return node.isImmutable() || node.isInert();
+export default function isTokenOrInert(node: TextNode): boolean {
+  return node.isToken() || node.isInert();
 }


### PR DESCRIPTION
Fixes #914.

This PR removes `__flags` from `OutlineNode`, and also all the associated methods on `OutlineNode` to do with flags. Instead, we now have separate properties on `TextNode` to represent the same concepts. Well, almost.

I've removed immutability entirely – it was wonky before and didn't really make too much sense. Instead, we can now tag a `TextNode` as being a `token`, which works in much of the same way. Specifically, the whole text node gets removed in one go and text entered into the middle of a token causes it become plain text again.

So in summary, this removes `OutlineNode.__flags` and adds `TextNode.__mode` and `TextNode.__detail`.

Here are the mappings:

- Immutable -> TextNode.__mode for token
- Segmented -> TextNode.__mode for segmented
- Inert -> TextNode.__mode for inert
- Unmergeable -> TextNode.__detail for unmergeable
- Directionless -> TextNode.__detail for directionless