### PR TITLE
Support plain and bold text pasted from Google docs

### DIFF
--- a/packages/lexical-helpers/src/LexicalEventHelpers.js
+++ b/packages/lexical-helpers/src/LexicalEventHelpers.js
@@ -87,7 +87,11 @@ const DOM_NODE_NAME_TO_LEXICAL_NODE: DOMConversionMap = {
     return {node: null, format: 'underline'};
   },
   b: (domNode: Node) => {
-    return {node: null, format: 'bold'};
+    // $FlowFixMe[incompatible-type] domNode is a <b> since we matched it by nodeName
+    const b: HTMLElement = domNode;
+    // Google Docs wraps all copied HTML in a <b> with font-weight normal
+    const hasNormalFontWeight = b.style.fontWeight === 'normal';
+    return {node: null, format: hasNormalFontWeight ? null : 'bold'};
   },
   strong: (domNode: Node) => {
     return {node: null, format: 'bold'};
@@ -129,7 +133,13 @@ const DOM_NODE_NAME_TO_LEXICAL_NODE: DOMConversionMap = {
       node: isGitHubCodeTable ? $createCodeNode() : null,
     };
   },
-  span: (domNode: Node) => ({node: null}),
+  span: (domNode: Node) => {
+    // $FlowFixMe[incompatible-type] domNode is a <span> since we matched it by nodeName
+    const span: HTMLSpanElement = domNode;
+    // Google Docs uses span tags + font-weight for bold text
+    const hasBoldFontWeight = span.style.fontWeight === '700';
+    return {node: null, format: hasBoldFontWeight ? 'bold' : null};
+  },
   '#text': (domNode: Node) => ({node: $createTextNode(domNode.textContent)}),
   pre: (domNode: Node) => ({node: $createCodeNode()}),
   div: (domNode: Node) => {

--- a/packages/lexical-helpers/src/__tests__/unit/LexicalEventHelpers.test.js
+++ b/packages/lexical-helpers/src/__tests__/unit/LexicalEventHelpers.test.js
@@ -127,176 +127,210 @@ describe('LexicalEventHelpers', () => {
   });
 
   describe('onPasteForRichText', () => {
-    const suite = [
-      {
-        name: 'onPasteForRichText should produce the correct editor state from a pasted HTML h1 element',
-        inputs: [pasteHTML(`<meta charset='utf-8'><h1>Hello</h1>`)],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><h1 class="editor-heading-h1" dir="ltr"><span data-lexical-text="true">Hello</span></h1></div>',
-      },
-      {
-        name: 'onPasteForRichText should produce the correct editor state from a pasted HTML h2 element',
-        inputs: [pasteHTML(`<meta charset='utf-8'><h2>From</h2>`)],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><h2 class="editor-heading-h2" dir="ltr"><span data-lexical-text="true">From</span></h2></div>',
-      },
-      {
-        name: 'onPasteForRichText should produce the correct editor state from a pasted HTML h3 element',
-        inputs: [pasteHTML(`<meta charset='utf-8'><h3>The</h3>`)],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><h3 class="editor-heading-h3" dir="ltr"><span data-lexical-text="true">The</span></h3></div>',
-      },
-      {
-        name: 'onPasteForRichText should produce the correct editor state from a pasted HTML ul element',
-        inputs: [
-          pasteHTML(
-            `<meta charset='utf-8'><ul><li>Other side</li><li>I must have called</li></ul>`,
-          ),
-        ],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><ul class="editor-list-ul"><li value="1" class="editor-listitem" dir="ltr"><span data-lexical-text="true">Other side</span></li><li value="2" class="editor-listitem" dir="ltr"><span data-lexical-text="true">I must have called</span></li></ul></div>',
-      },
-      {
-        name: 'onPasteForRichText should produce the correct editor state from pasted HTML ol element',
-        inputs: [
-          pasteHTML(
-            `<meta charset='utf-8'><ol><li>To tell you</li><li>I’m sorry</li></ol>`,
-          ),
-        ],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><ol class="editor-list-ol"><li value="1" class="editor-listitem" dir="ltr"><span data-lexical-text="true">To tell you</span></li><li value="2" class="editor-listitem" dir="ltr"><span data-lexical-text="true">I’m sorry</span></li></ol></div>',
-      },
-      {
-        name: 'onPasteForRichText should produce the correct editor state from pasted DOM Text Node',
-        inputs: [pasteHTML(`<meta charset='utf-8'>A thousand times`)],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">A thousand times</span></p></div>',
-      },
-      {
-        name: 'onPasteForRichText should produce the correct editor state from a pasted HTML b element',
-        inputs: [pasteHTML(`<meta charset='utf-8'><b>Bold</b>`)],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><strong class="editor-text-bold" data-lexical-text="true">Bold</strong></p></div>',
-      },
-      {
-        name: 'onPasteForRichText should produce the correct editor state from a pasted HTML i element',
-        inputs: [pasteHTML(`<meta charset='utf-8'><i>Italic</i>`)],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><em class="editor-text-italic" data-lexical-text="true">Italic</em></p></div>',
-      },
-      {
-        name: 'onPasteForRichText should produce the correct editor state from a pasted HTML u element',
-        inputs: [pasteHTML(`<meta charset='utf-8'><u>Underline</u>`)],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span class="editor-text-underline" data-lexical-text="true">Underline</span></p></div>',
-      },
-      {
-        name: 'onPasteForRichText should produce the correct editor state from pasted heading node followed by a DOM Text Node',
-        inputs: [
-          pasteHTML(
-            `<meta charset='utf-8'><h1>Lyrics to Hello by Adele</h1>A thousand times`,
-          ),
-        ],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><h1 class="editor-heading-h1" dir="ltr"><span data-lexical-text="true">Lyrics to Hello by Adele</span></h1><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">A thousand times</span></p></div>',
-      },
-      {
-        name: 'onPasteForRichText should produce the correct editor state from a pasted HTML anchor element',
-        inputs: [
-          pasteHTML(
-            `<meta charset='utf-8'><a href="https://facebook.com">Facebook</a>`,
-          ),
-        ],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph"><a href="https://facebook.com/" dir="ltr"><span data-lexical-text="true">Facebook</span></a></p></div>',
-      },
-      {
-        name: 'onPasteForRichText should produce the correct editor state from a pasted combination of an HTML text node followed by an anchor node',
-        inputs: [
-          pasteHTML(
-            `<meta charset='utf-8'>Welcome to<a href="https://facebook.com">Facebook!</a>`,
-          ),
-        ],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Welcome to</span><a href="https://facebook.com/" dir="ltr"><span data-lexical-text="true">Facebook!</span></a></p></div>',
-      },
-      {
-        name: 'onPasteForRichText should produce the correct editor state from a pasted combination of HTML anchor elements and text nodes',
-        inputs: [
-          pasteHTML(
-            `<meta charset='utf-8'>Welcome to<a href="https://facebook.com">Facebook!</a>We hope you like it here.`,
-          ),
-        ],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Welcome to</span><a href="https://facebook.com/" dir="ltr"><span data-lexical-text="true">Facebook!</span></a><span data-lexical-text="true">We hope you like it here.</span></p></div>',
-      },
-      {
-        name: 'onPasteForRichText should ignore DOM node types that do not have transformers, but still process their children.',
-        inputs: [
-          pasteHTML(
-            `<meta charset='utf-8'><doesnotexist><ul><li>Hello</li><li>from the other</li><li>side</li></ul></doesnotexist>`,
-          ),
-        ],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><ul class="editor-list-ul"><li value="1" class="editor-listitem" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="editor-listitem" dir="ltr"><span data-lexical-text="true">from the other</span></li><li value="3" class="editor-listitem" dir="ltr"><span data-lexical-text="true">side</span></li></ul></div>',
-      },
-      {
-        name: 'onPasteForRichText should ignore multiple levels of DOM node types that do not have transformers, but still process their children.',
-        inputs: [
-          pasteHTML(
-            `<meta charset='utf-8'><doesnotexist><doesnotexist><ul><li>Hello</li><li>from the other</li><li>side</li></ul></doesnotexist></doesnotexist>`,
-          ),
-        ],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><ul class="editor-list-ul"><li value="1" class="editor-listitem" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="editor-listitem" dir="ltr"><span data-lexical-text="true">from the other</span></li><li value="3" class="editor-listitem" dir="ltr"><span data-lexical-text="true">side</span></li></ul></div>',
-      },
-      {
-        name: 'onPasteForRichText should respect htmlTransforms passed in via the editor config.',
-        inputs: [
-          pasteHTML(
-            `<meta charset='utf-8'><testhtmltagname>World, hello!</testhtmltagname>`,
-          ),
-        ],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Hello world!</span></p></div>',
-      },
-      {
-        name: 'onPasteForRichText should preserve formatting from HTML tags on deeply nested text nodes.',
-        inputs: [
-          pasteHTML(
-            `<meta charset='utf-8'>Welcome to<b><a href="https://facebook.com">Facebook!</a></b>We hope you like it here.`,
-          ),
-        ],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Welcome to</span><a href="https://facebook.com/" dir="ltr"><strong class="editor-text-bold" data-lexical-text="true">Facebook!</strong></a><span data-lexical-text="true">We hope you like it here.</span></p></div>',
-      },
-      {
-        name: 'onPasteForRichText should preserve formatting from HTML tags on deeply nested and top level text nodes.',
-        inputs: [
-          pasteHTML(
-            `<meta charset='utf-8'>Welcome to<b><a href="https://facebook.com">Facebook!</a>We hope you like it here.</b>`,
-          ),
-        ],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Welcome to</span><a href="https://facebook.com/" dir="ltr"><strong class="editor-text-bold" data-lexical-text="true">Facebook!</strong></a><strong class="editor-text-bold" data-lexical-text="true">We hope you like it here.</strong></p></div>',
-      },
-      {
-        name: 'onPasteForRichText should preserve multiple types of formatting on deeply nested text nodes and top level text nodes',
-        inputs: [
-          pasteHTML(
-            `<meta charset='utf-8'>Welcome to<b><i><a href="https://facebook.com">Facebook!</a>We hope you like it here.</i></b>`,
-          ),
-        ],
-        expectedHTML:
-          '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Welcome to</span><a href="https://facebook.com/" dir="ltr"><strong class="editor-text-bold editor-text-italic" data-lexical-text="true">Facebook!</strong></a><strong class="editor-text-bold editor-text-italic" data-lexical-text="true">We hope you like it here.</strong></p></div>',
-      },
-    ];
-    suite.forEach((testUnit, i) => {
-      const name = testUnit.name || 'Test case';
-      test(name + ` (#${i + 1})`, async () => {
-        await applySelectionInputs(testUnit.inputs, update, editor);
-        // Validate HTML matches
-        expect(container.innerHTML).toBe(testUnit.expectedHTML);
+    describe('baseline', () => {
+      const suite = [
+        {
+          name: 'should produce the correct editor state from a pasted HTML h1 element',
+          inputs: [pasteHTML(`<meta charset='utf-8'><h1>Hello</h1>`)],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><h1 class="editor-heading-h1" dir="ltr"><span data-lexical-text="true">Hello</span></h1></div>',
+        },
+        {
+          name: 'should produce the correct editor state from a pasted HTML h2 element',
+          inputs: [pasteHTML(`<meta charset='utf-8'><h2>From</h2>`)],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><h2 class="editor-heading-h2" dir="ltr"><span data-lexical-text="true">From</span></h2></div>',
+        },
+        {
+          name: 'should produce the correct editor state from a pasted HTML h3 element',
+          inputs: [pasteHTML(`<meta charset='utf-8'><h3>The</h3>`)],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><h3 class="editor-heading-h3" dir="ltr"><span data-lexical-text="true">The</span></h3></div>',
+        },
+        {
+          name: 'should produce the correct editor state from a pasted HTML ul element',
+          inputs: [
+            pasteHTML(
+              `<meta charset='utf-8'><ul><li>Other side</li><li>I must have called</li></ul>`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><ul class="editor-list-ul"><li value="1" class="editor-listitem" dir="ltr"><span data-lexical-text="true">Other side</span></li><li value="2" class="editor-listitem" dir="ltr"><span data-lexical-text="true">I must have called</span></li></ul></div>',
+        },
+        {
+          name: 'should produce the correct editor state from pasted HTML ol element',
+          inputs: [
+            pasteHTML(
+              `<meta charset='utf-8'><ol><li>To tell you</li><li>I’m sorry</li></ol>`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><ol class="editor-list-ol"><li value="1" class="editor-listitem" dir="ltr"><span data-lexical-text="true">To tell you</span></li><li value="2" class="editor-listitem" dir="ltr"><span data-lexical-text="true">I’m sorry</span></li></ol></div>',
+        },
+        {
+          name: 'should produce the correct editor state from pasted DOM Text Node',
+          inputs: [pasteHTML(`<meta charset='utf-8'>A thousand times`)],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">A thousand times</span></p></div>',
+        },
+        {
+          name: 'should produce the correct editor state from a pasted HTML b element',
+          inputs: [pasteHTML(`<meta charset='utf-8'><b>Bold</b>`)],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><strong class="editor-text-bold" data-lexical-text="true">Bold</strong></p></div>',
+        },
+        {
+          name: 'should produce the correct editor state from a pasted HTML i element',
+          inputs: [pasteHTML(`<meta charset='utf-8'><i>Italic</i>`)],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><em class="editor-text-italic" data-lexical-text="true">Italic</em></p></div>',
+        },
+        {
+          name: 'should produce the correct editor state from a pasted HTML u element',
+          inputs: [pasteHTML(`<meta charset='utf-8'><u>Underline</u>`)],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span class="editor-text-underline" data-lexical-text="true">Underline</span></p></div>',
+        },
+        {
+          name: 'should produce the correct editor state from pasted heading node followed by a DOM Text Node',
+          inputs: [
+            pasteHTML(
+              `<meta charset='utf-8'><h1>Lyrics to Hello by Adele</h1>A thousand times`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><h1 class="editor-heading-h1" dir="ltr"><span data-lexical-text="true">Lyrics to Hello by Adele</span></h1><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">A thousand times</span></p></div>',
+        },
+        {
+          name: 'should produce the correct editor state from a pasted HTML anchor element',
+          inputs: [
+            pasteHTML(
+              `<meta charset='utf-8'><a href="https://facebook.com">Facebook</a>`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph"><a href="https://facebook.com/" dir="ltr"><span data-lexical-text="true">Facebook</span></a></p></div>',
+        },
+        {
+          name: 'should produce the correct editor state from a pasted combination of an HTML text node followed by an anchor node',
+          inputs: [
+            pasteHTML(
+              `<meta charset='utf-8'>Welcome to<a href="https://facebook.com">Facebook!</a>`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Welcome to</span><a href="https://facebook.com/" dir="ltr"><span data-lexical-text="true">Facebook!</span></a></p></div>',
+        },
+        {
+          name: 'should produce the correct editor state from a pasted combination of HTML anchor elements and text nodes',
+          inputs: [
+            pasteHTML(
+              `<meta charset='utf-8'>Welcome to<a href="https://facebook.com">Facebook!</a>We hope you like it here.`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Welcome to</span><a href="https://facebook.com/" dir="ltr"><span data-lexical-text="true">Facebook!</span></a><span data-lexical-text="true">We hope you like it here.</span></p></div>',
+        },
+        {
+          name: 'should ignore DOM node types that do not have transformers, but still process their children.',
+          inputs: [
+            pasteHTML(
+              `<meta charset='utf-8'><doesnotexist><ul><li>Hello</li><li>from the other</li><li>side</li></ul></doesnotexist>`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><ul class="editor-list-ul"><li value="1" class="editor-listitem" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="editor-listitem" dir="ltr"><span data-lexical-text="true">from the other</span></li><li value="3" class="editor-listitem" dir="ltr"><span data-lexical-text="true">side</span></li></ul></div>',
+        },
+        {
+          name: 'should ignore multiple levels of DOM node types that do not have transformers, but still process their children.',
+          inputs: [
+            pasteHTML(
+              `<meta charset='utf-8'><doesnotexist><doesnotexist><ul><li>Hello</li><li>from the other</li><li>side</li></ul></doesnotexist></doesnotexist>`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><ul class="editor-list-ul"><li value="1" class="editor-listitem" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="editor-listitem" dir="ltr"><span data-lexical-text="true">from the other</span></li><li value="3" class="editor-listitem" dir="ltr"><span data-lexical-text="true">side</span></li></ul></div>',
+        },
+        {
+          name: 'should respect htmlTransforms passed in via the editor config.',
+          inputs: [
+            pasteHTML(
+              `<meta charset='utf-8'><testhtmltagname>World, hello!</testhtmltagname>`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Hello world!</span></p></div>',
+        },
+        {
+          name: 'should preserve formatting from HTML tags on deeply nested text nodes.',
+          inputs: [
+            pasteHTML(
+              `<meta charset='utf-8'>Welcome to<b><a href="https://facebook.com">Facebook!</a></b>We hope you like it here.`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Welcome to</span><a href="https://facebook.com/" dir="ltr"><strong class="editor-text-bold" data-lexical-text="true">Facebook!</strong></a><span data-lexical-text="true">We hope you like it here.</span></p></div>',
+        },
+        {
+          name: 'should preserve formatting from HTML tags on deeply nested and top level text nodes.',
+          inputs: [
+            pasteHTML(
+              `<meta charset='utf-8'>Welcome to<b><a href="https://facebook.com">Facebook!</a>We hope you like it here.</b>`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Welcome to</span><a href="https://facebook.com/" dir="ltr"><strong class="editor-text-bold" data-lexical-text="true">Facebook!</strong></a><strong class="editor-text-bold" data-lexical-text="true">We hope you like it here.</strong></p></div>',
+        },
+        {
+          name: 'should preserve multiple types of formatting on deeply nested text nodes and top level text nodes',
+          inputs: [
+            pasteHTML(
+              `<meta charset='utf-8'>Welcome to<b><i><a href="https://facebook.com">Facebook!</a>We hope you like it here.</i></b>`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Welcome to</span><a href="https://facebook.com/" dir="ltr"><strong class="editor-text-bold editor-text-italic" data-lexical-text="true">Facebook!</strong></a><strong class="editor-text-bold editor-text-italic" data-lexical-text="true">We hope you like it here.</strong></p></div>',
+        },
+      ];
+      suite.forEach((testUnit, i) => {
+        const name = testUnit.name || 'Test case';
+        test(name + ` (#${i + 1})`, async () => {
+          await applySelectionInputs(testUnit.inputs, update, editor);
+          // Validate HTML matches
+          expect(container.innerHTML).toBe(testUnit.expectedHTML);
+        });
+      });
+    });
+    describe('Google Docs', () => {
+      const suite = [
+        {
+          name: 'should produce the correct editor state from Normal text',
+          inputs: [
+            pasteHTML(
+              `<b style="font-weight:normal;" id="docs-internal-guid-2c706577-7fff-f54a-fe65-12f480020fac"><span style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Get schwifty!</span></b>`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Get schwifty!</span></p></div>',
+        },
+        {
+          name: 'should produce the correct editor state from bold text',
+          inputs: [
+            pasteHTML(
+              `<b style="font-weight:normal;" id="docs-internal-guid-9db03964-7fff-c26c-8b1e-9484fb3b54a4"><span style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Get schwifty!</span></b>`,
+            ),
+          ],
+          expectedHTML:
+            '<div contenteditable="true" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><strong class="editor-text-bold" data-lexical-text="true">Get schwifty!</strong></p></div>',
+        },
+      ];
+      suite.forEach((testUnit, i) => {
+        const name = testUnit.name || 'Test case';
+        test(name + ` (#${i + 1})`, async () => {
+          await applySelectionInputs(testUnit.inputs, update, editor);
+          // Validate HTML matches
+          expect(container.innerHTML).toBe(testUnit.expectedHTML);
+        });
       });
     });
   });

--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -38,7 +38,7 @@ export type DOMConversionMap = {
 };
 type DOMConversionOutput = {
   node: LexicalNode | null,
-  format?: TextFormatType,
+  format?: ?TextFormatType,
   after?: (
     lexicalChildren: Array<LexicalNode>,
     lexicalNode: ?LexicalNode,


### PR DESCRIPTION
An alternative to #1155, this puts in special case logic to ignore b tags with font-weight set to normal, and also adds logic to support pasting bold text from Google Docs.

Quip uses \<b> for bold text, so this is probably a better approach that #1155.

Also starts to adds some tests for specific popular editor surfaces, like Google Docs.