### PR TITLE
Switch to.skipIf for mode-specific tests

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CharacterLimit-test.js
+++ b/packages/lexical-playground/__tests__/e2e/CharacterLimit-test.js
@@ -13,15 +13,11 @@ import {
   assertSelection,
   repeat,
   E2E_BROWSER,
-  IS_COLLAB,
 } from '../utils';
 import {moveToEditorBeginning, moveToLineBeginning} from '../keyboardShortcuts';
 
 function testSuite(e2e, charset: 'UTF-8' | 'UTF-16') {
-  it('displays overflow on text', async () => {
-    if (IS_COLLAB) {
-      return;
-    }
+  it.skipIf(e2e.isCollab, 'displays overflow on text', async () => {
     const {page} = e2e;
     await page.focus('div[contenteditable="true"]');
 
@@ -58,10 +54,7 @@ function testSuite(e2e, charset: 'UTF-8' | 'UTF-16') {
     });
   });
 
-  it('displays overflow on immutable nodes', async () => {
-    if (IS_COLLAB) {
-      return;
-    }
+  it.skipIf(e2e.isCollab, 'displays overflow on immutable nodes', async () => {
     // The smile emoji (S) is length 2, so for 1234S56:
     // - 1234 is non-overflow text
     // - S takes characters 5 and 6, since it's immutable and can't be split we count the whole
@@ -83,10 +76,7 @@ function testSuite(e2e, charset: 'UTF-8' | 'UTF-16') {
     );
   });
 
-  it('can type new lines inside overflow', async () => {
-    if (IS_COLLAB) {
-      return;
-    }
+  it.skipIf(e2e.isCollab, 'can type new lines inside overflow', async () => {
     const {page, isRichText} = e2e;
     await page.focus('div[contenteditable="true"]');
 
@@ -112,127 +102,122 @@ function testSuite(e2e, charset: 'UTF-8' | 'UTF-16') {
     );
   });
 
-  it('can delete text in front and overflow is recomputed', async () => {
-    if (IS_COLLAB) {
-      return;
-    }
-    const {page, isRichText} = e2e;
-    await page.focus('div[contenteditable="true"]');
+  it.skipIf(
+    e2e.isCollab,
+    'can delete text in front and overflow is recomputed',
+    async () => {
+      const {page, isRichText} = e2e;
+      await page.focus('div[contenteditable="true"]');
 
-    await page.keyboard.type('123456');
-    await page.keyboard.press('Enter');
-    await page.keyboard.press('7');
-    await moveToEditorBeginning(page);
+      await page.keyboard.type('123456');
+      await page.keyboard.press('Enter');
+      await page.keyboard.press('7');
+      await moveToEditorBeginning(page);
 
-    await page.keyboard.press('Delete');
-    if (isRichText) {
+      await page.keyboard.press('Delete');
+      if (isRichText) {
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">23456</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">7</span></div></p>',
+        );
+      } else {
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">23456</span><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><br><span data-lexical-text="true">7</span></div></p>',
+        );
+      }
+
+      await page.keyboard.press('Delete');
+      if (isRichText) {
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">3456</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">7</span></p>',
+        );
+      } else {
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">3456</span><br><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">7</span></div></p>',
+        );
+      }
+    },
+  );
+
+  it.skipIf(
+    e2e.isCollab,
+    'can delete text in front and overflow is recomputed (immutable nodes)',
+    async () => {
+      // See 'displays overflow on immutable nodes'
+      const {page} = e2e;
+      await page.focus('div[contenteditable="true"]');
+
+      await page.keyboard.type('1234:)56');
+      await moveToLineBeginning(page);
+
+      await page.keyboard.press('Delete');
+      if (charset === 'UTF-16') {
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">234</span><span class="emoji happysmile" data-lexical-text="true">🙂</span><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">56</span></div></p>',
+        );
+      } else if (charset === 'UTF-8') {
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">234</span><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span class="emoji happysmile" data-lexical-text="true">🙂</span><span data-lexical-text="true">56</span></div></p>',
+        );
+      }
+    },
+  );
+
+  it.skipIf(
+    e2e.isCollab || e2e.isPlainText,
+    'can overflow in lists',
+    async () => {
+      const {page} = e2e;
+      await page.focus('div[contenteditable="true"]');
+
+      await page.keyboard.type('- 1234');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('56');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('7');
       await assertHTML(
         page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">23456</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">7</span></div></p>',
+        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><span data-lexical-text="true">1234</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><span data-lexical-text="true">5</span><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">6</span></div></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">7</span></div></li></ul>',
       );
-    } else {
+
+      await repeat(3, async () => await page.keyboard.press('Backspace'));
       await assertHTML(
         page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">23456</span><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><br><span data-lexical-text="true">7</span></div></p>',
+        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><span data-lexical-text="true">1234</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><span data-lexical-text="true">5</span></li></ul',
       );
-    }
+    },
+  );
 
-    await page.keyboard.press('Delete');
-    if (isRichText) {
+  it.skipIf(
+    e2e.isCollab || e2e.isPlainText,
+    'can delete an overflowed paragraph',
+    async () => {
+      const {page} = e2e;
+      await page.focus('div[contenteditable="true"]');
+
+      await page.keyboard.type('12345');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('6');
       await assertHTML(
         page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">3456</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">7</span></p>',
+        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">12345</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">6</span></div></p>',
       );
-    } else {
+
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('Backspace');
       await assertHTML(
         page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">3456</span><br><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">7</span></div></p>',
+        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">12345</span><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">6</span></div></p>',
       );
-    }
-  });
+    },
+  );
 
