### PR TITLE
Add logError command

### DIFF
--- a/packages/lexical/src/LexicalUpdates.js
+++ b/packages/lexical/src/LexicalUpdates.js
@@ -368,6 +368,7 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
     }
   } catch (error) {
     // Report errors
+    editor.execCommand('logError', error);
     editor._onError(error);
     // Reset editor and restore incoming editor state to the DOM
     if (!isAttemptingToRecoverFromReconcilerError) {
@@ -638,6 +639,7 @@ function beginUpdate(
     }
   } catch (error) {
     // Report errors
+    editor.execCommand('logError', error);
     editor._onError(error);
     // Restore existing editor state to the DOM
     editor._pendingEditorState = currentEditorState;


### PR DESCRIPTION
Having logError command will enable plugins react to errors regardless onError function of the surface.

I see it useful for this 3 cases:
1. General logging
2. Adding error display plugin with the report error button
3. Capturing expected errors for plugins and their graceful handling, like errors related to failed network