### PR TITLE
Improve Table Resizing

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -438,12 +438,16 @@ test.describe('Tables', () => {
         <p><br /></p>
         <table>
           <tr>
-            <th style="background-color: #ACCEF7; caret-color: transparent;">
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <span data-lexical-text="true">a</span>
               </p>
             </th>
-            <th style="background-color: #ACCEF7; caret-color: transparent;">
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <span data-lexical-text="true">bb</span>
               </p>
@@ -461,12 +465,16 @@ test.describe('Tables', () => {
             </th>
           </tr>
           <tr>
-            <th style="background-color: #ACCEF7; caret-color: transparent;">
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <span data-lexical-text="true">d</span>
               </p>
             </th>
-            <td style="background-color: #ACCEF7; caret-color: transparent;">
+            <td
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <span data-lexical-text="true">e</span>
               </p>
@@ -547,12 +555,16 @@ test.describe('Tables', () => {
         <p><br /></p>
         <table>
           <tr>
-            <th style="background-color: #ACCEF7; caret-color: transparent;">
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <span data-lexical-text="true">a</span>
               </p>
             </th>
-            <th style="background-color: #ACCEF7; caret-color: transparent;">
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <span data-lexical-text="true">bb</span>
               </p>
@@ -570,12 +582,16 @@ test.describe('Tables', () => {
             </th>
           </tr>
           <tr>
-            <th style="background-color: #ACCEF7; caret-color: transparent;">
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <span data-lexical-text="true">d</span>
               </p>
             </th>
-            <td style="background-color: #ACCEF7; caret-color: transparent;">
+            <td
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <span data-lexical-text="true">e</span>
               </p>
@@ -686,12 +702,16 @@ test.describe('Tables', () => {
         <p><br /></p>
         <table>
           <tr>
-            <th style="background-color: #ACCEF7; caret-color: transparent;">
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <span data-lexical-text="true">a</span>
               </p>
             </th>
-            <th style="background-color: #ACCEF7; caret-color: transparent;">
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <span data-lexical-text="true">bb</span>
               </p>
@@ -709,12 +729,16 @@ test.describe('Tables', () => {
             </th>
           </tr>
           <tr>
-            <th style="background-color: #ACCEF7; caret-color: transparent;">
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <span data-lexical-text="true">d</span>
               </p>
             </th>
-            <td style="background-color: #ACCEF7; caret-color: transparent;">
+            <td
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <span data-lexical-text="true">e</span>
               </p>
@@ -812,12 +836,16 @@ test.describe('Tables', () => {
         <p><br /></p>
         <table>
           <tr>
-            <th style="background-color: #ACCEF7; caret-color: transparent;">
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <strong data-lexical-text="true">a</strong>
               </p>
             </th>
-            <th style="background-color: #ACCEF7; caret-color: transparent;">
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <strong data-lexical-text="true">bb</strong>
               </p>
@@ -835,12 +863,16 @@ test.describe('Tables', () => {
             </th>
           </tr>
           <tr>
-            <th style="background-color: #ACCEF7; caret-color: transparent;">
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <strong data-lexical-text="true">d</strong>
               </p>
             </th>
-            <td style="background-color: #ACCEF7; caret-color: transparent;">
+            <td
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;"
+            >
               <p dir="ltr">
                 <strong data-lexical-text="true">e</strong>
               </p>

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -100,7 +100,7 @@
 .PlaygroundEditorTheme__tableCell {
   border: 1px solid black;
   padding: 8px;
-  height: 40px;
+  height: 20px;
   min-width: 75px;
   vertical-align: top;
   text-align: start;

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.js
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.js
@@ -833,7 +833,7 @@ export function $updateDOMForSelection(
 
       if (lexicalNode && selectedCellNodes.has(lexicalNode)) {
         cell.highlighted = true;
-        elemStyle.setProperty('background-color', '#ACCEF7');
+        elemStyle.setProperty('background-color', 'rgb(172, 206, 247)');
         elemStyle.setProperty('caret-color', 'transparent');
         highlightedCells.push(cell);
       } else {


### PR DESCRIPTION
This PR removes the ability to "resize" a cell from the left and top. 

Currently it's pretty hard to know which Cell is being updated by the resize action because it's determined by the direction you enter the resizer hover from (aka the cell above or below, or the cell left or right). If we only allow you to use the bottom and right resizers (to grow and shrink) you have the same ability, but it's a lot more clear what you're actually doing. When you release the resizer handle you'll be left with the exact result you had in mind.

I also changed the color of the resizer and changed the background color of the table selection to match a common browser (Chrome).

https://user-images.githubusercontent.com/13852400/161831174-6a800ce3-7684-412f-8faa-db5f31f1bfcd.mov
 

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/13852400/161831160-65a6cf4a-8738-42aa-9ae3-e3156eb683ee.png">
