### PR TITLE
Change add* API prefixes to register*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,19 +37,19 @@
 
 - Added GridSelection to support table selection. Selection is now `null | RangeSelection | GridSelection | NodeSelection`.
 - The editor now natively supports read only mode. Use `editor.setReadOnly(boolean)` and `editor.isReadOnly()` to find the read only mode.
-- An additional listener has been added to support listening to readonly changes. Use `editor.addListener('readonly', value => {... })` to react to read only mode changes.
+- An additional listener has been added to support listening to readonly changes. Use `editor.registerListener('readonly', value => {... })` to react to read only mode changes.
 - The BootstrapPlugin has been removed. Instead now use the `initialEditorState` prop on either the PlainTextPlugin or RichTextPlugin to initialize editor state.
 
 ## 0.1.10 (February 22, 2022)
 
 - Added NodeSelection to support multiple non-adjacent node selection. Selection is now `null | RangeSelection | NodeSelection`. Upgrade note: `selection !== null` -> `$isRangeSelection(selection)`.
 - HTML to DOM conversion has been to moved to the nodes themselves. Nodes now take an optional `static convertDOM(): DOMConversionMap | null`.
-- When onError is not passed to `createEditor({onError})` errors will now throw by default. Also, removed `addListener('error')`.
+- When onError is not passed to `createEditor({onError})` errors will now throw by default. Also, removed `registerListener('error')`.
 - Fixed BootstrapPlugin race condition.
 
 ## 0.1.9 (February 18, 2022)
 
-- Added `addListener('mutation', Class<LexicalNode>, Map<NodeKey, NodeMutation>)` to track created/destroyed nodes. `NodeMutation = 'created' | 'destroyed'`
+- Added `registerListener('mutation', Class<LexicalNode>, Map<NodeKey, NodeMutation>)` to track created/destroyed nodes. `NodeMutation = 'created' | 'destroyed'`
 - Removed `$log()`.
 - Moved TableNode/Row/Cell to its own `@lexical/table` package.
 - Composition fixes.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ There are a few ways to update an editor instance:
 - Trigger an update with `editor.update()`
 - Setting the editor state via `editor.setEditorState()`
 - Applying a change as part of an existing update via `editor.addNodeTransform()`
-- Using a command listener with `editor.addListener('command', () => {...}, priority)`
+- Using a command listener with `editor.registerListener('command', () => {...}, priority)`
 
 The most common way to update the editor is to use `editor.update()`. Calling this function
 requires a function to be passed in that will provide access to mutate the underlying
