### PR TITLE
Fix bug in Lexical update cycle

### DIFF
--- a/packages/lexical/src/LexicalUpdates.js
+++ b/packages/lexical/src/LexicalUpdates.js
@@ -514,12 +514,12 @@ function processNestedUpdates(editor: LexicalEditor): boolean {
       if (options.skipTransforms) {
         skipTransforms = true;
       }
-    }
-    if (onUpdate) {
-      editor._deferred.push(onUpdate);
-    }
-    if (tag) {
-      editor._updateTags.add(tag);
+      if (onUpdate) {
+        editor._deferred.push(onUpdate);
+      }
+      if (tag) {
+        editor._updateTags.add(tag);
+      }
     }
     nextUpdateFn();
   }


### PR DESCRIPTION
We had a nasty bug in the update cycle logic. Specifically, `tag` and `skipTransforms` options were not persisted between tested updates, meaning they were incorrectly discarded.