### PR TITLE
move list logic out of ToolbarPlugin, unify insertion and indent

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -46,6 +46,7 @@ module.name_mapper='^lexical-react/useLexicalPlainTextWithCollab' -> '<PROJECT_R
 module.name_mapper='^lexical-react/useLexicalEditorEvents' -> '<PROJECT_ROOT>/packages/lexical-react/src/useLexicalEditorEvents.js'
 module.name_mapper='^lexical-react/useLexicalAutoFormatter' -> '<PROJECT_ROOT>/packages/lexical-react/src/useLexicalAutoFormatter.js'
 module.name_mapper='^lexical-react/useLexicalDecorators' -> '<PROJECT_ROOT>/packages/lexical-react/src/useLexicalDecorators.js'
+module.name_mapper='^lexical-react/useLexicalList' -> '<PROJECT_ROOT>/packages/lexical-react/src/useLexicalList.js'
 module.name_mapper='^lexical-react/useLexicalNestedList' -> '<PROJECT_ROOT>/packages/lexical-react/src/useLexicalNestedList.js'
 module.name_mapper='^lexical-react/useLexicalIsBlank' -> '<PROJECT_ROOT>/packages/lexical-react/src/useLexicalIsBlank.js'
 module.name_mapper='^lexical-react/useLexicalIsTextContentEmpty' -> '<PROJECT_ROOT>/packages/lexical-react/src/useLexicalIsTextContentEmpty.js'

