### PR TITLE
Fix blur for Firefox

### DIFF
--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -618,6 +618,10 @@ class BaseLexicalEditor {
     if (rootElement !== null) {
       rootElement.blur();
     }
+    const domSelection = window.getSelection();
+    if (domSelection !== null) {
+      domSelection.removeAllRanges();
+    }
   }
 }
 


### PR DESCRIPTION
It's a known issue that FF doesn't actually change selection on a blur, it just hides the caret. This ensures FF plays ball too.