### PR TITLE
Cancel concurrent job if starting a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ editor.addListener('update', ({editorState}) => {
     // Just like editor.update(), .read() expects a closure where you can use
     // the $ prefixed helper functions.
   });
-}); 
+});
 ```
 
 ### Creating custom Lexical nodes


### PR DESCRIPTION
Noticed that when pushing new commit into the PR, existing CI job is not canceled. This update should fix it and cancel any concurrent job from same branch and workflow ([doc](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow))