### PR TITLE
Optimize onDocumentSelectionChange

### DIFF
--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -523,6 +523,7 @@ function onDocumentSelectionChange(event: Event): void {
       if (possibleLexicalEditor !== undefined) {
         onSelectionChange(possibleLexicalEditor);
       }
+      return;
     }
     node = node.parentNode;
   }


### PR DESCRIPTION
Early return can help us stop going through the entire DOM stack.