### PR TITLE
Handle selection update for empty root

### DIFF
--- a/packages/lexical/src/LexicalNode.js
+++ b/packages/lexical/src/LexicalNode.js
@@ -97,9 +97,12 @@ export function removeNode(
     parent !== null &&
     !$isRootNode(parent) &&
     !parent.canBeEmpty() &&
-    parent.getChildrenSize() === 0
+    parent.isEmpty()
   ) {
     removeNode(parent, restoreSelection);
+  }
+  if (parent !== null && $isRootNode(parent) && parent.isEmpty()) {
+    parent.selectEnd();
   }
 }
 

--- a/packages/lexical/src/__tests__/utils/index.js
+++ b/packages/lexical/src/__tests__/utils/index.js
@@ -25,6 +25,9 @@ type TestEnv = {
 export function createTestEditor(config = {}): LexicalEditor {
   const customNodes = config.nodes || [];
   const editor = createEditor({
+    onError: (e) => {
+      throw e;
+    },
     ...config,
     nodes: [
       ...ExtendedNodes,

--- a/packages/lexical/src/nodes/base/__tests__/unit/LexicalRootNode.test.js
+++ b/packages/lexical/src/nodes/base/__tests__/unit/LexicalRootNode.test.js
@@ -5,7 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {$createParagraphNode, $getRoot, $isRootNode} from 'lexical';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRootNode,
+} from 'lexical';
 
 import {
   $createTestDecoratorNode,
@@ -68,6 +74,50 @@ describe('LexicalRootNode tests', () => {
           return $getRoot().getTextContent();
         }),
       ).toBe('Hello world');
+    });
+
+    test('RootNode.clear() to handle selection update', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
+        const text = $createTextNode('Hello');
+        paragraph.append(text);
+        text.select();
+      });
+      await editor.update(() => {
+        const root = $getRoot();
+        root.clear();
+      });
+      await editor.update(() => {
+        const root = $getRoot();
+        const selection = $getSelection();
+        expect(selection.anchor.getNode()).toBe(root);
+        expect(selection.focus.getNode()).toBe(root);
+      });
+    });
+
+    test('RootNode is selected when its only child removed', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
+        const text = $createTextNode('Hello');
+        paragraph.append(text);
+        text.select();
+      });
+      await editor.update(() => {
+        const root = $getRoot();
+        root.getFirstChild().remove();
+      });
+      await editor.update(() => {
+        const root = $getRoot();
+        const selection = $getSelection();
+        expect(selection.anchor.getNode()).toBe(root);
+        expect(selection.focus.getNode()).toBe(root);
+      });
     });
   });
 });


### PR DESCRIPTION
It's common for lexical to update selection when caller changes tree structure, however empty root was an exception (either `root.clear()` or `rootOnlyChild.remove()` thrown `updateEditor: selection has been lost because the previously selected nodes have been removed`