### PR TITLE
Expand toMatchEditorInlineSnapshot API

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables-test.js
+++ b/packages/lexical-playground/__tests__/e2e/Tables-test.js
@@ -98,96 +98,96 @@ describe('Tables', () => {
         await insertTable(page);
 
         await expect(page).toMatchEditorInlineSnapshot(`
-                <p><br /></p>
-                <table>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                </table>
-                <p><br /></p>
-              `);
+            <p><br /></p>
+            <table>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <th>
+                  <p><br /></p>
+                </th>
+                <th>
+                  <p><br /></p>
+                </th>
+                <th>
+                  <p><br /></p>
+                </th>
+                <th>
+                  <p><br /></p>
+                </th>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+            </table>
+            <p><br /></p>
+        `);
       },
     );
 
@@ -200,96 +200,96 @@ describe('Tables', () => {
       await page.keyboard.type('abc');
 
       await expect(page).toMatchEditorInlineSnapshot(`
-              <p><br /></p>
-              <table>
-                <tr>
-                  <th>
-                    <p dir="ltr"><span data-lexical-text="true">abc</span></p>
-                  </th>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                </tr>
-                <tr>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                </tr>
-                <tr>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                </tr>
-                <tr>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                </tr>
-                <tr>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                </tr>
-              </table>
-              <p><br /></p>
-            `);
+          <p><br /></p>
+          <table>
+            <tr>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">abc</span></p>
+              </th>
+              <th>
+                <p><br /></p>
+              </th>
+              <th>
+                <p><br /></p>
+              </th>
+              <th>
+                <p><br /></p>
+              </th>
+              <th>
+                <p><br /></p>
+              </th>
+            </tr>
+            <tr>
+              <th>
+                <p><br /></p>
+              </th>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <p><br /></p>
+              </th>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <p><br /></p>
+              </th>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <p><br /></p>
+              </th>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+            </tr>
+          </table>
+          <p><br /></p>
+      `);
     });
 
     it.skipIf(e2e.isPlainText, `Can navigate table with keyboard`, async () => {
@@ -301,96 +301,96 @@ describe('Tables', () => {
       await fillTablePartiallyWithText(page);
 
       await expect(page).toMatchEditorInlineSnapshot(`
-              <p><br /></p>
-              <table>
-                <tr>
-                  <th>
-                    <p dir="ltr"><span data-lexical-text="true">a</span></p>
-                  </th>
-                  <th>
-                    <p dir="ltr"><span data-lexical-text="true">bb</span></p>
-                  </th>
-                  <th>
-                    <p dir="ltr"><span data-lexical-text="true">cc</span></p>
-                  </th>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                </tr>
-                <tr>
-                  <th>
-                    <p dir="ltr"><span data-lexical-text="true">d</span></p>
-                  </th>
-                  <td>
-                    <p dir="ltr"><span data-lexical-text="true">e</span></p>
-                  </td>
-                  <td>
-                    <p dir="ltr"><span data-lexical-text="true">f</span></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                </tr>
-                <tr>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                </tr>
-                <tr>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                </tr>
-                <tr>
-                  <th>
-                    <p><br /></p>
-                  </th>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                  <td>
-                    <p><br /></p>
-                  </td>
-                </tr>
-              </table>
-              <p><br /></p>
-            `);
+          <p><br /></p>
+          <table>
+            <tr>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">a</span></p>
+              </th>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">bb</span></p>
+              </th>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+              </th>
+              <th>
+                <p><br /></p>
+              </th>
+              <th>
+                <p><br /></p>
+              </th>
+            </tr>
+            <tr>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">d</span></p>
+              </th>
+              <td>
+                <p dir="ltr"><span data-lexical-text="true">e</span></p>
+              </td>
+              <td>
+                <p dir="ltr"><span data-lexical-text="true">f</span></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <p><br /></p>
+              </th>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <p><br /></p>
+              </th>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <p><br /></p>
+              </th>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+            </tr>
+          </table>
+          <p><br /></p>
+      `);
     });
 
     it.skipIf(
@@ -405,190 +405,194 @@ describe('Tables', () => {
         await fillTablePartiallyWithText(page);
         await selectCellsFromTableCords(page, {x: 0, y: 0}, {x: 1, y: 1});
 
-        await expect(page).toMatchEditorInlineSnapshot(`
-                <p><br /></p>
-                <table>
-                  <tr>
-                    <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
-                      <p dir="ltr"><span data-lexical-text="true">a</span></p>
-                    </th>
-                    <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
-                      <p dir="ltr"><span data-lexical-text="true">bb</span></p>
-                    </th>
-                    <th>
-                      <p dir="ltr"><span data-lexical-text="true">cc</span></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                  </tr>
-                  <tr>
-                    <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
-                      <p dir="ltr"><span data-lexical-text="true">d</span></p>
-                    </th>
-                    <td style="background-color: rgb(163, 187, 255); caret-color: transparent">
-                      <p dir="ltr"><span data-lexical-text="true">e</span></p>
-                    </td>
-                    <td>
-                      <p dir="ltr"><span data-lexical-text="true">f</span></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                </table>
-                <p><br /></p>
-              `);
+        await expect({
+          page,
+          ignoreSecondFrame: true,
+          ignoreInlineStyles: false,
+        }).toMatchEditorInlineSnapshot(`
+            <p><br /></p>
+            <table>
+              <tr>
+                <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
+                  <p dir="ltr"><span data-lexical-text="true">a</span></p>
+                </th>
+                <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
+                  <p dir="ltr"><span data-lexical-text="true">bb</span></p>
+                </th>
+                <th>
+                  <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+                </th>
+                <th>
+                  <p><br /></p>
+                </th>
+                <th>
+                  <p><br /></p>
+                </th>
+              </tr>
+              <tr>
+                <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
+                  <p dir="ltr"><span data-lexical-text="true">d</span></p>
+                </th>
+                <td style="background-color: rgb(163, 187, 255); caret-color: transparent">
+                  <p dir="ltr"><span data-lexical-text="true">e</span></p>
+                </td>
+                <td>
+                  <p dir="ltr"><span data-lexical-text="true">f</span></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+            </table>
+            <p><br /></p>
+        `);
 
         // Check that the highlight styles are applied.
         await expect(page).toMatchEditorInlineSnapshot(`
+          <p><br /></p>
+          <table>
+            <tr>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">a</span></p>
+              </th>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">bb</span></p>
+              </th>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+              </th>
+              <th>
                 <p><br /></p>
-                <table>
-                  <tr>
-                    <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
-                      <p dir="ltr"><span data-lexical-text="true">a</span></p>
-                    </th>
-                    <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
-                      <p dir="ltr"><span data-lexical-text="true">bb</span></p>
-                    </th>
-                    <th>
-                      <p dir="ltr"><span data-lexical-text="true">cc</span></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                  </tr>
-                  <tr>
-                    <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
-                      <p dir="ltr"><span data-lexical-text="true">d</span></p>
-                    </th>
-                    <td style="background-color: rgb(163, 187, 255); caret-color: transparent">
-                      <p dir="ltr"><span data-lexical-text="true">e</span></p>
-                    </td>
-                    <td>
-                      <p dir="ltr"><span data-lexical-text="true">f</span></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                </table>
+              </th>
+              <th>
                 <p><br /></p>
-              `);
+              </th>
+            </tr>
+            <tr>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">d</span></p>
+              </th>
+              <td>
+                <p dir="ltr"><span data-lexical-text="true">e</span></p>
+              </td>
+              <td>
+                <p dir="ltr"><span data-lexical-text="true">f</span></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <p><br /></p>
+              </th>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <p><br /></p>
+              </th>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <p><br /></p>
+              </th>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+              <td>
+                <p><br /></p>
+              </td>
+            </tr>
+          </table>
+          <p><br /></p>
+        `);
       },
     );
 
@@ -612,97 +616,101 @@ describe('Tables', () => {
         ]);
 
         // Check that the character styles are applied.
-        await expect(page).toMatchEditorInlineSnapshot(`
-                <p><br /></p>
-                <table>
-                  <tr>
-                    <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
-                      <p dir="ltr"><strong data-lexical-text="true">a</strong></p>
-                    </th>
-                    <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
-                      <p dir="ltr"><strong data-lexical-text="true">bb</strong></p>
-                    </th>
-                    <th>
-                      <p dir="ltr"><span data-lexical-text="true">cc</span></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                  </tr>
-                  <tr>
-                    <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
-                      <p dir="ltr"><strong data-lexical-text="true">d</strong></p>
-                    </th>
-                    <td style="background-color: rgb(163, 187, 255); caret-color: transparent">
-                      <p dir="ltr"><strong data-lexical-text="true">e</strong></p>
-                    </td>
-                    <td>
-                      <p dir="ltr"><span data-lexical-text="true">f</span></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                </table>
-                <p><br /></p>
-              `);
+        await expect({
+          page,
+          ignoreSecondFrame: true,
+          ignoreInlineStyles: false,
+        }).toMatchEditorInlineSnapshot(`
+            <p><br /></p>
+            <table>
+              <tr>
+                <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
+                  <p dir="ltr"><strong data-lexical-text="true">a</strong></p>
+                </th>
+                <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
+                  <p dir="ltr"><strong data-lexical-text="true">bb</strong></p>
+                </th>
+                <th>
+                  <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+                </th>
+                <th>
+                  <p><br /></p>
+                </th>
+                <th>
+                  <p><br /></p>
+                </th>
+              </tr>
+              <tr>
+                <th style="background-color: rgb(163, 187, 255); caret-color: transparent">
+                  <p dir="ltr"><strong data-lexical-text="true">d</strong></p>
+                </th>
+                <td style="background-color: rgb(163, 187, 255); caret-color: transparent">
+                  <p dir="ltr"><strong data-lexical-text="true">e</strong></p>
+                </td>
+                <td>
+                  <p dir="ltr"><span data-lexical-text="true">f</span></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+            </table>
+            <p><br /></p>
+        `);
       },
     );
 
