### PR TITLE
Use tab command instead of outdent indent

### DIFF
--- a/packages/lexical-table/src/lexicalTableCoreHelpers.js
+++ b/packages/lexical-table/src/lexicalTableCoreHelpers.js
@@ -514,14 +514,17 @@ export function $applyCustomTableHandlers(
         }
       }
 
-      if (type === 'indentContent' || type === 'outdentContent') {
+      if (type === 'keyTab') {
+        const event: KeyboardEvent = payload;
+
         if (selection.isCollapsed() && highlightedCells.length === 0) {
           const currentCords = tableNode.getCordsFromCellNode(tableCellNode);
+          event.preventDefault();
 
           selectGridNodeInDirection(
             currentCords.x,
             currentCords.y,
-            type === 'indentContent' ? 'forward' : 'backward',
+            !event.shiftKey && type === 'keyTab' ? 'forward' : 'backward',
           );
 
           return true;


### PR DESCRIPTION
Use tab command instead of outdent indent otherwise the toolbar indent buttons will change selection, not indentation.