### PR TITLE
Improve selectionchange for nested editors

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection-test.js
+++ b/packages/lexical-playground/__tests__/e2e/Selection-test.js
@@ -41,11 +41,6 @@ describe('Selection', () => {
     it('keeps single active selection for nested editors', async () => {
       const {page, isRichText} = e2e;
 
-      // Temporary disabled because of: https://github.com/facebook/lexical/pull/1273
-      if (true) {
-        return;
-      }
-      
       if (!isRichText) {
         return;
       }


### PR DESCRIPTION
### Current implementation:
1. When `selectionchange` fired - get editor closest to anchor
2. Trigger onSelectionChange on that editor and on all parent editors, onSelectionChange uses `isSelectionWithinEditor` to determine if editor should be treated as active (and keep selection) or inactive (and have its selection nullified)

### New implementation:
1. When `selectionchange` fired - get editor closest to anchor
2. Get its root editor (via _parentEditor refs) and using `activeNestedEditorsMap` get previous active editor
3. Now we have refs to both previous and new active editors and can call `onSelectionChange` on both to nullify / update selection
4. Note that `activeNestedEditorsMap` only contains refs to _nested_ active editors, so regular editors won't take any extra memory in that map

Pros: 
- Only call `onSelectionChange` on (at max) two editors regardless of nesting level
- Knowing in advance if calling onSelectionChange on active or inactive editor, hence no need to use `isSelectionWithinEditor` and extra checks to determine it. Given selectionchange is triggered during typing, it'll have positive impact on typing performance

Cons:
- Extra memory to store `<rootEditorKey, nestedEditor>` mapping for nested active editors