### PR TITLE
Fix bug with Google Input IME tools

### DIFF
--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -368,12 +368,10 @@ function onCompositionStart(
     if (selection !== null && !editor.isComposing()) {
       const anchor = selection.anchor;
       $setCompositionKey(anchor.key);
-      const data = event.data;
       if (
-        data != null &&
-        (!lastKeyWasMaybeAndroidSoftKey ||
-          anchor.type === 'element' ||
-          !selection.isCollapsed())
+        !lastKeyWasMaybeAndroidSoftKey ||
+        anchor.type === 'element' ||
+        !selection.isCollapsed()
       ) {
         // We insert an empty space, ready for the composition
         // to get inserted into the new node we create. If


### PR DESCRIPTION
It turns out that Google's IME tools don't pass through an `event.data`, so the wrong behavior was being observed.