### PR TITLE
Grid Selection 1: Break mega function into methods on LexicalTableSelection class.

### DIFF
--- a/packages/lexical-react/src/LexicalTablePlugin.js
+++ b/packages/lexical-react/src/LexicalTablePlugin.js
@@ -7,12 +7,17 @@
  * @flow strict
  */
 
-import type {CommandListenerEditorPriority, ElementNode} from 'lexical';
+import type {TableSelection} from '@lexical/table';
+import type {
+  CommandListenerEditorPriority,
+  ElementNode,
+  NodeKey,
+} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
-  $applyTableHandlers,
   $createTableNodeWithDimensions,
+  applyTableHandlers,
   TableCellNode,
   TableNode,
   TableRowNode,
@@ -79,7 +84,7 @@ export default function TablePlugin(): React$Node {
   }, [editor]);
 
   useEffect(() => {
-    const listeners = new Map();
+    const tableSelections = new Map<NodeKey, TableSelection>();
 
     return editor.addListener('mutation', TableNode, (nodeMutations) => {
       // eslint-disable-next-line no-for-of-loops/no-for-of-loops
@@ -90,18 +95,18 @@ export default function TablePlugin(): React$Node {
             const tableNode = $getNodeByKey(nodeKey);
 
             if (tableElement && tableNode) {
-              const removeListeners = $applyTableHandlers(
+              const tableSelection = applyTableHandlers(
                 tableNode,
                 tableElement,
                 editor,
               );
 
-              listeners.set(nodeKey, removeListeners);
+              tableSelections.set(nodeKey, tableSelection);
             }
           });
         } else if (mutation === 'destroyed') {
-          const cleanup = listeners.get(nodeKey);
-          if (cleanup) cleanup();
+          const tableSelection = tableSelections.get(nodeKey);
+          if (tableSelection) tableSelection.removeListeners();
         }
       }
     });

--- a/packages/lexical-table/LexicalTable.d.ts
+++ b/packages/lexical-table/LexicalTable.d.ts
@@ -7,6 +7,7 @@ import type {
   ElementNode,
   LexicalEditor,
 } from 'lexical';
