### PR TITLE
Add `scroll-into-view` tag and plugit to support custom scrollable element

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -73,6 +73,7 @@ module.name_mapper='^@lexical/react/LexicalTablePlugin' -> '<PROJECT_ROOT>/packa
 module.name_mapper='^@lexical/react/LexicalLinkPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalLinkPlugin.js.flow'
 module.name_mapper='^@lexical/react/LexicalAutoLinkPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalAutoLinkPlugin.js.flow'
 module.name_mapper='^@lexical/react/LexicalListPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalListPlugin.js.flow'
+module.name_mapper='^@lexical/react/LexicalAutoScrollPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalAutoScrollPlugin.js.flow'
 
 module.name_mapper='^@lexical/yjs$' -> '<PROJECT_ROOT>/packages/lexical-yjs/src/index.js'
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -31,6 +31,8 @@ module.exports = {
           '<rootDir>/packages/lexical-react/src/DEPRECATED_useLexicalRichText.js',
         '^@lexical/react/LexicalAutoLinkPlugin$':
           '<rootDir>/packages/lexical-react/src/LexicalAutoLinkPlugin.js',
+        '^@lexical/react/LexicalAutoScrollPlugin$':
+          '<rootDir>/packages/lexical-react/src/LexicalAutoScrollPlugin.js',
         '^@lexical/react/LexicalCollaborationPlugin$':
           '<rootDir>/packages/lexical-react/src/LexicalCollaborationPlugin.js',
         '^@lexical/react/LexicalComposerContext$':

--- a/packages/lexical-playground/__tests__/e2e/AutoScroll.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoScroll.spec.mjs
@@ -22,7 +22,7 @@ test.describe('Auto scroll while typing', () => {
       (selector) => {
         const element = document.querySelector(selector);
         element.style.overflow = 'auto';
-        element.style.maxHeight = '100px';
+        element.style.maxHeight = '200px';
       },
       selector_,
     );
@@ -35,6 +35,7 @@ test.describe('Auto scroll while typing', () => {
         const selection = document.getSelection();
         const range = selection.getRangeAt(0);
         const element = document.createElement('span');
+        element.innerHTML = '|';
         range.insertNode(element);
         const selectionRect = element.getBoundingClientRect();
         element.parentNode.removeChild(element);
@@ -56,10 +57,10 @@ test.describe('Auto scroll while typing', () => {
       name: 'Can auto scroll if content editable element is scrollable',
       selector: '.ContentEditable__root',
     },
-    // {
-    //   name: 'Can auto scroll if parent element is scrollable',
-    //   selector: '.editor-container',
-    // },
+    {
+      name: 'Can auto scroll if parent element is scrollable',
+      selector: '.editor-container',
+    },
   ].forEach((testCase) => {
     [true, false].forEach((isSoftLineBreak) => {
       test(`${testCase.name}${

--- a/packages/lexical-playground/src/Editor.jsx
+++ b/packages/lexical-playground/src/Editor.jsx
@@ -8,6 +8,7 @@
  */
 
 import AutoFormatterPlugin from '@lexical/react/LexicalAutoFormatterPlugin';
+import AutoScrollPlugin from '@lexical/react/LexicalAutoScrollPlugin';
 import CharacterLimitPlugin from '@lexical/react/LexicalCharacterLimitPlugin';
 import LexicalClearEditorPlugin from '@lexical/react/LexicalClearEditorPlugin';
 import {CollaborationPlugin} from '@lexical/react/LexicalCollaborationPlugin';
@@ -19,6 +20,7 @@ import PlainTextPlugin from '@lexical/react/LexicalPlainTextPlugin';
 import RichTextPlugin from '@lexical/react/LexicalRichTextPlugin';
 import TablesPlugin from '@lexical/react/LexicalTablePlugin';
 import * as React from 'react';
+import {useRef} from 'react';
 
 import {createWebsocketProvider} from './collaboration';
 import {useSettings} from './context/SettingsContext';
@@ -68,6 +70,7 @@ export default function Editor(): React$Node {
     ? 'Enter some rich text...'
     : 'Enter some plain text...';
   const placeholder = <Placeholder>{text}</Placeholder>;
+  const scrollRef = useRef(null);
 
   return (
     <>
@@ -75,7 +78,9 @@ export default function Editor(): React$Node {
       <div
         className={`editor-container ${showTreeView ? 'tree-view' : ''} ${
           !isRichText ? 'plain-text' : ''
-        }`}>
+        }`}
+        ref={scrollRef}
+      >
         <AutoFocusPlugin />
         <LexicalClearEditorPlugin />
         <MentionsPlugin />
@@ -88,6 +93,7 @@ export default function Editor(): React$Node {
         <AutoLinkPlugin />
         <CharacterStylesPopupPlugin />
         <EquationsPlugin />
+        <AutoScrollPlugin scrollRef={scrollRef} />
         {isRichText ? (
           <>
             {isCollab ? (

--- a/packages/lexical-playground/src/ui/ContentEditable.css
+++ b/packages/lexical-playground/src/ui/ContentEditable.css
@@ -20,5 +20,5 @@
   outline: 0;
   padding: 10px;
   overflow: auto;
-  resize: vetical;
+  resize: vertical;
 }

--- a/packages/lexical-playground/vite.config.js
+++ b/packages/lexical-playground/vite.config.js
@@ -105,6 +105,7 @@ const moduleResolution = [
   'LexicalListPlugin',
   'LexicalAutoLinkPlugin',
   'LexicalOnChangePlugin',
+  'LexicalAutoScrollPlugin',
 ].forEach((module) => {
   let resolvedPath = path.resolve(`../lexical-react/src/${module}.js`);
   if (fs.existsSync(resolvedPath)) {

--- a/packages/lexical-react/LexicalAutoScrollPlugin.d.ts
+++ b/packages/lexical-react/LexicalAutoScrollPlugin.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$ReadOnly} from 'utility-types';
+type Props = $ReadOnly<{
+  scrollRef: { current: HTMLElement | null };
+}>;
+export default function LexicalAutoScrollPlugin(props: Props): null;

--- a/packages/lexical-react/flow/LexicalAutoScrollPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalAutoScrollPlugin.js.flow
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+type Props = $ReadOnly<{
+  scrollRef: {current: HTMLElement | null},
+}>;
+declare export default function LexicalAutoScrollPlugin(props: Props): React$Node;

--- a/packages/lexical-react/src/LexicalAutoScrollPlugin.js
+++ b/packages/lexical-react/src/LexicalAutoScrollPlugin.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$getSelection, $isRangeSelection} from 'lexical';
+import useLayoutEffect from 'shared/useLayoutEffect';
+
+type Props = $ReadOnly<{
+  scrollRef: {current: HTMLElement | null},
+}>;
+
+export default function LexicalAutoScrollPlugin({
+  scrollRef,
+}: Props): React$Node {
+  const [editor] = useLexicalComposerContext();
+  useLayoutEffect(() => {
+    return editor.registerUpdateListener(({tags, editorState}) => {
+      const scrollElement = scrollRef.current;
+      if (scrollElement === null || !tags.has('scroll-into-view')) {
+        return;
+      }
+
+      const selection = editorState.read(() => $getSelection());
+      if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+        return;
+      }
+
+      const anchorElement = editor.getElementByKey(selection.anchor.key);
+      if (anchorElement === null) {
+        return;
+      }
+
+      const scrollRect = scrollElement.getBoundingClientRect();
+      const rect = anchorElement.getBoundingClientRect();
+      if (rect.bottom > scrollRect.bottom) {
+        anchorElement.scrollIntoView(false);
+      } else if (rect.top < scrollRect.top) {
+        anchorElement.scrollIntoView();
+      }
+    });
+  }, [editor, scrollRef]);
+
+  return null;
+}

--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -756,7 +756,11 @@ export function updateEditorState(
   return reconcileMutatedNodes;
 }
 
-function scrollIntoViewIfNeeded(node: Node, rootElement: ?HTMLElement): void {
+function scrollIntoViewIfNeeded(
+  editor: LexicalEditor,
+  node: Node,
+  rootElement: ?HTMLElement,
+): void {
   const element: Element =
     // $FlowFixMe: this is valid, as we are checking the nodeType
     node.nodeType === DOM_TEXT_TYPE ? node.parentNode : node;
@@ -775,6 +779,8 @@ function scrollIntoViewIfNeeded(node: Node, rootElement: ?HTMLElement): void {
         element.scrollIntoView();
       }
     }
+
+    editor._updateTags.add('scroll-into-view');
   }
 }
 
@@ -871,7 +877,7 @@ function reconcileSelection(
       nextFocusOffset,
     );
     if (nextSelection.isCollapsed() && rootElement === activeElement) {
-      scrollIntoViewIfNeeded(nextAnchorNode, rootElement);
+      scrollIntoViewIfNeeded(editor, nextAnchorNode, rootElement);
     }
   } catch (error) {
     // If we encounter an error, continue. This can sometimes


### PR DESCRIPTION
Command will allow adding custom handlers for scrolling. Like for a new plugin that allows scrolling explicitly passed container. Or if some users would want to work for any scrollable parent, it could use something like "scroll-into-view-if-needed" npm library that checks all parent elements and scroll them if needed. Not adding it as a default option as it's heavier performance wise and called during typing.