### PR TITLE
[EZ]correcting the flow type for getStates of provider awareness

### DIFF
--- a/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow
@@ -20,7 +20,7 @@ export type UserState = {
 export type ProviderAwareness = {
   getLocalState: () => UserState,
   setLocalState: (UserState) => void,
-  getStates: () => Array<UserState>,
+  getStates: () => Map<number, UserState>,
   on: (type: 'update', cb: () => void) => void,
   off: (type: 'update', cb: () => void) => void,
 };

--- a/packages/lexical-yjs/src/Bindings.js
+++ b/packages/lexical-yjs/src/Bindings.js
@@ -20,7 +20,7 @@ import {XmlText} from 'yjs';
 
 import {$createCollabElementNode} from './CollabElementNode';
 
-export type ClientID = string;
+export type ClientID = number;
 
 export type Binding = {
   clientID: number,

--- a/packages/lexical-yjs/src/index.js
+++ b/packages/lexical-yjs/src/index.js
@@ -23,7 +23,7 @@ export type UserState = {
 
 export type ProviderAwareness = {
   getLocalState: () => UserState,
-  getStates: () => Array<UserState>,
+  getStates: () => Map<number, UserState>,
   off: (type: 'update', cb: () => void) => void,
   on: (type: 'update', cb: () => void) => void,
   setLocalState: (UserState) => void,


### PR DESCRIPTION
getState() in ProviderAwareness interface had a wrong type `Array<UserState>` instead. Corrected it to be `Map<number, UserState> `according to https://github.com/yjs/y-protocols/blob/master/awareness.js#L152 

test plan:
flow - no error
npm run dev - collab cursor still works