### PR TITLE
Define root package.json name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "Outline",
+  "name": "lexical-monorepo",
   "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "lexical-monorepo",
       "version": "0.1.5",
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "lexical-monorepo",
   "description": "Lexical is an extensible text editor library that provides excellent reliability, accessible and performance.",
   "version": "0.1.5",
   "license": "MIT",


### PR DESCRIPTION
Adding name to root `package.json`, as otherwise it uses project folder name for .lock file's name field