### PR TITLE
Markdown which change paragraph styling do not make sense within lists.

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/List-test.js
+++ b/packages/lexical-playground/__tests__/e2e/List-test.js
@@ -795,5 +795,22 @@ describe('Nested List', () => {
       await redo(page);
       await assertHTML(page, forwardHTML);
     });
+
+    it(`Should not process paragraph markdown inside list.`, async () => {
+      const {isRichText, page} = e2e;
+
+      if (!isRichText) {
+        return;
+      }
+
+      await focusEditor(page);
+
+      await toggleBulletList(page);
+      await page.keyboard.type('# ');
+      await assertHTML(
+        page,
+        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq kmwttqpk i2mu9gw5"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><span data-lexical-text="true"># </span></li></ul>',
+      );
+    });
   });
 });

--- a/packages/lexical-react/src/useLexicalAutoFormatter.js
+++ b/packages/lexical-react/src/useLexicalAutoFormatter.js
@@ -168,10 +168,14 @@ function getMatchResultContextForCriteria(
   };
 
   let shouldFormat = false;
+
+  const parentNode = textNodeWithOffset.node.getParent();
   const paragraphStartConditionPasses =
     autoFormatCriteria.requiresParagraphStart !== null &&
     autoFormatCriteria.requiresParagraphStart === true &&
-    textNodeWithOffset.node.getPreviousSibling() === null;
+    textNodeWithOffset.node.getPreviousSibling() === null &&
+    parentNode !== null &&
+    $isParagraphNode(parentNode);
 
   if (paragraphStartConditionPasses) {
     const text = textNodeWithOffset.node.getTextContent();


### PR DESCRIPTION
Paragraph markdown such as # or > typed within a list should be ignored as such a change seems nonsensical from a user stand point.
fixes #1108