### PR TITLE
Unit test for adding listeners while triggering existing ones

### DIFF
--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
@@ -1876,4 +1876,22 @@ describe('LexicalEditor tests', () => {
     editor.setReadOnly(false);
     expect(readOnlyFn.mock.calls).toEqual([[true], [false]]);
   });
+
+  it('does not add new listeners while triggering existing', async () => {
+    const updateListener = jest.fn();
+    init();
+    editor.registerUpdateListener(() => {
+      updateListener();
+
+      editor.registerUpdateListener(() => {
+        updateListener();
+      });
+    });
+
+    await update(() => {
+      $getRoot().getFirstChild().replace($createParagraphNode());
+    });
+
+    expect(updateListener).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Ensures that if new listeners are added while editor is triggering existing ones those new listeners handlers won't be executed