### PR TITLE
fix null value from getLocalState() when provider awareness reset during reload

### DIFF
--- a/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow
@@ -18,7 +18,7 @@ export type UserState = {
 };
 
 export type ProviderAwareness = {
-  getLocalState: () => UserState,
+  getLocalState: () => UserState | null,
   setLocalState: (UserState) => void,
   getStates: () => Map<number, UserState>,
   on: (type: 'update', cb: () => void) => void,

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.js
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.js
@@ -75,7 +75,7 @@ export function CollaborationPlugin({
   );
   collabContext.clientID = binding.clientID;
   useYjsHistory(editor, binding);
-  useYjsFocusTracking(editor, provider);
+  useYjsFocusTracking(editor, provider, name, color);
 
   return cursors;
 }

--- a/packages/lexical-react/src/shared/useYjsCollaboration.js
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.js
@@ -193,21 +193,26 @@ export function useYjsCollaboration(
   return [cursorsContainer, binding];
 }
 
-export function useYjsFocusTracking(editor: LexicalEditor, provider: Provider) {
+export function useYjsFocusTracking(
+  editor: LexicalEditor,
+  provider: Provider,
+  name: string,
+  color: string,
+) {
   useEffect(() => {
     return editor.addListener(
       'command',
       (type, payload) => {
         if (type === 'focus') {
-          setLocalStateFocus(provider, true);
+          setLocalStateFocus(provider, name, color, true);
         } else if (type === 'blur') {
-          setLocalStateFocus(provider, false);
+          setLocalStateFocus(provider, name, color, false);
         }
         return false;
       },
       EditorPriority,
     );
-  }, [editor, provider]);
+  }, [color, editor, name, provider]);
 }
 
 export function useYjsHistory(

--- a/packages/lexical-yjs/src/index.js
+++ b/packages/lexical-yjs/src/index.js
@@ -22,7 +22,7 @@ export type UserState = {
 };
 
 export type ProviderAwareness = {
-  getLocalState: () => UserState,
+  getLocalState: () => UserState | null,
   getStates: () => Map<number, UserState>,
   off: (type: 'update', cb: () => void) => void,
   on: (type: 'update', cb: () => void) => void,
@@ -85,12 +85,25 @@ export function initLocalState(
   });
 }
 
-export function setLocalStateFocus(provider: Provider, focusing: boolean) {
+export function setLocalStateFocus(
+  provider: Provider,
+  name: string,
+  color: string,
+  focusing: boolean,
+) {
   const {awareness} = provider;
-  awareness.setLocalState({
-    ...awareness.getLocalState(),
-    focusing,
-  });
+  let localState = awareness.getLocalState();
+  if (localState === null) {
+    localState = {
+      anchorPos: null,
+      color,
+      focusPos: null,
+      focusing: focusing,
+      name,
+    };
+  }
+  localState.focusing = focusing;
+  awareness.setLocalState(localState);
 }
 
 export {syncCursorPositions} from './SyncCursors';


### PR DESCRIPTION
according to https://github.com/yjs/y-protocols/blob/master/awareness.js#L95, awareness.getLocalState could be null as return value. When provider reloads, provider.awareness will be destroyed and recreated. A new awareness won't have localstate initially thus will return null. Fixing the setLocalStateFocus logic in lexical that if localState doesn't exist, re-initialize it.