### PR TITLE
Fix insertText bug with text tokens

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Emoticons.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Emoticons.spec.mjs
@@ -6,277 +6,323 @@
  *
  */
 
-import {moveToLineBeginning, moveToLineEnd} from '../keyboardShortcuts/index.mjs';
-import { assertHTML,
+import {
+  moveToLineBeginning,
+  moveToLineEnd,
+} from '../keyboardShortcuts/index.mjs';
+import {
+  assertHTML,
   assertSelection,
   focusEditor,
-initialize ,
+  initialize,
   repeat,
-  test
+  test,
 } from '../utils/index.mjs';
 
 test.describe('Emoticons', () => {
-  test.beforeEach(({isCollab, page }) => initialize({ isCollab, page }));
-    test(`Can handle a single emoticon`, async ({page, browserName}) => {
-      await focusEditor(page);
-      await page.keyboard.type('This is an emoji :)');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">This is an emoji </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span></p>',
-      );
-      await assertSelection(page, {
-        anchorOffset: 2,
-        anchorPath: [0, 1, 0, 0],
-        focusOffset: 2,
-        focusPath: [0, 1, 0, 0],
-      });
-
-      await page.keyboard.press('Backspace');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">This is an emoji </span></p>',
-      );
-      await assertSelection(page, {
-        anchorOffset: 17,
-        anchorPath: [0, 0, 0],
-        focusOffset: 17,
-        focusPath: [0, 0, 0],
-      });
-
-      await page.keyboard.type(':)');
-      await page.keyboard.press('ArrowLeft');
-      if (browserName === 'firefox') {
-        await assertSelection(page, {
-          anchorOffset: 0,
-          anchorPath: [0, 1, 0, 0],
-          focusOffset: 0,
-          focusPath: [0, 1, 0, 0],
-        });
-      } else {
-        await assertSelection(page, {
-          anchorOffset: 17,
-          anchorPath: [0, 0, 0],
-          focusOffset: 17,
-          focusPath: [0, 0, 0],
-        });
-      }
-
-      await page.keyboard.press('ArrowRight');
-      await assertSelection(page, {
-        anchorOffset: 2,
-        anchorPath: [0, 1, 0, 0],
-        focusOffset: 2,
-        focusPath: [0, 1, 0, 0],
-      });
-
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('Delete');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">This is an emoji </span></p>',
-      );
-      await assertSelection(page, {
-        anchorOffset: 17,
-        anchorPath: [0, 0, 0],
-        focusOffset: 17,
-        focusPath: [0, 0, 0],
-      });
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+  test(`Can handle a single emoticon`, async ({page, browserName}) => {
+    await focusEditor(page);
+    await page.keyboard.type('This is an emoji :)');
+    await assertHTML(
+      page,
+      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">This is an emoji </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span></p>',
+    );
+    await assertSelection(page, {
+      anchorOffset: 2,
+      anchorPath: [0, 1, 0, 0],
+      focusOffset: 2,
+      focusPath: [0, 1, 0, 0],
     });
 
-    test(`Can enter multiple emoticons`, async ({isRichText, browserName, page}) => {
-      await focusEditor(page);
-      await page.keyboard.type(':) :) <3 :(');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span></p>',
-      );
-      await assertSelection(page, {
-        anchorOffset: 2,
-        anchorPath: [0, 6, 0, 0],
-        focusOffset: 2,
-        focusPath: [0, 6, 0, 0],
-      });
+    await page.keyboard.press('Backspace');
+    await assertHTML(
+      page,
+      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">This is an emoji </span></p>',
+    );
+    await assertSelection(page, {
+      anchorOffset: 17,
+      anchorPath: [0, 0, 0],
+      focusOffset: 17,
+      focusPath: [0, 0, 0],
+    });
 
-      await page.keyboard.down('Shift');
-      await page.keyboard.press('Enter');
-      await page.keyboard.up('Shift');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><br></p>',
-      );
-      await assertSelection(page, {
-        anchorOffset: 8,
-        anchorPath: [0],
-        focusOffset: 8,
-        focusPath: [0],
-      });
-
-      await page.keyboard.type(':) :) <3 :(');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span></p>',
-      );
-      await assertSelection(page, {
-        anchorOffset: 2,
-        anchorPath: [0, 14, 0, 0],
-        focusOffset: 2,
-        focusPath: [0, 14, 0, 0],
-      });
-
-      await page.keyboard.press('Enter');
-      if (isRichText) {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span></p><p class="PlaygroundEditorTheme__paragraph"><br></p>',
-        );
-        await assertSelection(page, {
-          anchorOffset: 0,
-          anchorPath: [1],
-          focusOffset: 0,
-          focusPath: [1],
-        });
-      } else {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><br></p>',
-        );
-        await assertSelection(page, {
-          anchorOffset: 16,
-          anchorPath: [0],
-          focusOffset: 16,
-          focusPath: [0],
-        });
-      }
-
-      await page.keyboard.type(':) :) <3 :(');
-      if (isRichText) {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span></p><p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span></p>',
-        );
-        await assertSelection(page, {
-          anchorOffset: 2,
-          anchorPath: [1, 6, 0, 0],
-          focusOffset: 2,
-          focusPath: [1, 6, 0, 0],
-        });
-      } else {
-        await assertHTML(
-          page,
-          '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span></p>',
-        );
-        await assertSelection(page, {
-          anchorOffset: 2,
-          anchorPath: [0, 22, 0, 0],
-          focusOffset: 2,
-          focusPath: [0, 22, 0, 0],
-        });
-      }
-
-      await moveToLineBeginning(page);
-      // This should not crash on a deletion on an immutable node
-      await page.keyboard.press('Backspace');
-      await moveToLineEnd(page);
-
-      await repeat(22, async () => await page.keyboard.press('Backspace'));
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph"><br></p>',
-      );
+    await page.keyboard.type(':)');
+    await page.keyboard.press('ArrowLeft');
+    if (browserName === 'firefox') {
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [0],
+        anchorPath: [0, 1, 0, 0],
         focusOffset: 0,
-        focusPath: [0],
+        focusPath: [0, 1, 0, 0],
       });
