### PR TITLE
readOnly can be passed through LexicalEditor constructor

### DIFF
--- a/packages/lexical-react/src/DEPRECATED_useLexical.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexical.js
@@ -23,11 +23,11 @@ export default function useLexical<EditorContext>(editorConfig: {
   context?: EditorContext,
   disableEvents?: boolean,
   editorState?: EditorState,
-  isReadOnly?: boolean,
   namespace?: string,
   nodes?: Array<Class<LexicalNode>>,
   onError: (error: Error) => void,
   parentEditor?: LexicalEditor,
+  readOnly?: boolean,
   theme?: EditorThemeClasses,
 }): [LexicalEditor, (null | HTMLElement) => void, boolean] {
   const editor = useMemo(

--- a/packages/lexical-react/src/LexicalComposer.js
+++ b/packages/lexical-react/src/LexicalComposer.js
@@ -21,10 +21,10 @@ type Props = {
   children: React$Node,
   initialConfig?: {
     editor?: LexicalEditor | null,
-    isReadOnly?: boolean,
     namespace?: string,
     nodes?: Array<Class<LexicalNode>>,
     onError: (error: Error, editor: LexicalEditor) => void,
+    readOnly?: boolean,
     theme?: EditorThemeClasses,
   },
 };
@@ -65,11 +65,11 @@ export default function LexicalComposer({
       if (editor === null) {
         const newEditor = createEditor<LexicalComposerContextType>({
           context,
-          isReadOnly: true,
           namespace,
           nodes,
           onError: (error) => onError(error, newEditor),
           parentEditor,
+          readOnly: true,
           theme: composerTheme,
         });
         editor = newEditor;
@@ -84,7 +84,7 @@ export default function LexicalComposer({
   );
 
   useLayoutEffect(() => {
-    const isReadOnly = initialConfig.isReadOnly;
+    const isReadOnly = initialConfig.readOnly;
     const [editor] = composerContext;
     editor.setReadOnly(isReadOnly || false);
     // We only do this for init

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -34,7 +34,7 @@ type CommandListener = (
   payload: CommandPayload,
   editor: LexicalEditor,
 ) => boolean;
-export type ReadOnlyListener = (isReadOnly: boolean) => void;
+export type ReadOnlyListener = (readOnly: boolean) => void;
 
 type CommandPayload = any;
 type Listeners = {
@@ -114,7 +114,7 @@ export declare class LexicalEditor {
   focus(callbackFn?: () => void): void;
   blur(): void;
   isReadOnly(): boolean;
-  setReadOnly(isReadOnly: boolean): void;
+  setReadOnly(readOnly: boolean): void;
 }
 type EditorUpdateOptions = {
   onUpdate?: () => void;
@@ -207,7 +207,7 @@ export function createEditor<EditorContext>(editorConfig?: {
   nodes?: Array<Class<LexicalNode>>;
   onError: (error: Error) => void;
   disableEvents?: boolean;
-  isReadOnly?: boolean;
+  readOnly?: boolean;
 }): LexicalEditor;
 
 /**

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -37,7 +37,7 @@ type CommandListener = (
   payload: CommandPayload,
   editor: LexicalEditor,
 ) => boolean;
-export type ReadOnlyListener = (isReadOnly: boolean) => void;
+export type ReadOnlyListener = (readOnly: boolean) => void;
 
 //$FlowFixMe
 type CommandPayload = any;
@@ -126,7 +126,7 @@ declare export class LexicalEditor {
   focus(callbackFn?: () => void): void;
   blur(): void;
   isReadOnly(): boolean;
-  setReadOnly(isReadOnly: boolean): void;
+  setReadOnly(readOnly: boolean): void;
 }
 type EditorUpdateOptions = {
   onUpdate?: () => void,
@@ -219,7 +219,7 @@ declare export function createEditor<EditorContext>(editorConfig?: {
   nodes?: Array<Class<LexicalNode>>,
   onError: (error: Error) => void,
   disableEvents?: boolean,
-  isReadOnly?: boolean,
+  readOnly?: boolean,
 }): LexicalEditor;
 
 /**

--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -141,7 +141,7 @@ export type CommandListener = (
   payload: CommandPayload,
   editor: LexicalEditor,
 ) => boolean;
-export type ReadOnlyListener = (isReadOnly: boolean) => void;
+export type ReadOnlyListener = (readOnly: boolean) => void;
 
 export type CommandListenerEditorPriority = 0;
 export type CommandListenerLowPriority = 1;
@@ -247,11 +247,11 @@ export function createEditor<EditorContext>(editorConfig?: {
   context?: EditorContext,
   disableEvents?: boolean,
   editorState?: EditorState,
-  isReadOnly?: boolean,
   namespace?: string,
   nodes?: Array<Class<LexicalNode>>,
   onError: ErrorHandler,
   parentEditor?: LexicalEditor,
+  readOnly?: boolean,
   theme?: EditorThemeClasses,
 }): LexicalEditor {
   const config = editorConfig || {};
@@ -270,7 +270,7 @@ export function createEditor<EditorContext>(editorConfig?: {
     ...(config.nodes || []),
   ];
   const onError = config.onError;
-  const isReadOnly = config.isReadOnly || false;
+  const isReadOnly = config.readOnly || false;
 
   const registeredNodes = new Map();
   for (let i = 0; i < nodes.length; i++) {
@@ -344,7 +344,7 @@ class BaseLexicalEditor {
     config: EditorConfig<{...}>,
     onError: ErrorHandler,
     htmlConversions: DOMConversionCache,
-    isReadOnly: boolean,
+    readOnly: boolean,
   ) {
     this._parentEditor = parentEditor;
     // The root element associated with this editor
@@ -632,9 +632,9 @@ class BaseLexicalEditor {
   isReadOnly(): boolean {
     return this._readOnly;
   }
-  setReadOnly(isReadOnly: boolean): void {
-    this._readOnly = isReadOnly;
-    triggerListeners('readonly', getSelf(this), true, isReadOnly);
+  setReadOnly(readOnly: boolean): void {
+    this._readOnly = readOnly;
+    triggerListeners('readonly', getSelf(this), true, readOnly);
   }
 }
 
@@ -698,7 +698,7 @@ declare export class LexicalEditor {
   isReadOnly(): boolean;
   parseEditorState(stringifiedEditorState: string): EditorState;
   setEditorState(editorState: EditorState, options?: EditorSetOptions): void;
-  setReadOnly(isReadOnly: boolean): void;
+  setReadOnly(readOnly: boolean): void;
   setRootElement(rootElement: null | HTMLElement): void;
   update(updateFn: () => void, options?: EditorUpdateOptions): boolean;
 }


### PR DESCRIPTION
Note for reviewers:

I think the default to `false` is the most user-friendly, otherwise we'll go back to the BootstrapPlugin point when users won't understand why they can type on the editor. Advanced users who understand SSR and race conditions can start with `true` instead