### PR TITLE
Fix cannot tab out of the editor

### DIFF
--- a/packages/outline-react/src/shared/usePlainTextSetup.js
+++ b/packages/outline-react/src/shared/usePlainTextSetup.js
@@ -151,8 +151,6 @@ export default function usePlainTextSetup(
               return true;
             case 'insertImage':
             case 'insertTable':
-            case 'indentContent':
-            case 'outdentContent':
             case 'formatElement':
             case 'formatText': {
               return true;


### PR DESCRIPTION
Right now you can't tab out of the editor, neither in plain text nor in rich text. For rich text, and for certain editors, this behavior might be OK (it seems to be the case for Quip) but certainly not for plain text