### PR TITLE
Remove bootstrap from plain/rich text hooks

### DIFF
--- a/packages/lexical-react/src/DEPRECATED_useLexicalPlainText.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalPlainText.js
@@ -11,14 +11,12 @@ import type {HistoryState} from './DEPRECATED_useLexicalHistory';
 import type {LexicalEditor} from 'lexical';
 
 import {useLexicalHistory} from './DEPRECATED_useLexicalHistory';
-import useBootstrapEditor from './shared/useBootstrapEditor';
 import usePlainTextSetup from './shared/usePlainTextSetup';
 
 export default function useLexicalPlainText(
   editor: LexicalEditor,
   externalHistoryState?: HistoryState,
 ): void {
-  useBootstrapEditor(editor);
   usePlainTextSetup(editor);
   useLexicalHistory(editor, externalHistoryState);
 }

--- a/packages/lexical-react/src/DEPRECATED_useLexicalRichText.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalRichText.js
@@ -11,14 +11,12 @@ import type {HistoryState} from './DEPRECATED_useLexicalHistory';
 import type {LexicalEditor} from 'lexical';
 
 import {useLexicalHistory} from './DEPRECATED_useLexicalHistory';
-import useBootstrapEditor from './shared/useBootstrapEditor';
 import {useRichTextSetup} from './shared/useRichTextSetup';
 
 export default function useLexicalRichText(
   editor: LexicalEditor,
   externalHistoryState?: HistoryState,
 ): void {
-  useBootstrapEditor(editor);
   useRichTextSetup(editor);
   useLexicalHistory(editor, externalHistoryState);
 }


### PR DESCRIPTION
This is a trap.. The modern plugin based version doesn't use it so this one shouldn't either