+    } else {
+      await assertSelection(page, {
+        anchorOffset: 17,
+        anchorPath: [0, 0, 0],
+        focusOffset: 17,
+        focusPath: [0, 0, 0],
+      });
+    }
 
-      await page.keyboard.type(':):):):):)');
-      await page.keyboard.press('ArrowLeft');
-      if (browserName === 'firefox') {
-        await assertSelection(page, {
-          anchorOffset: 0,
-          anchorPath: [0, 4, 0, 0],
-          focusOffset: 0,
-          focusPath: [0, 4, 0, 0],
-        });
-      } else {
-        await assertSelection(page, {
-          anchorOffset: 2,
-          anchorPath: [0, 3, 0, 0],
-          focusOffset: 2,
-          focusPath: [0, 3, 0, 0],
-        });
-      }
+    await page.keyboard.press('ArrowRight');
+    await assertSelection(page, {
+      anchorOffset: 2,
+      anchorPath: [0, 1, 0, 0],
+      focusOffset: 2,
+      focusPath: [0, 1, 0, 0],
+    });
 
-      await page.keyboard.press('ArrowLeft');
-      if (browserName === 'firefox') {
-        await assertSelection(page, {
-          anchorOffset: 0,
-          anchorPath: [0, 3, 0, 0],
-          focusOffset: 0,
-          focusPath: [0, 3, 0, 0],
-        });
-      } else {
-        await assertSelection(page, {
-          anchorOffset: 2,
-          anchorPath: [0, 2, 0, 0],
-          focusOffset: 2,
-          focusPath: [0, 2, 0, 0],
-        });
-      }
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('Delete');
+    await assertHTML(
+      page,
+      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">This is an emoji </span></p>',
+    );
+    await assertSelection(page, {
+      anchorOffset: 17,
+      anchorPath: [0, 0, 0],
+      focusOffset: 17,
+      focusPath: [0, 0, 0],
+    });
+  });
 
