### PR TITLE
Bump timeout to 60s

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -21,6 +21,7 @@ const config = {
     },
   ],
   retries: 5,
+  timeout: 60000,
   use: {
     // this causes issues in the CI on on current version.
     //trace: 'retain-on-failure',


### PR DESCRIPTION
It looks like the very first test case times out pretty frequently. I suspect (from the videos) this is because the initial browser launch takes too long and, by the time the "load" event fires and the test starts, the timeout is already exceeded.

I could increase the timeout for just the first test, but then we'd have to remember to change it if we every introduce a test that comes earlier in alphabetical order. For now I'm just increasing the global timeout to 60s to see if it mitigates the issue.