### PR TITLE
Set siblingDOM to prev element before destroying nodes.

### DIFF
--- a/packages/lexical/src/core/LexicalReconciler.js
+++ b/packages/lexical/src/core/LexicalReconciler.js
@@ -557,9 +557,7 @@ function reconcileNodeChildren(
 
       if (!nextHasPrevKey) {
         // Remove prev
-        siblingDOM = getNextSibling(
-          getElementByKeyOrThrow(activeEditor, prevKey),
-        );
+        siblingDOM = getNextSibling(getPrevElementByKeyOrThrow(prevKey));
         destroyNode(prevKey, dom);
         prevIndex++;
       } else if (!prevHasNextKey) {


### PR DESCRIPTION
When you're moving nodes around in a nested structure, it's possible to briefly have two nodes in the DOM with the same Lexical key. After we create the new node, but before we destroy the old one, we try to get a new siblingDOM as a reference to pass to the DOM insertBefore method. If getElementByKey returns the newly created DOM element, it can have a different sibling than the prev element had. If you move it up a level in a nested structure, this can lead to a situation where we try to call the DOM insertBefore method of a the DOM element we are currently reconciling and pass a reference node (the siblingDOM of the newly created node) that is actually not a child of that element. Obviously, this fails.

This change makes it so that, when we destroy a node, we get the next sibling (the reference node for insertBefore) based on the node's position in the prev state, rather than it's new position.

I know this narrative description is potentially difficult to reason about, and I will update with a way to reproduce and/or hopefully a test so others can take a closer look and see if this is the right thing to do.