@@ -722,96 +730,96 @@ describe('Tables', () => {
 
         // Check that the text was cleared.
         await expect(page).toMatchEditorInlineSnapshot(`
-                <p><br /></p>
-                <table>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <th>
-                      <p dir="ltr"><span data-lexical-text="true">cc</span></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p dir="ltr"><span data-lexical-text="true">f</span></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <p><br /></p>
-                    </th>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                    <td>
-                      <p><br /></p>
-                    </td>
-                  </tr>
-                </table>
-                <p><br /></p>
-              `);
+            <p><br /></p>
+            <table>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <th>
+                  <p><br /></p>
+                </th>
+                <th>
+                  <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+                </th>
+                <th>
+                  <p><br /></p>
+                </th>
+                <th>
+                  <p><br /></p>
+                </th>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p dir="ltr"><span data-lexical-text="true">f</span></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <p><br /></p>
+                </th>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+                <td>
+                  <p><br /></p>
+                </td>
+              </tr>
+            </table>
+            <p><br /></p>
+        `);
       },
     );
   });

--- a/packages/lexical-playground/__tests__/utils/index.js
+++ b/packages/lexical-playground/__tests__/utils/index.js
@@ -25,7 +25,7 @@ export const IS_COLLAB =
 
 jest.setTimeout(60000);
 
-const retryCount = 2;
+const retryCount = 20;
 
 type Config = $ReadOnly<{
   appSettings?: AppSettings,
@@ -554,35 +554,128 @@ export async function dragMouse(page, firstBoundingBox, secondBoundingBox) {
 }
 
 expect.extend({
-  async toMatchEditorInlineSnapshot(pageOrParentElement, ...args) {
+  async toMatchEditorInlineSnapshot(pageOrOptions, ...args) {
     // Setting error field allows jest to know where the matcher was called
     // to populate inline snapshot during update cycle
     this.error = new Error();
+    let html;
 
-    const editorElement = await getEditorElement(pageOrParentElement);
-    const html = await editorElement.innerHTML();
-    return toMatchInlineSnapshot.call(this, new HtmlForPrettier(html), ...args);
+    const {
+      page,
+      ignoreSecondFrame,
+      ignoreClasses,
+      ignoreInlineStyles,
+      parentSelector,
+    } = isElement(pageOrOptions)
+      ? {
+          page: pageOrOptions,
+          ignoreSecondFrame: false,
+          ignoreClasses: true,
+          ignoreInlineStyles: true,
+          parentSelector: '.editor-shell',
+        }
+      : {
+          page: pageOrOptions.page,
+          ignoreSecondFrame: pageOrOptions.ignoreSecondFrame === true,
+          ignoreClasses: pageOrOptions.ignoreClasses !== false,
+          ignoreInlineStyles: pageOrOptions.ignoreInlineStyles !== false,
+          parentSelector: pageOrOptions.parentSelector || '.editor-shell',
+        };
+
+    const editorSelector = `${parentSelector} div[contenteditable="true"]`;
+
+    if (!isElement(page)) {
+      throw new Error(
+        'toMatchEditorInlineSnapshot expects page or options object with page property',
+      );
+    }
+
+    if (IS_COLLAB) {
+      // For collab we make sure that left and right sides are matching each other
+      // and then asserting it to the snapshot
+      const leftFrame = await page.frame('left');
+      const leftFrameEditor = await leftFrame.$(editorSelector);
+      const leftFrameHTML = new PrettyHTML(await leftFrameEditor.innerHTML(), {
+        ignoreClasses,
+        ignoreInlineStyles,
+      }).prettify();
+
+      if (!ignoreSecondFrame) {
+        let attempts = 5;
+
+        while (attempts--) {
+          const rightFrame = await page.frame('right');
+          const rightFrameEditor = await rightFrame.$(editorSelector);
+          const rightFrameHTML = new PrettyHTML(
+            await rightFrameEditor.innerHTML(),
+            {ignoreClasses, ignoreInlineStyles},
+          ).prettify();
+
+          if (rightFrameHTML === leftFrameHTML) {
+            break;
+          }
+
+          if (!attempts) {
+            // Returning as a matcher for a nicer left vs right diff formatting
+            return expect(leftFrameHTML).toBe(rightFrameHTML);
+          }
+
+          await sleep(500);
+        }
+      }
+
+      html = leftFrameHTML;
+    } else {
+      const editor = await page.$(editorSelector);
+      html = await editor.innerHTML();
+    }
+
+    return toMatchInlineSnapshot.call(
+      this,
+      new PrettyHTML(html, {ignoreClasses, ignoreInlineStyles}),
+      ...args,
+    );
   },
 });
 
+function isElement(element) {
+  return element && typeof element.$ === 'function';
+}
+
 // Wrapper around HTML string that is used as indicator for snapshot serializer
 // that it should use own formatter (below)
-class HtmlForPrettier {
-  constructor(html) {
+class PrettyHTML {
+  constructor(html, {ignoreClasses, ignoreInlineStyles}) {
     this.html = html;
+    this.ignoreClasses = ignoreClasses;
+    this.ignoreInlineStyles = ignoreInlineStyles;
+  }
+
+  prettify() {
+    let html = this.html;
+
+    if (this.ignoreClasses) {
+      html = html.replace(/\sclass="([^"]*)"/g, '');
+    }
+
+    if (this.ignoreInlineStyles) {
+      html = html.replace(/\sstyle="([^"]*)"/g, '');
+    }
+
+    return prettier
+      .format(html, {
+        parser: 'html',
+        htmlWhitespaceSensitivity: 'ignore',
+      })
+      .trim();
   }
 }
 
 expect.addSnapshotSerializer({
   test: (value) => {
-    return value instanceof HtmlForPrettier;
+    return value instanceof PrettyHTML;
   },
   print: (value) => {
-    return prettier
-      .format(value.html.replace(/\sclass="([^"]*)"/g, ''), {
-        parser: 'html',
-        htmlWhitespaceSensitivity: 'ignore',
-      })
-      .trim();
+    return value.prettify();
   },
 });


### PR DESCRIPTION
- Support collab
- Optionally keep css class names
- Optionally skip second frame validation in collab

Basic usage (for non-nested editors) will remain same, and it works well in collab (validating that both frames html match) and non-collab mode.
```js
await expect(page).toMatchEditorInlineSnapshot()
```

For more complex cases:
```js
await expect({

  // The only required option
  page,

  // For nested editors using finder callback that will receive current page or frame (for collab) as first argument
  finderFn: (pageOrFrame) => pageOrFrame.$('.image-editor-container'),

  // Will keep class names if it's important for specific scenario, but by default will strip it to have better readability
  ignoreClasses: false,

  // Will not check that both frames have same HTML, fallse by default
  ignoreSecondFrame: true

}).toMatchEditorInlineSnapshot()
```



