### PR TITLE
Enable linting for scripts and fix lint errors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,4 +7,3 @@ packages/eslint-plugin-stylex
 packages/stylex
 packages/**/vite.config.js
 **/node_modules
-scripts/**

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
     'no-function-declare-after-return',
     'react',
     'no-only-tests',
-    'eslint-plugin-stylex'
+    'eslint-plugin-stylex',
   ],
 
   parser: 'babel-eslint',
@@ -118,6 +118,13 @@ module.exports = {
         'no-var': ERROR,
         'prefer-const': ERROR,
         strict: OFF,
+      },
+    },
+    {
+      // node scripts should be console logging so don't lint against that
+      files: ['scripts/**/*.js'],
+      rules: {
+        'no-console': OFF,
       },
     },
   ],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -201,6 +201,7 @@ async function build(name, inputFile, outputFile) {
       // Extract error codes from invariant() messages into a file.
       {
         transform(source) {
+          // eslint-disable-next-line no-unused-expressions
           extractCodes && findAndRecordErrorCodes(source);
           return source;
         },

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -3,8 +3,6 @@
 'use strict';
 
 const {exec} = require('child-process-promise');
-const fs = require('fs');
-const path = require('path');
 
 async function prepareLexicalCorePackage() {
   await exec(`rm -rf ./packages/lexical/npm`);

--- a/scripts/prepare-size-compare.js
+++ b/scripts/prepare-size-compare.js
@@ -3,8 +3,6 @@
 'use strict';
 
 const {exec} = require('child-process-promise');
-const fs = require('fs');
-const path = require('path');
 
 async function prepareBaseBuild() {
   const currentBranch = (


### PR DESCRIPTION
Linting will help us catch bugs! I disabled `no-console` for the scripts folder.