### PR TITLE
Do not intercept clear editor command when clearing history

### DIFF
--- a/packages/lexical-react/src/useLexicalHistory.js
+++ b/packages/lexical-react/src/useLexicalHistory.js
@@ -374,6 +374,8 @@ export function useLexicalHistory(
           redo();
           return true;
         case 'clearEditor':
+          clearHistory();
+          return false;
         case 'clearHistory':
           clearHistory();
           return true;


### PR DESCRIPTION
When calling `clearEditor` command we want to clear history, but don't need to intercept command as other plugins might need to do their clean up as well