### PR TITLE
Use ParagraphNodes in TableCellNodes

### DIFF
--- a/packages/lexical-helpers/src/LexicalNodeHelpers.js
+++ b/packages/lexical-helpers/src/LexicalNodeHelpers.js
@@ -25,6 +25,7 @@ import {
 import {$createTableNode} from 'lexical/TableNode';
 import {$createTableRowNode} from 'lexical/TableRowNode';
 import {$createTableCellNode} from 'lexical/TableCellNode';
+import {$createParagraphNode} from 'lexical/ParagraphNode';
 
 export function $dfs__DEPRECATED(
   startingNode: LexicalNode,
@@ -171,15 +172,18 @@ export function $createTableNodeWithDimensions(
   const tableNode = $createTableNode();
 
   for (let iRow = 0; iRow < rowCount; iRow++) {
-    const tableRow = $createTableRowNode();
+    const tableRowNode = $createTableRowNode();
 
     for (let iColumn = 0; iColumn < columnCount; iColumn++) {
-      const tableCell = $createTableCellNode(iRow === 0 && includeHeader);
-      tableCell.append($createTextNode());
-      tableRow.append(tableCell);
+      const tableCellNode = $createTableCellNode(iRow === 0 && includeHeader);
+      const paragraphNode = $createParagraphNode();
+      paragraphNode.append($createTextNode());
+
+      tableCellNode.append(paragraphNode);
+      tableRowNode.append(tableCellNode);
     }
 
-    tableNode.append(tableRow);
+    tableNode.append(tableRowNode);
   }
 
   return tableNode;


### PR DESCRIPTION
This PR fixes a few bugs
1. [Paragraph styles applying to the entire cell and not individual lines](https://github.com/facebook/lexical/issues/1135)
2. [Inability to hard/soft return in a cell](https://github.com/facebook/lexical/issues/1135)
3. Not being able to backspace onto the previous "line".

Before:
https://user-images.githubusercontent.com/13852400/151471554-d27fd2f6-98b9-4d23-9fb4-f91e6d2f4c34.mov

After:
https://user-images.githubusercontent.com/13852400/151471561-04493e61-1fb4-4995-b070-b2ad2b2141e7.mov




