### PR TITLE
[RFC][WIP] Bootstrap + Lexical Session

### DIFF
--- a/packages/lexical-playground/src/Editor.js
+++ b/packages/lexical-playground/src/Editor.js
@@ -31,7 +31,6 @@ import ExcalidrawPlugin from './plugins/ExcalidrawPlugin';
 import LinkPlugin from '@lexical/react/LexicalLinkPlugin';
 import SpeechToTextPlugin from './plugins/SpeechToTextPlugin';
 import CodeHighlightPlugin from './plugins/CodeHighlightPlugin';
-import Placeholder from './ui/Placeholder';
 import {createWebsocketProvider} from './collaboration';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {useSharedHistoryContext} from './context/SharedHistoryContext';
@@ -43,6 +42,7 @@ import HorizontalRulePlugin from './plugins/HorizontalRulePlugin';
 import CharacterStylesPopupPlugin from './plugins/CharacterStylesPopupPlugin';
 import {useSettings} from './context/SettingsContext';
 import AutoFocusPlugin from './plugins/AutoFocusPlugin';
+import Placeholder from './ui/Placeholder';
 
 const skipCollaborationInit =
   window.parent != null && window.parent.frames.right === window;
@@ -59,12 +59,12 @@ export default function Editor(): React$Node {
       showTreeView,
     },
   } = useSettings();
-  const text = isCollab
+  const placeholderText = isCollab
     ? 'Enter some collaborative rich text...'
     : isRichText
     ? 'Enter some rich text...'
     : 'Enter some plain text...';
