### PR TITLE
RFC Support for non-clipboard paste events

### DIFF
--- a/packages/lexical-react/src/shared/clipboardEvents.js
+++ b/packages/lexical-react/src/shared/clipboardEvents.js
@@ -105,10 +105,13 @@ export function onPasteForRichText(
   event: ClipboardEvent,
   editor: LexicalEditor,
 ): void {
+  const clipboardData = event.clipboardData;
+  if (clipboardData === undefined) {
+    return;
+  }
   event.preventDefault();
   editor.update(() => {
     const selection = $getSelection();
-    const clipboardData = event.clipboardData;
     if (clipboardData != null && $isRangeSelection(selection)) {
       $insertDataTransferForRichText(clipboardData, selection, editor);
     }

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -229,6 +229,12 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
         editor.execCommand('insertText', data);
       }
       return;
+    } else if (
+      inputType === 'insertFromPaste' ||
+      inputType === 'insertFromPasteAsQuotation'
+    ) {
+      editor.execCommand('paste', event);
+      return;
     }
 
     // Prevent the browser from carrying out
@@ -259,11 +265,6 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
         // Used for Android
         $setCompositionKey(null);
         editor.execCommand('insertParagraph');
-        break;
-      }
-      case 'insertFromPaste':
-      case 'insertFromPasteAsQuotation': {
-        editor.execCommand('paste', event);
         break;
       }
       case 'deleteByComposition': {


### PR DESCRIPTION
_Disclaimer: not the final code. Just want to check whether you're OK with the approach or we should just simply not support non-clipboard events._

@trueadm pointed out people can't paste on WWW on FF - https://bugzilla.mozilla.org/show_bug.cgi?id=1758366

Don't think it's a regression, we just never supported non-clipboard events `dom.event.clipboardevents.enabled === false`

My initial thought process was that there were two options:
1. Try interpret the `insertPasteForRichText` event
2. Let the browser do its thing

I couldn't quite get the first one working even though the API technically should support it:

`event.dataTransfer[0].getAsString(console.info) // Never called for some reason`

So this PR proposes the second, let the paste without clipboard be interpreted by the MutationObserver. I'm also adding the empty paragraph case check, so that for simple pastes on an empty paragraph we create a new TextNode and append the content in it