### PR TITLE
Fix history stack merging when undo executed within merge time window

### DIFF
--- a/packages/lexical-playground/__tests__/regression/1055-fast-typing-undo.js
+++ b/packages/lexical-playground/__tests__/regression/1055-fast-typing-undo.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {initializeE2E, assertHTML, focusEditor, IS_COLLAB} from '../utils';
+
+import {undo} from '../keyboardShortcuts';
+
+describe('Regression test #1055', () => {
+  initializeE2E((e2e) => {
+    it(`Adds new editor state into undo stack right after undo was done`, async () => {
+      if (IS_COLLAB) {
+        // Collab uses its own undo/redo
+        return;
+      }
+
+      const {page} = e2e;
+      await focusEditor(page);
+      await page.keyboard.type('hello');
+      await undo(page);
+      await assertHTML(
+        page,
+        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1"><br /></p>',
+      );
+      await page.keyboard.type('hello');
+      await assertHTML(
+        page,
+        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello</span></p>',
+      );
+      await undo(page);
+      await assertHTML(
+        page,
+        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1"><br /></p>',
+      );
+    });
+  });
+});

--- a/packages/lexical-react/src/useLexicalHistory.js
+++ b/packages/lexical-react/src/useLexicalHistory.js
@@ -200,6 +200,15 @@ function createMergeActionGetter(
     tags,
   ) => {
     const changeTime = Date.now();
+
+    // If applying changes from history stack there's no need
+    // to run history logic again, as history entries already calculated
+    if (tags.has('historic')) {
+      prevChangeType = OTHER;
+      prevChangeTime = changeTime;
+      return DISCARD;
+    }
+
     const changeType = getChangeType(
       prevEditorState,
       nextEditorState,
@@ -266,11 +275,6 @@ export function useLexicalHistory(
       dirtyElements,
       tags,
     }) => {
-      // If applying changes from history stack there's no need
-      // to run history logic again, as history entries already calculated
-      if (tags.has('historic')) {
-        return;
-      }
       const current = historyState.current;
       const redoStack = historyState.redoStack;
       const undoStack = historyState.undoStack;


### PR DESCRIPTION
Fixes #1055

Update lastChangeType/lastChangeTime when applying undo/redo states, so that next history state wouldn't try to merge with previous one