### PR TITLE
Find scrollable parent before .scrollIntoView

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/AutoScroll-test.js
+++ b/packages/lexical-playground/__tests__/e2e/AutoScroll-test.js
@@ -6,38 +6,43 @@
  *
  */
 
-import {evaluate, focusEditor, initializeE2E} from '../utils';
+import {E2E_BROWSER, evaluate, focusEditor, initializeE2E} from '../utils';
 
 describe('Auto scroll while typing', () => {
   initializeE2E((e2e) => {
-    async function addScroll(page, selector) {
+    async function addScroll(page, selector_) {
       await evaluate(
         page,
-        (selectorArg) => {
-          const element = document.querySelector(selectorArg);
+        (selector) => {
+          const element = document.querySelector(selector);
           element.style.overflow = 'auto';
-          element.style.maxHeight = '50px';
+          element.style.maxHeight = '100px';
         },
-        selector,
+        selector_,
       );
     }
 
-    async function isCaretVisible(page) {
-      return await evaluate(page, () => {
-        const selection = document.getSelection();
-        const anchorNode = selection.anchorNode;
-        const element =
-          anchorNode.nodeName === '#text' ? anchorNode.parentNode : anchorNode;
+    async function isCaretVisible(page, selector_) {
+      return await evaluate(
+        page,
+        (selector) => {
+          const selection = document.getSelection();
+          const range = selection.getRangeAt(0);
+          const element = document.createElement('span');
+          range.insertNode(element);
+          const selectionRect = element.getBoundingClientRect();
+          element.parentNode.removeChild(element);
+          const containerRect = document
+            .querySelector(selector)
+            .getBoundingClientRect();
 
-        const rect = element.getBoundingClientRect();
-        const elementFromPoint = document.elementFromPoint(rect.left, rect.top);
-
-        return (
-          rect.bottom <= window.innerHeight &&
-          rect.top >= 0 &&
-          elementFromPoint === element
-        );
-      });
+          return (
+            selectionRect.top >= containerRect.top &&
+            selectionRect.top < containerRect.bottom
+          );
+        },
+        selector_,
+      );
     }
 
     [
@@ -50,17 +55,33 @@ describe('Auto scroll while typing', () => {
         selector: '.editor-container',
       },
     ].forEach((testCase) => {
-      it.skipIf(e2e.isPlainText, testCase.name, async () => {
-        const {page} = e2e;
+      [true, false].forEach((isSoftLineBreak) => {
+        it.skipIf(
+          // TODO:
+          // skip due to existing bug with safari - #1473
+          (e2e.isPlainText || isSoftLineBreak) && E2E_BROWSER === 'webkit',
+          `${testCase.name}${isSoftLineBreak ? ' (soft line break)' : ''}`,
+          async () => {
+            const {page} = e2e;
 
-        await focusEditor(page);
-        await addScroll(page, testCase.selector);
+            await focusEditor(page);
+            await addScroll(page, testCase.selector);
 
-        for (let i = 0; i < 15; i++) {
-          await page.keyboard.type('Hello');
-          await page.keyboard.press('Enter');
-          expect(await isCaretVisible(page)).toBe(true);
-        }
+            for (let i = 0; i < 15; i++) {
+              await page.keyboard.type('Hello');
+
+              if (isSoftLineBreak) {
+                await page.keyboard.down('Shift');
+                await page.keyboard.press('Enter');
+                await page.keyboard.up('Shift');
+              } else {
+                await page.keyboard.press('Enter');
+              }
+
+              expect(await isCaretVisible(page, testCase.selector)).toBe(true);
+            }
+          },
+        );
       });
     });
   });

--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -749,10 +749,34 @@ export function updateEditorState(
   return reconcileMutatedNodes;
 }
 
-function scrollIntoViewIfNeeded(node: Node, rootElement: ?HTMLElement): void {
-  const element: Element =
+function getClosestAnchorElement(
+  anchorNode: Node,
+  anchorOffset: number,
+): Element {
+  if (anchorNode.nodeType === DOM_TEXT_TYPE) {
     // $FlowFixMe: this is valid, as we are checking the nodeType
-    node.nodeType === DOM_TEXT_TYPE ? node.parentNode : node;
+    return anchorNode.parentNode;
+  }
+
+  const childNode = anchorNode.childNodes[anchorOffset];
+  if (
+    childNode.nodeType === DOM_TEXT_TYPE ||
+    // Using parent element for a new line block will provide
+    // better check for visibility than linebreak itself
+    (childNode instanceof HTMLBRElement && anchorNode.childNodes.length === 1)
+  ) {
+    // $FlowFixMe: this is valid, as we are checking the nodeType
+    return anchorNode;
+  }
+
+  // $FlowFixMe: this is valid, as we are checking the nodeType
+  return childNode;
+}
+
+function scrollIntoViewIfNeeded(
+  element: Element,
+  rootElement: ?HTMLElement,
+): void {
   if (element !== null) {
     const rect = element.getBoundingClientRect();
 
@@ -767,23 +791,18 @@ function scrollIntoViewIfNeeded(node: Node, rootElement: ?HTMLElement): void {
       }
 
       let scrollableElement = rootElement;
-      while (
-        scrollableElement &&
-        scrollableElement.scrollHeight <= scrollableElement.clientHeight
-      ) {
+      while (scrollableElement) {
+        if (scrollableElement.scrollHeight > scrollableElement.clientHeight) {
+          const scrollRect = scrollableElement.getBoundingClientRect();
+          if (rect.bottom > scrollRect.bottom) {
+            element.scrollIntoView(false);
+            return;
+          } else if (rect.top < scrollRect.top) {
+            element.scrollIntoView();
+            return;
+          }
+        }
         scrollableElement = scrollableElement.parentElement;
-      }
-
-      // Fallback if hasn't found scrollable parent node up in a tree
-      if (scrollableElement == null) {
-        scrollableElement = rootElement;
-      }
-
-      const rootRect = scrollableElement.getBoundingClientRect();
-      if (rect.bottom > rootRect.bottom) {
-        element.scrollIntoView(false);
-      } else if (rect.top < rootRect.top) {
-        element.scrollIntoView();
       }
     }
   }
@@ -880,7 +899,10 @@ function reconcileSelection(
       nextFocusOffset,
     );
     if (nextSelection.isCollapsed() && rootElement === activeElement) {
-      scrollIntoViewIfNeeded(nextAnchorNode, rootElement);
+      scrollIntoViewIfNeeded(
+        getClosestAnchorElement(nextAnchorNode, nextAnchorOffset),
+        rootElement,
+      );
     }
   } catch (error) {
     // If we encounter an error, continue. This can sometimes


### PR DESCRIPTION
This would allow lexical to scroll into view in cases when root element is scrollable or any of its parents. E.g. example with editor within the dialog:

<img width="1014" alt="Screen Shot 2022-03-14 at 5 06 38 PM" src="https://user-images.githubusercontent.com/132642/158262404-8a348707-889d-4a26-8fb7-825dd464c174.png">

It can also be a plugin, the only question if is it fine to keep default functionality in that case