### PR TITLE
Remove exposed EditorState prop on $getRoot

### DIFF
--- a/packages/lexical/src/LexicalMutations.js
+++ b/packages/lexical/src/LexicalMutations.js
@@ -12,7 +12,6 @@ import type {LexicalEditor} from './LexicalEditor';
 import type {RangeSelection} from './LexicalSelection';
 
 import {
-  $getRoot,
   $getSelection,
   $isDecoratorNode,
   $isElementNode,
@@ -25,6 +24,7 @@ import {
   $getNearestNodeFromDOMNode,
   $updateTextNodeFromDOMContent,
   getNodeFromDOMNode,
+  internalGetRoot,
 } from './LexicalUtils';
 
 // The time between a text entry event and the mutation observer firing.
@@ -161,7 +161,7 @@ export function $flushMutations(
             }
             if (removedDOMsLength !== unremovedBRs) {
               if (targetDOM === rootElement) {
-                targetNode = $getRoot(currentEditorState);
+                targetNode = internalGetRoot(currentEditorState);
               }
               badDOMTargets.set(targetDOM, targetNode);
             }

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -340,8 +340,12 @@ export function markAllNodesAsDirty(editor: LexicalEditor, type: string): void {
   );
 }
 
-export function $getRoot(editorState?: EditorState): RootNode {
-  return (((editorState || getActiveEditorState())._nodeMap.get(
+export function $getRoot(): RootNode {
+  return internalGetRoot(getActiveEditorState());
+}
+
+export function internalGetRoot(editorState: EditorState): RootNode {
+  return ((editorState._nodeMap.get(
     'root',
     // $FlowFixMe: root is always in our Map
   ): any): RootNode);


### PR DESCRIPTION
The EditorState param shouldn't be exposed on the $-function to public