### PR TITLE
[RFC] Replace stylex with plain css

### DIFF
--- a/packages/lexical-playground/src/nodes/ImageNode.css
+++ b/packages/lexical-playground/src/nodes/ImageNode.css
@@ -1,0 +1,31 @@
+.ImageNode__contentEditable {
+  min-height: 0;
+  border: 0;
+  resize: none;
+  cursor: text;
+  caret-color: rgb(5, 5, 5);
+  display: block;
+  position: relative;
+  tab-size: 1;
+  outline: 0;
+  padding: 10px;
+  user-select: text;
+  font-size: 12px;
+  width: calc(100% - 20px);
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+.ImageNode__placeholder {
+  font-size: 12px;
+  color: #888;
+  overflow: hidden;
+  position: absolute;
+  text-overflow: ellipsis;
+  top: 10px;
+  left: 10px;
+  user-select: none;
+  white-space: nowrap;
+  display: inline-block;
+  pointer-events: none;
+}

--- a/packages/lexical-playground/src/nodes/ImageNode.js
+++ b/packages/lexical-playground/src/nodes/ImageNode.js
@@ -48,44 +48,10 @@ import TablesPlugin from '@lexical/react/LexicalTablePlugin';
 import TableCellActionMenuPlugin from '../plugins/TableActionMenuPlugin';
 import ImagesPlugin from '../plugins/ImagesPlugin';
 import LinkPlugin from '@lexical/react/LexicalLinkPlugin';
-import stylex from 'stylex';
 import TreeViewPlugin from '../plugins/TreeViewPlugin';
 import {useSettings} from '../context/SettingsContext';
 
 const LowPriority: CommandListenerLowPriority = 1;
-
-const styles = stylex.create({
-  contentEditable: {
-    minHeight: 0,
-    border: 0,
-    resize: 'none',
-    cursor: 'text',
-    caretColor: 'rgb(5, 5, 5)',
-    display: 'block',
-    position: 'relative',
-    tabSize: 1,
-    outline: 0,
-    padding: 10,
-    userSelect: 'text',
-    fontSize: 12,
-    width: 'calc(100% - 20px)',
-    whiteSpace: 'pre-wrap',
-    overflowWrap: 'break-word',
-  },
-  placeholder: {
-    fontSize: 12,
-    color: '#888',
-    overflow: 'hidden',
-    position: 'absolute',
-    textOverflow: 'ellipsis',
-    top: 10,
-    left: 10,
-    userSelect: 'none',
-    whiteSpace: 'nowrap',
-    display: 'inline-block',
-    pointerEvents: 'none',
-  },
-});
 
 const imageCache = new Set();
 
@@ -464,10 +430,10 @@ function ImageComponent({
               )}
               <RichTextPlugin
                 contentEditable={
-                  <ContentEditable className={stylex(styles.contentEditable)} />
+                  <ContentEditable className="ImageNode__contentEditable" />
                 }
                 placeholder={
-                  <Placeholder className={stylex(styles.placeholder)}>
+                  <Placeholder className="ImageNode__placeholder">
                     Enter a caption...
                   </Placeholder>
                 }

--- a/packages/lexical-playground/src/ui/Placeholder.css
+++ b/packages/lexical-playground/src/ui/Placeholder.css
@@ -1,0 +1,13 @@
+.Placeholder__root {
+  font-size: 15px;
+  color: #999;
+  overflow: hidden;
+  position: absolute;
+  text-overflow: ellipsis;
+  top: 10px;
+  left: 10px;
+  user-select: none;
+  white-space: nowrap;
+  display: inline-block;
+  pointer-events: none;
+}

--- a/packages/lexical-playground/src/ui/Placeholder.js
+++ b/packages/lexical-playground/src/ui/Placeholder.js
@@ -8,23 +8,7 @@
  */
 
 import * as React from 'react';
-import stylex from 'stylex';
-
-const styles = stylex.create({
-  root: {
-    fontSize: 15,
-    color: '#999',
-    overflow: 'hidden',
-    position: 'absolute',
-    textOverflow: 'ellipsis',
-    top: 10,
-    left: 10,
-    userSelect: 'none',
-    whiteSpace: 'nowrap',
-    display: 'inline-block',
-    pointerEvents: 'none',
-  },
-});
+import './Placeholder.css';
 
 export default function Placeholder({
   children,
@@ -33,5 +17,5 @@ export default function Placeholder({
   children: string,
   className?: string,
 }): React$Node {
-  return <div className={className || stylex(styles.root)}>{children}</div>;
+  return <div className={className || 'Placeholder__root'}>{children}</div>;
 }


### PR DESCRIPTION
Creating PR only to validate the approach. Will merge it after tests are migrated to inline snapshots that are not including css classes so switching from hashed stylex classes to plain css names will be easier:

- `<FileName>.css` to extract stylex styles
- `<FileName>__<styleName>` for classes to have at least some namespacing

Open for other suggestions!

Coud use `<FileName>.module.css` for CRA built in css modules, but IIRC we wanted to get rid of CRA