--- a/packages/lexical-playground/craco.config.js
+++ b/packages/lexical-playground/craco.config.js
@@ -44,6 +44,7 @@ module.exports = {
         'lexical-react/dist/useLexicalDecorators',
       'lexical-react/useLexicalNestedList':
         'lexical-react/dist/useLexicalNestedList',
+      'lexical-react/useLexicalList': 'lexical-react/dist/useLexicalList',
       'lexical-react/useLexicalIsBlank': 'lexical-react/dist/useLexicalIsBlank',
       'lexical-react/useLexicalIsTextContentEmpty':
         'lexical-react/dist/useLexicalIsTextContentEmpty',

--- a/packages/lexical-playground/src/plugins/ActionsPlugin.js
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.js
@@ -13,9 +13,9 @@ import * as React from 'react';
 import {useLexicalComposerContext} from 'lexical-react/LexicalComposerContext';
 import {useCollaborationContext} from '../context/CollaborationContext';
 import {useCallback, useEffect, useState} from 'react';
-import useLexicalNestedList from 'lexical-react/useLexicalNestedList';
 import {$createStickyNode} from '../nodes/StickyNode';
 import {$log, $getRoot, createEditorStateRef} from 'lexical';
+import useLexicalList from 'lexical-react/useLexicalList';
 
 const EditorPriority: CommandListenerEditorPriority = 0;
 
@@ -34,7 +34,7 @@ export default function ActionsPlugins({
   const [isReadOnly, setIsReadyOnly] = useState(false);
   const [connected, setConnected] = useState(false);
   const [editor] = useLexicalComposerContext();
-  useLexicalNestedList(editor);
+  useLexicalList(editor);
   const {yjsDocMap} = useCollaborationContext();
   const isCollab = yjsDocMap.get('main') !== undefined;
 

--- a/packages/lexical-react/src/useLexicalList.js
+++ b/packages/lexical-react/src/useLexicalList.js
@@ -1,0 +1,374 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {
+  LexicalEditor,
+  LexicalNode,
+  CommandListenerLowPriority,
+  ElementNode,
+} from 'lexical';
+
+import {useEffect} from 'react';
+import {
+  $getSelection,
+  $log,
+  $isLeafNode,
+  $isRootNode,
+  $isElementNode,
+} from 'lexical';
+import {
+  $createListItemNode,
+  $isListItemNode,
+  ListItemNode,
+} from 'lexical/ListItemNode';
+import {$createListNode, $isListNode} from 'lexical/ListNode';
+import type {ListNode} from 'lexical/ListNode';
+import {
+  $getAllListItems,
+  $getNearestNodeOfType,
+  $getTopListNode,
+} from 'lexical/nodes';
+import {$createParagraphNode} from 'lexical/ParagraphNode';
+
+const LowPriority: CommandListenerLowPriority = 1;
+
+function removeList(editor: LexicalEditor) {
+  editor.update(() => {
+    $log('removeList');
+    const selection = $getSelection();
+    if (selection !== null) {
+      const listNodes = new Set();
+      const nodes = selection.getNodes();
+      for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        if ($isLeafNode(node)) {
+          const listItemNode = $getNearestNodeOfType(node, ListItemNode);
+          if (listItemNode != null) {
+            listNodes.add($getTopListNode(listItemNode));
+          }
+        }
+      }
+      listNodes.forEach((listNode) => {
+        let insertionPoint = listNode;
+        const listItems = $getAllListItems(listNode);
+        listItems.forEach((listItemNode) => {
+          if (listItemNode != null) {
+            const paragraph = $createParagraphNode();
+            paragraph.append(...listItemNode.getChildren());
+            insertionPoint.insertAfter(paragraph);
+            insertionPoint = paragraph;
+            listItemNode.remove();
+          }
+        });
+        listNode.remove();
+      });
+    }
+  });
+}
+
+function createListOrMerge(node: ElementNode, listType: 'ul' | 'ol'): ListNode {
+  if ($isListNode(node)) {
+    return node;
+  }
+  const previousSibling = node.getPreviousSibling();
+  const nextSibling = node.getNextSibling();
+  const listItem = $createListItemNode();
+  if ($isListNode(previousSibling)) {
+    listItem.append(node);
+    previousSibling.append(listItem);
+    // if there are lists on both sides, merge them.
+    if ($isListNode(nextSibling)) {
+      previousSibling.append(...nextSibling.getChildren());
+      nextSibling.remove();
+    }
+    return previousSibling;
+  } else if ($isListNode(nextSibling)) {
+    listItem.append(node);
+    nextSibling.getFirstChildOrThrow().insertBefore(listItem);
+    return nextSibling;
+  } else {
+    const list = $createListNode(listType);
+    list.append(listItem);
+    node.replace(list);
+    listItem.append(node);
+    return list;
+  }
+}
+
+function insertList(editor: LexicalEditor, listType: 'ul' | 'ol') {
+  editor.update(() => {
+    $log('formatList');
+    const selection = $getSelection();
+    if (selection !== null) {
+      const nodes = selection.getNodes();
+      const anchor = selection.anchor;
+      const anchorNode = anchor.getNode();
+      const anchorNodeParent = anchorNode.getParent();
+      // This is a special case for when there's nothing selected
+      if (nodes.length === 0) {
+        const list = $createListNode(listType);
+        if ($isRootNode(anchorNodeParent)) {
+          anchorNode.replace(list);
+          const listItem = $createListItemNode();
+          list.append(listItem);
+        } else if ($isListItemNode(anchorNode)) {
+          const parent = anchorNode.getParentOrThrow();
+          list.append(...parent.getChildren());
+          parent.replace(list);
+        }
+        return;
+      } else {
+        const handled = new Set();
+        for (let i = 0; i < nodes.length; i++) {
+          const node = nodes[i];
+          if (
+            $isElementNode(node) &&
+            node.isEmpty() &&
+            !handled.has(node.getKey())
+          ) {
+            createListOrMerge(node, listType);
+            continue;
+          }
+          if ($isLeafNode(node)) {
+            let parent = node.getParent();
+            while (parent != null) {
+              const parentKey = parent.getKey();
+              if ($isListNode(parent)) {
+                if (!handled.has(parentKey)) {
+                  const newListNode = $createListNode(listType);
+                  newListNode.append(...parent.getChildren());
+                  parent.replace(newListNode);
+                  handled.add(parentKey);
+                }
+                break;
+              } else {
+                const nextParent = parent.getParent();
+                if ($isRootNode(nextParent) && !handled.has(parentKey)) {
+                  handled.add(parentKey);
+                  createListOrMerge(parent, listType);
+                  break;
+                }
+                parent = nextParent;
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+}
+
+function maybeIndentOrOutdent(direction: 'indent' | 'outdent'): boolean {
+  const selection = $getSelection();
+  if (selection === null) {
+    return false;
+  }
+  const selectedNodes = selection.getNodes();
+  let listItemNodes = [];
+  if (selectedNodes.length === 0) {
+    selectedNodes.push(selection.anchor.getNode());
+  }
+  if (selectedNodes.length === 1) {
+    // Only 1 node selected. Selection may not contain the ListNodeItem so we traverse the tree to
+    // find whether this is part of a ListItemNode
+    const nearestListItemNode = findNearestListItemNode(selectedNodes[0]);
+    if (nearestListItemNode !== null) {
+      listItemNodes = [nearestListItemNode];
+    }
+  } else {
+    listItemNodes = getUniqueListItemNodes(selectedNodes);
+  }
+  if (listItemNodes.length > 0) {
+    if (direction === 'indent') {
+      handleIndent(listItemNodes);
+    } else {
+      handleOutdent(listItemNodes);
+    }
+    return true;
+  }
+  return false;
+}
+
+function isNestedListNode(node: ?LexicalNode): boolean %checks {
+  return $isListItemNode(node) && $isListNode(node.getFirstChild());
+}
+
+function findNearestListItemNode(node: LexicalNode): ListItemNode | null {
+  let currentNode = node;
+  while (currentNode !== null) {
+    if ($isListItemNode(currentNode)) {
+      return currentNode;
+    }
+    currentNode = currentNode.getParent();
+  }
+  return null;
+}
+
+function getUniqueListItemNodes(
+  nodeList: Array<LexicalNode>,
+): Array<ListItemNode> {
+  const keys = new Set<ListItemNode>();
+  for (let i = 0; i < nodeList.length; i++) {
+    const node = nodeList[i];
+    if ($isListItemNode(node)) {
+      keys.add(node);
+    }
+  }
+  return Array.from(keys);
+}
+
+function handleIndent(listItemNodes: Array<ListItemNode>): void {
+  // go through each node and decide where to move it.
+  listItemNodes.forEach((listItemNode) => {
+    if (isNestedListNode(listItemNode)) {
+      return;
+    }
+    const parent = listItemNode.getParent();
+    const nextSibling = listItemNode.getNextSibling();
+    const previousSibling = listItemNode.getPreviousSibling();
+    // if there are nested lists on either side, merge them all together.
+    if (isNestedListNode(nextSibling) && isNestedListNode(previousSibling)) {
+      const innerList = previousSibling.getFirstChild();
+      if ($isListNode(innerList)) {
+        innerList.append(listItemNode);
+        const nextInnerList = nextSibling.getFirstChild();
+        if ($isListNode(nextInnerList)) {
+          const children = nextInnerList.getChildren();
+          innerList.append(...children);
+          nextInnerList.remove();
+        }
+        innerList.getChildren().forEach((child) => child.markDirty());
+      }
+    } else if (isNestedListNode(nextSibling)) {
+      // if the ListItemNode is next to a nested ListNode, merge them
+      const innerList = nextSibling.getFirstChild();
+      if ($isListNode(innerList)) {
+        const firstChild = innerList.getFirstChild();
+        if (firstChild !== null) {
+          firstChild.insertBefore(listItemNode);
+        }
+        innerList.getChildren().forEach((child) => child.markDirty());
+      }
+    } else if (isNestedListNode(previousSibling)) {
+      const innerList = previousSibling.getFirstChild();
+      if ($isListNode(innerList)) {
+        innerList.append(listItemNode);
+        innerList.getChildren().forEach((child) => child.markDirty());
+      }
+    } else {
+      // otherwise, we need to create a new nested ListNode
+      if ($isListNode(parent)) {
+        const newListItem = $createListItemNode();
+        const newList = $createListNode(parent.getTag());
+        newListItem.append(newList);
+        newList.append(listItemNode);
+        if (previousSibling) {
+          previousSibling.insertAfter(newListItem);
+        } else if (nextSibling) {
+          nextSibling.insertBefore(newListItem);
+        } else {
+          parent.append(newListItem);
+        }
+      }
+    }
+    if ($isListNode(parent)) {
+      parent.getChildren().forEach((child) => child.markDirty());
+    }
+  });
+}
+
+function handleOutdent(listItemNodes: Array<ListItemNode>): void {
+  // go through each node and decide where to move it.
+  listItemNodes.forEach((listItemNode) => {
+    if (isNestedListNode(listItemNode)) {
+      return;
+    }
+    const parentList = listItemNode.getParent();
+    const grandparentListItem = parentList ? parentList.getParent() : undefined;
+    const greatGrandparentList = grandparentListItem
+      ? grandparentListItem.getParent()
+      : undefined;
+    // If it doesn't have these ancestors, it's not indented.
+    if (
+      $isListNode(greatGrandparentList) &&
+      $isListItemNode(grandparentListItem) &&
+      $isListNode(parentList)
+    ) {
+      // if it's the first child in it's parent list, insert it into the
+      // great grandparent list before the grandparent
+      const firstChild = parentList ? parentList.getFirstChild() : undefined;
+      const lastChild = parentList ? parentList.getLastChild() : undefined;
+      if (listItemNode.is(firstChild)) {
+        grandparentListItem.insertBefore(listItemNode);
+        if (parentList.isEmpty()) {
+          grandparentListItem.remove();
+        }
+        // if it's the last child in it's parent list, insert it into the
+        // great grandparent list after the grandparent.
+      } else if (listItemNode.is(lastChild)) {
+        grandparentListItem.insertAfter(listItemNode);
+        if (parentList.isEmpty()) {
+          grandparentListItem.remove();
+        }
+      } else {
+        // otherwise, we need to split the siblings into two new nested lists
+        const tag = parentList.getTag();
+        const previousSiblingsListItem = $createListItemNode();
+        const previousSiblingsList = $createListNode(tag);
+        previousSiblingsListItem.append(previousSiblingsList);
+        listItemNode
+          .getPreviousSiblings()
+          .forEach((sibling) => previousSiblingsList.append(sibling));
+        const nextSiblingsListItem = $createListItemNode();
+        const nextSiblingsList = $createListNode(tag);
+        nextSiblingsListItem.append(nextSiblingsList);
+        nextSiblingsList.append(...listItemNode.getNextSiblings());
+        // put the sibling nested lists on either side of the grandparent list item in the great grandparent.
+        grandparentListItem.insertBefore(previousSiblingsListItem);
+        grandparentListItem.insertAfter(nextSiblingsListItem);
+        // replace the grandparent list item (now between the siblings) with the outdented list item.
+        grandparentListItem.replace(listItemNode);
+      }
+      parentList.getChildren().forEach((child) => child.markDirty());
+      greatGrandparentList.getChildren().forEach((child) => child.markDirty());
+    }
+  });
+}
+
+export default function useLexicalList(editor: LexicalEditor): void {
+  useEffect(() => {
+    return editor.addListener(
+      'command',
+      (type) => {
+        if (type === 'indentContent') {
+          const hasHandledIndention = maybeIndentOrOutdent('indent');
+          if (hasHandledIndention) {
+            return true;
+          }
+        } else if (type === 'outdentContent') {
+          const hasHandledIndention = maybeIndentOrOutdent('outdent');
+          if (hasHandledIndention) {
+            return true;
+          }
+        } else if (type === 'insertOrderedList') {
+          insertList(editor, 'ol');
+          return true;
+        } else if (type === 'insertUnorderedList') {
+          insertList(editor, 'ul');
+          return true;
+        } else if (type === 'removeList') {
+          removeList(editor);
+          return true;
+        }
+        return false;
+      },
+      LowPriority,
+    );
+  }, [editor]);
+}

--- a/packages/lexical/src/helpers/LexicalNodeHelpers.js
+++ b/packages/lexical/src/helpers/LexicalNodeHelpers.js
@@ -104,6 +104,25 @@ export function $isLastItemInList(listItem: ListItemNode): boolean {
   return isLast;
 }
 
+// This should probably be $getAllChildrenOfType
+export function $getAllListItems(node: ListNode): Array<ListItemNode> {
+  let listItemNodes: Array<ListItemNode> = [];
+  //$FlowFixMe - the result of this will always be an array of ListItemNodes.
+  const listChildren: Array<ListItemNode> = node
+    .getChildren()
+    .filter($isListItemNode);
+  for (let i = 0; i < listChildren.length; i++) {
+    const listItemNode = listChildren[i];
+    const firstChild = listItemNode.getFirstChild();
+    if ($isListNode(firstChild)) {
+      listItemNodes = listItemNodes.concat($getAllListItems(firstChild));
+    } else {
+      listItemNodes.push(listItemNode);
+    }
+  }
+  return listItemNodes;
+}
+
 export function $getNearestNodeOfType<T: LexicalNode>(
   node: LexicalNode,
   klass: Class<T>,


### PR DESCRIPTION
Moved the list logic out of Toolbar and into a hook that includes all the list implementation stuff. (insert, remove, indent, outdent). useLexicalNestedList is deprecated and will be removed after we sync and I change over the BizInbox composer code.