### PR TITLE
Improve Caching in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
     env:
       CI: true
       GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
-      WHAT: EVER
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -169,7 +168,6 @@ jobs:
         browser: ['chromium', 'firefox', 'webkit']
     env:
       CI: true
-      PLAYWRIGHT_BROWSERS_PATH: 0
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -197,7 +195,6 @@ jobs:
         browser: ['chromium', 'firefox']
     env:
       CI: true
-      PLAYWRIGHT_BROWSERS_PATH: 0
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Looking into the CI logs, I discovered the root cause of one of the issues we have been seeing intermittently:

<img width="1344" alt="Screen Shot 2022-03-08 at 12 09 41 AM" src="https://user-images.githubusercontent.com/14864325/157194025-7f5ee057-d758-47c4-b5d6-d016497d6fec.png">

Seems like the hashFiles function in the cache key expression is called again in the Post Run step, wherein it actually matches every package-lock file in the newly-installed node_modules. Instead, we should just worry about the workspace level node_modules and package-lock - there's no need to recursively hash all the package-locks in the CI.

This also changes to using npm ci instead of npm install (theoretically faster), moves to caching the Playwright browser binaries explicitly, and skips the install step entirely when we have a cache hit. This should improve performance somewhat, but we'll need to monitor to see exactly what happens.

Either way, we shouldn't see this error anymore.



