### PR TITLE
Add {@import} plugin to embed package README into docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
         "prettier-plugin-organize-attributes": "^0.0.5",
         "pretty-quick": "^3.1.3",
         "react-test-renderer": "^17.0.2",
-        "remark-import-partial": "0.0.2",
         "rollup": "^2.60.2",
         "serve": "^13.0.2",
         "start-server-and-test": "^1.13.0",
@@ -22576,7 +22575,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/remark-import-partial/-/remark-import-partial-0.0.2.tgz",
       "integrity": "sha512-HuIcpGITU/PK+fZvYYamayCH/jlsoB2Uxj1QaGBgTYtcpozvJQth+PKp9NUZpksUldGAmJf59IyMJgczMpbhwg==",
-      "dev": true,
       "dependencies": {
         "unist-util-visit": "2.0.2"
       }
@@ -22585,7 +22583,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
       "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0",
@@ -27972,7 +27969,8 @@
         "clsx": "^1.1.1",
         "prism-react-renderer": "^1.2.1",
         "react": "^18.0.0-alpha-64931821a-20210808",
-        "react-dom": "^18.0.0-alpha-64931821a-20210808"
+        "react-dom": "^18.0.0-alpha-64931821a-20210808",
+        "remark-import-partial": "0.0.2"
       },
       "devDependencies": {
         "buffer": "^6.0.3",
@@ -40115,6 +40113,7 @@
         "prism-react-renderer": "^1.2.1",
         "react": "^18.0.0-alpha-64931821a-20210808",
         "react-dom": "^18.0.0-alpha-64931821a-20210808",
+        "remark-import-partial": "0.0.2",
         "webpack": "^5.70.0"
       }
     },
@@ -43124,7 +43123,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/remark-import-partial/-/remark-import-partial-0.0.2.tgz",
       "integrity": "sha512-HuIcpGITU/PK+fZvYYamayCH/jlsoB2Uxj1QaGBgTYtcpozvJQth+PKp9NUZpksUldGAmJf59IyMJgczMpbhwg==",
-      "dev": true,
       "requires": {
         "unist-util-visit": "2.0.2"
       },
@@ -43133,7 +43131,6 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
           "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
