### PR TITLE
Add dropdowns to group controls in toolbar

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
@@ -21,7 +21,6 @@ import {
   initialize,
   pasteFromClipboard,
   test,
-  waitForSelector,
 } from '../utils/index.mjs';
 
 test.describe('Auto Links', () => {
@@ -158,7 +157,6 @@ test.describe('Auto Links', () => {
     await page.keyboard.type('hm');
 
     await selectAll(page);
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await assertHTML(

--- a/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
@@ -17,13 +17,10 @@ import {
   pasteFromClipboard,
   selectOption,
   test,
-  waitForSelector,
 } from '../utils/index.mjs';
 
 async function toggleCodeBlock(page) {
-  await waitForSelector(page, '.block-controls');
   await click(page, '.block-controls');
-  await waitForSelector(page, '.dropdown .icon.code');
   await click(page, '.dropdown .icon.code');
 }
 

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -24,8 +24,8 @@ import {
   IS_LINUX,
   IS_WINDOWS,
   pasteFromClipboard,
+  selectFromAlignDropdown,
   test,
-  waitForSelector,
 } from '../utils/index.mjs';
 
 test.describe('CopyAndPaste', () => {
@@ -1212,7 +1212,6 @@ test.describe('CopyAndPaste', () => {
     //      |- Text "World"
     await page.keyboard.type('Hello');
     await selectAll(page);
-    await waitForSelector(page, '.link');
     await click(page, '.link');
     await page.keyboard.press('ArrowRight');
     await page.keyboard.press('Space');
@@ -1350,7 +1349,6 @@ test.describe('CopyAndPaste', () => {
 
     await selectAll(page);
 
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await assertHTML(
@@ -1363,7 +1361,6 @@ test.describe('CopyAndPaste', () => {
     );
 
     await click(page, '.link');
-    await waitForSelector(page, '.link-input');
     await click(page, '.link-edit');
     await focus(page, '.link-input');
     await page.keyboard.type('facebook.com');
@@ -1406,16 +1403,14 @@ test.describe('CopyAndPaste', () => {
       focusPath: [0, 1, 0, 0],
     });
 
-    await waitForSelector(page, '.indent');
-    await click(page, '.indent');
+    await selectFromAlignDropdown(page, '.indent');
 
     await assertHTML(
       page,
       '<ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"><ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">world!</span></li></ul></li></ul>',
     );
 
-    await waitForSelector(page, '.outdent');
-    await click(page, '.outdent');
+    await selectFromAlignDropdown(page, '.outdent');
 
     await assertHTML(
       page,

--- a/packages/lexical-playground/__tests__/e2e/ElementFormat.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ElementFormat.spec.mjs
@@ -8,13 +8,12 @@
 
 import {
   assertHTML,
-  click,
   focusEditor,
   html,
   initialize,
   repeat,
+  selectFromAlignDropdown,
   test,
-  waitForSelector,
 } from '../utils/index.mjs';
 
 test.describe('Element format', () => {
@@ -32,11 +31,9 @@ test.describe('Element format', () => {
     await repeat(10, async () => {
       await page.keyboard.press('ArrowLeft');
     });
-    await waitForSelector(page, '.format.indent');
-    await click(page, '.format.indent');
-    await click(page, '.format.indent');
-    await waitForSelector(page, '.format.center-align');
-    await click(page, '.format.center-align');
+    await selectFromAlignDropdown(page, '.indent');
+    await selectFromAlignDropdown(page, '.indent');
+    await selectFromAlignDropdown(page, '.center-align');
 
     await assertHTML(
       page,

--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
@@ -10,13 +10,13 @@ import {moveToLineBeginning, selectAll} from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
   assertSelection,
-  click,
   copyToClipboard,
   focusEditor,
   html,
   initialize,
   pasteFromClipboard,
   repeat,
+  selectFromInsertDropdown,
   test,
   waitForSelector,
 } from '../utils/index.mjs';
@@ -31,9 +31,7 @@ test.describe('HorizontalRule', () => {
     test.skip(isPlainText);
     await focusEditor(page);
 
-    await waitForSelector(page, 'button .horizontal-rule');
-
-    await click(page, 'button .horizontal-rule');
+    await selectFromInsertDropdown(page, '.horizontal-rule');
 
     await waitForSelector(page, 'hr');
 
@@ -190,9 +188,7 @@ test.describe('HorizontalRule', () => {
       `,
     );
 
-    await waitForSelector(page, 'button .horizontal-rule');
-
-    await click(page, 'button .horizontal-rule');
+    await selectFromInsertDropdown(page, '.horizontal-rule');
 
     await waitForSelector(page, 'hr');
 
@@ -262,9 +258,7 @@ test.describe('HorizontalRule', () => {
       focusPath: [0, 0, 0],
     });
 
-    await waitForSelector(page, 'button .horizontal-rule');
-
-    await click(page, 'button .horizontal-rule');
+    await selectFromInsertDropdown(page, '.horizontal-rule');
 
     await waitForSelector(page, 'hr');
 
@@ -306,9 +300,7 @@ test.describe('HorizontalRule', () => {
 
     await focusEditor(page);
 
-    await waitForSelector(page, 'button .horizontal-rule');
-
-    await click(page, 'button .horizontal-rule');
+    await selectFromInsertDropdown(page, '.horizontal-rule');
 
     await waitForSelector(page, 'hr');
 

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -14,6 +14,7 @@ import {
   focusEditor,
   html,
   initialize,
+  selectFromInsertDropdown,
   test,
   waitForSelector,
 } from '../utils/index.mjs';
@@ -32,9 +33,7 @@ test.describe('Images', () => {
     test.skip(isPlainText);
     await focusEditor(page);
 
-    await waitForSelector(page, 'button .image');
-
-    await click(page, 'button .image');
+    await selectFromInsertDropdown(page, '.image');
 
     await waitForSelector(page, '.editor-image img');
 
@@ -97,9 +96,7 @@ test.describe('Images', () => {
       focusPath: [0],
     });
 
-    await click(page, 'button .image');
-
-    await waitForSelector(page, '.editor-image img');
+    await selectFromInsertDropdown(page, '.image');
 
     await click(page, '.editor-image img');
 
@@ -141,7 +138,7 @@ test.describe('Images', () => {
 
     await click(page, 'div[contenteditable="true"]');
 
-    await click(page, 'button .image');
+    await selectFromInsertDropdown(page, '.image');
 
     await waitForSelector(page, '.editor-image img');
 
@@ -199,13 +196,9 @@ test.describe('Images', () => {
 
     await focusEditor(page);
 
-    await waitForSelector(page, 'button .image');
+    await selectFromInsertDropdown(page, '.image');
 
-    await click(page, 'button .image');
-
-    await waitForSelector(page, '.editor-image img');
-
-    await click(page, 'button .image');
+    await selectFromInsertDropdown(page, '.image');
 
     await focusEditor(page);
     await page.keyboard.press('ArrowLeft');
@@ -290,8 +283,8 @@ test.describe('Images', () => {
     });
 
     await page.keyboard.type('Test');
-    await click(page, 'button .image');
-    await click(page, 'button .image');
+    await selectFromInsertDropdown(page, '.image');
+    await selectFromInsertDropdown(page, '.image');
 
     await focusEditor(page);
     await page.keyboard.press('ArrowLeft');

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -49,7 +49,6 @@ test.describe('Links', () => {
     );
 
     // link
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await assertHTML(
@@ -81,7 +80,6 @@ test.describe('Links', () => {
 
     // set url
     await waitForSelector(page, '.link-input');
-    await waitForSelector(page, '.link-edit');
     await click(page, '.link-edit');
     await focus(page, '.link-input');
     await page.keyboard.type('facebook.com');
@@ -113,7 +111,6 @@ test.describe('Links', () => {
     });
 
     // unlink
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await assertHTML(
@@ -155,7 +152,6 @@ test.describe('Links', () => {
     );
 
     // link
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await assertHTML(
@@ -194,7 +190,6 @@ test.describe('Links', () => {
       `,
     );
 
-    await waitForSelector(page, '.link');
     await click(page, '.link');
     await assertHTML(
       page,
@@ -263,7 +258,6 @@ test.describe('Links', () => {
     await selectCharacters(page, 'right', 5);
 
     // link
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await assertHTML(
@@ -301,7 +295,6 @@ test.describe('Links', () => {
     }
 
     // set url
-    await waitForSelector(page, '.link-input');
     await click(page, '.link-edit');
     await focus(page, '.link-input');
     await page.keyboard.type('facebook.com');
@@ -343,7 +336,6 @@ test.describe('Links', () => {
     }
 
     // unlink
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await assertHTML(
@@ -388,7 +380,6 @@ test.describe('Links', () => {
     await selectCharacters(page, 'left', 5);
 
     // link
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await assertHTML(
@@ -427,7 +418,6 @@ test.describe('Links', () => {
     }
 
     // set url
-    await waitForSelector(page, '.link-input');
     await click(page, '.link-edit');
     await focus(page, '.link-input');
     await page.keyboard.type('facebook.com');
@@ -469,7 +459,6 @@ test.describe('Links', () => {
     }
 
     // unlink
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await assertHTML(
@@ -503,7 +492,6 @@ test.describe('Links', () => {
       await page.keyboard.press('ArrowLeft');
     });
 
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await assertHTML(
@@ -527,9 +515,7 @@ test.describe('Links', () => {
 
     await page.keyboard.press('ArrowLeft');
 
-    await waitForSelector(page, '.block-controls');
     await click(page, '.block-controls');
-    await waitForSelector(page, '.dropdown .icon.large-heading');
     await click(page, '.dropdown .icon.large-heading');
 
     await assertHTML(
@@ -562,7 +548,6 @@ test.describe('Links', () => {
 
     await selectAll(page);
 
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await assertHTML(

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -21,35 +21,30 @@ import {
   focusEditor,
   html,
   initialize,
+  selectFromAlignDropdown,
   test,
   waitForSelector,
 } from '../utils/index.mjs';
 
 async function toggleBulletList(page) {
-  await waitForSelector(page, '.block-controls');
   await click(page, '.block-controls');
-  await waitForSelector(page, '.dropdown .icon.bullet-list');
   await click(page, '.dropdown .icon.bullet-list');
 }
 
 async function toggleNumberedList(page) {
-  await waitForSelector(page, '.block-controls');
   await click(page, '.block-controls');
-  await waitForSelector(page, '.dropdown .icon.numbered-list');
   await click(page, '.dropdown .icon.numbered-list');
 }
 
 async function clickIndentButton(page, times = 1) {
-  await waitForSelector(page, 'button .indent');
   for (let i = 0; i < times; i++) {
-    await click(page, 'button .indent');
+    await selectFromAlignDropdown(page, '.indent');
   }
 }
 
 async function clickOutdentButton(page, times = 1) {
-  await waitForSelector(page, 'button .outdent');
   for (let i = 0; i < times; i++) {
-    await click(page, 'button .outdent');
+    await selectFromAlignDropdown(page, '.outdent');
   }
 }
 
@@ -459,7 +454,6 @@ test.describe('Nested List', () => {
     await selectCharacters(page, 'left', 3);
 
     // link
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await assertHTML(

--- a/packages/lexical-playground/__tests__/e2e/ListMaxIndentLevel.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ListMaxIndentLevel.spec.mjs
@@ -12,21 +12,18 @@ import {
   click,
   focusEditor,
   initialize,
+  selectFromAlignDropdown,
   test,
-  waitForSelector,
 } from '../utils/index.mjs';
 
 async function toggleBulletList(page) {
-  await waitForSelector(page, '.block-controls');
   await click(page, '.block-controls');
-  await waitForSelector(page, '.dropdown .icon.bullet-list');
   await click(page, '.dropdown .icon.bullet-list');
 }
 
 async function clickIndentButton(page, times = 1) {
-  await waitForSelector(page, 'button .indent');
   for (let i = 0; i < times; i++) {
-    await click(page, 'button .indent');
+    await selectFromAlignDropdown(page, '.indent');
   }
 }
 

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -15,27 +15,11 @@ import {
   focusEditor,
   html,
   initialize,
+  insertTable,
   IS_COLLAB,
   pasteFromClipboard,
   test,
-  waitForSelector,
 } from '../utils/index.mjs';
-
-async function insertTable(page) {
-  // Open modal
-  await waitForSelector(page, 'button .table');
-  await click(page, 'button .table');
-
-  // Confirm default 3x3 dimensions
-  await waitForSelector(
-    page,
-    'div[data-test-id="table-model-confirm-insert"] > .Button__root',
-  );
-  await click(
-    page,
-    'div[data-test-id="table-model-confirm-insert"] > .Button__root',
-  );
-}
 
 async function fillTablePartiallyWithText(page) {
   await page.keyboard.type('a');

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -423,7 +423,6 @@ test.describe('TextFormatting', () => {
     await page.keyboard.press('u');
     await keyUpCtrlOrMeta(page);
 
-    await waitForSelector(page, '.strikethrough');
     await click(page, '.strikethrough');
 
     await assertHTML(
@@ -451,7 +450,6 @@ test.describe('TextFormatting', () => {
       focusPath: [0, 1, 0],
     });
 
-    await waitForSelector(page, '.strikethrough');
     await click(page, '.strikethrough');
 
     await assertHTML(

--- a/packages/lexical-playground/__tests__/regression/1083-backspace-with-element-at-front.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/1083-backspace-with-element-at-front.spec.mjs
@@ -15,7 +15,6 @@ import {
   initialize,
   repeat,
   test,
-  waitForSelector,
 } from '../utils/index.mjs';
 
 test.describe('Regression test #1083', () => {
@@ -29,7 +28,6 @@ test.describe('Regression test #1083', () => {
 
     await page.keyboard.type('Hello');
     await selectAll(page);
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await moveToLineEnd(page);
@@ -80,7 +78,6 @@ test.describe('Regression test #1083', () => {
       await page.keyboard.press('ArrowLeft');
     });
     await page.keyboard.up('Shift');
-    await waitForSelector(page, '.link');
     await click(page, '.link');
 
     await moveToLineEnd(page);

--- a/packages/lexical-playground/src/images/icons/plus.svg
+++ b/packages/lexical-playground/src/images/icons/plus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus" viewBox="0 0 16 16">
+  <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/>
+</svg>

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -16,6 +16,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background: #eee;
+  padding: 0 20px;
 }
 
 header {
@@ -42,9 +43,9 @@ header h1 {
 }
 
 .editor-shell {
-  margin: 20px auto 20px auto;
+  margin: 20px auto;
   border-radius: 2px;
-  width: 1080px;
+  max-width: 1000px;
   color: #000;
   position: relative;
   line-height: 20px;
@@ -71,7 +72,7 @@ header h1 {
 
 .test-recorder-output {
   margin: 20px auto 20px auto;
-  width: 1080px;
+  width: 100%;
 }
 
 pre {
@@ -334,6 +335,10 @@ i.horizontal-rule {
   background-image: url(images/icons/horizontal-rule.svg);
 }
 
+.icon.plus {
+  background-image: url(images/icons/plus.svg);
+}
+
 i.image {
   background-image: url(images/icons/file-image.svg);
 }
@@ -354,6 +359,7 @@ i.youtube {
   background-image: url(images/icons/youtube.svg);
 }
 
+.icon.left-align,
 i.left-align {
   background-image: url(images/icons/text-left.svg);
 }
@@ -597,7 +603,7 @@ select.font-family {
   background-color: #fff;
   border-radius: 8px;
   border: 0;
-  min-width: 268px;
+  max-width: 250px;
 }
 
 .dropdown .item .active {
@@ -623,7 +629,7 @@ select.font-family {
   display: flex;
   line-height: 20px;
   flex-grow: 1;
-  width: 200px;
+  min-width: 150px;
 }
 
 .dropdown .item .icon {
@@ -634,6 +640,19 @@ select.font-family {
   margin-right: 12px;
   line-height: 16px;
   background-size: contain;
+}
+
+.dropdown .divider {
+  width: auto;
+  background-color: #eee;
+  margin: 4px 8px;
+  height: 1px;
+}
+
+@media screen and (max-width: 1000px) {
+  .dropdown-button-text {
+    display: none !important;
+  }
 }
 
 .icon.paragraph {
@@ -1096,6 +1115,7 @@ i.chevron-down {
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
   vertical-align: middle;
+  overflow: auto;
 }
 
 .toolbar button.toolbar-item {
@@ -1106,6 +1126,7 @@ i.chevron-down {
   padding: 8px;
   cursor: pointer;
   vertical-align: middle;
+  flex-shrink: 0;
 }
 
 .toolbar button.toolbar-item:disabled {
@@ -1166,15 +1187,14 @@ i.chevron-down {
 .toolbar .toolbar-item .text {
   display: flex;
   line-height: 20px;
-  width: 200px;
   vertical-align: middle;
   font-size: 14px;
   color: #777;
   text-overflow: ellipsis;
-  width: 70px;
   overflow: hidden;
   height: 20px;
   text-align: left;
+  padding-right: 10px;
 }
 
 .toolbar .toolbar-item .icon {

--- a/packages/lexical-playground/src/ui/DropDown.jsx
+++ b/packages/lexical-playground/src/ui/DropDown.jsx
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import {useEffect, useRef, useState} from 'react';
+import * as React from 'react';
+// $FlowFixMe
+import {createPortal} from 'react-dom';
+
+export default function DropDown({
+  buttonLabel,
+  buttonAriaLabel,
+  buttonClassName,
+  buttonIconClassName,
+  children,
+}: {
+  buttonAriaLabel?: string,
+  buttonClassName: string,
+  buttonIconClassName?: string,
+  buttonLabel?: string,
+  children: React.Node,
+}): React$Node {
+  const dropDownRef = useRef<HTMLElement | null>(null);
+  const buttonRef = useRef<HTMLElement | null>(null);
+  const [showDropDown, setShowDropDown] = useState(false);
+
+  useEffect(() => {
+    const button = buttonRef.current;
+    const dropDown = dropDownRef.current;
+
+    if (showDropDown && button !== null && dropDown !== null) {
+      const {top, left} = button.getBoundingClientRect();
+      dropDown.style.top = `${top + 40}px`;
+      dropDown.style.left = `${Math.min(
+        left,
+        window.innerWidth - dropDown.offsetWidth - 20,
+      )}px`;
+    }
+  }, [dropDownRef, buttonRef, showDropDown]);
+
+  useEffect(() => {
+    const button = buttonRef.current;
+
+    if (button !== null && showDropDown) {
+      const handle = (event: MouseEvent) => {
+        // $FlowFixMe: no idea why flow is complaining
+        const target: HTMLElement = event.target;
+        if (!button.contains(target)) {
+          setShowDropDown(false);
+        }
+      };
+      document.addEventListener('click', handle);
+
+      return () => {
+        document.removeEventListener('click', handle);
+      };
+    }
+  }, [dropDownRef, buttonRef, showDropDown]);
+
+  return (
+    <>
+      <button
+        aria-label={buttonAriaLabel || buttonLabel}
+        className={buttonClassName}
+        onClick={() => setShowDropDown(!showDropDown)}
+        ref={buttonRef}
+      >
+        {buttonIconClassName && <span className={buttonIconClassName} />}
+        {buttonLabel && (
+          <span className="text dropdown-button-text">{buttonLabel}</span>
+        )}
+        <i className="chevron-down" />
+      </button>
+
+      {showDropDown &&
+        createPortal(
+          <div className="dropdown" ref={dropDownRef}>
+            {children}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}


### PR DESCRIPTION
- Update editor to shrink w/screen, should be usable on phone too (toolbar is scrollable)
- Update e2e tests, including `click` update that now internally does waitForSelector since we called it before almost every single `click` call

https://user-images.githubusercontent.com/132642/163031657-3ddfacb8-75c5-4a6f-b0d3-dbd283e00b70.mov