@@ -215,7 +215,7 @@ If you want to know when the editor updates so you can react to the changes, you
 listener to the editor, as shown below:
 
 ```js
-editor.addListener('update', ({editorState}) => {
+editor.registerListener('update', ({editorState}) => {
   // The latest EditorState can be found as `editorState`.
   // To read the contents of the EditorState, use the following API:
 

--- a/examples/decorators.md
+++ b/examples/decorators.md
@@ -64,7 +64,7 @@ function VideoPlugin(): React$Node {
 
   useEffect(() => {
     // Similar with command listener, which returns unlisten callback
-    const removeListener = editor.addListener(
+    const removeListener = editor.registerListener(
       'command',
       (type, payload) => {
         // Adding custom command that will be handled by this plugin

--- a/packages/lexical-playground/src/nodes/ImageNode.jsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.jsx
@@ -309,13 +309,13 @@ function ImageComponent({
   const [selection, setSelection] = useState(null);
 
   useEffect(() => {
-    return editor.addListener('update', ({editorState}) => {
+    return editor.registerListener('update', ({editorState}) => {
       setSelection(editorState.read(() => $getSelection()));
     });
   }, [editor]);
 
   useEffect(() => {
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type, payload) => {
         if (type === 'click') {

--- a/packages/lexical-playground/src/nodes/StickyNode.jsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.jsx
@@ -117,7 +117,7 @@ function StickyComponent({
       }
     });
 
-    const removeRootListener = editor.addListener(
+    const removeRootListener = editor.registerListener(
       'root',
       (nextRootElem, prevRootElem) => {
         if (prevRootElem !== null) {
@@ -236,8 +236,7 @@ function StickyComponent({
           document.addEventListener('pointerup', handlePointerUp);
           event.preventDefault();
         }
-      }}
-    >
+      }}>
       <button onClick={handleDelete} className="delete">
         X
       </button>
@@ -248,8 +247,7 @@ function StickyComponent({
         initialConfig={{
           decoratorEditor: decoratorEditor,
           theme: StickyEditorTheme,
-        }}
-      >
+        }}>
         {isCollab ? (
           <CollaborationPlugin
             id={decoratorEditor.id}

--- a/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
@@ -34,7 +34,7 @@ export default function ActionsPlugins({
   const isCollab = yjsDocMap.get('main') !== undefined;
 
   useEffect(() => {
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type, payload) => {
         if (type === 'readOnly') {

--- a/packages/lexical-playground/src/plugins/AutocompletePlugin.jsx
+++ b/packages/lexical-playground/src/plugins/AutocompletePlugin.jsx
@@ -51,7 +51,7 @@ function useTypeahead(editor: LexicalEditor): void {
         'AutocompletePlugin: TypeaheadNode not registered on editor',
       );
     }
-    return editor.addListener('textcontent', (_text) => {
+    return editor.registerListener('textcontent', (_text) => {
       setText(_text);
     });
   }, [editor]);
@@ -153,7 +153,7 @@ function useTypeahead(editor: LexicalEditor): void {
 
   // Rerender on editor updates
   useEffect(() => {
-    return editor.addListener('update', ({editorState}) => {
+    return editor.registerListener('update', ({editorState}) => {
       editorState.read(() => {
         const typeaheadNode = $getRoot()
           .getAllTextNodes(true)

--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
@@ -97,13 +97,13 @@ function FloatingCharacterStylesEditor({
 
   useEffect(() => {
     return withSubscriptions(
-      editor.addListener('update', ({editorState}) => {
+      editor.registerListener('update', ({editorState}) => {
         editorState.read(() => {
           updateCharacterStylesEditor();
         });
       }),
 
-      editor.addListener(
+      editor.registerListener(
         'command',
         (type) => {
           if (type === 'selectionChange') {
@@ -194,7 +194,7 @@ function useCharacterStylesPopup(editor: LexicalEditor): React$Node {
   const [isCode, setIsCode] = useState(false);
 
   useEffect(() => {
-    return editor.addListener('update', ({editorState}) => {
+    return editor.registerListener('update', ({editorState}) => {
       editorState.read(() => {
         const selection = $getSelection();
 

--- a/packages/lexical-playground/src/plugins/CodeHighlightPlugin.js
+++ b/packages/lexical-playground/src/plugins/CodeHighlightPlugin.js
@@ -81,7 +81,7 @@ export default function CodeHighlightPlugin(): React$Node {
       editor.addNodeTransform(CodeHighlightNode, (node) =>
         textNodeTransform(node, editor),
       ),
-      editor.addListener(
+      editor.registerListener(
         'command',
         (type, payload): boolean =>
           type === 'indentContent' || type === 'outdentContent'

--- a/packages/lexical-playground/src/plugins/ExcalidrawPlugin.js
+++ b/packages/lexical-playground/src/plugins/ExcalidrawPlugin.js
@@ -27,7 +27,7 @@ export default function ExcalidrawPlugin(): React$Node {
       );
     }
 
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type) => {
         if (type === 'insertExcalidraw') {

--- a/packages/lexical-playground/src/plugins/HorizontalRulePlugin.js
+++ b/packages/lexical-playground/src/plugins/HorizontalRulePlugin.js
@@ -20,7 +20,7 @@ export default function HorizontalRulePlugin(): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type) => {
         if (type === 'insertHorizontalRule') {

--- a/packages/lexical-playground/src/plugins/ImagesPlugin.js
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin.js
@@ -26,7 +26,7 @@ export default function ImagesPlugin(): React$Node {
       throw new Error('ImagesPlugin: ImageNode not registered on editor');
     }
 
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type) => {
         if (type === 'insertImage') {

--- a/packages/lexical-playground/src/plugins/ListMaxIndentLevelPlugin.js
+++ b/packages/lexical-playground/src/plugins/ListMaxIndentLevelPlugin.js
@@ -75,7 +75,7 @@ export default function ListMaxIndentLevelPlugin({maxDepth}: Props): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type) => {
         if (type !== 'indentContent') {

--- a/packages/lexical-playground/src/plugins/MentionsPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/MentionsPlugin.jsx
@@ -677,7 +677,7 @@ function MentionsTypeahead({
   }, [results, selectedIndex, updateSelectedIndex]);
 
   useEffect(() => {
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type, payload) => {
         switch (type) {
@@ -1022,7 +1022,10 @@ function useMentions(editor: LexicalEditor): React$Node {
       startTransition(() => setResolution(null));
     };
 
-    const removeUpdateListener = editor.addListener('update', updateListener);
+    const removeUpdateListener = editor.registerListener(
+      'update',
+      updateListener,
+    );
 
     return () => {
       activeRange = null;

--- a/packages/lexical-playground/src/plugins/PollPlugin.js
+++ b/packages/lexical-playground/src/plugins/PollPlugin.js
@@ -24,7 +24,7 @@ export default function PollPlugin(): React$Node {
       throw new Error('PollPlugin: PollNode not registered on editor');
     }
 
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type, payload) => {
         if (type === 'insertPoll') {

--- a/packages/lexical-playground/src/plugins/SpeechToTextPlugin.js
+++ b/packages/lexical-playground/src/plugins/SpeechToTextPlugin.js
@@ -95,7 +95,7 @@ function SpeechToTextPlugin(): null {
   }, [editor, isEnabled, report]);
 
   useEffect(() => {
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type, payload: boolean) => {
         if (type === 'speechToText') {

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin.jsx
@@ -57,16 +57,20 @@ function TableActionMenu({
   });
 
   useEffect(() => {
-    return editor.addListener('mutation', TableCellNode, (nodeMutations) => {
-      const nodeUpdated =
-        nodeMutations.get(tableCellNode.getKey()) === 'updated';
+    return editor.registerListener(
+      'mutation',
+      TableCellNode,
+      (nodeMutations) => {
+        const nodeUpdated =
+          nodeMutations.get(tableCellNode.getKey()) === 'updated';
 
-      if (nodeUpdated) {
-        editor.getEditorState().read(() => {
-          updateTableCellNode(tableCellNode.getLatest());
-        });
-      }
-    });
+        if (nodeUpdated) {
+          editor.getEditorState().read(() => {
+            updateTableCellNode(tableCellNode.getLatest());
+          });
+        }
+      },
+    );
   }, [editor, tableCellNode]);
 
   useEffect(() => {
@@ -459,7 +463,7 @@ function TableCellActionMenuContainer(): React.MixedElement {
   }, [editor]);
 
   useEffect(() => {
-    return editor.addListener('update', () => {
+    return editor.registerListener('update', () => {
       editor.getEditorState().read(() => {
         moveMenu();
       });

--- a/packages/lexical-playground/src/plugins/TableCellResizer.jsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer.jsx
@@ -55,7 +55,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): React$Node {
     useState<MouseDraggingDirection | null>(null);
 
   useEffect(() => {
-    return editor.addListener('update', ({editorState}) => {
+    return editor.registerListener('update', ({editorState}) => {
       editorState.read(() => {
         const selection = $getSelection();
         const isGridSelection = $isGridSelection(selection);

--- a/packages/lexical-playground/src/plugins/TestRecorderPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/TestRecorderPlugin.jsx
@@ -258,7 +258,7 @@ ${steps.map(formatStep).join(`\n`)}
       }
     };
 
-    return editor.addListener(
+    return editor.registerListener(
       'root',
       (
         rootElement: null | HTMLElement,
@@ -292,7 +292,7 @@ ${steps.map(formatStep).join(`\n`)}
   }, [generateTestContent, steps]);
 
   useEffect(() => {
-    const removeUpdateListener = editor.addListener(
+    const removeUpdateListener = editor.registerListener(
       'update',
       ({editorState, dirtyLeaves, dirtyElements}) => {
         if (!isRecording) {
@@ -329,7 +329,7 @@ ${steps.map(formatStep).join(`\n`)}
     if (!isRecording) {
       return;
     }
-    const removeUpdateListener = editor.addListener('update', () => {
+    const removeUpdateListener = editor.registerListener('update', () => {
       const rootElement = editor.getRootElement();
       if (rootElement !== null) {
         setCurrentInnerHTML(rootElement?.innerHTML);

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -164,13 +164,13 @@ function FloatingLinkEditor({editor}: {editor: LexicalEditor}): React$Node {
 
   useEffect(() => {
     return withSubscriptions(
-      editor.addListener('update', ({editorState}) => {
+      editor.registerListener('update', ({editorState}) => {
         editorState.read(() => {
           updateLinkEditor();
         });
       }),
 
-      editor.addListener(
+      editor.registerListener(
         'command',
         (type) => {
           if (type === 'selectionChange') {
@@ -562,7 +562,7 @@ export default function ToolbarPlugin(): React$Node {
   }, [activeEditor]);
 
   useEffect(() => {
-    return activeEditor.addListener('update', ({editorState}) => {
+    return activeEditor.registerListener('update', ({editorState}) => {
       editorState.read(() => {
         updateToolbar();
       });
@@ -570,7 +570,7 @@ export default function ToolbarPlugin(): React$Node {
   }, [activeEditor, updateToolbar]);
 
   useEffect(() => {
-    const removeCommandListener = editor.addListener(
+    const removeCommandListener = editor.registerListener(
       'command',
       (type, payload, _editor) => {
         if (type === 'selectionChange') {

--- a/packages/lexical-react/src/LexicalClearEditorPlugin.js
+++ b/packages/lexical-react/src/LexicalClearEditorPlugin.js
@@ -20,7 +20,7 @@ type Props = $ReadOnly<{
 export default function LexicalClearEditorPlugin({onClear}: Props): React$Node {
   const [editor] = useLexicalComposerContext();
   useLayoutEffect(() => {
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type, payload) => {
         if (type === 'clearEditor') {

--- a/packages/lexical-react/src/LexicalContentEditable.jsx
+++ b/packages/lexical-react/src/LexicalContentEditable.jsx
@@ -66,7 +66,7 @@ export default function LexicalContentEditable({
   );
   useLayoutEffect(() => {
     setReadOnly(editor.isReadOnly());
-    return editor.addListener('readonly', (currentIsReadOnly) => {
+    return editor.registerListener('readonly', (currentIsReadOnly) => {
       setReadOnly(currentIsReadOnly);
     });
   }, [editor]);

--- a/packages/lexical-react/src/LexicalLinkPlugin.js
+++ b/packages/lexical-react/src/LexicalLinkPlugin.js
@@ -100,7 +100,7 @@ export default function LinkPlugin(): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type, payload) => {
         if (type === 'toggleLink') {

--- a/packages/lexical-react/src/LexicalOnChangePlugin.js
+++ b/packages/lexical-react/src/LexicalOnChangePlugin.js
@@ -24,7 +24,7 @@ export default function OnChangePlugin({
   const [editor] = useLexicalComposerContext();
   useLayoutEffect(() => {
     if (onChange) {
-      return editor.addListener(
+      return editor.registerListener(
         'update',
         ({editorState, dirtyElements, dirtyLeaves, prevEditorState}) => {
           if (

--- a/packages/lexical-react/src/LexicalTablePlugin.js
+++ b/packages/lexical-react/src/LexicalTablePlugin.js
@@ -44,7 +44,7 @@ export default function TablePlugin(): React$Node {
         'TablePlugin: TableNode, TableCellNode or TableRowNode not registered on editor',
       );
     }
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type, payload) => {
         if (type === 'insertTable') {
@@ -87,7 +87,7 @@ export default function TablePlugin(): React$Node {
   useEffect(() => {
     const tableSelections = new Map<NodeKey, TableSelection>();
 
-    return editor.addListener('mutation', TableNode, (nodeMutations) => {
+    return editor.registerListener('mutation', TableNode, (nodeMutations) => {
       for (const [nodeKey, mutation] of nodeMutations) {
         if (mutation === 'created') {
           editor.update(() => {

--- a/packages/lexical-react/src/LexicalTreeView.jsx
+++ b/packages/lexical-react/src/LexicalTreeView.jsx
@@ -70,7 +70,7 @@ export default function TreeView({
   const [isPlaying, setIsPlaying] = useState(false);
   useEffect(() => {
     setContent(generateContent(editor.getEditorState()));
-    return editor.addListener('update', ({editorState}) => {
+    return editor.registerListener('update', ({editorState}) => {
       const compositionKey = editor._compositionKey;
       const treeText = generateContent(editor.getEditorState());
       const compositionText =

--- a/packages/lexical-react/src/shared/useAutoFormatter.js
+++ b/packages/lexical-react/src/shared/useAutoFormatter.js
@@ -217,7 +217,7 @@ export default function useAutoFormatter(editor: LexicalEditor): void {
     // However, given "#A B", where the user delets "A" should not.
 
     let priorTriggerState: null | AutoFormatTriggerState = null;
-    return editor.addListener('update', ({tags}) => {
+    return editor.registerListener('update', ({tags}) => {
       // Examine historic so that we are not running autoformatting within markdown.
       if (tags.has('historic') === false) {
         const currentTriggerState = getTriggerState(editor.getEditorState());

--- a/packages/lexical-react/src/shared/useCanShowPlaceholder.js
+++ b/packages/lexical-react/src/shared/useCanShowPlaceholder.js
@@ -23,7 +23,7 @@ export default function useLexicalCanShowPlaceholder(
   );
 
   useLayoutEffect(() => {
-    return editor.addListener('update', ({editorState}) => {
+    return editor.registerListener('update', ({editorState}) => {
       const isComposing = editor.isComposing();
       const currentCanShowPlaceholder = editorState.read(
         $canShowPlaceholderCurry(isComposing),

--- a/packages/lexical-react/src/shared/useCharacterLimit.js
+++ b/packages/lexical-react/src/shared/useCharacterLimit.js
@@ -56,10 +56,10 @@ export function useCharacterLimit(
     let lastComputedTextLength = 0;
 
     return withSubscriptions(
-      editor.addListener('textcontent', (currentText: string) => {
+      editor.registerListener('textcontent', (currentText: string) => {
         text = currentText;
       }),
-      editor.addListener('update', ({dirtyLeaves}) => {
+      editor.registerListener('update', ({dirtyLeaves}) => {
         const isComposing = editor.isComposing();
         const hasDirtyLeaves = dirtyLeaves.size > 0;
         if (isComposing || !hasDirtyLeaves) {

--- a/packages/lexical-react/src/shared/useDecorators.js
+++ b/packages/lexical-react/src/shared/useDecorators.js
@@ -23,7 +23,7 @@ export default function useDecorators(
   );
   // Subscribe to changes
   useLayoutEffect(() => {
-    return editor.addListener('decorator', (nextDecorators) => {
+    return editor.registerListener('decorator', (nextDecorators) => {
       flushSync(() => {
         setDecorators(nextDecorators);
       });

--- a/packages/lexical-react/src/shared/useEditorEvents.js
+++ b/packages/lexical-react/src/shared/useEditorEvents.js
@@ -57,7 +57,7 @@ export default function useEditorEvents(
       });
     }
 
-    return editor.addListener(
+    return editor.registerListener(
       'root',
       (
         rootElement: null | HTMLElement,

--- a/packages/lexical-react/src/shared/useHistory.js
+++ b/packages/lexical-react/src/shared/useHistory.js
@@ -390,8 +390,8 @@ export function useHistory(
     };
 
     return withSubscriptions(
-      editor.addListener('command', applyCommand, EditorPriority),
-      editor.addListener('update', applyChange),
+      editor.registerListener('command', applyCommand, EditorPriority),
+      editor.registerListener('update', applyChange),
     );
   }, [clearHistory, delay, editor, historyState]);
 }

--- a/packages/lexical-react/src/shared/useList.js
+++ b/packages/lexical-react/src/shared/useList.js
@@ -22,7 +22,7 @@ const LowPriority: CommandListenerLowPriority = 1;
 
 export default function useList(editor: LexicalEditor): void {
   useEffect(() => {
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type) => {
         if (type === 'indentContent') {

--- a/packages/lexical-react/src/shared/usePlainTextSetup.js
+++ b/packages/lexical-react/src/shared/usePlainTextSetup.js
@@ -31,7 +31,7 @@ export default function usePlainTextSetup(
   initialEditorState?: InitialEditorStateType,
 ): void {
   useLayoutEffect(() => {
-    const removeListener = editor.addListener(
+    const removeListener = editor.registerListener(
       'command',
       (type, payload): boolean => {
         const selection = $getSelection();

--- a/packages/lexical-react/src/shared/useRichTextSetup.js
+++ b/packages/lexical-react/src/shared/useRichTextSetup.js
@@ -41,7 +41,7 @@ export default function useRichTextSetup(
   initialEditorState?: InitialEditorStateType,
 ): void {
   useLayoutEffect(() => {
-    const removeListener = editor.addListener(
+    const removeListener = editor.registerListener(
       'command',
       (type, payload): boolean => {
         const selection = $getSelection();

--- a/packages/lexical-react/src/shared/useYjsCollaboration.jsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.jsx
@@ -107,7 +107,7 @@ export function useYjsCollaboration(
     awareness.on('update', onAwarenessUpdate);
     root.getSharedType().observeDeep(onYjsTreeChanges);
 
-    const removeListener = editor.addListener(
+    const removeListener = editor.registerListener(
       'update',
       ({
         prevEditorState,
@@ -167,7 +167,7 @@ export function useYjsCollaboration(
   }, [binding]);
 
   useEffect(() => {
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type, payload) => {
         if (type === 'toggleConnect') {
@@ -200,7 +200,7 @@ export function useYjsFocusTracking(
   color: string,
 ) {
   useEffect(() => {
-    return editor.addListener(
+    return editor.registerListener(
       'command',
       (type, payload) => {
         if (type === 'focus') {
@@ -245,7 +245,7 @@ export function useYjsHistory(
       return false;
     };
 
-    return editor.addListener('command', applyCommand, EditorPriority);
+    return editor.registerListener('command', applyCommand, EditorPriority);
   });
 
   const clearHistory = useCallback(() => {

--- a/packages/lexical-react/src/useLexicalIsTextContentEmpty.js
+++ b/packages/lexical-react/src/useLexicalIsTextContentEmpty.js
@@ -24,7 +24,7 @@ export default function useLexicalIsTextContentEmpty(
   );
 
   useLayoutEffect(() => {
-    return editor.addListener('update', ({editorState}) => {
+    return editor.registerListener('update', ({editorState}) => {
       const isComposing = editor.isComposing();
       const currentIsEmpty = editorState.read(
         $isRootTextContentEmptyCurry(isComposing, trim),

--- a/packages/lexical-react/src/useLexicalNodeSelection.js
+++ b/packages/lexical-react/src/useLexicalNodeSelection.js
@@ -38,7 +38,7 @@ export default function useLexicalNodeSelection(
   );
 
   useEffect(() => {
-    return editor.addListener('update', () => {
+    return editor.registerListener('update', () => {
       setIsSelected(isNodeSelected(editor, key));
     });
   }, [editor, key]);

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.js
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.js
@@ -142,7 +142,7 @@ export function applyTableHandlers(
   );
 
   tableSelection.listenersToRemove.add(
-    editor.addListener(
+    editor.registerListener(
       'command',
       (type, payload) => {
         const selection = $getSelection();

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -82,17 +82,20 @@ export declare class LexicalEditor {
   _key: string;
   _readOnly: boolean;
   isComposing(): boolean;
-  addListener(type: 'update', listener: UpdateListener): () => void;
-  addListener(type: 'root', listener: RootListener): () => void;
-  addListener(type: 'decorator', listener: DecoratorListener): () => void;
-  addListener(type: 'textcontent', listener: TextContentListener): () => void;
-  addListener(
+  registerListener(type: 'update', listener: UpdateListener): () => void;
+  registerListener(type: 'root', listener: RootListener): () => void;
+  registerListener(type: 'decorator', listener: DecoratorListener): () => void;
+  registerListener(
+    type: 'textcontent',
+    listener: TextContentListener,
+  ): () => void;
+  registerListener(
     type: 'command',
     listener: CommandListener,
     priority: CommandListenerPriority,
   ): () => void;
-  addListener(type: 'readonly', listener: ReadOnlyListener): () => void;
-  addListener(
+  registerListener(type: 'readonly', listener: ReadOnlyListener): () => void;
+  registerListener(
     type: 'mutation',
     klass: Class<LexicalNode>,
     listener: MutationListener,

--- a/packages/lexical/README.md
+++ b/packages/lexical/README.md
@@ -90,7 +90,7 @@ There are a few ways to update an editor instance:
 - Trigger an update with `editor.update()`
 - Setting the editor state via `editor.setEditorState()`
 - Applying a change as part of an existing update via `editor.addNodeTransform()`
-- Using a command listener with `editor.addListener('command', () => {...}, priority)`
+- Using a command listener with `editor.registerListener('command', () => {...}, priority)`
 
 The most common way to update the editor is to use `editor.update()`. Calling this function
 requires a function to be passed in that will provide access to mutate the underlying
@@ -140,7 +140,7 @@ If you want to know when the editor updates so you can react to the changes, you
 listener to the editor, as shown below:
 
 ```js
