### PR TITLE
LexicalComposer to track whether the editor is ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ function onChange(editorState) {
 // desired, so you don't pay the cost for plugins until you
 // actually use them.
 function MyCustomAutoFocusPlugin() {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   useEffect(() => {
     // Focus the editor when the effect fires!

--- a/examples/decorators.md
+++ b/examples/decorators.md
@@ -60,7 +60,7 @@ As any other custom Lexical node, decorator nodes need to be registered _before_
 
 ```js
 function VideoPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   useEffect(() => {
     // Similar with command listener, which returns unlisten callback
@@ -99,7 +99,7 @@ Then assuming we have a some UE insert a video into the editor:
 
 ```js
 function ToolbarVideoButton(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const insertVideo = useCallback(
     (url) => {
       // Executing command defined in a plugin

--- a/examples/emoticons.md
+++ b/examples/emoticons.md
@@ -141,7 +141,7 @@ Since we're usin Lexical react, we can take advantage of Lexical's plugin system
 // EmoticonPlugin.js
 
 export default function EmoticonPlugin() {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   return null;
 }
 ```
@@ -169,7 +169,7 @@ function useEmoticons(editor) {
 }
 
 export default function EmoticonPlugin() {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useEmoticons(editor);
   return null;
 }
@@ -200,7 +200,7 @@ function useEmoticons(editor) {
 }
 
 export default function EmoticonPlugin() {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useEmoticons(editor);
   return null;
 }
@@ -231,7 +231,7 @@ function useEmoticons(editor) {
 }
 
 export default function EmoticonPlugin() {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useEmoticons(editor);
   return null;
 }

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.js
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.js
@@ -17,7 +17,7 @@ import type {
 
 import * as React from 'react';
 import {DecoratorNode, $getNodeByKey} from 'lexical';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {useCallback, useState} from 'react';
 import ExcalidrawModal from './ExcalidrawModal';
 import ExcalidrawImage from './ExcalidrawImage';
@@ -32,7 +32,7 @@ function ExcalidrawComponent({
   const [hasFocus, setHasFocus] = useState<boolean>(false);
   const [isModalOpen, setModalOpen] = useState<boolean>(true);
   const [elements, setElements] = useState([]);
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   const handleKeyDown = (event) => {
     if (

--- a/packages/lexical-playground/src/nodes/ImageNode.js
+++ b/packages/lexical-playground/src/nodes/ImageNode.js
@@ -25,7 +25,7 @@ import {
   $getSelection,
   $isNodeSelection,
 } from 'lexical';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import useLexicalNodeSelection from '@lexical/react/useLexicalNodeSelection';
 import {
   useCollaborationContext,
@@ -336,7 +336,7 @@ function ImageComponent({
     useLexicalNodeSelection(nodeKey);
   const [isResizing, setIsResizing] = useState<boolean>(false);
   const {yjsDocMap} = useCollaborationContext();
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const isCollab = yjsDocMap.get('main') !== undefined;
   const [decoratorEditor] = useLexicalDecoratorMap<DecoratorEditor>(
     state,

--- a/packages/lexical-playground/src/nodes/PollNode.js
+++ b/packages/lexical-playground/src/nodes/PollNode.js
@@ -19,7 +19,7 @@ import {DecoratorNode, createDecoratorArray, createDecoratorMap} from 'lexical';
 import * as React from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 import useLexicalDecoratorMap from '@lexical/react/useLexicalDecoratorMap';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationPlugin';
 import stylex from 'stylex';
 import Button from '../ui/Button';
@@ -270,7 +270,7 @@ function PollComponent({
   decoratorMap: DecoratorMap,
   question: string,
 }): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const [options] = useLexicalDecoratorMap(decoratorMap, 'options', () =>
     createDecoratorArray(editor, [
       createPollOptionMap(editor, ''),

--- a/packages/lexical-playground/src/nodes/StickyNode.js
+++ b/packages/lexical-playground/src/nodes/StickyNode.js
@@ -26,7 +26,7 @@ import {
 } from 'lexical';
 // $FlowFixMe
 import {createPortal} from 'react-dom';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {
   useCollaborationContext,
   CollaborationPlugin,
@@ -99,7 +99,7 @@ function StickyComponent({
   color: 'pink' | 'yellow',
   decoratorStateMap: DecoratorMap,
 }): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const stickyContainerRef = useRef<null | HTMLElement>(null);
   const positioningRef = useRef<{
     x: number,

--- a/packages/lexical-playground/src/plugins/ActionsPlugin.js
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.js
@@ -10,7 +10,7 @@
 import type {CommandListenerEditorPriority} from 'lexical';
 
 import * as React from 'react';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationPlugin';
 import {useCallback, useEffect, useState} from 'react';
 import {$createStickyNode} from '../nodes/StickyNode';
@@ -28,7 +28,7 @@ export default function ActionsPlugins({
   const [isReadOnly, setIsReadyOnly] = useState(false);
   const [isSpeechToText, setIsSpeechToText] = useState(false);
   const [connected, setConnected] = useState(false);
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const {yjsDocMap} = useCollaborationContext();
   const isCollab = yjsDocMap.get('main') !== undefined;
 

--- a/packages/lexical-playground/src/plugins/AutoFocusPlugin.js
+++ b/packages/lexical-playground/src/plugins/AutoFocusPlugin.js
@@ -7,12 +7,12 @@
  * @flow strict
  */
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 
 import {useEffect} from 'react';
 
 export default function AutoFocusPlugin(): null {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   useEffect(() => {
     editor.focus();

--- a/packages/lexical-playground/src/plugins/AutocompletePlugin.js
+++ b/packages/lexical-playground/src/plugins/AutocompletePlugin.js
@@ -9,7 +9,7 @@
 
 import type {LexicalEditor, NodeKey} from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 
 import {
   $isTextNode,
@@ -293,7 +293,7 @@ class TypeaheadServer {
 }
 
 export default function AutocompletePlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useTypeahead(editor);
 
   return null;

--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.js
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.js
@@ -14,7 +14,7 @@ import {TextNode, $isTextNode, $getSelection, $isRangeSelection} from 'lexical';
 // $FlowFixMe
 import {createPortal} from 'react-dom';
 import {$isLinkNode} from 'lexical/LinkNode';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import withSubscriptions from '@lexical/react/withSubscriptions';
 
 import {$isAtNodeEnd} from '@lexical/helpers/selection';
@@ -250,6 +250,6 @@ function useCharacterStylesPopup(editor: LexicalEditor): React$Node {
 }
 
 export default function CharacterStylesPopupPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   return useCharacterStylesPopup(editor);
 }

--- a/packages/lexical-playground/src/plugins/CodeHighlightPlugin.js
+++ b/packages/lexical-playground/src/plugins/CodeHighlightPlugin.js
@@ -27,7 +27,7 @@ import {
 } from 'lexical';
 import {useEffect} from 'react';
 import withSubscriptions from '@lexical/react/withSubscriptions';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import Prism from 'prismjs/components/prism-core';
 import 'prismjs/components/prism-clike';
 import 'prismjs/components/prism-javascript';
@@ -61,7 +61,7 @@ export const getCodeLanguages = (): Array<string> =>
     .sort();
 
 export default function CodeHighlightPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useEffect(() => {
     if (!editor.hasNodes([CodeNode, CodeHighlightNode])) {
       throw new Error(

--- a/packages/lexical-playground/src/plugins/EmojisPlugin.js
+++ b/packages/lexical-playground/src/plugins/EmojisPlugin.js
@@ -12,7 +12,7 @@ import type {LexicalEditor} from 'lexical';
 import {$createEmojiNode, EmojiNode} from '../nodes/EmojiNode';
 import {useEffect} from 'react';
 import {TextNode} from 'lexical';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 
 const emojis: Map<string, [string, string]> = new Map([
   [':)', ['emoji happysmile', '🙂']],
@@ -68,7 +68,7 @@ function useEmojis(editor: LexicalEditor): void {
 }
 
 export default function EmojisPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useEmojis(editor);
   return null;
 }

--- a/packages/lexical-playground/src/plugins/ExcalidrawPlugin.js
+++ b/packages/lexical-playground/src/plugins/ExcalidrawPlugin.js
@@ -9,7 +9,7 @@
 
 import type {CommandListenerEditorPriority} from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
 import {$getSelection, $isRangeSelection} from 'lexical';
 import {$createExcalidrawNode, ExcalidrawNode} from '../nodes/ExcalidrawNode';
@@ -17,7 +17,7 @@ import {$createExcalidrawNode, ExcalidrawNode} from '../nodes/ExcalidrawNode';
 const EditorPriority: CommandListenerEditorPriority = 0;
 
 export default function ExcalidrawPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   useEffect(() => {
     if (!editor.hasNodes([ExcalidrawNode])) {

--- a/packages/lexical-playground/src/plugins/HorizontalRulePlugin.js
+++ b/packages/lexical-playground/src/plugins/HorizontalRulePlugin.js
@@ -9,7 +9,7 @@
 
 import type {CommandListenerEditorPriority} from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {$getSelection, $isRangeSelection} from 'lexical';
 import {useEffect} from 'react';
 
@@ -18,7 +18,7 @@ import {$createHorizontalRuleNode} from '@lexical/react/LexicalHorizontalRuleNod
 const EditorPriority: CommandListenerEditorPriority = 0;
 
 export default function HorizontalRulePlugin(): null {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   useEffect(() => {
     return editor.addListener(

--- a/packages/lexical-playground/src/plugins/ImagesPlugin.js
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin.js
@@ -9,7 +9,7 @@
 
 import type {CommandListenerEditorPriority} from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
 import {$getSelection, $isRootNode, $isRangeSelection} from 'lexical';
 import {$createImageNode, ImageNode} from '../nodes/ImageNode';
@@ -19,7 +19,7 @@ import yellowFlowerImage from '../images/image/yellow-flower.jpg';
 const EditorPriority: CommandListenerEditorPriority = 0;
 
 export default function ImagesPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   useEffect(() => {
     if (!editor.hasNodes([ImageNode])) {

--- a/packages/lexical-playground/src/plugins/KeywordsPlugin.js
+++ b/packages/lexical-playground/src/plugins/KeywordsPlugin.js
@@ -17,7 +17,7 @@ import {
   $isLineBreakNode,
   $isParagraphNode,
 } from 'lexical';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {
   KeywordNode,
   $isKeywordNode,
@@ -246,7 +246,7 @@ function $convertKeywordNodeToPlainTextNode(node: KeywordNode): void {
 }
 
 export default function KeywordsPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useKeywords(editor);
   return null;
 }

--- a/packages/lexical-playground/src/plugins/MentionsPlugin.js
+++ b/packages/lexical-playground/src/plugins/MentionsPlugin.js
@@ -13,7 +13,7 @@ import type {
   CommandListenerLowPriority,
 } from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 
 // $FlowFixMe
 import {createPortal} from 'react-dom';
@@ -1019,6 +1019,6 @@ function useMentions(editor: LexicalEditor): React$Node {
 }
 
 export default function MentionsPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   return useMentions(editor);
 }

--- a/packages/lexical-playground/src/plugins/PollPlugin.js
+++ b/packages/lexical-playground/src/plugins/PollPlugin.js
@@ -9,7 +9,7 @@
 
 import type {CommandListenerEditorPriority} from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
 import {$getSelection, $isRootNode, $isRangeSelection} from 'lexical';
 import {$createPollNode, PollNode} from '../nodes/PollNode';
@@ -17,7 +17,7 @@ import {$createPollNode, PollNode} from '../nodes/PollNode';
 const EditorPriority: CommandListenerEditorPriority = 0;
 
 export default function PollPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useEffect(() => {
     if (!editor.hasNodes([PollNode])) {
       throw new Error('PollPlugin: PollNode not registered on editor');

--- a/packages/lexical-playground/src/plugins/SpeechToTextPlugin.js
+++ b/packages/lexical-playground/src/plugins/SpeechToTextPlugin.js
@@ -13,7 +13,7 @@ import type {
   RangeSelection,
 } from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {$getSelection, $isRangeSelection} from 'lexical';
 import {useEffect, useRef, useState} from 'react';
 import useReport from '../hooks/useReport';
@@ -38,7 +38,7 @@ export const SUPPORT_SPEECH_RECOGNITION: boolean =
   'SpeechRecognition' in window || 'webkitSpeechRecognition' in window;
 
 function SpeechToTextPlugin(): null {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const [isEnabled, setIsEnabled] = useState<boolean>(false);
   const recognition = useRef<SpeechRecognition | null>(null);
   const report = useReport();

--- a/packages/lexical-playground/src/plugins/StickyPlugin.js
+++ b/packages/lexical-playground/src/plugins/StickyPlugin.js
@@ -7,12 +7,12 @@
  * @flow strict
  */
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
 import {StickyNode} from '../nodes/StickyNode';
 
 export default function StickyPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useEffect(() => {
     if (!editor.hasNodes([StickyNode])) {
       throw new Error('StickyPlugin: StickyNode not registered on editor');

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin.js
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 // $FlowFixMe
 import {createPortal} from 'react-dom';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {$getSelection, $setSelection, $isRangeSelection} from 'lexical';
 import {
   $deleteTableColumn,
@@ -38,7 +38,7 @@ function TableActionMenu({
   setIsMenuOpen,
   contextRef,
 }: TableCellActionMenuProps) {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const dropDownRef = useRef();
 
   const [selectionCounts, updateSelectionCounts] = useState({
@@ -263,7 +263,7 @@ function TableActionMenu({
 }
 
 function TableCellActionMenuContainer(): React.MixedElement {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   const menuButtonRef = useRef(null);
   const menuRootRef = useRef(null);
@@ -390,7 +390,7 @@ function TableCellActionMenuContainer(): React.MixedElement {
 }
 
 export default function TableActionMenuPlugin(): React.Portal {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   return useMemo(
     () =>

--- a/packages/lexical-playground/src/plugins/TestRecorderPlugin.js
+++ b/packages/lexical-playground/src/plugins/TestRecorderPlugin.js
@@ -10,7 +10,7 @@
 import type {LexicalEditor} from 'lexical';
 
 import * as React from 'react';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 
 import {$createTextNode, $getRoot, $createParagraphNode} from 'lexical';
 import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
@@ -433,7 +433,7 @@ ${steps.map(formatStep).join(`\n`)}
 }
 
 export default function TreeViewPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const [testRecorderButton, testRecorderOutput] = useTestRecorder(editor);
 
   return (

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.js
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.js
@@ -18,7 +18,7 @@ import type {
 import * as React from 'react';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {$isHeadingNode} from 'lexical/HeadingNode';
 import {$createHeadingNode} from 'lexical/HeadingNode';
 import {$isListNode, ListNode} from '@lexical/list';
@@ -498,7 +498,7 @@ function Select({
 }
 
 export default function ToolbarPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const [activeEditor, setActiveEditor] = useState(editor);
   const toolbarRef = useRef(null);
   const [blockType, setBlockType] = useState('paragraph');

--- a/packages/lexical-playground/src/plugins/TreeViewPlugin.js
+++ b/packages/lexical-playground/src/plugins/TreeViewPlugin.js
@@ -9,10 +9,10 @@
 
 import LexicalTreeView from '@lexical/react/LexicalTreeView';
 import * as React from 'react';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 
 export default function TreeViewPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   return (
     <LexicalTreeView
       viewClassName="tree-view-output"

--- a/packages/lexical-playground/src/ui/ContentEditable.js
+++ b/packages/lexical-playground/src/ui/ContentEditable.js
@@ -12,7 +12,7 @@ import type {CommandListenerEditorPriority} from 'lexical';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 import LexicalContentEditable from '@lexical/react/LexicalContentEditable';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import stylex from 'stylex';
 
 const EditorPriority: CommandListenerEditorPriority = 0;
@@ -38,7 +38,7 @@ export default function ContentEditable({
 }: {
   className?: string,
 }): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const [isReadOnly, setIsReadyOnly] = useState(false);
 
   useEffect(() => {

--- a/packages/lexical-react/README.md
+++ b/packages/lexical-react/README.md
@@ -45,7 +45,7 @@ function onChange(editorState) {
 // desired, so you don't pay the cost for plugins until you
 // actually use them.
 function MyCustomAutoFocusPlugin() {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   useEffect(() => {
     // Focus the editor when the effect fires!

--- a/packages/lexical-react/src/LexicalAutoFormatterPlugin.js
+++ b/packages/lexical-react/src/LexicalAutoFormatterPlugin.js
@@ -7,12 +7,12 @@
  * @flow strict
  */
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 
 import useAutoFormatter from './shared/useAutoFormatter';
 
 export default function AutoFormatterPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useAutoFormatter(editor);
 
   return null;

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.js
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.js
@@ -9,7 +9,7 @@
 
 import type {ElementNode, LexicalEditor, LexicalNode} from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import withSubscriptions from '@lexical/react/withSubscriptions';
 import {
   $createTextNode,
@@ -248,7 +248,7 @@ export default function AutoLinkPlugin({
   matchers: Array<LinkMatcher>,
   onChange?: ChangeHandler,
 }): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useAutoLink(editor, matchers, onChange);
   return null;
 }

--- a/packages/lexical-react/src/LexicalBootstrapPlugin.js
+++ b/packages/lexical-react/src/LexicalBootstrapPlugin.js
@@ -9,7 +9,7 @@
 
 import type {LexicalEditor} from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 
 import useBootstrapEditor from './shared/useBootstrapEditor';
 
@@ -20,7 +20,7 @@ export default function LexicalBootstrapPlugin({
   clearEditorFn?: (LexicalEditor) => void,
   initialPayloadFn?: (LexicalEditor) => void,
 }): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useBootstrapEditor(editor, initialPayloadFn, clearEditorFn);
 
   return null;

--- a/packages/lexical-react/src/LexicalCharacterLimitPlugin.js
+++ b/packages/lexical-react/src/LexicalCharacterLimitPlugin.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
 import {useMemo, useState} from 'react';
 
@@ -41,7 +41,7 @@ export default function CharacterLimitPlugin({
 }: {
   charset: 'UTF-8' | 'UTF-16',
 }): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const [remainingCharacters, setRemainingCharacters] = useState(0);
   const characterLimitProps = useMemo(
     () => ({

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.js
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.js
@@ -10,7 +10,7 @@
 import type {Provider} from '@lexical/yjs';
 import type {Doc} from 'yjs';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {createContext, useContext, useMemo} from 'react';
 
 import {
@@ -59,7 +59,7 @@ export function CollaborationPlugin({
 }): React$Node {
   const collabContext = useCollaborationContext();
   const {yjsDocMap, name, color} = collabContext;
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const provider = useMemo(
     () => providerFactory(id, yjsDocMap),
     [id, providerFactory, yjsDocMap],

--- a/packages/lexical-react/src/LexicalComposerContext.js
+++ b/packages/lexical-react/src/LexicalComposerContext.js
@@ -12,14 +12,20 @@ import type {EditorThemeClasses, LexicalEditor} from 'lexical';
 import {createContext as createReactContext, useContext} from 'react';
 import invariant from 'shared/invariant';
 
-export type LexicalComposerContextType = {
+export type LexicalComposerContextType = $ReadOnly<{
   getTheme: () => ?EditorThemeClasses,
-};
+}>;
 
-export type LexicalComposerContextWithEditor = [
-  LexicalEditor,
-  LexicalComposerContextType,
-];
+export type ReadyType = $ReadOnly<{
+  isReady: () => void | boolean,
+  onReady: (listener: () => void) => () => void,
+}>;
+
+export type LexicalComposerContextWithEditor = $ReadOnly<{
+  context: LexicalComposerContextType,
+  editor: LexicalEditor,
+  ready: ReadyType,
+}>;
 
 export const LexicalComposerContext: React$Context<?LexicalComposerContextWithEditor> =
   createReactContext<?LexicalComposerContextWithEditor>(null);
@@ -46,7 +52,7 @@ export function createLexicalComposerContext(
   };
 }
 
-export function useLexicalComposerContext(): LexicalComposerContextWithEditor {
+function useLexicalComposerContext(): LexicalComposerContextWithEditor {
   const composerContext = useContext(LexicalComposerContext);
 
   if (composerContext == null) {
@@ -56,4 +62,22 @@ export function useLexicalComposerContext(): LexicalComposerContextWithEditor {
     );
   }
   return composerContext;
+}
+
+export function useLexicalComposerEditor(): LexicalEditor {
+  const {editor} = useLexicalComposerContext();
+  return editor;
+}
+
+export function useLexicalComposerEditorContext(): LexicalComposerContextType {
+  const {context} = useLexicalComposerContext();
+  return context;
+}
+
+export function useLexicalComposerReady(): [
+  () => void | boolean,
+  (listener: () => void) => () => void,
+] {
+  const {ready} = useLexicalComposerContext();
+  return [ready.isReady, ready.onReady];
 }

--- a/packages/lexical-react/src/LexicalContentEditable.js
+++ b/packages/lexical-react/src/LexicalContentEditable.js
@@ -7,9 +7,12 @@
  * @flow strict
  */
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {
+  useLexicalComposerEditor,
+  useLexicalComposerReady,
+} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
-import {useCallback} from 'react';
+import {useCallback, useLayoutEffect, useState} from 'react';
 
 export type Props = $ReadOnly<{
   ariaActiveDescendantID?: string,
@@ -49,20 +52,27 @@ export default function LexicalContentEditable({
   autoComplete,
   autoCorrect,
   className,
-  readOnly = false,
+  readOnly: userReadOnly = false,
   role = 'textbox',
   spellCheck = true,
   style,
   tabIndex,
   testid,
 }: Props): React.MixedElement {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
+  const [isReady, onReady] = useLexicalComposerReady();
   const ref = useCallback(
     (rootElement: null | HTMLElement) => {
       editor.setRootElement(rootElement);
     },
     [editor],
   );
+  const [readOnly, setReadOnly] = useState(() => !isReady());
+  useLayoutEffect(() => {
+    return onReady(() => {
+      setReadOnly(false);
+    });
+  }, [onReady]);
 
   return (
     <div

--- a/packages/lexical-react/src/LexicalHashtagPlugin.js
+++ b/packages/lexical-react/src/LexicalHashtagPlugin.js
@@ -9,7 +9,7 @@
 
 import type {LexicalEditor} from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {TextNode} from 'lexical';
 import {$toggleHashtag} from 'lexical/HashtagNode';
 import {useEffect} from 'react';
@@ -285,7 +285,7 @@ function useHashtags(editor: LexicalEditor): void {
 }
 
 export default function HashtagPlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useHashtags(editor);
 
   return null;

--- a/packages/lexical-react/src/LexicalHistoryPlugin.js
+++ b/packages/lexical-react/src/LexicalHistoryPlugin.js
@@ -9,7 +9,7 @@
 
 import type {HistoryState} from './shared/useHistory';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 
 import {useHistory} from './shared/useHistory';
 
@@ -22,7 +22,7 @@ export function HistoryPlugin({
 }: {
   externalHistoryState?: HistoryState,
 }): null {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useHistory(editor, externalHistoryState);
 
   return null;

--- a/packages/lexical-react/src/LexicalLinkPlugin.js
+++ b/packages/lexical-react/src/LexicalLinkPlugin.js
@@ -9,7 +9,7 @@
 
 import type {CommandListenerEditorPriority} from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {$getSelection, $setSelection} from 'lexical';
 import {$createLinkNode, $isLinkNode} from 'lexical/LinkNode';
 import {useEffect} from 'react';
@@ -97,7 +97,7 @@ function toggleLink(url: null | string) {
 }
 
 export default function LinkPlugin(): null {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   useEffect(() => {
     return editor.addListener(

--- a/packages/lexical-react/src/LexicalListPlugin.js
+++ b/packages/lexical-react/src/LexicalListPlugin.js
@@ -7,12 +7,12 @@
  * @flow strict
  */
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 
 import useList from './shared/useList';
 
 export default function ListPlugin(): null {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useList(editor);
 
   return null;

--- a/packages/lexical-react/src/LexicalOnChangePlugin.js
+++ b/packages/lexical-react/src/LexicalOnChangePlugin.js
@@ -9,7 +9,7 @@
 
 import type {EditorState, LexicalEditor} from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
 export default function OnChangePlugin({
@@ -17,7 +17,7 @@ export default function OnChangePlugin({
 }: {
   onChange: (editorState: EditorState, editor: LexicalEditor) => void,
 }): null {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   useLayoutEffect(() => {
     if (onChange) {
       return editor.addListener('update', ({editorState}) => {

--- a/packages/lexical-react/src/LexicalPlainTextPlugin.js
+++ b/packages/lexical-react/src/LexicalPlainTextPlugin.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
 
 import useCanShowPlaceholder from './shared/useCanShowPlaceholder';
@@ -21,7 +21,7 @@ export default function PlainTextPlugin({
   contentEditable: React$Node,
   placeholder: React$Node,
 }): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const showPlaceholder = useCanShowPlaceholder(editor);
   usePlainTextSetup(editor);
   const decorators = useDecorators(editor);

--- a/packages/lexical-react/src/LexicalRichTextPlugin.js
+++ b/packages/lexical-react/src/LexicalRichTextPlugin.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
 
 import useCanShowPlaceholder from './shared/useCanShowPlaceholder';
@@ -21,7 +21,7 @@ export default function RichTextPlugin({
   contentEditable: React$Node,
   placeholder: React$Node,
 }): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const showPlaceholder = useCanShowPlaceholder(editor);
   useRichTextSetup(editor);
   const decorators = useDecorators(editor);

--- a/packages/lexical-react/src/LexicalTablePlugin.js
+++ b/packages/lexical-react/src/LexicalTablePlugin.js
@@ -9,7 +9,7 @@
 
 import type {CommandListenerEditorPriority, ElementNode} from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {
   $createTableNodeWithDimensions,
   TableCellNode,
@@ -28,7 +28,7 @@ import invariant from 'shared/invariant';
 const EditorPriority: CommandListenerEditorPriority = 0;
 
 export default function TablePlugin(): React$Node {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   useEffect(() => {
     if (!editor.hasNodes([TableNode, TableCellNode, TableRowNode])) {

--- a/packages/lexical-react/src/__tests__/unit/utils.js
+++ b/packages/lexical-react/src/__tests__/unit/utils.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import LexicalContentEditable from '@lexical/react/LexicalContentEditable';
 import * as React from 'react';
 import {createRoot} from 'react-dom';
@@ -24,7 +24,7 @@ import LexicalRichTextPlugin from '../../LexicalRichTextPlugin';
 
 function Editor({doc, provider, setEditor}) {
   const {yjsDocMap} = useCollaborationContext();
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
 
   yjsDocMap.set('main', doc);
 

--- a/packages/lexical-react/src/shared/useBootstrapEditor.js
+++ b/packages/lexical-react/src/shared/useBootstrapEditor.js
@@ -78,16 +78,15 @@ export default function useBootstrapEditor(
   clearEditorFn?: (LexicalEditor) => void,
 ): void {
   useLayoutEffect(() => {
+    initEditor(
+      editor,
+      initialPayloadFn != null ? initialPayloadFn : defaultInitEditor,
+    );
+  }, [editor, initialPayloadFn]);
+  useLayoutEffect(() => {
     return editor.addListener(
       'command',
       (type, payload): boolean => {
-        if (type === 'bootstrapEditor') {
-          initEditor(
-            editor,
-            initialPayloadFn != null ? initialPayloadFn : defaultInitEditor,
-          );
-          return true;
-        }
         if (type === 'clearEditor') {
           clearEditor(
             editor,

--- a/packages/lexical-react/src/shared/usePlainTextSetup.js
+++ b/packages/lexical-react/src/shared/usePlainTextSetup.js
@@ -18,12 +18,12 @@ import {
 } from '@lexical/helpers/events';
 import {$moveCharacter} from '@lexical/helpers/selection';
 import {$getSelection, $isRangeSelection} from 'lexical';
-import {useEffect} from 'react';
+import {useLayoutEffect} from 'react';
 
 import useLexicalDragonSupport from './useLexicalDragonSupport';
 
 export default function usePlainTextSetup(editor: LexicalEditor): void {
-  useEffect(() => {
+  useLayoutEffect(() => {
     const removeListener = editor.addListener(
       'command',
       (type, payload): boolean => {
@@ -145,12 +145,7 @@ export default function usePlainTextSetup(editor: LexicalEditor): void {
       },
       (0: CommandListenerEditorPriority),
     );
-    const bootstrapCommandHandled = editor.execCommand('bootstrapEditor');
-    if (__DEV__ && !bootstrapCommandHandled) {
-      console.warn(
-        'bootstrapEditor command was not handled. Did you forget to add <BootstrapPlugin />?',
-      );
-    }
+    editor.execCommand('eventListeners');
     return removeListener;
   }, [editor]);
 

--- a/packages/lexical-react/src/shared/useRichTextSetup.js
+++ b/packages/lexical-react/src/shared/useRichTextSetup.js
@@ -28,12 +28,12 @@ import {
   $isNodeSelection,
   $isRangeSelection,
 } from 'lexical';
-import {useEffect} from 'react';
+import {useLayoutEffect} from 'react';
 
 import useLexicalDragonSupport from './useLexicalDragonSupport';
 
 export function useRichTextSetup(editor: LexicalEditor): void {
-  useEffect(() => {
+  useLayoutEffect(() => {
     const removeListener = editor.addListener(
       'command',
       (type, payload): boolean => {
@@ -225,12 +225,7 @@ export function useRichTextSetup(editor: LexicalEditor): void {
       },
       (0: CommandListenerEditorPriority),
     );
-    const bootstrapCommandHandled = editor.execCommand('bootstrapEditor');
-    if (__DEV__ && !bootstrapCommandHandled) {
-      console.warn(
-        'bootstrapEditor command was not handled. Did you forget to add <BootstrapPlugin />?',
-      );
-    }
+    editor.execCommand('eventListeners');
     return removeListener;
   }, [editor]);
 

--- a/packages/lexical-react/src/useLexicalNodeSelection.js
+++ b/packages/lexical-react/src/useLexicalNodeSelection.js
@@ -9,7 +9,7 @@
 
 import type {LexicalEditor, NodeKey} from 'lexical';
 
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalComposerEditor} from '@lexical/react/LexicalComposerContext';
 import {
   $createNodeSelection,
   $getNodeByKey,
@@ -32,7 +32,7 @@ function isNodeSelected(editor: LexicalEditor, key: NodeKey): boolean {
 export default function useLexicalNodeSelection(
   key: NodeKey,
 ): [boolean, (boolean) => void, () => void] {
-  const [editor] = useLexicalComposerContext();
+  const editor = useLexicalComposerEditor();
   const [isSelected, setIsSelected] = useState(() =>
     isNodeSelected(editor, key),
   );


### PR DESCRIPTION
This overrides https://github.com/facebook/lexical/pull/1335

Editor ready-ness is a basic editor property that is used in 100% of the applications. We need to understand whether the editor is ready before allowing the users to type on it, otherwise bad things can happen.

Previous we attempted to chain the events:
1. Events
2. Bootstrap
3. Contenteditable

But there's a catch with with event chaining with commands, they're still susceptible to race conditions. Hence, why we patched it with a combination of `useLayoutEffect` + `useEffect` in https://github.com/facebook/lexical/pull/1337

But we can do better, especially when we consider this is done in 100% of the application. We can leverage LexicalComposer to keep track of these prerequisites that make the editor editor: events and bootstrap. In fact, these two can come in any order.

For this reason, I'm introducing `ready`. LexicalContentEditable will listen to this value to understand whether the editor should be writable by the user.

---

At the same time, I'm leveraging this to refactor how we call overly used editor from the hook. I added a hook that can directly retrieve this value and also makes it easier to use context and ready as independent hooks.