### PR TITLE
Make extract return an empty list when the selection is at the end of a text node.

### DIFF
--- a/packages/outline-playground/__tests__/e2e/Links-test.js
+++ b/packages/outline-playground/__tests__/e2e/Links-test.js
@@ -97,6 +97,37 @@ describe('Links', () => {
       });
     });
 
+    it(`Does nothing if the selection is collapsed at the end of a text node.`, async () => {
+      const {isRichText, page} = e2e;
+      if (!isRichText) {
+        return;
+      }
+
+      await focusEditor(page);
+      await page.keyboard.type('Hello');
+
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-outline-text="true">Hello</span></p>',
+      );
+
+      // link
+      await waitForSelector(page, '.link');
+      await click(page, '.link');
+
+      await assertHTML(
+        page,
+        '<p class="editor-paragraph PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-outline-text="true">Hello</span></p>',
+      );
+
+      await assertSelection(page, {
+        anchorPath: [0, 0, 0],
+        anchorOffset: 5,
+        focusPath: [0, 0, 0],
+        focusOffset: 5,
+      });
+    });
+
     it(`Can type text before and after`, async () => {
       const {isRichText, page} = e2e;
       if (!isRichText) {

--- a/packages/outline/src/core/OutlineSelection.js
+++ b/packages/outline/src/core/OutlineSelection.js
@@ -1070,7 +1070,7 @@ export class Selection {
           anchorOffset > focusOffset ? anchorOffset : focusOffset;
         const splitNodes = firstNode.splitText(startOffset, endOffset);
         const node = startOffset === 0 ? splitNodes[0] : splitNodes[1];
-        return [node];
+        return node != null ? [node] : [];
       }
       return [firstNode];
     }

--- a/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
+++ b/packages/outline/src/helpers/__tests__/unit/OutlineSelectionHelpers.test.js
@@ -1838,3 +1838,34 @@ describe('OutlineSelectionHelpers tests', () => {
     });
   });
 });
+
+describe('extract', () => {
+  test('', async () => {
+    const editor = createTestEditor();
+    editor.addListener('error', (error) => {
+      throw error;
+    });
+    const element = document.createElement('div');
+    editor.setRootElement(element);
+    await editor.update(() => {
+      const root = $getRoot();
+      const paragraph = $createParagraphNode();
+      const text = $createTextNode('Existing text...');
+      paragraph.append(text);
+      root.append(paragraph);
+
+      setAnchorPoint({
+        type: 'text',
+        offset: 16,
+        key: text.getKey(),
+      });
+      setFocusPoint({
+        type: 'text',
+        offset: 16,
+        key: text.getKey(),
+      });
+      const selection = $getSelection();
+      expect(selection.extract()).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1009