### PR TITLE
Fix mergeWithSibling

### DIFF
--- a/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
+++ b/packages/outline/src/__tests__/unit/OutlineTextNode.test.js
@@ -20,7 +20,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import {$createTextNode, $getRoot, $getNodeByKey} from 'outline';
+import {$createTextNode, $getRoot, $getNodeByKey, $getSelection} from 'outline';
 
 import {$createParagraphNode} from 'outline/ParagraphNode';
 import {
@@ -725,5 +725,29 @@ describe('OutlineTextNode tests', () => {
         });
       },
     );
+  });
+
+  test('mergeWithSibling', async () => {
+    await update(() => {
+      const paragraph = $getRoot().getFirstChild();
+      const textNode1 = $createTextNode('1');
+      const textNode2 = $createTextNode('2');
+      const textNode3 = $createTextNode('3');
+      paragraph.append(textNode1, textNode2, textNode3);
+      textNode2.select();
+
+      const selection = $getSelection();
+      textNode2.mergeWithSibling(textNode1);
+      expect(selection.anchor.getNode()).toBe(textNode2);
+      expect(selection.anchor.offset).toBe(1);
+      expect(selection.focus.offset).toBe(1);
+
+      textNode2.mergeWithSibling(textNode3);
+      expect(selection.anchor.getNode()).toBe(textNode2);
+      expect(selection.anchor.offset).toBe(1);
+      expect(selection.focus.offset).toBe(1);
+    });
+
+    expect(getEditorStateTextContent(editor.getEditorState())).toBe('123');
   });
 });

--- a/packages/outline/src/core/OutlineNormalization.js
+++ b/packages/outline/src/core/OutlineNormalization.js
@@ -30,11 +30,11 @@ function $canSimpleTextNodesBeMerged(
 }
 
 function $mergeTextNodes(node1: TextNode, node2: TextNode): TextNode {
-  node1.mergeWithSibling(node2);
+  const writableNode1 = node1.mergeWithSibling(node2);
   const normalizedNodes = getActiveEditor()._normalizedNodes;
   normalizedNodes.add(node1.__key);
   normalizedNodes.add(node2.__key);
-  return node1.getLatest();
+  return writableNode1;
 }
 
 export function $normalizeTextNode(textNode: TextNode): void {

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -604,7 +604,7 @@ export class TextNode extends OutlineNode {
 
     return splitNodes;
   }
-  mergeWithSibling(target: TextNode): void {
+  mergeWithSibling(target: TextNode): TextNode {
     const isBefore = target === this.getPreviousSibling();
     if (!isBefore && target !== this.getNextSibling()) {
       invariant(
@@ -622,7 +622,6 @@ export class TextNode extends OutlineNode {
       $setCompositionKey(key);
     }
     const selection = $getSelection();
-
     if (selection !== null) {
       const anchor = selection.anchor;
       const focus = selection.focus;
@@ -647,8 +646,11 @@ export class TextNode extends OutlineNode {
         selection.dirty = true;
       }
     }
-    this.setTextContent(text + target.__text);
+    const newText = isBefore ? target.__text + text : text + target.__text;
+    this.setTextContent(newText);
+
     target.remove();
+    return this.getLatest();
   }
 }
 


### PR DESCRIPTION
`isBefore` wasn't taken into consideration for the new text so when merging with previous TextNode its text would be put at the end.

---

This PR also changes the signature a bit, it will return itself which is more practical than having the user do `getLatest` themselves.

When looking into the signature I also tested with inheritance. A MentionNode would work like this:

```
  mergeWithSibling(target: TextNode): MentionNode {
    super.mergeWithSibling(target);
    return this.getLatest();
  }
```

It's not ideal but probably the best we can do with Flow given that Flow can see a MentionNode as a TextNode or a MentionNode so it's quite restrictive in terms of what we can enforce at the higher level of the hierarchy.


