### PR TITLE
Fix cached getTextContent for Decorators

### DIFF
--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -153,11 +153,14 @@ function createNode(
   } else {
     if ($isDecoratorNode(node)) {
       const decorator = node.decorate(activeEditor);
+      const text = node.getTextContent();
       if (decorator !== null) {
         reconcileDecorator(key, decorator);
       }
       // Decorators are always non editable
       dom.contentEditable = 'false';
+      subTreeTextContent += text;
+      editorTextContent += text;
     } else {
       const text = node.getTextContent();
       if ($isTextNode(node)) {

--- a/packages/lexical/src/nodes/base/__tests__/unit/LexicalRootNode.test.js
+++ b/packages/lexical/src/nodes/base/__tests__/unit/LexicalRootNode.test.js
@@ -5,9 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {$isRootNode} from 'lexical';
+import {$isRootNode, $getRoot} from 'lexical';
+import {$createParagraphNode} from 'lexical/ParagraphNode';
 import {$createRootNode} from '../../LexicalRootNode';
-import {initializeUnitTest} from '../../../../__tests__/utils';
+import {
+  $createTestDecoratorNode,
+  initializeUnitTest,
+} from '../../../../__tests__/utils';
 
 describe('LexicalRootNode tests', () => {
   initializeUnitTest((testEnv) => {
@@ -49,6 +53,21 @@ describe('LexicalRootNode tests', () => {
 
     test('RootNode.isRootNode()', () => {
       expect($isRootNode(rootNode)).toBe(true);
+    });
+
+    test('Cached getTextContent with decorators', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
+        paragraph.append($createTestDecoratorNode());
+      });
+      expect(
+        editor.getEditorState().read(() => {
+          return $getRoot().getTextContent();
+        }),
+      ).toBe('Hello world');
     });
   });
 });


### PR DESCRIPTION
While the computation was fine when dirty, the cached content never took decorators into consideration

Closes #1174