### PR TITLE
Adding coding language support to code block markdown

### DIFF
--- a/packages/lexical-react/src/shared/AutoFormatterUtils.js
+++ b/packages/lexical-react/src/shared/AutoFormatterUtils.js
@@ -177,7 +177,6 @@ const markdownUnorderedListAsterisk: AutoFormatCriteria = {
 const markdownCodeBlock: AutoFormatCriteria = {
   ...paragraphStartBase,
   nodeTransformationKind: 'paragraphCodeBlock',
-  // regEx: /(```)(js|javascript|py|hack|)/,
   regEx: /^(```)([a-z]*)( )/,
 };
 


### PR DESCRIPTION
Lexical CodeNode has a setLanguage method.
This PR adds support for no language, 'javascript', 'js', 'py' and 'hack' to be added to the CodeNode.
e.g. ```js
