### PR TITLE
Fix Safari text replacement bug

### DIFF
--- a/packages/lexical/src/helpers/LexicalEventHelpers.js
+++ b/packages/lexical/src/helpers/LexicalEventHelpers.js
@@ -1028,7 +1028,7 @@ export function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
       case 'insertFromPaste': {
         const dataTransfer = event.dataTransfer;
         if (dataTransfer != null) {
-          $insertDataTransferForRichText(dataTransfer, selection, editor);
+          $insertDataTransferForPlainText(dataTransfer, selection);
         } else {
           if (data) {
             editor.execCommand('insertText', data);


### PR DESCRIPTION
This fixes a bug that was discovered internally when using Safari with text replacement. Here's how you can repro before:

- Type some text
- Insert line break
- Type `- asdas`
- Press up and then type space, then something that gets corrected with spellcheck like `wouldnt`. Press space so Safari correctrs the spelling.

Note how this breaks and the line below gets merged. Looking into this @acywatson it seems this happens because Safari provides a HTML version of the text replacement too, so this might be a bigger issue. This PR forces this code path to be plain text to avoid the bug.

I wasn't able to make an e2e test as spellchecking doesn't seem to be configurable for Playwright :/