+import {TableSelection} from './src/TableSelection';
 
 export enum TableCellHeaderState {
   NO_STATUS = 0,
@@ -125,11 +126,11 @@ export type SelectionShape = {
   toY: number;
 };
 
-declare function $applyTableHandlers(
+declare function applyTableHandlers(
   tableNode: TableNode,
   tableElement: HTMLElement,
   editor: LexicalEditor,
-): () => void;
+): TableSelection;
 
 /**
  * LexicalTableUtils
@@ -185,3 +186,31 @@ declare function $deleteTableColumn(
   tableNode: TableNode,
   targetIndex: number,
 ): TableNode;
+
+/**
+ * LexicalTableSelection.js
+ */
+declare class TableSelection {
+  currentX: number;
+  currentY: number;
+  listenersToRemove: Set<() => void>;
+  domListeners: Set<() => void>;
+  grid: Grid;
+  highlightedCells: Array<Cell>;
+  isHighlightingCells: boolean;
+  isSelecting: boolean;
+  startX: number;
+  startY: number;
+  nodeKey: string;
+  editor: LexicalEditor;
+  constructor(editor: LexicalEditor, nodeKey: string): void;
+  getGrid(): Grid;
+  hasHighlightedCells(): boolean;
+  removeListeners(): void;
+  trackTableGrid(): void;
+  clearHighlight(): void;
+  addCellToSelection(cell: Cell): void;
+  startSelecting(cell: Cell): void;
+  formatCells(type: TextFormatType): void;
+  clearText(): void;
+}

--- a/packages/lexical-table/LexicalTable.js.flow
+++ b/packages/lexical-table/LexicalTable.js.flow
@@ -14,6 +14,7 @@ import type {
   ParagraphNode,
   RangeSelection,
   LexicalEditor,
+  TextFormatType,
 } from 'lexical';
 
 import {ElementNode} from 'lexical';
@@ -142,11 +143,11 @@ export type SelectionShape = {
   toY: number,
 };
 
-declare export function $applyTableHandlers(
+declare export function applyTableHandlers(
   tableNode: TableNode,
   tableElement: HTMLElement,
   editor: LexicalEditor,
-): () => void;
+): TableSelection;
 
 declare export function $getElementGridForTableNode(
   editor: LexicalEditor,
@@ -207,3 +208,31 @@ declare export function $deleteTableColumn(
   tableNode: TableNode,
   targetIndex: number,
 ): TableNode;
+
+/**
+ * LexicalTableSelection.js
+ */
+declare export class TableSelection {
+  currentX: number;
+  currentY: number;
+  listenersToRemove: Set<() => void>;
+  domListeners: Set<() => void>;
+  grid: Grid;
+  highlightedCells: Array<Cell>;
+  isHighlightingCells: boolean;
+  isSelecting: boolean;
+  startX: number;
+  startY: number;
+  nodeKey: string;
+  editor: LexicalEditor;
+  constructor(editor: LexicalEditor, nodeKey: string): void;
+  getGrid(): Grid;
+  hasHighlightedCells(): boolean;
+  removeListeners(): void;
+  trackTableGrid(): void;
+  clearHighlight(): void;
+  addCellToSelection(cell: Cell): void;
+  startSelecting(cell: Cell): void;
+  formatCells(type: TextFormatType): void;
+  clearText(): void;
+}

--- a/packages/lexical-table/src/LexicalTableNode.js
+++ b/packages/lexical-table/src/LexicalTableNode.js
@@ -8,7 +8,7 @@
  */
 
 import type {TableCellNode} from './LexicalTableCellNode';
-import type {Cell, Grid, SelectionShape} from './LexicalTableSelectionHelpers';
+import type {Cell, Grid, SelectionShape} from './LexicalTableSelection';
 import type {EditorConfig, LexicalEditor, LexicalNode, NodeKey} from 'lexical';
 
 import {addClassNamesToElement} from '@lexical/helpers/elements';

--- a/packages/lexical-table/src/LexicalTableSelection.js
+++ b/packages/lexical-table/src/LexicalTableSelection.js
@@ -1,0 +1,309 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {LexicalEditor, TextFormatType} from 'lexical';
+
+import {
+  $createParagraphNode,
+  $createRangeSelection,
+  $createTextNode,
+  $getNearestNodeFromDOMNode,
+  $getNodeByKey,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  $setSelection,
+} from 'lexical';
+import getDOMSelection from 'shared/getDOMSelection';
+
+import {$isTableNode} from './LexicalTableNode';
+import {getTableGrid} from './LexicalTableSelectionHelpers';
+
+export type Cell = {
+  elem: HTMLElement,
+  highlighted: boolean,
+  x: number,
+  y: number,
+};
+
+export type Cells = Array<Array<Cell>>;
+
+export type Grid = {
+  cells: Cells,
+  columns: number,
+  rows: number,
+};
+
+export type SelectionShape = {
+  fromX: number,
+  fromY: number,
+  toX: number,
+  toY: number,
+};
+
+const removeHighlightStyle = document.createElement('style');
+
+removeHighlightStyle.appendChild(
+  document.createTextNode('::selection{background-color: transparent}'),
+);
+
+export class TableSelection {
+  currentX: number;
+  currentY: number;
+  listenersToRemove: Set<() => void>;
+  domListeners: Set<() => void>;
+  grid: Grid;
+  highlightedCells: Array<Cell>;
+  isHighlightingCells: boolean;
+  isSelecting: boolean;
+  startX: number;
+  startY: number;
+  nodeKey: string;
+  editor: LexicalEditor;
+
+  constructor(editor: LexicalEditor, nodeKey: string) {
+    this.isSelecting = false;
+    this.isHighlightingCells = false;
+    this.startX = -1;
+    this.startY = -1;
+    this.currentX = -1;
+    this.currentY = -1;
+    this.highlightedCells = [];
+    this.listenersToRemove = new Set();
+    this.nodeKey = nodeKey;
+    this.editor = editor;
+    this.grid = {cells: [], columns: 0, rows: 0};
+
+    this.trackTableGrid();
+  }
+
+  getGrid(): Grid {
+    return this.grid;
+  }
+
+  hasHighlightedCells(): boolean {
+    return this.highlightedCells.length > 0;
+  }
+
+  removeListeners() {
+    Array.from(this.listenersToRemove).forEach((removeListener) =>
+      removeListener(),
+    );
+  }
+
+  trackTableGrid() {
+    const observer = new MutationObserver((records) => {
+      this.editor.update(() => {
+        let gridNeedsRedraw = false;
+        for (let i = 0; i < records.length; i++) {
+          const record = records[i];
+          const target = record.target;
+          const nodeName = target.nodeName;
+          if (nodeName === 'TABLE' || nodeName === 'TR') {
+            gridNeedsRedraw = true;
+            break;
+          }
+        }
+        if (!gridNeedsRedraw) {
+          return;
+        }
+
+        const tableElement = this.editor.getElementByKey(this.nodeKey);
+        if (!tableElement) {
+          throw new Error('Expected to find TableElement in DOM');
+        }
+        this.grid = getTableGrid(tableElement);
+      });
+    });
+
+    this.editor.update(() => {
+      const tableElement = this.editor.getElementByKey(this.nodeKey);
+      if (!tableElement) {
+        throw new Error('Expected to find TableElement in DOM');
+      }
+
+      this.grid = getTableGrid(tableElement);
+
+      observer.observe(tableElement, {
+        childList: true,
+        subtree: true,
+      });
+    });
+  }
+
+  clearHighlight() {
+    this.editor.update(() => {
+      const tableNode = $getNodeByKey(this.nodeKey);
+      if (!$isTableNode(tableNode)) {
+        throw new Error('Expected TableNode.');
+      }
+
+      const tableElement = this.editor.getElementByKey(this.nodeKey);
+      if (!tableElement) {
+        throw new Error('Expected to find TableElement in DOM');
+      }
+
+      const grid = getTableGrid(tableElement);
+
+      this.isHighlightingCells = false;
+      this.isSelecting = false;
+      this.startX = -1;
+      this.startY = -1;
+      this.currentX = -1;
+      this.currentY = -1;
+
+      tableNode.setSelectionState(null, grid);
+
+      this.highlightedCells = [];
+
+      const parent = removeHighlightStyle.parentNode;
+      if (parent != null) {
+        parent.removeChild(removeHighlightStyle);
+      }
+    });
+  }
+
+  addCellToSelection(cell: Cell) {
+    this.editor.update(() => {
+      const tableNode = $getNodeByKey(this.nodeKey);
+      if (!$isTableNode(tableNode)) {
+        throw new Error('Expected TableNode.');
+      }
+
+      const tableElement = this.editor.getElementByKey(this.nodeKey);
+      if (!tableElement) {
+        throw new Error('Expected to find TableElement in DOM');
+      }
+
+      const cellX = cell.x;
+      const cellY = cell.y;
+      if (
+        !this.isHighlightingCells &&
+        (this.startX !== cellX || this.startY !== cellY)
+      ) {
+        const domSelection = getDOMSelection();
+        const anchorNode = domSelection.anchorNode;
+        if (anchorNode !== null) {
+          // Collapse the selection
+          domSelection.setBaseAndExtent(anchorNode, 0, anchorNode, 0);
+        }
+        this.isHighlightingCells = true;
+        if (document.body) {
+          document.body.appendChild(removeHighlightStyle);
+        }
+      } else if (cellX === this.currentX && cellY === this.currentY) {
+        return;
+      }
+      this.currentX = cellX;
+      this.currentY = cellY;
+
+      if (this.isHighlightingCells) {
+        const fromX = Math.min(this.startX, this.currentX);
+        const toX = Math.max(this.startX, this.currentX);
+        const fromY = Math.min(this.startY, this.currentY);
+        const toY = Math.max(this.startY, this.currentY);
+
+        this.highlightedCells = tableNode.setSelectionState(
+          {
+            fromX,
+            fromY,
+            toX,
+            toY,
+          },
+          this.grid,
+        );
+      }
+    });
+  }
+
+  startSelecting(cell: Cell) {
+    this.isSelecting = true;
+    this.startX = cell.x;
+    this.startY = cell.y;
+
+    document.addEventListener(
+      'mouseup',
+      () => {
+        this.isSelecting = false;
+      },
+      {
+        capture: true,
+        once: true,
+      },
+    );
+  }
+
+  formatCells(type: TextFormatType) {
+    this.editor.update(() => {
+      let selection = $getSelection();
+      if (!$isRangeSelection(selection)) {
+        selection = $createRangeSelection();
+      }
+      // This is to make Flow play ball.
+      const formatSelection = selection;
+      const anchor = formatSelection.anchor;
+      const focus = formatSelection.focus;
+      this.highlightedCells.forEach((highlightedCell) => {
+        const cellNode = $getNearestNodeFromDOMNode(highlightedCell.elem);
+        if ($isElementNode(cellNode) && cellNode.getTextContentSize() !== 0) {
+          anchor.set(cellNode.getKey(), 0, 'element');
+          focus.set(cellNode.getKey(), cellNode.getChildrenSize(), 'element');
+          formatSelection.formatText(type);
+        }
+      });
+      // Collapse selection
+      selection.anchor.set(
+        selection.anchor.key,
+        selection.anchor.offset,
+        selection.anchor.type,
+      );
+      selection.focus.set(
+        selection.anchor.key,
+        selection.anchor.offset,
+        selection.anchor.type,
+      );
+      $setSelection(selection);
+    });
+  }
+
+  clearText() {
+    this.editor.update(() => {
+      const tableNode = $getNodeByKey(this.nodeKey);
+      if (!$isTableNode(tableNode)) {
+        throw new Error('Expected TableNode.');
+      }
+
+      if (this.highlightedCells.length === this.grid.columns * this.grid.rows) {
+        tableNode.selectPrevious();
+        // Delete entire table
+        tableNode.remove();
+        this.clearHighlight();
+        return;
+      }
+      this.highlightedCells.forEach(({elem}) => {
+        const cellNode = $getNearestNodeFromDOMNode(elem);
+
+        if ($isElementNode(cellNode)) {
+          const paragraphNode = $createParagraphNode();
+          const textNode = $createTextNode();
+          paragraphNode.append(textNode);
+          cellNode.append(paragraphNode);
+
+          cellNode.getChildren().forEach((child) => {
+            if (child !== paragraphNode) {
+              child.remove();
+            }
+          });
+        }
+      });
+      tableNode.setSelectionState(null, this.grid);
+      $setSelection(null);
+    });
+  }
+}

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.js
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.js
@@ -8,59 +8,263 @@
  */
 
 import type {TableNode} from './LexicalTableNode';
-import type {
-  CommandListenerCriticalPriority,
-  CommandListenerLowPriority,
-  LexicalEditor,
-  TextFormatType,
-} from 'lexical';
+import type {Cell, Cells, Grid} from './LexicalTableSelection';
+import type {CommandListenerCriticalPriority, LexicalEditor} from 'lexical';
 
 import {$findMatchingParent} from '@lexical/helpers/nodes';
 import {
-  $createParagraphNode,
-  $createRangeSelection,
-  $createTextNode,
-  $getNearestNodeFromDOMNode,
   $getSelection,
   $isElementNode,
   $isParagraphNode,
   $isRangeSelection,
-  $setSelection,
 } from 'lexical';
-import getDOMSelection from 'shared/getDOMSelection';
 
 import {$isTableCellNode} from './LexicalTableCellNode';
+import {TableSelection} from './LexicalTableSelection';
 
-export type Cell = {
-  elem: HTMLElement,
-  highlighted: boolean,
-  x: number,
-  y: number,
-};
-
-export type Cells = Array<Array<Cell>>;
-
-export type Grid = {
-  cells: Cells,
-  columns: number,
-  rows: number,
-};
-
-export type SelectionShape = {
-  fromX: number,
-  fromY: number,
-  toX: number,
-  toY: number,
-};
-
-const LowPriority: CommandListenerLowPriority = 1;
 const CriticalPriority: CommandListenerCriticalPriority = 4;
 
-const removeHighlightStyle = document.createElement('style');
+const LEXICAL_ELEMENT_KEY = '__lexicalTableSelection';
 
-removeHighlightStyle.appendChild(
-  document.createTextNode('::selection{background-color: transparent}'),
-);
+export function applyTableHandlers(
+  tableNode: TableNode,
+  tableElement: HTMLElement,
+  editor: LexicalEditor,
+): TableSelection {
+  const rootElement = editor.getRootElement();
+
+  if (rootElement === null) {
+    throw new Error('No root element.');
+  }
+
+  const tableSelection = new TableSelection(editor, tableNode.getKey());
+
+  // This is the anchor of the selection.
+  tableElement.addEventListener('mousedown', (event: MouseEvent) => {
+    setTimeout(() => {
+      // $FlowFixMe: event.target is always a Node on the DOM
+      const cell = getCellFromTarget(event.target);
+      if (cell !== null) {
+        tableSelection.startSelecting(cell);
+      }
+    }, 0);
+  });
+
+  // This is adjusting the focus of the selection.
+  tableElement.addEventListener('mousemove', (event: MouseEvent) => {
+    if (tableSelection.isSelecting) {
+      // $FlowFixMe: event.target is always a Node on the DOM
+      const cell = getCellFromTarget(event.target);
+      if (cell !== null) {
+        const cellX = cell.x;
+        const cellY = cell.y;
+        if (
+          tableSelection.isSelecting &&
+          (tableSelection.startX !== cellX || tableSelection.startY !== cellY)
+        ) {
+          event.preventDefault();
+          tableSelection.addCellToSelection(cell);
+        }
+      }
+    }
+  });
+
+  // Select entire table at this point, when grid selection is ready.
+  tableElement.addEventListener('mouseleave', (event: MouseEvent) => {
+    if (tableSelection.isSelecting) {
+      return;
+    }
+  });
+
+  tableSelection.listenersToRemove.add(
+    // Clear selection when clicking outside of dom.
+    window.addEventListener('mousedown', (e) => {
+      if (
+        !tableSelection.isSelecting &&
+        tableSelection.hasHighlightedCells() &&
+        rootElement.contains(e.target)
+      ) {
+        editor.update(() => {
+          tableNode.setSelectionState(null, tableSelection.grid);
+          tableSelection.clearHighlight();
+        });
+      }
+    }),
+  );
+
+  tableSelection.listenersToRemove.add(
+    editor.addListener(
+      'command',
+      (type, payload) => {
+        const selection = $getSelection();
+
+        if (!$isRangeSelection(selection)) {
+          return false;
+        }
+
+        const tableCellNode = $findMatchingParent(
+          selection.anchor.getNode(),
+          (n) => $isTableCellNode(n),
+        );
+
+        if (!$isTableCellNode(tableCellNode)) {
+          return false;
+        }
+
+        // There is an active selection.
+        if (tableSelection.hasHighlightedCells()) {
+          if (type === 'deleteCharacter') {
+            tableSelection.clearText();
+            return true;
+          } else if (type === 'formatText') {
+            tableSelection.formatCells(payload);
+            return true;
+          } else if (type === 'insertText') {
+            tableSelection.clearHighlight();
+            return false;
+          }
+        }
+
+        // There is no active selection.
+        if (!tableSelection.hasHighlightedCells()) {
+          if (type === 'deleteCharacter') {
+            if (
+              !tableSelection.hasHighlightedCells() &&
+              selection.isCollapsed() &&
+              selection.anchor.offset === 0 &&
+              selection.anchor.getNode().getPreviousSiblings().length === 0
+            ) {
+              return true;
+            }
+          }
+
+          if (type === 'keyTab') {
+            const event: KeyboardEvent = payload;
+
+            if (
+              selection.isCollapsed() &&
+              !tableSelection.hasHighlightedCells()
+            ) {
+              const currentCords = tableNode.getCordsFromCellNode(
+                tableCellNode,
+                tableSelection.grid,
+              );
+              event.preventDefault();
+
+              selectGridNodeInDirection(
+                tableSelection,
+                tableNode,
+                currentCords.x,
+                currentCords.y,
+                !event.shiftKey && type === 'keyTab' ? 'forward' : 'backward',
+              );
+
+              return true;
+            }
+          }
+
+          if (
+            type === 'keyArrowDown' ||
+            type === 'keyArrowUp' ||
+            type === 'keyArrowLeft' ||
+            type === 'keyArrowRight'
+          ) {
+            const event: KeyboardEvent = payload;
+
+            if (
+              selection.isCollapsed() &&
+              !tableSelection.hasHighlightedCells()
+            ) {
+              const currentCords = tableNode.getCordsFromCellNode(
+                tableCellNode,
+                tableSelection.grid,
+              );
+              const elementParentNode = $findMatchingParent(
+                selection.anchor.getNode(),
+                (n) => $isElementNode(n),
+              );
+
+              if (elementParentNode == null) {
+                throw new Error('Expected BlockNode Parent');
+              }
+
+              const firstChild = tableCellNode.getFirstChild();
+              const lastChild = tableCellNode.getLastChild();
+
+              const isSelectionInFirstBlock =
+                (firstChild && elementParentNode.isParentOf(firstChild)) ||
+                elementParentNode === firstChild;
+
+              const isSelectionInLastBlock =
+                (lastChild && elementParentNode.isParentOf(lastChild)) ||
+                elementParentNode === lastChild;
+
+              if (
+                (type === 'keyArrowUp' && isSelectionInFirstBlock) ||
+                (type === 'keyArrowDown' && isSelectionInLastBlock)
+              ) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                event.stopPropagation();
+
+                selectGridNodeInDirection(
+                  tableSelection,
+                  tableNode,
+                  currentCords.x,
+                  currentCords.y,
+                  type === 'keyArrowUp' ? 'up' : 'down',
+                );
+
+                return true;
+              }
+
+              if (
+                (type === 'keyArrowLeft' && selection.anchor.offset === 0) ||
+                (type === 'keyArrowRight' &&
+                  selection.anchor.offset ===
+                    selection.anchor.getNode().getTextContentSize())
+              ) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                event.stopPropagation();
+
+                selectGridNodeInDirection(
+                  tableSelection,
+                  tableNode,
+                  currentCords.x,
+                  currentCords.y,
+                  type === 'keyArrowLeft' ? 'backward' : 'forward',
+                );
+
+                return true;
+              }
+            }
+          }
+        }
+
+        return false;
+      },
+      CriticalPriority,
+    ),
+  );
+
+  return tableSelection;
+}
+
+export function attachTableSelectionToTableElement(
+  tableElement: HTMLElement,
+  tableSelection: TableSelection,
+) {
+  // $FlowFixMe
+  tableElement[LEXICAL_ELEMENT_KEY] = this;
+}
+
+export function getTableSelectionFromTableElement(
+  tableElement: HTMLElement,
+): TableSelection {
+  // $FlowFixMe
+  return tableElement[LEXICAL_ELEMENT_KEY];
+}
 
 export function getCellFromTarget(node: Node): Cell | null {
   let currentNode = node;
@@ -140,42 +344,6 @@ export function getTableGrid(tableElement: HTMLElement): Grid {
   return grid;
 }
 
-export function trackTableGrid(
-  tableNode: TableNode,
-  tableElement: HTMLElement,
-  editor: LexicalEditor,
-  cb: (grid: Grid) => void,
-): Grid {
-  const observer = new MutationObserver((records) => {
-    editor.update(() => {
-      let gridNeedsRedraw = false;
-      for (let i = 0; i < records.length; i++) {
-        const record = records[i];
-        const target = record.target;
-        const nodeName = target.nodeName;
-        if (nodeName === 'TABLE' || nodeName === 'TR') {
-          gridNeedsRedraw = true;
-          break;
-        }
-      }
-      if (!gridNeedsRedraw) {
-        return;
-      }
-
-      const grid = getTableGrid(tableElement);
-
-      cb(grid);
-    });
-  });
-
-  observer.observe(tableElement, {
-    childList: true,
-    subtree: true,
-  });
-
-  return getTableGrid(tableElement);
-}
-
 export function updateCells(
   fromX: number,
   toX: number,
@@ -183,9 +351,11 @@ export function updateCells(
   toY: number,
   cells: Cells,
 ): Array<Cell> {
-  const highlighted = [];
+  const highlightedCells = [];
+
   for (let y = 0; y < cells.length; y++) {
     const row = cells[y];
+
     for (let x = 0; x < row.length; x++) {
       const cell = row[x];
       const elemStyle = cell.elem.style;
@@ -195,7 +365,7 @@ export function updateCells(
           elemStyle.setProperty('background-color', 'rgb(163, 187, 255)');
           elemStyle.setProperty('caret-color', 'transparent');
         }
-        highlighted.push(cell);
+        highlightedCells.push(cell);
       } else if (cell.highlighted) {
         cell.highlighted = false;
         elemStyle.removeProperty('background-color');
@@ -207,431 +377,73 @@ export function updateCells(
       }
     }
   }
-  return highlighted;
+
+  return highlightedCells;
 }
 
-export function $applyTableHandlers(
+const selectGridNodeInDirection = (
+  tableSelection: TableSelection,
   tableNode: TableNode,
-  tableElement: HTMLElement,
-  editor: LexicalEditor,
-): () => void {
-  const rootElement = editor.getRootElement();
+  x: number,
+  y: number,
+  direction: 'backward' | 'forward' | 'up' | 'down',
+): boolean => {
+  switch (direction) {
+    case 'backward':
+    case 'forward': {
+      const isForward = direction === 'forward';
 
-  if (rootElement === null) {
-    throw new Error('No root element.');
-  }
-
-  let grid = trackTableGrid(tableNode, tableElement, editor, (g) => {
-    grid = g;
-  });
-
-  let isSelected = false;
-  let isHighlightingCells = false;
-  let startX = -1;
-  let startY = -1;
-  let currentX = -1;
-  let currentY = -1;
-  let highlightedCells = [];
-  const editorListeners = new Set();
-  let deleteCharacterListener = null;
-
-  if (grid == null) {
-    throw new Error('Table grid not found.');
-  }
-
-  tableElement.addEventListener('mousemove', (event: MouseEvent) => {
-    if (isSelected) {
-      // $FlowFixMe: event.target is always a Node on the DOM
-      const cell = getCellFromTarget(event.target);
-      if (cell !== null) {
-        const cellX = cell.x;
-        const cellY = cell.y;
-        if (!isHighlightingCells && (startX !== cellX || startY !== cellY)) {
-          event.preventDefault();
-          const domSelection = getDOMSelection();
-          const anchorNode = domSelection.anchorNode;
-          if (anchorNode !== null) {
-            // Collapse the selection
-            domSelection.setBaseAndExtent(anchorNode, 0, anchorNode, 0);
-          }
-          isHighlightingCells = true;
-          if (document.body) {
-            document.body.appendChild(removeHighlightStyle);
-          }
-          if (deleteCharacterListener === null) {
-            deleteCharacterListener = editor.addListener(
-              'command',
-              (type, payload) => {
-                if (type === 'deleteCharacter') {
-                  if (highlightedCells.length === grid.columns * grid.rows) {
-                    tableNode.selectPrevious();
-                    // Delete entire table
-                    tableNode.remove();
-                    clearHighlight();
-                    return true;
-                  }
-                  highlightedCells.forEach(({elem}) => {
-                    const cellNode = $getNearestNodeFromDOMNode(elem);
-
-                    if ($isElementNode(cellNode)) {
-                      const paragraphNode = $createParagraphNode();
-                      const textNode = $createTextNode();
-                      paragraphNode.append(textNode);
-                      cellNode.append(paragraphNode);
-
-                      cellNode.getChildren().forEach((child) => {
-                        if (child !== paragraphNode) {
-                          child.remove();
-                        }
-                      });
-                    }
-                  });
-                  tableNode.setSelectionState(null, grid);
-                  $setSelection(null);
-                  return true;
-                } else if (type === 'formatText') {
-                  formatCells(payload);
-                  return true;
-                } else if (type === 'insertText') {
-                  clearHighlight();
-                  return false;
-                }
-                return false;
-              },
-              LowPriority,
-            );
-
-            editorListeners.add(deleteCharacterListener);
-          }
-        } else if (cellX === currentX && cellY === currentY) {
-          return;
-        }
-        currentX = cellX;
-        currentY = cellY;
-
-        if (isHighlightingCells) {
-          const fromX = Math.min(startX, currentX);
-          const toX = Math.max(startX, currentX);
-          const fromY = Math.min(startY, currentY);
-          const toY = Math.max(startY, currentY);
-
-          editor.update(() => {
-            highlightedCells = tableNode.setSelectionState(
-              {
-                fromX,
-                fromY,
-                toX,
-                toY,
-              },
-              grid,
-            );
-          });
-        }
-      }
-    }
-  });
-
-  const clearHighlight = () => {
-    editor.update(() => {
-      isHighlightingCells = false;
-      isSelected = false;
-      startX = -1;
-      startY = -1;
-      currentX = -1;
-      currentY = -1;
-
-      editor.update(() => {
-        tableNode.setSelectionState(null, grid);
-      });
-
-      highlightedCells = [];
-      if (deleteCharacterListener !== null) {
-        deleteCharacterListener();
-        deleteCharacterListener = null;
-        editorListeners.delete(deleteCharacterListener);
-      }
-      const parent = removeHighlightStyle.parentNode;
-      if (parent != null) {
-        parent.removeChild(removeHighlightStyle);
-      }
-    });
-  };
-
-  tableElement.addEventListener('mouseleave', (event: MouseEvent) => {
-    if (isSelected) {
-      return;
-    }
-  });
-
-  const formatCells = (type: TextFormatType) => {
-    let selection = $getSelection();
-    if (!$isRangeSelection(selection)) {
-      selection = $createRangeSelection();
-    }
-    // This is to make Flow play ball.
-    const formatSelection = selection;
-    const anchor = formatSelection.anchor;
-    const focus = formatSelection.focus;
-    highlightedCells.forEach((highlightedCell) => {
-      const cellNode = $getNearestNodeFromDOMNode(highlightedCell.elem);
-      if ($isElementNode(cellNode) && cellNode.getTextContentSize() !== 0) {
-        anchor.set(cellNode.getKey(), 0, 'element');
-        focus.set(cellNode.getKey(), cellNode.getChildrenSize(), 'element');
-        formatSelection.formatText(type);
-      }
-    });
-    // Collapse selection
-    selection.anchor.set(
-      selection.anchor.key,
-      selection.anchor.offset,
-      selection.anchor.type,
-    );
-    selection.focus.set(
-      selection.anchor.key,
-      selection.anchor.offset,
-      selection.anchor.type,
-    );
-    $setSelection(selection);
-  };
-
-  tableElement.addEventListener('mousedown', (event: MouseEvent) => {
-    if (isSelected) {
-      if (isHighlightingCells) {
-        clearHighlight();
-      }
-      return;
-    }
-    setTimeout(() => {
-      if (isHighlightingCells) {
-        clearHighlight();
-      }
-      // $FlowFixMe: event.target is always a Node on the DOM
-      const cell = getCellFromTarget(event.target);
-      if (cell !== null) {
-        isSelected = true;
-        startX = cell.x;
-        startY = cell.y;
-
-        document.addEventListener(
-          'mouseup',
-          () => {
-            isSelected = false;
-          },
-          {
-            capture: true,
-            once: true,
-          },
+      if (x !== (isForward ? tableSelection.grid.columns - 1 : 0)) {
+        selectTableCellNode(
+          tableNode.getCellNodeFromCordsOrThrow(
+            x + (isForward ? 1 : -1),
+            y,
+            tableSelection.grid,
+          ),
         );
-      }
-    }, 0);
-  });
-
-  window.addEventListener('click', (e) => {
-    if (
-      highlightedCells.length > 0 &&
-      !tableElement.contains(e.target) &&
-      rootElement.contains(e.target)
-    ) {
-      editor.update(() => {
-        tableNode.setSelectionState(null, grid);
-      });
-    }
-  });
-
-  const selectGridNodeInDirection = (
-    x: number,
-    y: number,
-    direction: 'backward' | 'forward' | 'up' | 'down',
-  ): boolean => {
-    switch (direction) {
-      case 'backward':
-      case 'forward': {
-        const isForward = direction === 'forward';
-
-        if (x !== (isForward ? grid.columns - 1 : 0)) {
+      } else {
+        if (y !== (isForward ? tableSelection.grid.rows - 1 : 0)) {
           selectTableCellNode(
             tableNode.getCellNodeFromCordsOrThrow(
-              x + (isForward ? 1 : -1),
-              y,
-              grid,
+              isForward ? 0 : tableSelection.grid.columns - 1,
+              y + (isForward ? 1 : -1),
+              tableSelection.grid,
             ),
           );
-        } else {
-          if (y !== (isForward ? grid.rows - 1 : 0)) {
-            selectTableCellNode(
-              tableNode.getCellNodeFromCordsOrThrow(
-                isForward ? 0 : grid.columns - 1,
-                y + (isForward ? 1 : -1),
-                grid,
-              ),
-            );
-          } else if (!isForward) {
-            tableNode.selectPrevious();
-          } else {
-            tableNode.selectNext();
-          }
-        }
-        return true;
-      }
-
-      case 'up': {
-        if (y !== 0) {
-          selectTableCellNode(
-            tableNode.getCellNodeFromCordsOrThrow(x, y - 1, grid),
-          );
-        } else {
+        } else if (!isForward) {
           tableNode.selectPrevious();
-        }
-        return true;
-      }
-
-      case 'down': {
-        if (y !== grid.rows - 1) {
-          selectTableCellNode(
-            tableNode.getCellNodeFromCordsOrThrow(x, y + 1, grid),
-          );
         } else {
           tableNode.selectNext();
         }
-        return true;
       }
+      return true;
     }
 
-    return false;
-  };
-
-  const genericCommandListener = editor.addListener(
-    'command',
-    (type, payload) => {
-      const selection = $getSelection();
-
-      if (!$isRangeSelection(selection)) {
-        return false;
+    case 'up': {
+      if (y !== 0) {
+        selectTableCellNode(
+          tableNode.getCellNodeFromCordsOrThrow(x, y - 1, tableSelection.grid),
+        );
+      } else {
+        tableNode.selectPrevious();
       }
+      return true;
+    }
 
-      const tableCellNode = $findMatchingParent(
-        selection.anchor.getNode(),
-        (n) => $isTableCellNode(n),
-      );
-
-      if (!$isTableCellNode(tableCellNode)) {
-        return false;
+    case 'down': {
+      if (y !== tableSelection.grid.rows - 1) {
+        selectTableCellNode(
+          tableNode.getCellNodeFromCordsOrThrow(x, y + 1, tableSelection.grid),
+        );
+      } else {
+        tableNode.selectNext();
       }
+      return true;
+    }
+  }
 
-      if (type === 'deleteCharacter') {
-        if (
-          highlightedCells.length === 0 &&
-          selection.isCollapsed() &&
-          selection.anchor.offset === 0 &&
-          selection.anchor.getNode().getPreviousSiblings().length === 0
-        ) {
-          return true;
-        }
-      }
-
-      if (type === 'keyTab') {
-        const event: KeyboardEvent = payload;
-
-        if (selection.isCollapsed() && highlightedCells.length === 0) {
-          const currentCords = tableNode.getCordsFromCellNode(
-            tableCellNode,
-            grid,
-          );
-          event.preventDefault();
-
-          selectGridNodeInDirection(
-            currentCords.x,
-            currentCords.y,
-            !event.shiftKey && type === 'keyTab' ? 'forward' : 'backward',
-          );
-
-          return true;
-        }
-      }
-
-      if (
-        type === 'keyArrowDown' ||
-        type === 'keyArrowUp' ||
-        type === 'keyArrowLeft' ||
-        type === 'keyArrowRight'
-      ) {
-        const event: KeyboardEvent = payload;
-
-        if (selection.isCollapsed() && highlightedCells.length === 0) {
-          const currentCords = tableNode.getCordsFromCellNode(
-            tableCellNode,
-            grid,
-          );
-          const elementParentNode = $findMatchingParent(
-            selection.anchor.getNode(),
-            (n) => $isElementNode(n),
-          );
-
-          if (elementParentNode == null) {
-            throw new Error('Expected BlockNode Parent');
-          }
-
-          const firstChild = tableCellNode.getFirstChild();
-          const lastChild = tableCellNode.getLastChild();
-
-          const isSelectionInFirstBlock =
-            (firstChild && elementParentNode.isParentOf(firstChild)) ||
-            elementParentNode === firstChild;
-
-          const isSelectionInLastBlock =
-            (lastChild && elementParentNode.isParentOf(lastChild)) ||
-            elementParentNode === lastChild;
-
-          if (
-            (type === 'keyArrowUp' && isSelectionInFirstBlock) ||
-            (type === 'keyArrowDown' && isSelectionInLastBlock)
-          ) {
-            event.preventDefault();
-            event.stopImmediatePropagation();
-            event.stopPropagation();
-
-            selectGridNodeInDirection(
-              currentCords.x,
-              currentCords.y,
-              type === 'keyArrowUp' ? 'up' : 'down',
-            );
-
-            return true;
-          }
-
-          if (
-            (type === 'keyArrowLeft' && selection.anchor.offset === 0) ||
-            (type === 'keyArrowRight' &&
-              selection.anchor.offset ===
-                selection.anchor.getNode().getTextContentSize())
-          ) {
-            event.preventDefault();
-            event.stopImmediatePropagation();
-            event.stopPropagation();
-
-            selectGridNodeInDirection(
-              currentCords.x,
-              currentCords.y,
-              type === 'keyArrowLeft' ? 'backward' : 'forward',
-            );
-
-            return true;
-          }
-        }
-      }
-
-      return false;
-    },
-    CriticalPriority,
-  );
-
-  editorListeners.add(genericCommandListener);
-
-  return () =>
-    Array.from(editorListeners).forEach((removeListener) =>
-      removeListener ? removeListener() : null,
-    );
-}
+  return false;
+};
 
 function selectTableCellNode(tableCell) {
   const possibleParagraph = tableCell

--- a/packages/lexical-table/src/LexicalTableUtils.js
+++ b/packages/lexical-table/src/LexicalTableUtils.js
@@ -6,7 +6,7 @@
  *
  * @flow strict
  */
-import type {Grid} from './LexicalTableSelectionHelpers';
+import type {Grid} from './LexicalTableSelection';
 import type {LexicalNode} from 'lexical';
 
 import {$findMatchingParent} from '@lexical/helpers/nodes';

--- a/packages/lexical-table/src/index.js
+++ b/packages/lexical-table/src/index.js
@@ -24,7 +24,8 @@ import {
   $isTableRowNode,
   TableRowNode,
 } from './LexicalTableRowNode';
-import {$applyTableHandlers} from './LexicalTableSelectionHelpers';
+import {TableSelection} from './LexicalTableSelection';
+import {applyTableHandlers} from './LexicalTableSelectionHelpers';
 import {
   $createTableNodeWithDimensions,
   $deleteTableColumn,
@@ -39,7 +40,6 @@ import {
 } from './LexicalTableUtils';
 
 export {
-  $applyTableHandlers,
   $createTableCellNode,
   $createTableNode,
   $createTableNodeWithDimensions,
@@ -57,8 +57,10 @@ export {
   $isTableNode,
   $isTableRowNode,
   $removeTableRowAtIndex,
+  applyTableHandlers,
   TableCellHeaderStates,
   TableCellNode,
   TableNode,
   TableRowNode,
+  TableSelection,
 };

--- a/packages/lexical-table/src/utils.js
+++ b/packages/lexical-table/src/utils.js
@@ -6,7 +6,7 @@
  *
  * @flow strict
  */
-import type {Grid} from './LexicalTableSelectionHelpers';
+import type {Grid} from './LexicalTableSelection';
 import type {LexicalNode} from 'lexical';
 
 import {$findMatchingParent} from '@lexical/helpers/nodes';


### PR DESCRIPTION
Per discussion with Dominic, this PR splits the long complicated `attachTableHandlers` function into smaller methods on a `LexicalTableSelection` class that shares & maintains an internal state.

This makes it easier to swap in GridSelection in #1453.