### PR TITLE
Fix autolink test (FF not handling link popup in e2e)

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
@@ -14,12 +14,13 @@ import {
   selectAll,
 } from '../keyboardShortcuts/index.mjs';
 import {
-  applyLink,
   assertHTML,
+  click,
   focusEditor,
   initialize,
   pasteFromClipboard,
   test,
+  waitForSelector,
 } from '../utils/index.mjs';
 
 test.describe('Auto Links', () => {
@@ -101,17 +102,19 @@ test.describe('Auto Links', () => {
     await page.keyboard.type('hm');
 
     await selectAll(page);
-    await applyLink(page);
+    await waitForSelector(page, '.link');
+    await click(page, '.link');
+
     await assertHTML(
       page,
-      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><a href="https://facebook.com" class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">hm</span></a></p>',
+      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><a href="https://" class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">hm</span></a></p>',
     );
     await moveLeft(page, 1);
     await moveRight(page, 1);
     await page.keyboard.type('ttps://facebook.co');
     await assertHTML(
       page,
-      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><a href="https://facebook.com" class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">https://facebook.com</span></a></p>',
+      '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><a href="https://" class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">https://facebook.com</span></a></p>',
     );
   });
 });

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -434,17 +434,6 @@ export async function dragMouse(page, firstBoundingBox, secondBoundingBox) {
   await page.mouse.up();
 }
 
-export async function applyLink(page, url = 'facebook.com') {
-  await waitForSelector(page, '.link');
-  await click(page, '.link');
-  await waitForSelector(page, '.link-input');
-  await waitForSelector(page, '.link-edit');
-  await click(page, '.link-edit');
-  await focus(page, '.link-input');
-  await page.keyboard.type(url);
-  await page.keyboard.press('Enter');
-}
-
 expect.extend({
   async toMatchEditorInlineSnapshot(pageOrOptions, ...args) {
     // Setting error field allows jest to know where the matcher was called


### PR DESCRIPTION
FF does not handle link popup well in e2e test (need to re-select text before editing the link). Getting rid of it for auto-link test and will look for a generic fix as a follow up