### PR TITLE
window.Promise when CAN_USE_DOM

### DIFF
--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -83,13 +83,12 @@ export function getRegisteredNodeOrThrow(
 
 export const isArray = Array.isArray;
 
-const NativePromise = Promise;
-
 export const scheduleMicroTask: (fn: () => void) => void =
   typeof queueMicrotask === 'function'
     ? queueMicrotask
     : (fn) => {
-        NativePromise.resolve().then(fn);
+        // No window prefix intended (#1400)
+        Promise.resolve().then(fn);
       };
 
 export function isSelectionWithinEditor(


### PR DESCRIPTION
> in Lexical.dev.js in the top-level scope, NativePromise is defined as window.Promise which makes things throw ("window is not defined") in a node environment

Closes https://github.com/facebook/lexical/issues/1177 
Closes #1400