### PR TITLE
Fix bug in beginUpdate

### DIFF
--- a/packages/lexical/src/LexicalUpdates.js
+++ b/packages/lexical/src/LexicalUpdates.js
@@ -649,10 +649,10 @@ function beginUpdate(
       });
     }
   } else {
-    updateTags.clear();
-    editor._deferred = [];
     pendingEditorState._flushSync = false;
     if (editorStateWasCloned) {
+      updateTags.clear();
+      editor._deferred = [];
       editor._pendingEditorState = null;
     }
   }


### PR DESCRIPTION
We should only clear them down when we clone the editor state.