### PR TITLE
Improve waitForReact timing

### DIFF
--- a/packages/outline-react/src/__tests__/unit/utils.js
+++ b/packages/outline-react/src/__tests__/unit/utils.js
@@ -195,6 +195,6 @@ export async function waitForReact(cb) {
   await ReactTestUtils.act(async () => {
     cb();
     await Promise.resolve().then();
-    await Promise.resolve().then();
+    await new Promise(resolve => setTimeout(resolve, 100));
   });
 }


### PR DESCRIPTION
Every now and then, the collaboration tests can fail unexpectedly. I think this is an async problem because we're using React concurrent mode. Let's see if this fixes the problem.