### PR TITLE
DO NOT MERGE - show that assertHTML is broken

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
@@ -30,7 +30,7 @@ test.describe('CodeBlock', () => {
         });
         await assertHTML(
           page,
-          '<code class="PlaygroundEditorTheme__code PlaygroundEditorTheme__ltr" spellcheck="false" dir="ltr"><span class="PlaygroundEditorTheme__tokenFunction" data-lexical-text="true">alert</span><span class="PlaygroundEditorTheme__tokenPunctuation" data-lexical-text="true">(</span><span class="PlaygroundEditorTheme__tokenProperty" data-lexical-text="true">1</span><span class="PlaygroundEditorTheme__tokenPunctuation" data-lexical-text="true">)</span><span class="PlaygroundEditorTheme__tokenPunctuation" data-lexical-text="true">;</span></code>',
+          'abcdefg',
         );
 
         // Remove code block (back to a normal paragraph) and check that highlights are converted into regular text


### PR DESCRIPTION
I was playing around the code block test file in order to merge the code wrap pr I was working on a few weeks ago and noticed that the tests pass for any string in assertHTML. The only thing that will make them fail is an empty string.

```
$ npm run test-e2e:chromium CodeBlock

> lexical-monorepo@0.1.16 test-e2e:chromium
> cross-env E2E_BROWSER=chromium playwright test --project="chromium" "CodeBlock"

Using config at /Users/jhaa/Dev/lexical/playwright.config.js

Running 13 tests using 1 worker

  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:21:5 › CodeBlock › Can create code bloc
  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:51:5 › CodeBlock › Can create code bloc
  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:75:5 › CodeBlock › Can switch highlight
  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:96:5 › CodeBlock › Can maintain indent
  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:113:5 › CodeBlock › Can (un)indent mult
  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:157:5 › CodeBlock › Can move around lin
  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:253:7 › CodeBlock › Code block html pas
  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:253:7 › CodeBlock › Code block html pas
  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:253:7 › CodeBlock › Code block html pas
  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:253:7 › CodeBlock › Code block html pas
  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:253:7 › CodeBlock › Code block html pas
  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:253:7 › CodeBlock › Code block html pas
  ✓  [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:253:7 › CodeBlock › Code block html pas


  13 passed (7s)
```