-      await page.keyboard.press('ArrowLeft');
-      if (browserName === 'firefox') {
-        await assertSelection(page, {
-          anchorOffset: 0,
-          anchorPath: [0, 2, 0, 0],
-          focusOffset: 0,
-          focusPath: [0, 2, 0, 0],
-        });
-      } else {
-        await assertSelection(page, {
-          anchorOffset: 2,
-          anchorPath: [0, 1, 0, 0],
-          focusOffset: 2,
-          focusPath: [0, 1, 0, 0],
-        });
-      }
+  test(`Can enter multiple emoticons`, async ({
+    isRichText,
+    browserName,
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type(':) :) <3 :(');
+    await assertHTML(
+      page,
+      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span></p>',
+    );
+    await assertSelection(page, {
+      anchorOffset: 2,
+      anchorPath: [0, 6, 0, 0],
+      focusOffset: 2,
+      focusPath: [0, 6, 0, 0],
+    });
 
-      await page.keyboard.press('ArrowLeft');
-      if (browserName === 'firefox') {
-        await assertSelection(page, {
-          anchorOffset: 0,
-          anchorPath: [0, 1, 0, 0],
-          focusOffset: 0,
-          focusPath: [0, 1, 0, 0],
-        });
-      } else {
-        await assertSelection(page, {
-          anchorOffset: 2,
-          anchorPath: [0, 0, 0, 0],
-          focusOffset: 2,
-          focusPath: [0, 0, 0, 0],
-        });
-      }
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Enter');
+    await page.keyboard.up('Shift');
+    await assertHTML(
+      page,
+      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><br></p>',
+    );
+    await assertSelection(page, {
+      anchorOffset: 8,
+      anchorPath: [0],
+      focusOffset: 8,
+      focusPath: [0],
+    });
 
-      await page.keyboard.press('ArrowLeft');
+    await page.keyboard.type(':) :) <3 :(');
+    await assertHTML(
+      page,
+      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span></p>',
+    );
+    await assertSelection(page, {
+      anchorOffset: 2,
+      anchorPath: [0, 14, 0, 0],
+      focusOffset: 2,
+      focusPath: [0, 14, 0, 0],
+    });
+
+    await page.keyboard.press('Enter');
+    if (isRichText) {
+      await assertHTML(
+        page,
+        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span></p><p class="PlaygroundEditorTheme__paragraph"><br></p>',
+      );
       await assertSelection(page, {
         anchorOffset: 0,
+        anchorPath: [1],
+        focusOffset: 0,
+        focusPath: [1],
+      });
+    } else {
+      await assertHTML(
+        page,
+        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><br></p>',
+      );
+      await assertSelection(page, {
+        anchorOffset: 16,
+        anchorPath: [0],
+        focusOffset: 16,
+        focusPath: [0],
+      });
+    }
+
+    await page.keyboard.type(':) :) <3 :(');
+    if (isRichText) {
+      await assertHTML(
+        page,
+        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span></p><p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span></p>',
+      );
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [1, 6, 0, 0],
+        focusOffset: 2,
+        focusPath: [1, 6, 0, 0],
+      });
+    } else {
+      await assertHTML(
+        page,
+        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span><br><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span data-lexical-text="true"> </span><span class="emoji heart" data-lexical-text="true"><span class="emoji-inner">❤</span></span><span data-lexical-text="true"> </span><span class="emoji unhappysmile" data-lexical-text="true"><span class="emoji-inner">🙁</span></span></p>',
+      );
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [0, 22, 0, 0],
+        focusOffset: 2,
+        focusPath: [0, 22, 0, 0],
+      });
+    }
+
+    await moveToLineBeginning(page);
+    // This should not crash on a deletion on an immutable node
+    await page.keyboard.press('Backspace');
+    await moveToLineEnd(page);
+
+    await repeat(22, async () => await page.keyboard.press('Backspace'));
+    await assertHTML(
+      page,
+      '<p class="PlaygroundEditorTheme__paragraph"><br></p>',
+    );
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0],
+      focusOffset: 0,
+      focusPath: [0],
+    });
+
+    await page.keyboard.type(':):):):):)');
+    await page.keyboard.press('ArrowLeft');
+    if (browserName === 'firefox') {
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0, 4, 0, 0],
+        focusOffset: 0,
+        focusPath: [0, 4, 0, 0],
+      });
+    } else {
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [0, 3, 0, 0],
+        focusOffset: 2,
+        focusPath: [0, 3, 0, 0],
+      });
+    }
+
+    await page.keyboard.press('ArrowLeft');
+    if (browserName === 'firefox') {
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0, 3, 0, 0],
+        focusOffset: 0,
+        focusPath: [0, 3, 0, 0],
+      });
+    } else {
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [0, 2, 0, 0],
+        focusOffset: 2,
+        focusPath: [0, 2, 0, 0],
+      });
+    }
+
+    await page.keyboard.press('ArrowLeft');
+    if (browserName === 'firefox') {
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0, 2, 0, 0],
+        focusOffset: 0,
+        focusPath: [0, 2, 0, 0],
+      });
+    } else {
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [0, 1, 0, 0],
+        focusOffset: 2,
+        focusPath: [0, 1, 0, 0],
+      });
+    }
+
+    await page.keyboard.press('ArrowLeft');
+    if (browserName === 'firefox') {
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0, 1, 0, 0],
+        focusOffset: 0,
+        focusPath: [0, 1, 0, 0],
+      });
+    } else {
+      await assertSelection(page, {
+        anchorOffset: 2,
         anchorPath: [0, 0, 0, 0],
-        focusOffset: 0,
+        focusOffset: 2,
         focusPath: [0, 0, 0, 0],
       });
+    }
 
