### PR TITLE
Make internallyMarkParentElementsAsDirty private

### DIFF
--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -28,7 +28,6 @@ import {
   $getNodeByKey,
   $internallyMarkNodeAsDirty,
   $internallyMarkSiblingsAsDirty,
-  markParentElementsAsDirty,
   $setCompositionKey,
 } from './OutlineUtils';
 import invariant from 'shared/invariant';
@@ -465,10 +464,6 @@ export class OutlineNode {
     // Ensure we get the latest node from pending state
     const latestNode = this.getLatest();
     const parent = latestNode.__parent;
-    const dirtyElements = editor._dirtyElements;
-    if (parent !== null) {
-      markParentElementsAsDirty(parent, nodeMap, dirtyElements);
-    }
     const cloneNotNeeded = editor._cloneNotNeeded;
     if (cloneNotNeeded.has(key)) {
       // Transforms clear the dirty node set on each iteration to keep track on newly dirty nodes

--- a/packages/outline/src/core/OutlineUtils.js
+++ b/packages/outline/src/core/OutlineUtils.js
@@ -164,7 +164,7 @@ export function $generateKey(node: OutlineNode): NodeKey {
   return key;
 }
 
-export function markParentElementsAsDirty(
+function $internallyMarkParentElementsAsDirty(
   parentKey: NodeKey,
   nodeMap: NodeMap,
   dirtyElements: Map<NodeKey, IntentionallyMarkedAsDirtyElement>,
@@ -194,7 +194,7 @@ export function $internallyMarkNodeAsDirty(node: OutlineNode): void {
   const nodeMap = editorState._nodeMap;
   const dirtyElements = editor._dirtyElements;
   if (parent !== null) {
-    markParentElementsAsDirty(parent, nodeMap, dirtyElements);
+    $internallyMarkParentElementsAsDirty(parent, nodeMap, dirtyElements);
   }
   const key = latest.__key;
   editor._dirtyType = HAS_DIRTY_NODES;


### PR DESCRIPTION
We don't need to explicitly mark parents dirty when calling OutlineNode.getWritable. Why?

(First of, ignore the `internallyMarkNodeAsDirty` in `if (cloneNotNeeded.has(key)) {`, this serves a different purpose as it says in the comment)

1. When a node is not cloned and marked as dirty, parents are already marked as dirty by the `$internallyMarkNodeAsDirty` function.
2. When a node is cloned we can assume that parents are either marked as dirty or it's someone else responsibility to do so. For example, when you append a dirty node, the append function will already mark the Element dirty for you.

The only case when this would not work is when hacking the children directly but you shouldn't do this in the first place.

```
parent.__children = [...]
child.__parent = parentKey;
child.getWritable();
```
