### PR TITLE
Revisit generic types on OutlineNode

### DIFF
--- a/packages/outline-yjs/src/Utils.js
+++ b/packages/outline-yjs/src/Utils.js
@@ -230,6 +230,7 @@ export function syncPropertiesFromYjs(
       if (writableNode === undefined) {
         writableNode = outlineNode.getWritable();
       }
+      // $FlowFixMe
       writableNode[property] = nextValue;
     }
   }

--- a/packages/outline/src/core/OutlineNode.js
+++ b/packages/outline/src/core/OutlineNode.js
@@ -448,14 +448,16 @@ export class OutlineNode {
   isComposing(): boolean {
     return this.__key === $getCompositionKey();
   }
-  getLatest<N: OutlineNode>(): N {
-    const latest = $getNodeByKey<N>(this.__key);
+  // $FlowFixMe this is OutlineNode
+  getLatest<T: OutlineNode>(this: T): T {
+    const latest = $getNodeByKey(this.__key);
     if (latest === null) {
       invariant(false, 'getLatest: node not found');
     }
     return latest;
   }
-  getWritable<N>(): N {
+  // $FlowFixMe this is OutlineNode
+  getWritable<T: OutlineNode>(this: T): T {
     errorOnReadOnly();
     const editorState = getActiveEditorState();
     const editor = getActiveEditor();
@@ -473,17 +475,17 @@ export class OutlineNode {
     const constructor = latestNode.constructor;
     const mutableNode = constructor.clone(latestNode);
     mutableNode.__parent = parent;
-    if ($isElementNode(mutableNode)) {
+    if ($isElementNode(latestNode) && $isElementNode(mutableNode)) {
       mutableNode.__children = Array.from(latestNode.__children);
       mutableNode.__indent = latestNode.__indent;
       mutableNode.__format = latestNode.__format;
       mutableNode.__dir = latestNode.__dir;
-    } else if ($isTextNode(mutableNode)) {
+    } else if ($isTextNode(latestNode) && $isTextNode(mutableNode)) {
       mutableNode.__format = latestNode.__format;
       mutableNode.__style = latestNode.__style;
       mutableNode.__mode = latestNode.__mode;
       mutableNode.__detail = latestNode.__detail;
-    } else if ($isDecoratorNode(mutableNode)) {
+    } else if ($isDecoratorNode(latestNode) && $isDecoratorNode(mutableNode)) {
       mutableNode.__ref = latestNode.__ref;
     }
     cloneNotNeeded.add(key);
@@ -491,6 +493,7 @@ export class OutlineNode {
     $internallyMarkNodeAsDirty(mutableNode);
     // Update reference in node map
     nodeMap.set(key, mutableNode);
+    // $FlowFixMe this is OutlineNode
     return mutableNode;
   }
   // TODO remove this completely
@@ -533,7 +536,7 @@ export class OutlineNode {
   replace<N: OutlineNode>(replaceWith: N): N {
     errorOnReadOnly();
     const toReplaceKey = this.__key;
-    const writableReplaceWith = replaceWith.getWritable<N>();
+    const writableReplaceWith = replaceWith.getWritable();
     const oldParent = writableReplaceWith.getParent();
     if (oldParent !== null) {
       const writableParent = oldParent.getWritable();

--- a/packages/outline/src/core/OutlineTextNode.js
+++ b/packages/outline/src/core/OutlineTextNode.js
@@ -263,7 +263,7 @@ export class TextNode extends OutlineNode {
     return self.__text;
   }
   getFormatFlags(type: TextFormatType, alignWithFormat: null | number): number {
-    const self = this.getLatest<TextNode>();
+    const self = this.getLatest();
     const format = self.__format;
     return toggleTextFormatType(format, type, alignWithFormat);
   }

--- a/packages/outline/src/extensions/OutlineLinkNode.js
+++ b/packages/outline/src/extensions/OutlineLinkNode.js
@@ -54,7 +54,7 @@ export class LinkNode extends ElementNode {
   }
 
   setURL(url: string): void {
-    const writable = this.getWritable<LinkNode>();
+    const writable = this.getWritable();
     writable.__url = url;
   }
 

--- a/packages/outline/src/helpers/OutlineSelectionHelpers.js
+++ b/packages/outline/src/helpers/OutlineSelectionHelpers.js
@@ -33,19 +33,20 @@ function $cloneWithProperties<T: OutlineNode>(node: T): T {
   const constructor = latest.constructor;
   const clone = constructor.clone(latest);
   clone.__parent = latest.__parent;
-  if ($isElementNode(latest)) {
+  if ($isElementNode(latest) && $isElementNode(clone)) {
     clone.__children = Array.from(latest.__children);
     clone.__format = latest.__format;
     clone.__indent = latest.__indent;
     clone.__dir = latest.__dir;
-  } else if ($isTextNode(latest)) {
+  } else if ($isTextNode(latest) && $isTextNode(clone)) {
     clone.__format = latest.__format;
     clone.__style = latest.__style;
     clone.__mode = latest.__mode;
     clone.__detail = latest.__detail;
-  } else if ($isDecoratorNode(latest)) {
+  } else if ($isDecoratorNode(latest) && $isDecoratorNode(clone)) {
     clone.__ref = latest.__ref;
   }
+  // $FlowFixMe
   return clone;
 }
 


### PR DESCRIPTION
The current generic types on getLatest and getWritable were hiding dangerous any types. Even when the generic was passed the type could be incorrect. This PR addresses it (unfortunately I can't quite get Flow to like my solution so $FlowFixMe is necessary but should be better than before)

I think this should work: https://flow.org/try/#0MYGwhgzhAEBiD29oG8BQ0PQOYFMAuAMmHjhHgDwAqAXHIgHwAUeAFgJYS2UCUXK6mQWwBm0ZgCcArjm79B8zOPyTxAO2isOAbgEKAvtBwgIOOQvlK8K9apwB3OvEbcd56Ht3vPuQsVJ4AOXgAcRxbcTZgCCpaBHgmTU5HXkczBRExPCkZNLdoS2sNdghXcwMjE1y3ArVoWwc451L9Tw8PVFBIGAAhMHFDAA8SVQATGDjcn17xZ1oyCNUsKsxgeFUyaAAjPtpp6ABeIo4AOh8iEjImz0Ea9QBybfE75q921GFJVWA8NjXoSQgkjAIBAAE8AJKqFg4CJ4MBfHDgiCwNi2Rjw0GaRaxRCyNAeAFAkEQqEwthwhFIlFo+rQabOFxAA

Closes #956