### PR TITLE
Tables: Fix clear selection + Add empty paragraph node when cell is "cleared"

### DIFF
--- a/packages/lexical/src/nodes/extended/LexicalTableNode.js
+++ b/packages/lexical/src/nodes/extended/LexicalTableNode.js
@@ -253,7 +253,7 @@ function applyCellSelection(
                   highlightedCells.forEach(({elem}) => {
                     const cellNode = $getNearestNodeFromDOMNode(elem);
 
-                    if (cellNode != null && $isElementNode(cellNode)) {
+                    if ($isElementNode(cellNode)) {
                       cellNode.clear();
 
                       const paragraphNode = $createParagraphNode();


### PR DESCRIPTION
As of now, clearing a cell via selection throws an error because the actual selection is lost. 

This fixes that bug and inserts a new `ParagraphNode` in the `TableCell` after its contents are removed.

https://user-images.githubusercontent.com/13852400/152871344-a1070a31-17c9-41d9-8f94-e94b6388439d.mov

