### PR TITLE
Fix indenting on backspace for lists and paragraphs

### DIFF
--- a/packages/lexical-react/src/shared/useRichTextSetup.js
+++ b/packages/lexical-react/src/shared/useRichTextSetup.js
@@ -226,7 +226,7 @@ export function useRichTextSetup(editor: LexicalEditor, init: boolean): void {
                   anchor.type === 'element'
                     ? anchor.getNode()
                     : anchor.getNode().getParentOrThrow();
-                if (element.isIndented()) {
+                if (element.getIndent() > 0) {
                   return editor.execCommand('outdentContent');
                 }
               }

--- a/packages/lexical/src/nodes/base/LexicalElementNode.js
+++ b/packages/lexical/src/nodes/base/LexicalElementNode.js
@@ -464,9 +464,6 @@ export class ElementNode extends LexicalNode {
   canInsertTextAfter(): boolean {
     return true;
   }
-  isIndented(): boolean {
-    return this.getIndent() > 0;
-  }
   isInline(): boolean {
     return false;
   }

--- a/packages/lexical/src/nodes/extended/LexicalListItemNode.js
+++ b/packages/lexical/src/nodes/extended/LexicalListItemNode.js
@@ -230,10 +230,21 @@ export class ListItemNode extends ElementNode {
     return true;
   }
 
-  isIndented(): boolean {
-    const listNode = this.getParentOrThrow();
-    const listNodeParent = listNode.getParentOrThrow();
-    return $isListItemNode(listNodeParent);
+  getIndent(): number {
+    // ListItemNode should always have a ListNode for a parent.
+    let listNodeParent = this.getParentOrThrow().getParentOrThrow();
+    let indentLevel = 0;
+    while ($isListItemNode(listNodeParent)) {
+      listNodeParent = listNodeParent.getParentOrThrow().getParentOrThrow();
+      indentLevel++;
+    }
+    return indentLevel;
+  }
+
+  setIndent(): this {
+    // TODO move indent/outdent logic to this file and use here.
+    invariant(true, 'setIndent is not implemented on ListItemNode');
+    return this;
   }
 
   insertBefore(nodeToInsert: LexicalNode): LexicalNode {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -48,5 +48,8 @@
   "46": "rootNode.append: Only element or decorator nodes can be appended to the root node",
   "47": "getListItemValue: list node is not parent of list item node",
   "48": "Should never happen",
-  "49": "append: attemtping to append self"
+  "49": "append: attemtping to append self",
+  "50": "Node %s and selection point do not match.",
+  "51": "setIndent is not implemented on ListItemNode",
+  "52": "Expected node %s to to be a ElementNode."
 }


### PR DESCRIPTION
Originally, I was trying to fix this in Selection.deleteCharacter or ListItemNode.collapseAtStart. Really, though, what we want to do is not delete a character at all, but instead outdent when the backspace key is pressed within an indented element and the selection is at a certain position.

Fixes #1157 