### PR TITLE
Transforms not to trigger on subtrees

### DIFF
--- a/packages/outline/src/core/OutlineUpdates.js
+++ b/packages/outline/src/core/OutlineUpdates.js
@@ -208,8 +208,10 @@ function applyAllTransforms(
       untransformedDirtyElements,
     );
     for (let i = 0; i < untransformedDirtyElementsLength; i++) {
-      const nodeKey = untransformedDirtyElementsArr[i][0];
-      if (nodeKey === 'root') {
+      const currentUntransformedDirtyElement = untransformedDirtyElementsArr[i];
+      const nodeKey = currentUntransformedDirtyElement[0];
+      const intentionallyMarkedAsDirty = currentUntransformedDirtyElement[1];
+      if (nodeKey === 'root' || !intentionallyMarkedAsDirty) {
         continue;
       }
       const nodeIntentionallyMarkedAsDirty =


### PR DESCRIPTION
Given that transforms now trigger on siblings, they no longer need to trigger on subtrees.

I think there's a nicer and more efficient way to do this which we can pair with the `dirtyLeaves` + `dirtyElements` merging. We consider `dirtyNodes` to always have the explicitly marked as dirty (so no `markParentElementsAsDirty`), and in the reconciler process we can mark the parents dirty of all element nodes prior doing the reconciliation. Since it's the last in the chain it should be fine to even tamper with the `dirtyNodes` Set