### PR TITLE
Add NodeSelection

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -60,6 +60,8 @@ module.name_mapper='^@lexical/react/LexicalNestedComposer' -> '<PROJECT_ROOT>/pa
 module.name_mapper='^@lexical/react/withSubscriptions' -> '<PROJECT_ROOT>/packages/lexical-react/src/withSubscriptions.js'
 module.name_mapper='^@lexical/react/LexicalContentEditable' -> '<PROJECT_ROOT>/packages/lexical-react/src/LexicalContentEditable.js'
 module.name_mapper='^@lexical/react/LexicalNestedComposer' -> '<PROJECT_ROOT>/packages/lexical-react/src/LexicalNestedComposer.js'
+module.name_mapper='^@lexical/react/LexicalHorizontalRuleNode' -> '<PROJECT_ROOT>/packages/lexical-react/src/LexicalHorizontalRuleNode.js'
+module.name_mapper='^@lexical/react/useLexicalNodeSelection' -> '<PROJECT_ROOT>/packages/lexical-react/src/useLexicalNodeSelection.js'
 
 # Composer Plugins
 module.name_mapper='^@lexical/react/LexicalAutoFormatterPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/src/LexicalAutoFormatterPlugin.js'
@@ -75,7 +77,6 @@ module.name_mapper='^@lexical/react/LexicalLinkPlugin' -> '<PROJECT_ROOT>/packag
 module.name_mapper='^@lexical/react/LexicalAutoLinkPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/src/LexicalAutoLinkPlugin.js'
 module.name_mapper='^@lexical/react/LexicalListPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/src/LexicalListPlugin.js'
 module.name_mapper='^@lexical/react/LexicalOnChangePlugin' -> '<PROJECT_ROOT>/packages/lexical-react/src/LexicalOnChangePlugin.js'
-module.name_mapper='^@lexical/react/LexicalHorizontalRuleNode' -> '<PROJECT_ROOT>/packages/lexical-react/src/LexicalHorizontalRuleNode.js'
 
 module.name_mapper='^@lexical/yjs$' -> '<PROJECT_ROOT>/packages/lexical-yjs/src/index.js'
 

--- a/packages/lexical-helpers/src/LexicalEventHelpers.js
+++ b/packages/lexical-helpers/src/LexicalEventHelpers.js
@@ -27,6 +27,7 @@ import {
   $getSelection,
   $isDecoratorNode,
   $isElementNode,
+  $isRangeSelection,
   $isTextNode,
 } from 'lexical';
 import {$createCodeNode} from 'lexical/CodeNode';
