### PR TITLE
Fix multiline links

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -551,4 +551,40 @@ test.describe('Links', () => {
       `,
     );
   });
+
+  test('Can create multiline links', async ({page}) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello world');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Hello world');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Hello world');
+
+    await selectAll(page);
+
+    await waitForSelector(page, '.link');
+    await click(page, '.link');
+
+    await assertHTML(
+      page,
+      html`
+        <p dir="ltr">
+          <a dir="ltr" href="https://">
+            <span data-lexical-text="true">Hello world</span>
+          </a>
+        </p>
+        <p dir="ltr">
+          <a dir="ltr" href="https://">
+            <span data-lexical-text="true">Hello world</span>
+          </a>
+        </p>
+        <p dir="ltr">
+          <a dir="ltr" href="https://">
+            <span data-lexical-text="true">Hello world</span>
+          </a>
+        </p>
+      `,
+      {ignoreClasses: true},
+    );
+  });
 });

--- a/packages/lexical-react/src/LexicalLinkPlugin.js
+++ b/packages/lexical-react/src/LexicalLinkPlugin.js
@@ -16,7 +16,7 @@ import {
   TOGGLE_LINK_COMMAND,
 } from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$getSelection, $setSelection} from 'lexical';
+import {$getSelection, $isElementNode, $setSelection} from 'lexical';
 import {useEffect} from 'react';
 
 const EditorPriority: CommandListenerEditorPriority = 0;
@@ -44,8 +44,6 @@ function toggleLink(url: null | string) {
       });
     } else {
       // Add or merge LinkNodes
-      let prevParent = null;
-      let linkNode = null;
       if (nodes.length === 1) {
         const firstNode = nodes[0];
         // if the first node is a LinkNode or if its
@@ -59,15 +57,21 @@ function toggleLink(url: null | string) {
             // set parent to be the current linkNode
             // so that other nodes in the same parent
             // aren't handled separately below.
-            linkNode = parent;
             parent.setURL(url);
             return;
           }
         }
       }
+
+      let prevParent = null;
+      let linkNode = null;
       nodes.forEach((node) => {
         const parent = node.getParent();
-        if (parent === linkNode || parent === null) {
+        if (
+          parent === linkNode ||
+          parent === null ||
+          ($isElementNode(node) && !node.isInline())
+        ) {
           return;
         }
         if (!parent.is(prevParent)) {


### PR DESCRIPTION
Selecting multiline text & applying link to it caused extra wrapping over paragraph nodes. Updated code to ignore non-inline element nodes while wrapping selection nodes into links

## Before
(see tree view)
<img width="435" alt="Screen Shot 2022-04-04 at 10 31 22 PM" src="https://user-images.githubusercontent.com/132642/161667498-4be66995-5f28-443e-b237-b460889e2b7a.png">

## After
<img width="458" alt="Screen Shot 2022-04-04 at 10 30 58 PM" src="https://user-images.githubusercontent.com/132642/161667495-9e99a029-f2cc-4243-9981-a67a2931de74.png">

