### PR TITLE
[RFC] DecoratorEditor -> DecoratorEditorState

### DIFF
--- a/packages/lexical-playground/src/nodes/ImageNode.js
+++ b/packages/lexical-playground/src/nodes/ImageNode.js
@@ -13,7 +13,7 @@ import type {
   LexicalNode,
   LexicalEditor,
   DecoratorMap,
-  DecoratorEditor,
+  DecoratorEditorState,
   CommandListenerLowPriority,
 } from 'lexical';
 
@@ -21,7 +21,7 @@ import * as React from 'react';
 import {
   DecoratorNode,
   $getNodeByKey,
-  createDecoratorEditor,
+  createDecoratorEditorState,
   $getSelection,
   $isNodeSelection,
 } from 'lexical';
@@ -332,10 +332,10 @@ function ImageComponent({
   const {yjsDocMap} = useCollaborationContext();
   const [editor] = useLexicalComposerContext();
   const isCollab = yjsDocMap.get('main') !== undefined;
-  const [decoratorEditor] = useLexicalDecoratorMap<DecoratorEditor>(
+  const [decoratorEditor] = useLexicalDecoratorMap<DecoratorEditorState>(
     state,
     'caption',
-    () => createDecoratorEditor(),
+    () => createDecoratorEditorState(),
   );
   const [selection, setSelection] = useState(null);
 

--- a/packages/lexical-playground/src/nodes/StickyNode.js
+++ b/packages/lexical-playground/src/nodes/StickyNode.js
@@ -12,7 +12,7 @@ import type {
   LexicalNode,
   LexicalEditor,
   DecoratorMap,
-  DecoratorEditor,
+  DecoratorEditorState,
   NodeKey,
 } from 'lexical';
 
@@ -22,7 +22,7 @@ import {
   DecoratorNode,
   $getNodeByKey,
   $setSelection,
-  createDecoratorEditor,
+  createDecoratorEditorState,
 } from 'lexical';
 // $FlowFixMe
 import {createPortal} from 'react-dom';
@@ -117,10 +117,10 @@ function StickyComponent({
   });
   const {yjsDocMap} = useCollaborationContext();
   const isCollab = yjsDocMap.get('main') !== undefined;
-  const [decoratorEditor] = useLexicalDecoratorMap<DecoratorEditor>(
+  const [decoratorEditor] = useLexicalDecoratorMap<DecoratorEditorState>(
     decoratorStateMap,
     'caption',
-    () => createDecoratorEditor(),
+    () => createDecoratorEditorState(),
   );
 
   useEffect(() => {

--- a/packages/lexical-react/flow/LexicalNestedComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalNestedComposer.js.flow
@@ -7,11 +7,15 @@
  * @flow strict
  */
 
-import type {DecoratorEditor, EditorThemeClasses, LexicalNode} from 'lexical';
+import type {
+  DecoratorEditorState,
+  EditorThemeClasses,
+  LexicalNode,
+} from 'lexical';
 
 declare export default function LexicalNestedComposer({
   initialConfig: $ReadOnly<{
-    decoratorEditor: DecoratorEditor,
+    decoratorEditor: DecoratorEditorState,
     theme?: EditorThemeClasses,
   }>,
   children: React$Node,

--- a/packages/lexical-react/src/LexicalNestedComposer.js
+++ b/packages/lexical-react/src/LexicalNestedComposer.js
@@ -8,7 +8,7 @@
  */
 
 import type {LexicalComposerContextType} from '@lexical/react/LexicalComposerContext';
-import type {DecoratorEditor, EditorThemeClasses} from 'lexical';
+import type {DecoratorEditorState, EditorThemeClasses} from 'lexical';
 
 import {
   createLexicalComposerContext,
@@ -26,7 +26,7 @@ export default function LexicalNestedComposer({
 }: {
   children: React$Node,
   initialConfig: $ReadOnly<{
-    decoratorEditor: DecoratorEditor,
+    decoratorEditor: DecoratorEditorState,
     theme?: EditorThemeClasses,
   }>,
 }): React$Node {

--- a/packages/lexical-yjs/src/SyncDecoratorStates.js
+++ b/packages/lexical-yjs/src/SyncDecoratorStates.js
@@ -13,10 +13,10 @@ import type {DecoratorArray, DecoratorMap, DecoratorStateValue} from 'lexical';
 
 import {
   createDecoratorArray,
-  createDecoratorEditor,
+  createDecoratorEditorState,
   createDecoratorMap,
   isDecoratorArray,
-  isDecoratorEditor,
+  isDecoratorEditorState,
   isDecoratorMap,
 } from 'lexical';
 import invariant from 'shared/invariant';
@@ -118,7 +118,7 @@ export function syncLexicalDecoratorMapKeyToYjs(
         observeDecoratorMap(binding, collabNode, lexicalValue, yjsValue);
       }
       syncLexicalDecoratorMapToYjs(binding, collabNode, lexicalValue, yjsValue);
-    } else if (isDecoratorEditor(lexicalValue)) {
+    } else if (isDecoratorEditorState(lexicalValue)) {
       let doc;
       if (yjsValue === undefined) {
         yjsValue = new YMap();
@@ -189,7 +189,7 @@ function syncLexicalDecoratorArrayValueToYjs(
         observeDecoratorMap(binding, collabNode, lexicalValue, yjsValue);
       }
       syncLexicalDecoratorMapToYjs(binding, collabNode, lexicalValue, yjsValue);
-    } else if (isDecoratorEditor(lexicalValue)) {
+    } else if (isDecoratorEditorState(lexicalValue)) {
       let doc;
       if (yjsValue === undefined) {
         yjsValue = new YMap();
@@ -295,7 +295,7 @@ function syncYjsDecoratorMapKeyToLexical(
           const yjsDocMap = binding.docMap;
           const id = yjsValue.get('id');
           const doc = yjsValue.get('doc');
-          nextValue = createDecoratorEditor(id);
+          nextValue = createDecoratorEditorState(id);
           yjsValue._lexicalValue = nextValue;
           yjsValue._collabNode = collabNode;
           yjsDocMap.set(id, doc);
@@ -355,7 +355,7 @@ export function syncYjsDecoratorArrayValueToLexical(
           const yjsDocMap = binding.docMap;
           const id = yjsValue.get('id');
           const doc = yjsValue.get('doc');
-          nextValue = createDecoratorEditor(id);
+          nextValue = createDecoratorEditorState(id);
           yjsValue._lexicalValue = nextValue;
           yjsValue._collabNode = collabNode;
           yjsDocMap.set(id, doc);

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -501,13 +501,13 @@ export function $getPreviousSelection():
  */
 export type DecoratorStateValue =
   | DecoratorMap
-  | DecoratorEditor
+  | DecoratorEditorState
   | DecoratorArray
   | null
   | boolean
   | number
   | string;
-export declare class DecoratorEditor {
+export declare class DecoratorEditorState {
   id: string;
   editorState: null | EditorState | string;
   editor: null | LexicalEditor;
@@ -544,11 +544,13 @@ export declare class DecoratorMap {
     map: Array<[string, DecoratorStateValue]>;
   };
 }
-export function createDecoratorEditor(
+export function createDecoratorEditorState(
   id?: string,
   editorState?: string | EditorState,
-): DecoratorEditor;
-export function isDecoratorEditor(obj: unknown | null | undefined): boolean;
+): DecoratorEditorState;
+export function isDecoratorEditorState(
+  obj: unknown | null | undefined,
+): boolean;
 export function createDecoratorMap(
   editor: LexicalEditor,
   map?: Map<string, DecoratorStateValue>,

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -554,14 +554,14 @@ declare export function $getPreviousSelection():
 
 export type DecoratorStateValue =
   | DecoratorMap
-  | DecoratorEditor
+  | DecoratorEditorState
   | DecoratorArray
   | null
   | boolean
   | number
   | string;
 
-declare export class DecoratorEditor {
+declare export class DecoratorEditorState {
   id: string;
   editorState: null | EditorState | string;
   editor: null | LexicalEditor;
@@ -617,14 +617,14 @@ declare export class DecoratorMap {
   }>;
 }
 
-declare export function createDecoratorEditor(
+declare export function createDecoratorEditorState(
   id?: string,
   editorState?: string | EditorState,
-): DecoratorEditor;
+): DecoratorEditorState;
 
-declare export function isDecoratorEditor(
+declare export function isDecoratorEditorState(
   obj: ?mixed,
-): boolean %checks(obj instanceof DecoratorEditor);
+): boolean %checks(obj instanceof DecoratorEditorState);
 
 declare export function createDecoratorMap(
   editor: LexicalEditor,

--- a/packages/lexical/src/LexicalParsing.js
+++ b/packages/lexical/src/LexicalParsing.js
@@ -25,7 +25,7 @@ import {
 } from './LexicalUpdates';
 import {
   createDecoratorArray,
-  createDecoratorEditor,
+  createDecoratorEditorState,
   createDecoratorMap,
 } from './nodes/base/LexicalDecoratorNode';
 
@@ -114,7 +114,10 @@ function createDecoratorValueFromParse(
   } else if (typeof parsedValue === 'object') {
     const bindingType = parsedValue.type;
     if (bindingType === 'editor') {
-      value = createDecoratorEditor(parsedValue.id, parsedValue.editorState);
+      value = createDecoratorEditorState(
+        parsedValue.id,
+        parsedValue.editorState,
+      );
     } else if (bindingType === 'array') {
       value = createDecoratorArrayFromParse(editor, parsedValue);
     } else {

--- a/packages/lexical/src/index.js
+++ b/packages/lexical/src/index.js
@@ -33,7 +33,7 @@ import {VERSION} from './LexicalVersion';
 import {
   $isDecoratorNode,
   createDecoratorArray,
-  createDecoratorEditor,
+  createDecoratorEditorState,
   createDecoratorMap,
   DecoratorNode,
   isDecoratorArray,
@@ -91,7 +91,7 @@ export {
   $setCompositionKey,
   $setSelection,
   createDecoratorArray,
-  createDecoratorEditor,
+  createDecoratorEditorState,
   createDecoratorMap,
   createEditor,
   DecoratorNode,

--- a/packages/lexical/src/nodes/base/LexicalDecoratorNode.js
+++ b/packages/lexical/src/nodes/base/LexicalDecoratorNode.js
@@ -20,7 +20,7 @@ import {createUID} from '../../LexicalUtils';
 
 export type DecoratorStateValue =
   | DecoratorMap
-  | DecoratorEditor
+  | DecoratorEditorState
   | DecoratorArray
   | null
   | boolean
@@ -44,15 +44,13 @@ function isStringified(
   return typeof editorState === 'string';
 }
 
-export class DecoratorEditor {
+export class DecoratorEditorState {
   id: string;
   editorState: null | EditorState | string;
-  editor: null | LexicalEditor;
 
   constructor(id?: string, editorState?: string | EditorState) {
     this.id = id || createUID();
     this.editorState = editorState || null;
-    this.editor = null;
   }
 
   init(editor: LexicalEditor): void {
@@ -69,7 +67,6 @@ export class DecoratorEditor {
   }
 
   set(editor: LexicalEditor): void {
-    this.editor = editor;
     this.editorState = editor.getEditorState();
   }
 
@@ -94,15 +91,15 @@ export class DecoratorEditor {
   }
 }
 
-export function createDecoratorEditor(
+export function createDecoratorEditorState(
   id?: string,
   editorState?: string | EditorState,
-): DecoratorEditor {
-  return new DecoratorEditor(id, editorState);
+): DecoratorEditorState {
+  return new DecoratorEditorState(id, editorState);
 }
 
 export function isDecoratorEditor(x?: mixed): boolean %checks {
-  return x instanceof DecoratorEditor;
+  return x instanceof DecoratorEditorState;
 }
 
 export class DecoratorMap {


### PR DESCRIPTION
Why the editor prop? Nothing else is attached to editor. DecoratorNode, etc. The DecoratorEditor is simply a transport layer for the EditorState

I can do the same for Map/etc. if this PR makes any sense