-          "dev": true,
           "requires": {
             "@types/unist": "^2.0.0",
             "unist-util-is": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "prettier-plugin-organize-attributes": "^0.0.5",
     "pretty-quick": "^3.1.3",
     "react-test-renderer": "^17.0.2",
-    "remark-import-partial": "0.0.2",
     "rollup": "^2.60.2",
     "serve": "^13.0.2",
     "start-server-and-test": "^1.13.0",

--- a/packages/lexical-history/README.md
+++ b/packages/lexical-history/README.md
@@ -1,3 +1,28 @@
 # `@lexical/history`
 
 This package contains history helpers for Lexical.
+
+### Methods
+
+#### `registerHistory`
+
+Registers necessary listeners to manage undo/redo history stack and related editor commands. It returns `unregister` callback that cleans up all listeners and should be called on editor unmount.
+
+```js
+function registerHistory(
+  editor: LexicalEditor,
+  externalHistoryState: HistoryState,
+  delay: number,
+): () => void
+```
+
+### Commands
+
+History package handles `undo`, `redo` and `clearHistory` commands. It also triggers `canUndo` and `canRedo` commands when history state is changed. These commands could be used to work with history state:
+
+```jsx
+<Toolbar>
+  <Button onClick={() => editor.execCommand('undo')}>Undo</Button>
+  <Button onClick={() => editor.execCommand('redo')}>Redo</Button>
+</Toolbar>
+```

--- a/packages/lexical-website-new/docs/api/lexical-history.md
+++ b/packages/lexical-website-new/docs/api/lexical-history.md
@@ -1,32 +1,7 @@
 ---
+title: ''
 sidebar_position: 5
+sidebar_label: '@lexical/history'
 ---
 
-# @lexical/history
-
-Adds history and undo/redo support.
-
-### Methods
-
-#### `registerHistory`
-
-Registers necessary listeners to manage undo/redo history stack and related editor commands. It returns `unregister` callback that cleans up all listeners and should be called on editor unmount.
-
-```js
-function registerHistory(
-  editor: LexicalEditor,
-  externalHistoryState: HistoryState,
-  delay: number,
-): () => void
-```
-
-### Commands
-
-History package handles `undo`, `redo` and `clearHistory` commands. It also triggers `canUndo` and `canRedo` commands when history state is changed. These commands could be used to work with history state:
-
-```jsx
-<Toolbar>
-  <Button onClick={() => editor.execCommand('undo')}>Undo</Button>
-  <Button onClick={() => editor.execCommand('redo')}>Redo</Button>
-</Toolbar>
-```
+{@import ../../../lexical-history/README.md}

--- a/packages/lexical-website-new/package-lock.json
+++ b/packages/lexical-website-new/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "lexical-website-new",
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "2.0.0-beta.16",
@@ -14,7 +15,8 @@
         "clsx": "^1.1.1",
         "prism-react-renderer": "^1.2.1",
         "react": "^18.0.0-alpha-64931821a-20210808",
-        "react-dom": "^18.0.0-alpha-64931821a-20210808"
+        "react-dom": "^18.0.0-alpha-64931821a-20210808",
+        "remark-import-partial": "0.0.2"
       },
       "devDependencies": {
         "buffer": "^6.0.3",
@@ -3931,8 +3933,6 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
       "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -3947,9 +3947,7 @@
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -10612,6 +10610,28 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-import-partial": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/remark-import-partial/-/remark-import-partial-0.0.2.tgz",
+      "integrity": "sha512-HuIcpGITU/PK+fZvYYamayCH/jlsoB2Uxj1QaGBgTYtcpozvJQth+PKp9NUZpksUldGAmJf59IyMJgczMpbhwg==",
+      "dependencies": {
+        "unist-util-visit": "2.0.2"
+      }
+    },
+    "node_modules/remark-import-partial/node_modules/unist-util-visit": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
+      "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-mdx": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.22.tgz",
@@ -16305,13 +16325,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "requires": {},
+      "requires": {
+        "ajv": "^8.0.0"
+      },
       "dependencies": {
         "ajv": {
-          "version": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
           "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
-          "optional": true,
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -16322,9 +16343,7 @@
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "optional": true,
-          "peer": true
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
     },
@@ -21136,6 +21155,26 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-2.0.0.tgz",
       "integrity": "sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ=="
+    },
+    "remark-import-partial": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/remark-import-partial/-/remark-import-partial-0.0.2.tgz",
+      "integrity": "sha512-HuIcpGITU/PK+fZvYYamayCH/jlsoB2Uxj1QaGBgTYtcpozvJQth+PKp9NUZpksUldGAmJf59IyMJgczMpbhwg==",
+      "requires": {
+        "unist-util-visit": "2.0.2"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
+          "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0",
+            "unist-util-visit-parents": "^3.0.0"
+          }
+        }
+      }
     },
     "remark-mdx": {
       "version": "1.6.22",

--- a/packages/lexical-website-new/package.json
+++ b/packages/lexical-website-new/package.json
@@ -21,7 +21,8 @@
     "clsx": "^1.1.1",
     "prism-react-renderer": "^1.2.1",
     "react": "^18.0.0-alpha-64931821a-20210808",
-    "react-dom": "^18.0.0-alpha-64931821a-20210808"
+    "react-dom": "^18.0.0-alpha-64931821a-20210808",
+    "remark-import-partial": "0.0.2"
   },
   "devDependencies": {
     "buffer": "^6.0.3",


### PR DESCRIPTION
Follow up for #1558 to allow embedding markdown. Now we can put all documentation into package-specific readmes and embed them into documentation:

```md
---
title: ''
sidebar_position: 5
sidebar_label: '@lexical/history'
---

{@import ../../../lexical-history/README.md}
```