### PR TITLE
Add it#skipIf to conditionaly skip tests for non-collab/non-rich-text modes

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/AutoLinks-test.js
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks-test.js
@@ -16,81 +16,82 @@ import {
 
 describe('Auto Links', () => {
   initializeE2E((e2e) => {
-    it('Can convert url-like text into links', async () => {
-      const {isRichText, page} = e2e;
-      if (!isRichText) {
-        return;
-      }
+    it.skipIf(
+      e2e.isPlainText,
+      'Can convert url-like text into links',
+      async () => {
+        const {page} = e2e;
 
-      await focusEditor(page);
-      await page.keyboard.type(
-        'Hello http://example.com and https://example.com/path?with=query#and-hash and www.example.com',
-      );
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><a href="http://example.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">http://example.com</span></a><span data-lexical-text="true"> and </span><a href="https://example.com/path?with=query#and-hash" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">https://example.com/path?with=query#and-hash</span></a><span data-lexical-text="true"> and </span><a href="www.example.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">www.example.com</span></a></p>',
-      );
-    });
-
-    it('Can destruct links if add non-spacing text in front or right after it', async () => {
-      const {isRichText, page} = e2e;
-      if (!isRichText) {
-        return;
-      }
-
-      const htmlWithLink =
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><a href="http://example.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">http://example.com</span></a></p>';
-
-      await focusEditor(page);
-      await page.keyboard.type('http://example.com');
-      await assertHTML(page, htmlWithLink);
-
-      // Add non-url text after the link
-      await page.keyboard.type('!');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">http://example.com!</span></p>',
-      );
-      await page.keyboard.press('Backspace');
-      await assertHTML(page, htmlWithLink);
-
-      // Add non-url text before the link
-      await moveToLineBeginning(page);
-      await page.keyboard.type('!');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">!http://example.com</span></p>',
-      );
-      await page.keyboard.press('Backspace');
-      await assertHTML(page, htmlWithLink);
-
-      // Add newline after link
-      await moveToLineEnd(page);
-      await page.keyboard.press('Enter');
-      await assertHTML(
-        page,
-        htmlWithLink +
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br /></p>',
-      );
-      await page.keyboard.press('Backspace');
-      await assertHTML(page, htmlWithLink);
-    });
-
-    it('Can create link when pasting text with urls', async () => {
-      const {isRichText, page} = e2e;
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      await pasteFromClipboard(page, {
-        'text/plain':
+        await focusEditor(page);
+        await page.keyboard.type(
           'Hello http://example.com and https://example.com/path?with=query#and-hash and www.example.com',
-      });
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><a href="http://example.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">http://example.com</span></a><span data-lexical-text="true"> and </span><a href="https://example.com/path?with=query#and-hash" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">https://example.com/path?with=query#and-hash</span></a><span data-lexical-text="true"> and </span><a href="www.example.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">www.example.com</span></a></p>',
-      );
-    });
+        );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><a href="http://example.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">http://example.com</span></a><span data-lexical-text="true"> and </span><a href="https://example.com/path?with=query#and-hash" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">https://example.com/path?with=query#and-hash</span></a><span data-lexical-text="true"> and </span><a href="www.example.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">www.example.com</span></a></p>',
+        );
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      'Can destruct links if add non-spacing text in front or right after it',
+      async () => {
+        const {page} = e2e;
+        const htmlWithLink =
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><a href="http://example.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">http://example.com</span></a></p>';
+
+        await focusEditor(page);
+        await page.keyboard.type('http://example.com');
+        await assertHTML(page, htmlWithLink);
+
+        // Add non-url text after the link
+        await page.keyboard.type('!');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">http://example.com!</span></p>',
+        );
+        await page.keyboard.press('Backspace');
+        await assertHTML(page, htmlWithLink);
+
+        // Add non-url text before the link
+        await moveToLineBeginning(page);
+        await page.keyboard.type('!');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">!http://example.com</span></p>',
+        );
+        await page.keyboard.press('Backspace');
+        await assertHTML(page, htmlWithLink);
+
+        // Add newline after link
+        await moveToLineEnd(page);
+        await page.keyboard.press('Enter');
+        await assertHTML(
+          page,
+          htmlWithLink +
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br /></p>',
+        );
+        await page.keyboard.press('Backspace');
+        await assertHTML(page, htmlWithLink);
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      'Can create link when pasting text with urls',
+      async () => {
+        const {page} = e2e;
+        await focusEditor(page);
+        await pasteFromClipboard(page, {
+          'text/plain':
+            'Hello http://example.com and https://example.com/path?with=query#and-hash and www.example.com',
+        });
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><a href="http://example.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">http://example.com</span></a><span data-lexical-text="true"> and </span><a href="https://example.com/path?with=query#and-hash" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">https://example.com/path?with=query#and-hash</span></a><span data-lexical-text="true"> and </span><a href="www.example.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">www.example.com</span></a></p>',
+        );
+      },
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/History-test.js
+++ b/packages/lexical-playground/__tests__/e2e/History-test.js
@@ -13,342 +13,340 @@ import {
   assertSelection,
   repeat,
   sleep,
-  IS_COLLAB,
   focusEditor,
 } from '../utils';
 
 describe('History', () => {
   initializeE2E((e2e) => {
-    it(`Can type two paragraphs of text and correctly undo and redo`, async () => {
-      if (IS_COLLAB) {
-        return;
-      }
-      const {isRichText, page} = e2e;
+    it.skipIf(
+      e2e.isCollab,
+      `Can type two paragraphs of text and correctly undo and redo`,
+      async () => {
+        const {isRichText, page} = e2e;
 
-      await page.focus('div[contenteditable="true"]');
-
-      await page.keyboard.type('hello');
-      await sleep(1001); // default merge interval is 1000
-      await page.keyboard.type(' world');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('hello world again');
-      await repeat(6, async () => {
-        await page.keyboard.press('ArrowLeft');
-      });
-      await page.keyboard.type(', again and');
-
-      if (isRichText) {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world, again and again</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [1, 0, 0],
-          anchorOffset: 22,
-          focusPath: [1, 0, 0],
-          focusOffset: 22,
+        await page.focus('div[contenteditable="true"]');
+        await page.keyboard.type('hello');
+        await sleep(1001); // default merge interval is 1000
+        await page.keyboard.type(' world');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('hello world again');
+        await repeat(6, async () => {
+          await page.keyboard.press('ArrowLeft');
         });
-      } else {
+        await page.keyboard.type(', again and');
+
+        if (isRichText) {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world, again and again</span></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [1, 0, 0],
+            anchorOffset: 22,
+            focusPath: [1, 0, 0],
+            focusOffset: 22,
+          });
+        } else {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><span data-lexical-text="true">hello world, again and again</span></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [0, 2, 0],
+            anchorOffset: 22,
+            focusPath: [0, 2, 0],
+            focusOffset: 22,
+          });
+        }
+
+        await undo(page);
+
+        if (isRichText) {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world again</span></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [1, 0, 0],
+            anchorOffset: 11,
+            focusPath: [1, 0, 0],
+            focusOffset: 11,
+          });
+        } else {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><span data-lexical-text="true">hello world again</span></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [0, 2, 0],
+            anchorOffset: 11,
+            focusPath: [0, 2, 0],
+            focusOffset: 11,
+          });
+        }
+
+        await undo(page);
+
+        if (isRichText) {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><br></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [1],
+            anchorOffset: 0,
+            focusPath: [1],
+            focusOffset: 0,
+          });
+        } else {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><br></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [0],
+            anchorOffset: 2,
+            focusPath: [0],
+            focusOffset: 2,
+          });
+        }
+
+        await undo(page);
+
         await assertHTML(
           page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><span data-lexical-text="true">hello world, again and again</span></p>',
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p>',
         );
         await assertSelection(page, {
-          anchorPath: [0, 2, 0],
-          anchorOffset: 22,
-          focusPath: [0, 2, 0],
-          focusOffset: 22,
-        });
-      }
-
-      await undo(page);
-
-      if (isRichText) {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world again</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [1, 0, 0],
+          anchorPath: [0, 0, 0],
           anchorOffset: 11,
-          focusPath: [1, 0, 0],
+          focusPath: [0, 0, 0],
           focusOffset: 11,
         });
