### PR TITLE
Rename command pub/sub methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ There are a few ways to update an editor instance:
 - Trigger an update with `editor.update()`
 - Setting the editor state via `editor.setEditorState()`
 - Applying a change as part of an existing update via `editor.addNodeTransform()`
-- Using a command listener with `editor.registerCommandListener( () => {...}, priority)`
+- Using a command listener with `editor.registerCommand( () => {...}, priority)`
 
 The most common way to update the editor is to use `editor.update()`. Calling this function
 requires a function to be passed in that will provide access to mutate the underlying

--- a/examples/decorators.md
+++ b/examples/decorators.md
@@ -64,7 +64,7 @@ function VideoPlugin(): React$Node {
 
   useEffect(() => {
     // Similar with command listener, which returns unlisten callback
-    const removeListener = editor.registerCommandListener(
+    const removeListener = editor.registerCommand(
       'insertVideo',
       (payload) => {
         // Adding custom command that will be handled by this plugin
@@ -99,7 +99,7 @@ function ToolbarVideoButton(): React$Node {
   const insertVideo = useCallback(
     (url) => {
       // Executing command defined in a plugin
-      editor.execCommand('insertVideo', url);
+      editor.dispatchCommand('insertVideo', url);
     },
     [editor],
   );

--- a/packages/lexical-code/src/index.js
+++ b/packages/lexical-code/src/index.js
@@ -750,22 +750,22 @@ export function registerCodeHighlighting(editor: LexicalEditor): () => void {
     editor.addNodeTransform(CodeHighlightNode, (node) =>
       textNodeTransform(node, editor),
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'indentContent',
       (payload): boolean => handleMultilineIndent('indentContent'),
       1,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'outdentContent',
       (payload): boolean => handleMultilineIndent('outdentContent'),
       1,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyArrowUp',
       (payload): boolean => handleShiftLines('keyArrowUp', payload),
       1,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyArrowDown',
       (payload): boolean => handleShiftLines('keyArrowDown', payload),
       1,

--- a/packages/lexical-file/src/fileImportExport.js
+++ b/packages/lexical-file/src/fileImportExport.js
@@ -18,7 +18,7 @@ export function importFile(editor: LexicalEditor) {
       JSON.stringify(json.editorState),
     );
     editor.setEditorState(editorState);
-    editor.execCommand('clearHistory');
+    editor.dispatchCommand('clearHistory');
   });
 }
 

--- a/packages/lexical-history/README.md
+++ b/packages/lexical-history/README.md
@@ -22,7 +22,7 @@ History package handles `undo`, `redo` and `clearHistory` commands. It also trig
 
 ```jsx
 <Toolbar>
-  <Button onClick={() => editor.execCommand('undo')}>Undo</Button>
-  <Button onClick={() => editor.execCommand('redo')}>Redo</Button>
+  <Button onClick={() => editor.dispatchCommand('undo')}>Undo</Button>
+  <Button onClick={() => editor.dispatchCommand('redo')}>Redo</Button>
 </Toolbar>
 ```

--- a/packages/lexical-history/src/index.js
+++ b/packages/lexical-history/src/index.js
@@ -267,11 +267,11 @@ function redo(editor: LexicalEditor, historyState: HistoryState): void {
     const current = historyState.current;
     if (current !== null) {
       undoStack.push(current);
-      editor.execCommand('canUndo', true);
+      editor.dispatchCommand('canUndo', true);
     }
     const historyStateEntry = redoStack.pop();
     if (redoStack.length === 0) {
-      editor.execCommand('canRedo', false);
+      editor.dispatchCommand('canRedo', false);
     }
     historyState.current = historyStateEntry;
     historyStateEntry.editor.setEditorState(historyStateEntry.editorState, {
@@ -289,10 +289,10 @@ function undo(editor: LexicalEditor, historyState: HistoryState): void {
     const historyStateEntry = undoStack.pop();
     if (current !== null) {
       redoStack.push(current);
-      editor.execCommand('canRedo', true);
+      editor.dispatchCommand('canRedo', true);
     }
     if (undoStack.length === 0) {
-      editor.execCommand('canUndo', false);
+      editor.dispatchCommand('canUndo', false);
     }
     historyState.current = historyStateEntry;
     historyStateEntry.editor.setEditorState(
@@ -350,7 +350,7 @@ export function registerHistory(
           ...current,
           undoSelection: prevEditorState.read($getSelection),
         });
-        editor.execCommand('canUndo', true);
+        editor.dispatchCommand('canUndo', true);
       }
     } else if (mergeAction === DISCARD_HISTORY_CANDIDATE) {
       return;
@@ -364,7 +364,7 @@ export function registerHistory(
   };
 
   const unregisterCommandListener = mergeRegister(
-    editor.registerCommandListener(
+    editor.registerCommand(
       'undo',
       () => {
         undo(editor, historyState);
@@ -372,7 +372,7 @@ export function registerHistory(
       },
       EditorPriority,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'redo',
       () => {
         redo(editor, historyState);
@@ -380,7 +380,7 @@ export function registerHistory(
       },
       EditorPriority,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'clearEditor',
       () => {
         clearHistory(historyState);
@@ -388,7 +388,7 @@ export function registerHistory(
       },
       EditorPriority,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'clearHistory',
       () => {
         clearHistory(historyState);

--- a/packages/lexical-markdown/src/utils.js
+++ b/packages/lexical-markdown/src/utils.js
@@ -640,7 +640,7 @@ function transformTextNodeWithLink(scanningContext: ScanningContext) {
 
   $setSelection(newSelectionForLink);
 
-  scanningContext.editor.execCommand('toggleLink', url);
+  scanningContext.editor.dispatchCommand('toggleLink', url);
 
   // Place caret at end of final capture group.
   selectAfterFinalCaptureGroup(scanningContext);

--- a/packages/lexical-plain-text/src/index.js
+++ b/packages/lexical-plain-text/src/index.js
@@ -128,7 +128,7 @@ export function registerPlainText(
   initialEditorState?: InitialEditorStateType,
 ): () => void {
   const removeListener = mergeRegister(
-    editor.registerCommandListener(
+    editor.registerCommand(
       'deleteCharacter',
       (payload) => {
         const selection = $getSelection();
@@ -141,7 +141,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'deleteWord',
       (payload) => {
         const selection = $getSelection();
@@ -154,7 +154,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'deleteLine',
       (payload) => {
         const selection = $getSelection();
@@ -167,7 +167,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'insertText',
       (payload) => {
         const selection = $getSelection();
@@ -192,7 +192,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'removeText',
       (payload) => {
         const selection = $getSelection();
@@ -204,7 +204,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'insertLineBreak',
       (payload) => {
         const selection = $getSelection();
@@ -217,7 +217,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'insertParagraph',
       (payload) => {
         const selection = $getSelection();
@@ -229,7 +229,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'indentContent',
       (payload) => {
         const selection = $getSelection();
@@ -240,7 +240,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'outdentContent',
       (payload) => {
         const selection = $getSelection();
@@ -251,7 +251,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'insertHorizontalRule',
       (payload) => {
         const selection = $getSelection();
@@ -262,7 +262,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'insertImage',
       (payload) => {
         const selection = $getSelection();
@@ -273,7 +273,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'insertTable',
       (payload) => {
         const selection = $getSelection();
@@ -284,7 +284,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'formatElement',
       (payload) => {
         const selection = $getSelection();
@@ -295,7 +295,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'formatText',
       (payload) => {
         const selection = $getSelection();
@@ -306,7 +306,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyArrowLeft',
       (payload) => {
         const selection = $getSelection();
@@ -324,7 +324,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyArrowRight',
       (payload) => {
         const selection = $getSelection();
@@ -342,7 +342,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyBackspace',
       (payload) => {
         const selection = $getSelection();
@@ -351,11 +351,11 @@ export function registerPlainText(
         }
         const event: KeyboardEvent = payload;
         event.preventDefault();
-        return editor.execCommand('deleteCharacter', true);
+        return editor.dispatchCommand('deleteCharacter', true);
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyDelete',
       (payload) => {
         const selection = $getSelection();
@@ -364,11 +364,11 @@ export function registerPlainText(
         }
         const event: KeyboardEvent = payload;
         event.preventDefault();
-        return editor.execCommand('deleteCharacter', false);
+        return editor.dispatchCommand('deleteCharacter', false);
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyEnter',
       (payload) => {
         const selection = $getSelection();
@@ -377,11 +377,11 @@ export function registerPlainText(
         }
         const event: KeyboardEvent = payload;
         event.preventDefault();
-        return editor.execCommand('insertLineBreak');
+        return editor.dispatchCommand('insertLineBreak');
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'copy',
       (payload) => {
         const selection = $getSelection();
@@ -394,7 +394,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'cut',
       (payload) => {
         const selection = $getSelection();
@@ -407,7 +407,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'paste',
       (payload) => {
         const selection = $getSelection();
@@ -420,7 +420,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'drop',
       (payload) => {
         const selection = $getSelection();
@@ -434,7 +434,7 @@ export function registerPlainText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'dragstart',
       (payload) => {
         const selection = $getSelection();

--- a/packages/lexical-playground/src/nodes/EquationNode.jsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.jsx
@@ -61,7 +61,7 @@ function EquationComponent({
   useEffect(() => {
     if (showEquationEditor) {
       return mergeRegister(
-        editor.registerCommandListener(
+        editor.registerCommand(
           'selectionChange',
           (payload) => {
             const activeElement = document.activeElement;
@@ -73,7 +73,7 @@ function EquationComponent({
           },
           HighPriority,
         ),
-        editor.registerCommandListener(
+        editor.registerCommand(
           'keyEscape',
           (payload) => {
             const activeElement = document.activeElement;

--- a/packages/lexical-playground/src/nodes/ImageNode.jsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.jsx
@@ -242,7 +242,8 @@ function ImageResizer({
           ref={buttonRef}
           onClick={() => {
             setShowCaption(!showCaption);
-          }}>
+          }}
+        >
           Add Caption
         </button>
       )}
@@ -332,7 +333,7 @@ function ImageComponent({
       editor.registerUpdateListener(({editorState}) => {
         setSelection(editorState.read(() => $getSelection()));
       }),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'click',
         (payload) => {
           const event: MouseEvent = payload;
@@ -352,8 +353,8 @@ function ImageComponent({
         },
         LowPriority,
       ),
-      editor.registerCommandListener('keyDelete', onDelete, LowPriority),
-      editor.registerCommandListener('keyBackspace', onDelete, LowPriority),
+      editor.registerCommand('keyDelete', onDelete, LowPriority),
+      editor.registerCommand('keyBackspace', onDelete, LowPriority),
     );
   }, [
     clearSelection,
@@ -426,7 +427,8 @@ function ImageComponent({
             <LexicalNestedComposer
               initialConfig={{
                 decoratorEditor: decoratorEditor,
-              }}>
+              }}
+            >
               <MentionsPlugin />
               <TablesPlugin />
               <TableCellActionMenuPlugin />

--- a/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
@@ -37,7 +37,7 @@ export default function ActionsPlugins({
 
   useEffect(() => {
     return mergeRegister(
-      editor.registerCommandListener(
+      editor.registerCommand(
         'readOnly',
         (payload) => {
           const readOnly = payload;
@@ -46,7 +46,7 @@ export default function ActionsPlugins({
         },
         EditorPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'connected',
         (payload) => {
           const isConnected = payload;
@@ -77,7 +77,7 @@ export default function ActionsPlugins({
       {SUPPORT_SPEECH_RECOGNITION && (
         <button
           onClick={() => {
-            editor.execCommand('speechToText', !isSpeechToText);
+            editor.dispatchCommand('speechToText', !isSpeechToText);
             setIsSpeechToText(!isSpeechToText);
           }}
           className={
@@ -111,7 +111,7 @@ export default function ActionsPlugins({
       <button
         className="action-button clear"
         onClick={() => {
-          editor.execCommand('clearEditor');
+          editor.dispatchCommand('clearEditor');
           editor.focus();
         }}
       >
@@ -132,7 +132,7 @@ export default function ActionsPlugins({
         <button
           className="action-button connect"
           onClick={() => {
-            editor.execCommand('toggleConnect', !connected);
+            editor.dispatchCommand('toggleConnect', !connected);
           }}
         >
           <i className={connected ? 'disconnect' : 'connect'} />

--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
@@ -54,9 +54,9 @@ function FloatingCharacterStylesEditor({
 
   const insertLink = useCallback(() => {
     if (!isLink) {
-      editor.execCommand('toggleLink', 'https://');
+      editor.dispatchCommand('toggleLink', 'https://');
     } else {
-      editor.execCommand('toggleLink', null);
+      editor.dispatchCommand('toggleLink', null);
     }
   }, [editor, isLink]);
 
@@ -103,7 +103,7 @@ function FloatingCharacterStylesEditor({
         });
       }),
 
-      editor.registerCommandListener(
+      editor.registerCommand(
         'selectionChange',
         () => {
           updateCharacterStylesEditor();
@@ -118,48 +118,54 @@ function FloatingCharacterStylesEditor({
     <div ref={popupCharStylesEditorRef} className="character-style-popup">
       <button
         onClick={() => {
-          editor.execCommand('formatText', 'bold');
+          editor.dispatchCommand('formatText', 'bold');
         }}
         className={'popup-item spaced ' + (isBold ? 'active' : '')}
-        aria-label="Format Bold">
+        aria-label="Format Bold"
+      >
         <i className="format bold" />
       </button>
       <button
         onClick={() => {
-          editor.execCommand('formatText', 'italic');
+          editor.dispatchCommand('formatText', 'italic');
         }}
         className={'popup-item spaced ' + (isItalic ? 'active' : '')}
-        aria-label="Format Italics">
+        aria-label="Format Italics"
+      >
         <i className="format italic" />
       </button>
       <button
         onClick={() => {
-          editor.execCommand('formatText', 'underline');
+          editor.dispatchCommand('formatText', 'underline');
         }}
         className={'popup-item spaced ' + (isUnderline ? 'active' : '')}
-        aria-label="Format Underline">
+        aria-label="Format Underline"
+      >
         <i className="format underline" />
       </button>
       <button
         onClick={() => {
-          editor.execCommand('formatText', 'strikethrough');
+          editor.dispatchCommand('formatText', 'strikethrough');
         }}
         className={'popup-item spaced ' + (isStrikethrough ? 'active' : '')}
-        aria-label="Format Strikethrough">
+        aria-label="Format Strikethrough"
+      >
         <i className="format strikethrough" />
       </button>
       <button
         onClick={() => {
-          editor.execCommand('formatText', 'code');
+          editor.dispatchCommand('formatText', 'code');
         }}
         className={'popup-item spaced ' + (isCode ? 'active' : '')}
-        aria-label="Insert Code">
+        aria-label="Insert Code"
+      >
         <i className="format code" />
       </button>
       <button
         onClick={insertLink}
         className={'popup-item spaced ' + (isLink ? 'active' : '')}
-        aria-label="Insert Link">
+        aria-label="Insert Link"
+      >
         <i className="format link" />
       </button>
     </div>

--- a/packages/lexical-playground/src/plugins/EquationsPlugin.js
+++ b/packages/lexical-playground/src/plugins/EquationsPlugin.js
@@ -30,7 +30,7 @@ export default function EquationsPlugin(): React$Node {
       );
     }
 
-    return editor.registerCommandListener(
+    return editor.registerCommand(
       'insertEquation',
       (payload) => {
         const {equation, inline} = payload;

--- a/packages/lexical-playground/src/plugins/ExcalidrawPlugin.js
+++ b/packages/lexical-playground/src/plugins/ExcalidrawPlugin.js
@@ -27,7 +27,7 @@ export default function ExcalidrawPlugin(): React$Node {
       );
     }
 
-    return editor.registerCommandListener(
+    return editor.registerCommand(
       'insertExcalidraw',
       () => {
         const selection = $getSelection();

--- a/packages/lexical-playground/src/plugins/HorizontalRulePlugin.js
+++ b/packages/lexical-playground/src/plugins/HorizontalRulePlugin.js
@@ -20,7 +20,7 @@ export default function HorizontalRulePlugin(): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    return editor.registerCommandListener(
+    return editor.registerCommand(
       'insertHorizontalRule',
       (type) => {
         const selection = $getSelection();

--- a/packages/lexical-playground/src/plugins/ImagesPlugin.js
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin.js
@@ -26,7 +26,7 @@ export default function ImagesPlugin(): React$Node {
       throw new Error('ImagesPlugin: ImageNode not registered on editor');
     }
 
-    return editor.registerCommandListener(
+    return editor.registerCommand(
       'insertImage',
       () => {
         const selection = $getSelection();

--- a/packages/lexical-playground/src/plugins/ListMaxIndentLevelPlugin.js
+++ b/packages/lexical-playground/src/plugins/ListMaxIndentLevelPlugin.js
@@ -75,7 +75,7 @@ export default function ListMaxIndentLevelPlugin({maxDepth}: Props): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    return editor.registerCommandListener(
+    return editor.registerCommand(
       'indentContent',
       () => !isIndentPermitted(maxDepth ?? 7),
       highPriority,

--- a/packages/lexical-playground/src/plugins/MentionsPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/MentionsPlugin.jsx
@@ -596,7 +596,8 @@ function MentionsTypeaheadItem({
       id={'typeahead-item-' + index}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      onClick={onClick}>
+      onClick={onClick}
+    >
       {result}
     </li>
   );
@@ -679,7 +680,7 @@ function MentionsTypeahead({
 
   useEffect(() => {
     return mergeRegister(
-      editor.registerCommandListener(
+      editor.registerCommand(
         'keyArrowDown',
         (payload) => {
           const event: KeyboardEvent = payload;
@@ -697,7 +698,7 @@ function MentionsTypeahead({
         },
         LowPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'keyArrowUp',
         (payload) => {
           const event: KeyboardEvent = payload;
@@ -712,7 +713,7 @@ function MentionsTypeahead({
         },
         LowPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'keyEscape',
         (payload) => {
           const event: KeyboardEvent = payload;
@@ -726,7 +727,7 @@ function MentionsTypeahead({
         },
         LowPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'keyTab',
         (payload) => {
           const event: KeyboardEvent = payload;
@@ -740,7 +741,7 @@ function MentionsTypeahead({
         },
         LowPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'keyEnter',
         (payload) => {
           const event: KeyboardEvent = payload;
@@ -773,7 +774,8 @@ function MentionsTypeahead({
       aria-label="Suggested mentions"
       id="mentions-typeahead"
       ref={divRef}
-      role="listbox">
+      role="listbox"
+    >
       <ul>
         {results.slice(0, SUGGESTION_LIST_LENGTH_LIMIT).map((result, i) => (
           <MentionsTypeaheadItem

--- a/packages/lexical-playground/src/plugins/PollPlugin.js
+++ b/packages/lexical-playground/src/plugins/PollPlugin.js
@@ -24,7 +24,7 @@ export default function PollPlugin(): React$Node {
       throw new Error('PollPlugin: PollNode not registered on editor');
     }
 
-    return editor.registerCommandListener(
+    return editor.registerCommand(
       'insertPoll',
       (payload) => {
         const selection = $getSelection();

--- a/packages/lexical-playground/src/plugins/SpeechToTextPlugin.js
+++ b/packages/lexical-playground/src/plugins/SpeechToTextPlugin.js
@@ -28,10 +28,10 @@ const VOICE_COMMANDS: $ReadOnly<{
     selection.insertParagraph();
   },
   redo: ({editor}) => {
-    editor.execCommand('redo');
+    editor.dispatchCommand('redo');
   },
   undo: ({editor}) => {
-    editor.execCommand('undo');
+    editor.dispatchCommand('undo');
   },
 };
 
@@ -95,7 +95,7 @@ function SpeechToTextPlugin(): null {
   }, [editor, isEnabled, report]);
 
   useEffect(() => {
-    return editor.registerCommandListener(
+    return editor.registerCommand(
       'speechToText',
       (payload: boolean) => {
         setIsEnabled(payload);

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -179,7 +179,7 @@ function FloatingLinkEditor({editor}: {editor: LexicalEditor}): React$Node {
         });
       }),
 
-      editor.registerCommandListener(
+      editor.registerCommand(
         'selectionChange',
         () => {
           updateLinkEditor();
@@ -211,7 +211,7 @@ function FloatingLinkEditor({editor}: {editor: LexicalEditor}): React$Node {
               event.preventDefault();
               if (lastSelection !== null) {
                 if (linkUrl !== '') {
-                  editor.execCommand('toggleLink', linkUrl);
+                  editor.dispatchCommand('toggleLink', linkUrl);
                 }
                 setEditMode(false);
               }
@@ -255,7 +255,7 @@ function InsertTableDialog({
   const [columns, setColumns] = useState('5');
 
   const onClick = () => {
-    activeEditor.execCommand('insertTable', {columns, rows});
+    activeEditor.dispatchCommand('insertTable', {columns, rows});
     onClose();
   };
 
@@ -265,7 +265,8 @@ function InsertTableDialog({
       <Input label="No of columns" onChange={setColumns} value={columns} />
       <div
         className="ToolbarPlugin__dialogActions"
-        data-test-id="table-model-confirm-insert">
+        data-test-id="table-model-confirm-insert"
+      >
         <Button onClick={onClick}>Confirm</Button>
       </div>
     </>
@@ -282,7 +283,7 @@ function InsertPollDialog({
   const [question, setQuestion] = useState('');
 
   const onClick = () => {
-    activeEditor.execCommand('insertPoll', question);
+    activeEditor.dispatchCommand('insertPoll', question);
     onClose();
   };
 
@@ -311,7 +312,7 @@ function InsertTweetDialog({
 
   const onClick = () => {
     const tweetID = text.split('status/')?.[1];
-    activeEditor.execCommand('insertTweet', tweetID);
+    activeEditor.dispatchCommand('insertTweet', tweetID);
     onClose();
   };
 
@@ -343,7 +344,7 @@ function InsertEquationDialog({
 }): React$Node {
   const onEquationConfirm = useCallback(
     (equation: string, inline: boolean) => {
-      activeEditor.execCommand('insertEquation', {equation, inline});
+      activeEditor.dispatchCommand('insertEquation', {equation, inline});
       onClose();
     },
     [activeEditor, onClose],
@@ -438,18 +439,18 @@ function BlockOptionsDropdownList({
 
   const formatBulletList = () => {
     if (blockType !== 'ul') {
-      editor.execCommand('insertUnorderedList');
+      editor.dispatchCommand('insertUnorderedList');
     } else {
-      editor.execCommand('removeList');
+      editor.dispatchCommand('removeList');
     }
     setShowBlockOptionsDropDown(false);
   };
 
   const formatNumberedList = () => {
     if (blockType !== 'ol') {
-      editor.execCommand('insertOrderedList');
+      editor.dispatchCommand('insertOrderedList');
     } else {
-      editor.execCommand('removeList');
+      editor.dispatchCommand('removeList');
     }
     setShowBlockOptionsDropDown(false);
   };
@@ -632,7 +633,7 @@ export default function ToolbarPlugin(): React$Node {
 
   useEffect(() => {
     return mergeRegister(
-      editor.registerCommandListener(
+      editor.registerCommand(
         'selectionChange',
         (_payload, newEditor) => {
           updateToolbar();
@@ -641,7 +642,7 @@ export default function ToolbarPlugin(): React$Node {
         },
         LowPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'canUndo',
         (payload) => {
           setCanUndo(payload);
@@ -649,7 +650,7 @@ export default function ToolbarPlugin(): React$Node {
         },
         LowPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'canRedo',
         (payload) => {
           setCanRedo(payload);
@@ -688,9 +689,9 @@ export default function ToolbarPlugin(): React$Node {
 
   const insertLink = useCallback(() => {
     if (!isLink) {
-      editor.execCommand('toggleLink', 'https://');
+      editor.dispatchCommand('toggleLink', 'https://');
     } else {
-      editor.execCommand('toggleLink', null);
+      editor.dispatchCommand('toggleLink', null);
     }
   }, [editor, isLink]);
 
@@ -714,19 +715,21 @@ export default function ToolbarPlugin(): React$Node {
       <button
         disabled={!canUndo}
         onClick={() => {
-          activeEditor.execCommand('undo');
+          activeEditor.dispatchCommand('undo');
         }}
         className="toolbar-item spaced"
-        aria-label="Undo">
+        aria-label="Undo"
+      >
         <i className="format undo" />
       </button>
       <button
         disabled={!canRedo}
         onClick={() => {
-          activeEditor.execCommand('redo');
+          activeEditor.dispatchCommand('redo');
         }}
         className="toolbar-item"
-        aria-label="Redo">
+        aria-label="Redo"
+      >
         <i className="format redo" />
       </button>
       <Divider />
@@ -737,7 +740,8 @@ export default function ToolbarPlugin(): React$Node {
             onClick={() =>
               setShowBlockOptionsDropDown(!showBlockOptionsDropDown)
             }
-            aria-label="Formatting Options">
+            aria-label="Formatting Options"
+          >
             <span className={'icon block-type ' + blockType} />
             <span className="text">{blockTypeToBlockName[blockType]}</span>
             <i className="chevron-down" />
@@ -807,50 +811,56 @@ export default function ToolbarPlugin(): React$Node {
           <Divider />
           <button
             onClick={() => {
-              activeEditor.execCommand('formatText', 'bold');
+              activeEditor.dispatchCommand('formatText', 'bold');
             }}
             className={'toolbar-item spaced ' + (isBold ? 'active' : '')}
-            aria-label="Format Bold">
+            aria-label="Format Bold"
+          >
             <i className="format bold" />
           </button>
           <button
             onClick={() => {
-              activeEditor.execCommand('formatText', 'italic');
+              activeEditor.dispatchCommand('formatText', 'italic');
             }}
             className={'toolbar-item spaced ' + (isItalic ? 'active' : '')}
-            aria-label="Format Italics">
+            aria-label="Format Italics"
+          >
             <i className="format italic" />
           </button>
           <button
             onClick={() => {
-              activeEditor.execCommand('formatText', 'underline');
+              activeEditor.dispatchCommand('formatText', 'underline');
             }}
             className={'toolbar-item spaced ' + (isUnderline ? 'active' : '')}
-            aria-label="Format Underline">
+            aria-label="Format Underline"
+          >
             <i className="format underline" />
           </button>
           <button
             onClick={() => {
-              activeEditor.execCommand('formatText', 'strikethrough');
+              activeEditor.dispatchCommand('formatText', 'strikethrough');
             }}
             className={
               'toolbar-item spaced ' + (isStrikethrough ? 'active' : '')
             }
-            aria-label="Format Strikethrough">
+            aria-label="Format Strikethrough"
+          >
             <i className="format strikethrough" />
           </button>
           <button
             onClick={() => {
-              activeEditor.execCommand('formatText', 'code');
+              activeEditor.dispatchCommand('formatText', 'code');
             }}
             className={'toolbar-item spaced ' + (isCode ? 'active' : '')}
-            aria-label="Insert Code">
+            aria-label="Insert Code"
+          >
             <i className="format code" />
           </button>
           <button
             onClick={insertLink}
             className={'toolbar-item spaced ' + (isLink ? 'active' : '')}
-            aria-label="Insert Link">
+            aria-label="Insert Link"
+          >
             <i className="format link" />
           </button>
           {isLink &&
@@ -860,26 +870,29 @@ export default function ToolbarPlugin(): React$Node {
             )}
           <button
             onClick={() => {
-              activeEditor.execCommand('insertHorizontalRule');
+              activeEditor.dispatchCommand('insertHorizontalRule');
             }}
             className="toolbar-item spaced"
-            aria-label="Insert Horizontal Rule">
+            aria-label="Insert Horizontal Rule"
+          >
             <i className="format horizontal-rule" />
           </button>
           <button
             onClick={() => {
-              activeEditor.execCommand('insertImage');
+              activeEditor.dispatchCommand('insertImage');
             }}
             className="toolbar-item spaced"
-            aria-label="Insert Image">
+            aria-label="Insert Image"
+          >
             <i className="format image" />
           </button>
           <button
             onClick={() => {
-              activeEditor.execCommand('insertExcalidraw');
+              activeEditor.dispatchCommand('insertExcalidraw');
             }}
             className="toolbar-item spaced"
-            aria-label="Insert Excalidraw">
+            aria-label="Insert Excalidraw"
+          >
             <i className="format diagram-2" />
           </button>
           <button
@@ -892,7 +905,8 @@ export default function ToolbarPlugin(): React$Node {
               ));
             }}
             className="toolbar-item"
-            aria-label="Insert Table">
+            aria-label="Insert Table"
+          >
             <i className="format table" />
           </button>
           <button
@@ -905,7 +919,8 @@ export default function ToolbarPlugin(): React$Node {
               ));
             }}
             className="toolbar-item"
-            aria-label="Insert Poll">
+            aria-label="Insert Poll"
+          >
             <i className="format poll" />
           </button>
           <button
@@ -918,7 +933,8 @@ export default function ToolbarPlugin(): React$Node {
               ));
             }}
             className="toolbar-item"
-            aria-label="Insert tweet">
+            aria-label="Insert tweet"
+          >
             <i className="format tweet" />
           </button>
           <button
@@ -931,7 +947,8 @@ export default function ToolbarPlugin(): React$Node {
               ));
             }}
             className="toolbar-item"
-            aria-label="Insert Equation">
+            aria-label="Insert Equation"
+          >
             <i className="format equation" />
           </button>
         </>
@@ -940,51 +957,57 @@ export default function ToolbarPlugin(): React$Node {
       <Divider />
       <button
         onClick={() => {
-          activeEditor.execCommand('formatElement', 'left');
+          activeEditor.dispatchCommand('formatElement', 'left');
         }}
         className="toolbar-item spaced"
-        aria-label="Left Align">
+        aria-label="Left Align"
+      >
         <i className="format left-align" />
       </button>
       <button
         onClick={() => {
-          activeEditor.execCommand('formatElement', 'center');
+          activeEditor.dispatchCommand('formatElement', 'center');
         }}
         className="toolbar-item spaced"
-        aria-label="Center Align">
+        aria-label="Center Align"
+      >
         <i className="format center-align" />
       </button>
       <button
         onClick={() => {
-          activeEditor.execCommand('formatElement', 'right');
+          activeEditor.dispatchCommand('formatElement', 'right');
         }}
         className="toolbar-item spaced"
-        aria-label="Right Align">
+        aria-label="Right Align"
+      >
         <i className="format right-align" />
       </button>
       <button
         onClick={() => {
-          activeEditor.execCommand('formatElement', 'justify');
+          activeEditor.dispatchCommand('formatElement', 'justify');
         }}
         className="toolbar-item"
-        aria-label="Justify Align">
+        aria-label="Justify Align"
+      >
         <i className="format justify-align" />
       </button>
       <Divider />
       <button
         onClick={() => {
-          activeEditor.execCommand('outdentContent');
+          activeEditor.dispatchCommand('outdentContent');
         }}
         className="toolbar-item spaced"
-        aria-label="Outdent">
+        aria-label="Outdent"
+      >
         <i className={'format ' + (isRTL ? 'indent' : 'outdent')} />
       </button>
       <button
         onClick={() => {
-          activeEditor.execCommand('indentContent');
+          activeEditor.dispatchCommand('indentContent');
         }}
         className="toolbar-item"
-        aria-label="Indent">
+        aria-label="Indent"
+      >
         <i className={'format ' + (isRTL ? 'outdent' : 'indent')} />
       </button>
       {modal}

--- a/packages/lexical-playground/src/plugins/TwitterPlugin.js
+++ b/packages/lexical-playground/src/plugins/TwitterPlugin.js
@@ -25,7 +25,7 @@ export default function TwitterPlugin(): React$Node {
       throw new Error('TwitterPlugin: TweetNode not registered on editor');
     }
 
-    return editor.registerCommandListener(
+    return editor.registerCommand(
       'insertTweet',
       (payload) => {
         const selection = $getSelection();

--- a/packages/lexical-react/src/LexicalClearEditorPlugin.js
+++ b/packages/lexical-react/src/LexicalClearEditorPlugin.js
@@ -18,7 +18,7 @@ type Props = $ReadOnly<{
 export default function LexicalClearEditorPlugin({onClear}: Props): React$Node {
   const [editor] = useLexicalComposerContext();
   useLayoutEffect(() => {
-    return editor.registerCommandListener(
+    return editor.registerCommand(
       'clearEditor',
       (payload) => {
         editor.update(() => {

--- a/packages/lexical-react/src/LexicalLinkPlugin.js
+++ b/packages/lexical-react/src/LexicalLinkPlugin.js
@@ -106,7 +106,7 @@ export default function LinkPlugin(): null {
   }, [editor]);
 
   useEffect(() => {
-    return editor.registerCommandListener(
+    return editor.registerCommand(
       'toggleLink',
       (payload) => {
         const url: string | null = payload;

--- a/packages/lexical-react/src/LexicalTablePlugin.js
+++ b/packages/lexical-react/src/LexicalTablePlugin.js
@@ -44,7 +44,7 @@ export default function TablePlugin(): React$Node {
         'TablePlugin: TableNode, TableCellNode or TableRowNode not registered on editor',
       );
     }
-    return editor.registerCommandListener(
+    return editor.registerCommand(
       'insertTable',
       (payload) => {
         const {columns, rows} = payload;

--- a/packages/lexical-react/src/shared/useList.js
+++ b/packages/lexical-react/src/shared/useList.js
@@ -24,7 +24,7 @@ const LowPriority: CommandListenerLowPriority = 1;
 export default function useList(editor: LexicalEditor): void {
   useEffect(() => {
     return mergeRegister(
-      editor.registerCommandListener(
+      editor.registerCommand(
         'indentContent',
         () => {
           const hasHandledIndention = indentList();
@@ -35,7 +35,7 @@ export default function useList(editor: LexicalEditor): void {
         },
         LowPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'outdentContent',
         () => {
           const hasHandledIndention = outdentList();
@@ -46,7 +46,7 @@ export default function useList(editor: LexicalEditor): void {
         },
         LowPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'insertOrderedList',
         () => {
           insertList(editor, 'ol');
@@ -54,7 +54,7 @@ export default function useList(editor: LexicalEditor): void {
         },
         LowPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'insertUnorderedList',
         () => {
           insertList(editor, 'ul');
@@ -62,7 +62,7 @@ export default function useList(editor: LexicalEditor): void {
         },
         LowPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'removeList',
         () => {
           removeList(editor);
@@ -70,7 +70,7 @@ export default function useList(editor: LexicalEditor): void {
         },
         LowPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'insertParagraph',
         () => {
           const hasHandledInsertParagraph = $handleListInsertParagraph();

--- a/packages/lexical-react/src/shared/useYjsCollaboration.jsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.jsx
@@ -62,7 +62,7 @@ export function useYjsCollaboration(
     const {awareness} = provider;
 
     const onStatus = ({status}: {status: string}) => {
-      editor.execCommand('connected', status === 'connected');
+      editor.dispatchCommand('connected', status === 'connected');
     };
 
     const onSync = (isSynced: boolean) => {
@@ -167,7 +167,7 @@ export function useYjsCollaboration(
   }, [binding]);
 
   useEffect(() => {
-    return editor.registerCommandListener(
+    return editor.registerCommand(
       'toggleConnect',
       (payload) => {
         if (connect !== undefined && disconnect !== undefined) {
@@ -199,7 +199,7 @@ export function useYjsFocusTracking(
 ) {
   useEffect(() => {
     return mergeRegister(
-      editor.registerCommandListener(
+      editor.registerCommand(
         'focus',
         (payload) => {
           setLocalStateFocus(provider, name, color, false);
@@ -207,7 +207,7 @@ export function useYjsFocusTracking(
         },
         EditorPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'blur',
         (payload) => {
           setLocalStateFocus(provider, name, color, false);
@@ -237,7 +237,7 @@ export function useYjsHistory(
     };
 
     return mergeRegister(
-      editor.registerCommandListener(
+      editor.registerCommand(
         'undo',
         () => {
           undo();
@@ -245,7 +245,7 @@ export function useYjsHistory(
         },
         EditorPriority,
       ),
-      editor.registerCommandListener(
+      editor.registerCommand(
         'redo',
         () => {
           redo();

--- a/packages/lexical-rich-text/src/index.js
+++ b/packages/lexical-rich-text/src/index.js
@@ -304,7 +304,7 @@ export function registerRichText(
   initialEditorState?: InitialEditorStateType,
 ): () => void {
   const removeListener = mergeRegister(
-    editor.registerCommandListener(
+    editor.registerCommand(
       'click',
       (payload) => {
         const selection = $getSelection();
@@ -316,7 +316,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'deleteCharacter',
       (payload) => {
         const selection = $getSelection();
@@ -329,7 +329,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'deleteWord',
       (payload) => {
         const selection = $getSelection();
@@ -342,7 +342,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'deleteLine',
       (payload) => {
         const selection = $getSelection();
@@ -355,7 +355,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'insertText',
       (payload) => {
         const selection = $getSelection();
@@ -381,7 +381,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'removeText',
       (payload) => {
         const selection = $getSelection();
@@ -393,7 +393,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'formatText',
       (payload) => {
         const selection = $getSelection();
@@ -406,7 +406,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'formatElement',
       (payload) => {
         const selection = $getSelection();
@@ -421,7 +421,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'insertLineBreak',
       (payload) => {
         const selection = $getSelection();
@@ -434,7 +434,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'insertParagraph',
       (payload) => {
         const selection = $getSelection();
@@ -446,7 +446,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'indentContent',
       (payload) => {
         const selection = $getSelection();
@@ -460,7 +460,7 @@ export function registerRichText(
             ? anchor.getNode()
             : anchor.getNode().getParentOrThrow();
         if (parentBlock.canInsertTab()) {
-          editor.execCommand('insertText', '\t');
+          editor.dispatchCommand('insertText', '\t');
         } else {
           if (parentBlock.getIndent() !== 10) {
             parentBlock.setIndent(parentBlock.getIndent() + 1);
@@ -470,7 +470,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'outdentContent',
       (payload) => {
         const selection = $getSelection();
@@ -488,7 +488,7 @@ export function registerRichText(
           const textContent = anchorNode.getTextContent();
           const character = textContent[anchor.offset - 1];
           if (character === '\t') {
-            editor.execCommand('deleteCharacter', true);
+            editor.dispatchCommand('deleteCharacter', true);
           }
         } else {
           if (parentBlock.getIndent() !== 0) {
@@ -499,7 +499,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyArrowLeft',
       (payload) => {
         const selection = $getSelection();
@@ -517,7 +517,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyArrowRight',
       (payload) => {
         const selection = $getSelection();
@@ -535,7 +535,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyBackspace',
       (payload) => {
         const selection = $getSelection();
@@ -551,14 +551,14 @@ export function registerRichText(
               ? anchor.getNode()
               : anchor.getNode().getParentOrThrow();
           if (element.getIndent() > 0) {
-            return editor.execCommand('outdentContent');
+            return editor.dispatchCommand('outdentContent');
           }
         }
-        return editor.execCommand('deleteCharacter', true);
+        return editor.dispatchCommand('deleteCharacter', true);
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyDelete',
       (payload) => {
         const selection = $getSelection();
@@ -567,11 +567,11 @@ export function registerRichText(
         }
         const event: KeyboardEvent = payload;
         event.preventDefault();
-        return editor.execCommand('deleteCharacter', false);
+        return editor.dispatchCommand('deleteCharacter', false);
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyEnter',
       (payload) => {
         const selection = $getSelection();
@@ -581,13 +581,13 @@ export function registerRichText(
         const event: KeyboardEvent = payload;
         event.preventDefault();
         if (event.shiftKey) {
-          return editor.execCommand('insertLineBreak');
+          return editor.dispatchCommand('insertLineBreak');
         }
-        return editor.execCommand('insertParagraph');
+        return editor.dispatchCommand('insertParagraph');
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyTab',
       (payload) => {
         const selection = $getSelection();
@@ -596,13 +596,13 @@ export function registerRichText(
         }
         const event: KeyboardEvent = payload;
         event.preventDefault();
-        return editor.execCommand(
+        return editor.dispatchCommand(
           event.shiftKey ? 'outdentContent' : 'indentContent',
         );
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyEscape',
       (payload) => {
         const selection = $getSelection();
@@ -614,7 +614,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'drop',
       (payload) => {
         const selection = $getSelection();
@@ -628,7 +628,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'dragstart',
       (payload) => {
         const selection = $getSelection();
@@ -642,7 +642,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'copy',
       (payload) => {
         const selection = $getSelection();
@@ -655,7 +655,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'cut',
       (payload) => {
         const selection = $getSelection();
@@ -668,7 +668,7 @@ export function registerRichText(
       },
       0,
     ),
-    editor.registerCommandListener(
+    editor.registerCommand(
       'paste',
       (payload) => {
         const selection = $getSelection();

--- a/packages/lexical-table/src/LexicalTableSelection.js
+++ b/packages/lexical-table/src/LexicalTableSelection.js
@@ -170,7 +170,7 @@ export class TableSelection {
 
       $updateDOMForSelection(grid, null);
       $setSelection(null);
-      this.editor.execCommand('selectionChange');
+      this.editor.dispatchCommand('selectionChange');
 
       const parent = removeHighlightStyle.parentNode;
       if (parent != null) {
@@ -236,7 +236,7 @@ export class TableSelection {
           );
 
           $setSelection(this.gridSelection);
-          this.editor.execCommand('selectionChange');
+          this.editor.dispatchCommand('selectionChange');
           $updateDOMForSelection(this.grid, this.gridSelection);
         }
       }
@@ -282,7 +282,7 @@ export class TableSelection {
       });
 
       $setSelection(selection);
-      this.editor.execCommand('selectionChange');
+      this.editor.dispatchCommand('selectionChange');
     });
   }
 
@@ -324,7 +324,7 @@ export class TableSelection {
       });
       $updateDOMForSelection(this.grid, null);
       $setSelection(null);
-      this.editor.execCommand('selectionChange');
+      this.editor.dispatchCommand('selectionChange');
     });
   }
 }

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.js
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.js
@@ -150,7 +150,7 @@ export function applyTableHandlers(
   );
 
   tableSelection.listenersToRemove.add(
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyArrowDown',
       (payload) => {
         const selection = $getSelection();
@@ -253,7 +253,7 @@ export function applyTableHandlers(
     ),
   );
   tableSelection.listenersToRemove.add(
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyArrowUp',
       (payload) => {
         const selection = $getSelection();
@@ -356,7 +356,7 @@ export function applyTableHandlers(
     ),
   );
   tableSelection.listenersToRemove.add(
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyArrowLeft',
       (payload) => {
         const selection = $getSelection();
@@ -453,7 +453,7 @@ export function applyTableHandlers(
     ),
   );
   tableSelection.listenersToRemove.add(
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyArrowRight',
       (payload) => {
         const selection = $getSelection();
@@ -554,7 +554,7 @@ export function applyTableHandlers(
     ),
   );
   tableSelection.listenersToRemove.add(
-    editor.registerCommandListener(
+    editor.registerCommand(
       'deleteCharacter',
       (payload) => {
         const selection = $getSelection();
@@ -591,7 +591,7 @@ export function applyTableHandlers(
     ),
   );
   tableSelection.listenersToRemove.add(
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyBackspace',
       (payload) => {
         const selection = $getSelection();
@@ -620,7 +620,7 @@ export function applyTableHandlers(
     ),
   );
   tableSelection.listenersToRemove.add(
-    editor.registerCommandListener(
+    editor.registerCommand(
       'formatText',
       (payload) => {
         const selection = $getSelection();
@@ -645,7 +645,7 @@ export function applyTableHandlers(
     ),
   );
   tableSelection.listenersToRemove.add(
-    editor.registerCommandListener(
+    editor.registerCommand(
       'insertText',
       (payload) => {
         const selection = $getSelection();
@@ -670,7 +670,7 @@ export function applyTableHandlers(
     ),
   );
   tableSelection.listenersToRemove.add(
-    editor.registerCommandListener(
+    editor.registerCommand(
       'keyTab',
       (payload) => {
         const selection = $getSelection();

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -85,7 +85,7 @@ export declare class LexicalEditor {
   registerRootListener(listener: RootListener): () => void;
   registerDecoratorListener(listener: DecoratorListener): () => void;
   registerTextContentListener(listener: TextContentListener): () => void;
-  registerCommandListener(
+  registerCommand(
     listener: CommandListener,
     priority: CommandListenerPriority,
   ): () => void;
@@ -98,7 +98,7 @@ export declare class LexicalEditor {
     klass: Class<T>,
     listener: Transform<T>,
   ): () => void;
-  execCommand(type: string, payload: CommandPayload): boolean;
+  dispatchCommand(type: string, payload: CommandPayload): boolean;
   hasNodes(nodes: Array<Class<LexicalNode>>): boolean;
   getDecorators<X>(): Record<NodeKey, X>;
   getRootElement(): null | HTMLElement;

--- a/packages/lexical/README.md
+++ b/packages/lexical/README.md
@@ -90,7 +90,7 @@ There are a few ways to update an editor instance:
 - Trigger an update with `editor.update()`
 - Setting the editor state via `editor.setEditorState()`
 - Applying a change as part of an existing update via `editor.addNodeTransform()`
-- Using a command listener with `editor.registerCommandListener( () => {...}, priority)`
+- Using a command listener with `editor.registerCommand( () => {...}, priority)`
 
 The most common way to update the editor is to use `editor.update()`. Calling this function
 requires a function to be passed in that will provide access to mutate the underlying

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -95,7 +95,7 @@ declare export class LexicalEditor {
   registerRootListener(listener: RootListener): () => void;
   registerDecoratorListener(listener: DecoratorListener): () => void;
   registerTextContentListener(listener: TextContentListener): () => void;
-  registerCommandListener(
+  registerCommand(
     type: string,
     listener: CommandListener,
     priority: CommandListenerPriority,
@@ -109,7 +109,7 @@ declare export class LexicalEditor {
     klass: Class<T>,
     listener: Transform<T>,
   ): () => void;
-  execCommand(type: string, payload?: CommandPayload): boolean;
+  dispatchCommand(type: string, payload?: CommandPayload): boolean;
   hasNodes(nodes: Array<Class<LexicalNode>>): boolean;
   getDecorators<X>(): {
     [NodeKey]: X,

--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -419,11 +419,11 @@ export class LexicalEditor {
       listenerSetOrMap.delete(listener);
     };
   }
-  registerCommandListener(
+  registerCommand(
     type: string,
     listener: CommandListener,
     priority: CommandListenerPriority,
-  ): (() => void) | void {
+  ): () => void {
     if (priority === undefined) {
       invariant(false, 'Listener for type "command" requires a "priority".');
     }
@@ -441,7 +441,7 @@ export class LexicalEditor {
     if (listenersInPriorityOrder === undefined) {
       invariant(
         false,
-        'registerCommandListener: Command type of "%s" not found in command map',
+        'registerCommand: Command type of "%s" not found in command map',
         type,
       );
     }
@@ -508,9 +508,8 @@ export class LexicalEditor {
     }
     return true;
   }
-  execCommand(type: string, payload?: CommandPayload): boolean {
-    const result = triggerCommandListeners(this, type, payload);
-    return result;
+  dispatchCommand(type: string, payload?: CommandPayload): boolean {
+    return triggerCommandListeners(this, type, payload);
   }
   getDecorators(): {[NodeKey]: mixed} {
     return this._decorators;

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -124,7 +124,7 @@ function onSelectionChange(
         selection.format = 0;
       }
     }
-    editor.execCommand('selectionChange');
+    editor.dispatchCommand('selectionChange');
   });
 }
 
@@ -152,7 +152,7 @@ function onClick(event: MouseEvent, editor: LexicalEditor): void {
         }
       }
     }
-    editor.execCommand('click', event);
+    editor.dispatchCommand('click', event);
   });
 }
 
@@ -207,7 +207,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
       // Used for Android
       $setCompositionKey(null);
       event.preventDefault();
-      editor.execCommand('deleteCharacter', true);
+      editor.dispatchCommand('deleteCharacter', true);
       return;
     }
     const data = event.data;
@@ -227,10 +227,10 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
     if (inputType === 'insertText') {
       if (data === '\n') {
         event.preventDefault();
-        editor.execCommand('insertLineBreak');
+        editor.dispatchCommand('insertLineBreak');
       } else if (data === '\n\n') {
         event.preventDefault();
-        editor.execCommand('insertParagraph');
+        editor.dispatchCommand('insertParagraph');
       } else if (data == null && event.dataTransfer) {
         // Gets around a Safari text replacement bug.
         const text = event.dataTransfer.getData('text/plain');
@@ -241,7 +241,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
         $shouldPreventDefaultAndInsertText(selection, data, true)
       ) {
         event.preventDefault();
-        editor.execCommand('insertText', data);
+        editor.dispatchCommand('insertText', data);
       }
       return;
     }
@@ -255,88 +255,88 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
       case 'insertFromYank':
       case 'insertFromDrop':
       case 'insertReplacementText': {
-        editor.execCommand('insertText', event);
+        editor.dispatchCommand('insertText', event);
         break;
       }
       case 'insertFromComposition': {
         // This is the end of composition
         $setCompositionKey(null);
-        editor.execCommand('insertText', event);
+        editor.dispatchCommand('insertText', event);
         break;
       }
       case 'insertLineBreak': {
         // Used for Android
         $setCompositionKey(null);
-        editor.execCommand('insertLineBreak');
+        editor.dispatchCommand('insertLineBreak');
         break;
       }
       case 'insertParagraph': {
         // Used for Android
         $setCompositionKey(null);
-        editor.execCommand('insertParagraph');
+        editor.dispatchCommand('insertParagraph');
         break;
       }
       case 'insertFromPaste':
       case 'insertFromPasteAsQuotation': {
-        editor.execCommand('paste', event);
+        editor.dispatchCommand('paste', event);
         break;
       }
       case 'deleteByComposition': {
         if ($canRemoveText(anchorNode, focusNode)) {
-          editor.execCommand('removeText');
+          editor.dispatchCommand('removeText');
         }
         break;
       }
       case 'deleteByDrag':
       case 'deleteByCut': {
-        editor.execCommand('removeText');
+        editor.dispatchCommand('removeText');
         break;
       }
       case 'deleteContent': {
-        editor.execCommand('deleteCharacter', false);
+        editor.dispatchCommand('deleteCharacter', false);
         break;
       }
       case 'deleteWordBackward': {
-        editor.execCommand('deleteWord', true);
+        editor.dispatchCommand('deleteWord', true);
         break;
       }
       case 'deleteWordForward': {
-        editor.execCommand('deleteWord', false);
+        editor.dispatchCommand('deleteWord', false);
         break;
       }
       case 'deleteHardLineBackward':
       case 'deleteSoftLineBackward': {
-        editor.execCommand('deleteLine', true);
+        editor.dispatchCommand('deleteLine', true);
         break;
       }
       case 'deleteContentForward':
       case 'deleteHardLineForward':
       case 'deleteSoftLineForward': {
-        editor.execCommand('deleteLine', false);
+        editor.dispatchCommand('deleteLine', false);
         break;
       }
       case 'formatStrikeThrough': {
-        editor.execCommand('formatText', 'strikethrough');
+        editor.dispatchCommand('formatText', 'strikethrough');
         break;
       }
       case 'formatBold': {
-        editor.execCommand('formatText', 'bold');
+        editor.dispatchCommand('formatText', 'bold');
         break;
       }
       case 'formatItalic': {
-        editor.execCommand('formatText', 'italic');
+        editor.dispatchCommand('formatText', 'italic');
         break;
       }
       case 'formatUnderline': {
-        editor.execCommand('formatText', 'underline');
+        editor.dispatchCommand('formatText', 'underline');
         break;
       }
       case 'historyUndo': {
-        editor.execCommand('undo');
+        editor.dispatchCommand('undo');
         break;
       }
       case 'historyRedo': {
-        editor.execCommand('redo');
+        editor.dispatchCommand('redo');
         break;
       }
       default:
@@ -356,7 +356,7 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
       $isRangeSelection(selection) &&
       $shouldPreventDefaultAndInsertText(selection, data, false)
     ) {
-      editor.execCommand('insertText', data);
+      editor.dispatchCommand('insertText', data);
     } else {
       $updateSelectedTextFromDOM(editor, null);
     }
@@ -384,7 +384,7 @@ function onCompositionStart(
         // to get inserted into the new node we create. If
         // we don't do this, Safari will fail on us because
         // there is no text node matching the selection.
-        editor.execCommand('insertText', ' ');
+        editor.dispatchCommand('insertText', ' ');
       }
     }
   });
@@ -430,64 +430,64 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
   const {keyCode, shiftKey, ctrlKey, metaKey, altKey} = event;
 
   if (isMoveForward(keyCode, ctrlKey, shiftKey, altKey, metaKey)) {
-    editor.execCommand('keyArrowRight', event);
+    editor.dispatchCommand('keyArrowRight', event);
   } else if (isMoveBackward(keyCode, ctrlKey, shiftKey, altKey, metaKey)) {
-    editor.execCommand('keyArrowLeft', event);
+    editor.dispatchCommand('keyArrowLeft', event);
   } else if (isMoveUp(keyCode, ctrlKey, shiftKey, altKey, metaKey)) {
-    editor.execCommand('keyArrowUp', event);
+    editor.dispatchCommand('keyArrowUp', event);
   } else if (isMoveDown(keyCode, ctrlKey, shiftKey, altKey, metaKey)) {
-    editor.execCommand('keyArrowDown', event);
+    editor.dispatchCommand('keyArrowDown', event);
   } else if (isLineBreak(keyCode, shiftKey)) {
-    editor.execCommand('keyEnter', event);
+    editor.dispatchCommand('keyEnter', event);
   } else if (isOpenLineBreak(keyCode, ctrlKey)) {
     event.preventDefault();
-    editor.execCommand('insertLineBreak', true);
+    editor.dispatchCommand('insertLineBreak', true);
   } else if (isParagraph(keyCode, shiftKey)) {
-    editor.execCommand('keyEnter', event);
+    editor.dispatchCommand('keyEnter', event);
   } else if (isDeleteBackward(keyCode, altKey, metaKey, ctrlKey)) {
     if (isBackspace(keyCode)) {
-      editor.execCommand('keyBackspace', event);
+      editor.dispatchCommand('keyBackspace', event);
     } else {
-      editor.execCommand('deleteCharacter', true);
+      editor.dispatchCommand('deleteCharacter', true);
     }
   } else if (isEscape(keyCode)) {
-    editor.execCommand('keyEscape', event);
+    editor.dispatchCommand('keyEscape', event);
   } else if (isDeleteForward(keyCode, ctrlKey, shiftKey, altKey, metaKey)) {
     if (isDelete(keyCode)) {
-      editor.execCommand('keyDelete', event);
+      editor.dispatchCommand('keyDelete', event);
     } else {
       event.preventDefault();
-      editor.execCommand('deleteCharacter', false);
+      editor.dispatchCommand('deleteCharacter', false);
     }
   } else if (isDeleteWordBackward(keyCode, altKey, ctrlKey)) {
     event.preventDefault();
-    editor.execCommand('deleteWord', true);
+    editor.dispatchCommand('deleteWord', true);
   } else if (isDeleteWordForward(keyCode, altKey, ctrlKey)) {
     event.preventDefault();
-    editor.execCommand('deleteWord', false);
+    editor.dispatchCommand('deleteWord', false);
   } else if (isDeleteLineBackward(keyCode, metaKey)) {
     event.preventDefault();
-    editor.execCommand('deleteLine', true);
+    editor.dispatchCommand('deleteLine', true);
   } else if (isDeleteLineForward(keyCode, metaKey)) {
     event.preventDefault();
-    editor.execCommand('deleteLine', false);
+    editor.dispatchCommand('deleteLine', false);
   } else if (isBold(keyCode, metaKey, ctrlKey)) {
     event.preventDefault();
-    editor.execCommand('formatText', 'bold');
+    editor.dispatchCommand('formatText', 'bold');
   } else if (isUnderline(keyCode, metaKey, ctrlKey)) {
     event.preventDefault();
-    editor.execCommand('formatText', 'underline');
+    editor.dispatchCommand('formatText', 'underline');
   } else if (isItalic(keyCode, metaKey, ctrlKey)) {
     event.preventDefault();
-    editor.execCommand('formatText', 'italic');
+    editor.dispatchCommand('formatText', 'italic');
   } else if (isTab(keyCode, altKey, ctrlKey, metaKey)) {
-    editor.execCommand('keyTab', event);
+    editor.dispatchCommand('keyTab', event);
   } else if (isUndo(keyCode, shiftKey, metaKey, ctrlKey)) {
     event.preventDefault();
-    editor.execCommand('undo');
+    editor.dispatchCommand('undo');
   } else if (isRedo(keyCode, shiftKey, metaKey, ctrlKey)) {
     event.preventDefault();
-    editor.execCommand('redo');
+    editor.dispatchCommand('redo');
   }
 }
 
@@ -564,7 +564,7 @@ export function addRootElementEvents(
           }
         : (event: Event) => {
             if (!editor.isReadOnly()) {
-              editor.execCommand(eventName, event);
+              editor.dispatchCommand(eventName, event);
             }
           };
     rootElement.addEventListener(eventName, eventHandler);

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
@@ -1481,20 +1481,20 @@ describe('LexicalEditor tests', () => {
     const commandListener = jest.fn();
     const command = 'insertTestDecoratorNode';
     const payload = 'testPayload';
-    const removeCommandListener = editor.registerCommandListener(
+    const removeCommandListener = editor.registerCommand(
       command,
       commandListener,
       0,
     );
-    editor.execCommand(command, payload);
-    editor.execCommand(command, payload);
-    editor.execCommand(command, payload);
+    editor.dispatchCommand(command, payload);
+    editor.dispatchCommand(command, payload);
+    editor.dispatchCommand(command, payload);
     expect(commandListener).toHaveBeenCalledTimes(3);
     expect(commandListener).toHaveBeenCalledWith(payload, editor);
     removeCommandListener();
-    editor.execCommand(command, payload);
-    editor.execCommand(command, payload);
-    editor.execCommand(command, payload);
+    editor.dispatchCommand(command, payload);
+    editor.dispatchCommand(command, payload);
+    editor.dispatchCommand(command, payload);
     expect(commandListener).toHaveBeenCalledTimes(3);
     expect(commandListener).toHaveBeenCalledWith(payload, editor);
   });
@@ -1504,12 +1504,12 @@ describe('LexicalEditor tests', () => {
     const commandListener = jest.fn();
     const commandListenerTwo = jest.fn();
     const command = 'insertTestDecoratorNode';
-    const removeCommandListener = editor.registerCommandListener(
+    const removeCommandListener = editor.registerCommand(
       command,
       commandListener,
       0,
     );
-    const removeCommandListenerTwo = editor.registerCommandListener(
+    const removeCommandListenerTwo = editor.registerCommand(
       command,
       commandListenerTwo,
       0,


### PR DESCRIPTION
Following #1512 , we've decided to rename `execCommand` and `registerCommandListener`