### PR TITLE
Remove prefix from internal functions

### DIFF
--- a/packages/lexical/src/LexicalParsing.js
+++ b/packages/lexical/src/LexicalParsing.js
@@ -76,7 +76,7 @@ export function $createNodeFromParse(
 ): LexicalNode {
   errorOnReadOnly();
   const editor = getActiveEditor();
-  return $internalCreateNodeFromParse(parsedNode, parsedNodeMap, editor, null);
+  return internalCreateNodeFromParse(parsedNode, parsedNodeMap, editor, null);
 }
 
 function createDecoratorValueFromParse(
@@ -133,7 +133,7 @@ function createDecoratorMapFromParse(
   return createDecoratorMap(editor, map);
 }
 
-export function $internalCreateNodeFromParse(
+export function internalCreateNodeFromParse(
   parsedNode: $FlowFixMe,
   parsedNodeMap: ParsedNodeMap,
   editor: LexicalEditor,
@@ -166,7 +166,7 @@ export function $internalCreateNodeFromParse(
       const childKey = children[i];
       const parsedChild = parsedNodeMap.get(childKey);
       if (parsedChild !== undefined) {
-        const child = $internalCreateNodeFromParse(
+        const child = internalCreateNodeFromParse(
           parsedChild,
           parsedNodeMap,
           editor,

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -328,7 +328,7 @@ export class Selection {
 
   applyDOMRange(range: StaticRange): void {
     const editor = getActiveEditor();
-    const resolvedSelectionPoints = $resolveSelectionPoints(
+    const resolvedSelectionPoints = internalResolveSelectionPoints(
       range.startContainer,
       range.startOffset,
       range.endContainer,
@@ -1384,7 +1384,10 @@ function $removeSegment(node: TextNode, isBackward: boolean): void {
   }
 }
 
-function $resolveSelectionPoint(dom: Node, offset: number): null | PointType {
+function internalResolveSelectionPoint(
+  dom: Node,
+  offset: number,
+): null | PointType {
   let resolvedOffset = offset;
   let resolvedNode: LexicalNode | null;
   // If we have selection on an element, we will
@@ -1462,7 +1465,7 @@ function $resolveSelectionPoint(dom: Node, offset: number): null | PointType {
   return $createPoint(resolvedNode.__key, resolvedOffset, 'text');
 }
 
-function $resolveSelectionPoints(
+function internalResolveSelectionPoints(
   anchorDOM: null | Node,
   anchorOffset: number,
   focusDOM: null | Node,
@@ -1476,11 +1479,17 @@ function $resolveSelectionPoints(
   ) {
     return null;
   }
-  const resolvedAnchorPoint = $resolveSelectionPoint(anchorDOM, anchorOffset);
+  const resolvedAnchorPoint = internalResolveSelectionPoint(
+    anchorDOM,
+    anchorOffset,
+  );
   if (resolvedAnchorPoint === null) {
     return null;
   }
-  const resolvedFocusPoint = $resolveSelectionPoint(focusDOM, focusOffset);
+  const resolvedFocusPoint = internalResolveSelectionPoint(
+    focusDOM,
+    focusOffset,
+  );
   if (resolvedFocusPoint === null) {
     return null;
   }
@@ -1550,7 +1559,7 @@ function $resolveSelectionPoints(
 // This is used to make a selection when the existing
 // selection is null, i.e. forcing selection on the editor
 // when it current exists outside the editor.
-export function $makeSelection(
+export function internalMakeSelection(
   anchorKey: NodeKey,
   anchorOffset: number,
   focusKey: NodeKey,
@@ -1580,7 +1589,9 @@ function getActiveEventType(): string | void {
   return event && event.type;
 }
 
-export function $createSelection(editor: LexicalEditor): null | Selection {
+export function internalCreateSelection(
+  editor: LexicalEditor,
+): null | Selection {
   // When we create a selection, we try to use the previous
   // selection where possible, unless an actual user selection
   // change has occurred. When we do need to create a new selection
@@ -1629,7 +1640,7 @@ export function $createSelection(editor: LexicalEditor): null | Selection {
   }
   // Let's resolve the text nodes from the offsets and DOM nodes we have from
   // native selection.
-  const resolvedSelectionPoints = $resolveSelectionPoints(
+  const resolvedSelectionPoints = internalResolveSelectionPoints(
     anchorDOM,
     anchorOffset,
     focusDOM,
@@ -1657,7 +1668,7 @@ export function $getPreviousSelection(): null | Selection {
   return editor._editorState._selection;
 }
 
-export function $createSelectionFromParse(
+export function internalCreateSelectionFromParse(
   parsedSelection: null | {
     anchor: {
       key: string,

--- a/packages/lexical/src/LexicalUpdates.js
+++ b/packages/lexical/src/LexicalUpdates.js
@@ -18,7 +18,10 @@ import type {LexicalNode} from './LexicalNode';
 import type {ParsedNode, NodeParserState} from './LexicalParsing';
 
 import {updateEditorState} from './LexicalReconciler';
-import {$createSelection, $createSelectionFromParse} from './LexicalSelection';
+import {
+  internalCreateSelection,
+  internalCreateSelectionFromParse,
+} from './LexicalSelection';
 import {FULL_RECONCILE, NO_DIRTY_NODES} from './LexicalConstants';
 import {resetEditor} from './LexicalEditor';
 import {initMutationObserver} from './LexicalMutations';
@@ -38,7 +41,7 @@ import {
   $garbageCollectDetachedDecorators,
   $garbageCollectDetachedNodes,
 } from './LexicalGC';
-import {$internalCreateNodeFromParse} from './LexicalParsing';
+import {internalCreateNodeFromParse} from './LexicalParsing';
 import {applySelectionTransforms} from './LexicalSelection';
 import {$isTextNode} from '.';
 import {$normalizeTextNode} from './LexicalNormalization';
@@ -258,7 +261,7 @@ export function parseEditorState(
     const parsedNodeMap = new Map(parsedEditorState._nodeMap);
     // $FlowFixMe: root always exists in Map
     const parsedRoot = ((parsedNodeMap.get('root'): any): ParsedNode);
-    $internalCreateNodeFromParse(
+    internalCreateNodeFromParse(
       parsedRoot,
       parsedNodeMap,
       editor,
@@ -270,7 +273,7 @@ export function parseEditorState(
     isReadOnlyMode = previousReadOnlyMode;
     activeEditor = previousActiveEditor;
   }
-  editorState._selection = $createSelectionFromParse(
+  editorState._selection = internalCreateSelectionFromParse(
     nodeParserState.remappedSelection || nodeParserState.originalSelection,
   );
   return editorState;
@@ -553,7 +556,7 @@ function beginUpdate(
 
   try {
     if (editorStateWasCloned) {
-      pendingEditorState._selection = $createSelection(editor);
+      pendingEditorState._selection = internalCreateSelection(editor);
     }
     const startingCompositionKey = editor._compositionKey;
     updateFn();

--- a/packages/lexical/src/nodes/base/LexicalElementNode.js
+++ b/packages/lexical/src/nodes/base/LexicalElementNode.js
@@ -13,7 +13,7 @@ import type {PointType, Selection} from '../../LexicalSelection';
 import {$isRootNode, $isTextNode, TextNode} from '../../';
 import {LexicalNode} from '../../LexicalNode';
 import {
-  $makeSelection,
+  internalMakeSelection,
   $getSelection,
   moveSelectionPointToSibling,
 } from '../../LexicalSelection';
@@ -216,7 +216,7 @@ export class ElementNode extends LexicalNode {
     }
     const key = this.__key;
     if (selection === null) {
-      return $makeSelection(
+      return internalMakeSelection(
         key,
         anchorOffset,
         key,

--- a/packages/lexical/src/nodes/base/LexicalTextNode.js
+++ b/packages/lexical/src/nodes/base/LexicalTextNode.js
@@ -14,7 +14,7 @@ import type {EditorConfig, TextNodeThemeClasses} from '../../LexicalEditor';
 import {LexicalNode} from '../../LexicalNode';
 import {
   $getSelection,
-  $makeSelection,
+  internalMakeSelection,
   $updateElementSelectionOnCreateDeleteNode,
   adjustPointOffsetForMergedSibling,
 } from '../../LexicalSelection';
@@ -424,7 +424,7 @@ export class TextNode extends LexicalNode {
       focusOffset = 0;
     }
     if (selection === null) {
-      return $makeSelection(
+      return internalMakeSelection(
         key,
         anchorOffset,
         key,


### PR DESCRIPTION
Internal core functions shouldn't have a $ prefix. These functions are core behavior and have to be used in very specific ways, so instead they have the `internal` prefix. Fixes #1226