-      } else {
+
+        await undo(page);
+
         await assertHTML(
           page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><span data-lexical-text="true">hello world again</span></p>',
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello</span></p>',
         );
         await assertSelection(page, {
-          anchorPath: [0, 2, 0],
-          anchorOffset: 11,
-          focusPath: [0, 2, 0],
-          focusOffset: 11,
+          anchorPath: [0, 0, 0],
+          anchorOffset: 5,
+          focusPath: [0, 0, 0],
+          focusOffset: 5,
         });
-      }
 
-      await undo(page);
+        await undo(page);
 
-      if (isRichText) {
         await assertHTML(
           page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><br></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [1],
-          anchorOffset: 0,
-          focusPath: [1],
-          focusOffset: 0,
-        });
-      } else {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><br></p>',
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
         );
         await assertSelection(page, {
           anchorPath: [0],
-          anchorOffset: 2,
-          focusPath: [0],
-          focusOffset: 2,
-        });
-      }
-
-      await undo(page);
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 11,
-        focusPath: [0, 0, 0],
-        focusOffset: 11,
-      });
-
-      await undo(page);
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 5,
-        focusPath: [0, 0, 0],
-        focusOffset: 5,
-      });
-
-      await undo(page);
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 0,
-        focusPath: [0],
-        focusOffset: 0,
-      });
-
-      await redo(page);
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 5,
-        focusPath: [0, 0, 0],
-        focusOffset: 5,
-      });
-
-      await redo(page);
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 11,
-        focusPath: [0, 0, 0],
-        focusOffset: 11,
-      });
-
-      await redo(page);
-
-      if (isRichText) {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p',
-        );
-        await assertSelection(page, {
-          anchorPath: [1],
           anchorOffset: 0,
-          focusPath: [1],
+          focusPath: [0],
           focusOffset: 0,
         });