-  it('can delete text in front and overflow is recomputed (immutable nodes)', async () => {
-    if (IS_COLLAB) {
-      return;
-    }
-    // See 'displays overflow on immutable nodes'
-    const {page} = e2e;
-    await page.focus('div[contenteditable="true"]');
-
-    await page.keyboard.type('1234:)56');
-    await moveToLineBeginning(page);
-
-    await page.keyboard.press('Delete');
-    if (charset === 'UTF-16') {
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">234</span><span class="emoji happysmile" data-lexical-text="true">🙂</span><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">56</span></div></p>',
-      );
-    } else if (charset === 'UTF-8') {
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">234</span><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span class="emoji happysmile" data-lexical-text="true">🙂</span><span data-lexical-text="true">56</span></div></p>',
-      );
-    }
-  });
-
-  it('can overflow in lists', async () => {
-    if (IS_COLLAB) {
-      return;
-    }
-    const {page, isRichText} = e2e;
-    if (!isRichText) {
-      return;
-    }
-    await page.focus('div[contenteditable="true"]');
-
-    await page.keyboard.type('- 1234');
-    await page.keyboard.press('Enter');
-    await page.keyboard.type('56');
-    await page.keyboard.press('Enter');
-    await page.keyboard.type('7');
-    await assertHTML(
-      page,
-      '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><span data-lexical-text="true">1234</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><span data-lexical-text="true">5</span><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">6</span></div></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">7</span></div></li></ul>',
-    );
-
-    await repeat(3, async () => await page.keyboard.press('Backspace'));
-    await assertHTML(
-      page,
-      '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><span data-lexical-text="true">1234</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><span data-lexical-text="true">5</span></li></ul',
-    );
-  });
-
-  it('can delete an overflowed paragraph', async () => {
-    if (IS_COLLAB) {
-      return;
-    }
-    const {page, isRichText} = e2e;
-    if (!isRichText) {
-      return;
-    }
-    await page.focus('div[contenteditable="true"]');
-
-    await page.keyboard.type('12345');
-    await page.keyboard.press('Enter');
-    await page.keyboard.type('6');
-    await assertHTML(
-      page,
-      '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">12345</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">6</span></div></p>',
-    );
-
-    await page.keyboard.press('ArrowLeft');
-    await page.keyboard.press('Backspace');
-    await assertHTML(
-      page,
-      '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">12345</span><div class="PlaygroundEditorTheme__characterLimit rse6dlih c49fpdai"><span data-lexical-text="true">6</span></div></p>',
-    );
-  });
-
-  it('handles accented characters', async () => {
-    if (IS_COLLAB) {
-      return;
-    }
+  it.skipIf(e2e.isCollab, 'handles accented characters', async () => {
     const {page} = e2e;
     await page.focus('div[contenteditable="true"]');
 
@@ -251,10 +236,7 @@ function testSuite(e2e, charset: 'UTF-8' | 'UTF-16') {
     }
   });
 
-  it('handles graphemes', async () => {
-    if (IS_COLLAB) {
-      return;
-    }
+  it.skipIf(e2e.isCollab, 'handles graphemes', async () => {
     const {page} = e2e;
     await page.focus('div[contenteditable="true"]');
 

--- a/packages/lexical-playground/__tests__/e2e/CodeBlock-test.js
+++ b/packages/lexical-playground/__tests__/e2e/CodeBlock-test.js
@@ -96,69 +96,71 @@ describe('CodeBlock', () => {
       }
     });
 
-    it('Can maintain indent when creating new lines', async () => {
-      const {page, isRichText} = e2e;
-      if (!isRichText) {
-        return;
-      }
-      await focusEditor(page);
-      await page.keyboard.type('``` alert(1);');
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Tab');
-      await page.keyboard.type('alert(2);');
-      await page.keyboard.press('Enter');
-      await assertHTML(
-        page,
-        '<code class="PlaygroundEditorTheme__code igcfgt1w ne4oaoub b6ax4al1 q46jt4gp b0eko5f3 r5g9zsuq fwlpnqze l9mvetk9 f6xnxolp l7ghb35v kmwttqpk th51lws0 mfn553m3 fxyi2ncp PlaygroundEditorTheme__ltr gkum2dnh" spellcheck="false" dir="ltr"><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">alert</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenProperty hteo0ag1" data-lexical-text="true">1</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span><br><span data-lexical-text="true">	</span><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">alert</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenProperty hteo0ag1" data-lexical-text="true">2</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span><br><span data-lexical-text="true">	</span></code>',
-      );
-    });
+    it.skipIf(
+      e2e.isPlainText,
+      'Can maintain indent when creating new lines',
+      async () => {
+        const {page} = e2e;
+        await focusEditor(page);
+        await page.keyboard.type('``` alert(1);');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Tab');
+        await page.keyboard.type('alert(2);');
+        await page.keyboard.press('Enter');
+        await assertHTML(
+          page,
+          '<code class="PlaygroundEditorTheme__code igcfgt1w ne4oaoub b6ax4al1 q46jt4gp b0eko5f3 r5g9zsuq fwlpnqze l9mvetk9 f6xnxolp l7ghb35v kmwttqpk th51lws0 mfn553m3 fxyi2ncp PlaygroundEditorTheme__ltr gkum2dnh" spellcheck="false" dir="ltr"><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">alert</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenProperty hteo0ag1" data-lexical-text="true">1</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span><br><span data-lexical-text="true">	</span><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">alert</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenProperty hteo0ag1" data-lexical-text="true">2</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span><br><span data-lexical-text="true">	</span></code>',
+        );
+      },
+    );
 
-    it('Can move around lines with option+arrow keys', async () => {
-      const abcHTML =
-        '<code class="PlaygroundEditorTheme__code igcfgt1w ne4oaoub b6ax4al1 q46jt4gp b0eko5f3 r5g9zsuq fwlpnqze l9mvetk9 f6xnxolp l7ghb35v kmwttqpk th51lws0 mfn553m3 fxyi2ncp PlaygroundEditorTheme__ltr gkum2dnh" spellcheck="false" dir="ltr"><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">a</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span><br><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">b</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span><br><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">c</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span></code>';
-      const bcaHTML =
-        '<code class="PlaygroundEditorTheme__code igcfgt1w ne4oaoub b6ax4al1 q46jt4gp b0eko5f3 r5g9zsuq fwlpnqze l9mvetk9 f6xnxolp l7ghb35v kmwttqpk th51lws0 mfn553m3 fxyi2ncp PlaygroundEditorTheme__ltr gkum2dnh" spellcheck="false" dir="ltr"><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">b</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span><br><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">c</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span><br><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">a</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span></code>';
-      const endOfFirstLine = {
-        anchorPath: [0, 3, 0],
-        anchorOffset: 1,
-        focusPath: [0, 3, 0],
-        focusOffset: 1,
-      };
-      const endOfLastLine = {
-        anchorPath: [0, 13, 0],
-        anchorOffset: 1,
-        focusPath: [0, 13, 0],
-        focusOffset: 1,
-      };
-      const {page, isRichText} = e2e;
-      if (!isRichText) {
-        return;
-      }
-      await focusEditor(page);
-      await page.keyboard.type('``` a();\nb();\nc();');
-      await assertHTML(page, abcHTML);
-      await assertSelection(page, endOfLastLine);
-      await page.keyboard.press('ArrowUp');
-      await page.keyboard.press('ArrowUp');
-      // Workaround for #1173: just insert and remove a space to fix Firefox losing the selection
-      await page.keyboard.type(' ');
-      await page.keyboard.press('Backspace');
-      await assertSelection(page, endOfFirstLine);
-      // End workaround
-      // Ensure attempting to move a line up at the top of a codeblock no-ops
-      await page.keyboard.down('Alt');
-      await page.keyboard.press('ArrowUp');
-      await assertSelection(page, endOfFirstLine);
-      await assertHTML(page, abcHTML);
-      await page.keyboard.press('ArrowDown');
-      await page.keyboard.press('ArrowDown');
-      await assertSelection(page, endOfLastLine);
-      // Can't move a line down and out of codeblock
-      await assertHTML(page, bcaHTML);
-      await page.keyboard.press('ArrowDown');
-      await assertSelection(page, endOfLastLine);
-      await assertHTML(page, bcaHTML);
-    });
+    it.skipIf(
+      e2e.isPlainText,
+      'Can move around lines with option+arrow keys',
+      async () => {
+        const abcHTML =
+          '<code class="PlaygroundEditorTheme__code igcfgt1w ne4oaoub b6ax4al1 q46jt4gp b0eko5f3 r5g9zsuq fwlpnqze l9mvetk9 f6xnxolp l7ghb35v kmwttqpk th51lws0 mfn553m3 fxyi2ncp PlaygroundEditorTheme__ltr gkum2dnh" spellcheck="false" dir="ltr"><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">a</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span><br><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">b</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span><br><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">c</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span></code>';
+        const bcaHTML =
+          '<code class="PlaygroundEditorTheme__code igcfgt1w ne4oaoub b6ax4al1 q46jt4gp b0eko5f3 r5g9zsuq fwlpnqze l9mvetk9 f6xnxolp l7ghb35v kmwttqpk th51lws0 mfn553m3 fxyi2ncp PlaygroundEditorTheme__ltr gkum2dnh" spellcheck="false" dir="ltr"><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">b</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span><br><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">c</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span><br><span class="PlaygroundEditorTheme__tokenFunction jloxbjlh" data-lexical-text="true">a</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation mudd945w" data-lexical-text="true">;</span></code>';
+        const endOfFirstLine = {
+          anchorPath: [0, 3, 0],
+          anchorOffset: 1,
+          focusPath: [0, 3, 0],
+          focusOffset: 1,
+        };
+        const endOfLastLine = {
+          anchorPath: [0, 13, 0],
+          anchorOffset: 1,
+          focusPath: [0, 13, 0],
+          focusOffset: 1,
+        };
+        const {page} = e2e;
+        await focusEditor(page);
+        await page.keyboard.type('``` a();\nb();\nc();');
+        await assertHTML(page, abcHTML);
+        await assertSelection(page, endOfLastLine);
+        await page.keyboard.press('ArrowUp');
+        await page.keyboard.press('ArrowUp');
+        // Workaround for #1173: just insert and remove a space to fix Firefox losing the selection
+        await page.keyboard.type(' ');
+        await page.keyboard.press('Backspace');
+        await assertSelection(page, endOfFirstLine);
+        // End workaround
+        // Ensure attempting to move a line up at the top of a codeblock no-ops
+        await page.keyboard.down('Alt');
+        await page.keyboard.press('ArrowUp');
+        await assertSelection(page, endOfFirstLine);
+        await assertHTML(page, abcHTML);
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('ArrowDown');
+        await assertSelection(page, endOfLastLine);
+        // Can't move a line down and out of codeblock
+        await assertHTML(page, bcaHTML);
+        await page.keyboard.press('ArrowDown');
+        await assertSelection(page, endOfLastLine);
+        await assertHTML(page, bcaHTML);
+      },
+    );
 
     /**
      * Code example for tests:
@@ -213,19 +215,19 @@ describe('CodeBlock', () => {
     ];
 
     CODE_PASTING_TESTS.forEach((testCase, i) => {
-      it(`Code block html paste: ${testCase.name}`, async () => {
-        const {page, isRichText} = e2e;
+      it.skipIf(
+        e2e.isPlainText,
+        `Code block html paste: ${testCase.name}`,
+        async () => {
+          const {page} = e2e;
 
-        if (!isRichText) {
-          return;
-        }
-
-        await focusEditor(page);
-        await pasteFromClipboard(page, {
-          'text/html': testCase.pastedHTML,
-        });
-        await assertHTML(page, testCase.expectedHTML);
-      });
+          await focusEditor(page);
+          await pasteFromClipboard(page, {
+            'text/html': testCase.pastedHTML,
+          });
+          await assertHTML(page, testCase.expectedHTML);
+        },
+      );
     });
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste-test.js
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste-test.js
@@ -356,572 +356,567 @@ describe('CopyAndPaste', () => {
       });
     });
 
-    it('Copy and paste of partial list items into an empty editor', async () => {
-      const {isRichText, page} = e2e;
+    it.skipIf(
+      e2e.isPlainText,
+      'Copy and paste of partial list items into an empty editor',
+      async () => {
+        const {page} = e2e;
 
-      if (!isRichText) {
-        return;
-      }
+        await focusEditor(page);
 
-      await focusEditor(page);
+        // Add three list items
+        await page.keyboard.type('- one');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('two');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('three');
 
-      // Add three list items
-      await page.keyboard.type('- one');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('two');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('three');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
 
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Enter');
+        // Add a paragraph
+        await page.keyboard.type('Some text.');
 
-      // Add a paragraph
-      await page.keyboard.type('Some text.');
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text.</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [1, 0, 0],
+          anchorOffset: 10,
+          focusPath: [1, 0, 0],
+          focusOffset: 10,
+        });
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text.</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [1, 0, 0],
-        anchorOffset: 10,
-        focusPath: [1, 0, 0],
-        focusOffset: 10,
-      });
+        await page.keyboard.down('Shift');
+        await moveToLineBeginning(page);
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.up('Shift');
 
-      await page.keyboard.down('Shift');
-      await moveToLineBeginning(page);
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.up('Shift');
+        await assertSelection(page, {
+          anchorPath: [1, 0, 0],
+          anchorOffset: 10,
+          focusPath: [0, 2, 0, 0],
+          focusOffset: 3,
+        });
 
-      await assertSelection(page, {
-        anchorPath: [1, 0, 0],
-        anchorOffset: 10,
-        focusPath: [0, 2, 0, 0],
-        focusOffset: 3,
-      });
+        // Copy the partial list item and paragraph
+        const clipboard = await copyToClipboard(page);
 
-      // Copy the partial list item and paragraph
-      const clipboard = await copyToClipboard(page);
+        // Select all and remove content
+        await selectAll(page);
+        await page.keyboard.press('Backspace');
+        await page.keyboard.press('Backspace');
 
-      // Select all and remove content
-      await selectAll(page);
-      await page.keyboard.press('Backspace');
-      await page.keyboard.press('Backspace');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 0,
+          focusPath: [0],
+          focusOffset: 0,
+        });
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 0,
-        focusPath: [0],
-        focusOffset: 0,
-      });
+        // Paste
 
-      // Paste
+        await pasteFromClipboard(page, clipboard);
 
-      await pasteFromClipboard(page, clipboard);
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">ee</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text.</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [1, 0, 0],
+          anchorOffset: 10,
+          focusPath: [1, 0, 0],
+          focusOffset: 10,
+        });
+      },
+    );
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">ee</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text.</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [1, 0, 0],
-        anchorOffset: 10,
-        focusPath: [1, 0, 0],
-        focusOffset: 10,
-      });
-    });
+    it.skipIf(
+      e2e.isPlainText,
+      'Copy and paste of partial list items into the list',
+      async () => {
+        const {page} = e2e;
 
-    it('Copy and paste of partial list items into the list', async () => {
-      const {isRichText, page} = e2e;
+        await focusEditor(page);
 
-      if (!isRichText) {
-        return;
-      }
+        // Add three list items
+        await page.keyboard.type('- one');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('two');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('three');
 
-      await focusEditor(page);
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
 
-      // Add three list items
-      await page.keyboard.type('- one');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('two');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('three');
+        // Add a paragraph
+        await page.keyboard.type('Some text.');
 
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Enter');
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text.</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [1, 0, 0],
+          anchorOffset: 10,
+          focusPath: [1, 0, 0],
+          focusOffset: 10,
+        });
 
-      // Add a paragraph
-      await page.keyboard.type('Some text.');
+        await page.keyboard.down('Shift');
+        await moveToLineBeginning(page);
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.up('Shift');
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text.</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [1, 0, 0],
-        anchorOffset: 10,
-        focusPath: [1, 0, 0],
-        focusOffset: 10,
-      });
+        await assertSelection(page, {
+          anchorPath: [1, 0, 0],
+          anchorOffset: 10,
+          focusPath: [0, 2, 0, 0],
+          focusOffset: 3,
+        });
 
-      await page.keyboard.down('Shift');
-      await moveToLineBeginning(page);
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.up('Shift');
+        // Copy the partial list item and paragraph
+        const clipboard = await copyToClipboard(page);
 
-      await assertSelection(page, {
-        anchorPath: [1, 0, 0],
-        anchorOffset: 10,
-        focusPath: [0, 2, 0, 0],
-        focusOffset: 3,
-      });
-
-      // Copy the partial list item and paragraph
-      const clipboard = await copyToClipboard(page);
-
-      // Select all and remove content
-      await page.keyboard.press('ArrowUp');
-      await page.keyboard.press('ArrowUp');
-      if (!IS_WINDOWS && E2E_BROWSER === 'firefox') {
+        // Select all and remove content
         await page.keyboard.press('ArrowUp');
-      }
-      await moveToLineEnd(page);
-
-      await page.keyboard.down('Enter');
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text.</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 1],
-        anchorOffset: 0,
-        focusPath: [0, 1],
-        focusOffset: 0,
-      });
-
-      await pasteFromClipboard(page, clipboard);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">ee</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text.</span></p><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text.</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [1, 0, 0],
-        anchorOffset: 10,
-        focusPath: [1, 0, 0],
-        focusOffset: 10,
-      });
-    });
-
-    it('Copy and paste of list items and paste back into list', async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      await page.keyboard.type('- one');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('two');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('three');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('four');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('five');
-
-      await page.keyboard.press('ArrowUp');
-      await page.keyboard.press('ArrowUp');
-
-      await moveToLineBeginning(page);
-      await page.keyboard.down('Shift');
-      await page.keyboard.press('ArrowDown');
-      await moveToLineEnd(page);
-      await page.keyboard.up('Shift');
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 2, 0, 0],
-        anchorOffset: 0,
-        focusPath: [0, 3, 0, 0],
-        focusOffset: 4,
-      });
-
-      const clipboard = await copyToClipboard(page);
-
-      await page.keyboard.press('Backspace');
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 2],
-        anchorOffset: 0,
-        focusPath: [0, 2],
-        focusOffset: 0,
-      });
-
-      await pasteFromClipboard(page, clipboard);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 3, 0, 0],
-        anchorOffset: 4,
-        focusPath: [0, 3, 0, 0],
-        focusOffset: 4,
-      });
-    });
-
-    it('Copy and paste of list items and paste back into list on an existing item', async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      await page.keyboard.type('- one');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('two');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('three');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('four');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('five');
-
-      await page.keyboard.press('ArrowUp');
-      await page.keyboard.press('ArrowUp');
-
-      await moveToLineBeginning(page);
-      await page.keyboard.down('Shift');
-      await page.keyboard.press('ArrowDown');
-      await moveToLineEnd(page);
-      await page.keyboard.up('Shift');
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 2, 0, 0],
-        anchorOffset: 0,
-        focusPath: [0, 3, 0, 0],
-        focusOffset: 4,
-      });
-
-      const clipboard = await copyToClipboard(page);
-
-      await page.keyboard.press('ArrowRight');
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 3, 0, 0],
-        anchorOffset: 4,
-        focusPath: [0, 3, 0, 0],
-        focusOffset: 4,
-      });
-
-      await pasteFromClipboard(page, clipboard);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">fourthree</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="6" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 4, 0, 0],
-        anchorOffset: 4,
-        focusPath: [0, 4, 0, 0],
-        focusOffset: 4,
-      });
-    });
-
-    it('Copy and paste two paragraphs into list on an existing item', async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      await page.keyboard.type('Hello');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('World');
-
-      await selectAll(page);
-
-      const clipboard = await copyToClipboard(page);
-
-      await page.keyboard.press('Backspace');
-
-      await page.keyboard.type('- one');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('two');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('three');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('four');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('five');
-
-      await page.keyboard.press('ArrowUp');
-      await page.keyboard.press('ArrowUp');
-
-      await moveToLineBeginning(page);
-      await page.keyboard.press('ArrowDown');
-      await moveToLineEnd(page);
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft');
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 3, 0, 0],
-        anchorOffset: 2,
-        focusPath: [0, 3, 0, 0],
-        focusOffset: 2,
-      });
-
-      await pasteFromClipboard(page, clipboard);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">foHello</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Worldur</span></p><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
-      );
-      await assertSelection(page, {
-        anchorPath: [1, 0, 0],
-        anchorOffset: 5,
-        focusPath: [1, 0, 0],
-        focusOffset: 5,
-      });
-    });
-
-    it('Copy and paste two paragraphs at the end of a list', async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      await page.keyboard.type('Hello');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('World');
-
-      await selectAll(page);
-
-      const clipboard = await copyToClipboard(page);
-
-      await page.keyboard.press('Backspace');
-
-      await page.keyboard.type('- one');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('two');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('three');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('four');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('five');
-      await page.keyboard.press('Enter');
-
-      await pasteFromClipboard(page, clipboard);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li><li value="6" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">World</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [1, 0, 0],
-        anchorOffset: 5,
-        focusPath: [1, 0, 0],
-        focusOffset: 5,
-      });
-
-      await pasteFromClipboard(page, clipboard);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li><li value="6" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">WorldHello</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">World</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [2, 0, 0],
-        anchorOffset: 5,
-        focusPath: [2, 0, 0],
-        focusOffset: 5,
-      });
-    });
-
-    it('Copy and paste an inline element into a leaf node', async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      // Root
-      //   |- Paragraph
-      //      |- Link
-      //         |- Text "Hello"
-      //      |- Text "World"
-      await page.keyboard.type('Hello');
-      await selectAll(page);
-      await waitForSelector(page, '.link');
-      await click(page, '.link');
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.press('Space');
-      await page.keyboard.type('World');
-
-      await selectAll(page);
-
-      const clipboard = await copyToClipboard(page);
-
-      await page.keyboard.press('ArrowRight');
-
-      await pasteFromClipboard(page, clipboard);
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></a><span data-lexical-text="true"> World</span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></a><span data-lexical-text="true"> World</span></p>',
-      );
-    });
-
-    it('HTML Copy + paste a plain DOM text node', async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      const clipboard = {'text/html': 'Hello!'};
-
-      await pasteFromClipboard(page, clipboard);
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 6,
-        focusPath: [0, 0, 0],
-        focusOffset: 6,
-      });
-    });
-
-    it('HTML Copy + paste a paragraph element', async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      const clipboard = {'text/html': '<p>Hello!<p>'};
-
-      await pasteFromClipboard(page, clipboard);
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello!</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"></br></p>',
-      );
-
-      await assertSelection(page, {
-        anchorPath: [1],
-        anchorOffset: 0,
-        focusPath: [1],
-        focusOffset: 0,
-      });
-    });
-
-    it('HTML Copy + paste an anchor element', async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      const clipboard = {
-        'text/html': '<a href="https://facebook.com">Facebook!</a>',
-      };
-
-      await pasteFromClipboard(page, clipboard);
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><a class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" href="https://facebook.com/"><span data-lexical-text="true">Facebook!</span></a></p>',
-      );
-
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0, 0],
-        anchorOffset: 9,
-        focusPath: [0, 0, 0, 0],
-        focusOffset: 9,
-      });
-
-      await selectAll(page);
-
-      await waitForSelector(page, '.link');
-      await click(page, '.link');
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">Facebook!</span></p>',
-      );
-
-      await click(page, '.link');
-      await waitForSelector(page, '.link-input');
-      await click(page, '.link-edit');
-      await focus(page, '.link-input');
-      await page.keyboard.type('facebook.com');
-      await page.keyboard.press('Enter');
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><a href="https://facebook.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Facebook!</span></a></p>',
-      );
-    });
-
-    it('HTML Copy + paste a list element', async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
+        await page.keyboard.press('ArrowUp');
+        if (!IS_WINDOWS && E2E_BROWSER === 'firefox') {
+          await page.keyboard.press('ArrowUp');
+        }
+        await moveToLineEnd(page);
+
+        await page.keyboard.down('Enter');
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text.</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 1],
+          anchorOffset: 0,
+          focusPath: [0, 1],
+          focusOffset: 0,
+        });
+
+        await pasteFromClipboard(page, clipboard);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">ee</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text.</span></p><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text.</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [1, 0, 0],
+          anchorOffset: 10,
+          focusPath: [1, 0, 0],
+          focusOffset: 10,
+        });
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      'Copy and paste of list items and paste back into list',
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+
+        await page.keyboard.type('- one');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('two');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('three');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('four');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('five');
+
+        await page.keyboard.press('ArrowUp');
+        await page.keyboard.press('ArrowUp');
+
+        await moveToLineBeginning(page);
+        await page.keyboard.down('Shift');
+        await page.keyboard.press('ArrowDown');
+        await moveToLineEnd(page);
+        await page.keyboard.up('Shift');
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 2, 0, 0],
+          anchorOffset: 0,
+          focusPath: [0, 3, 0, 0],
+          focusOffset: 4,
+        });
+
+        const clipboard = await copyToClipboard(page);
+
+        await page.keyboard.press('Backspace');
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 2],
+          anchorOffset: 0,
+          focusPath: [0, 2],
+          focusOffset: 0,
+        });
+
+        await pasteFromClipboard(page, clipboard);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 3, 0, 0],
+          anchorOffset: 4,
+          focusPath: [0, 3, 0, 0],
+          focusOffset: 4,
+        });
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      'Copy and paste of list items and paste back into list on an existing item',
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+
+        await page.keyboard.type('- one');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('two');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('three');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('four');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('five');
+
+        await page.keyboard.press('ArrowUp');
+        await page.keyboard.press('ArrowUp');
+
+        await moveToLineBeginning(page);
+        await page.keyboard.down('Shift');
+        await page.keyboard.press('ArrowDown');
+        await moveToLineEnd(page);
+        await page.keyboard.up('Shift');
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 2, 0, 0],
+          anchorOffset: 0,
+          focusPath: [0, 3, 0, 0],
+          focusOffset: 4,
+        });
+
+        const clipboard = await copyToClipboard(page);
+
+        await page.keyboard.press('ArrowRight');
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 3, 0, 0],
+          anchorOffset: 4,
+          focusPath: [0, 3, 0, 0],
+          focusOffset: 4,
+        });
+
+        await pasteFromClipboard(page, clipboard);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">fourthree</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="6" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 4, 0, 0],
+          anchorOffset: 4,
+          focusPath: [0, 4, 0, 0],
+          focusOffset: 4,
+        });
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      'Copy and paste two paragraphs into list on an existing item',
+      async () => {
+        const {page} = e2e;
+        await focusEditor(page);
+
+        await page.keyboard.type('Hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('World');
+
+        await selectAll(page);
+
+        const clipboard = await copyToClipboard(page);
+
+        await page.keyboard.press('Backspace');
+
+        await page.keyboard.type('- one');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('two');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('three');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('four');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('five');
+
+        await page.keyboard.press('ArrowUp');
+        await page.keyboard.press('ArrowUp');
+
+        await moveToLineBeginning(page);
+        await page.keyboard.press('ArrowDown');
+        await moveToLineEnd(page);
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 3, 0, 0],
+          anchorOffset: 2,
+          focusPath: [0, 3, 0, 0],
+          focusOffset: 2,
+        });
+
+        await pasteFromClipboard(page, clipboard);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">foHello</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Worldur</span></p><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li></ul>',
+        );
+        await assertSelection(page, {
+          anchorPath: [1, 0, 0],
+          anchorOffset: 5,
+          focusPath: [1, 0, 0],
+          focusOffset: 5,
+        });
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      'Copy and paste two paragraphs at the end of a list',
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+
+        await page.keyboard.type('Hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('World');
+
+        await selectAll(page);
+
+        const clipboard = await copyToClipboard(page);
+
+        await page.keyboard.press('Backspace');
+
+        await page.keyboard.type('- one');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('two');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('three');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('four');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('five');
+        await page.keyboard.press('Enter');
+
+        await pasteFromClipboard(page, clipboard);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li><li value="6" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">World</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [1, 0, 0],
+          anchorOffset: 5,
+          focusPath: [1, 0, 0],
+          focusOffset: 5,
+        });
+
+        await pasteFromClipboard(page, clipboard);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">four</span></li><li value="5" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">five</span></li><li value="6" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">WorldHello</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">World</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [2, 0, 0],
+          anchorOffset: 5,
+          focusPath: [2, 0, 0],
+          focusOffset: 5,
+        });
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      'Copy and paste an inline element into a leaf node',
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+
+        // Root
+        //   |- Paragraph
+        //      |- Link
+        //         |- Text "Hello"
+        //      |- Text "World"
+        await page.keyboard.type('Hello');
+        await selectAll(page);
+        await waitForSelector(page, '.link');
+        await click(page, '.link');
+        await page.keyboard.press('ArrowRight');
+        await page.keyboard.press('Space');
+        await page.keyboard.type('World');
+
+        await selectAll(page);
+
+        const clipboard = await copyToClipboard(page);
+
+        await page.keyboard.press('ArrowRight');
+
+        await pasteFromClipboard(page, clipboard);
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></a><span data-lexical-text="true"> World</span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></a><span data-lexical-text="true"> World</span></p>',
+        );
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      'HTML Copy + paste a plain DOM text node',
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+
+        const clipboard = {'text/html': 'Hello!'};
+
+        await pasteFromClipboard(page, clipboard);
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 6,
+          focusPath: [0, 0, 0],
+          focusOffset: 6,
+        });
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      'HTML Copy + paste a paragraph element',
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+
+        const clipboard = {'text/html': '<p>Hello!<p>'};
+
+        await pasteFromClipboard(page, clipboard);
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello!</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"></br></p>',
+        );
+
+        await assertSelection(page, {
+          anchorPath: [1],
+          anchorOffset: 0,
+          focusPath: [1],
+          focusOffset: 0,
+        });
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      'HTML Copy + paste an anchor element',
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+
+        const clipboard = {
+          'text/html': '<a href="https://facebook.com">Facebook!</a>',
+        };
+
+        await pasteFromClipboard(page, clipboard);
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><a class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" href="https://facebook.com/"><span data-lexical-text="true">Facebook!</span></a></p>',
+        );
+
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0, 0],
+          anchorOffset: 9,
+          focusPath: [0, 0, 0, 0],
+          focusOffset: 9,
+        });
+
+        await selectAll(page);
+
+        await waitForSelector(page, '.link');
+        await click(page, '.link');
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">Facebook!</span></p>',
+        );
+
+        await click(page, '.link');
+        await waitForSelector(page, '.link-input');
+        await click(page, '.link-edit');
+        await focus(page, '.link-input');
+        await page.keyboard.type('facebook.com');
+        await page.keyboard.press('Enter');
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><a href="https://facebook.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Facebook!</span></a></p>',
+        );
+      },
+    );
+
+    it.skipIf(e2e.isPlainText, 'HTML Copy + paste a list element', async () => {
+      const {page} = e2e;
 
       await focusEditor(page);
 

--- a/packages/lexical-playground/__tests__/e2e/File-test.js
+++ b/packages/lexical-playground/__tests__/e2e/File-test.js
@@ -20,11 +20,8 @@ import {selectAll} from '../keyboardShortcuts';
 
 describe('File', () => {
   initializeE2E((e2e) => {
-    it(`Can import/export`, async () => {
-      const {isRichText, page} = e2e;
-      if (!isRichText) {
-        return;
-      }
+    it.skipIf(e2e.isPlainText, `Can import/export`, async () => {
+      const {page} = e2e;
 
       await focusEditor(page);
       await page.keyboard.type('Hello World');

--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule-test.js
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule-test.js
@@ -19,191 +19,191 @@ import {
 
 describe('HorizontalRule', () => {
   initializeE2E((e2e) => {
-    it('Can create a horizontal rule and move selection around it', async () => {
-      const {isRichText, page} = e2e;
+    it.skipIf(
+      e2e.isPlainText,
+      'Can create a horizontal rule and move selection around it',
+      async () => {
+        const {page} = e2e;
 
-      if (!isRichText) {
-        return;
-      }
+        await focusEditor(page);
 
-      await focusEditor(page);
+        await waitForSelector(page, 'button .horizontal-rule');
 
-      await waitForSelector(page, 'button .horizontal-rule');
+        await click(page, 'button .horizontal-rule');
 
-      await click(page, 'button .horizontal-rule');
+        await waitForSelector(page, 'hr');
 
-      await waitForSelector(page, 'hr');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br /></p><hr contenteditable="false" /><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br /></p>',
+        );
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br /></p><hr contenteditable="false" /><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br /></p>',
-      );
-
-      await assertSelection(page, {
-        anchorPath: [2],
-        anchorOffset: 0,
-        focusPath: [2],
-        focusOffset: 0,
-      });
-
-      await page.keyboard.press('ArrowUp');
-
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 0,
-        focusPath: [0],
-        focusOffset: 0,
-      });
-
-      await page.keyboard.press('ArrowRight');
-
-      await assertSelection(page, {
-        anchorPath: [2],
-        anchorOffset: 0,
-        focusPath: [2],
-        focusOffset: 0,
-      });
-
-      await page.keyboard.press('ArrowLeft');
-
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 0,
-        focusPath: [0],
-        focusOffset: 0,
-      });
-
-      await page.keyboard.type('Some text');
-
-      await page.keyboard.press('ArrowRight');
-
-      await assertSelection(page, {
-        anchorPath: [2],
-        anchorOffset: 0,
-        focusPath: [2],
-        focusOffset: 0,
-      });
-
-      await page.keyboard.type('Some more text');
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text</span></p><hr contenteditable="false"><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some more text</span></p>',
-      );
-
-      await moveToLineBeginning(page);
-
-      await page.keyboard.press('ArrowLeft');
-
-      if (E2E_BROWSER === 'webkit') {
         await assertSelection(page, {
-          anchorPath: [0, 0, 0],
-          anchorOffset: 9,
-          focusPath: [0, 0, 0],
-          focusOffset: 9,
+          anchorPath: [2],
+          anchorOffset: 0,
+          focusPath: [2],
+          focusOffset: 0,
         });
-      } else {
+
+        await page.keyboard.press('ArrowUp');
+
         await assertSelection(page, {
           anchorPath: [0],
-          anchorOffset: 1,
+          anchorOffset: 0,
           focusPath: [0],
-          focusOffset: 1,
+          focusOffset: 0,
         });
-      }
-    });
 
-    it('Will add a horizontal rule at the end of a current TextNode and move selection to the new ParagraphNode.', async () => {
-      const {isRichText, page} = e2e;
+        await page.keyboard.press('ArrowRight');
 
-      if (!isRichText) {
-        return;
-      }
+        await assertSelection(page, {
+          anchorPath: [2],
+          anchorOffset: 0,
+          focusPath: [2],
+          focusOffset: 0,
+        });
 
-      await focusEditor(page);
+        await page.keyboard.press('ArrowLeft');
 
-      await page.keyboard.type('Test');
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 0,
+          focusPath: [0],
+          focusOffset: 0,
+        });
 
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 4,
-        focusPath: [0, 0, 0],
-        focusOffset: 4,
-      });
+        await page.keyboard.type('Some text');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span></p>',
-      );
+        await page.keyboard.press('ArrowRight');
 
-      await waitForSelector(page, 'button .horizontal-rule');
+        await assertSelection(page, {
+          anchorPath: [2],
+          anchorOffset: 0,
+          focusPath: [2],
+          focusOffset: 0,
+        });
 
-      await click(page, 'button .horizontal-rule');
+        await page.keyboard.type('Some more text');
 
-      await waitForSelector(page, 'hr');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some text</span></p><hr contenteditable="false"><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Some more text</span></p>',
+        );
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span></p><hr contenteditable="false"><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
-      );
+        await moveToLineBeginning(page);
 
-      await assertSelection(page, {
-        anchorPath: [2],
-        anchorOffset: 0,
-        focusPath: [2],
-        focusOffset: 0,
-      });
-    });
+        await page.keyboard.press('ArrowLeft');
 
-    it('Will add a horizontal rule and split a TextNode across 2 paragraphs if the carat is in the middle of the TextNode, moving selection to the start of the new ParagraphNode.', async () => {
-      const {isRichText, page} = e2e;
+        if (E2E_BROWSER === 'webkit') {
+          await assertSelection(page, {
+            anchorPath: [0, 0, 0],
+            anchorOffset: 9,
+            focusPath: [0, 0, 0],
+            focusOffset: 9,
+          });
+        } else {
+          await assertSelection(page, {
+            anchorPath: [0],
+            anchorOffset: 1,
+            focusPath: [0],
+            focusOffset: 1,
+          });
+        }
+      },
+    );
 
-      if (!isRichText) {
-        return;
-      }
+    it.skipIf(
+      e2e.isPlainText,
+      'Will add a horizontal rule at the end of a current TextNode and move selection to the new ParagraphNode.',
+      async () => {
+        const {page} = e2e;
 
-      await focusEditor(page);
+        await focusEditor(page);
 
-      await page.keyboard.type('Test');
+        await page.keyboard.type('Test');
 
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 4,
-        focusPath: [0, 0, 0],
-        focusOffset: 4,
-      });
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 4,
+          focusPath: [0, 0, 0],
+          focusOffset: 4,
+        });
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span></p>',
-      );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span></p>',
+        );
 
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft');
+        await waitForSelector(page, 'button .horizontal-rule');
 
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 2,
-        focusPath: [0, 0, 0],
-        focusOffset: 2,
-      });
+        await click(page, 'button .horizontal-rule');
 
-      await waitForSelector(page, 'button .horizontal-rule');
+        await waitForSelector(page, 'hr');
 
-      await click(page, 'button .horizontal-rule');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span></p><hr contenteditable="false"><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
+        );
 
-      await waitForSelector(page, 'hr');
+        await assertSelection(page, {
+          anchorPath: [2],
+          anchorOffset: 0,
+          focusPath: [2],
+          focusOffset: 0,
+        });
+      },
+    );
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Te</span></p><hr contenteditable="false"><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">st</span></p>',
-      );
+    it.skipIf(
+      e2e.isPlainText,
+      'Will add a horizontal rule and split a TextNode across 2 paragraphs if the carat is in the middle of the TextNode, moving selection to the start of the new ParagraphNode.',
+      async () => {
+        const {page} = e2e;
 
-      await assertSelection(page, {
-        anchorPath: [2, 0, 0],
-        anchorOffset: 0,
-        focusPath: [2, 0, 0],
-        focusOffset: 0,
-      });
-    });
+        await focusEditor(page);
+
+        await page.keyboard.type('Test');
+
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 4,
+          focusPath: [0, 0, 0],
+          focusOffset: 4,
+        });
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span></p>',
+        );
+
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 2,
+          focusPath: [0, 0, 0],
+          focusOffset: 2,
+        });
+
+        await waitForSelector(page, 'button .horizontal-rule');
+
+        await click(page, 'button .horizontal-rule');
+
+        await waitForSelector(page, 'hr');
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Te</span></p><hr contenteditable="false"><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">st</span></p>',
+        );
+
+        await assertSelection(page, {
+          anchorPath: [2, 0, 0],
+          anchorOffset: 0,
+          focusPath: [2, 0, 0],
+          focusOffset: 0,
+        });
+      },
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/Images-test.js
+++ b/packages/lexical-playground/__tests__/e2e/Images-test.js
@@ -17,200 +17,200 @@ import {
 
 describe('Images', () => {
   initializeE2E((e2e) => {
-    it(`Can create a decorator and move selection around it`, async () => {
-      const {isRichText, page} = e2e;
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create a decorator and move selection around it`,
+      async () => {
+        const {page} = e2e;
 
-      if (!isRichText) {
-        return;
-      }
+        await focusEditor(page);
 
-      await focusEditor(page);
+        await waitForSelector(page, 'button .image');
 
-      await waitForSelector(page, 'button .image');
+        await click(page, 'button .image');
 
-      await click(page, 'button .image');
+        await waitForSelector(page, '.editor-image img');
 
-      await waitForSelector(page, '.editor-image img');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 1,
+          focusPath: [0],
+          focusOffset: 1,
+        });
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 1,
-        focusPath: [0],
-        focusOffset: 1,
-      });
+        await focusEditor(page);
+        await page.keyboard.press('ArrowLeft');
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 0,
+          focusPath: [0],
+          focusOffset: 0,
+        });
 
-      await focusEditor(page);
-      await page.keyboard.press('ArrowLeft');
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 0,
-        focusPath: [0],
-        focusOffset: 0,
-      });
+        await page.keyboard.press('ArrowRight');
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 1,
+          focusPath: [0],
+          focusOffset: 1,
+        });
 
-      await page.keyboard.press('ArrowRight');
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 1,
-        focusPath: [0],
-        focusOffset: 1,
-      });
+        await page.keyboard.press('ArrowRight');
+        await page.keyboard.press('Backspace');
 
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.press('Backspace');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 0,
+          focusPath: [0],
+          focusOffset: 0,
+        });
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 0,
-        focusPath: [0],
-        focusOffset: 0,
-      });
+        await click(page, 'button .image');
 
-      await click(page, 'button .image');
+        await waitForSelector(page, '.editor-image img');
 
-      await waitForSelector(page, '.editor-image img');
+        await click(page, '.editor-image img');
 
-      await click(page, '.editor-image img');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;" class="focused"><button class="image-caption-button">Add Caption</button><div class="image-resizer-ne"></div><div class="image-resizer-se"></div><div class="image-resizer-sw"></div><div class="image-resizer-nw"></div></span><br></p>',
+          true,
+        );
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;" class="focused"><button class="image-caption-button">Add Caption</button><div class="image-resizer-ne"></div><div class="image-resizer-se"></div><div class="image-resizer-sw"></div><div class="image-resizer-nw"></div></span><br></p>',
-        true,
-      );
+        await page.keyboard.press('Backspace');
 
-      await page.keyboard.press('Backspace');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
+        );
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
-      );
+        await click(page, 'button .image');
 
-      await click(page, 'button .image');
+        await waitForSelector(page, '.editor-image img');
 
-      await waitForSelector(page, '.editor-image img');
+        await focusEditor(page);
 
-      await focusEditor(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 1,
+          focusPath: [0],
+          focusOffset: 1,
+        });
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 1,
-        focusPath: [0],
-        focusOffset: 1,
-      });
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('Delete');
 
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('Delete');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
+        );
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
-      );
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 0,
+          focusPath: [0],
+          focusOffset: 0,
+        });
+      },
+    );
 
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 0,
-        focusPath: [0],
-        focusOffset: 0,
-      });
-    });
+    it.skipIf(
+      e2e.isPlainText,
+      'Can add images and delete them correctly',
+      async () => {
+        const {page} = e2e;
 
-    it('Can add images and delete them correctly', async () => {
-      const {isRichText, page} = e2e;
+        await focusEditor(page);
 
-      if (!isRichText) {
-        return;
-      }
+        await waitForSelector(page, 'button .image');
 
-      await focusEditor(page);
+        await click(page, 'button .image');
 
-      await waitForSelector(page, 'button .image');
+        await waitForSelector(page, '.editor-image img');
 
-      await click(page, 'button .image');
+        await click(page, 'button .image');
 
-      await waitForSelector(page, '.editor-image img');
+        await focusEditor(page);
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
 
-      await click(page, 'button .image');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 0,
+          focusPath: [0],
+          focusOffset: 0,
+        });
 
-      await focusEditor(page);
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('Delete');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 0,
+          focusPath: [0],
+          focusOffset: 0,
+        });
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 0,
-        focusPath: [0],
-        focusOffset: 0,
-      });
+        await page.keyboard.press('Delete');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0],
+          anchorOffset: 0,
+          focusPath: [0],
+          focusOffset: 0,
+        });
 
-      await page.keyboard.press('Delete');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 0,
-        focusPath: [0],
-        focusOffset: 0,
-      });
+        await page.keyboard.type('Test');
+        await click(page, 'button .image');
+        await click(page, 'button .image');
 
-      await page.keyboard.press('Delete');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0],
-        anchorOffset: 0,
-        focusPath: [0],
-        focusOffset: 0,
-      });
+        await focusEditor(page);
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
 
-      await page.keyboard.type('Test');
-      await click(page, 'button .image');
-      await click(page, 'button .image');
-
-      await focusEditor(page);
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft');
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 4,
-        focusPath: [0, 0, 0],
-        focusOffset: 4,
-      });
-      await page.keyboard.press('Delete');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 4,
-        focusPath: [0, 0, 0],
-        focusOffset: 4,
-      });
-    });
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 4,
+          focusPath: [0, 0, 0],
+          focusOffset: 4,
+        });
+        await page.keyboard.press('Delete');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 4,
+          focusPath: [0, 0, 0],
+          focusOffset: 4,
+        });
+      },
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/Links-test.js
+++ b/packages/lexical-playground/__tests__/e2e/Links-test.js
@@ -25,112 +25,111 @@ import {
 
 describe('Links', () => {
   initializeE2E((e2e) => {
-    it(`Can convert a text node into a link`, async () => {
-      const {isRichText, page} = e2e;
-      if (!isRichText) {
-        return;
-      }
+    it.skipIf(
+      e2e.isPlainText,
+      `Can convert a text node into a link`,
+      async () => {
+        const {page} = e2e;
 
-      await focusEditor(page);
-      await page.keyboard.type('Hello');
-      await selectAll(page);
+        await focusEditor(page);
+        await page.keyboard.type('Hello');
+        await selectAll(page);
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p>',
-      );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p>',
+        );
 
-      // link
-      await waitForSelector(page, '.link');
-      await click(page, '.link');
+        // link
+        await waitForSelector(page, '.link');
+        await click(page, '.link');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></a></p>',
-      );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></a></p>',
+        );
 
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0, 0],
-        anchorOffset: 0,
-        focusPath: [0, 0, 0, 0],
-        focusOffset: 5,
-      });
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0, 0],
+          anchorOffset: 0,
+          focusPath: [0, 0, 0, 0],
+          focusOffset: 5,
+        });
 
-      await selectAll(page);
+        await selectAll(page);
 
-      // set url
-      await waitForSelector(page, '.link-input');
-      await waitForSelector(page, '.link-edit');
-      await click(page, '.link-edit');
-      await focus(page, '.link-input');
-      await page.keyboard.type('facebook.com');
-      await page.keyboard.press('Enter');
+        // set url
+        await waitForSelector(page, '.link-input');
+        await waitForSelector(page, '.link-edit');
+        await click(page, '.link-edit');
+        await focus(page, '.link-input');
+        await page.keyboard.type('facebook.com');
+        await page.keyboard.press('Enter');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><a href="https://facebook.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></a></p',
-      );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><a href="https://facebook.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></a></p',
+        );
 
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0, 0],
-        anchorOffset: 0,
-        focusPath: [0, 0, 0, 0],
-        focusOffset: 5,
-      });
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0, 0],
+          anchorOffset: 0,
+          focusPath: [0, 0, 0, 0],
+          focusOffset: 5,
+        });
 
-      // unlink
-      await waitForSelector(page, '.link');
-      await click(page, '.link');
+        // unlink
+        await waitForSelector(page, '.link');
+        await click(page, '.link');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p>',
-      );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p>',
+        );
 
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 0,
-        focusPath: [0, 0, 0],
-        focusOffset: 5,
-      });
-    });
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 0,
+          focusPath: [0, 0, 0],
+          focusOffset: 5,
+        });
+      },
+    );
 
-    it(`Does nothing if the selection is collapsed at the end of a text node.`, async () => {
-      const {isRichText, page} = e2e;
-      if (!isRichText) {
-        return;
-      }
+    it.skipIf(
+      e2e.isPlainText,
+      `Does nothing if the selection is collapsed at the end of a text node.`,
+      async () => {
+        const {page} = e2e;
 
-      await focusEditor(page);
-      await page.keyboard.type('Hello');
+        await focusEditor(page);
+        await page.keyboard.type('Hello');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p>',
-      );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p>',
+        );
 
-      // link
-      await waitForSelector(page, '.link');
-      await click(page, '.link');
+        // link
+        await waitForSelector(page, '.link');
+        await click(page, '.link');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p>',
-      );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p>',
+        );
 
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 5,
-        focusPath: [0, 0, 0],
-        focusOffset: 5,
-      });
-    });
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 5,
+          focusPath: [0, 0, 0],
+          focusOffset: 5,
+        });
+      },
+    );
 
-    it(`Can type text before and after`, async () => {
-      const {isRichText, page} = e2e;
-      if (!isRichText) {
-        return;
-      }
+    it.skipIf(e2e.isPlainText, `Can type text before and after`, async () => {
+      const {page} = e2e;
 
       await focusEditor(page);
       await page.keyboard.type('An Awesome Website');
@@ -158,178 +157,178 @@ describe('Links', () => {
       );
     });
 
-    it(`Can convert part of a text node into a link with forwards selection`, async () => {
-      const {isRichText, page} = e2e;
+    it.skipIf(
+      e2e.isPlainText,
+      `Can convert part of a text node into a link with forwards selection`,
+      async () => {
+        const {page} = e2e;
 
-      if (!isRichText) {
-        return;
-      }
+        await focusEditor(page);
+        await page.keyboard.type('Hello world');
 
-      await focusEditor(page);
-      await page.keyboard.type('Hello world');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world</span></p>',
+        );
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world</span></p>',
-      );
+        await moveLeft(page, 5);
+        await selectCharacters(page, 'right', 5);
 
-      await moveLeft(page, 5);
-      await selectCharacters(page, 'right', 5);
+        // link
+        await waitForSelector(page, '.link');
+        await click(page, '.link');
 
-      // link
-      await waitForSelector(page, '.link');
-      await click(page, '.link');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">world</span></a></p>',
+        );
+        if (E2E_BROWSER === 'webkit') {
+          await assertSelection(page, {
+            anchorPath: [0, 1, 0, 0],
+            anchorOffset: 0,
+            focusPath: [0, 1, 0, 0],
+            focusOffset: 5,
+          });
+        } else {
+          await assertSelection(page, {
+            anchorPath: [0, 0, 0],
+            anchorOffset: 6,
+            focusPath: [0, 1, 0, 0],
+            focusOffset: 5,
+          });
+        }
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">world</span></a></p>',
-      );
-      if (E2E_BROWSER === 'webkit') {
-        await assertSelection(page, {
-          anchorPath: [0, 1, 0, 0],
-          anchorOffset: 0,
-          focusPath: [0, 1, 0, 0],
-          focusOffset: 5,
-        });
-      } else {
+        // set url
+        await waitForSelector(page, '.link-input');
+        await click(page, '.link-edit');
+        await focus(page, '.link-input');
+        await page.keyboard.type('facebook.com');
+        await page.keyboard.press('Enter');
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><a href="https://facebook.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">world</span></a></p>',
+        );
+
+        if (E2E_BROWSER === 'webkit') {
+          await assertSelection(page, {
+            anchorPath: [0, 1, 0, 0],
+            anchorOffset: 0,
+            focusPath: [0, 1, 0, 0],
+            focusOffset: 5,
+          });
+        } else {
+          await assertSelection(page, {
+            anchorPath: [0, 0, 0],
+            anchorOffset: 6,
+            focusPath: [0, 1, 0, 0],
+            focusOffset: 5,
+          });
+        }
+
+        // unlink
+        await waitForSelector(page, '.link');
+        await click(page, '.link');
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world</span></p>',
+        );
+
         await assertSelection(page, {
           anchorPath: [0, 0, 0],
           anchorOffset: 6,
-          focusPath: [0, 1, 0, 0],
-          focusOffset: 5,
+          focusPath: [0, 0, 0],
+          focusOffset: 11,
         });
-      }
+      },
+    );
 
-      // set url
-      await waitForSelector(page, '.link-input');
-      await click(page, '.link-edit');
-      await focus(page, '.link-input');
-      await page.keyboard.type('facebook.com');
-      await page.keyboard.press('Enter');
+    it.skipIf(
+      e2e.isPlainText,
+      `Can convert part of a text node into a link with backwards selection`,
+      async () => {
+        const {page} = e2e;
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><a href="https://facebook.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">world</span></a></p>',
-      );
+        await focusEditor(page);
+        await page.keyboard.type('Hello world');
 
-      if (E2E_BROWSER === 'webkit') {
-        await assertSelection(page, {
-          anchorPath: [0, 1, 0, 0],
-          anchorOffset: 0,
-          focusPath: [0, 1, 0, 0],
-          focusOffset: 5,
-        });
-      } else {
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world</span></p>',
+        );
+
+        await selectCharacters(page, 'left', 5);
+
+        // link
+        await waitForSelector(page, '.link');
+        await click(page, '.link');
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">world</span></a></p>',
+        );
+
+        if (E2E_BROWSER === 'webkit') {
+          await assertSelection(page, {
+            anchorPath: [0, 1, 0, 0],
+            anchorOffset: 5,
+            focusPath: [0, 1, 0, 0],
+            focusOffset: 0,
+          });
+        } else {
+          await assertSelection(page, {
+            anchorPath: [0, 1, 0, 0],
+            anchorOffset: 5,
+            focusPath: [0, 0, 0],
+            focusOffset: 6,
+          });
+        }
+
+        // set url
+        await waitForSelector(page, '.link-input');
+        await click(page, '.link-edit');
+        await focus(page, '.link-input');
+        await page.keyboard.type('facebook.com');
+        await page.keyboard.press('Enter');
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><a href="https://facebook.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">world</span></a></p>',
+        );
+
+        if (E2E_BROWSER === 'webkit') {
+          await assertSelection(page, {
+            anchorPath: [0, 1, 0, 0],
+            anchorOffset: 5,
+            focusPath: [0, 1, 0, 0],
+            focusOffset: 0,
+          });
+        } else {
+          await assertSelection(page, {
+            anchorPath: [0, 1, 0, 0],
+            anchorOffset: 5,
+            focusPath: [0, 0, 0],
+            focusOffset: 6,
+          });
+        }
+
+        // unlink
+        await waitForSelector(page, '.link');
+        await click(page, '.link');
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world</span></p>',
+        );
+
         await assertSelection(page, {
           anchorPath: [0, 0, 0],
-          anchorOffset: 6,
-          focusPath: [0, 1, 0, 0],
-          focusOffset: 5,
-        });
-      }
-
-      // unlink
-      await waitForSelector(page, '.link');
-      await click(page, '.link');
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world</span></p>',
-      );
-
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 6,
-        focusPath: [0, 0, 0],
-        focusOffset: 11,
-      });
-    });
-
-    it(`Can convert part of a text node into a link with backwards selection`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      await page.keyboard.type('Hello world');
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world</span></p>',
-      );
-
-      await selectCharacters(page, 'left', 5);
-
-      // link
-      await waitForSelector(page, '.link');
-      await click(page, '.link');
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">world</span></a></p>',
-      );
-
-      if (E2E_BROWSER === 'webkit') {
-        await assertSelection(page, {
-          anchorPath: [0, 1, 0, 0],
-          anchorOffset: 5,
-          focusPath: [0, 1, 0, 0],
-          focusOffset: 0,
-        });
-      } else {
-        await assertSelection(page, {
-          anchorPath: [0, 1, 0, 0],
-          anchorOffset: 5,
+          anchorOffset: 11,
           focusPath: [0, 0, 0],
           focusOffset: 6,
         });
-      }
-
-      // set url
-      await waitForSelector(page, '.link-input');
-      await click(page, '.link-edit');
-      await focus(page, '.link-input');
-      await page.keyboard.type('facebook.com');
-      await page.keyboard.press('Enter');
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><a href="https://facebook.com" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">world</span></a></p>',
-      );
-
-      if (E2E_BROWSER === 'webkit') {
-        await assertSelection(page, {
-          anchorPath: [0, 1, 0, 0],
-          anchorOffset: 5,
-          focusPath: [0, 1, 0, 0],
-          focusOffset: 0,
-        });
-      } else {
-        await assertSelection(page, {
-          anchorPath: [0, 1, 0, 0],
-          anchorOffset: 5,
-          focusPath: [0, 0, 0],
-          focusOffset: 6,
-        });
-      }
-
-      // unlink
-      await waitForSelector(page, '.link');
-      await click(page, '.link');
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world</span></p>',
-      );
-
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 11,
-        focusPath: [0, 0, 0],
-        focusOffset: 6,
-      });
-    });
+      },
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/List-test.js
+++ b/packages/lexical-playground/__tests__/e2e/List-test.js
@@ -54,12 +54,8 @@ async function clickOutdentButton(page, times = 1) {
 
 describe('Nested List', () => {
   initializeE2E((e2e) => {
-    it(`Can toggle an empty list on/off`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
+    it.skipIf(e2e.isPlainText, `Can toggle an empty list on/off`, async () => {
+      const {page} = e2e;
 
       await focusEditor(page);
 
@@ -82,807 +78,807 @@ describe('Nested List', () => {
         '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
       );
     });
-    it(`Can create a list and indent/outdent it`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      await toggleBulletList(page);
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="1"><br></li></ul>',
-      );
-
-      // Should allow indenting an empty list item
-      await clickIndentButton(page, 2);
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create a list and indent/outdent it`,
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+        await toggleBulletList(page);
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="1"><br></li></ul>',
+        );
+
+        // Should allow indenting an empty list item
+        await clickIndentButton(page, 2);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="1"><br></li></ul></li></ul></li></ul>',
+        );
+
+        // Backspace should "unindent" the first list item.
+        await page.keyboard.press('Backspace');
+        await page.keyboard.press('Backspace');
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="1"><br></li></ul>',
+        );
+
+        await page.keyboard.type('Hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('from');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('the');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('other');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('side');
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul>',
+        );
+
+        await selectAll(page);
+
+        await clickIndentButton(page, 3);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul></li></ul></li></ul></li></ul',
+        );
+
+        await clickOutdentButton(page, 3);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul>',
+        );
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      'Should outdent if indented when the backspace key is pressed',
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+        await toggleBulletList(page);
+
+        await page.keyboard.type('Hello');
+        await page.keyboard.press('Enter');
+
+        await clickIndentButton(page, 3);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li></ul></li></ul></li></ul></li></ul>',
+        );
+
+        await page.keyboard.press('Backspace');
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li></ul></li></ul></li></ul>',
+        );
+
+        await page.keyboard.press('Backspace');
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li></ul></li></ul>',
+        );
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      `Can indent/outdent mutliple list nodes in a list with multiple levels of indentation`,
+      async () => {
+        const {page} = e2e;
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="1"><br></li></ul></li></ul></li></ul>',
-      );
+        await focusEditor(page);
 
-      // Backspace should "unindent" the first list item.
-      await page.keyboard.press('Backspace');
-      await page.keyboard.press('Backspace');
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="1"><br></li></ul>',
-      );
+        await toggleBulletList(page);
 
-      await page.keyboard.type('Hello');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('from');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('the');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('other');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('side');
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li></ul>',
+        );
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul>',
-      );
+        await page.keyboard.type('Hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('from');
 
-      await selectAll(page);
+        await clickIndentButton(page);
+
+        // - Hello
+        //    - from
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li></ul></li></ul>',
+        );
+
+        await selectAll(page);
 
-      await clickIndentButton(page, 3);
+        await clickIndentButton(page, 3);
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul></li></ul></li></ul></li></ul',
-      );
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li></ul></li></ul></li></ul></li></ul></li></ul>',
+        );
 
-      await clickOutdentButton(page, 3);
+        await clickOutdentButton(page, 3);
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul>',
-      );
-    });
-
-    it('Should outdent if indented when the backspace key is pressed', async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li></ul></li></ul>',
+        );
 
-      await focusEditor(page);
-      await toggleBulletList(page);
+        await page.keyboard.press('ArrowRight');
 
-      await page.keyboard.type('Hello');
-      await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('the');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('other');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('side');
 
-      await clickIndentButton(page, 3);
+        await clickOutdentButton(page);
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li></ul></li></ul></li></ul></li></ul>',
-      );
+        // - Hello
+        //    - from
+        //    - the
+        //    - other
+        // - side
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></li></ul></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></li></ul>',
+        );
 
-      await page.keyboard.press('Backspace');
+        await selectAll(page);
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li></ul></li></ul></li></ul>',
-      );
+        await clickIndentButton(page);
 
-      await page.keyboard.press('Backspace');
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></li></ul></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></li></ul></li></ul>',
+        );
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li></ul></li></ul>',
-      );
-    });
+        await clickOutdentButton(page);
 
-    it(`Can indent/outdent mutliple list nodes in a list with multiple levels of indentation`, async () => {
-      const {isRichText, page} = e2e;
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></li></ul></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></li></ul>',
+        );
+      },
+    );
 
-      if (!isRichText) {
-        return;
-      }
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create a list and then toggle it back to original state.`,
+      async () => {
+        const {page} = e2e;
 
-      await focusEditor(page);
+        await focusEditor(page);
 
-      await toggleBulletList(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br/></p>',
+        );
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li></ul>',
-      );
+        await page.keyboard.type('Hello');
 
-      await page.keyboard.type('Hello');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('from');
+        await toggleBulletList(page);
 
-      await clickIndentButton(page);
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li></ul>',
+        );
 
-      // - Hello
-      //    - from
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li></ul></li></ul>',
-      );
+        await toggleBulletList(page);
 
-      await selectAll(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p>',
+        );
 
-      await clickIndentButton(page, 3);
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('from');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('the');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('other');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('side');
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li></ul></li></ul></li></ul></li></ul></li></ul>',
-      );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></p>',
+        );
 
-      await clickOutdentButton(page, 3);
+        await selectAll(page);
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li></ul></li></ul>',
-      );
+        await toggleBulletList(page);
 
-      await page.keyboard.press('ArrowRight');
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul>',
+        );
 
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('the');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('other');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('side');
+        await toggleBulletList(page);
 
-      await clickOutdentButton(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></p>',
+        );
 
-      // - Hello
-      //    - from
-      //    - the
-      //    - other
-      // - side
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></li></ul></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></li></ul>',
-      );
+        // works for an indented list
 
-      await selectAll(page);
+        await toggleBulletList(page);
 
-      await clickIndentButton(page);
+        await clickIndentButton(page, 3);
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></li></ul></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></li></ul></li></ul>',
-      );
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul></li></ul></li></ul></li></ul',
+        );
 
-      await clickOutdentButton(page);
+        await toggleBulletList(page);
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></li></ul></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></li></ul>',
-      );
-    });
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></p>',
+        );
+      },
+    );
 
-    it(`Can create a list and then toggle it back to original state.`, async () => {
-      const {isRichText, page} = e2e;
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create a list containing inline blocks and then toggle it back to original state.`,
+      async () => {
+        const {page} = e2e;
 
-      if (!isRichText) {
-        return;
-      }
+        await focusEditor(page);
 
-      await focusEditor(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br/></p>',
+        );
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br/></p>',
-      );
+        await page.keyboard.type('One two three');
 
-      await page.keyboard.type('Hello');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">One two three</span></p>',
+        );
 
-      await toggleBulletList(page);
+        await moveLeft(page, 6);
+        await selectCharacters(page, 'left', 3);
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li></ul>',
-      );
+        // link
+        await waitForSelector(page, '.link');
+        await click(page, '.link');
 
-      await toggleBulletList(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">One </span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></a><span data-lexical-text="true"> three</span></p>',
+        );
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p>',
-      );
+        // move to end of paragraph to close the floating link bar
+        await moveToParagraphEnd(page);
 
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('from');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('the');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('other');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('side');
+        await toggleBulletList(page);
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></p>',
-      );
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">One </span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></a><span data-lexical-text="true"> three</span></li></ul>',
+        );
 
-      await selectAll(page);
+        await toggleBulletList(page);
 
-      await toggleBulletList(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">One </span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></a><span data-lexical-text="true"> three</span></p>',
+        );
+      },
+    );
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul>',
-      );
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create mutliple bullet lists and then toggle off the list.`,
+      async () => {
+        const {page} = e2e;
 
-      await toggleBulletList(page);
+        await focusEditor(page);
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></p>',
-      );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br/></p>',
+        );
 
-      // works for an indented list
+        await page.keyboard.type('Hello');
 
-      await toggleBulletList(page);
+        await toggleBulletList(page);
 
-      await clickIndentButton(page, 3);
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('from');
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="1"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul></li></ul></li></ul></li></ul',
-      );
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
 
-      await toggleBulletList(page);
+        await page.keyboard.type('the');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></p>',
-      );
-    });
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
 
-    it(`Can create a list containing inline blocks and then toggle it back to original state.`, async () => {
-      const {isRichText, page} = e2e;
+        await page.keyboard.type('other');
 
-      if (!isRichText) {
-        return;
-      }
+        await toggleBulletList(page);
 
-      await focusEditor(page);
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('side');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br/></p>',
-      );
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
+        );
 
-      await page.keyboard.type('One two three');
+        await selectAll(page);
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">One two three</span></p>',
-      );
+        await toggleBulletList(page);
 
-      await moveLeft(page, 6);
-      await selectCharacters(page, 'left', 3);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></p>',
+        );
 
-      // link
-      await waitForSelector(page, '.link');
-      await click(page, '.link');
+        await toggleBulletList(page);
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">One </span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></a><span data-lexical-text="true"> three</span></p>',
-      );
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="3"><br></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="5"><br></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="6"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="7"><span data-lexical-text="true">side</span></li></ul>',
+        );
+      },
+    );
 
-      // move to end of paragraph to close the floating link bar
-      await moveToParagraphEnd(page);
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create an unordered list and convert it to an ordered list `,
+      async () => {
+        const {page} = e2e;
 
-      await toggleBulletList(page);
+        await focusEditor(page);
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">One </span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></a><span data-lexical-text="true"> three</span></li></ul>',
-      );
+        await waitForSelector(page, '.block-controls');
 
-      await toggleBulletList(page);
+        await toggleBulletList(page);
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">One </span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">two</span></a><span data-lexical-text="true"> three</span></p>',
-      );
-    });
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="1"><br></li></ul>',
+        );
 
-    it(`Can create mutliple bullet lists and then toggle off the list.`, async () => {
-      const {isRichText, page} = e2e;
+        await toggleNumberedList(page);
 
-      if (!isRichText) {
-        return;
-      }
+        await assertHTML(
+          page,
+          '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="1"><br></li></ol>',
+        );
 
-      await focusEditor(page);
+        await toggleBulletList(page);
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br/></p>',
-      );
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="1"><br></li></ul>',
+        );
+      },
+    );
 
-      await page.keyboard.type('Hello');
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create a single item unordered list with text and convert it to an ordered list `,
+      async () => {
+        const {page} = e2e;
 
-      await toggleBulletList(page);
+        await focusEditor(page);
 
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('from');
+        await toggleBulletList(page);
 
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Enter');
+        await page.keyboard.type('Hello');
 
-      await page.keyboard.type('the');
+        await toggleNumberedList(page);
 
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Enter');
+        await assertHTML(
+          page,
+          '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li></ol>',
+        );
 
-      await page.keyboard.type('other');
+        await toggleBulletList(page);
 
-      await toggleBulletList(page);
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li></ul>',
+        );
+      },
+    );
 
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('side');
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create a multi-line unordered list and convert it to an ordered list `,
+      async () => {
+        const {page} = e2e;
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
-      );
+        await focusEditor(page);
 
-      await selectAll(page);
+        await toggleBulletList(page);
 
-      await toggleBulletList(page);
+        await page.keyboard.type('Hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('from');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('the');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('other');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('side');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">other</span></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></p>',
-      );
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul>',
+        );
 
-      await toggleBulletList(page);
+        await toggleNumberedList(page);
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="3"><br></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="5"><br></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="6"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="7"><span data-lexical-text="true">side</span></li></ul>',
-      );
-    });
+        await assertHTML(
+          page,
+          '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ol>',
+        );
 
-    it(`Can create an unordered list and convert it to an ordered list `, async () => {
-      const {isRichText, page} = e2e;
+        await toggleBulletList(page);
 
-      if (!isRichText) {
-        return;
-      }
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul>',
+        );
+      },
+    );
 
-      await focusEditor(page);
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create a multi-line unordered list and convert it to an ordered list when no nodes are in the selection`,
+      async () => {
+        const {page} = e2e;
 
-      await waitForSelector(page, '.block-controls');
+        await focusEditor(page);
 
-      await toggleBulletList(page);
+        await toggleBulletList(page);
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="1"><br></li></ul>',
-      );
+        await page.keyboard.type('Hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('from');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('the');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('other');
+        await page.keyboard.press('Enter');
 
-      await toggleNumberedList(page);
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="5"><br/></li></ul>',
+        );
 
-      await assertHTML(
-        page,
-        '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="1"><br></li></ol>',
-      );
+        await toggleNumberedList(page);
 
-      await toggleBulletList(page);
+        await assertHTML(
+          page,
+          '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="5"><br/></li></ol>',
+        );
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="1"><br></li></ul>',
-      );
-    });
+        await toggleBulletList(page);
 
-    it(`Can create a single item unordered list with text and convert it to an ordered list `, async () => {
-      const {isRichText, page} = e2e;
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="5"><br/></li></ul>',
+        );
+      },
+    );
 
-      if (!isRichText) {
-        return;
-      }
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create an indented multi-line unordered list and convert it to an ordered list `,
+      async () => {
+        const {page} = e2e;
 
-      await focusEditor(page);
+        await focusEditor(page);
 
-      await toggleBulletList(page);
+        await toggleBulletList(page);
 
-      await page.keyboard.type('Hello');
+        await page.keyboard.type('Hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('from');
+        await clickIndentButton(page);
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('the');
+        await clickIndentButton(page);
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('other');
+        await clickOutdentButton(page);
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('side');
+        await clickOutdentButton(page);
 
-      await toggleNumberedList(page);
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
+        );
 
-      await assertHTML(
-        page,
-        '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li></ol>',
-      );
+        await selectAll(page);
 
-      await toggleBulletList(page);
+        await toggleNumberedList(page);
 
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li></ul>',
-      );
-    });
+        await assertHTML(
+          page,
+          '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ol class="PlaygroundEditorTheme__ol2 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz lsbdvidr"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ol class="PlaygroundEditorTheme__ol3 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz l4ftupyc"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ol></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ol></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ol>',
+        );
 
-    it(`Can create a multi-line unordered list and convert it to an ordered list `, async () => {
-      const {isRichText, page} = e2e;
+        await toggleBulletList(page);
 
-      if (!isRichText) {
-        return;
-      }
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
+        );
+      },
+    );
 
-      await focusEditor(page);
-
-      await toggleBulletList(page);
-
-      await page.keyboard.type('Hello');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('from');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('the');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('other');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('side');
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul>',
-      );
-
-      await toggleNumberedList(page);
-
-      await assertHTML(
-        page,
-        '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ol>',
-      );
-
-      await toggleBulletList(page);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul>',
-      );
-    });
-
-    it(`Can create a multi-line unordered list and convert it to an ordered list when no nodes are in the selection`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      await toggleBulletList(page);
-
-      await page.keyboard.type('Hello');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('from');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('the');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('other');
-      await page.keyboard.press('Enter');
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="5"><br/></li></ul>',
-      );
-
-      await toggleNumberedList(page);
-
-      await assertHTML(
-        page,
-        '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="5"><br/></li></ol>',
-      );
-
-      await toggleBulletList(page);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k" value="5"><br/></li></ul>',
-      );
-    });
-
-    it(`Can create an indented multi-line unordered list and convert it to an ordered list `, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      await toggleBulletList(page);
-
-      await page.keyboard.type('Hello');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('from');
-      await clickIndentButton(page);
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('the');
-      await clickIndentButton(page);
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('other');
-      await clickOutdentButton(page);
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('side');
-      await clickOutdentButton(page);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
-      );
-
-      await selectAll(page);
-
-      await toggleNumberedList(page);
-
-      await assertHTML(
-        page,
-        '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ol class="PlaygroundEditorTheme__ol2 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz lsbdvidr"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ol class="PlaygroundEditorTheme__ol3 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz l4ftupyc"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ol></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ol></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ol>',
-      );
-
-      await toggleBulletList(page);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
-      );
-    });
-
-    it(`Can create an indented multi-line unordered list and convert individual lists in the nested structure to a numbered list. `, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      await toggleBulletList(page);
-
-      await page.keyboard.type('Hello');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('from');
-      await clickIndentButton(page);
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('the');
-      await clickIndentButton(page);
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('other');
-      await clickOutdentButton(page);
-
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('side');
-      await clickOutdentButton(page);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
-      );
-
-      await toggleNumberedList(page);
-
-      await assertHTML(
-        page,
-        '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ol>',
-      );
-
-      await toggleBulletList(page);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
-      );
-
-      // move to next item up in list
-      await page.keyboard.press('ArrowUp');
-
-      await toggleNumberedList(page);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ol class="PlaygroundEditorTheme__ol2 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz lsbdvidr"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ol></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
-      );
-
-      await toggleBulletList(page);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
-      );
-
-      // move to next item up in list
-      await page.keyboard.press('ArrowUp');
-
-      await toggleNumberedList(page);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ol class="PlaygroundEditorTheme__ol3 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz l4ftupyc"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ol></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
-      );
-
-      await toggleBulletList(page);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
-      );
-    });
-
-    it(`Should merge selected nodes into existing list siblings of the same type when formatting to a list`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      // Hello
-      // - from
-      // the
-      // - other
-      // side
-      await page.keyboard.type('Hello');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('from');
-      await toggleBulletList(page);
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('the');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('other');
-      await toggleBulletList(page);
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('side');
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></p><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">other</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></p>',
-      );
-
-      await selectAll(page);
-
-      await toggleBulletList(page);
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul>',
-      );
-    });
-
-    it(`Should NOT merge selected nodes into existing list siblings of a different type when formatting to a list`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      // - Hello
-      // - from
-      // the
-      await toggleBulletList(page);
-      await page.keyboard.type('Hello');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('from');
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('the');
-      await toggleNumberedList(page);
-
-      // - Hello
-      // - from
-      // 1. the
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li></ul><ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></li></ol>',
-      );
-
-      await clearEditor(page);
-
-      // Hello
-      // 1. from
-      // 2. the
-      await page.keyboard.type('Hello');
-      await page.keyboard.press('Enter');
-      await toggleNumberedList(page);
-      await page.keyboard.type('from');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('the');
-      await page.keyboard.press('ArrowUp');
-      await page.keyboard.press('ArrowUp');
-      await toggleNumberedList(page);
-
-      // 1. Hello
-      // 2. from
-      // 3. the
-      await assertHTML(
-        page,
-        '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></li></ol>',
-      );
-    });
-
-    it(`Should clear all indentation when pressing 'enter' on an empty indented bullet`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      await page.keyboard.type('a');
-      await toggleBulletList(page);
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Tab');
-      await page.keyboard.press('Enter');
-
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">a</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
-      );
-    });
-
-    it(`Should create list with start number markdown`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      // Trigger markdown using 321 digits followed by "." and a trigger of " ".
-      await page.keyboard.type('321. ');
-
-      // forward case is the normal case.
-      // undo case is when the user presses undo.
-
-      const forwardHTML =
-        '<ol start="321" class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="321" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li></ol>';
-
-      const undoHTML =
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">321. </span></p>';
-
-      await assertHTML(page, forwardHTML);
-      if (IS_COLLAB) {
-        // Collab uses its own undo/redo
-        return;
-      }
-      await undo(page);
-      await assertHTML(page, undoHTML);
-      await redo(page);
-      await assertHTML(page, forwardHTML);
-    });
-
-    it(`Should not process paragraph markdown inside list.`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-
-      await toggleBulletList(page);
-      await page.keyboard.type('# ');
-      await assertHTML(
-        page,
-        '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><span data-lexical-text="true"># </span></li></ul>',
-      );
-    });
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create an indented multi-line unordered list and convert individual lists in the nested structure to a numbered list. `,
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+
+        await toggleBulletList(page);
+
+        await page.keyboard.type('Hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('from');
+        await clickIndentButton(page);
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('the');
+        await clickIndentButton(page);
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('other');
+        await clickOutdentButton(page);
+
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('side');
+        await clickOutdentButton(page);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
+        );
+
+        await toggleNumberedList(page);
+
+        await assertHTML(
+          page,
+          '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ol>',
+        );
+
+        await toggleBulletList(page);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
+        );
+
+        // move to next item up in list
+        await page.keyboard.press('ArrowUp');
+
+        await toggleNumberedList(page);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ol class="PlaygroundEditorTheme__ol2 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz lsbdvidr"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ol></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
+        );
+
+        await toggleBulletList(page);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
+        );
+
+        // move to next item up in list
+        await page.keyboard.press('ArrowUp');
+
+        await toggleNumberedList(page);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ol class="PlaygroundEditorTheme__ol3 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz l4ftupyc"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ol></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
+        );
+
+        await toggleBulletList(page);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__nestedListItem a75w6hnp" value="2"><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">the</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">other</span></li></ul></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">side</span></li></ul>',
+        );
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      `Should merge selected nodes into existing list siblings of the same type when formatting to a list`,
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+
+        // Hello
+        // - from
+        // the
+        // - other
+        // side
+        await page.keyboard.type('Hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('from');
+        await toggleBulletList(page);
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('the');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('other');
+        await toggleBulletList(page);
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('side');
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></p><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">from</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></p><ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">other</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">side</span></p>',
+        );
+
+        await selectAll(page);
+
+        await toggleBulletList(page);
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">Hello</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="2"><span data-lexical-text="true">from</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="3"><span data-lexical-text="true">the</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="4"><span data-lexical-text="true">other</span></li><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="5"><span data-lexical-text="true">side</span></li></ul>',
+        );
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      `Should NOT merge selected nodes into existing list siblings of a different type when formatting to a list`,
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+
+        // - Hello
+        // - from
+        // the
+        await toggleBulletList(page);
+        await page.keyboard.type('Hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('from');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('the');
+        await toggleNumberedList(page);
+
+        // - Hello
+        // - from
+        // 1. the
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li></ul><ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></li></ol>',
+        );
+
+        await clearEditor(page);
+
+        // Hello
+        // 1. from
+        // 2. the
+        await page.keyboard.type('Hello');
+        await page.keyboard.press('Enter');
+        await toggleNumberedList(page);
+        await page.keyboard.type('from');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('the');
+        await page.keyboard.press('ArrowUp');
+        await page.keyboard.press('ArrowUp');
+        await toggleNumberedList(page);
+
+        // 1. Hello
+        // 2. from
+        // 3. the
+        await assertHTML(
+          page,
+          '<ol class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">from</span></li><li value="3" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">the</span></li></ol>',
+        );
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      `Should clear all indentation when pressing 'enter' on an empty indented bullet`,
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+        await page.keyboard.type('a');
+        await toggleBulletList(page);
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Tab');
+        await page.keyboard.press('Enter');
+
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr" value="1"><span data-lexical-text="true">a</span></li></ul><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
+        );
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      `Should create list with start number markdown`,
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+        // Trigger markdown using 321 digits followed by "." and a trigger of " ".
+        await page.keyboard.type('321. ');
+
+        // forward case is the normal case.
+        // undo case is when the user presses undo.
+
+        const forwardHTML =
+          '<ol start="321" class="PlaygroundEditorTheme__ol1 srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="321" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><br></li></ol>';
+
+        const undoHTML =
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">321. </span></p>';
+
+        await assertHTML(page, forwardHTML);
+        if (IS_COLLAB) {
+          // Collab uses its own undo/redo
+          return;
+        }
+        await undo(page);
+        await assertHTML(page, undoHTML);
+        await redo(page);
+        await assertHTML(page, forwardHTML);
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      `Should not process paragraph markdown inside list.`,
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+
+        await toggleBulletList(page);
+        await page.keyboard.type('# ');
+        await assertHTML(
+          page,
+          '<ul class="PlaygroundEditorTheme__ul srn514ro oxkhqvkx rl78xhln nch0832m m8h3af8h l7ghb35v kjdc1dyq p9ctufpz"><li value="1" class="PlaygroundEditorTheme__listItem th51lws0 r26s8xbz mfn553m3 gug11x0k"><span data-lexical-text="true"># </span></li></ul>',
+        );
+      },
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/Markdown-test.js
+++ b/packages/lexical-playground/__tests__/e2e/Markdown-test.js
@@ -115,139 +115,139 @@ describe('Markdown', () => {
       const markdownText = triggersAndExpectations[i].markdownText;
 
       if (triggersAndExpectations[i].isBlockTest === false) {
-        it(`Should create stylized (e.g. BIUS) text from plain text using a markdown shortcut e.g. ${markdownText}`, async () => {
-          const {isRichText, page} = e2e;
+        it.skipIf(
+          e2e.isPlainText,
+          `Should create stylized (e.g. BIUS) text from plain text using a markdown shortcut e.g. ${markdownText}`,
+          async () => {
+            const {page} = e2e;
 
-          if (!isRichText) {
-            return;
-          }
+            const text = 'x' + markdownText + 'y';
 
-          const text = 'x' + markdownText + 'y';
+            await focusEditor(page);
+            await page.keyboard.type(text);
+            await repeat(text.length, async () => {
+              await page.keyboard.press('ArrowLeft');
+            });
+            await assertSelection(page, {
+              anchorPath: [0, 0, 0],
+              anchorOffset: 0,
+              focusPath: [0, 0, 0],
+              focusOffset: 0,
+            });
 
-          await focusEditor(page);
-          await page.keyboard.type(text);
-          await repeat(text.length, async () => {
-            await page.keyboard.press('ArrowLeft');
-          });
-          await assertSelection(page, {
-            anchorPath: [0, 0, 0],
-            anchorOffset: 0,
-            focusPath: [0, 0, 0],
-            focusOffset: 0,
-          });
+            await repeat(1 + markdownText.length, async () => {
+              await page.keyboard.press('ArrowRight');
+            });
 
-          await repeat(1 + markdownText.length, async () => {
-            await page.keyboard.press('ArrowRight');
-          });
+            // Trigger markdown.
+            await page.keyboard.type(' ');
 
-          // Trigger markdown.
-          await page.keyboard.type(' ');
+            await checkHTMLExpectationsIncludingUndoRedo(
+              page,
+              triggersAndExpectations[i].expectation,
+              triggersAndExpectations[i].undoHTML,
+            );
+          },
+        );
 
-          await checkHTMLExpectationsIncludingUndoRedo(
-            page,
-            triggersAndExpectations[i].expectation,
-            triggersAndExpectations[i].undoHTML,
-          );
-        });
+        it.skipIf(
+          e2e.isPlainText,
+          `Should create stylized (e.g. BIUS) text from already stylized text using a markdown shortcut e.g. ${markdownText}`,
+          async () => {
+            const {page} = e2e;
 
-        it(`Should create stylized (e.g. BIUS) text from already stylized text using a markdown shortcut e.g. ${markdownText}`, async () => {
-          const {isRichText, page} = e2e;
+            const text = 'x' + markdownText + 'y';
 
-          if (!isRichText) {
-            return;
-          }
+            await focusEditor(page);
+            await page.keyboard.type(text);
+            await repeat(text.length, async () => {
+              await page.keyboard.press('ArrowLeft');
+            });
+            await assertSelection(page, {
+              anchorPath: [0, 0, 0],
+              anchorOffset: 0,
+              focusPath: [0, 0, 0],
+              focusOffset: 0,
+            });
 
-          const text = 'x' + markdownText + 'y';
+            // Select first 2 characters.
+            await page.keyboard.down('Shift');
+            await repeat(2, async () => {
+              await page.keyboard.press('ArrowRight');
+            });
+            await page.keyboard.up('Shift');
 
-          await focusEditor(page);
-          await page.keyboard.type(text);
-          await repeat(text.length, async () => {
-            await page.keyboard.press('ArrowLeft');
-          });
-          await assertSelection(page, {
-            anchorPath: [0, 0, 0],
-            anchorOffset: 0,
-            focusPath: [0, 0, 0],
-            focusOffset: 0,
-          });
+            // Make underline.
+            await keyDownCtrlOrMeta(page);
+            await page.keyboard.press('u');
+            await keyUpCtrlOrMeta(page);
 
-          // Select first 2 characters.
-          await page.keyboard.down('Shift');
-          await repeat(2, async () => {
-            await page.keyboard.press('ArrowRight');
-          });
-          await page.keyboard.up('Shift');
+            // Back to beginning.
+            await repeat(2, async () => {
+              await page.keyboard.press('ArrowLeft');
+            });
 
-          // Make underline.
-          await keyDownCtrlOrMeta(page);
-          await page.keyboard.press('u');
-          await keyUpCtrlOrMeta(page);
+            // Move to end.
+            await repeat(text.length, async () => {
+              await page.keyboard.press('ArrowRight');
+            });
 
-          // Back to beginning.
-          await repeat(2, async () => {
-            await page.keyboard.press('ArrowLeft');
-          });
+            // Select last two characters.
+            await page.keyboard.down('Shift');
+            await repeat(2, async () => {
+              await page.keyboard.press('ArrowLeft');
+            });
+            await page.keyboard.up('Shift');
 
-          // Move to end.
-          await repeat(text.length, async () => {
-            await page.keyboard.press('ArrowRight');
-          });
+            // Make underline.
+            await keyDownCtrlOrMeta(page);
+            await page.keyboard.press('u');
+            await keyUpCtrlOrMeta(page);
 
-          // Select last two characters.
-          await page.keyboard.down('Shift');
-          await repeat(2, async () => {
-            await page.keyboard.press('ArrowLeft');
-          });
-          await page.keyboard.up('Shift');
+            // Back to beginning of text.
+            await repeat(text.length, async () => {
+              await page.keyboard.press('ArrowLeft');
+            });
 
-          // Make underline.
-          await keyDownCtrlOrMeta(page);
-          await page.keyboard.press('u');
-          await keyUpCtrlOrMeta(page);
+            // Move after markdown text.
+            await repeat(1 + markdownText.length, async () => {
+              await page.keyboard.press('ArrowRight');
+            });
 
-          // Back to beginning of text.
-          await repeat(text.length, async () => {
-            await page.keyboard.press('ArrowLeft');
-          });
+            // Trigger markdown.
+            await page.keyboard.type(' ');
 
-          // Move after markdown text.
-          await repeat(1 + markdownText.length, async () => {
-            await page.keyboard.press('ArrowRight');
-          });
-
-          // Trigger markdown.
-          await page.keyboard.type(' ');
-
-          await checkHTMLExpectationsIncludingUndoRedo(
-            page,
-            triggersAndExpectations[i].stylizedExpectation,
-            triggersAndExpectations[i].stylizedUndoHTML,
-          );
-        });
+            await checkHTMLExpectationsIncludingUndoRedo(
+              page,
+              triggersAndExpectations[i].stylizedExpectation,
+              triggersAndExpectations[i].stylizedUndoHTML,
+            );
+          },
+        );
       }
 
       if (triggersAndExpectations[i].isBlockTest === true) {
-        it(`Should test markdown with the (${markdownText}) trigger. Should include undo and redo.`, async () => {
-          const {isRichText, page} = e2e;
+        it.skipIf(
+          e2e.isPlainText,
+          `Should test markdown with the (${markdownText}) trigger. Should include undo and redo.`,
+          async () => {
+            const {page} = e2e;
 
-          if (!isRichText) {
-            return;
-          }
+            await focusEditor(page);
 
-          await focusEditor(page);
+            await page.keyboard.type(markdownText);
 
-          await page.keyboard.type(markdownText);
+            const forwardHTML = triggersAndExpectations[i].expectation;
 
-          const forwardHTML = triggersAndExpectations[i].expectation;
+            const undoHTML = `<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">${markdownText}</span></p>`;
 
-          const undoHTML = `<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span data-lexical-text="true">${markdownText}</span></p>`;
-
-          await checkHTMLExpectationsIncludingUndoRedo(
-            page,
-            forwardHTML,
-            undoHTML,
-          );
-        });
+            await checkHTMLExpectationsIncludingUndoRedo(
+              page,
+              forwardHTML,
+              undoHTML,
+            );
+          },
+        );
       }
     }
   });

--- a/packages/lexical-playground/__tests__/e2e/Selection-test.js
+++ b/packages/lexical-playground/__tests__/e2e/Selection-test.js
@@ -38,58 +38,58 @@ describe('Selection', () => {
       expect(await editorHasFocus()).toEqual(false);
     });
 
-    it('keeps single active selection for nested editors', async () => {
-      const {page, isRichText} = e2e;
+    it.skipIf(
+      e2e.isPlainText,
+      'keeps single active selection for nested editors',
+      async () => {
+        const {page} = e2e;
 
-      if (!isRichText) {
-        return;
-      }
+        const hasSelection = async (parentSelector) =>
+          await evaluate(
+            page,
+            (parentSelector) => {
+              return (
+                document
+                  .querySelector(`${parentSelector} > .tree-view-output pre`)
+                  .__lexicalEditor.getEditorState()._selection !== null
+              );
+            },
+            parentSelector,
+          );
 
-      const hasSelection = async (parentSelector) =>
-        await evaluate(
-          page,
-          (parentSelector) => {
-            return (
-              document
-                .querySelector(`${parentSelector} > .tree-view-output pre`)
-                .__lexicalEditor.getEditorState()._selection !== null
-            );
-          },
-          parentSelector,
-        );
-
-      await focusEditor(page);
-      await insertImage(page, 'Hello world');
-      expect(await hasSelection('.image-caption-container')).toBe(true);
-      expect(await hasSelection('.editor-shell')).toBe(false);
-
-      // Click outside of the editor and check that selection remains the same
-      await click(page, 'header img');
-      expect(await hasSelection('.image-caption-container')).toBe(true);
-      expect(await hasSelection('.editor-shell')).toBe(false);
-
-      // Back to root editor
-      if (E2E_BROWSER === 'firefox') {
-        // TODO:
-        // In firefox .focus() on editor does not trigger selectionchange, while checking it
-        // explicitly clicking on an editor (passing position that is on the right side to
-        // prevent clicking on image and its nested editor)
-        await click(page, '.editor-shell', {position: {x: 600, y: 150}});
-      } else {
         await focusEditor(page);
-      }
-      expect(await hasSelection('.image-caption-container')).toBe(false);
-      expect(await hasSelection('.editor-shell')).toBe(true);
+        await insertImage(page, 'Hello world');
+        expect(await hasSelection('.image-caption-container')).toBe(true);
+        expect(await hasSelection('.editor-shell')).toBe(false);
 
-      // Click outside of the editor and check that selection remains the same
-      await click(page, 'header img');
-      expect(await hasSelection('.image-caption-container')).toBe(false);
-      expect(await hasSelection('.editor-shell')).toBe(true);
+        // Click outside of the editor and check that selection remains the same
+        await click(page, 'header img');
+        expect(await hasSelection('.image-caption-container')).toBe(true);
+        expect(await hasSelection('.editor-shell')).toBe(false);
 
-      // Back to nested editor editor
-      await focusEditor(page, '.image-caption-container');
-      expect(await hasSelection('.image-caption-container')).toBe(true);
-      expect(await hasSelection('.editor-shell')).toBe(false);
-    });
+        // Back to root editor
+        if (E2E_BROWSER === 'firefox') {
+          // TODO:
+          // In firefox .focus() on editor does not trigger selectionchange, while checking it
+          // explicitly clicking on an editor (passing position that is on the right side to
+          // prevent clicking on image and its nested editor)
+          await click(page, '.editor-shell', {position: {x: 600, y: 150}});
+        } else {
+          await focusEditor(page);
+        }
+        expect(await hasSelection('.image-caption-container')).toBe(false);
+        expect(await hasSelection('.editor-shell')).toBe(true);
+
+        // Click outside of the editor and check that selection remains the same
+        await click(page, 'header img');
+        expect(await hasSelection('.image-caption-container')).toBe(false);
+        expect(await hasSelection('.editor-shell')).toBe(true);
+
+        // Back to nested editor editor
+        await focusEditor(page, '.image-caption-container');
+        expect(await hasSelection('.image-caption-container')).toBe(true);
+        expect(await hasSelection('.editor-shell')).toBe(false);
+      },
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting-test.js
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting-test.js
@@ -23,635 +23,635 @@ import {
 
 describe('TextFormatting', () => {
   initializeE2E((e2e) => {
-    it(`Can create bold text using the shortcut`, async () => {
-      const {isRichText, page} = e2e;
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create bold text using the shortcut`,
+      async () => {
+        const {page} = e2e;
 
-      if (!isRichText) {
-        return;
-      }
+        await focusEditor(page);
+        await page.keyboard.type('Hello');
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await page.keyboard.type(' World');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true"> World</strong></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 6,
+          focusPath: [0, 1, 0],
+          focusOffset: 6,
+        });
 
-      await focusEditor(page);
-      await page.keyboard.type('Hello');
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await page.keyboard.type(' World');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true"> World</strong></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 6,
-        focusPath: [0, 1, 0],
-        focusOffset: 6,
-      });
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await page.keyboard.type('!');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true"> World</strong><span data-lexical-text="true">!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 2, 0],
+          anchorOffset: 1,
+          focusPath: [0, 2, 0],
+          focusOffset: 1,
+        });
+      },
+    );
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await page.keyboard.type('!');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true"> World</strong><span data-lexical-text="true">!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 1,
-        focusPath: [0, 2, 0],
-        focusOffset: 1,
-      });
-    });
+    it.skipIf(
+      e2e.isPlainText,
+      `Can create italic text using the shortcut`,
+      async () => {
+        const {page} = e2e;
 
-    it(`Can create italic text using the shortcut`, async () => {
-      const {isRichText, page} = e2e;
+        await focusEditor(page);
+        await page.keyboard.type('Hello');
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await page.keyboard.type(' World');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span><em class="PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true"> World</em></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 6,
+          focusPath: [0, 1, 0],
+          focusOffset: 6,
+        });
 
-      if (!isRichText) {
-        return;
-      }
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await page.keyboard.type('!');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span><em class="PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true"> World</em><span data-lexical-text="true">!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 2, 0],
+          anchorOffset: 1,
+          focusPath: [0, 2, 0],
+          focusOffset: 1,
+        });
+      },
+    );
 
-      await focusEditor(page);
-      await page.keyboard.type('Hello');
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await page.keyboard.type(' World');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span><em class="PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true"> World</em></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 6,
-        focusPath: [0, 1, 0],
-        focusOffset: 6,
-      });
+    it.skipIf(
+      e2e.isPlainText,
+      `Can select text and boldify it with the shortcut`,
+      async () => {
+        const {page} = e2e;
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await page.keyboard.type('!');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span><em class="PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true"> World</em><span data-lexical-text="true">!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 1,
-        focusPath: [0, 2, 0],
-        focusOffset: 1,
-      });
-    });
-
-    it(`Can select text and boldify it with the shortcut`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      await page.keyboard.type('Hello world!');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.down('Shift');
-      await repeat(5, async () => {
+        await focusEditor(page);
+        await page.keyboard.type('Hello world!');
         await page.keyboard.press('ArrowLeft');
-      });
-      await page.keyboard.up('Shift');
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 11,
-        focusPath: [0, 0, 0],
-        focusOffset: 6,
-      });
+        await page.keyboard.down('Shift');
+        await repeat(5, async () => {
+          await page.keyboard.press('ArrowLeft');
+        });
+        await page.keyboard.up('Shift');
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 11,
+          focusPath: [0, 0, 0],
+          focusOffset: 6,
+        });
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">world</strong><span data-lexical-text="true">!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 6,
-        focusPath: [0, 0, 0],
-        focusOffset: 11,
-      });
-    });
-
-    it('Should not format the text in the subsequent paragraph after a triple click selection event.', async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      await page.keyboard.type('hello world');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('hello world');
-
-      await click(page, 'div[contenteditable="true"] > p', {
-        clickCount: 1,
-        delay: 100,
-      });
-      await click(page, 'div[contenteditable="true"] > p', {
-        clickCount: 2,
-        delay: 100,
-      });
-      await click(page, 'div[contenteditable="true"] > p', {
-        clickCount: 3,
-        delay: 100,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.type('b');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">hello world</strong></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p>',
-      );
-    });
-
-    it(`Can select text and italicify it with the shortcut`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      await page.keyboard.type('Hello world!');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.down('Shift');
-      await repeat(5, async () => {
-        await page.keyboard.press('ArrowLeft');
-      });
-      await page.keyboard.up('Shift');
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 11,
-        focusPath: [0, 0, 0],
-        focusOffset: 6,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><em class="PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true">world</em><span data-lexical-text="true">!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 6,
-        focusPath: [0, 0, 0],
-        focusOffset: 11,
-      });
-    });
-
-    it(`Can select text and underline+strikethrough`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      await page.keyboard.type('Hello world!');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.down('Shift');
-      await repeat(5, async () => {
-        await page.keyboard.press('ArrowLeft');
-      });
-      await page.keyboard.up('Shift');
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 11,
-        focusPath: [0, 0, 0],
-        focusOffset: 6,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('u');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span class="PlaygroundEditorTheme__textUnderline o570zoyu" data-lexical-text="true">world</span><span data-lexical-text="true">!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('u');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 6,
-        focusPath: [0, 0, 0],
-        focusOffset: 11,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('u');
-      await keyUpCtrlOrMeta(page);
-
-      await waitForSelector(page, '.strikethrough');
-      await click(page, '.strikethrough');
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span class="PlaygroundEditorTheme__textUnderlineStrikethrough kf6cyplv" data-lexical-text="true">world</span><span data-lexical-text="true">!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
-
-      await waitForSelector(page, '.strikethrough');
-      await click(page, '.strikethrough');
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span class="PlaygroundEditorTheme__textUnderline o570zoyu" data-lexical-text="true">world</span><span data-lexical-text="true">!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
-    });
-
-    it(`Can select text and change the font-size`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      await page.keyboard.type('Hello world!');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.down('Shift');
-      await repeat(5, async () => {
-        await page.keyboard.press('ArrowLeft');
-      });
-      await page.keyboard.up('Shift');
-
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 11,
-        focusPath: [0, 0, 0],
-        focusOffset: 6,
-      });
-
-      await waitForSelector(page, '.font-size');
-      await selectOption(page, '.font-size', {value: '10px'});
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span data-lexical-text="true" style="font-size: 10px;">world</span><span data-lexical-text="true">!</span></p>',
-      );
-
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
-    });
-
-    it(`Can select text and change the font-size and font-family`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      await page.keyboard.type('Hello world!');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.down('Shift');
-      await repeat(5, async () => {
-        await page.keyboard.press('ArrowLeft');
-      });
-      await page.keyboard.up('Shift');
-
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 11,
-        focusPath: [0, 0, 0],
-        focusOffset: 6,
-      });
-
-      await waitForSelector(page, '.font-size');
-      await selectOption(page, '.font-size', {value: '10px'});
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span data-lexical-text="true" style="font-size: 10px;">world</span><span data-lexical-text="true">!</span></p>',
-      );
-
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
-
-      await waitForSelector(page, '.font-family');
-      await selectOption(page, '.font-family', {value: 'Georgia'});
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span data-lexical-text="true" style="font-size: 10px; font-family: Georgia;">world</span><span data-lexical-text="true">!</span></p>',
-      );
-
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
-
-      await waitForSelector(page, '.font-size');
-      await selectOption(page, '.font-size', {value: '20px'});
-
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span data-lexical-text="true" style="font-size: 20px; font-family: Georgia;">world</span><span data-lexical-text="true">!</span></p>',
-      );
-
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
-    });
-
-    it(`Can select multiple text parts and format them with shortcuts`, async () => {
-      const {isRichText, page} = e2e;
-
-      if (!isRichText) {
-        return;
-      }
-
-      await focusEditor(page);
-      await page.keyboard.type('Hello world!');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.down('Shift');
-      await repeat(5, async () => {
-        await page.keyboard.press('ArrowLeft');
-      });
-      await page.keyboard.up('Shift');
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 11,
-        focusPath: [0, 0, 0],
-        focusOffset: 6,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">world</strong><span data-lexical-text="true">!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 1, 0],
-        focusOffset: 5,
-      });
-
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.down('Shift');
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.up('Shift');
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 1,
-        focusPath: [0, 1, 0],
-        focusOffset: 3,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">w</strong><strong class="PlaygroundEditorTheme__textBold igjjae4c PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true">or</strong><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">ld</strong><span data-lexical-text="true">!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 2,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">w</strong><em class="PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true">or</em><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">ld</strong><span data-lexical-text="true">!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 2, 0],
-        anchorOffset: 0,
-        focusPath: [0, 2, 0],
-        focusOffset: 2,
-      });
-
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.down('Shift');
-      await repeat(5, async () => {
-        await page.keyboard.press('ArrowRight');
-      });
-      await page.keyboard.up('Shift');
-      await assertSelection(page, {
-        anchorPath: [0, 1, 0],
-        anchorOffset: 0,
-        focusPath: [0, 3, 0],
-        focusOffset: 2,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello w</span><em class="PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true">or</em><span data-lexical-text="true">ld!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 6,
-        focusPath: [0, 2, 0],
-        focusOffset: 2,
-      });
-
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><em class="PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true">world</em><span data-lexical-text="true">!</span></p>',
-      );
-
-      if (E2E_BROWSER === 'webkit') {
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">world</strong><span data-lexical-text="true">!</span></p>',
+        );
         await assertSelection(page, {
           anchorPath: [0, 1, 0],
           anchorOffset: 0,
           focusPath: [0, 1, 0],
           focusOffset: 5,
         });
-      } else {
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world!</span></p>',
+        );
         await assertSelection(page, {
           anchorPath: [0, 0, 0],
           anchorOffset: 6,
+          focusPath: [0, 0, 0],
+          focusOffset: 11,
+        });
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      'Should not format the text in the subsequent paragraph after a triple click selection event.',
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+        await page.keyboard.type('hello world');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('hello world');
+
+        await click(page, 'div[contenteditable="true"] > p', {
+          clickCount: 1,
+          delay: 100,
+        });
+        await click(page, 'div[contenteditable="true"] > p', {
+          clickCount: 2,
+          delay: 100,
+        });
+        await click(page, 'div[contenteditable="true"] > p', {
+          clickCount: 3,
+          delay: 100,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.type('b');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">hello world</strong></p><p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello world</span></p>',
+        );
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      `Can select text and italicify it with the shortcut`,
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+        await page.keyboard.type('Hello world!');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.down('Shift');
+        await repeat(5, async () => {
+          await page.keyboard.press('ArrowLeft');
+        });
+        await page.keyboard.up('Shift');
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 11,
+          focusPath: [0, 0, 0],
+          focusOffset: 6,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><em class="PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true">world</em><span data-lexical-text="true">!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
           focusPath: [0, 1, 0],
           focusOffset: 5,
         });
-      }
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('i');
-      await keyUpCtrlOrMeta(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world!</span></p>',
-      );
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 6,
-        focusPath: [0, 0, 0],
-        focusOffset: 11,
-      });
-    });
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 6,
+          focusPath: [0, 0, 0],
+          focusOffset: 11,
+        });
+      },
+    );
 
-    it(`Can insert range of formatted text and select part and replace with character`, async () => {
-      const {isRichText, page} = e2e;
+    it.skipIf(
+      e2e.isPlainText,
+      `Can select text and underline+strikethrough`,
+      async () => {
+        const {page} = e2e;
 
-      if (!isRichText) {
-        return;
-      }
+        await focusEditor(page);
+        await page.keyboard.type('Hello world!');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.down('Shift');
+        await repeat(5, async () => {
+          await page.keyboard.press('ArrowLeft');
+        });
+        await page.keyboard.up('Shift');
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 11,
+          focusPath: [0, 0, 0],
+          focusOffset: 6,
+        });
 
-      await focusEditor(page);
-      await page.keyboard.type('123');
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('u');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span class="PlaygroundEditorTheme__textUnderline o570zoyu" data-lexical-text="true">world</span><span data-lexical-text="true">!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 1, 0],
+          focusOffset: 5,
+        });
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('u');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 6,
+          focusPath: [0, 0, 0],
+          focusOffset: 11,
+        });
 
-      await page.keyboard.type('456');
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('u');
+        await keyUpCtrlOrMeta(page);
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
+        await waitForSelector(page, '.strikethrough');
+        await click(page, '.strikethrough');
 
-      await page.keyboard.type('789');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span class="PlaygroundEditorTheme__textUnderlineStrikethrough kf6cyplv" data-lexical-text="true">world</span><span data-lexical-text="true">!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 1, 0],
+          focusOffset: 5,
+        });
 
-      await page.keyboard.down('Shift');
-      await page.keyboard.press('Enter');
-      await page.keyboard.up('Shift');
+        await waitForSelector(page, '.strikethrough');
+        await click(page, '.strikethrough');
 
-      await page.keyboard.type('abc');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span class="PlaygroundEditorTheme__textUnderline o570zoyu" data-lexical-text="true">world</span><span data-lexical-text="true">!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 1, 0],
+          focusOffset: 5,
+        });
+      },
+    );
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
+    it.skipIf(
+      e2e.isPlainText,
+      `Can select text and change the font-size`,
+      async () => {
+        const {page} = e2e;
 
-      await page.keyboard.type('def');
+        await focusEditor(page);
+        await page.keyboard.type('Hello world!');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.down('Shift');
+        await repeat(5, async () => {
+          await page.keyboard.press('ArrowLeft');
+        });
+        await page.keyboard.up('Shift');
 
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('b');
-      await keyUpCtrlOrMeta(page);
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 11,
+          focusPath: [0, 0, 0],
+          focusOffset: 6,
+        });
 
-      await page.keyboard.type('ghi');
+        await waitForSelector(page, '.font-size');
+        await selectOption(page, '.font-size', {value: '10px'});
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">123</span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">456</strong><span data-lexical-text="true">789</span><br><span data-lexical-text="true">abc</span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">def</strong><span data-lexical-text="true">ghi</span></p>',
-      );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span data-lexical-text="true" style="font-size: 10px;">world</span><span data-lexical-text="true">!</span></p>',
+        );
 
-      await assertSelection(page, {
-        anchorPath: [0, 6, 0],
-        anchorOffset: 3,
-        focusPath: [0, 6, 0],
-        focusOffset: 3,
-      });
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 1, 0],
+          focusOffset: 5,
+        });
+      },
+    );
 
-      await page.keyboard.press('ArrowUp');
-      await moveToLineBeginning(page);
+    it.skipIf(
+      e2e.isPlainText,
+      `Can select text and change the font-size and font-family`,
+      async () => {
+        const {page} = e2e;
 
-      await page.keyboard.press('ArrowRight');
-      await page.keyboard.press('ArrowRight');
+        await focusEditor(page);
+        await page.keyboard.type('Hello world!');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.down('Shift');
+        await repeat(5, async () => {
+          await page.keyboard.press('ArrowLeft');
+        });
+        await page.keyboard.up('Shift');
 
-      await page.keyboard.down('Shift');
-      await page.keyboard.press('ArrowDown');
-      await repeat(8, async () => {
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 11,
+          focusPath: [0, 0, 0],
+          focusOffset: 6,
+        });
+
+        await waitForSelector(page, '.font-size');
+        await selectOption(page, '.font-size', {value: '10px'});
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span data-lexical-text="true" style="font-size: 10px;">world</span><span data-lexical-text="true">!</span></p>',
+        );
+
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 1, 0],
+          focusOffset: 5,
+        });
+
+        await waitForSelector(page, '.font-family');
+        await selectOption(page, '.font-family', {value: 'Georgia'});
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span data-lexical-text="true" style="font-size: 10px; font-family: Georgia;">world</span><span data-lexical-text="true">!</span></p>',
+        );
+
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 1, 0],
+          focusOffset: 5,
+        });
+
+        await waitForSelector(page, '.font-size');
+        await selectOption(page, '.font-size', {value: '20px'});
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><span data-lexical-text="true" style="font-size: 20px; font-family: Georgia;">world</span><span data-lexical-text="true">!</span></p>',
+        );
+
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 1, 0],
+          focusOffset: 5,
+        });
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      `Can select multiple text parts and format them with shortcuts`,
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+        await page.keyboard.type('Hello world!');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.down('Shift');
+        await repeat(5, async () => {
+          await page.keyboard.press('ArrowLeft');
+        });
+        await page.keyboard.up('Shift');
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 11,
+          focusPath: [0, 0, 0],
+          focusOffset: 6,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">world</strong><span data-lexical-text="true">!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 1, 0],
+          focusOffset: 5,
+        });
+
+        await page.keyboard.press('ArrowLeft');
         await page.keyboard.press('ArrowRight');
-      });
-      await page.keyboard.down('Shift');
+        await page.keyboard.down('Shift');
+        await page.keyboard.press('ArrowRight');
+        await page.keyboard.press('ArrowRight');
+        await page.keyboard.up('Shift');
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 1,
+          focusPath: [0, 1, 0],
+          focusOffset: 3,
+        });
 
-      await page.keyboard.type('c');
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">w</strong><strong class="PlaygroundEditorTheme__textBold igjjae4c PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true">or</strong><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">ld</strong><span data-lexical-text="true">!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 2, 0],
+          anchorOffset: 0,
+          focusPath: [0, 2, 0],
+          focusOffset: 2,
+        });
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">12c</span></p>',
-      );
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">w</strong><em class="PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true">or</em><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">ld</strong><span data-lexical-text="true">!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 2, 0],
+          anchorOffset: 0,
+          focusPath: [0, 2, 0],
+          focusOffset: 2,
+        });
 
-      await assertSelection(page, {
-        anchorPath: [0, 0, 0],
-        anchorOffset: 3,
-        focusPath: [0, 0, 0],
-        focusOffset: 3,
-      });
-    });
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.down('Shift');
+        await repeat(5, async () => {
+          await page.keyboard.press('ArrowRight');
+        });
+        await page.keyboard.up('Shift');
+        await assertSelection(page, {
+          anchorPath: [0, 1, 0],
+          anchorOffset: 0,
+          focusPath: [0, 3, 0],
+          focusOffset: 2,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello w</span><em class="PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true">or</em><span data-lexical-text="true">ld!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 6,
+          focusPath: [0, 2, 0],
+          focusOffset: 2,
+        });
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello </span><em class="PlaygroundEditorTheme__textItalic qp0gn4il" data-lexical-text="true">world</em><span data-lexical-text="true">!</span></p>',
+        );
+
+        if (E2E_BROWSER === 'webkit') {
+          await assertSelection(page, {
+            anchorPath: [0, 1, 0],
+            anchorOffset: 0,
+            focusPath: [0, 1, 0],
+            focusOffset: 5,
+          });
+        } else {
+          await assertSelection(page, {
+            anchorPath: [0, 0, 0],
+            anchorOffset: 6,
+            focusPath: [0, 1, 0],
+            focusOffset: 5,
+          });
+        }
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('i');
+        await keyUpCtrlOrMeta(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello world!</span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 6,
+          focusPath: [0, 0, 0],
+          focusOffset: 11,
+        });
+      },
+    );
+
+    it.skipIf(
+      e2e.isPlainText,
+      `Can insert range of formatted text and select part and replace with character`,
+      async () => {
+        const {page} = e2e;
+
+        await focusEditor(page);
+        await page.keyboard.type('123');
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+
+        await page.keyboard.type('456');
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+
+        await page.keyboard.type('789');
+
+        await page.keyboard.down('Shift');
+        await page.keyboard.press('Enter');
+        await page.keyboard.up('Shift');
+
+        await page.keyboard.type('abc');
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+
+        await page.keyboard.type('def');
+
+        await keyDownCtrlOrMeta(page);
+        await page.keyboard.press('b');
+        await keyUpCtrlOrMeta(page);
+
+        await page.keyboard.type('ghi');
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">123</span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">456</strong><span data-lexical-text="true">789</span><br><span data-lexical-text="true">abc</span><strong class="PlaygroundEditorTheme__textBold igjjae4c" data-lexical-text="true">def</strong><span data-lexical-text="true">ghi</span></p>',
+        );
+
+        await assertSelection(page, {
+          anchorPath: [0, 6, 0],
+          anchorOffset: 3,
+          focusPath: [0, 6, 0],
+          focusOffset: 3,
+        });
+
+        await page.keyboard.press('ArrowUp');
+        await moveToLineBeginning(page);
+
+        await page.keyboard.press('ArrowRight');
+        await page.keyboard.press('ArrowRight');
+
+        await page.keyboard.down('Shift');
+        await page.keyboard.press('ArrowDown');
+        await repeat(8, async () => {
+          await page.keyboard.press('ArrowRight');
+        });
+        await page.keyboard.down('Shift');
+
+        await page.keyboard.type('c');
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">12c</span></p>',
+        );
+
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0],
+          anchorOffset: 3,
+          focusPath: [0, 0, 0],
+          focusOffset: 3,
+        });
+      },
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/regression/1055-fast-typing-undo.js
+++ b/packages/lexical-playground/__tests__/regression/1055-fast-typing-undo.js
@@ -6,36 +6,35 @@
  *
  */
 
-import {initializeE2E, assertHTML, focusEditor, IS_COLLAB} from '../utils';
+import {initializeE2E, assertHTML, focusEditor} from '../utils';
 
 import {undo} from '../keyboardShortcuts';
 
 describe('Regression test #1055', () => {
   initializeE2E((e2e) => {
-    it(`Adds new editor state into undo stack right after undo was done`, async () => {
-      if (IS_COLLAB) {
-        // Collab uses its own undo/redo
-        return;
-      }
-
-      const {page} = e2e;
-      await focusEditor(page);
-      await page.keyboard.type('hello');
-      await undo(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br /></p>',
-      );
-      await page.keyboard.type('hello');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello</span></p>',
-      );
-      await undo(page);
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br /></p>',
-      );
-    });
+    it.skipIf(
+      e2e.isCollab,
+      `Adds new editor state into undo stack right after undo was done`,
+      async () => {
+        const {page} = e2e;
+        await focusEditor(page);
+        await page.keyboard.type('hello');
+        await undo(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br /></p>',
+        );
+        await page.keyboard.type('hello');
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">hello</span></p>',
+        );
+        await undo(page);
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br /></p>',
+        );
+      },
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/regression/1083-backspace-with-element-at-front.js
+++ b/packages/lexical-playground/__tests__/regression/1083-backspace-with-element-at-front.js
@@ -18,72 +18,74 @@ import {moveToLineEnd, selectAll} from '../keyboardShortcuts';
 
 describe('Regression test #1083', () => {
   initializeE2E((e2e) => {
-    it(`Backspace with ElementNode at the front of the paragraph`, async () => {
-      const {isRichText, page} = e2e;
-      if (!isRichText) {
-        return;
-      }
-      await focusEditor(page);
+    it.skipIf(
+      e2e.isPlainText,
+      `Backspace with ElementNode at the front of the paragraph`,
+      async () => {
+        const {page} = e2e;
+        await focusEditor(page);
 
-      await page.keyboard.type('Hello');
-      await selectAll(page);
-      await waitForSelector(page, '.link');
-      await click(page, '.link');
+        await page.keyboard.type('Hello');
+        await selectAll(page);
+        await waitForSelector(page, '.link');
+        await click(page, '.link');
 
-      await moveToLineEnd(page);
-      await page.keyboard.type('World');
+        await moveToLineEnd(page);
+        await page.keyboard.type('World');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></a><span data-lexical-text="true">World</span></p>',
-      );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></a><span data-lexical-text="true">World</span></p>',
+        );
 
-      await selectAll(page);
-      await page.keyboard.press('Backspace');
+        await selectAll(page);
+        await page.keyboard.press('Backspace');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
-      );
-    });
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
+        );
+      },
+    );
 
-    it(`Backspace with ElementNode at the front of the selection`, async () => {
-      const {isRichText, page} = e2e;
-      if (!isRichText) {
-        return;
-      }
-      await focusEditor(page);
+    it.skipIf(
+      e2e.isPlainText,
+      `Backspace with ElementNode at the front of the selection`,
+      async () => {
+        const {page} = e2e;
+        await focusEditor(page);
 
-      await page.keyboard.type('Say');
+        await page.keyboard.type('Say');
 
-      await page.keyboard.type('Hello');
-      await page.keyboard.down('Shift');
-      await repeat('Hello'.length, async () => {
-        await page.keyboard.press('ArrowLeft');
-      });
-      await page.keyboard.up('Shift');
-      await waitForSelector(page, '.link');
-      await click(page, '.link');
+        await page.keyboard.type('Hello');
+        await page.keyboard.down('Shift');
+        await repeat('Hello'.length, async () => {
+          await page.keyboard.press('ArrowLeft');
+        });
+        await page.keyboard.up('Shift');
+        await waitForSelector(page, '.link');
+        await click(page, '.link');
 
-      await moveToLineEnd(page);
-      await page.keyboard.type('World');
+        await moveToLineEnd(page);
+        await page.keyboard.type('World');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Say</span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></a><span data-lexical-text="true">World</span></p>',
-      );
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Say</span><a href="https://" class="PlaygroundEditorTheme__link ec0vvsmr rn8ck1ys PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Hello</span></a><span data-lexical-text="true">World</span></p>',
+        );
 
-      await page.keyboard.down('Shift');
-      await repeat('HelloWorld'.length, async () => {
-        await page.keyboard.press('ArrowLeft');
-      });
-      await page.keyboard.up('Shift');
-      await page.keyboard.press('Backspace');
+        await page.keyboard.down('Shift');
+        await repeat('HelloWorld'.length, async () => {
+          await page.keyboard.press('ArrowLeft');
+        });
+        await page.keyboard.up('Shift');
+        await page.keyboard.press('Backspace');
 
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Say</span></p>',
-      );
-    });
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Say</span></p>',
+        );
+      },
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/utils/index.js
+++ b/packages/lexical-playground/__tests__/utils/index.js
@@ -113,7 +113,7 @@ export function initializeE2E(runTests, config: Config = {}) {
     }
   });
 
-  if (!E2E_DEBUG) {
+  if (!E2E_DEBUG && !global.it._overridden) {
     const it = global.it;
     // if we mark the test as flaky, overwrite the original 'it' function
     // to attempt the test 10 times before actually failing
@@ -158,7 +158,8 @@ export function initializeE2E(runTests, config: Config = {}) {
       return result;
     };
     global.it = newIt;
-
+    // Preventing from overridding global.it twice (in case test suite runs initializeE2E twice)
+    newIt._overridden = true;
     newIt.skipIf = async (condition, description, test) => {
       if (typeof condition === 'function' ? condition() : !!condition) {
         it.skip(description, test);


### PR DESCRIPTION
This PR only replaces `it()` with `it.skipIf()` for mode-specific tests, there's a reformatting on top of it hence GH shows so many line changes

Plain text tests got most of the boost - on local test time dropped from 152 to 40 seconds, CI time depends on a platform and around 50-60% better than before