### PR TITLE
Fix possible issues around removeRootElementEvents

### DIFF
--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -585,7 +585,7 @@ export function removeRootElementEvents(rootElement: HTMLElement): void {
     removeHandles[i]();
   }
   // $FlowFixMe: internal field
-  rootElement._lexicalEventHandles = [];
+  rootElement.__lexicalEventHandles = [];
 }
 
 function cleanActiveNestedEditorsMap(editor: LexicalEditor) {


### PR DESCRIPTION
Internally, we noticed some odd occurring JS errors relating to the logic in `removeRootElementEvents`. This PR attempts to clean up the logic a bit to hopefully make the error go away/or clearer to understand why is happening.