-      } else {
+
+        await redo(page);
+
         await assertHTML(
           page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><br></p>',
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello</span></p>',
         );
         await assertSelection(page, {
-          anchorPath: [0],
-          anchorOffset: 2,
-          focusPath: [0],
-          focusOffset: 2,
+          anchorPath: [0, 0, 0],
+          anchorOffset: 5,
+          focusPath: [0, 0, 0],
+          focusOffset: 5,
         });
-      }
 
-      await redo(page);
+        await redo(page);
 
-      if (isRichText) {
         await assertHTML(
           page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world again</span></p>',
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p>',
         );
         await assertSelection(page, {
-          anchorPath: [1, 0, 0],
-          anchorOffset: 17,
-          focusPath: [1, 0, 0],
-          focusOffset: 17,
+          anchorPath: [0, 0, 0],
+          anchorOffset: 11,
+          focusPath: [0, 0, 0],
+          focusOffset: 11,
         });
-      } else {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><span data-lexical-text="true">hello world again</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [0, 2, 0],
-          anchorOffset: 17,
-          focusPath: [0, 2, 0],
-          focusOffset: 17,
+
+        await redo(page);
+
+        if (isRichText) {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p',
+          );
+          await assertSelection(page, {
+            anchorPath: [1],
+            anchorOffset: 0,
+            focusPath: [1],
+            focusOffset: 0,
+          });
+        } else {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><br></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [0],
+            anchorOffset: 2,
+            focusPath: [0],
+            focusOffset: 2,
+          });
+        }
+
+        await redo(page);
+
+        if (isRichText) {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world again</span></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [1, 0, 0],
+            anchorOffset: 17,
+            focusPath: [1, 0, 0],
+            focusOffset: 17,
+          });
+        } else {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><span data-lexical-text="true">hello world again</span></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [0, 2, 0],
+            anchorOffset: 17,
+            focusPath: [0, 2, 0],
+            focusOffset: 17,
+          });
+        }
+
+        await redo(page);
+
+        if (isRichText) {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world, again and again</span></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [1, 0, 0],
+            anchorOffset: 22,
+            focusPath: [1, 0, 0],
+            focusOffset: 22,
+          });
+        } else {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><span data-lexical-text="true">hello world, again and again</span></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [0, 2, 0],
+            anchorOffset: 22,
+            focusPath: [0, 2, 0],
+            focusOffset: 22,
+          });
+        }
+
+        await repeat(4, async () => {
+          await page.keyboard.press('Backspace');
         });
