### PR TITLE
add missing export in useLexicalCharacterLimit

### DIFF
--- a/packages/lexical-react/src/DEPRECATED_useLexicalCharacterLimit.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalCharacterLimit.js
@@ -12,4 +12,5 @@ export {
   mergePrevious,
   isOverflowNode,
   OverflowNode,
+  useCharacterLimit,
 } from './shared/useCharacterLimit';


### PR DESCRIPTION
I think this export was missed when we deprecated all the hooks.