### PR TITLE
Improve indent/outdent behavior with commands

### DIFF
--- a/packages/outline-playground/src/plugins/ActionsPlugin.js
+++ b/packages/outline-playground/src/plugins/ActionsPlugin.js
@@ -14,7 +14,6 @@ import {useOutlineComposerContext} from 'outline-react/OutlineComposerContext';
 import {useCollaborationContext} from '../context/CollaborationContext';
 import {useEffect, useState} from 'react';
 import {log, isElementNode, $getSelection, createEditorStateRef} from 'outline';
-import {isListItemNode} from 'outline/ListItemNode';
 import {ImageNode, $createEmojiNode} from '../nodes/ImageNode';
 import yellowFlowerImage from '../images/image/yellow-flower.jpg';
 import useOutlineNestedList from 'outline-react/useOutlineNestedList';
@@ -40,7 +39,7 @@ export default function ActionsPlugins({
   const [isReadOnly, setIsReadyOnly] = useState(false);
   const [connected, setConnected] = useState(false);
   const [editor] = useOutlineComposerContext();
-  const [indent, outdent] = useOutlineNestedList(editor);
+  useOutlineNestedList(editor);
   const {yjsDocMap} = useCollaborationContext();
   const isCollab = yjsDocMap.get('main') !== undefined;
 
@@ -133,37 +132,11 @@ export default function ActionsPlugins({
   };
 
   const applyOutdent = () => {
-    editor.update(() => {
-      const selection = $getSelection();
-      if (selection !== null) {
-        const node = selection.anchor.getNode();
-        const element = isElementNode(node) ? node : node.getParentOrThrow();
-        if (!isListItemNode(element)) {
-          if (element.getIndent() !== 0) {
-            element.setIndent(element.getIndent() - 1);
-          }
-        } else {
-          outdent();
-        }
-      }
-    });
+    editor.execCommand('outdentContent');
   };
 
   const applyIndent = () => {
-    editor.update(() => {
-      const selection = $getSelection();
-      if (selection !== null) {
-        const node = selection.anchor.getNode();
-        const element = isElementNode(node) ? node : node.getParentOrThrow();
-        if (!isListItemNode(element)) {
-          if (element.getIndent() !== 10) {
-            element.setIndent(element.getIndent() + 1);
-          }
-        } else {
-          indent();
-        }
-      }
-    });
+    editor.execCommand('indentContent');
   };
 
   return (

--- a/packages/outline-react/src/shared/useRichTextSetup.js
+++ b/packages/outline-react/src/shared/useRichTextSetup.js
@@ -167,6 +167,43 @@ export function useRichTextSetup(
             case 'insertParagraph':
               selection.insertParagraph();
               return true;
+            case 'indentContent': {
+              // Handle code blocks
+              const anchor = selection.anchor;
+              const parentBlock =
+                anchor.type === 'element'
+                  ? anchor.getNode()
+                  : anchor.getNode().getParentOrThrow();
+              if (parentBlock.canInsertTab()) {
+                editor.execCommand('insertText', '\t');
+              } else {
+                if (parentBlock.getIndent() !== 10) {
+                  parentBlock.setIndent(parentBlock.getIndent() + 1);
+                }
+              }
+              return true;
+            }
+            case 'outdentContent': {
+              // Handle code blocks
+              const anchor = selection.anchor;
+              const anchorNode = anchor.getNode();
+              const parentBlock =
+                anchor.type === 'element'
+                  ? anchor.getNode()
+                  : anchor.getNode().getParentOrThrow();
+              if (parentBlock.canInsertTab()) {
+                const textContent = anchorNode.getTextContent();
+                const character = textContent[anchor.offset - 1];
+                if (character === '\t') {
+                  editor.execCommand('deleteCharacter', true);
+                }
+              } else {
+                if (parentBlock.getIndent() !== 0) {
+                  parentBlock.setIndent(parentBlock.getIndent() - 1);
+                }
+              }
+              return true;
+            }
           }
           return false;
         },

--- a/packages/outline/src/core/OutlineEditor.js
+++ b/packages/outline/src/core/OutlineEditor.js
@@ -420,8 +420,8 @@ class BaseOutlineEditor {
       transforms.delete(listener);
     };
   }
-  execCommand(type: string, payload?: CommandPayload): void {
-    triggerCommandListeners(getSelf(this), type, payload);
+  execCommand(type: string, payload?: CommandPayload): boolean {
+    return triggerCommandListeners(getSelf(this), type, payload);
   }
   getDecorators(): {[NodeKey]: ReactNode} {
     return this._decorators;
@@ -569,7 +569,7 @@ declare export class OutlineEditor {
     klass: Class<T>,
     listener: Transform<T>,
   ): () => void;
-  execCommand(type: string, payload: CommandPayload): void;
+  execCommand(type: string, payload: CommandPayload): boolean;
   getDecorators(): {[NodeKey]: ReactNode};
   getRootElement(): null | HTMLElement;
   setRootElement(rootElement: null | HTMLElement): void;

--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -490,22 +490,24 @@ export function triggerCommandListeners(
   editor: OutlineEditor,
   type: string,
   payload: CommandPayload,
-): void {
+): boolean {
   if (editor._updating === false) {
+    let returnVal = false;
     editor.update(() => {
-      triggerCommandListeners(editor, type, payload);
+      returnVal = triggerCommandListeners(editor, type, payload);
     });
-    return;
+    return returnVal;
   }
   const commandListeners = editor._listeners.command;
-  propagation: for (let i = 4; i >= 0; i--) {
+  for (let i = 4; i >= 0; i--) {
     const listeners = Array.from(commandListeners[i]);
     for (let s = 0; s < listeners.length; s++) {
       if (listeners[s](type, payload) === true) {
-        break propagation;
+        return true;
       }
     }
   }
+  return false;
 }
 
 function triggerEnqueuedUpdates(editor: OutlineEditor): void {

--- a/packages/outline/src/helpers/OutlineEventHelpers.js
+++ b/packages/outline/src/helpers/OutlineEventHelpers.js
@@ -305,6 +305,7 @@ export function onKeyDown(event: KeyboardEvent, editor: OutlineEditor): void {
   }
   editor.update((state) => {
     log('onKeyDown');
+
     const selection = $getSelection();
     if (selection === null) {
       return;
@@ -357,23 +358,10 @@ export function onKeyDown(event: KeyboardEvent, editor: OutlineEditor): void {
       event.preventDefault();
       editor.execCommand('formatText', 'italic');
     } else if (isTab(event)) {
-      // Handle code blocks
-      const anchor = selection.anchor;
-      if (anchor.type === 'text') {
-        const anchorNode = anchor.getNode();
-        const parentBlock = anchorNode.getParentOrThrow();
-        if (parentBlock.canInsertTab()) {
-          if (event.shiftKey) {
-            const textContent = anchorNode.getTextContent();
-            const character = textContent[anchor.offset - 1];
-            if (character === '\t') {
-              editor.execCommand('deleteCharacter', true);
-            }
-          } else {
-            editor.execCommand('insertText', '\t');
-          }
-          event.preventDefault();
-        }
+      if (
+        editor.execCommand(event.shiftKey ? 'outdentContent' : 'indentContent')
+      ) {
+        event.preventDefault();
       }
     } else if (isUndo(event)) {
       event.preventDefault();

--- a/packages/outline/src/helpers/OutlineKeyHelpers.js
+++ b/packages/outline/src/helpers/OutlineKeyHelpers.js
@@ -120,7 +120,7 @@ export function isRedo(event: KeyboardEvent): boolean {
 
 export function isTab(event: KeyboardEvent): boolean {
   return (
-    event.keyCode === 90 && !event.altKey && !event.ctrlKey && !event.metaKey
+    event.keyCode === 9 && !event.altKey && !event.ctrlKey && !event.metaKey
   );
 }
 


### PR DESCRIPTION
It's important to ensure that we can make complex event interactions, such as tabbing for indent and outdent to work universally between plugins. This PR attempts to improve on the existing implementations to simplify much of that logic.