-      }
 
-      await redo(page);
+        if (isRichText) {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world, again again</span></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [1, 0, 0],
+            anchorOffset: 18,
+            focusPath: [1, 0, 0],
+            focusOffset: 18,
+          });
+        } else {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><span data-lexical-text="true">hello world, again again</span></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [0, 2, 0],
+            anchorOffset: 18,
+            focusPath: [0, 2, 0],
+            focusOffset: 18,
+          });
+        }
 
-      if (isRichText) {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world, again and again</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [1, 0, 0],
-          anchorOffset: 22,
-          focusPath: [1, 0, 0],
-          focusOffset: 22,
-        });
-      } else {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><span data-lexical-text="true">hello world, again and again</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [0, 2, 0],
-          anchorOffset: 22,
-          focusPath: [0, 2, 0],
-          focusOffset: 22,
-        });
-      }
+        await undo(page);
 
-      await repeat(4, async () => {
-        await page.keyboard.press('Backspace');
-      });
+        if (isRichText) {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world, again and again</span></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [1, 0, 0],
+            anchorOffset: 22,
+            focusPath: [1, 0, 0],
+            focusOffset: 22,
+          });
+        } else {
+          await assertHTML(
+            page,
+            '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><span data-lexical-text="true">hello world, again and again</span></p>',
+          );
+          await assertSelection(page, {
+            anchorPath: [0, 2, 0],
+            anchorOffset: 22,
+            focusPath: [0, 2, 0],
+            focusOffset: 22,
+          });
+        }
+      },
+    );
 
-      if (isRichText) {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world, again again</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [1, 0, 0],
-          anchorOffset: 18,
-          focusPath: [1, 0, 0],
-          focusOffset: 18,
-        });
-      } else {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><span data-lexical-text="true">hello world, again again</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [0, 2, 0],
-          anchorOffset: 18,
-          focusPath: [0, 2, 0],
-          focusOffset: 18,
-        });
-      }
+    it.skipIf(
+      e2e.isCollab || e2e.isPlainText,
+      'Can coalesce when switching inline styles (#1151)',
+      async () => {
+        const {page} = e2e;
 
-      await undo(page);
+        await focusEditor(page);
+        await toggleBold(page);
+        await page.keyboard.type('foo');
+        await toggleBold(page);
+        await page.keyboard.type('bar');
+        await toggleBold(page);
+        await page.keyboard.type('baz');
 
-      if (isRichText) {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world, again and again</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [1, 0, 0],
-          anchorOffset: 22,
-          focusPath: [1, 0, 0],
-          focusOffset: 22,
-        });
-      } else {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span><br><span data-lexical-text="true">hello world, again and again</span></p>',
-        );
-        await assertSelection(page, {
-          anchorPath: [0, 2, 0],
-          anchorOffset: 22,
-          focusPath: [0, 2, 0],
-          focusOffset: 22,
-        });
-      }
-    });
+        const step1HTML =
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">foo</strong><span data-lexical-text="true">bar</span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">baz</strong></p>';
+        const step2HTML =
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">foo</strong><span data-lexical-text="true">bar</span></p>';
+        const step3HTML =
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">foo</strong></p>';
+        const step4HTML =
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br /></p>';
 
