### PR TITLE
Don't stop the build for unused imports

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -123,7 +123,13 @@ async function build(name, inputFile, outputFile) {
     onwarn(warning) {
       if (warning.code === 'CIRCULAR_DEPENDENCY') {
         // Ignored
+      } else if (warning.code === 'UNUSED_EXTERNAL_IMPORT') {
+        // Important, but not enough to stop the build
+        console.error();
+        console.error(warning.message || warning);
+        console.error();
       } else if (typeof warning.code === 'string') {
+        console.error(warning);
         // This is a warning coming from Rollup itself.
         // These tend to be important (e.g. clashes in namespaced exports)
         // so we'll fail the build on any of them.


### PR DESCRIPTION
Minor QOL fix: unused import warnings were killing my build watcher in the background, which led to me being very confused as to why my changes weren't showing up in the browser.

In the future, it may also be prudent to change `npm run dev` to make 'the build has killed itself and will no longer run' more obvious, because the build watcher is independent of the webserver. Currently if you run them together via `npm run dev` the webserver will happily serve increasingly outdated changes.