### PR TITLE
Rename engine -> library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "description": "Outline is an extensible text editor engine that provides excellent reliability, accessible and performance.",
+  "description": "Outline is an extensible text editor library that provides excellent reliability, accessible and performance.",
   "version": "0.1.0",
   "license": "MIT",
   "author": {

--- a/packages/outline-website/pages/index.js
+++ b/packages/outline-website/pages/index.js
@@ -6,7 +6,7 @@ export default function Home() {
     <div className={styles.container}>
       <Head>
         <title>Outline</title>
-        <meta name="description" content="Outline is an extensible text editor engine that provides excellent reliability, accessible and performance." />
+        <meta name="description" content="Outline is an extensible text editor library that provides excellent reliability, accessible and performance." />
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
@@ -17,7 +17,7 @@ export default function Home() {
         </h1>
 
         <p className={styles.description}>
-          An extensible text editor engine that does things differently.
+          An extensible text editor library that does things differently.
         </p>
         <p>
           Coming early 2022

--- a/packages/outline/package.json
+++ b/packages/outline/package.json
@@ -4,7 +4,7 @@
     "name": "Dominic Gannaway",
     "email": "dg@domgan.com"
   },
-  "description": "Outline is an extensible text editor engine that provides excellent reliability, accessible and performance.",
+  "description": "Outline is an extensible text editor library that provides excellent reliability, accessible and performance.",
   "keywords": [
     "react",
     "outline",


### PR DESCRIPTION
Responding to feedback that "engine" sounds less approachable than something like "library".