### PR TITLE
Fix Excalidraw on playground

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.jsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.jsx
@@ -88,10 +88,16 @@ export default function ExcalidrawModal({
     setElements(els);
   };
 
+  // This is a hacky work-around for Excalidraw + Vite.
+  // In DEV, Vite pulls this in fine, in prod it doesn't. It seems
+  // like a module resolution issue with ESM vs CJS?
+  const _Excalidraw =
+    Excalidraw.$$typeof != null ? Excalidraw : Excalidraw.default;
+
   return (
     <div className="ExcalidrawModal__modal">
       <div className="ExcalidrawModal__row">
-        <Excalidraw
+        <_Excalidraw
           onChange={onChange}
           initialData={{
             appState: {isLoading: false},


### PR DESCRIPTION
This should stop the playground from crashing when attempting to use Excalidraw on the playground in prod.