-editor.addListener('update', ({editorState}) => {
+editor.registerListener('update', ({editorState}) => {
   // The latest EditorState can be found as `editorState`.
   // To read the contents of the EditorState, use the following API:
 

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -92,17 +92,20 @@ declare export class LexicalEditor {
   _key: string;
   _readOnly: boolean;
   isComposing(): boolean;
-  addListener(type: 'update', listener: UpdateListener): () => void;
-  addListener(type: 'root', listener: RootListener): () => void;
-  addListener(type: 'decorator', listener: DecoratorListener): () => void;
-  addListener(type: 'textcontent', listener: TextContentListener): () => void;
-  addListener(
+  registerListener(type: 'update', listener: UpdateListener): () => void;
+  registerListener(type: 'root', listener: RootListener): () => void;
+  registerListener(type: 'decorator', listener: DecoratorListener): () => void;
+  registerListener(
+    type: 'textcontent',
+    listener: TextContentListener,
+  ): () => void;
+  registerListener(
     type: 'command',
     listener: CommandListener,
     priority: CommandListenerPriority,
   ): () => void;
-  addListener(type: 'readonly', listener: ReadOnlyListener): () => void;
-  addListener(
+  registerListener(type: 'readonly', listener: ReadOnlyListener): () => void;
+  registerListener(
     type: 'mutation',
     klass: Class<LexicalNode>,
     listener: MutationListener,

--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -389,7 +389,7 @@ class BaseLexicalEditor {
   isComposing(): boolean {
     return this._compositionKey != null;
   }
-  addListener(
+  registerListener(
     type: ListenerType,
     arg1:
       | UpdateListener
@@ -632,7 +632,7 @@ class BaseLexicalEditor {
   }
 }
 
-// We export this to make the addListener types work properly.
+// We export this to make the registerListener types work properly.
 // For some reason, we can't do this via an interface without
 // Flow messing up the types. It's hacky, but it improves DX.
 declare export class LexicalEditor {
@@ -662,20 +662,6 @@ declare export class LexicalEditor {
   _updateTags: Set<string>;
   _updating: boolean;
 
-  addListener(type: 'update', listener: UpdateListener): () => void;
-  addListener(type: 'root', listener: RootListener): () => void;
-  addListener(type: 'decorator', listener: DecoratorListener): () => void;
-  addListener(type: 'textcontent', listener: TextContentListener): () => void;
-  addListener(
-    type: 'mutation',
-    klass: Class<LexicalNode>,
-    listener: MutationListener,
-  ): () => void;
-  addListener(
-    type: 'command',
-    listener: CommandListener,
-    priority: CommandListenerPriority,
-  ): () => void;
   addNodeTransform<T: LexicalNode>(
     klass: Class<T>,
     listener: Transform<T>,
@@ -691,6 +677,23 @@ declare export class LexicalEditor {
   isComposing(): boolean;
   isReadOnly(): boolean;
   parseEditorState(stringifiedEditorState: string): EditorState;
+  registerListener(type: 'update', listener: UpdateListener): () => void;
+  registerListener(type: 'root', listener: RootListener): () => void;
+  registerListener(type: 'decorator', listener: DecoratorListener): () => void;
+  registerListener(
+    type: 'textcontent',
+    listener: TextContentListener,
+  ): () => void;
+  registerListener(
+    type: 'mutation',
+    klass: Class<LexicalNode>,
+    listener: MutationListener,
+  ): () => void;
+  registerListener(
+    type: 'command',
+    listener: CommandListener,
+    priority: CommandListenerPriority,
+  ): () => void;
   setEditorState(editorState: EditorState, options?: EditorSetOptions): void;
   setReadOnly(readOnly: boolean): void;
   setRootElement(rootElement: null | HTMLElement): void;

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
@@ -788,11 +788,11 @@ describe('LexicalEditor tests', () => {
       }, [changeElement]);
 
       React.useEffect(() => {
-        return editor.addListener('root', rootListener);
+        return editor.registerListener('root', rootListener);
       }, []);
 
       React.useEffect(() => {
-        return editor.addListener('update', updateListener);
+        return editor.registerListener('update', updateListener);
       }, []);
 
       const ref = React.useCallback((node) => {
@@ -832,7 +832,7 @@ describe('LexicalEditor tests', () => {
       );
       // Subscribe to changes
       React.useEffect(() => {
-        return editor.addListener('decorator', (nextDecorators) => {
+        return editor.registerListener('decorator', (nextDecorators) => {
           setDecorators(nextDecorators);
         });
       }, []);
@@ -855,7 +855,7 @@ describe('LexicalEditor tests', () => {
         editor = React.useMemo(() => createTestEditor(), []);
 
         React.useEffect(() => {
-          editor.addListener('root', listener);
+          editor.registerListener('root', listener);
         }, []);
 
         const ref = React.useCallback((node) => {
@@ -901,7 +901,7 @@ describe('LexicalEditor tests', () => {
         DEPRECATED__useLexicalRichText(editor);
 
         React.useEffect(() => {
-          editor.addListener('root', listener);
+          editor.registerListener('root', listener);
         }, []);
 
         const ref = React.useCallback((node) => {
@@ -1502,7 +1502,7 @@ describe('LexicalEditor tests', () => {
       paragraph.append(textNode);
     });
 
-    editor.addListener('textcontent', (text) => {
+    editor.registerListener('textcontent', (text) => {
       fn(text);
     });
     await editor.update(() => {
@@ -1519,8 +1519,8 @@ describe('LexicalEditor tests', () => {
     const paragraphNodeMutations = jest.fn();
     const textNodeMutations = jest.fn();
 
-    editor.addListener('mutation', ParagraphNode, paragraphNodeMutations);
-    editor.addListener('mutation', TextNode, textNodeMutations);
+    editor.registerListener('mutation', ParagraphNode, paragraphNodeMutations);
+    editor.registerListener('mutation', TextNode, textNodeMutations);
 
     const paragraphKeys = [];
     const textNodeKeys = [];
@@ -1588,7 +1588,7 @@ describe('LexicalEditor tests', () => {
     });
     const initialEditorState = editor.getEditorState();
     const textNodeMutations = jest.fn();
-    editor.addListener('mutation', TextNode, textNodeMutations);
+    editor.registerListener('mutation', TextNode, textNodeMutations);
 
     const textNodeKeys = [];
     await editor.update(() => {
@@ -1635,8 +1635,8 @@ describe('LexicalEditor tests', () => {
     init();
     const paragraphNodeMutations = jest.fn();
     const textNodeMutations = jest.fn();
-    editor.addListener('mutation', ParagraphNode, paragraphNodeMutations);
-    editor.addListener('mutation', TextNode, textNodeMutations);
+    editor.registerListener('mutation', ParagraphNode, paragraphNodeMutations);
+    editor.registerListener('mutation', TextNode, textNodeMutations);
 
     await editor.update(() => {
       $getRoot().append($createParagraphNode());
@@ -1649,7 +1649,7 @@ describe('LexicalEditor tests', () => {
   it('mutation listeners with normalization', async () => {
     init();
     const textNodeMutations = jest.fn();
-    editor.addListener('mutation', TextNode, textNodeMutations);
+    editor.registerListener('mutation', TextNode, textNodeMutations);
 
     const textNodeKeys = [];
     await editor.update(() => {
@@ -1690,8 +1690,8 @@ describe('LexicalEditor tests', () => {
     const paragraphNodeMutations = jest.fn();
     const textNodeMutations = jest.fn();
 
-    editor.addListener('mutation', ParagraphNode, paragraphNodeMutations);
-    editor.addListener('mutation', TextNode, textNodeMutations);
+    editor.registerListener('mutation', ParagraphNode, paragraphNodeMutations);
+    editor.registerListener('mutation', TextNode, textNodeMutations);
 
     const paragraphNodeKeys = [];
     const textNodeKeys = [];
@@ -1745,8 +1745,8 @@ describe('LexicalEditor tests', () => {
 
     const tableCellMutations = jest.fn();
     const tableRowMutations = jest.fn();
-    editor.addListener('mutation', TableCellNode, tableCellMutations);
-    editor.addListener('mutation', TableRowNode, tableRowMutations);
+    editor.registerListener('mutation', TableCellNode, tableCellMutations);
+    editor.registerListener('mutation', TableRowNode, tableRowMutations);
 
     // Create Table
     await editor.update(() => {
@@ -1792,7 +1792,7 @@ describe('LexicalEditor tests', () => {
   it('readonly listener', () => {
     init();
     const readOnlyFn = jest.fn();
-    editor.addListener('readonly', readOnlyFn);
+    editor.registerListener('readonly', readOnlyFn);
 
     expect(editor.isReadOnly()).toBe(false);
     editor.setReadOnly(true);


### PR DESCRIPTION
As discussed in https://github.com/facebook/lexical/issues/1503. This PR changes the `add` prefix to `register` instead, for the reasons outlined in the issue.