### PR TITLE
Scroll edited element into view when the root element has height limit

### DIFF
--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -699,7 +699,7 @@ export function updateEditorState(
   }
 }
 
-function scrollIntoViewIfNeeded(node: Node): void {
+function scrollIntoViewIfNeeded(node: Node, rootElement: ?HTMLElement): void {
   const element: Element =
     // $FlowFixMe: this is valid, as we are checking the nodeType
     node.nodeType === DOM_TEXT_TYPE ? node.parentNode : node;
@@ -710,6 +710,13 @@ function scrollIntoViewIfNeeded(node: Node): void {
       element.scrollIntoView(false);
     } else if (rect.top < 0) {
       element.scrollIntoView();
+    } else if (rootElement) {
+      const rootRect = rootElement.getBoundingClientRect();
+      if (rect.top < rootRect.top) {
+        element.scrollIntoView();
+      } else if (rect.bottom > rootRect.bottom) {
+        element.scrollIntoView(false);
+      }
     }
   }
 }
@@ -805,7 +812,7 @@ function reconcileSelection(
       nextFocusOffset,
     );
     if (nextSelection.isCollapsed() && rootElement === activeElement) {
-      scrollIntoViewIfNeeded(nextAnchorNode);
+      scrollIntoViewIfNeeded(nextAnchorNode, rootElement);
     }
   } catch (error) {
     // If we encounter an error, continue. This can sometimes


### PR DESCRIPTION
When the root element has a height limit (`height` or `max-height`), Lexical should scroll the edited element into view when it is over the top or below the bottom of the root element.

This fixes #1218 

### before

https://user-images.githubusercontent.com/118264/152433662-f72f8a59-cf47-4927-83bb-ba12258e0336.mp4




### after

https://user-images.githubusercontent.com/118264/152433673-e3267b14-f86d-4401-9127-5f1adcd758b6.mp4



