### PR TITLE
Improve handling of composed text on TextNode

### DIFF
--- a/packages/lexical/src/LexicalNode.js
+++ b/packages/lexical/src/LexicalNode.js
@@ -34,9 +34,9 @@ import {
   $generateKey,
   $getCompositionKey,
   $getNodeByKey,
-  $internallyMarkNodeAsDirty,
-  $internallyMarkSiblingsAsDirty,
   $setCompositionKey,
+  internalMarkNodeAsDirty,
+  internalMarkSiblingsAsDirty,
 } from './LexicalUtils';
 
 export type NodeMap = Map<NodeKey, LexicalNode>;
@@ -84,7 +84,7 @@ export function removeNode(
   if (index === -1) {
     invariant(false, 'Node is not a child of its parent');
   }
-  $internallyMarkSiblingsAsDirty(nodeToRemove);
+  internalMarkSiblingsAsDirty(nodeToRemove);
   parentChildren.splice(index, 1);
   const writableNodeToRemove = nodeToRemove.getWritable();
   writableNodeToRemove.__parent = null;
@@ -479,7 +479,7 @@ export class LexicalNode {
     const cloneNotNeeded = editor._cloneNotNeeded;
     if (cloneNotNeeded.has(key)) {
       // Transforms clear the dirty node set on each iteration to keep track on newly dirty nodes
-      $internallyMarkNodeAsDirty(latestNode);
+      internalMarkNodeAsDirty(latestNode);
       return latestNode;
     }
     const constructor = latestNode.constructor;
@@ -500,7 +500,7 @@ export class LexicalNode {
     }
     cloneNotNeeded.add(key);
     mutableNode.__key = key;
-    $internallyMarkNodeAsDirty(mutableNode);
+    internalMarkNodeAsDirty(mutableNode);
     // Update reference in node map
     nodeMap.set(key, mutableNode);
     // $FlowFixMe this is LexicalNode
@@ -555,7 +555,7 @@ export class LexicalNode {
       if (index === -1) {
         invariant(false, 'Node is not a child of its parent');
       }
-      $internallyMarkSiblingsAsDirty(writableReplaceWith);
+      internalMarkSiblingsAsDirty(writableReplaceWith);
       children.splice(index, 1);
     }
     const newParent = this.getParentOrThrow();
@@ -569,7 +569,7 @@ export class LexicalNode {
     children.splice(index, 0, newKey);
     writableReplaceWith.__parent = newParent.__key;
     removeNode(this, false);
-    $internallyMarkSiblingsAsDirty(writableReplaceWith);
+    internalMarkSiblingsAsDirty(writableReplaceWith);
     const selection = $getSelection();
     if (selection !== null) {
       const anchor = selection.anchor;
@@ -601,7 +601,7 @@ export class LexicalNode {
       if (index === -1) {
         invariant(false, 'Node is not a child of its parent');
       }
-      $internallyMarkSiblingsAsDirty(writableNodeToInsert);
+      internalMarkSiblingsAsDirty(writableNodeToInsert);
 
       if (selection !== null) {
         const oldParentKey = oldParent.getKey();
@@ -628,7 +628,7 @@ export class LexicalNode {
       invariant(false, 'Node is not a child of its parent');
     }
     children.splice(index + 1, 0, insertKey);
-    $internallyMarkSiblingsAsDirty(writableNodeToInsert);
+    internalMarkSiblingsAsDirty(writableNodeToInsert);
     if (selection !== null) {
       $updateElementSelectionOnCreateDeleteNode(
         selection,
@@ -657,7 +657,7 @@ export class LexicalNode {
       if (index === -1) {
         invariant(false, 'Node is not a child of its parent');
       }
-      $internallyMarkSiblingsAsDirty(writableNodeToInsert);
+      internalMarkSiblingsAsDirty(writableNodeToInsert);
       children.splice(index, 1);
     }
     const writableParent = this.getParentOrThrow().getWritable();
@@ -669,7 +669,7 @@ export class LexicalNode {
       invariant(false, 'Node is not a child of its parent');
     }
     children.splice(index, 0, insertKey);
-    $internallyMarkSiblingsAsDirty(writableNodeToInsert);
+    internalMarkSiblingsAsDirty(writableNodeToInsert);
     const selection = $getSelection();
     if (selection !== null) {
       $updateElementSelectionOnCreateDeleteNode(

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -181,7 +181,7 @@ export function $generateKey(node: LexicalNode): NodeKey {
   return key;
 }
 
-function $internallyMarkParentElementsAsDirty(
+function internalMarkParentElementsAsDirty(
   parentKey: NodeKey,
   nodeMap: NodeMap,
   dirtyElements: Map<NodeKey, IntentionallyMarkedAsDirtyElement>,
@@ -202,7 +202,7 @@ function $internallyMarkParentElementsAsDirty(
 
 // Never use this function directly! It will break
 // the cloning heuristic. Instead use node.getWritable().
-export function $internallyMarkNodeAsDirty(node: LexicalNode): void {
+export function internalMarkNodeAsDirty(node: LexicalNode): void {
   errorOnInfiniteTransforms();
   const latest = node.getLatest();
   const parent = latest.__parent;
@@ -211,7 +211,7 @@ export function $internallyMarkNodeAsDirty(node: LexicalNode): void {
   const nodeMap = editorState._nodeMap;
   const dirtyElements = editor._dirtyElements;
   if (parent !== null) {
-    $internallyMarkParentElementsAsDirty(parent, nodeMap, dirtyElements);
+    internalMarkParentElementsAsDirty(parent, nodeMap, dirtyElements);
   }
   const key = latest.__key;
   editor._dirtyType = HAS_DIRTY_NODES;
@@ -223,14 +223,14 @@ export function $internallyMarkNodeAsDirty(node: LexicalNode): void {
   }
 }
 
-export function $internallyMarkSiblingsAsDirty(node: LexicalNode) {
+export function internalMarkSiblingsAsDirty(node: LexicalNode) {
   const previousNode = node.getPreviousSibling();
   const nextNode = node.getNextSibling();
   if (previousNode !== null) {
-    $internallyMarkNodeAsDirty(previousNode);
+    internalMarkNodeAsDirty(previousNode);
   }
   if (nextNode !== null) {
-    $internallyMarkNodeAsDirty(nextNode);
+    internalMarkNodeAsDirty(nextNode);
   }
 }
 

--- a/packages/lexical/src/index.js
+++ b/packages/lexical/src/index.js
@@ -17,7 +17,6 @@ import {
   $isRangeSelection,
 } from './LexicalSelection';
 import {
-  $getCompositionKey,
   $getNearestNodeFromDOMNode,
   $getNodeByKey,
   $getRoot,
@@ -98,7 +97,6 @@ export {
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
-  $getCompositionKey,
   $getNearestNodeFromDOMNode,
   $getNodeByKey,
   $getPreviousSelection,

--- a/packages/lexical/src/nodes/base/LexicalElementNode.js
+++ b/packages/lexical/src/nodes/base/LexicalElementNode.js
@@ -23,8 +23,8 @@ import {
 import {errorOnReadOnly, getActiveEditor} from '../../LexicalUpdates';
 import {
   $getNodeByKey,
-  $internallyMarkNodeAsDirty,
-  $internallyMarkSiblingsAsDirty,
+  internalMarkNodeAsDirty,
+  internalMarkSiblingsAsDirty,
 } from '../../LexicalUtils';
 
 export type ElementFormatType = 'left' | 'center' | 'right' | 'justify';
@@ -269,7 +269,7 @@ export class ElementNode extends LexicalNode {
     const nodesToAppendLength = nodesToAppend.length;
     const lastChild = this.getLastChild();
     if (lastChild !== null) {
-      $internallyMarkNodeAsDirty(lastChild);
+      internalMarkNodeAsDirty(lastChild);
     }
     for (let i = 0; i < nodesToAppendLength; i++) {
       const nodeToAppend = nodesToAppend[i];
@@ -341,7 +341,7 @@ export class ElementNode extends LexicalNode {
         if (index === -1) {
           invariant(false, 'Node is not a child of its parent');
         }
-        $internallyMarkSiblingsAsDirty(nodeToInsert);
+        internalMarkSiblingsAsDirty(nodeToInsert);
         children.splice(index, 1);
       }
       // Set child parent to self
@@ -353,11 +353,11 @@ export class ElementNode extends LexicalNode {
     // Mark range edges siblings as dirty
     const nodeBeforeRange = this.getChildAtIndex(start - 1);
     if (nodeBeforeRange) {
-      $internallyMarkNodeAsDirty(nodeBeforeRange);
+      internalMarkNodeAsDirty(nodeBeforeRange);
     }
     const nodeAfterRange = this.getChildAtIndex(start + deleteCount);
     if (nodeAfterRange) {
-      $internallyMarkNodeAsDirty(nodeAfterRange);
+      internalMarkNodeAsDirty(nodeAfterRange);
     }
 
     // Remove defined range of children


### PR DESCRIPTION
This PR is a subset of what I did in https://github.com/facebook/lexical/pull/1295.

Notably, this PR improves how text nodes are mutated during composition. Instead of replacing the entire `nodeValue` we can instead opt to apply diffs to the DOM text node via `insertData` and `removeData`. This works really well in Chrome, but doesn't work perfectly in FF or Safari. I'll try and reach out to those browser vendors as this seems like a browser issue. This also keeps Lexical on par with how other popular web editors work.