### PR TITLE
[RFC] DFS Iterable

### DIFF
--- a/packages/lexical-helpers/src/__tests__/unit/LexicalNodeHelpers.test.js
+++ b/packages/lexical-helpers/src/__tests__/unit/LexicalNodeHelpers.test.js
@@ -26,6 +26,7 @@ import {
   $createTestElementNode,
   initializeUnitTest,
 } from '../../../../lexical/src/__tests__/utils';
+import {$dfs} from '../../LexicalNodeHelpers';
 
 describe('LexicalNodeHelpers tests', () => {
   initializeUnitTest((testEnv) => {
@@ -37,7 +38,7 @@ describe('LexicalNodeHelpers tests', () => {
      *
      *  DFS: R, P1, B1, T1, B2, T2, T3, P2, T4, T5, B3, T6
      */
-    test('DFS node order', async () => {
+    test.only('DFS node order', async () => {
       const editor: LexicalEditor = testEnv.editor;
       let expectedKeys: Array<NodeKey> = [];
       await editor.update((state: State) => {
@@ -81,8 +82,7 @@ describe('LexicalNodeHelpers tests', () => {
 
       const dfsKeys = [];
       await editor.update((state: State) => {
-        const root = $getRoot();
-        $dfs__DEPRECATED(root, (node: LexicalNode) => {
+        $dfs().forEach((node: LexicalNode) => {
           dfsKeys.push(node.getKey());
           return node;
         });


### PR DESCRIPTION
Redefined API to have `startingNode` and `endingNode` and has both a simple `forEach` and `Iterable`. Iterable makes it possible to skip branches without peeking at every single children.

For the majority of cases the API should be as simple as:

```
$dfs().forEach(node => { ... })
```

But the CharacterLimitPlugin and some WWW will have to leverage iterators to skip branches.