### PR TITLE
Get non-inline elements for indent/outdent/format command handlers

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/ElementFormat.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ElementFormat.spec.mjs
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  assertHTML,
+  click,
+  focusEditor,
+  html,
+  initialize,
+  repeat,
+  test,
+  waitForSelector,
+} from '../utils/index.mjs';
+
+test.describe('Element format', () => {
+  test.beforeEach(({isCollab, isPlainText, page}) => {
+    test.skip(isPlainText);
+    initialize({isCollab, page});
+  });
+
+  test('can indent/align paragraph when caret is within link', async ({
+    page,
+    isPlainText,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello https://lexical.io world');
+    await repeat(10, async () => {
+      await page.keyboard.press('ArrowLeft');
+    });
+    await waitForSelector(page, '.format.indent');
+    await click(page, '.format.indent');
+    await click(page, '.format.indent');
+    await waitForSelector(page, '.format.center-align');
+    await click(page, '.format.center-align');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          style="padding-inline-start: 80px; text-align: center;"
+          dir="ltr"
+        >
+          <span data-lexical-text="true">Hello</span>
+          <a
+            href="https://lexical.io"
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+          >
+            <span data-lexical-text="true">https://lexical.io</span>
+          </a>
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+      {
+        ignoreClasses: false,
+        ignoreInlineStyles: false,
+      },
+    );
+  });
+});

--- a/packages/lexical-rich-text/src/index.js
+++ b/packages/lexical-rich-text/src/index.js
@@ -29,12 +29,15 @@ import {
   $moveCharacter,
   $shouldOverrideDefaultCharacterSelection,
 } from '@lexical/selection';
-import {addClassNamesToElement, mergeRegister} from '@lexical/utils';
+import {
+  $getNearestBlockElementAncestorOrThrow,
+  addClassNamesToElement,
+  mergeRegister,
+} from '@lexical/utils';
 import {
   $createParagraphNode,
   $getRoot,
   $getSelection,
-  $isElementNode,
   $isGridSelection,
   $isNodeSelection,
   $isRangeSelection,
@@ -438,7 +441,7 @@ export function registerRichText(
           return false;
         }
         const node = selection.anchor.getNode();
-        const element = $isElementNode(node) ? node : node.getParentOrThrow();
+        const element = $getNearestBlockElementAncestorOrThrow(node);
         element.setFormat(format);
         return true;
       },
@@ -478,10 +481,9 @@ export function registerRichText(
         }
         // Handle code blocks
         const anchor = selection.anchor;
-        const parentBlock =
-          anchor.type === 'element'
-            ? anchor.getNode()
-            : anchor.getNode().getParentOrThrow();
+        const parentBlock = $getNearestBlockElementAncestorOrThrow(
+          anchor.getNode(),
+        );
         if (parentBlock.canInsertTab()) {
           editor.dispatchCommand(INSERT_TEXT_COMMAND, '\t');
         } else {
@@ -503,10 +505,9 @@ export function registerRichText(
         // Handle code blocks
         const anchor = selection.anchor;
         const anchorNode = anchor.getNode();
-        const parentBlock =
-          anchor.type === 'element'
-            ? anchor.getNode()
-            : anchor.getNode().getParentOrThrow();
+        const parentBlock = $getNearestBlockElementAncestorOrThrow(
+          anchor.getNode(),
+        );
         if (parentBlock.canInsertTab()) {
           const textContent = anchorNode.getTextContent();
           const character = textContent[anchor.offset - 1];
@@ -569,10 +570,9 @@ export function registerRichText(
         event.preventDefault();
         const {anchor} = selection;
         if (selection.isCollapsed() && anchor.offset === 0) {
-          const element =
-            anchor.type === 'element'
-              ? anchor.getNode()
-              : anchor.getNode().getParentOrThrow();
+          const element = $getNearestBlockElementAncestorOrThrow(
+            anchor.getNode(),
+          );
           if (element.getIndent() > 0) {
             return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND);
           }

--- a/packages/lexical-utils/LexicalUtils.d.ts
+++ b/packages/lexical-utils/LexicalUtils.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import type {LexicalNode} from 'lexical';
+import type {LexicalNode, ElementNode} from 'lexical';
 export type DFSNode = $ReadOnly<{
   depth: number;
   node: LexicalNode;
@@ -37,3 +37,6 @@ declare function $findMatchingParent(
 ): LexicalNode | null;
 type Func = () => void;
 declare function mergeRegister(...func: Array<Func>): () => void;
+declare function $getNearestBlockElementAncestorOrThrow(
+  startNode: LexicalNode,
+): ElementNode;

--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -6,7 +6,7 @@
  *
  * @flow strict
  */
-import type {LexicalNode} from 'lexical';
+import type {LexicalNode, ElementNode} from 'lexical';
 export type DFSNode = $ReadOnly<{
   depth: number,
   node: LexicalNode,
@@ -38,3 +38,6 @@ declare export function $findMatchingParent(
 ): LexicalNode | null;
 type Func = () => void;
 declare export function mergeRegister(...func: Array<Func>): () => void;
+declare export function $getNearestBlockElementAncestorOrThrow(
+  startNode: LexicalNode,
+): ElementNode;

--- a/packages/lexical-utils/src/index.js
+++ b/packages/lexical-utils/src/index.js
@@ -7,9 +7,10 @@
  * @flow strict
  */
 
-import type {LexicalNode} from 'lexical';
+import type {ElementNode, LexicalNode} from 'lexical';
 
 import {$getRoot, $isElementNode} from 'lexical';
+import invariant from 'shared/invariant';
 
 export type DFSNode = $ReadOnly<{
   depth: number,
@@ -92,6 +93,23 @@ export function $getNearestNodeOfType<T: LexicalNode>(
     parent = parent.getParent();
   }
   return parent;
+}
+
+export function $getNearestBlockElementAncestorOrThrow(
+  startNode: LexicalNode,
+): ElementNode {
+  const blockNode = $findMatchingParent(
+    startNode,
+    (node) => $isElementNode(node) && !node.isInline(),
+  );
+  if (!$isElementNode(blockNode)) {
+    invariant(
+      false,
+      'Expected node %s to have closest block element node.',
+      startNode.__key,
+    );
+  }
+  return blockNode;
 }
 
 export type DOMNodeToLexicalConversion = (element: Node) => LexicalNode;


### PR DESCRIPTION
We have several places where `.getParentOrThrow()` is used to get element node. The problem is that it can be inline element (e.g. link). For some commands, like indent/outdent content or format element it is wrong, as it expects block level node instead.

Not quite sure about helper's name 👀

#### Before

https://user-images.githubusercontent.com/132642/162064732-08b52606-9df9-41b1-950e-567244daca6c.mov


#### After

https://user-images.githubusercontent.com/132642/162064725-82cd5239-2ea1-4089-9f8e-d6085c581dba.mov

