### PR TITLE
Improve composition, remove fake space

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Composition-test.js
+++ b/packages/lexical-playground/__tests__/e2e/Composition-test.js
@@ -254,6 +254,42 @@ describe('Composition', () => {
           focusPath: [0, 1, 0],
           focusOffset: 6,
         });
+
+        await repeat(6, async () => {
+          await page.keyboard.press('Backspace');
+        });
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span style="clip-path: circle(0% at 50% 50%);">🙂</span></span><span class="emoji happysmile" data-lexical-text="true"><span style="clip-path: circle(0% at 50% 50%);">🙂</span></span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0, 0],
+          anchorOffset: 2,
+          focusPath: [0, 0, 0, 0],
+          focusOffset: 2,
+        });
+
+        await page.keyboard.imeSetComposition('ｓ', 1, 1);
+        await page.keyboard.imeSetComposition('す', 1, 1);
+        await page.keyboard.imeSetComposition('すｓ', 2, 2);
+        await page.keyboard.imeSetComposition('すｓｈ', 3, 3);
+        await page.keyboard.imeSetComposition('すし', 2, 2);
+        await page.keyboard.imeSetComposition('す', 1, 1);
+        await page.keyboard.imeSetComposition('', 0, 0);
+        // Escape would fire here
+        await page.keyboard.insertText('');
+
+        await assertHTML(
+          page,
+          '<p class="PlaygroundEditorTheme__paragraph m8h3af8h l7ghb35v kmwttqpk mfn553m3 om3e55n1 gjezrb0y PlaygroundEditorTheme__ltr gkum2dnh" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span style="clip-path: circle(0% at 50% 50%);">🙂</span></span><span class="emoji happysmile" data-lexical-text="true"><span style="clip-path: circle(0% at 50% 50%);">🙂</span></span></p>',
+        );
+        await assertSelection(page, {
+          anchorPath: [0, 0, 0, 0],
+          anchorOffset: 2,
+          focusPath: [0, 0, 0, 0],
+          focusOffset: 2,
+        });
       });
 
       it('Can type Hiragana via IME at the end of a mention', async () => {

--- a/packages/lexical/src/LexicalConstants.js
+++ b/packages/lexical/src/LexicalConstants.js
@@ -45,7 +45,7 @@ export const IS_ALIGN_RIGHT = 3;
 export const IS_ALIGN_JUSTIFY = 4;
 
 // Reconciliation
-export const NO_BREAK_SPACE_CHAR = '\u00A0';
+export const ZERO_WIDTH_CHAR = '\u200b';
 
 const RTL = '\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC';
 const LTR =

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -46,9 +46,9 @@ import {
   DOM_TEXT_TYPE,
   HAS_DIRTY_NODES,
   LTR_REGEX,
-  NO_BREAK_SPACE_CHAR,
   RTL_REGEX,
   TEXT_TYPE_TO_FORMAT,
+  ZERO_WIDTH_CHAR,
 } from './LexicalConstants';
 import {flushRootMutations} from './LexicalMutations';
 import {
@@ -465,13 +465,14 @@ export function $updateTextNodeFromDOMContent(
   compositionEnd: boolean,
 ): void {
   let node = textNode;
+
   if (node.isAttached() && (compositionEnd || !node.isDirty())) {
     const isComposing = node.isComposing();
     let normalizedTextContent = textContent;
 
     if (
       (isComposing || compositionEnd) &&
-      textContent[textContent.length - 1] === NO_BREAK_SPACE_CHAR
+      textContent[textContent.length - 1] === ZERO_WIDTH_CHAR
     ) {
       normalizedTextContent = textContent.slice(0, -1);
     }

--- a/packages/lexical/src/nodes/base/LexicalTextNode.js
+++ b/packages/lexical/src/nodes/base/LexicalTextNode.js
@@ -32,9 +32,9 @@ import {
   IS_TOKEN,
   IS_UNDERLINE,
   IS_UNMERGEABLE,
-  NO_BREAK_SPACE_CHAR,
   TEXT_MODE_TO_TYPE,
   TEXT_TYPE_TO_FORMAT,
+  ZERO_WIDTH_CHAR,
 } from '../../LexicalConstants';
 import {LexicalNode} from '../../LexicalNode';
 import {
@@ -185,7 +185,7 @@ function setTextContent(
   const firstChild: ?Text = dom.firstChild;
   const isComposing = node.isComposing();
   // Always add a suffix if we're composing a node
-  const suffix = isComposing ? NO_BREAK_SPACE_CHAR : '';
+  const suffix = isComposing ? ZERO_WIDTH_CHAR : '';
   const text = nextText + suffix;
 
   if (firstChild == null) {


### PR DESCRIPTION
We've always used a non breaking space at the end of composition to ensure the composed text DOM node can never really truely be deleted during termination. However, this adds visible spacing during composition which isn't ideal. This PR addresses that and adds a test to make sure we don't regress.