-    it('Can coalesce when switching inline styles (#1151)', async () => {
-      const {isRichText, page} = e2e;
-
-      // Collab has own undo/redo, and plain text does not have inline styles
-      if (IS_COLLAB || !isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      await toggleBold(page);
-      await page.keyboard.type('foo');
-      await toggleBold(page);
-      await page.keyboard.type('bar');
-      await toggleBold(page);
-      await page.keyboard.type('baz');
-
-      const step1HTML =
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">foo</strong><span data-lexical-text="true">bar</span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">baz</strong></p>';
-      const step2HTML =
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">foo</strong><span data-lexical-text="true">bar</span></p>';
-      const step3HTML =
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">foo</strong></p>';
-      const step4HTML =
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br /></p>';
-
-      await assertHTML(page, step1HTML);
-      await undo(page);
-      await assertHTML(page, step2HTML);
-      await undo(page);
-      await assertHTML(page, step3HTML);
-      await undo(page);
-      await assertHTML(page, step4HTML);
-      await redo(page);
-      await assertHTML(page, step3HTML);
-      await redo(page);
-      await assertHTML(page, step2HTML);
-      await redo(page);
-      await assertHTML(page, step1HTML);
-    });
+        await assertHTML(page, step1HTML);
+        await undo(page);
+        await assertHTML(page, step2HTML);
+        await undo(page);
+        await assertHTML(page, step3HTML);
+        await undo(page);
+        await assertHTML(page, step4HTML);
+        await redo(page);
+        await assertHTML(page, step3HTML);
+        await redo(page);
+        await assertHTML(page, step2HTML);
+        await redo(page);
+        await assertHTML(page, step1HTML);
+      },
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/utils/index.js
+++ b/packages/lexical-playground/__tests__/utils/index.js
@@ -65,6 +65,8 @@ export function initializeE2E(runTests, config: Config = {}) {
   }
   const e2e = {
     isRichText: appSettings.isRichText,
+    isPlainText: !appSettings.isRichText,
+    isCollab: IS_COLLAB,
     browser: null,
     page: null,
     async saveScreenshot() {
@@ -115,7 +117,7 @@ export function initializeE2E(runTests, config: Config = {}) {
     const it = global.it;
     // if we mark the test as flaky, overwrite the original 'it' function
     // to attempt the test 10 times before actually failing
-    global.it = async (description, test) => {
+    const newIt = async (description, test) => {
       const result = it(description, async () => {
         let count = 0;
         async function attempt() {
@@ -154,6 +156,15 @@ export function initializeE2E(runTests, config: Config = {}) {
         return await attempt();
       });
       return result;
+    };
+    global.it = newIt;
+
+    newIt.skipIf = async (condition, description, test) => {
+      if (typeof condition === 'function' ? condition() : !!condition) {
+        it.skip(description, test);
+      } else {
+        newIt(description, test);
+      }
     };
   }
 


### PR DESCRIPTION
We have plenty of e2e tests that are collab or rich-text specific, but we still run it (it opens browser and close as we hit `if (isRichText) return` inside text body) which wasting a lot of time especially for plain text mode. This PR adds `it.skipIf` to conditionally skip tests if they are mode-specific. 

The change for tests would be switching from
```js
it('replaces text in rich text mode', () => {
  if (!e2e.isRichText) {
    return;
  }
  ...
})
```
to
```js
it.skipIf(
  e2e.isPlainText,
  'replaces text in rich text mode', 
  () => {
    ...
  }
)
```


Here's time comparison of test in plain mode with test skip and without it:

```
➜  lexical git:(conditional-test-skip) time E2E_EDITOR_MODE=plain-text npm run test-e2e:chromium autolink
Running one project: e2e
Test Suites: 1 skipped, 0 of 1 total
Tests:       3 skipped, 3 total
Snapshots:   0 total
Time:        1.694 s
```

vs 

```
➜  lexical git:(main) time E2E_EDITOR_MODE=plain-text npm run test-e2e:chromium autolink
Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        4.762 s
```

I've updated couple of tests to validate the idea, we can migrate all of them when this one lands