### PR TITLE
Deprecate DFS helper

### DIFF
--- a/packages/outline-react/src/useOutlineCharacterLimit.js
+++ b/packages/outline-react/src/useOutlineCharacterLimit.js
@@ -24,7 +24,7 @@ import {
   $getRoot,
   $setSelection,
 } from 'outline';
-import {$dfs} from 'outline/nodes';
+import {$dfs__DEPRECATED} from 'outline/nodes';
 import {$textContentCurry} from 'outline/root';
 import {useEffect} from 'react';
 
@@ -131,7 +131,7 @@ function $wrapOverflowedNodes(offset: number) {
   let accumulatedLength = 0;
 
   let previousNode = root;
-  $dfs(root, (node: OutlineNode) => {
+  $dfs__DEPRECATED(root, (node: OutlineNode) => {
     if (isOverflowNode(node)) {
       const previousLength = accumulatedLength;
       const nextLength = accumulatedLength + node.getTextContentSize();

--- a/packages/outline/src/helpers/OutlineNodeHelpers.js
+++ b/packages/outline/src/helpers/OutlineNodeHelpers.js
@@ -26,7 +26,7 @@ import {$createTableNode} from 'outline/TableNode';
 import {$createTableRowNode} from 'outline/TableRowNode';
 import {$createTableCellNode} from 'outline/TableCellNode';
 
-export function $dfs(
+export function $dfs__DEPRECATED(
   startingNode: OutlineNode,
   nextNode: (OutlineNode) => null | OutlineNode,
 ) {

--- a/packages/outline/src/helpers/__tests__/unit/OutlineNodeHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineNodeHelpers.test.js
@@ -14,7 +14,7 @@ import {
   $createTestElementNode,
 } from '../../../__tests__/utils';
 import {
-  $dfs,
+  $dfs__DEPRECATED,
   $getTopListNode,
   $isLastItemInList,
   $areSiblingsNullOrSpace,
@@ -79,7 +79,7 @@ describe('OutlineNodeHelpers tests', () => {
       const dfsKeys = [];
       await editor.update((state: State) => {
         const root = $getRoot();
-        $dfs(root, (node: OutlineNode) => {
+        $dfs__DEPRECATED(root, (node: OutlineNode) => {
           dfsKeys.push(node.getKey());
           return node;
         });
@@ -105,7 +105,7 @@ describe('OutlineNodeHelpers tests', () => {
       const dfsKeys = [];
       await editor.update((state: State) => {
         const root = $getRoot();
-        $dfs(root, (node: OutlineNode) => {
+        $dfs__DEPRECATED(root, (node: OutlineNode) => {
           dfsKeys.push(node.getKey());
           if ($isParagraphNode(node)) {
             return (


### PR DESCRIPTION
When I first introduced this method I naively thought the CharacterLimit plugin would be its only user. Turns out it's pretty useful for many surfaces when we want to iterate through all the nodes as part of the submit behavior. I'll work on a better signature (likely an iterator) but for now I'm marking it as DEPRECATED so that it's a safe change after 0.1 (I know it's not ideal but that's the best I can think of).