### PR TITLE
Revert "Make $setPointValues private"

### DIFF
--- a/packages/outline/src/core/OutlineElementNode.js
+++ b/packages/outline/src/core/OutlineElementNode.js
@@ -12,7 +12,11 @@ import type {Selection} from './OutlineSelection';
 
 import {$isTextNode, TextNode} from '.';
 import {OutlineNode} from './OutlineNode';
-import {$makeSelection, $getSelection} from './OutlineSelection';
+import {
+  $makeSelection,
+  $getSelection,
+  $setPointValues,
+} from './OutlineSelection';
 import {errorOnReadOnly, getActiveEditor} from './OutlineUpdates';
 import {ELEMENT_TYPE_TO_FORMAT} from './OutlineConstants';
 import {$getNodeByKey, $internallyMarkNodeAsDirty} from './OutlineUtils';
@@ -213,8 +217,8 @@ export class ElementNode extends OutlineNode {
         'element',
       );
     } else {
-      selection.anchor.set(key, anchorOffset, 'element');
-      selection.focus.set(key, focusOffset, 'element');
+      $setPointValues(selection.anchor, key, anchorOffset, 'element');
+      $setPointValues(selection.focus, key, focusOffset, 'element');
       selection.dirty = true;
     }
     return selection;

--- a/packages/outline/src/core/OutlineSelection.js
+++ b/packages/outline/src/core/OutlineSelection.js
@@ -194,7 +194,7 @@ function $transferStartingElementPointToTextPoint(
   start.set(textNode.getKey(), 0, 'text');
 }
 
-function $setPointValues(
+export function $setPointValues(
   point: PointType,
   key: NodeKey,
   offset: number,

--- a/packages/outline/src/core/index.js
+++ b/packages/outline/src/core/index.js
@@ -56,6 +56,7 @@ import {
   $createEmptySelection as $createSelection,
   $getSelection,
   $getPreviousSelection,
+  $setPointValues,
 } from './OutlineSelection';
 import {$createNodeFromParse} from './OutlineParsing';
 import {createEditorStateRef, isEditorStateRef} from './OutlineReference';
@@ -86,6 +87,7 @@ export {
   $getPreviousSelection,
   $clearSelection,
   $setSelection,
+  $setPointValues,
   $setCompositionKey,
   $getCompositionKey,
   $getNearestNodeFromDOMNode,


### PR DESCRIPTION
Reverts facebookexternal/outline#994

@trueadm - I'm reverting this since it breaks `Should collaborate basic text insertion conflicts between two clients` when the composition key is moved but I'm not sure if that's correct