### PR TITLE
Further optimize onDocumentSelectionChange

### DIFF
--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -522,9 +522,10 @@ function onDocumentSelectionChange(event: Event): void {
       const possibleLexicalEditor = node.__lexicalEditor;
       if (possibleLexicalEditor !== undefined) {
         onSelectionChange(possibleLexicalEditor);
-        if (possibleLexicalEditor._parentEditor === null) {
-          return;
-        }
+        getEditorsToPropagate(possibleLexicalEditor).forEach((parentEditor) =>
+          onSelectionChange(parentEditor),
+        );
+        return;
       }
     }
     node = node.parentNode;


### PR DESCRIPTION
Turns out we can early return using the heuristic for if there is no parent editors, allowing for better compat with nested editors!