### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## 0.1.9 (February 18, 2022)
+
+- Added `addListener('mutation', Class<LexicalNode>, Map<NodeKey, NodeMutation>)` to track created/destroyed nodes. `NodeMutation = 'created' | 'destroyed'`
+- Removed `$log()`
+- Moved TableNode/Row/Cell to its own `@lexical/table` package
+- Composition fixes
+
+## 0.1.8 (February 11, 2022)
+
+- `Lexical{Plain/Rich}TextPlugin` and `DEPRECATED_use{Plain/Rich}TextPlugin` no longer create a ParagraphNode for you. This logic has been decoupled into a separate plugin <BootstrapPlugin />. The Bootstrap plugin also accepts an initialPayloadFn and clearEditorFn for custom initialization (i.e. edit behavior from server data). `<BootstrapPlugin /> <RichTextPlugin .. />`. If you're using the `DEPRECATED_{Plain/Rich}Text` version you may also want to copy-paste this hook and run it before the RichText initialization - https://github.com/facebook/lexical/blob/main/packages/lexical/src/__tests__/utils/DEPRECATED__useLexicalBootstrap.js
+- Bugfixes


### PR DESCRIPTION
Inspired from [React's](https://github.com/facebook/react/blob/main/CHANGELOG.md) but overly simplified

My idea behind this is to track breaking changes and be able to copy-paste them easily to teams rather than to have a formal document with authorship and every single bug fix in the code - we can do that after 1.0