-  const placeholder = <Placeholder>{text}</Placeholder>;
+  const placeholder = <Placeholder>{placeholderText}</Placeholder>;
 
   return (
     <>
@@ -73,6 +73,7 @@ export default function Editor(): React$Node {
         className={`editor-container ${showTreeView ? 'tree-view' : ''} ${
           !isRichText ? 'plain-text' : ''
         }`}>
+        <ContentEditable placeholder={placeholder} />
         <AutoFocusPlugin />
         <MentionsPlugin />
         <EmojisPlugin />
@@ -82,7 +83,6 @@ export default function Editor(): React$Node {
         <HorizontalRulePlugin />
         <SpeechToTextPlugin />
         <AutoLinkPlugin />
-        <BootstrapPlugin />
         <CharacterStylesPopupPlugin />
         {isRichText ? (
           <>
@@ -93,12 +93,12 @@ export default function Editor(): React$Node {
                 shouldBootstrap={!skipCollaborationInit}
               />
             ) : (
-              <HistoryPlugin externalHistoryState={historyState} />
+              <>
+                <HistoryPlugin externalHistoryState={historyState} />
+                <BootstrapPlugin />
+              </>
             )}
-            <RichTextPlugin
-              contentEditable={<ContentEditable />}
-              placeholder={placeholder}
-            />
+            <RichTextPlugin />
             <AutoFormatterPlugin />
             <CodeHighlightPlugin />
             <ListPlugin />
@@ -110,10 +110,7 @@ export default function Editor(): React$Node {
           </>
         ) : (
           <>
-            <PlainTextPlugin
-              contentEditable={<ContentEditable />}
-              placeholder={placeholder}
-            />
+            <PlainTextPlugin />
             <HistoryPlugin externalHistoryState={historyState} />
           </>
         )}

--- a/packages/lexical-playground/src/nodes/StickyNode.js
+++ b/packages/lexical-playground/src/nodes/StickyNode.js
@@ -36,13 +36,13 @@ import BootstrapPlugin from '@lexical/react/LexicalBootstrapPlugin';
 import useLayoutEffect from 'shared/useLayoutEffect';
 import StickyEditorTheme from '../themes/StickyEditorTheme';
 import Placeholder from '../ui/Placeholder';
-import ContentEditable from '../ui/ContentEditable';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import LexicalNestedComposer from '@lexical/react/LexicalNestedComposer';
 import {createWebsocketProvider} from '../collaboration';
 import {useSharedHistoryContext} from '../context/SharedHistoryContext';
 import useLexicalDecoratorMap from '@lexical/react/useLexicalDecoratorMap';
 import stylex from 'stylex';
+import ContentEditable from '../ui/ContentEditable';
 
 const styles = stylex.create({
   contentEditable: {
@@ -291,10 +291,9 @@ function StickyComponent({
           <HistoryPlugin externalHistoryState={historyState} />
         )}
         <BootstrapPlugin />
-        <PlainTextPlugin
-          contentEditable={
-            <ContentEditable className={stylex(styles.contentEditable)} />
-          }
+        <PlainTextPlugin />
+        <ContentEditable
+          className={stylex(styles.placeholder)}
           placeholder={
             <Placeholder className={stylex(styles.placeholder)}>
               What's up?

--- a/packages/lexical-playground/src/ui/ContentEditable.js
+++ b/packages/lexical-playground/src/ui/ContentEditable.js
@@ -35,8 +35,10 @@ const styles = stylex.create({
 
 export default function ContentEditable({
   className,
+  placeholder,
 }: {
   className?: string,
+  placeholder: React$Node,
 }): React$Node {
   const [editor] = useLexicalComposerContext();
   const [isReadOnly, setIsReadyOnly] = useState(false);
@@ -59,6 +61,7 @@ export default function ContentEditable({
     <LexicalContentEditable
       className={className || stylex(styles.root)}
       readOnly={isReadOnly}
+      placeholder={placeholder}
     />
   );
 }

--- a/packages/lexical-react/src/LexicalPlainTextPlugin.js
+++ b/packages/lexical-react/src/LexicalPlainTextPlugin.js
@@ -8,29 +8,12 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import * as React from 'react';
 
-import useCanShowPlaceholder from './shared/useCanShowPlaceholder';
-import useDecorators from './shared/useDecorators';
 import usePlainTextSetup from './shared/usePlainTextSetup';
 
-export default function PlainTextPlugin({
-  contentEditable,
-  placeholder,
-}: {
-  contentEditable: React$Node,
-  placeholder: React$Node,
-}): React$Node {
+export default function PlainTextPlugin(): null {
   const [editor] = useLexicalComposerContext();
-  const showPlaceholder = useCanShowPlaceholder(editor);
   usePlainTextSetup(editor);
-  const decorators = useDecorators(editor);
 
-  return (
-    <>
-      {contentEditable}
-      {showPlaceholder && placeholder}
-      {decorators}
-    </>
-  );
+  return null;
 }

--- a/packages/lexical-react/src/LexicalRichTextPlugin.js
+++ b/packages/lexical-react/src/LexicalRichTextPlugin.js
@@ -8,29 +8,12 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import * as React from 'react';
 
-import useCanShowPlaceholder from './shared/useCanShowPlaceholder';
-import useDecorators from './shared/useDecorators';
 import {useRichTextSetup} from './shared/useRichTextSetup';
 
-export default function RichTextPlugin({
-  contentEditable,
-  placeholder,
-}: {
-  contentEditable: React$Node,
-  placeholder: React$Node,
-}): React$Node {
+export default function RichTextPlugin(): null {
   const [editor] = useLexicalComposerContext();
-  const showPlaceholder = useCanShowPlaceholder(editor);
   useRichTextSetup(editor);
-  const decorators = useDecorators(editor);
 
-  return (
-    <>
-      {contentEditable}
-      {showPlaceholder && placeholder}
-      {decorators}
-    </>
-  );
+  return null;
 }

--- a/packages/lexical-react/src/shared/useBootstrapEditor.js
+++ b/packages/lexical-react/src/shared/useBootstrapEditor.js
@@ -78,16 +78,17 @@ export default function useBootstrapEditor(
   clearEditorFn?: (LexicalEditor) => void,
 ): void {
   useLayoutEffect(() => {
+    initEditor(
+      editor,
+      initialPayloadFn != null ? initialPayloadFn : defaultInitEditor,
+    );
+    // We only do this for init
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor]);
+  useLayoutEffect(() => {
     return editor.addListener(
       'command',
       (type, payload): boolean => {
-        if (type === 'bootstrapEditor') {
-          initEditor(
-            editor,
-            initialPayloadFn != null ? initialPayloadFn : defaultInitEditor,
-          );
-          return true;
-        }
         if (type === 'clearEditor') {
           clearEditor(
             editor,

--- a/packages/lexical-react/src/shared/useRichTextSetup.js
+++ b/packages/lexical-react/src/shared/useRichTextSetup.js
@@ -227,7 +227,8 @@ export function useRichTextSetup(editor: LexicalEditor): void {
       },
       EditorPriority,
     );
-    editor.execCommand('bootstrapEditor');
+    editor.execCommand('events', 'RICH_TEXT');
+    editor.getSession().set('events', 'RICH_TEXT');
     return removeListener;
   }, [editor]);
 

--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -170,7 +170,10 @@ export type CommandListenerPriority =
   | CommandListenerHighPriority
   | CommandListenerCriticalPriority;
 
-// $FlowFixMe: intentional
+export type Session = Session;
+// $FlowFixMe[unclear-type] intentional
+export type SessionPayload = any;
+// $FlowFixMe[unclear-type] intentional
 export type CommandPayload = any;
 
 type Listeners = {
@@ -205,6 +208,7 @@ export function resetEditor(
   editor._editorState = createEmptyEditorState();
   editor._pendingEditorState = pendingEditorState;
   editor._compositionKey = null;
+  editor._session = new Map();
   editor._dirtyType = NO_DIRTY_NODES;
   editor._cloneNotNeeded.clear();
   editor._dirtyLeaves = new Set();
@@ -307,6 +311,7 @@ class BaseLexicalEditor {
   _keyToDOMMap: Map<NodeKey, HTMLElement>;
   _updates: Array<[() => void, void | EditorUpdateOptions]>;
   _updating: boolean;
+  _session: Session;
   _listeners: Listeners;
   _nodes: RegisteredNodes;
   _decorators: {[NodeKey]: ReactNode};
@@ -343,6 +348,7 @@ class BaseLexicalEditor {
     this._keyToDOMMap = new Map();
     this._updates = [];
     this._updating = false;
+    this._session = new Map();
     // Listeners
     this._listeners = {
       command: [new Set(), new Set(), new Set(), new Set(), new Set()],
@@ -483,6 +489,9 @@ class BaseLexicalEditor {
   }
   execCommand(type: string, payload?: CommandPayload): boolean {
     return triggerCommandListeners(getSelf(this), type, payload);
+  }
+  getSession(): Session {
+    return this._session;
   }
   getDecorators(): {[NodeKey]: ReactNode} {
     return this._decorators;
@@ -630,6 +639,7 @@ declare export class LexicalEditor {
   _pendingDecorators: null | {[NodeKey]: ReactNode};
   _pendingEditorState: null | EditorState;
   _rootElement: null | HTMLElement;
+  _session: Session;
   _updates: Array<[() => void, void | EditorUpdateOptions]>;
   _updateTags: Set<string>;
   _updating: boolean;
@@ -659,6 +669,7 @@ declare export class LexicalEditor {
   getEditorState(): EditorState;
   getElementByKey(key: NodeKey): null | HTMLElement;
   getRootElement(): null | HTMLElement;
+  getSession(): Session;
   hasNodes(nodes: Array<Class<LexicalNode>>): boolean;
   isComposing(): boolean;
   parseEditorState(stringifiedEditorState: string): EditorState;


### PR DESCRIPTION
**Problem:**

Commands are a real-time pub-sub system without queue. If the publisher publishes a message and the receiver isn't  listener for it, it's lost.

**Solution:**

What we've been doing so far in a natural manner so far is to try understand the initial state to be able to interpret the results correctly later on the plugin and later set up a subscriber for future changes.

For example:
```
const [text, setText] = useState(() => editor.getEditorState().read($textContentCurry))
useEffect(() => {
  return editor.addListener('textcontent', textContent => {
    setText(textContent);
  });
}, [editor]);
```

The proposed solution on this diff doesn't mean to change this, instead, standarize it. We provide a session param that can work hand in hand with commands. A session is no more than just a `Map<string, any>`

**Bootstrap**

Now the content editable does not have race conditions regardless of the order of the plugin and whether they are lazy loaded.

```
isReadOnly = !session.has('events') && editor.getEditorState().read(() => $getRoot().isEmpty();
editor.addListener('update', () => {
  
});
editor.addListener('command', type => {
  if (type === 'events') { ... }
});
```

I believe we can likely make this more direct by making session listen-able for not necessarily as a V1.