### PR TITLE
Fix assertHTML: replace browser-based formatting with prettier

### DIFF
--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import { expect,test as base } from '@playwright/test';
+import {expect, test as base} from '@playwright/test';
 import jestSnapshot from 'jest-snapshot';
 import prettier from 'prettier';
 import {URLSearchParams} from 'url';
@@ -22,14 +22,17 @@ export const E2E_BROWSER = process.env.E2E_BROWSER;
 export const IS_MAC = process.platform === 'darwin';
 export const IS_WINDOWS = process.platform === 'win32';
 export const IS_LINUX = !IS_MAC && !IS_WINDOWS;
-export const IS_COLLAB = process.env.E2E_EDITOR_MODE === 'rich-text-with-collab';
+export const IS_COLLAB =
+  process.env.E2E_EDITOR_MODE === 'rich-text-with-collab';
 const IS_RICH_TEXT = process.env.E2E_EDITOR_MODE !== 'plain-text';
 const IS_PLAIN_TEXT = process.env.E2E_EDITOR_MODE === 'plain-text';
 
-export async function initialize({ page, isCollab, isCharLimit, isCharLimitUtf8 }) {
-  page.exposeFunction('expectToBeEqual', (actual, expected) => {
-    return expect(actual).toEqual(expected);
-  });
+export async function initialize({
+  page,
+  isCollab,
+  isCharLimit,
+  isCharLimitUtf8,
+}) {
   const appSettings = {};
   appSettings.isRichText = IS_RICH_TEXT;
   appSettings.disableBeforeInput =
@@ -56,10 +59,10 @@ export const test = base.extend({
   isCharLimitUtf8: false,
   isCollab: IS_COLLAB,
   isPlainText: IS_PLAIN_TEXT,
-  isRichText: IS_RICH_TEXT
+  isRichText: IS_RICH_TEXT,
 });
 
-export { expect } from '@playwright/test';
+export {expect} from '@playwright/test';
 
 function appSettingsToURLParams(appSettings) {
   const params = new URLSearchParams();
@@ -84,24 +87,9 @@ export async function clickSelectors(page, selectors) {
 
 async function assertHTMLOnPageOrFrame(page, pageOrFrame, expectedHtml) {
   const actualHtml = await pageOrFrame.innerHTML('div[contenteditable="true"]');
-  await page.evaluate(async (args) => {
-    const actualHtmlString = args.actualHtml;
-    const expectedHtmlString = args.expectedHtml;
-    // Assert HTML of the editor matches the given html
-    if (expectedHtmlString === '') {
-      // eslint-disable-next-line no-console
-      console.log('Output HTML:\n\n' + actualHtml);
-      throw new Error('Empty HTML assertion!');
-    }
-    // HTML might differ between browsers, so we use attach
-    // outputs to an element using JSDOM to normalize and prettify
-    // the output.
-    const actual = document.createElement('div');
-    actual.innerHTML = actualHtmlString;
-    const expected = document.createElement('div');
-    expected.innerHTML = expectedHtmlString;
-    await window.expectToBeEqual(actual, expected);
-  }, {actualHtml, expectedHtml});
+  expect(new PrettyHTML(expectedHtml).prettify()).toBe(
+    new PrettyHTML(actualHtml).prettify(),
+  );
 }
 
 export async function assertHTML(page, expectedHtml, ignoreSecondFrame) {
@@ -326,7 +314,7 @@ export async function sleep(delay) {
 export async function focusEditor(page, parentSelector = '.editor-shell') {
   const selector = `${parentSelector} div[contenteditable="true"]`;
   if (IS_COLLAB) {
-    await page.waitForSelector('iframe[name="left"]')
+    await page.waitForSelector('iframe[name="left"]');
     const leftFrame = page.frame('left');
     if ((await leftFrame.$$('.loading').length) !== 0) {
       await leftFrame.waitForSelector('.loading', {
@@ -533,7 +521,7 @@ function isElement(element) {
 // Wrapper around HTML string that is used as indicator for snapshot serializer
 // that it should use own formatter (below)
 class PrettyHTML {
-  constructor(html, {ignoreClasses, ignoreInlineStyles}) {
+  constructor(html, {ignoreClasses, ignoreInlineStyles} = {}) {
     this.html = html;
     this.ignoreClasses = ignoreClasses;
     this.ignoreInlineStyles = ignoreInlineStyles;


### PR DESCRIPTION
It looks like assertHTML was broken (at least it didn't catch mismatch in markup), so replaced browser-based formatting with prettier call.