### PR TITLE
Fix multiple autolinks in a row

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
@@ -187,4 +187,36 @@ test.describe('Auto Links', () => {
       {ignoreClasses: true},
     );
   });
+
+  test('Handles multiple autolinks in a row', async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    await pasteFromClipboard(page, {
+      'text/plain':
+        'https://1.com/ https://2.com/ https://3.com/ https://4.com/',
+    });
+    await assertHTML(
+      page,
+      html`
+        <p>
+          <a href="https://1.com/" dir="ltr">
+            <span data-lexical-text="true">https://1.com/</span>
+          </a>
+          <span data-lexical-text="true"></span>
+          <a href="https://2.com/" dir="ltr">
+            <span data-lexical-text="true">https://2.com/</span>
+          </a>
+          <span data-lexical-text="true"></span>
+          <a href="https://3.com/" dir="ltr">
+            <span data-lexical-text="true">https://3.com/</span>
+          </a>
+          <span data-lexical-text="true"></span>
+          <a href="https://4.com/" dir="ltr">
+            <span data-lexical-text="true">https://4.com/</span>
+          </a>
+        </p>
+      `,
+      {ignoreClasses: true},
+    );
+  });
 });

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.js
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.js
@@ -85,7 +85,6 @@ function handleLinkCreation(
   let text = nodeText;
   let textOffset = 0;
   let lastNode = node;
-  let lastNodeOffset = 0;
   let match;
   while ((match = findFirstMatch(text, matchers)) && match !== null) {
     const matchOffset = match.index;
@@ -116,19 +115,18 @@ function handleLinkCreation(
 
     if (contentBeforeMatchIsValid && contentAfterMatchIsValid) {
       let middleNode;
-      const lastNodeMatchOffset = offset - lastNodeOffset;
-      if (lastNodeMatchOffset === 0) {
+
+      if (matchOffset === 0) {
         [middleNode, lastNode] = lastNode.splitText(matchLength);
       } else {
         [, middleNode, lastNode] = lastNode.splitText(
-          lastNodeMatchOffset,
-          lastNodeMatchOffset + matchLength,
+          matchOffset,
+          matchOffset + matchLength,
         );
       }
       const linkNode = $createAutoLinkNode(match.url);
       linkNode.append($createTextNode(match.text));
       middleNode.replace(linkNode);
-      lastNodeOffset = lastNodeMatchOffset + matchLength;
       onChange(match.url, null);
     }
 


### PR DESCRIPTION
Auto link plugin had issue with multiple links in a row inserted at once (e.g. by copy paste or from initialStateFn) caused by incorrect offset calculation