### PR TITLE
Deprecate editor prop from LexicalComposer

### DIFF
--- a/packages/lexical-react/LexicalComposer.d.ts
+++ b/packages/lexical-react/LexicalComposer.d.ts
@@ -10,7 +10,7 @@ import {Class} from 'utility-types';
 import type {EditorThemeClasses, LexicalEditor, LexicalNode} from 'lexical';
 type Props = {
   initialConfig: {
-    editor?: LexicalEditor | null;
+    editor__DEPRECATED?: LexicalEditor | null;
     isReadOnly?: boolean;
     namespace?: string;
     nodes?: Array<Class<LexicalNode>>;

--- a/packages/lexical-react/flow/LexicalComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalComposer.js.flow
@@ -11,7 +11,7 @@ import type {EditorThemeClasses, LexicalEditor, LexicalNode} from 'lexical';
 
 type Props = {
   initialConfig: $ReadOnly<{
-    editor?: LexicalEditor | null,
+    editor__DEPRECATED?: LexicalEditor | null,
     isReadOnly?: boolean,
     namespace?: string,
     nodes?: $ReadOnlyArray<Class<LexicalNode>>,

--- a/packages/lexical-react/src/LexicalComposer.js
+++ b/packages/lexical-react/src/LexicalComposer.js
@@ -21,7 +21,7 @@ import useLayoutEffect from 'shared/useLayoutEffect';
 type Props = {
   children: React$Node,
   initialConfig: $ReadOnly<{
-    editor?: LexicalEditor | null,
+    editor__DEPRECATED?: LexicalEditor | null,
     namespace?: string,
     nodes?: $ReadOnlyArray<Class<LexicalNode>>,
     onError: (error: Error, editor: LexicalEditor) => void,
@@ -42,7 +42,7 @@ export default function LexicalComposer({
       const {
         theme,
         namespace,
-        editor: initialEditor,
+        editor__DEPRECATED: initialEditor,
         nodes,
         onError,
       } = initialConfig;


### PR DESCRIPTION
This prop is a bad idea, makes newcomers think it's fine to pass their own built-in editor. It's also confusing because LexicalComposer props and createEditor props are duplicated. 

Are there are valid use case other than making it easier to migrate surfaces using deprecated hooks? If that's the case maybe we should maybe this prop as deprecated as well until we can kill the hooks.