### PR TITLE
Remove deprecated error types

### DIFF
--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -14,7 +14,6 @@ import {Class, $ReadOnly} from 'utility-types';
 type ErrorHandler = (error: Error) => void;
 type MutationListeners = Map<MutationListener, Class<LexicalNode>>;
 export type NodeMutation = 'created' | 'destroyed';
-export type ErrorListener = (error: Error) => void;
 type UpdateListener = (arg0: {
   tags: Set<string>;
   prevEditorState: EditorState;
@@ -40,7 +39,6 @@ export type ReadOnlyListener = (readOnly: boolean) => void;
 type CommandPayload = any;
 type Listeners = {
   decorator: Set<DecoratorListener>;
-  error: Set<ErrorListener>;
   mutation: MutationListeners;
   textcontent: Set<TextContentListener>;
   root: Set<RootListener>;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -13,7 +13,6 @@
 
 type MutationListeners = Map<MutationListener, Class<LexicalNode>>;
 export type NodeMutation = 'created' | 'destroyed';
-export type ErrorListener = (error: Error) => void;
 type UpdateListener = ({
   tags: Set<string>,
   prevEditorState: EditorState,
@@ -44,7 +43,6 @@ export type ReadOnlyListener = (readOnly: boolean) => void;
 type CommandPayload = any;
 type Listeners = {
   decorator: Set<DecoratorListener>,
-  error: Set<ErrorListener>,
   mutation: MutationListeners,
   textcontent: Set<TextContentListener>,
   root: Set<RootListener>,


### PR DESCRIPTION
Error listeners were removed in #1274 but the type definition files were not updated. 

This PR removes them.