@@ -361,7 +362,7 @@ export function onPasteForPlainText(
   editor.update(() => {
     const selection = $getSelection();
     const clipboardData = event.clipboardData;
-    if (clipboardData != null && selection !== null) {
+    if (clipboardData != null && $isRangeSelection(selection)) {
       $insertDataTransferForPlainText(clipboardData, selection);
     }
   });
@@ -375,7 +376,7 @@ export function onPasteForRichText(
   editor.update(() => {
     const selection = $getSelection();
     const clipboardData = event.clipboardData;
-    if (clipboardData != null && selection !== null) {
+    if (clipboardData != null && $isRangeSelection(selection)) {
       $insertDataTransferForRichText(clipboardData, selection, editor);
     }
   });
@@ -388,7 +389,7 @@ export function onCutForPlainText(
   onCopyForPlainText(event, editor);
   editor.update(() => {
     const selection = $getSelection();
-    if (selection !== null) {
+    if ($isRangeSelection(selection)) {
       selection.removeText();
     }
   });
@@ -401,7 +402,7 @@ export function onCutForRichText(
   onCopyForRichText(event, editor);
   editor.update(() => {
     const selection = $getSelection();
-    if (selection !== null) {
+    if ($isRangeSelection(selection)) {
       selection.removeText();
     }
   });

--- a/packages/lexical-helpers/src/LexicalSelectionHelpers.js
+++ b/packages/lexical-helpers/src/LexicalSelectionHelpers.js
@@ -11,6 +11,7 @@ import type {
   ElementNode,
   LexicalNode,
   NodeKey,
+  NodeSelection,
   Point,
   RangeSelection,
   TextNode,
@@ -20,9 +21,11 @@ import {
   $isDecoratorNode,
   $isElementNode,
   $isLeafNode,
+  $isRangeSelection,
   $isRootNode,
   $isTextNode,
 } from 'lexical';
+import invariant from 'shared/invariant';
 
 const cssToStyles: Map<string, {[string]: string}> = new Map();
 
@@ -117,10 +120,13 @@ function $copyLeafNodeBranchToRoot(
   }
 }
 
-export function $cloneContents(selection: RangeSelection): {
+export function $cloneContents(selection: RangeSelection | NodeSelection): {
   nodeMap: Array<[NodeKey, LexicalNode]>,
   range: Array<NodeKey>,
 } {
+  if (!$isRangeSelection(selection)) {
+    invariant(false, 'TODO');
+  }
   const anchor = selection.anchor;
   const focus = selection.focus;
   const anchorOffset = anchor.getCharacterOffset();

--- a/packages/lexical-list/src/formatList.js
+++ b/packages/lexical-list/src/formatList.js
@@ -23,6 +23,7 @@ import {
   $getSelection,
   $isElementNode,
   $isLeafNode,
+  $isRangeSelection,
   $isRootNode,
 } from 'lexical';
 
@@ -37,7 +38,7 @@ import {
 export function insertList(editor: LexicalEditor, listType: 'ul' | 'ol'): void {
   editor.update(() => {
     const selection = $getSelection();
-    if (selection !== null) {
+    if ($isRangeSelection(selection)) {
       const nodes = selection.getNodes();
       const anchor = selection.anchor;
       const anchorNode = anchor.getNode();
@@ -128,7 +129,7 @@ function createListOrMerge(node: ElementNode, listType: 'ul' | 'ol'): ListNode {
 export function removeList(editor: LexicalEditor): void {
   editor.update(() => {
     const selection = $getSelection();
-    if (selection !== null) {
+    if ($isRangeSelection(selection)) {
       const listNodes = new Set();
       const nodes = selection.getNodes();
       const anchorNode = selection.anchor.getNode();
@@ -283,7 +284,7 @@ export function $handleOutdent(listItemNodes: Array<ListItemNode>): void {
 
 function maybeIndentOrOutdent(direction: 'indent' | 'outdent'): boolean {
   const selection = $getSelection();
-  if (selection === null) {
+  if (!$isRangeSelection(selection)) {
     return false;
   }
   const selectedNodes = selection.getNodes();

--- a/packages/lexical-playground/__tests__/e2e/Images-test.js
+++ b/packages/lexical-playground/__tests__/e2e/Images-test.js
@@ -33,7 +33,7 @@ describe('Images', () => {
 
         await assertHTML(
           page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
         );
         await assertSelection(page, {
           anchorPath: [0],
@@ -81,7 +81,7 @@ describe('Images', () => {
 
         await assertHTML(
           page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;" class="focused"><button class="image-caption-button">Add Caption</button><div class="image-resizer-ne"></div><div class="image-resizer-se"></div><div class="image-resizer-sw"></div><div class="image-resizer-nw"></div></span><br></p>',
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" style="width: inherit; height: inherit; max-width: 500px;" class="focused"><button class="image-caption-button">Add Caption</button><div class="image-resizer-ne"></div><div class="image-resizer-se"></div><div class="image-resizer-sw"></div><div class="image-resizer-nw"></div></span><br></p>',
           true,
         );
 
@@ -92,6 +92,8 @@ describe('Images', () => {
           '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><br></p>',
         );
 
+        await click(page, 'div[contenteditable="true"]');
+
         await click(page, 'button .image');
 
         await waitForSelector(page, '.editor-image img');
@@ -100,7 +102,7 @@ describe('Images', () => {
 
         await assertHTML(
           page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
         );
         await assertSelection(page, {
           anchorPath: [0],
@@ -148,7 +150,7 @@ describe('Images', () => {
 
         await assertHTML(
           page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" style="width: inherit; height: inherit; max-width: 500px;"></span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
         );
         await assertSelection(page, {
           anchorPath: [0],
@@ -160,7 +162,7 @@ describe('Images', () => {
         await page.keyboard.press('Delete');
         await assertHTML(
           page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y"><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
         );
         await assertSelection(page, {
           anchorPath: [0],
@@ -191,7 +193,7 @@ describe('Images', () => {
 
         await assertHTML(
           page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" style="width: inherit; height: inherit; max-width: 500px;"></span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
         );
         await assertSelection(page, {
           anchorPath: [0, 0, 0],
@@ -202,7 +204,7 @@ describe('Images', () => {
         await page.keyboard.press('Delete');
         await assertHTML(
           page,
-          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" tabindex="0" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span data-lexical-text="true">Test</span><span class="editor-image" data-lexical-decorator="true" contenteditable="false"><img src="/static/media/yellow-flower.95d22651.jpg" alt="Yellow flower in tilt shift lens" style="width: inherit; height: inherit; max-width: 500px;"></span><br></p>',
         );
         await assertSelection(page, {
           anchorPath: [0, 0, 0],

--- a/packages/lexical-playground/craco.config.js
+++ b/packages/lexical-playground/craco.config.js
@@ -71,6 +71,10 @@ module.exports = {
         '@lexical/react/dist/LexicalContentEditable',
       '@lexical/react/LexicalNestedComposer':
         '@lexical/react/dist/LexicalNestedComposer',
+      '@lexical/react/LexicalHorizontalRuleNode':
+        '@lexical/react/dist/LexicalHorizontalRuleNode',
+      '@lexical/react/useLexicalNodeSelection':
+        '@lexical/react/dist/useLexicalNodeSelection',
 
       // Composer and it's plugins
       '@lexical/react/LexicalComposer': '@lexical/react/dist/LexicalComposer',
@@ -90,7 +94,6 @@ module.exports = {
         'LexicalAutoLinkPlugin',
         'LexicalListPlugin',
         'LexicalOnChangePlugin',
-        'LexicalHorizontalRuleNode',
       ].reduce(
         (aliases, plugin) => ({
           ...aliases,

--- a/packages/lexical-playground/src/plugins/AutocompletePlugin.js
+++ b/packages/lexical-playground/src/plugins/AutocompletePlugin.js
@@ -18,6 +18,7 @@ import {
   $getNodeByKey,
   $getSelection,
   $getRoot,
+  $isRangeSelection,
 } from 'lexical';
 import {TypeaheadNode, $createTypeaheadNode} from '../nodes/TypeaheadNode';
 import {useEffect, useRef, useState, useCallback, useMemo} from 'react';
@@ -63,7 +64,7 @@ function useTypeahead(editor: LexicalEditor): void {
         function maybeRemoveTypeahead() {
           if (currentTypeaheadNode !== null) {
             const selection = $getSelection();
-            if (selection !== null) {
+            if ($isRangeSelection(selection)) {
               const anchor = selection.anchor;
               const focus = selection.focus;
               if (anchor.type === 'text' && focus.type === 'text') {
@@ -119,11 +120,16 @@ function useTypeahead(editor: LexicalEditor): void {
         }
 
         const selection = $getSelection();
-        const anchorNode = selection?.anchor.getNode();
-        const anchorOffset = selection?.anchor.offset;
-        const anchorLength = anchorNode?.getTextContentSize();
-        const isCaretPositionAtEnd =
-          anchorLength != null && anchorOffset === anchorLength;
+        let isCaretPositionAtEnd = false;
+
+        if ($isRangeSelection(selection)) {
+          const anchorNode = selection?.anchor.getNode();
+          const anchorOffset = selection?.anchor.offset;
+          const anchorLength = anchorNode?.getTextContentSize();
+          isCaretPositionAtEnd =
+            anchorLength != null && anchorOffset === anchorLength;
+        }
+
         if (
           suggestion === null ||
           !selectionCollapsed ||

--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.js
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.js
@@ -9,7 +9,7 @@
 
 import type {RangeSelection, LexicalEditor, ElementNode} from 'lexical';
 
-import {TextNode, $isTextNode, $getSelection} from 'lexical';
+import {TextNode, $isTextNode, $getSelection, $isRangeSelection} from 'lexical';
 
 // $FlowFixMe
 import {createPortal} from 'react-dom';
@@ -201,7 +201,7 @@ function useCharacterStylesPopup(editor: LexicalEditor): React$Node {
       editorState.read(() => {
         const selection = $getSelection();
 
-        if (selection === null) {
+        if (!$isRangeSelection(selection)) {
           return;
         }
 

--- a/packages/lexical-playground/src/plugins/CodeHighlightPlugin.js
+++ b/packages/lexical-playground/src/plugins/CodeHighlightPlugin.js
@@ -23,6 +23,7 @@ import {
   $isTextNode,
   $isLineBreakNode,
   $getSelection,
+  $isRangeSelection,
 } from 'lexical';
 import {useEffect} from 'react';
 import withSubscriptions from '@lexical/react/withSubscriptions';
@@ -183,7 +184,7 @@ function updateAndRetainSelection(
   updateFn: () => boolean,
 ): void {
   const selection = $getSelection();
-  if (!selection || !selection.anchor) {
+  if (!$isRangeSelection(selection) || !selection.anchor) {
     return;
   }
 
@@ -306,7 +307,7 @@ function handleShiftLines(
 ): boolean {
   // We only care about the alt+arrow keys
   const selection = $getSelection();
-  if (!event.altKey || selection == null) {
+  if (!event.altKey || !$isRangeSelection(selection)) {
     return false;
   }
 

--- a/packages/lexical-playground/src/plugins/EmojisPlugin.js
+++ b/packages/lexical-playground/src/plugins/EmojisPlugin.js
@@ -7,11 +7,11 @@
  * @flow strict
  */
 
-import type {LexicalEditor, RangeSelection} from 'lexical';
+import type {LexicalEditor} from 'lexical';
 
 import {$createEmojiNode, EmojiNode} from '../nodes/EmojiNode';
 import {useEffect} from 'react';
-import {$getSelection, TextNode} from 'lexical';
+import {TextNode} from 'lexical';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 const emojis: Map<string, [string, string]> = new Map([
@@ -25,10 +25,7 @@ const emojis: Map<string, [string, string]> = new Map([
   ['❤', ['emoji heart', '❤']],
 ]);
 
-function findAndTransformEmoji(
-  selection: null | RangeSelection,
-  node: TextNode,
-): null | TextNode {
+function findAndTransformEmoji(node: TextNode): null | TextNode {
   const text = node.getTextContent();
   for (let i = 0; i < text.length; i++) {
     const emojiData = emojis.get(text[i]) || emojis.get(text.slice(i, i + 2));
@@ -50,14 +47,13 @@ function findAndTransformEmoji(
 }
 
 function textNodeTransform(node: TextNode): void {
-  const selection = $getSelection();
   let targetNode = node;
 
   while (targetNode !== null) {
     if (!targetNode.isSimpleText()) {
       return;
     }
-    targetNode = findAndTransformEmoji(selection, targetNode);
+    targetNode = findAndTransformEmoji(targetNode);
   }
 }
 

--- a/packages/lexical-playground/src/plugins/ExcalidrawPlugin.js
+++ b/packages/lexical-playground/src/plugins/ExcalidrawPlugin.js
@@ -11,7 +11,7 @@ import type {CommandListenerEditorPriority} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
-import {$getSelection} from 'lexical';
+import {$getSelection, $isRangeSelection} from 'lexical';
 import {$createExcalidrawNode, ExcalidrawNode} from '../nodes/ExcalidrawNode';
 
 const EditorPriority: CommandListenerEditorPriority = 0;
@@ -31,7 +31,7 @@ export default function ExcalidrawPlugin(): React$Node {
       (type) => {
         if (type === 'insertExcalidraw') {
           const selection = $getSelection();
-          if (selection !== null) {
+          if ($isRangeSelection(selection)) {
             const excalidrawNode = $createExcalidrawNode();
             selection.insertNodes([excalidrawNode]);
           }

--- a/packages/lexical-playground/src/plugins/HorizontalRulePlugin.js
+++ b/packages/lexical-playground/src/plugins/HorizontalRulePlugin.js
@@ -10,7 +10,7 @@
 import type {CommandListenerEditorPriority} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$getSelection} from 'lexical';
+import {$getSelection, $isRangeSelection} from 'lexical';
 import {useEffect} from 'react';
 
 import {$createHorizontalRuleNode} from '@lexical/react/LexicalHorizontalRuleNode';
@@ -26,7 +26,7 @@ export default function HorizontalRulePlugin(): null {
       (type) => {
         if (type === 'insertHorizontalRule') {
           const selection = $getSelection();
-          if (selection === null) {
+          if (!$isRangeSelection(selection)) {
             return false;
           }
 

--- a/packages/lexical-playground/src/plugins/ImagesPlugin.js
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin.js
@@ -11,7 +11,7 @@ import type {CommandListenerEditorPriority} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
-import {$getSelection, $isRootNode} from 'lexical';
+import {$getSelection, $isRootNode, $isRangeSelection} from 'lexical';
 import {$createImageNode, ImageNode} from '../nodes/ImageNode';
 
 import yellowFlowerImage from '../images/image/yellow-flower.jpg';
@@ -31,7 +31,7 @@ export default function ImagesPlugin(): React$Node {
       (type) => {
         if (type === 'insertImage') {
           const selection = $getSelection();
-          if (selection !== null) {
+          if ($isRangeSelection(selection)) {
             if ($isRootNode(selection.anchor.getNode())) {
               selection.insertParagraph();
             }

--- a/packages/lexical-playground/src/plugins/MentionsPlugin.js
+++ b/packages/lexical-playground/src/plugins/MentionsPlugin.js
@@ -17,7 +17,7 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 // $FlowFixMe
 import {createPortal} from 'react-dom';
-import {$getSelection} from 'lexical';
+import {$getSelection, $isRangeSelection} from 'lexical';
 import React, {useCallback, useLayoutEffect, useRef} from 'react';
 import {startTransition, useEffect, useState} from 'react';
 import {$createMentionNode, MentionNode} from '../nodes/MentionNode';
@@ -868,7 +868,7 @@ function getMentionsTextToSearch(editor: LexicalEditor): string | null {
   let text = null;
   editor.getEditorState().read(() => {
     const selection = $getSelection();
-    if (selection == null) {
+    if (!$isRangeSelection(selection)) {
       return;
     }
     text = getTextUpToAnchor(selection);
@@ -910,7 +910,7 @@ function createMentionNodeFromSearchResult(
 ): void {
   editor.update(() => {
     const selection = $getSelection();
-    if (selection == null || !selection.isCollapsed()) {
+    if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
       return;
     }
     const anchor = selection.anchor;

--- a/packages/lexical-playground/src/plugins/PollPlugin.js
+++ b/packages/lexical-playground/src/plugins/PollPlugin.js
@@ -11,7 +11,7 @@ import type {CommandListenerEditorPriority} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
-import {$getSelection, $isRootNode} from 'lexical';
+import {$getSelection, $isRootNode, $isRangeSelection} from 'lexical';
 import {$createPollNode, PollNode} from '../nodes/PollNode';
 
 const EditorPriority: CommandListenerEditorPriority = 0;
@@ -28,7 +28,7 @@ export default function PollPlugin(): React$Node {
       (type, payload) => {
         if (type === 'insertPoll') {
           const selection = $getSelection();
-          if (selection !== null) {
+          if ($isRangeSelection(selection)) {
             const question: string = payload;
             const pollNode = $createPollNode(question);
             if ($isRootNode(selection.anchor.getNode())) {

--- a/packages/lexical-playground/src/plugins/SpeechToTextPlugin.js
+++ b/packages/lexical-playground/src/plugins/SpeechToTextPlugin.js
@@ -14,7 +14,7 @@ import type {
 } from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$getSelection} from 'lexical';
+import {$getSelection, $isRangeSelection} from 'lexical';
 import {useEffect, useRef, useState} from 'react';
 import useReport from '../hooks/useReport';
 
@@ -63,7 +63,7 @@ function SpeechToTextPlugin(): null {
 
           editor.update(() => {
             const selection = $getSelection();
-            if (selection !== null) {
+            if ($isRangeSelection(selection)) {
               const command = VOICE_COMMANDS[transcript.toLowerCase().trim()];
               if (command) {
                 command({editor, selection});

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin.js
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin.js
@@ -12,7 +12,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 // $FlowFixMe
 import {createPortal} from 'react-dom';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$getSelection, $setSelection} from 'lexical';
+import {$getSelection, $setSelection, $isRangeSelection} from 'lexical';
 import {
   $deleteTableColumn,
   $getTableCellNodeFromLexicalNode,
@@ -287,7 +287,7 @@ function TableCellActionMenuContainer(): React.MixedElement {
     const rootElement = editor.getRootElement();
 
     if (
-      selection !== null &&
+      $isRangeSelection(selection) &&
       rootElement !== null &&
       rootElement.contains(nativeSelection.anchorNode)
     ) {

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.js
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.js
@@ -24,7 +24,12 @@ import {$createHeadingNode} from 'lexical/HeadingNode';
 import {$isListNode, ListNode} from '@lexical/list';
 import {$createQuoteNode} from 'lexical/QuoteNode';
 import {$createCodeNode, $isCodeNode} from 'lexical/CodeNode';
-import {$getNodeByKey, $getSelection, $createParagraphNode} from 'lexical';
+import {
+  $getNodeByKey,
+  $getSelection,
+  $createParagraphNode,
+  $isRangeSelection,
+} from 'lexical';
 import {$isLinkNode} from 'lexical/LinkNode';
 import {
   $wrapLeafNodesInElements,
@@ -119,7 +124,7 @@ function FloatingLinkEditor({editor}: {editor: LexicalEditor}): React$Node {
 
   const updateLinkEditor = useCallback(() => {
     const selection = $getSelection();
-    if (selection !== null) {
+    if ($isRangeSelection(selection)) {
       const node = getSelectedNode(selection);
       const parent = node.getParent();
       if ($isLinkNode(parent)) {
@@ -346,7 +351,7 @@ function BlockOptionsDropdownList({
       editor.update(() => {
         const selection = $getSelection();
 
-        if (selection !== null) {
+        if ($isRangeSelection(selection)) {
           $wrapLeafNodesInElements(selection, () => $createParagraphNode());
         }
       });
@@ -359,7 +364,7 @@ function BlockOptionsDropdownList({
       editor.update(() => {
         const selection = $getSelection();
 
-        if (selection !== null) {
+        if ($isRangeSelection(selection)) {
           $wrapLeafNodesInElements(selection, () => $createHeadingNode('h1'));
         }
       });
@@ -372,7 +377,7 @@ function BlockOptionsDropdownList({
       editor.update(() => {
         const selection = $getSelection();
 
-        if (selection !== null) {
+        if ($isRangeSelection(selection)) {
           $wrapLeafNodesInElements(selection, () => $createHeadingNode('h2'));
         }
       });
@@ -403,7 +408,7 @@ function BlockOptionsDropdownList({
       editor.update(() => {
         const selection = $getSelection();
 
-        if (selection !== null) {
+        if ($isRangeSelection(selection)) {
           $wrapLeafNodesInElements(selection, () => $createQuoteNode());
         }
       });
@@ -416,7 +421,7 @@ function BlockOptionsDropdownList({
       editor.update(() => {
         const selection = $getSelection();
 
-        if (selection !== null) {
+        if ($isRangeSelection(selection)) {
           $wrapLeafNodesInElements(selection, () => $createCodeNode());
         }
       });
@@ -516,7 +521,7 @@ export default function ToolbarPlugin(): React$Node {
 
   const updateToolbar = useCallback(() => {
     const selection = $getSelection();
-    if (selection !== null) {
+    if ($isRangeSelection(selection)) {
       const anchorNode = selection.anchor.getNode();
       const element =
         anchorNode.getKey() === 'root'
@@ -600,7 +605,7 @@ export default function ToolbarPlugin(): React$Node {
     (styles: {[string]: string}) => {
       activeEditor.update(() => {
         const selection = $getSelection();
-        if (selection !== null) {
+        if ($isRangeSelection(selection)) {
           $patchStyleText(selection, styles);
         }
       });

--- a/packages/lexical-react/src/LexicalTablePlugin.js
+++ b/packages/lexical-react/src/LexicalTablePlugin.js
@@ -16,7 +16,12 @@ import {
   TableNode,
   TableRowNode,
 } from '@lexical/table';
-import {$createParagraphNode, $getSelection, $isRootNode} from 'lexical';
+import {
+  $createParagraphNode,
+  $getSelection,
+  $isRangeSelection,
+  $isRootNode,
+} from 'lexical';
 import {useEffect} from 'react';
 import invariant from 'shared/invariant';
 
@@ -38,7 +43,7 @@ export default function TablePlugin(): React$Node {
         if (type === 'insertTable') {
           const {columns, rows} = payload;
           const selection = $getSelection();
-          if (selection === null) {
+          if (!$isRangeSelection(selection)) {
             return true;
           }
           const focus = selection.focus;

--- a/packages/lexical-react/src/LexicalTreeView.js
+++ b/packages/lexical-react/src/LexicalTreeView.js
@@ -11,10 +11,17 @@ import type {
   EditorState,
   ElementNode,
   LexicalEditor,
+  NodeSelection,
   RangeSelection,
 } from 'lexical';
 
-import {$getRoot, $getSelection, $isElementNode, $isTextNode} from 'lexical';
+import {
+  $getRoot,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  $isTextNode,
+} from 'lexical';
 import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
 
@@ -211,6 +218,10 @@ function printRangeSelection(selection: RangeSelection): string {
   return res;
 }
 
+function printObjectSelection(selection: NodeSelection): string {
+  return `: node\n  └ [${Array.from(selection._objects).join(', ')}]`;
+}
+
 function generateContent(editorState: EditorState): string {
   let res = ' root\n';
 
@@ -237,7 +248,11 @@ function generateContent(editorState: EditorState): string {
       });
     });
 
-    return selection === null ? ': null' : printRangeSelection(selection);
+    return selection === null
+      ? ': null'
+      : $isRangeSelection(selection)
+      ? printRangeSelection(selection)
+      : printObjectSelection(selection);
   });
 
   return res + '\n selection' + selectionString;
@@ -365,7 +380,7 @@ function printSelectedCharsLine({
   // No selection or node is not selected.
   if (
     !$isTextNode(node) ||
-    selection === null ||
+    !$isRangeSelection(selection) ||
     !isSelected ||
     $isElementNode(node)
   ) {

--- a/packages/lexical-react/src/shared/AutoFormatterUtils.js
+++ b/packages/lexical-react/src/shared/AutoFormatterUtils.js
@@ -26,6 +26,7 @@ import {
   $createRangeSelection,
   $getSelection,
   $isElementNode,
+  $isRangeSelection,
   $setSelection,
 } from 'lexical';
 import {$createCodeNode} from 'lexical/CodeNode';
@@ -587,7 +588,7 @@ function removeTextInCaptureGroups(
 
         $setSelection(newSelection);
         const currentSelection = $getSelection();
-        if (currentSelection != null) {
+        if ($isRangeSelection(currentSelection)) {
           currentSelection.removeText();
 
           // Shift offsets for capture groups which are within the same node
@@ -705,7 +706,7 @@ function formatTextInCaptureGroupIndex(
 
     $setSelection(newSelection);
     const currentSelection = $getSelection();
-    if (currentSelection != null) {
+    if ($isRangeSelection(currentSelection)) {
       currentSelection.formatText(formatType);
 
       const finalSelection = $createRangeSelection();

--- a/packages/lexical-react/src/shared/useAutoFormatter.js
+++ b/packages/lexical-react/src/shared/useAutoFormatter.js
@@ -14,10 +14,15 @@ import type {
   ScanningContext,
 } from './AutoFormatterUtils.js';
 import type {TextNodeWithOffset} from '@lexical/helpers/text';
-import type {EditorState, LexicalEditor, RangeSelection} from 'lexical';
+import type {
+  EditorState,
+  LexicalEditor,
+  NodeSelection,
+  RangeSelection,
+} from 'lexical';
 
 import {$isListItemNode} from '@lexical/list';
-import {$getSelection, $isTextNode} from 'lexical';
+import {$getSelection, $isRangeSelection, $isTextNode} from 'lexical';
 import {$isCodeNode} from 'lexical/CodeNode';
 import {useEffect} from 'react';
 
@@ -62,9 +67,9 @@ function getCriteriaWithMatchResultContext(
 }
 
 function getTextNodeForAutoFormatting(
-  selection: null | RangeSelection,
+  selection: null | RangeSelection | NodeSelection,
 ): null | TextNodeWithOffset {
-  if (selection == null) {
+  if (!$isRangeSelection(selection)) {
     return null;
   }
 
@@ -176,7 +181,7 @@ function getTriggerState(
 
   editorState.read(() => {
     const selection = $getSelection();
-    if (selection == null || !selection.isCollapsed()) {
+    if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
       return;
     }
     const node = selection.anchor.getNode();

--- a/packages/lexical-react/src/shared/useCharacterLimit.js
+++ b/packages/lexical-react/src/shared/useCharacterLimit.js
@@ -16,6 +16,7 @@ import {
   $getRoot,
   $getSelection,
   $isLeafNode,
+  $isRangeSelection,
   $isTextNode,
   $setSelection,
 } from 'lexical';
@@ -142,7 +143,7 @@ function $wrapOverflowedNodes(offset: number): void {
         const selection = $getSelection();
         // Restore selection when the overflow children are removed
         if (
-          selection !== null &&
+          $isRangeSelection(selection) &&
           (!selection.anchor.getNode().isAttached() ||
             !selection.focus.getNode().isAttached())
         ) {
@@ -237,7 +238,7 @@ export function mergePrevious(overflowNode: OverflowNode): void {
   }
 
   const selection = $getSelection();
-  if (selection !== null) {
+  if ($isRangeSelection(selection)) {
     const anchor = selection.anchor;
     const anchorNode = anchor.getNode();
     const focus = selection.focus;

--- a/packages/lexical-react/src/shared/useHistory.js
+++ b/packages/lexical-react/src/shared/useHistory.js
@@ -14,11 +14,17 @@ import type {
   LexicalEditor,
   LexicalNode,
   NodeKey,
+  NodeSelection,
   RangeSelection,
 } from 'lexical';
 
 import withSubscriptions from '@lexical/react/withSubscriptions';
-import {$getSelection, $isRootNode, $isTextNode} from 'lexical';
+import {
+  $getSelection,
+  $isRangeSelection,
+  $isRootNode,
+  $isTextNode,
+} from 'lexical';
 import {useCallback, useEffect, useMemo} from 'react';
 
 type MergeAction = 0 | 1 | 2;
@@ -38,7 +44,7 @@ const EditorPriority: CommandListenerEditorPriority = 0;
 export type HistoryStateEntry = {
   editor: LexicalEditor,
   editorState: EditorState,
-  undoSelection?: RangeSelection | null,
+  undoSelection?: RangeSelection | NodeSelection | null,
 };
 
 export type HistoryState = {
@@ -99,8 +105,8 @@ function getChangeType(
     return COMPOSING_CHARACTER;
   }
   if (
-    nextSelection === null ||
-    prevSelection === null ||
+    !$isRangeSelection(nextSelection) ||
+    !$isRangeSelection(prevSelection) ||
     !prevSelection.isCollapsed() ||
     !nextSelection.isCollapsed()
   ) {

--- a/packages/lexical-react/src/shared/useLexicalDragonSupport.js
+++ b/packages/lexical-react/src/shared/useLexicalDragonSupport.js
@@ -9,7 +9,7 @@
 
 import type {LexicalEditor} from 'lexical';
 
-import {$getSelection, $isTextNode} from 'lexical';
+import {$getSelection, $isRangeSelection, $isTextNode} from 'lexical';
 import {useEffect} from 'react';
 
 export default function useLexicalDragonSupport(editor: LexicalEditor) {
@@ -49,7 +49,7 @@ export default function useLexicalDragonSupport(editor: LexicalEditor) {
               formatCommand;
               editor.update(() => {
                 const selection = $getSelection();
-                if (selection !== null) {
+                if ($isRangeSelection(selection)) {
                   const anchor = selection.anchor;
                   let anchorNode = anchor.getNode();
                   let setSelStart = 0;

--- a/packages/lexical-react/src/shared/usePlainTextSetup.js
+++ b/packages/lexical-react/src/shared/usePlainTextSetup.js
@@ -17,7 +17,7 @@ import {
   onPasteForPlainText,
 } from '@lexical/helpers/events';
 import {$moveCharacter} from '@lexical/helpers/selection';
-import {$getSelection} from 'lexical';
+import {$getSelection, $isRangeSelection} from 'lexical';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
 import useLexicalDragonSupport from './useLexicalDragonSupport';
@@ -30,7 +30,7 @@ export default function usePlainTextSetup(editor: LexicalEditor): void {
       'command',
       (type, payload): boolean => {
         const selection = $getSelection();
-        if (selection === null) {
+        if (!$isRangeSelection(selection)) {
           return false;
         }
         switch (type) {

--- a/packages/lexical-react/src/shared/useRichTextSetup.js
+++ b/packages/lexical-react/src/shared/useRichTextSetup.js
@@ -22,7 +22,12 @@ import {
   onPasteForRichText,
 } from '@lexical/helpers/events';
 import {$moveCharacter} from '@lexical/helpers/selection';
-import {$getSelection, $isElementNode} from 'lexical';
+import {
+  $getSelection,
+  $isElementNode,
+  $isNodeSelection,
+  $isRangeSelection,
+} from 'lexical';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
 import useLexicalDragonSupport from './useLexicalDragonSupport';
@@ -35,7 +40,11 @@ export function useRichTextSetup(editor: LexicalEditor): void {
       'command',
       (type, payload): boolean => {
         const selection = $getSelection();
-        if (selection === null) {
+        if (type === 'click' && $isNodeSelection(selection)) {
+          selection.clear();
+          return true;
+        }
+        if (!$isRangeSelection(selection)) {
           return false;
         }
         switch (type) {

--- a/packages/lexical-react/src/useLexicalNodeSelection.js
+++ b/packages/lexical-react/src/useLexicalNodeSelection.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {LexicalEditor, NodeKey} from 'lexical';
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {
+  $createNodeSelection,
+  $getNodeByKey,
+  $getSelection,
+  $isNodeSelection,
+  $setSelection,
+} from 'lexical';
+import {useCallback, useEffect, useState} from 'react';
+
+function isNodeSelected(editor: LexicalEditor, key: NodeKey): boolean {
+  return editor.getEditorState().read(() => {
+    const node = $getNodeByKey(key);
+    if (node === null) {
+      return false;
+    }
+    return node.isSelected();
+  });
+}
+
+export default function useLexicalNodeSelection(
+  key: NodeKey,
+): [boolean, (boolean) => void, () => void] {
+  const [editor] = useLexicalComposerContext();
+  const [isSelected, setIsSelected] = useState(() =>
+    isNodeSelected(editor, key),
+  );
+
+  useEffect(() => {
+    return editor.addListener('update', () => {
+      setIsSelected(isNodeSelected(editor, key));
+    });
+  }, [editor, key]);
+
+  const setSelected = useCallback(
+    (selected: boolean) => {
+      editor.update(() => {
+        let selection = $getSelection();
+        if (!$isNodeSelection(selection)) {
+          selection = $createNodeSelection();
+          $setSelection(selection);
+        }
+        if (selected) {
+          selection.add(key);
+        } else {
+          selection.delete(key);
+        }
+      });
+    },
+    [editor, key],
+  );
+
+  const clearSelected = useCallback(() => {
+    editor.update(() => {
+      const selection = $getSelection();
+      if ($isNodeSelection(selection)) {
+        selection.clear();
+      }
+    });
+  }, [editor]);
+
+  return [isSelected, setSelected, clearSelected];
+}

--- a/packages/lexical-table/src/LexicalTableNode.js
+++ b/packages/lexical-table/src/LexicalTableNode.js
@@ -27,6 +27,7 @@ import {
   $getNearestNodeFromDOMNode,
   $getSelection,
   $isElementNode,
+  $isRangeSelection,
   $setSelection,
   ElementNode,
 } from 'lexical';
@@ -345,7 +346,7 @@ function applyCustomTableHandlers(
 
   const formatCells = (type: TextFormatType) => {
     let selection = $getSelection();
-    if (selection === null) {
+    if (!$isRangeSelection(selection)) {
       selection = $createRangeSelection();
     }
     // This is to make Flow play ball.
@@ -472,7 +473,7 @@ function applyCustomTableHandlers(
     (type, payload) => {
       const selection = $getSelection();
 
-      if (selection == null) {
+      if (!$isRangeSelection(selection)) {
         return false;
       }
 

--- a/packages/lexical-yjs/src/CollabTextNode.js
+++ b/packages/lexical-yjs/src/CollabTextNode.js
@@ -12,7 +12,12 @@ import type {CollabElementNode} from './CollabElementNode';
 import type {NodeKey, NodeMap, TextNode} from 'lexical';
 import type {Map as YMap} from 'yjs';
 
-import {$getNodeByKey, $getSelection, $isTextNode} from 'lexical';
+import {
+  $getNodeByKey,
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+} from 'lexical';
 
 import {syncPropertiesFromLexical, syncPropertiesFromYjs} from './Utils';
 
@@ -66,7 +71,7 @@ function diffTextContentAndApplyDelta(
 ): void {
   const selection = $getSelection();
   let cursorOffset = nextText.length;
-  if (selection !== null && selection.isCollapsed()) {
+  if ($isRangeSelection(selection) && selection.isCollapsed()) {
     const anchor = selection.anchor;
     if (anchor.key === key) {
       cursorOffset = anchor.offset;

--- a/packages/lexical-yjs/src/SyncCursors.js
+++ b/packages/lexical-yjs/src/SyncCursors.js
@@ -9,7 +9,13 @@
 
 import type {Provider} from '.';
 import type {Binding} from './Bindings';
-import type {NodeKey, NodeMap, Point, RangeSelection} from 'lexical';
+import type {
+  NodeKey,
+  NodeMap,
+  NodeSelection,
+  Point,
+  RangeSelection,
+} from 'lexical';
 import type {
   AbsolutePosition,
   Map as YMap,
@@ -21,6 +27,7 @@ import {
   $getNodeByKey,
   $getSelection,
   $isElementNode,
+  $isRangeSelection,
   $isTextNode,
 } from 'lexical';
 import {
@@ -334,8 +341,8 @@ export function syncLocalCursorPosition(
         const focusKey = focusCollabNode.getKey();
 
         const selection = $getSelection();
-        if (selection === null) {
-          throw new Error('TODO: syncLocalCursorPosition');
+        if (!$isRangeSelection(selection)) {
+          return;
         }
         const anchor = selection.anchor;
         const focus = selection.focus;
@@ -475,8 +482,8 @@ export function syncCursorPositions(
 export function syncLexicalSelectionToYjs(
   binding: Binding,
   provider: Provider,
-  prevSelection: null | RangeSelection,
-  nextSelection: null | RangeSelection,
+  prevSelection: null | RangeSelection | NodeSelection,
+  nextSelection: null | RangeSelection | NodeSelection,
 ): void {
   const awareness = provider.awareness;
   const localState = awareness.getLocalState();
@@ -502,7 +509,7 @@ export function syncLexicalSelectionToYjs(
     }
   }
 
-  if (nextSelection !== null) {
+  if ($isRangeSelection(nextSelection)) {
     anchorPos = createRelativePosition(nextSelection.anchor, binding);
     focusPos = createRelativePosition(nextSelection.focus, binding);
   }

--- a/packages/lexical-yjs/src/SyncEditorStates.js
+++ b/packages/lexical-yjs/src/SyncEditorStates.js
@@ -20,6 +20,7 @@ import {
   $getNodeByKey,
   $getRoot,
   $getSelection,
+  $isRangeSelection,
   $isTextNode,
   $setSelection,
   isDecoratorArray,
@@ -172,13 +173,13 @@ export function syncYjsChangesToLexical(
       }
 
       const selection = $getSelection();
-      if (selection !== null) {
+      if ($isRangeSelection(selection)) {
         // We can't use Yjs's cursor position here, as it doesn't always
         // handle selection recovery correctly – especially on elements that
         // get moved around or split. So instead, we roll our own solution.
         if (doesSelectionNeedRecovering(selection)) {
           const prevSelection = currentEditorState._selection;
-          if (prevSelection !== null) {
+          if ($isRangeSelection(prevSelection)) {
             const prevOffsetView = $createOffsetView(
               editor,
               0,

--- a/packages/lexical/src/LexicalEditorState.js
+++ b/packages/lexical/src/LexicalEditorState.js
@@ -10,25 +10,15 @@
 import type {LexicalEditor} from './LexicalEditor';
 import type {LexicalNode, NodeKey, NodeMap} from './LexicalNode';
 import type {ParsedNode, ParsedSelection} from './LexicalParsing';
-import type {RangeSelection} from './LexicalSelection';
+import type {NodeSelection, RangeSelection} from './LexicalSelection';
 
+import {$isNodeSelection, $isRangeSelection} from './LexicalSelection';
 import {readEditorState} from './LexicalUpdates';
 import {$createRootNode} from './nodes/base/LexicalRootNode';
 
 export type ParsedEditorState = {
   _nodeMap: Array<[NodeKey, ParsedNode]>,
-  _selection: null | {
-    anchor: {
-      key: string,
-      offset: number,
-      type: 'text' | 'element',
-    },
-    focus: {
-      key: string,
-      offset: number,
-      type: 'text' | 'element',
-    },
-  },
+  _selection: null | ParsedSelection,
 };
 
 export type JSONEditorState = {
@@ -63,11 +53,14 @@ export function createEmptyEditorState(): EditorState {
 
 export class EditorState {
   _nodeMap: NodeMap;
-  _selection: null | RangeSelection;
+  _selection: null | RangeSelection | NodeSelection;
   _flushSync: boolean;
   _readOnly: boolean;
 
-  constructor(nodeMap: NodeMap, selection?: RangeSelection | null) {
+  constructor(
+    nodeMap: NodeMap,
+    selection?: RangeSelection | NodeSelection | null,
+  ) {
     this._nodeMap = nodeMap;
     this._selection = selection || null;
     this._flushSync = false;
@@ -79,7 +72,7 @@ export class EditorState {
   read<V>(callbackFn: () => V): V {
     return readEditorState(this, callbackFn);
   }
-  clone(selection?: RangeSelection | null): EditorState {
+  clone(selection?: RangeSelection | NodeSelection | null): EditorState {
     const editorState = new EditorState(
       this._nodeMap,
       selection === undefined ? this._selection : selection,
@@ -92,21 +85,26 @@ export class EditorState {
 
     return {
       _nodeMap: Array.from(this._nodeMap.entries()),
-      _selection:
-        selection === null
-          ? null
-          : {
-              anchor: {
-                key: selection.anchor.key,
-                offset: selection.anchor.offset,
-                type: selection.anchor.type,
-              },
-              focus: {
-                key: selection.focus.key,
-                offset: selection.focus.offset,
-                type: selection.focus.type,
-              },
+      _selection: $isRangeSelection(selection)
+        ? {
+            anchor: {
+              key: selection.anchor.key,
+              offset: selection.anchor.offset,
+              type: selection.anchor.type,
             },
+            focus: {
+              key: selection.focus.key,
+              offset: selection.focus.offset,
+              type: selection.focus.type,
+            },
+            type: 'range',
+          }
+        : $isNodeSelection(selection)
+        ? {
+            objects: Array.from(selection._objects),
+            type: 'object',
+          }
+        : null,
     };
   }
 }

--- a/packages/lexical/src/LexicalMutations.js
+++ b/packages/lexical/src/LexicalMutations.js
@@ -9,7 +9,7 @@
 
 import type {TextNode} from '.';
 import type {LexicalEditor} from './LexicalEditor';
-import type {RangeSelection} from './LexicalSelection';
+import type {NodeSelection, RangeSelection} from './LexicalSelection';
 
 import {
   $getRoot,
@@ -60,7 +60,9 @@ function isManagedLineBreak(
   );
 }
 
-function getLastSelection(editor: LexicalEditor): null | RangeSelection {
+function getLastSelection(
+  editor: LexicalEditor,
+): null | RangeSelection | NodeSelection {
   return editor.getEditorState().read(() => {
     const selection = $getSelection();
     return selection !== null ? selection.clone() : null;

--- a/packages/lexical/src/LexicalNode.js
+++ b/packages/lexical/src/LexicalNode.js
@@ -21,6 +21,7 @@ import {
 } from '.';
 import {
   $getSelection,
+  $isRangeSelection,
   $moveSelectionPointToEnd,
   $updateElementSelectionOnCreateDeleteNode,
   moveSelectionPointToSibling,
@@ -53,7 +54,7 @@ export function removeNode(
   }
   const selection = $getSelection();
   let selectionMoved = false;
-  if (selection !== null && restoreSelection) {
+  if ($isRangeSelection(selection) && restoreSelection) {
     const anchor = selection.anchor;
     const focus = selection.focus;
     if (anchor.key === key) {
@@ -89,7 +90,7 @@ export function removeNode(
   const writableNodeToRemove = nodeToRemove.getWritable();
   writableNodeToRemove.__parent = null;
 
-  if (selection !== null && restoreSelection && !selectionMoved) {
+  if ($isRangeSelection(selection) && restoreSelection && !selectionMoved) {
     $updateElementSelectionOnCreateDeleteNode(selection, parent, index, -1);
   }
   if (
@@ -184,6 +185,7 @@ export class LexicalNode {
     // For inline images inside of element nodes.
     // Without this change the image will be selected if the cursor is before or after it.
     if (
+      $isRangeSelection(selection) &&
       selection.anchor.type === 'element' &&
       selection.focus.type === 'element' &&
       selection.anchor.key === selection.focus.key &&
@@ -571,7 +573,7 @@ export class LexicalNode {
     removeNode(this, false);
     internalMarkSiblingsAsDirty(writableReplaceWith);
     const selection = $getSelection();
-    if (selection !== null) {
+    if ($isRangeSelection(selection)) {
       const anchor = selection.anchor;
       const focus = selection.focus;
       if (anchor.key === toReplaceKey) {
@@ -603,7 +605,7 @@ export class LexicalNode {
       }
       internalMarkSiblingsAsDirty(writableNodeToInsert);
 
-      if (selection !== null) {
+      if ($isRangeSelection(selection)) {
         const oldParentKey = oldParent.getKey();
         const oldIndex = nodeToInsert.getIndexWithinParent();
         const anchor = selection.anchor;
@@ -629,7 +631,7 @@ export class LexicalNode {
     }
     children.splice(index + 1, 0, insertKey);
     internalMarkSiblingsAsDirty(writableNodeToInsert);
-    if (selection !== null) {
+    if ($isRangeSelection(selection)) {
       $updateElementSelectionOnCreateDeleteNode(
         selection,
         writableParent,
@@ -671,7 +673,7 @@ export class LexicalNode {
     children.splice(index, 0, insertKey);
     internalMarkSiblingsAsDirty(writableNodeToInsert);
     const selection = $getSelection();
-    if (selection !== null) {
+    if ($isRangeSelection(selection)) {
       $updateElementSelectionOnCreateDeleteNode(
         selection,
         writableParent,

--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -15,7 +15,7 @@ import type {
   RegisteredNodes,
 } from './LexicalEditor';
 import type {NodeKey, NodeMap} from './LexicalNode';
-import type {RangeSelection} from './LexicalSelection';
+import type {NodeSelection, RangeSelection} from './LexicalSelection';
 import type {ElementNode} from './nodes/base/LexicalElementNode';
 import type {Node as ReactNode} from 'react';
 
@@ -25,6 +25,7 @@ import {
   $isDecoratorNode,
   $isElementNode,
   $isLineBreakNode,
+  $isRangeSelection,
   $isRootNode,
   $isTextNode,
 } from '.';
@@ -617,7 +618,6 @@ function reconcileRoot(
   prevEditorState: EditorState,
   nextEditorState: EditorState,
   editor: LexicalEditor,
-  selection: null | RangeSelection,
   dirtyType: 0 | 1 | 2,
   dirtyElements: Map<NodeKey, IntentionallyMarkedAsDirtyElement>,
   dirtyLeaves: Set<NodeKey>,
@@ -672,8 +672,8 @@ export function updateEditorState(
   rootElement: HTMLElement,
   currentEditorState: EditorState,
   pendingEditorState: EditorState,
-  currentSelection: RangeSelection | null,
-  pendingSelection: RangeSelection | null,
+  currentSelection: RangeSelection | NodeSelection | null,
+  pendingSelection: RangeSelection | NodeSelection | null,
   needsUpdate: boolean,
   editor: LexicalEditor,
 ): null | MutatedNodes {
@@ -691,7 +691,6 @@ export function updateEditorState(
         currentEditorState,
         pendingEditorState,
         editor,
-        pendingSelection,
         dirtyType,
         dirtyElements,
         dirtyLeaves,
@@ -744,8 +743,8 @@ function scrollIntoViewIfNeeded(node: Node, rootElement: ?HTMLElement): void {
 }
 
 function reconcileSelection(
-  prevSelection: RangeSelection | null,
-  nextSelection: RangeSelection | null,
+  prevSelection: RangeSelection | NodeSelection | null,
+  nextSelection: RangeSelection | NodeSelection | null,
   editor: LexicalEditor,
   domSelection: Selection,
 ): void {
@@ -764,7 +763,7 @@ function reconcileSelection(
     return;
   }
 
-  if (nextSelection === null) {
+  if (!$isRangeSelection(nextSelection)) {
     // We don't remove selection if the prevSelection is null because
     // of editor.setRootElement(). If this occurs on init when the
     // editor is already focused, then this can cause the editor to

--- a/packages/lexical/src/LexicalUpdates.js
+++ b/packages/lexical/src/LexicalUpdates.js
@@ -37,8 +37,10 @@ import {$normalizeTextNode} from './LexicalNormalization';
 import {internalCreateNodeFromParse} from './LexicalParsing';
 import {updateEditorState} from './LexicalReconciler';
 import {
+  $isNodeSelection,
+  $isRangeSelection,
   applySelectionTransforms,
-  internalCreateRangeSelection,
+  internalCreateSelection,
   internalCreateSelectionFromParse,
 } from './LexicalSelection';
 import {
@@ -590,7 +592,7 @@ function beginUpdate(
 
   try {
     if (editorStateWasCloned) {
-      pendingEditorState._selection = internalCreateRangeSelection(editor);
+      pendingEditorState._selection = internalCreateSelection(editor);
     }
     const startingCompositionKey = editor._compositionKey;
     updateFn();
@@ -615,7 +617,7 @@ function beginUpdate(
       pendingEditorState._flushSync = true;
     }
     const pendingSelection = pendingEditorState._selection;
-    if (pendingSelection !== null) {
+    if ($isRangeSelection(pendingSelection)) {
       const pendingNodeMap = pendingEditorState._nodeMap;
       const anchorKey = pendingSelection.anchor.key;
       const focusKey = pendingSelection.focus.key;
@@ -628,6 +630,11 @@ function beginUpdate(
           'updateEditor: selection has been lost because the previously selected nodes have been removed and ' +
             "selection wasn't moved to another node. Ensure selection changes after removing/replacing a selected node.",
         );
+      }
+    } else if ($isNodeSelection(pendingSelection)) {
+      // TODO: we should also validate node selection?
+      if (pendingSelection._objects.size === 0) {
+        pendingEditorState._selection = null;
       }
     }
   } catch (error) {

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -17,7 +17,7 @@ import type {
 } from './LexicalEditor';
 import type {EditorState} from './LexicalEditorState';
 import type {LexicalNode, NodeKey, NodeMap} from './LexicalNode';
-import type {RangeSelection} from './LexicalSelection';
+import type {NodeSelection, RangeSelection} from './LexicalSelection';
 import type {RootNode} from './nodes/base/LexicalRootNode';
 import type {TextFormatType, TextNode} from './nodes/base/LexicalTextNode';
 import type {Node as ReactNode} from 'react';
@@ -32,6 +32,7 @@ import {
   $isDecoratorNode,
   $isElementNode,
   $isLineBreakNode,
+  $isRangeSelection,
   $isTextNode,
 } from '.';
 import {
@@ -347,7 +348,9 @@ export function $getRoot(editorState?: EditorState): RootNode {
   ): any): RootNode);
 }
 
-export function $setSelection(selection: null | RangeSelection): void {
+export function $setSelection(
+  selection: null | RangeSelection | NodeSelection,
+): void {
   const editorState = getActiveEditorState();
   editorState._selection = selection;
 }
@@ -481,7 +484,7 @@ export function $updateTextNodeFromDOMContent(
         // to clear this input from occuring as that action wasn't
         // permitted.
         (parent !== null &&
-          prevSelection !== null &&
+          $isRangeSelection(prevSelection) &&
           !parent.canInsertTextBefore() &&
           prevSelection.anchor.offset === 0)
       ) {
@@ -490,7 +493,11 @@ export function $updateTextNodeFromDOMContent(
       }
       const selection = $getSelection();
 
-      if (selection === null || anchorOffset === null || focusOffset === null) {
+      if (
+        !$isRangeSelection(selection) ||
+        anchorOffset === null ||
+        focusOffset === null
+      ) {
         node.setTextContent(normalizedTextContent);
         return;
       }

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
@@ -10,6 +10,7 @@ import type {LexicalEditor} from 'lexical';
 
 import DEPRECATED__useLexicalRichText from '@lexical/react/DEPRECATED_useLexicalRichText';
 import {
+  $createNodeSelection,
   $createParagraphNode,
   $createTextNode,
   $getNodeByKey,
@@ -17,6 +18,7 @@ import {
   $getSelection,
   $isTextNode,
   $setCompositionKey,
+  $setSelection,
   ElementNode,
   ParagraphNode,
   TextNode,
@@ -959,78 +961,159 @@ describe('LexicalEditor tests', () => {
     let textKey;
     let parsedEditorState;
 
-    beforeEach(async () => {
-      init();
-      await update(() => {
-        const paragraph = $createParagraphNode();
-        originalText = $createTextNode('Hello world');
-        originalText.select(6, 11);
-        paragraph.append(originalText);
-        $getRoot().append(paragraph);
+    describe('range selection', () => {
+      beforeEach(async () => {
+        init();
+        await update(() => {
+          const paragraph = $createParagraphNode();
+          originalText = $createTextNode('Hello world');
+          originalText.select(6, 11);
+          paragraph.append(originalText);
+          $getRoot().append(paragraph);
+        });
+        const stringifiedEditorState = JSON.stringify(
+          editor.getEditorState().toJSON(),
+        );
+        parsedEditorState = editor.parseEditorState(stringifiedEditorState);
+        parsedEditorState.read(() => {
+          parsedRoot = $getRoot();
+          parsedParagraph = parsedRoot.getFirstChild();
+          paragraphKey = parsedParagraph.getKey();
+          parsedText = parsedParagraph.getFirstChild();
+          textKey = parsedText.getKey();
+          parsedSelection = $getSelection();
+        });
       });
-      const stringifiedEditorState = JSON.stringify(
-        editor.getEditorState().toJSON(),
-      );
-      parsedEditorState = editor.parseEditorState(stringifiedEditorState);
-      parsedEditorState.read(() => {
-        parsedRoot = $getRoot();
-        parsedParagraph = parsedRoot.getFirstChild();
-        paragraphKey = parsedParagraph.getKey();
-        parsedText = parsedParagraph.getFirstChild();
-        textKey = parsedText.getKey();
-        parsedSelection = $getSelection();
+
+      it('Parses the nodes of a stringified editor state', async () => {
+        expect(parsedRoot).toEqual({
+          __cachedText: null,
+          __children: [paragraphKey],
+          __dir: 'ltr',
+          __format: 0,
+          __indent: 0,
+          __key: 'root',
+          __parent: null,
+          __type: 'root',
+        });
+        expect(parsedParagraph).toEqual({
+          __children: [textKey],
+          __dir: 'ltr',
+          __format: 0,
+          __indent: 0,
+          __key: paragraphKey,
+          __parent: 'root',
+          __type: 'paragraph',
+        });
+        expect(parsedText).toEqual({
+          __detail: 0,
+          __format: 0,
+          __key: textKey,
+          __mode: 0,
+          __parent: paragraphKey,
+          __style: '',
+          __text: 'Hello world',
+          __type: 'text',
+        });
+      });
+
+      it('Parses the text content of the editor state', async () => {
+        expect(parsedEditorState.read(() => $getRoot().__cachedText)).toBe(
+          null,
+        );
+        expect(parsedEditorState.read(() => $getRoot().getTextContent())).toBe(
+          'Hello world',
+        );
+      });
+
+      it('Parses the selection offsets of a stringified editor state', async () => {
+        expect(parsedSelection.anchor.offset).toEqual(6);
+        expect(parsedSelection.focus.offset).toEqual(11);
+      });
+
+      it('Remaps the selection keys of a stringified editor state', async () => {
+        expect(parsedSelection.anchor.key).not.toEqual(originalText.__key);
+        expect(parsedSelection.focus.key).not.toEqual(originalText.__key);
+        expect(parsedSelection.anchor.key).toEqual(parsedText.__key);
+        expect(parsedSelection.focus.key).toEqual(parsedText.__key);
       });
     });
 
-    it('Parses the nodes of a stringified editor state', async () => {
-      expect(parsedRoot).toEqual({
-        __cachedText: null,
-        __children: [paragraphKey],
-        __dir: 'ltr',
-        __format: 0,
-        __indent: 0,
-        __key: 'root',
-        __parent: null,
-        __type: 'root',
+    describe('node selection', () => {
+      beforeEach(async () => {
+        init();
+        await update(() => {
+          const paragraph = $createParagraphNode();
+          originalText = $createTextNode('Hello world');
+          const selection = $createNodeSelection();
+          selection.add(originalText.getKey());
+          $setSelection(selection);
+          paragraph.append(originalText);
+          $getRoot().append(paragraph);
+        });
+        const stringifiedEditorState = JSON.stringify(
+          editor.getEditorState().toJSON(),
+        );
+        parsedEditorState = editor.parseEditorState(stringifiedEditorState);
+        parsedEditorState.read(() => {
+          parsedRoot = $getRoot();
+          parsedParagraph = parsedRoot.getFirstChild();
+          paragraphKey = parsedParagraph.getKey();
+          parsedText = parsedParagraph.getFirstChild();
+          textKey = parsedText.getKey();
+          parsedSelection = $getSelection();
+        });
       });
-      expect(parsedParagraph).toEqual({
-        __children: [textKey],
-        __dir: 'ltr',
-        __format: 0,
-        __indent: 0,
-        __key: paragraphKey,
-        __parent: 'root',
-        __type: 'paragraph',
+
+      it('Parses the nodes of a stringified editor state', async () => {
+        expect(parsedRoot).toEqual({
+          __cachedText: null,
+          __children: [paragraphKey],
+          __dir: 'ltr',
+          __format: 0,
+          __indent: 0,
+          __key: 'root',
+          __parent: null,
+          __type: 'root',
+        });
+        expect(parsedParagraph).toEqual({
+          __children: [textKey],
+          __dir: 'ltr',
+          __format: 0,
+          __indent: 0,
+          __key: paragraphKey,
+          __parent: 'root',
+          __type: 'paragraph',
+        });
+        expect(parsedText).toEqual({
+          __detail: 0,
+          __format: 0,
+          __key: textKey,
+          __mode: 0,
+          __parent: paragraphKey,
+          __style: '',
+          __text: 'Hello world',
+          __type: 'text',
+        });
       });
-      expect(parsedText).toEqual({
-        __detail: 0,
-        __format: 0,
-        __key: textKey,
-        __mode: 0,
-        __parent: paragraphKey,
-        __style: '',
-        __text: 'Hello world',
-        __type: 'text',
+
+      it('Parses the text content of the editor state', async () => {
+        expect(parsedEditorState.read(() => $getRoot().__cachedText)).toBe(
+          null,
+        );
+        expect(parsedEditorState.read(() => $getRoot().getTextContent())).toBe(
+          'Hello world',
+        );
       });
-    });
 
-    it('Parses the text content of the editor state', async () => {
-      expect(parsedEditorState.read(() => $getRoot().__cachedText)).toBe(null);
-      expect(parsedEditorState.read(() => $getRoot().getTextContent())).toBe(
-        'Hello world',
-      );
-    });
+      it('Parses the selection offsets of a stringified editor state', async () => {
+        expect(Array.from(parsedSelection._objects)).toEqual([textKey]);
+      });
 
-    it('Parses the selection offsets of a stringified editor state', async () => {
-      expect(parsedSelection.anchor.offset).toEqual(6);
-      expect(parsedSelection.focus.offset).toEqual(11);
-    });
-
-    it('Remaps the selection keys of a stringified editor state', async () => {
-      expect(parsedSelection.anchor.key).not.toEqual(originalText.__key);
-      expect(parsedSelection.focus.key).not.toEqual(originalText.__key);
-      expect(parsedSelection.anchor.key).toEqual(parsedText.__key);
-      expect(parsedSelection.focus.key).toEqual(parsedText.__key);
+      it('Remaps the selection keys of a stringified editor state', async () => {
+        expect(parsedSelection._objects.has(originalText.__key)).toEqual(false);
+        expect(parsedSelection._objects.has(parsedText.__key)).toEqual(true);
+      });
     });
   });
 

--- a/packages/lexical/src/__tests__/unit/LexicalEditorState.test.js
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorState.test.js
@@ -6,7 +6,13 @@
  *
  */
 
-import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+import {
+  $createNodeSelection,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $setSelection,
+} from 'lexical';
 
 import {EditorState} from '../../LexicalEditorState';
 import {$createRootNode} from '../../nodes/base/LexicalRootNode';
@@ -72,7 +78,7 @@ describe('LexicalEditorState tests', () => {
       });
     });
 
-    test('toJSON()', async () => {
+    test('toJSON() for range selection', async () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const paragraph = $createParagraphNode();
@@ -82,7 +88,23 @@ describe('LexicalEditorState tests', () => {
         $getRoot().append(paragraph);
       });
       expect(JSON.stringify(editor.getEditorState().toJSON())).toEqual(
-        `{\"_nodeMap\":[[\"root\",{\"__type\":\"root\",\"__parent\":null,\"__key\":\"root\",\"__children\":[\"1\"],\"__format\":0,\"__indent\":0,\"__dir\":\"ltr\",\"__cachedText\":\"Hello world\"}],[\"1\",{\"__type\":\"paragraph\",\"__parent\":\"root\",\"__key\":\"1\",\"__children\":[\"2\"],\"__format\":0,\"__indent\":0,\"__dir\":\"ltr\"}],[\"2\",{\"__type\":\"text\",\"__parent\":\"1\",\"__key\":\"2\",\"__text\":\"Hello world\",\"__format\":0,\"__style\":\"\",\"__mode\":0,\"__detail\":0}]],\"_selection\":{\"anchor\":{\"key\":\"2\",\"offset\":6,\"type\":\"text\"},\"focus\":{\"key\":\"2\",\"offset\":11,\"type\":\"text\"}}}`,
+        `{\"_nodeMap\":[[\"root\",{\"__type\":\"root\",\"__parent\":null,\"__key\":\"root\",\"__children\":[\"1\"],\"__format\":0,\"__indent\":0,\"__dir\":\"ltr\",\"__cachedText\":\"Hello world\"}],[\"1\",{\"__type\":\"paragraph\",\"__parent\":\"root\",\"__key\":\"1\",\"__children\":[\"2\"],\"__format\":0,\"__indent\":0,\"__dir\":\"ltr\"}],[\"2\",{\"__type\":\"text\",\"__parent\":\"1\",\"__key\":\"2\",\"__text\":\"Hello world\",\"__format\":0,\"__style\":\"\",\"__mode\":0,\"__detail\":0}]],\"_selection\":{\"anchor\":{\"key\":\"2\",\"offset\":6,\"type\":\"text\"},\"focus\":{\"key\":\"2\",\"offset\":11,\"type\":\"text\"},\"type\":\"range\"}}`,
+      );
+    });
+
+    test('toJSON() for node selection', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const paragraph = $createParagraphNode();
+        const text = $createTextNode('Hello world');
+        const selection = $createNodeSelection();
+        selection.add(text.getKey());
+        $setSelection(selection);
+        paragraph.append(text);
+        $getRoot().append(paragraph);
+      });
+      expect(JSON.stringify(editor.getEditorState().toJSON())).toEqual(
+        '{"_nodeMap":[["root",{"__type":"root","__parent":null,"__key":"root","__children":["1"],"__format":0,"__indent":0,"__dir":"ltr","__cachedText":"Hello world"}],["1",{"__type":"paragraph","__parent":"root","__key":"1","__children":["2"],"__format":0,"__indent":0,"__dir":"ltr"}],["2",{"__type":"text","__parent":"1","__key":"2","__text":"Hello world","__format":0,"__style":"","__mode":0,"__detail":0}]],"_selection":{"objects":["2"],"type":"object"}}',
       );
     });
 

--- a/packages/lexical/src/index.js
+++ b/packages/lexical/src/index.js
@@ -11,9 +11,11 @@ import {VERSION} from './LexicalConstants';
 import {createEditor} from './LexicalEditor';
 import {$createNodeFromParse} from './LexicalParsing';
 import {
+  $createEmptyObjectSelection as $createNodeSelection,
   $createEmptyRangeSelection as $createRangeSelection,
   $getPreviousSelection,
   $getSelection,
+  $isNodeSelection,
   $isRangeSelection,
 } from './LexicalSelection';
 import {
@@ -69,6 +71,7 @@ export type {LexicalNode, NodeKey, NodeMap} from './LexicalNode';
 export type {ParsedNode, ParsedNodeMap} from './LexicalParsing';
 export type {
   ElementPointType as ElementPoint,
+  NodeSelection,
   PointType as Point,
   RangeSelection,
   TextPointType as TextPoint,
@@ -85,9 +88,9 @@ export type {RootNode} from './nodes/base/LexicalRootNode';
 export type {TextFormatType} from './nodes/base/LexicalTextNode';
 
 export {
-  // Used during read/update/transform
   $createLineBreakNode,
   $createNodeFromParse,
+  $createNodeSelection,
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
@@ -98,9 +101,9 @@ export {
   $getSelection,
   $isDecoratorNode,
   $isElementNode,
-  // Node validation
   $isLeafNode,
   $isLineBreakNode,
+  $isNodeSelection,
   $isParagraphNode,
   $isRangeSelection,
   $isRootNode,
@@ -109,7 +112,6 @@ export {
   $setSelection,
   createDecoratorArray,
   createDecoratorEditor,
-  // Decorator state
   createDecoratorMap,
   createEditor,
   DecoratorNode,

--- a/packages/lexical/src/nodes/base/LexicalElementNode.js
+++ b/packages/lexical/src/nodes/base/LexicalElementNode.js
@@ -17,6 +17,7 @@ import {ELEMENT_TYPE_TO_FORMAT} from '../../LexicalConstants';
 import {LexicalNode} from '../../LexicalNode';
 import {
   $getSelection,
+  $isRangeSelection,
   internalMakeRangeSelection,
   moveSelectionPointToSibling,
 } from '../../LexicalSelection';
@@ -216,7 +217,7 @@ export class ElementNode extends LexicalNode {
       focusOffset = childrenCount;
     }
     const key = this.__key;
-    if (selection === null) {
+    if (!$isRangeSelection(selection)) {
       return internalMakeRangeSelection(
         key,
         anchorOffset,
@@ -373,7 +374,7 @@ export class ElementNode extends LexicalNode {
     if (deleteCount) {
       // Adjusting selection, in case node that was anchor/focus will be deleted
       const selection = $getSelection();
-      if (selection !== null) {
+      if ($isRangeSelection(selection)) {
         const nodesToRemoveKeySet = new Set(nodesToRemoveKeys);
         const nodesToInsertKeySet = new Set(nodesToInsertKeys);
         const isPointRemoved = (point: PointType): boolean => {

--- a/packages/lexical/src/nodes/base/LexicalTextNode.js
+++ b/packages/lexical/src/nodes/base/LexicalTextNode.js
@@ -9,7 +9,7 @@
 
 import type {EditorConfig, TextNodeThemeClasses} from '../../LexicalEditor';
 import type {NodeKey} from '../../LexicalNode';
-import type {RangeSelection} from '../../LexicalSelection';
+import type {NodeSelection, RangeSelection} from '../../LexicalSelection';
 
 import invariant from 'shared/invariant';
 
@@ -31,6 +31,7 @@ import {
 import {LexicalNode} from '../../LexicalNode';
 import {
   $getSelection,
+  $isRangeSelection,
   $updateElementSelectionOnCreateDeleteNode,
   adjustPointOffsetForMergedSibling,
   internalMakeRangeSelection,
@@ -384,7 +385,7 @@ export class TextNode extends LexicalNode {
 
   // Mutators
   selectionTransform(
-    prevSelection: null | RangeSelection,
+    prevSelection: null | RangeSelection | NodeSelection,
     nextSelection: RangeSelection,
   ): void {}
   setFormat(format: number): this {
@@ -444,7 +445,7 @@ export class TextNode extends LexicalNode {
       anchorOffset = 0;
       focusOffset = 0;
     }
-    if (selection === null) {
+    if (!$isRangeSelection(selection)) {
       return internalMakeRangeSelection(
         key,
         anchorOffset,
@@ -483,7 +484,7 @@ export class TextNode extends LexicalNode {
       }
     }
     const selection = $getSelection();
-    if (moveSelection && selection !== null) {
+    if (moveSelection && $isRangeSelection(selection)) {
       const newOffset = offset + handledTextLength;
       selection.setTextNodeRange(
         writableSelf,
@@ -568,7 +569,7 @@ export class TextNode extends LexicalNode {
       const siblingKey = sibling.__key;
       const nextTextSize = textSize + partSize;
 
-      if (selection !== null) {
+      if ($isRangeSelection(selection)) {
         const anchor = selection.anchor;
         const focus = selection.focus;
 
@@ -614,7 +615,7 @@ export class TextNode extends LexicalNode {
       writableParentChildren.splice(insertionIndex, 1, ...splitNodesKeys);
     }
 
-    if (selection !== null) {
+    if ($isRangeSelection(selection)) {
       $updateElementSelectionOnCreateDeleteNode(
         selection,
         parent,
@@ -643,7 +644,7 @@ export class TextNode extends LexicalNode {
       $setCompositionKey(key);
     }
     const selection = $getSelection();
-    if (selection !== null) {
+    if ($isRangeSelection(selection)) {
       const anchor = selection.anchor;
       const focus = selection.focus;
       if (anchor !== null && anchor.key === targetKey) {


### PR DESCRIPTION
This PR adds `NodeSelection` to Lexical! This is another type of selection, that allows for discrete nodes to be marked as selected. The API is as follows:

```js
import {$createNodeSelection, $getSelection, $isNodeSelection, $setSelection} from 'lexical';

editor.update(() => {
  let selection = $getSelection();

  if (!$isNodeSelection(selection)) {
    selection = $createNodeSelection();
    $setSelection(selection);
  }
  // Add key
  selection.add(someKey);
  // Delete key
  selection.delete(someKey);
  // Check for key
  selection.has(someKey);
  // Get all nodes
  const nodes = selection.getNodes();
  // Clear
  selection.clear();
});
```

There is also a React hook:

```js
const [isSelected, setSelected, clearSelection] = useLexicalNodeSelection(nodeKey);
```