### PR TITLE
Remove cell selection when user starts typing

### DIFF
--- a/packages/lexical/src/nodes/extended/LexicalTableNode.js
+++ b/packages/lexical/src/nodes/extended/LexicalTableNode.js
@@ -258,6 +258,9 @@ function applyCellSelection(
                 } else if (type === 'formatText') {
                   formatCells(payload);
                   return true;
+                } else if (type === 'insertText') {
+                  clearHighlight();
+                  return false;
                 }
                 return false;
               },


### PR DESCRIPTION
This PR fixes #1139 by removing the mocked Table Cell Selection when the user starts typing.

Note: This PR depends on #1191 (a la Stacks), but I'm rusty with GIT after using Mercurial Stacks for 1.5 years...

Before:
https://user-images.githubusercontent.com/13852400/151473270-6ddd0287-e18c-477d-9fe4-ecbaced645ed.mov

After:
https://user-images.githubusercontent.com/13852400/151473281-438c7fd6-c523-4695-ab1a-d8fa0984e8ae.mov