### PR TITLE
Refine TS React.Node type

### DIFF
--- a/packages/lexical-react/LexicalAutoLinkPlugin.d.ts
+++ b/packages/lexical-react/LexicalAutoLinkPlugin.d.ts
@@ -17,4 +17,4 @@ export type LinkMatcher = (text: string) => LinkMatcherResult | null;
 export default function LexicalAutoLinkPlugin(props: {
   matchers: Array<LinkMatcher>;
   onChange?: ChangeHandler;
-}): React.ReactNode;
+}): JSX.Element | null;

--- a/packages/lexical-react/LexicalCharacterLimitPlugin.d.ts
+++ b/packages/lexical-react/LexicalCharacterLimitPlugin.d.ts
@@ -8,4 +8,4 @@
 
 export default function LexicalCharacterLimitPlugin(props: {
   charset: 'UTF-8' | 'UTF-16';
-}): React.ReactNode;
+}): JSX.Element | null;

--- a/packages/lexical-react/LexicalClearEditorPlugin.d.ts
+++ b/packages/lexical-react/LexicalClearEditorPlugin.d.ts
@@ -11,4 +11,6 @@ import {$ReadOnly} from 'utility-types';
 type Props = $ReadOnly<{
   onClear?: () => void;
 }>;
-export default function LexicalClearEditorPlugin(arg0: Props): React.ReactNode;
+export default function LexicalClearEditorPlugin(
+  arg0: Props,
+): JSX.Element | null;

--- a/packages/lexical-react/LexicalCollaborationPlugin.d.ts
+++ b/packages/lexical-react/LexicalCollaborationPlugin.d.ts
@@ -51,6 +51,6 @@ export function CollaborationPlugin(arg0: {
   providerFactory: ProviderFactory;
   shouldBootstrap: boolean;
   username?: string;
-}): React.ReactNode;
+}): JSX.Element | null;
 export declare var CollaborationContext: React.Context<CollaborationContextType>;
 export function useCollaborationContext(): CollaborationContextType;

--- a/packages/lexical-react/LexicalComposer.d.ts
+++ b/packages/lexical-react/LexicalComposer.d.ts
@@ -17,6 +17,6 @@ type Props = {
     theme?: EditorThemeClasses;
     onError: (error: Error, editor: LexicalEditor) => void;
   };
-  children: React.ReactNode;
+  children: JSX.Element | null;
 };
-export default function LexicalComposer(arg0: Props): React.ReactNode;
+export default function LexicalComposer(arg0: Props): JSX.Element | null;

--- a/packages/lexical-react/LexicalContentEditable.d.ts
+++ b/packages/lexical-react/LexicalContentEditable.d.ts
@@ -29,4 +29,6 @@ export type Props = $ReadOnly<{
   tabIndex?: number;
   testid?: string;
 }>;
-export default function LexicalContentEditable(props: Props): React.ReactNode;
+export default function LexicalContentEditable(
+  props: Props,
+): JSX.Element | null;

--- a/packages/lexical-react/LexicalHashtagPlugin.d.ts
+++ b/packages/lexical-react/LexicalHashtagPlugin.d.ts
@@ -6,4 +6,4 @@
  *
  */
 
-export default function LexicalHashtagPlugin(): React.ReactNode;
+export default function LexicalHashtagPlugin(): JSX.Element | null;

--- a/packages/lexical-react/LexicalHistoryPlugin.d.ts
+++ b/packages/lexical-react/LexicalHistoryPlugin.d.ts
@@ -25,5 +25,5 @@ export type HistoryState = {
 };
 export function HistoryPlugin(arg0: {
   externalHistoryState?: HistoryState;
-}): React.ReactNode;
+}): JSX.Element | null;
 export function createEmptyHistoryState(): HistoryState;

--- a/packages/lexical-react/LexicalHorizontalRuleNode.d.ts
+++ b/packages/lexical-react/LexicalHorizontalRuleNode.d.ts
@@ -8,14 +8,14 @@
 
 import type {LexicalNode, LexicalCommand} from 'lexical';
 import {DecoratorNode} from 'lexical';
-export declare class HorizontalRuleNode extends DecoratorNode<React.ReactNode> {
+export declare class HorizontalRuleNode extends DecoratorNode<JSX.Element | null> {
   getType(): string;
   clone(node: HorizontalRuleNode): HorizontalRuleNode;
   createDOM(): HTMLElement;
   getTextContent(): '\n';
   isTopLevel(): true;
   updateDOM(): false;
-  decorate(): React.ReactNode;
+  decorate(): JSX.Element | null;
 }
 export function $createHorizontalRuleNode(): HorizontalRuleNode;
 export function $isHorizontalRuleNode(

--- a/packages/lexical-react/LexicalMarkdownShortcutPlugin.d.ts
+++ b/packages/lexical-react/LexicalMarkdownShortcutPlugin.d.ts
@@ -6,4 +6,4 @@
  *
  */
 
-export default function LexicalMarkdownShortcutPlugin(): React.ReactNode;
+export default function LexicalMarkdownShortcutPlugin(): JSX.Element | null;

--- a/packages/lexical-react/LexicalNestedComposer.d.ts
+++ b/packages/lexical-react/LexicalNestedComposer.d.ts
@@ -13,5 +13,5 @@ export default function LexicalNestedComposer(arg0: {
     decoratorEditor: DecoratorEditor;
     theme?: EditorThemeClasses;
   };
-  children: React.ReactNode;
-}): React.ReactNode;
+  children: JSX.Element | null;
+}): JSX.Element | null;

--- a/packages/lexical-react/LexicalPlainTextPlugin.d.ts
+++ b/packages/lexical-react/LexicalPlainTextPlugin.d.ts
@@ -9,7 +9,7 @@
 import type {EditorState} from 'lexical';
 type InitialEditorStateType = null | string | EditorState | (() => void);
 export default function PlainTextPlugin(arg0: {
-  contentEditable: React.ReactNode;
+  contentEditable: JSX.Element | null;
   initialEditorState?: InitialEditorStateType;
-  placeholder: React.ReactNode;
-}): React.ReactNode;
+  placeholder: JSX.Element | null;
+}): JSX.Element | null;

--- a/packages/lexical-react/LexicalRichTextPlugin.d.ts
+++ b/packages/lexical-react/LexicalRichTextPlugin.d.ts
@@ -9,7 +9,7 @@
 import type {EditorState} from 'lexical';
 type InitialEditorStateType = null | string | EditorState | (() => void);
 export default function RichTextPlugin(arg0: {
-  contentEditable: React.ReactNode;
+  contentEditable: JSX.Element | null;
   initialEditorState?: InitialEditorStateType;
-  placeholder: React.ReactNode;
-}): React.ReactNode;
+  placeholder: JSX.Element | null;
+}): JSX.Element | null;

--- a/packages/lexical-react/LexicalTreeView.d.ts
+++ b/packages/lexical-react/LexicalTreeView.d.ts
@@ -14,4 +14,4 @@ export default function TreeView(props: {
   timeTravelButtonClassName: string;
   viewClassName: string;
   editor: LexicalEditor;
-}): React.ReactNode;
+}): JSX.Element | null;


### PR DESCRIPTION
Feedback from Discord

> Is there any reason why LexicalComposer returns a ReactNode instead of ReactElement? it looks like from the dev.js file that you return React.createElement(...) which by default returns ReactElement but in the .d.ts file definition, you return ReactNode instead of ReactElement?

My research led me to some TS page in that ReactNode is not (fully?) supported - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/52080

I think the best alternative is `JSX.Element | null`