### PR TITLE
Fix collaboration bad merge bug

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Keywords-test.js
+++ b/packages/lexical-playground/__tests__/e2e/Keywords-test.js
@@ -18,7 +18,6 @@ import {
   waitForSelector,
   keyDownCtrlOrMeta,
   keyUpCtrlOrMeta,
-  IS_COLLAB,
 } from '../utils';
 
 const config = {appSettings: {isRichText: true}};
@@ -151,10 +150,6 @@ describe('Keywords', () => {
     });
 
     it('Can type "congrats Bob!" where " Bob!" is bold', async () => {
-      if (IS_COLLAB) {
-        // TODO Fixme #1265
-        return;
-      }
       const {page} = e2e;
 
       await focusEditor(page);

--- a/packages/lexical-yjs/src/CollabElementNode.js
+++ b/packages/lexical-yjs/src/CollabElementNode.js
@@ -150,7 +150,9 @@ export class CollabElementNode {
               delCount === 1 &&
               nodeIndex > 0 &&
               prevCollabNode instanceof CollabTextNode &&
-              length === nodeSize
+              length === nodeSize &&
+              // If the node has no keys, it's been deleted
+              Array.from(node._map.keys()).length === 0
             ) {
               // Merge the text node with previous.
               prevCollabNode._text += node._text;


### PR DESCRIPTION
When trying to merge text nodes in collab, we should check if the node to merge with has already been killed in the doc (has no keys), otherwise we might try and apply the merge heuristic when we should only be doing a single character deletion. Fixes #1265.