### PR TITLE
Add ElementNode#splice(start, deleteCount, nodesToInsert)

### DIFF
--- a/packages/lexical/src/LexicalNode.js
+++ b/packages/lexical/src/LexicalNode.js
@@ -56,11 +56,23 @@ export function removeNode(
     const anchor = selection.anchor;
     const focus = selection.focus;
     if (anchor.key === key) {
-      moveSelectionPointToSibling(anchor, nodeToRemove, parent);
+      moveSelectionPointToSibling(
+        anchor,
+        nodeToRemove,
+        parent,
+        nodeToRemove.getPreviousSibling(),
+        nodeToRemove.getNextSibling(),
+      );
       selectionMoved = true;
     }
     if (focus.key === key) {
-      moveSelectionPointToSibling(focus, nodeToRemove, parent);
+      moveSelectionPointToSibling(
+        focus,
+        nodeToRemove,
+        parent,
+        nodeToRemove.getPreviousSibling(),
+        nodeToRemove.getNextSibling(),
+      );
       selectionMoved = true;
     }
   }

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -1822,11 +1822,12 @@ export function moveSelectionPointToSibling(
   point: PointType,
   node: LexicalNode,
   parent: ElementNode,
+  prevSibling: LexicalNode | null,
+  nextSibling: LexicalNode | null,
 ): void {
   let siblingKey = null;
   let offset = 0;
   let type = null;
-  const prevSibling = node.getPreviousSibling();
   if (prevSibling !== null) {
     siblingKey = prevSibling.__key;
     if ($isTextNode(prevSibling)) {
@@ -1837,7 +1838,6 @@ export function moveSelectionPointToSibling(
       type = 'element';
     }
   } else {
-    const nextSibling = node.getNextSibling();
     if (nextSibling !== null) {
       siblingKey = nextSibling.__key;
       if ($isTextNode(nextSibling)) {


### PR DESCRIPTION
Main idea is to optimize multiple nodes insertion/deletion/replacement oppose to node-by-node operations with current API (remove/insertBefore/insertAfter/append). 

~~One question I have before we move on is _whether this one suppose to alter selection_. It should work fine for nodes insertion, but for replacement/deletion focus or anchor nodes. Although it's perfectly fine as it is for code highlighting, since plugin adjusts selection itself, it might not be the expectation for other callsites and will cause exception. I'd probably add `restoreSelection: true` option, to update selection by default, but allow opt-out if needed.~~

As discussed offline, this method suppose to handle selection properly by itself. This part will come as a follow up PR