### PR TITLE
Initial test of HR, no unit test yet

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Markdown-test.js
+++ b/packages/lexical-playground/__tests__/e2e/Markdown-test.js
@@ -108,7 +108,7 @@ describe('Markdown', () => {
       isBlockTest: true,
       undoHTML: '',
       expectation:
-        '<hr contenteditable="false"><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
+        '<div data-lexical-decorator="true" contenteditable="false" style="display: contents;"><hr></div><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
 
       markdownText: '*** ', // Ordered.
     },
@@ -116,7 +116,7 @@ describe('Markdown', () => {
       isBlockTest: true,
       undoHTML: '',
       expectation:
-        '<hr contenteditable="false"><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
+        '<div data-lexical-decorator="true" contenteditable="false" style="display: contents;"><hr></div><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
 
       markdownText: '--- ', // Ordered.
     },

--- a/packages/lexical-react/src/shared/AutoFormatterUtils.js
+++ b/packages/lexical-react/src/shared/AutoFormatterUtils.js
@@ -15,8 +15,8 @@ import {
   $joinTextNodesInElementNode,
 } from '@lexical/helpers/text';
 import {$createListItemNode, $createListNode} from '@lexical/list';
+import {$createHorizontalRuleNode} from '@lexical/react/LexicalHorizontalRuleNode';
 import {
-  $createHorizontalRuleNode,
   $createParagraphNode,
   $createRangeSelection,
   $getSelection,


### PR DESCRIPTION

Add support for markdown syntax *** and --- to generate horizontal rules.
Add unit tests for both markdown variations.

https://user-images.githubusercontent.com/1952520/154176296-d88e71c7-d2c1-4733-901d-18cc264cc2fe.mov

