### PR TITLE
add username prop to the collab plugin and use that for cursor name

### DIFF
--- a/packages/lexical-react/LexicalCollaborationPlugin.d.ts
+++ b/packages/lexical-react/LexicalCollaborationPlugin.d.ts
@@ -42,10 +42,12 @@ type CollaborationContextType = {
   name: string;
   yjsDocMap: Map<string, Doc>;
 };
+export type ProviderFactory = (id: string, yjsDocMap: Map<string, Doc>) => Provider;
 export function CollaborationPlugin(arg0: {
   id: string;
-  providerFactory: (id: string, yjsDocMap: Map<string, Doc>) => Provider;
+  providerFactory: ProviderFactory;
   shouldBootstrap: boolean;
+  username?: string;
 }): React.ReactNode;
 export declare var CollaborationContext: React.Context<CollaborationContextType>;
 export function useCollaborationContext(): CollaborationContextType;

--- a/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow
@@ -48,10 +48,13 @@ type CollaborationContextType = {
   yjsDocMap: Map<string, Doc>,
 };
 
+export type ProviderFactory = (id: string, yjsDocMap: Map<string, Doc>) => Provider;
+
 declare export function CollaborationPlugin(arg0: {
   id: string,
-  providerFactory: (id: string, yjsDocMap: Map<string, Doc>) => Provider,
+  providerFactory: ProviderFactory,
   shouldBootstrap: boolean,
+  username?: string
 }): React$Node;
 declare export var CollaborationContext: React$Context<CollaborationContextType>;
 declare export function useCollaborationContext(): CollaborationContextType;

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.js
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.js
@@ -52,12 +52,14 @@ export function CollaborationPlugin({
   id,
   providerFactory,
   shouldBootstrap,
+  username,
 }: {
   id: string,
   providerFactory: (id: string, yjsDocMap: Map<string, Doc>) => Provider,
   shouldBootstrap: boolean,
+  username?: string,
 }): React$Node {
-  const collabContext = useCollaborationContext();
+  const collabContext = useCollaborationContext(username);
   const {yjsDocMap, name, color} = collabContext;
   const [editor] = useLexicalComposerContext();
   const provider = useMemo(
@@ -88,6 +90,12 @@ export const CollaborationContext: React$Context<CollaborationContextType> =
     yjsDocMap: new Map(),
   });
 
-export function useCollaborationContext(): CollaborationContextType {
-  return useContext(CollaborationContext);
+export function useCollaborationContext(
+  username?: string,
+): CollaborationContextType {
+  const collabContext = useContext(CollaborationContext);
+  if (username != null) {
+    collabContext.name = username;
+  }
+  return collabContext;
 }

--- a/packages/lexical-yjs/src/SyncCursors.js
+++ b/packages/lexical-yjs/src/SyncCursors.js
@@ -162,7 +162,7 @@ function createCursorSelection(
   caret.style.cssText = `position:absolute;top:0;bottom:0;right:-1px;width:1px;background-color:rgb(${color});z-index:10;`;
   const name = document.createElement('span');
   name.textContent = cursor.name;
-  name.style.cssText = `position:absolute;left:-2px;top:-16px;background-color:rgb(${color});color:#fff;line-height:12px;height:12px;font-size:12px;padding:2px;font-family:Arial;font-weight:bold`;
+  name.style.cssText = `position:absolute;left:-2px;top:-16px;background-color:rgb(${color});color:#fff;line-height:12px;height:12px;font-size:12px;padding:2px;font-family:Arial;font-weight:bold;white-space:nowrap;`;
   caret.appendChild(name);
   return {
     anchor: {


### PR DESCRIPTION
this PR adds a new prop 'username' on collaborationPlugin where a surface can pass in username that's been used for collab cursor. Meanwhile, this also makes a small css change for displaying username without wrapping over