### PR TITLE
Improve tweet ID parsing logic

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -335,7 +335,7 @@ function InsertTweetDialog({
   const [text, setText] = useState('');
 
   const onClick = () => {
-    const tweetID = text.split('status/')?.[1];
+    const tweetID = text.split('status/')?.[1]?.split('?')?.[0];
     activeEditor.dispatchCommand(INSERT_TWEET_COMMAND, tweetID);
     onClose();
   };


### PR DESCRIPTION
The logic for getting he ID from the URL for the TwitterPlugin failed to strip out the URL params. This PR fixes that logic. 

