### PR TITLE
Fix decorator selection text content

### DIFF
--- a/packages/outline/src/core/OutlineSelection.js
+++ b/packages/outline/src/core/OutlineSelection.js
@@ -315,7 +315,10 @@ export class Selection {
           textContent += text;
         } else if ($isLineBreakNode(node)) {
           textContent += '\n';
-        } else if ($isDecoratorNode(node)) {
+        } else if (
+          $isDecoratorNode(node) &&
+          (node !== lastNode || !this.isCollapsed())
+        ) {
           textContent += node.getTextContent();
         }
       }


### PR DESCRIPTION
Decorator's text content should be included into selection#getTextContent only if decorator is selected. Right now it is included even if cursor put next/right before a decorator (which generates wrong textRange for UE's inlines)