### PR TITLE
Move window.getSelection into a shared module

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -78,6 +78,7 @@ module.name_mapper='^@lexical/react/LexicalListPlugin' -> '<PROJECT_ROOT>/packag
 
 module.name_mapper='^@lexical/yjs$' -> '<PROJECT_ROOT>/packages/lexical-yjs/src/index.js'
 
+module.name_mapper='^shared/getDOMSelection' -> '<PROJECT_ROOT>/packages/shared/src/getDOMSelection.js'
 module.name_mapper='^shared/invariant' -> '<PROJECT_ROOT>/packages/shared/src/invariant.js'
 module.name_mapper='^shared/environment' -> '<PROJECT_ROOT>/packages/shared/src/environment.js'
 module.name_mapper='^shared/useLayoutEffect' -> '<PROJECT_ROOT>/packages/shared/src/useLayoutEffect.js'

--- a/jest.config.js
+++ b/jest.config.js
@@ -86,6 +86,8 @@ module.exports = {
           '<rootDir>/packages/lexical/src/nodes/extended/LexicalQuoteNode.js',
         '^shared/canUseDOM$': '<rootDir>/packages/shared/src/canUseDOM.js',
         '^shared/environment$': '<rootDir>/packages/shared/src/environment.js',
+        '^shared/getDOMSelection$':
+          '<rootDir>/packages/shared/src/getDOMSelection.js',
         '^shared/invariant$': '<rootDir>/packages/shared/src/invariant.js',
         '^shared/useLayoutEffect$':
           '<rootDir>/packages/shared/src/useLayoutEffect.js',

--- a/packages/lexical-clipboard/src/clipboard.js
+++ b/packages/lexical-clipboard/src/clipboard.js
@@ -25,9 +25,10 @@ import {
   $getSelection,
   $isElementNode,
 } from 'lexical';
+import getDOMSelection from 'shared/getDOMSelection';
 
 export function getHtmlContent(editor: LexicalEditor): string | null {
-  const domSelection = window.getSelection();
+  const domSelection = getDOMSelection();
   // If we haven't selected a range, then don't copy anything
   if (domSelection.isCollapsed) {
     return null;

--- a/packages/lexical-playground/config/craco.config.js
+++ b/packages/lexical-playground/config/craco.config.js
@@ -102,6 +102,7 @@ module.exports = {
         {},
       ),
       //Shared
+      'shared/getDOMSelection': 'shared/dist/getDOMSelection',
       'shared/environment': 'shared/dist/environment',
       'shared/useLayoutEffect': 'shared/dist/useLayoutEffect',
       'shared/canUseDOM': 'shared/dist/canUseDOM',

--- a/packages/lexical-table/src/lexicalTableCoreHelpers.js
+++ b/packages/lexical-table/src/lexicalTableCoreHelpers.js
@@ -26,6 +26,7 @@ import {
   $isRangeSelection,
   $setSelection,
 } from 'lexical';
+import getDOMSelection from 'shared/getDOMSelection';
 
 import {$isTableCellNode} from './LexicalTableCellNode';
 
@@ -245,14 +246,12 @@ export function $applyCustomTableHandlers(
         const cellY = cell.y;
         if (!isHighlightingCells && (startX !== cellX || startY !== cellY)) {
           event.preventDefault();
-          const windowSelection = window.getSelection();
-          // Collapse the selection
-          windowSelection.setBaseAndExtent(
-            windowSelection.anchorNode,
-            0,
-            windowSelection.anchorNode,
-            0,
-          );
+          const domSelection = getDOMSelection();
+          const anchorNode = domSelection.anchorNode;
+          if (anchorNode !== null) {
+            // Collapse the selection
+            domSelection.setBaseAndExtent(anchorNode, 0, anchorNode, 0);
+          }
           isHighlightingCells = true;
           if (document.body) {
             document.body.appendChild(removeHighlightStyle);

--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -11,6 +11,7 @@ import type {EditorState} from './LexicalEditorState';
 import type {DOMConversion, LexicalNode, NodeKey} from './LexicalNode';
 import type {Node as ReactNode} from 'react';
 
+import getDOMSelection from 'shared/getDOMSelection';
 import invariant from 'shared/invariant';
 
 import {$getRoot, $getSelection, TextNode} from '.';
@@ -624,7 +625,7 @@ class BaseLexicalEditor {
     if (rootElement !== null) {
       rootElement.blur();
     }
-    const domSelection = window.getSelection();
+    const domSelection = getDOMSelection();
     if (domSelection !== null) {
       domSelection.removeAllRanges();
     }

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -13,6 +13,7 @@ import type {ElementNode} from './nodes/base/LexicalElementNode';
 import type {TextNode} from './nodes/base/LexicalTextNode';
 
 import {CAN_USE_BEFORE_INPUT, IS_FIREFOX} from 'shared/environment';
+import getDOMSelection from 'shared/getDOMSelection';
 
 import {
   $getRoot,
@@ -137,7 +138,7 @@ function onClick(event: MouseEvent, editor: LexicalEditor): void {
       ) {
         const lastSelection = editor.getEditorState()._selection;
         if (lastSelection !== null && selection.is(lastSelection)) {
-          window.getSelection().removeAllRanges();
+          getDOMSelection().removeAllRanges();
           selection.dirty = true;
         }
       }
@@ -510,7 +511,7 @@ function getRootElementRemoveHandles(
 const activeNestedEditorsMap: Map<string, LexicalEditor> = new Map();
 
 function onDocumentSelectionChange(event: Event): void {
-  const selection = window.getSelection();
+  const selection = getDOMSelection();
   const nextActiveEditor = getNearestEditorFromDOMNode(selection.anchorNode);
   if (nextActiveEditor === null) {
     return;

--- a/packages/lexical/src/LexicalMutations.js
+++ b/packages/lexical/src/LexicalMutations.js
@@ -15,6 +15,8 @@ import type {
   RangeSelection,
 } from './LexicalSelection';
 
+import getDOMSelection from 'shared/getDOMSelection';
+
 import {
   $getSelection,
   $isDecoratorNode,
@@ -78,7 +80,7 @@ function handleTextMutation(
   node: TextNode,
   editor: LexicalEditor,
 ): void {
-  const domSelection = window.getSelection();
+  const domSelection = getDOMSelection();
   let anchorOffset = null;
   let focusOffset = null;
   if (domSelection !== null && domSelection.anchorNode === target) {

--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -23,6 +23,7 @@ import type {
 import type {ElementNode} from './nodes/base/LexicalElementNode';
 import type {Node as ReactNode} from 'react';
 
+import getDOMSelection from 'shared/getDOMSelection';
 import invariant from 'shared/invariant';
 
 import {
@@ -683,7 +684,6 @@ export function updateEditorState(
 ): null | MutatedNodes {
   const observer = editor._observer;
   let reconcileMutatedNodes = null;
-
   if (needsUpdate && observer !== null) {
     const dirtyType = editor._dirtyType;
     const dirtyElements = editor._dirtyElements;
@@ -708,7 +708,7 @@ export function updateEditorState(
     }
   }
 
-  const domSelection: null | Selection = window.getSelection();
+  const domSelection = getDOMSelection();
   if (
     domSelection !== null &&
     (needsUpdate || pendingSelection === null || pendingSelection.dirty)

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -14,6 +14,7 @@ import type {ParsedSelection} from './LexicalParsing';
 import type {ElementNode} from './nodes/base/LexicalElementNode';
 import type {TextFormatType} from './nodes/base/LexicalTextNode';
 
+import getDOMSelection from 'shared/getDOMSelection';
 import invariant from 'shared/invariant';
 
 import {
@@ -1385,7 +1386,7 @@ export class RangeSelection implements BaseSelection {
       }
     }
 
-    const domSelection = window.getSelection();
+    const domSelection = getDOMSelection();
     // We use the DOM selection.modify API here to "tell" us what the selection
     // will be. We then use it to update the Lexical selection accordingly. This
     // is much more reliable than waiting for a beforeinput and using the ranges
@@ -1402,6 +1403,7 @@ export class RangeSelection implements BaseSelection {
     if (domSelection.rangeCount > 0) {
       const range = domSelection.getRangeAt(0);
       // Apply the DOM selection to our Lexical selection.
+      // $FlowFixMe[incompatible-call]
       this.applyDOMRange(range);
       // Because a range works on start and end, we might need to flip
       // the anchor and focus points to match what the DOM has, not what
@@ -1519,6 +1521,7 @@ function $moveNativeSelection(
   direction: 'backward' | 'forward' | 'left' | 'right',
   granularity: 'character' | 'word' | 'lineboundary',
 ): void {
+  // $FlowFixMe[prop-missing]
   domSelection.modify(alter, direction, granularity);
 }
 
@@ -1857,7 +1860,7 @@ export function internalCreateSelection(
 ): null | RangeSelection | NodeSelection | GridSelection {
   const currentEditorState = editor.getEditorState();
   const lastSelection = currentEditorState._selection;
-  const domSelection = window.getSelection();
+  const domSelection = getDOMSelection();
 
   if ($isNodeSelection(lastSelection)) {
     return lastSelection.clone();

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -28,6 +28,7 @@ import type {TextFormatType, TextNode} from './nodes/base/LexicalTextNode';
 import type {Node as ReactNode} from 'react';
 
 import {IS_APPLE} from 'shared/environment';
+import getDOMSelection from 'shared/getDOMSelection';
 import invariant from 'shared/invariant';
 
 import {
@@ -453,7 +454,7 @@ export function $updateSelectedTextFromDOM(
   compositionEnd: boolean,
 ): void {
   // Update the text content with the latest composition text
-  const domSelection = window.getSelection();
+  const domSelection = getDOMSelection();
   if (domSelection === null) {
     return;
   }
@@ -571,7 +572,7 @@ export function $shouldPreventDefaultAndInsertText(
   const anchor = selection.anchor;
   const focus = selection.focus;
   const anchorNode = anchor.getNode();
-  const domSelection = window.getSelection();
+  const domSelection = getDOMSelection();
   const domAnchorNode = domSelection !== null ? domSelection.anchorNode : null;
   const anchorKey = anchor.key;
   const backingAnchorElement = getActiveEditor().getElementByKey(anchorKey);

--- a/packages/shared/src/getDOMSelection.js
+++ b/packages/shared/src/getDOMSelection.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+const getSelection: () => Selection = window.getSelection;
+
+export default getSelection;


### PR DESCRIPTION
Heavily used function across core, better Flow types and less bytes in the minimized code