### PR TITLE
Add Grid, GridRow, GridCell base nodes

### DIFF
--- a/packages/lexical-table/src/LexicalTableCellNode.js
+++ b/packages/lexical-table/src/LexicalTableCellNode.js
@@ -10,21 +10,25 @@
 import type {EditorConfig, LexicalNode, NodeKey} from 'lexical';
 
 import {addClassNamesToElement} from '@lexical/helpers/elements';
-import {ElementNode} from 'lexical';
+import {GridCellNode} from 'lexical';
 
-export class TableCellNode extends ElementNode {
+export class TableCellNode extends GridCellNode {
   __isHeader: boolean;
 
-  static getType(): 'table-cell' {
-    return 'table-cell';
+  static getType(): 'tablecell' {
+    return 'tablecell';
   }
 
   static clone(node: TableCellNode): TableCellNode {
-    return new TableCellNode(false, node.__key);
+    return new TableCellNode(false, node.__colSpan, node.__key);
   }
 
-  constructor(isHeader?: boolean = false, key?: NodeKey): void {
-    super(key);
+  constructor(
+    isHeader?: boolean = false,
+    colSpan?: number = 1,
+    key?: NodeKey,
+  ): void {
+    super(colSpan, key);
     this.__isHeader = isHeader;
   }
 

--- a/packages/lexical-table/src/LexicalTableNode.js
+++ b/packages/lexical-table/src/LexicalTableNode.js
@@ -29,7 +29,7 @@ import {
   $isElementNode,
   $isRangeSelection,
   $setSelection,
-  ElementNode,
+  GridNode,
 } from 'lexical';
 import invariant from 'shared/invariant';
 
@@ -546,7 +546,7 @@ function applyCustomTableHandlers(
   );
 }
 
-export class TableNode extends ElementNode {
+export class TableNode extends GridNode {
   __selectionShape: ?SelectionShape;
   __grid: ?Grid;
 
@@ -559,6 +559,8 @@ export class TableNode extends ElementNode {
     selectionShape: ?SelectionShape,
     grid: ?Grid,
   ): TableNode {
+    // TODO: selectionShape and grid aren't being deeply cloned?
+    // They shouldn't really be on the table node IMO.
     return new TableNode(node.__key, node.__selectionShape, node.__grid);
   }
 

--- a/packages/lexical-table/src/LexicalTableRowNode.js
+++ b/packages/lexical-table/src/LexicalTableRowNode.js
@@ -10,11 +10,11 @@
 import type {EditorConfig, LexicalNode, NodeKey} from 'lexical';
 
 import {addClassNamesToElement} from '@lexical/helpers/elements';
-import {ElementNode} from 'lexical';
+import {GridRowNode} from 'lexical';
 
-export class TableRowNode extends ElementNode {
-  static getType(): 'table-row' {
-    return 'table-row';
+export class TableRowNode extends GridRowNode {
+  static getType(): 'tablerow' {
+    return 'tablerow';
   }
 
   static clone(node: TableRowNode): TableRowNode {

--- a/packages/lexical/src/index.js
+++ b/packages/lexical/src/index.js
@@ -37,6 +37,9 @@ import {
   isDecoratorMap,
 } from './nodes/base/LexicalDecoratorNode';
 import {$isElementNode, ElementNode} from './nodes/base/LexicalElementNode';
+import {$isGridCellNode, GridCellNode} from './nodes/base/LexicalGridCellNode';
+import {$isGridNode, GridNode} from './nodes/base/LexicalGridNode';
+import {$isGridRowNode, GridRowNode} from './nodes/base/LexicalGridRowNode';
 import {
   $createLineBreakNode,
   $isLineBreakNode,
@@ -101,6 +104,9 @@ export {
   $getSelection,
   $isDecoratorNode,
   $isElementNode,
+  $isGridCellNode,
+  $isGridNode,
+  $isGridRowNode,
   $isLeafNode,
   $isLineBreakNode,
   $isNodeSelection,
@@ -116,6 +122,9 @@ export {
   createEditor,
   DecoratorNode,
   ElementNode,
+  GridCellNode,
+  GridNode,
+  GridRowNode,
   isDecoratorArray,
   isDecoratorEditor,
   isDecoratorMap,

--- a/packages/lexical/src/nodes/base/LexicalGridCellNode.js
+++ b/packages/lexical/src/nodes/base/LexicalGridCellNode.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {LexicalNode, NodeKey} from 'lexical';
+
+import {ElementNode} from './LexicalElementNode';
+
+export class GridCellNode extends ElementNode {
+  __colSpan: number;
+
+  constructor(colSpan: number, key?: NodeKey) {
+    super(key);
+  }
+}
+
+export function $isGridCellNode(node: ?LexicalNode): boolean %checks {
+  return node instanceof GridCellNode;
+}

--- a/packages/lexical/src/nodes/base/LexicalGridNode.js
+++ b/packages/lexical/src/nodes/base/LexicalGridNode.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {LexicalNode} from '../../LexicalNode';
+
+import {ElementNode} from './LexicalElementNode';
+
+export class GridNode extends ElementNode {}
+
+export function $isGridNode(node: ?LexicalNode): boolean %checks {
+  return node instanceof GridNode;
+}

--- a/packages/lexical/src/nodes/base/LexicalGridRowNode.js
+++ b/packages/lexical/src/nodes/base/LexicalGridRowNode.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {LexicalNode} from '../../LexicalNode';
+
+import {ElementNode} from './LexicalElementNode';
+
+export class GridRowNode extends ElementNode {}
+
+export function $isGridRowNode(node: ?LexicalNode): boolean %checks {
+  return node instanceof GridRowNode;
+}


### PR DESCRIPTION
This adds three new base nodes, that are only intended to be extended for usages in cases such as tables and other custom grids. The reason for enforcing a base node is so that we can introduce a `GridSelection` and the heuristics between co-ords on the grid. This is difficult to do in core without core having some understanding of relationship that it can check for and enforce if needed. In the future, this might also allow core to improve performance on tables by using virtualization.