### PR TITLE
Extend timeout for page navigation on CI

### DIFF
--- a/packages/lexical-playground/__tests__/utils/index.js
+++ b/packages/lexical-playground/__tests__/utils/index.js
@@ -97,9 +97,7 @@ export function initializeE2E(runTests, config: Config = {}) {
     }?${urlParams.toString()}`;
     const context = await e2e.browser.newContext({acceptDownloads: true});
     const page = await context.newPage();
-    const navigationStart = performance.now();
     await page.goto(url, {timeout: 60000});
-    const navigationEnd = performance.now();
     e2e.page = page;
   });
   afterEach(async () => {


### PR DESCRIPTION
One of the issues we're having seems to be that the initial test in a suite sometimes hits the timeout before it loads. I think there are other issues and this one might not be the root cause, but this should make us more robust while I dive deeper.