### PR TITLE
Separate commands from listener object

### DIFF
--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -78,19 +78,17 @@ type RootListener = (
 ) => void;
 type TextContentListener = (text: string) => void;
 type MutationListener = (nodes: Map<NodeKey, NodeMutation>) => void;
-type CommandListener<P> = (payload: P, editor: LexicalEditor) => boolean;
 export type ReadOnlyListener = (readOnly: boolean) => void;
-
-type InternalCommandListener = CommandListener<any>;
-
 type Listeners = {
   decorator: Set<DecoratorListener>;
   mutation: MutationListeners;
   textcontent: Set<TextContentListener>;
   root: Set<RootListener>;
   update: Set<UpdateListener>;
-  command: Map<string, Array<Set<InternalCommandListener>>>;
 };
+type CommandListener<P> = (payload: P, editor: LexicalEditor) => boolean;
+// $FlowFixMe[unclear-type]
+type Commands = Map<LexicalCommand<any>, Array<Set<CommandListener<any>>>>;
 type RegisteredNodes = Map<string, RegisteredNode>;
 type RegisteredNode = {
   klass: Class<LexicalNode>;
@@ -113,6 +111,7 @@ export declare class LexicalEditor {
   _updating: boolean;
   _keyToDOMMap: Map<NodeKey, HTMLElement>;
   _listeners: Listeners;
+  _commands: Commands;
   _nodes: RegisteredNodes;
   _onError: ErrorHandler;
   _decorators: Record<NodeKey, unknown>;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -76,20 +76,17 @@ type RootListener = (
 type TextContentListener = (text: string) => void;
 type ErrorHandler = (error: Error) => void;
 type MutationListener = (nodes: Map<NodeKey, NodeMutation>) => void;
-type CommandListener<P> = (payload: P, editor: LexicalEditor) => boolean;
 export type ReadOnlyListener = (readOnly: boolean) => void;
-
-// $FlowFixMe
-type InternalCommandListener = CommandListener<any>;
-
 type Listeners = {
   decorator: Set<DecoratorListener>,
   mutation: MutationListeners,
   textcontent: Set<TextContentListener>,
   root: Set<RootListener>,
   update: Set<UpdateListener>,
-  command: Map<string, Array<Set<InternalCommandListener>>>,
 };
+type CommandListener<P> = (payload: P, editor: LexicalEditor) => boolean;
+// $FlowFixMe[unclear-type]
+type Commands = Map<LexicalCommand<any>, Array<Set<CommandListener<any>>>>;
 type RegisteredNodes = Map<string, RegisteredNode>;
 type RegisteredNode = {
   klass: Class<LexicalNode>,
@@ -114,6 +111,7 @@ declare export class LexicalEditor {
   _updating: boolean;
   _keyToDOMMap: Map<NodeKey, HTMLElement>;
   _listeners: Listeners;
+  _commands: Commands;
   _nodes: RegisteredNodes;
   _onError: ErrorHandler;
   _decorators: {

--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -147,9 +147,10 @@ export type CommandListenerPriority =
 // eslint-disable-next-line no-unused-vars
 export type LexicalCommand<T> = $ReadOnly<{}>;
 
+// $FlowFixMe[unclear-type]
+type Commands = Map<LexicalCommand<any>, Array<Set<CommandListener<any>>>>;
+
 type Listeners = {
-  // $FlowFixMe We don't want to require a generic within LexicalEditor just for commands.
-  command: Map<LexicalCommand<>, Array<Set<CommandListener>>>,
   decorator: Set<DecoratorListener>,
   mutation: MutationListeners,
   readonly: Set<ReadOnlyListener>,
@@ -164,8 +165,7 @@ export type ListenerType =
   | 'decorator'
   | 'textcontent'
   | 'mutation'
-  | 'readonly'
-  | 'command';
+  | 'readonly';
 
 export type TransformerType = 'text' | 'decorator' | 'element' | 'root';
 
@@ -306,6 +306,7 @@ export class LexicalEditor {
   _updates: Array<[() => void, void | EditorUpdateOptions]>;
   _updating: boolean;
   _listeners: Listeners;
+  _commands: Commands;
   _nodes: RegisteredNodes;
   _decorators: {[NodeKey]: mixed};
   _pendingDecorators: null | {[NodeKey]: mixed};
@@ -347,7 +348,6 @@ export class LexicalEditor {
     this._updating = false;
     // Listeners
     this._listeners = {
-      command: new Map(),
       decorator: new Set(),
       mutation: new Map(),
       readonly: new Set(),
@@ -355,6 +355,8 @@ export class LexicalEditor {
       textcontent: new Set(),
       update: new Set(),
     };
+    // Commands
+    this._commands = new Map();
     // Editor configuration for theme/context.
     this._config = config;
     // Mapping of types to their nodes
@@ -425,7 +427,7 @@ export class LexicalEditor {
     if (priority === undefined) {
       invariant(false, 'Listener for type "command" requires a "priority".');
     }
-    const commandsMap = this._listeners.command;
+    const commandsMap = this._commands;
     if (!commandsMap.has(command)) {
       commandsMap.set(command, [
         new Set(),

--- a/packages/lexical/src/LexicalUpdates.js
+++ b/packages/lexical/src/LexicalUpdates.js
@@ -474,12 +474,13 @@ export function triggerCommandListeners<P>(
   for (let i = 4; i >= 0; i--) {
     for (let e = 0; e < editors.length; e++) {
       const currentEditor = editors[e];
-      const commandListeners = currentEditor._listeners.command;
+      const commandListeners = currentEditor._commands;
       const listenerInPriorityOrder = commandListeners.get(type);
       if (listenerInPriorityOrder !== undefined) {
         const listeners = listenerInPriorityOrder[i];
         if (listeners !== undefined) {
           for (const listener of listeners) {
+            // $FlowFixMe[missing-type-arg]
             if (listener(payload, editor) === true) {
               return true;
             }

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
@@ -1515,7 +1515,7 @@ describe('LexicalEditor tests', () => {
       commandListenerTwo,
       0,
     );
-    expect(editor._listeners.command).toEqual(
+    expect(editor._commands).toEqual(
       new Map([
         [
           command,
@@ -1530,7 +1530,7 @@ describe('LexicalEditor tests', () => {
       ]),
     );
     removeCommandListener();
-    expect(editor._listeners.command).toEqual(
+    expect(editor._commands).toEqual(
       new Map([
         [
           command,
@@ -1545,7 +1545,7 @@ describe('LexicalEditor tests', () => {
       ]),
     );
     removeCommandListenerTwo();
-    expect(editor._listeners.command).toEqual(new Map());
+    expect(editor._commands).toEqual(new Map());
   });
 
   it('can register transforms before updates', async () => {


### PR DESCRIPTION
Commands aren't listeners, so it makes sense to remove them from the `_listeners` object on LexicalEditor and add them as their own individual map.