### PR TITLE
Rename to addNodeTransform

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ There are a few ways to update an editor instance:
 
 - Trigger an update with `editor.update()`
 - Setting the editor state via `editor.setEditorState()`
-- Applying a change as part of an existing update via `editor.addTransform()`
+- Applying a change as part of an existing update via `editor.addNodeTransform()`
 - Using a command listener with `editor.addListener('command', () => {...}, priority)`
 
 The most common way to update the editor is to use `editor.update()`. Calling this function

--- a/examples/emoticons.md
+++ b/examples/emoticons.md
@@ -159,7 +159,7 @@ Next, let's setup a transform to listen for changes. Transforms are special even
 
 function useEmoticons(editor) {
   useEffect(() => {
-    const removeTransform = editor.addTransform(TextNode, () => {
+    const removeTransform = editor.addNodeTransform(TextNode, () => {
       console.log('hello');
     });
     return () => {
@@ -192,7 +192,10 @@ function emoticonTransform(node) {
 
 function useEmoticons(editor) {
   useEffect(() => {
-    const removeTransform = editor.addTransform(TextNode, emoticonTransform);
+    const removeTransform = editor.addNodeTransform(
+      TextNode,
+      emoticonTransform,
+    );
     return () => {
       removeTransform();
     };
@@ -223,7 +226,7 @@ function emoticonTransform(node) {
 
 function useEmoticons(editor) {
   useEffect(() => {
-    const removeTransform = editor.addTransform(TextNode, emoticonTransform);
+    const removeTransform = editor.addNodeTransform(TextNode, emoticonTransform);
     return () => {
       removeTransform();
     };

--- a/packages/lexical-playground/src/plugins/CodeHighlightPlugin.js
+++ b/packages/lexical-playground/src/plugins/CodeHighlightPlugin.js
@@ -70,9 +70,13 @@ export default function CodeHighlightPlugin(): React$Node {
     }
 
     return withSubscriptions(
-      editor.addTransform(CodeNode, (node) => codeNodeTransform(node, editor)),
-      editor.addTransform(TextNode, (node) => textNodeTransform(node, editor)),
-      editor.addTransform(CodeHighlightNode, (node) =>
+      editor.addNodeTransform(CodeNode, (node) =>
+        codeNodeTransform(node, editor),
+      ),
+      editor.addNodeTransform(TextNode, (node) =>
+        textNodeTransform(node, editor),
+      ),
+      editor.addNodeTransform(CodeHighlightNode, (node) =>
         textNodeTransform(node, editor),
       ),
       editor.addListener(

--- a/packages/lexical-playground/src/plugins/EmojisPlugin.js
+++ b/packages/lexical-playground/src/plugins/EmojisPlugin.js
@@ -63,7 +63,7 @@ function useEmojis(editor: LexicalEditor): void {
       throw new Error('EmojisPlugin: EmojiNode not registered on editor');
     }
 
-    return editor.addTransform(TextNode, textNodeTransform);
+    return editor.addNodeTransform(TextNode, textNodeTransform);
   }, [editor]);
 }
 

--- a/packages/lexical-playground/src/plugins/KeywordsPlugin.js
+++ b/packages/lexical-playground/src/plugins/KeywordsPlugin.js
@@ -224,11 +224,11 @@ function useKeywords(editor: LexicalEditor): void {
       throw new Error('KeywordsPlugin: KeywordNode not registered on editor');
     }
 
-    const removePlainTextTransform = editor.addTransform(
+    const removePlainTextTransform = editor.addNodeTransform(
       TextNode,
       $plainTextTransform,
     );
-    const removeKeywordToPlainTextTransform = editor.addTransform(
+    const removeKeywordToPlainTextTransform = editor.addNodeTransform(
       KeywordNode,
       $keywordToPlainTextTransform,
     );

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.js
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.js
@@ -223,7 +223,7 @@ function useAutoLink(
     };
 
     return withSubscriptions(
-      editor.addTransform(TextNode, (textNode: TextNode) => {
+      editor.addNodeTransform(TextNode, (textNode: TextNode) => {
         const parent = textNode.getParentOrThrow();
         if ($isAutoLinkNode(parent)) {
           handleLinkEdit(parent, matchers, onChangeWrapped);
@@ -234,7 +234,7 @@ function useAutoLink(
           handleBadNeighbors(textNode, onChangeWrapped);
         }
       }),
-      editor.addTransform(AutoLinkNode, (linkNode: AutoLinkNode) => {
+      editor.addNodeTransform(AutoLinkNode, (linkNode: AutoLinkNode) => {
         handleLinkEdit(linkNode, matchers, onChangeWrapped);
       }),
     );

--- a/packages/lexical-react/src/LexicalHashtagPlugin.js
+++ b/packages/lexical-react/src/LexicalHashtagPlugin.js
@@ -361,11 +361,11 @@ function $convertHashtagNodeToPlainTextNode(node: HashtagNode): void {
 
 function useHashtags(editor: LexicalEditor): void {
   useEffect(() => {
-    const removePlainTextTransform = editor.addTransform(
+    const removePlainTextTransform = editor.addNodeTransform(
       TextNode,
       textNodeTransform,
     );
-    const removeHashtagToPlainTextTransform = editor.addTransform(
+    const removeHashtagToPlainTextTransform = editor.addNodeTransform(
       HashtagNode,
       $hashtagToPlainTextTransform,
     );

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -97,7 +97,7 @@ export declare class LexicalEditor {
     klass: Class<LexicalNode>,
     listener: MutationListener,
   ): () => void;
-  addTransform<T extends LexicalNode>(
+  addNodeTransform<T extends LexicalNode>(
     klass: Class<T>,
     listener: Transform<T>,
   ): () => void;
@@ -144,9 +144,9 @@ export type EditorThemeClasses = {
   //@ts-expect-error
   list?: {
     ul?: EditorThemeClassName;
-    ulDepth?: Array<EditorThemeClassName>,
+    ulDepth?: Array<EditorThemeClassName>;
     ol?: EditorThemeClassName;
-    olDepth?: Array<EditorThemeClassName>,
+    olDepth?: Array<EditorThemeClassName>;
     listitem?: EditorThemeClassName;
     nested?: {
       list?: EditorThemeClassName;

--- a/packages/lexical/README.md
+++ b/packages/lexical/README.md
@@ -89,7 +89,7 @@ There are a few ways to update an editor instance:
 
 - Trigger an update with `editor.update()`
 - Setting the editor state via `editor.setEditorState()`
-- Applying a change as part of an existing update via `editor.addTransform()`
+- Applying a change as part of an existing update via `editor.addNodeTransform()`
 - Using a command listener with `editor.addListener('command', () => {...}, priority)`
 
 The most common way to update the editor is to use `editor.update()`. Calling this function

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -107,7 +107,7 @@ declare export class LexicalEditor {
     klass: Class<LexicalNode>,
     listener: MutationListener,
   ): () => void;
-  addTransform<T: LexicalNode>(
+  addNodeTransform<T: LexicalNode>(
     klass: Class<T>,
     listener: Transform<T>,
   ): () => void;

--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -465,7 +465,7 @@ class BaseLexicalEditor {
       };
     }
   }
-  addTransform(
+  addNodeTransform(
     // There's no Flow-safe way to preserve the T in Transform<T>, but <T: LexicalNode> in the
     // declaration below guarantees these are LexicalNodes.
     klass: Class<LexicalNode>,
@@ -676,7 +676,7 @@ declare export class LexicalEditor {
     listener: CommandListener,
     priority: CommandListenerPriority,
   ): () => void;
-  addTransform<T: LexicalNode>(
+  addNodeTransform<T: LexicalNode>(
     klass: Class<T>,
     listener: Transform<T>,
   ): () => void;

--- a/packages/lexical/src/nodes/base/__tests__/unit/LexicalElementNode.test.js
+++ b/packages/lexical/src/nodes/base/__tests__/unit/LexicalElementNode.test.js
@@ -474,7 +474,7 @@ describe('LexicalElementNode tests', () => {
       const transforms = new Set();
       const expectedTransforms = [];
 
-      const removeTransform = editor.addTransform(TextNode, (node) => {
+      const removeTransform = editor.addNodeTransform(TextNode, (node) => {
         transforms.add(node.__key);
       });
 


### PR DESCRIPTION
@trueadm 's proposal based on user feedback, apparently the original addTextTransform was more intuitive. We can't call it `addTextTransform` as we handle more than just text but we can at least add the `Node` part to it.