### PR TITLE
Add setIndent implementation for list items

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.js
+++ b/packages/lexical-list/src/LexicalListItemNode.js
@@ -29,6 +29,7 @@ import {
 } from 'lexical';
 import invariant from 'shared/invariant';
 
+import {$handleIndent, $handleOutdent} from './formatList';
 import {$getTopListNode, $isLastItemInList} from './utils';
 
 export class ListItemNode extends ElementNode {
@@ -246,9 +247,17 @@ export class ListItemNode extends ElementNode {
     return indentLevel;
   }
 
-  setIndent(): this {
-    // TODO move indent/outdent logic to this file and use here.
-    invariant(true, 'setIndent is not implemented on ListItemNode');
+  setIndent(indent: number): this {
+    let currentIndent = this.getIndent();
+    while (currentIndent !== indent) {
+      if (currentIndent < indent) {
+        $handleIndent([this]);
+        currentIndent++;
+      } else {
+        $handleOutdent([this]);
+        currentIndent--;
+      }
+    }
     return this;
   }
 

--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.js
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.js
@@ -354,5 +354,47 @@ describe('LexicalListItemNode tests', () => {
         expect($isListItemNode(listItemNode)).toBe(true);
       });
     });
+
+    describe('ListItemNode.setIndent()', () => {
+      let listNode;
+      let listItemNode1;
+      let listItemNode2;
+
+      beforeEach(async () => {
+        const {editor} = testEnv;
+        await editor.update(() => {
+          const root = $getRoot();
+          listNode = new ListNode('ul', 1);
+          listItemNode1 = new ListItemNode();
+          listItemNode2 = new ListItemNode();
+          root.append(listNode);
+          listNode.append(listItemNode1, listItemNode2);
+          listItemNode1.append(new TextNode('one'));
+          listItemNode2.append(new TextNode('two'));
+        });
+      });
+
+      it('indents and outdents list item', async () => {
+        const {editor} = testEnv;
+        await editor.update(() => {
+          listItemNode1.setIndent(3);
+        });
+        await editor.update(() => {
+          expect(listItemNode1.getIndent()).toBe(3);
+        });
+        expect(editor.getRootElement().innerHTML).toBe(
+          '<ul><li value="1"><ul><li value="1"><ul><li value="1"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li></ul></li></ul></li></ul></li><li value="1" dir="ltr"><span data-lexical-text="true">two</span></li></ul>',
+        );
+        await editor.update(() => {
+          listItemNode1.setIndent(0);
+        });
+        await editor.update(() => {
+          expect(listItemNode1.getIndent()).toBe(0);
+        });
+        expect(editor.getRootElement().innerHTML).toBe(
+          '<ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" dir="ltr"><span data-lexical-text="true">two</span></li></ul>',
+        );
+      });
+    });
   });
 });

--- a/packages/lexical-list/src/formatList.js
+++ b/packages/lexical-list/src/formatList.js
@@ -166,7 +166,7 @@ export function removeList(editor: LexicalEditor): void {
   });
 }
 
-function handleIndent(listItemNodes: Array<ListItemNode>): void {
+export function $handleIndent(listItemNodes: Array<ListItemNode>): void {
   // go through each node and decide where to move it.
   listItemNodes.forEach((listItemNode) => {
     if (isNestedListNode(listItemNode)) {
@@ -226,7 +226,7 @@ function handleIndent(listItemNodes: Array<ListItemNode>): void {
   });
 }
 
-function handleOutdent(listItemNodes: Array<ListItemNode>): void {
+export function $handleOutdent(listItemNodes: Array<ListItemNode>): void {
   // go through each node and decide where to move it.
   listItemNodes.forEach((listItemNode) => {
     if (isNestedListNode(listItemNode)) {
@@ -306,9 +306,9 @@ function maybeIndentOrOutdent(direction: 'indent' | 'outdent'): boolean {
   }
   if (listItemNodes.length > 0) {
     if (direction === 'indent') {
-      handleIndent(listItemNodes);
+      $handleIndent(listItemNodes);
     } else {
-      handleOutdent(listItemNodes);
+      $handleOutdent(listItemNodes);
     }
     return true;
   }


### PR DESCRIPTION
Looks like we have all code needed to implement `setIndent` for list items, although not sure if it needs anything else