### PR TITLE
Fix empty check regression

### DIFF
--- a/packages/lexical/src/LexicalUpdates.js
+++ b/packages/lexical/src/LexicalUpdates.js
@@ -566,7 +566,7 @@ function beginUpdate(
     processNestedUpdates(editor, deferred);
     applySelectionTransforms(pendingEditorState, editor);
     if (editor._dirtyType !== NO_DIRTY_NODES) {
-      if (pendingEditorState.isEmpty()) {
+      if (!skipEmptyCheck && pendingEditorState.isEmpty()) {
         invariant(
           false,
           'updateEditor: the pending editor state is empty. Ensure the root not never becomes empty from an update.',


### PR DESCRIPTION
https://github.com/facebook/lexical/pull/845 removed the `skipEmptyCheck` logic causing a collab regression. This puts it back. This is hard to test as it depends on collab.