-      await page.keyboard.type('Hey');
-      await assertHTML(
-        page,
-        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">Hey</span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span></p>',
-      );
-      await assertSelection(page, {
-        anchorOffset: 3,
-        anchorPath: [0, 0, 0],
-        focusOffset: 3,
-        focusPath: [0, 0, 0],
-      });
+    await page.keyboard.press('ArrowLeft');
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0, 0, 0, 0],
+      focusOffset: 0,
+      focusPath: [0, 0, 0, 0],
     });
+
+    await page.keyboard.type('Hey');
+    await assertHTML(
+      page,
+      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">Hey</span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span><span class="emoji happysmile" data-lexical-text="true"><span class="emoji-inner">🙂</span></span></p>',
+    );
+    await assertSelection(page, {
+      anchorOffset: 3,
+      anchorPath: [0, 0, 0],
+      focusOffset: 3,
+      focusPath: [0, 0, 0],
+    });
+  });
+
+  test(`Can handle single emoticon replaced with text`, async ({page}) => {
+    await focusEditor(page);
+    await page.keyboard.type(':)');
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.up('Shift');
+    await page.keyboard.type('a');
+    await assertHTML(
+      page,
+      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">a</span></p>',
+    );
+    await assertSelection(page, {
+      anchorOffset: 1,
+      anchorPath: [0, 0, 0],
+      focusOffset: 1,
+      focusPath: [0, 0, 0],
+    });
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type(':) foo');
+    await page.keyboard.down('Shift');
+    await repeat(5, async () => {
+      await page.keyboard.press('ArrowLeft');
+    });
+    await page.keyboard.up('Shift');
+    await page.keyboard.type('a');
+    await assertHTML(
+      page,
+      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">a</span></p>',
+    );
+    await page.pause();
+    await assertSelection(page, {
+      anchorOffset: 1,
+      anchorPath: [0, 0, 0],
+      focusOffset: 1,
+      focusPath: [0, 0, 0],
+    });
+  });
 });

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -730,7 +730,9 @@ export class RangeSelection implements BaseSelection {
 
     if (selectedNodesLength === 1) {
       if ($isTokenOrInert(firstNode)) {
-        firstNode.remove();
+        const textNode = $createTextNode(text);
+        textNode.select();
+        firstNode.replace(textNode);
         return;
       }
       const firstNodeFormat = firstNode.getFormat();
@@ -875,7 +877,9 @@ export class RangeSelection implements BaseSelection {
       } else if (startOffset === firstNodeTextLength) {
         firstNode.select();
       } else {
-        firstNode.remove();
+        const textNode = $createTextNode(text);
+        textNode.select();
+        firstNode.replace(textNode);
       }
 
       // Remove all selected nodes that haven't already been removed.


### PR DESCRIPTION
This fixes an issue that the WhatsApps folks found regarding emojis (or text tokens to be exact). Replacing the token as the start of a selection range causes the inserted text to not be inserted at all.