### PR TITLE
Fix hashtag case with adjacent non-simple text node

### DIFF
--- a/packages/lexical-react/src/LexicalHashtagPlugin.js
+++ b/packages/lexical-react/src/LexicalHashtagPlugin.js
@@ -277,6 +277,9 @@ function textNodeTransform(node: TextNode): void {
 
   while (true) {
     const matchArr = REGEX.exec(text);
+    if (currentNode == null) {
+      return;
+    }
     const nextSibling = currentNode.getNextSibling();
     if (matchArr === null) {
       if (
@@ -316,9 +319,6 @@ function textNodeTransform(node: TextNode): void {
     }
     adjustedOffset += endOffset;
     $toggleHashtag(targetNode);
-    if (!currentNode) {
-      return;
-    }
   }
 }
 


### PR DESCRIPTION
When the next sibling is not a simple text and we're replacing the entire content up to the end of the existing node, then we should guard against erroneously creating a bad hashtag.