### PR TITLE
Improve CMD+A support for documents containing Tables

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelection.js
+++ b/packages/lexical-table/src/LexicalTableSelection.js
@@ -95,6 +95,7 @@ export class TableSelection {
   focusCellNodeKey: NodeKey | null;
   editor: LexicalEditor;
   gridSelection: GridSelection | null;
+  hasHijackedSelectionStyles: boolean;
 
   constructor(editor: LexicalEditor, tableNodeKey: string) {
     this.isHighlightingCells = false;
@@ -111,6 +112,7 @@ export class TableSelection {
     this.focusCellNodeKey = null;
     this.anchorCell = null;
     this.focusCell = null;
+    this.hasHijackedSelectionStyles = false;
 
     this.trackTableGrid();
   }
@@ -189,6 +191,7 @@ export class TableSelection {
       this.focusCellNodeKey = null;
       this.anchorCell = null;
       this.focusCell = null;
+      this.hasHijackedSelectionStyles = false;
 
       $updateDOMForSelection(grid, null);
       $setSelection(null);
@@ -206,6 +209,7 @@ export class TableSelection {
       }
 
       tableElement.classList.remove('disable-selection');
+      this.hasHijackedSelectionStyles = false;
     });
   }
 
@@ -217,6 +221,7 @@ export class TableSelection {
       }
 
       tableElement.classList.add('disable-selection');
+      this.hasHijackedSelectionStyles = true;
     });
   }
 

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.js
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.js
@@ -757,11 +757,9 @@ export function applyTableHandlers(
           const focusNode = selection.focus.getNode();
           const isAnchorInside = tableNode.isParentOf(anchorNode);
           const isFocusInside = tableNode.isParentOf(focusNode);
-
           const containsPartialTable =
             (isAnchorInside && !isFocusInside) ||
             (isFocusInside && !isAnchorInside);
-
           if (containsPartialTable) {
             const isBackward = selection.isBackward();
             const startNode = isBackward ? focusNode : anchorNode;

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.js
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.js
@@ -194,12 +194,6 @@ export function applyTableHandlers(
         const direction = 'down';
 
         if ($isRangeSelection(selection)) {
-          if (isRangeSelectionHijacked) {
-            // const nextSibling = tableNode.getNextSibling();
-            // nextSibling
-            // return;
-          }
-
           if (selection.isCollapsed()) {
             const tableCellNode = $findMatchingParent(
               selection.anchor.getNode(),

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.js
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.js
@@ -194,6 +194,12 @@ export function applyTableHandlers(
         const direction = 'down';
 
         if ($isRangeSelection(selection)) {
+          if (isRangeSelectionHijacked) {
+            // const nextSibling = tableNode.getNextSibling();
+            // nextSibling
+            // return;
+          }
+
           if (selection.isCollapsed()) {
             const tableCellNode = $findMatchingParent(
               selection.anchor.getNode(),
@@ -747,6 +753,7 @@ export function applyTableHandlers(
       SELECTION_CHANGE_COMMAND,
       (payload) => {
         const selection = $getSelection();
+
         if (
           selection &&
           $isRangeSelection(selection) &&
@@ -756,9 +763,11 @@ export function applyTableHandlers(
           const focusNode = selection.focus.getNode();
           const isAnchorInside = tableNode.isParentOf(anchorNode);
           const isFocusInside = tableNode.isParentOf(focusNode);
+
           const containsPartialTable =
             (isAnchorInside && !isFocusInside) ||
             (isFocusInside && !isAnchorInside);
+
           if (containsPartialTable) {
             const isBackward = selection.isBackward();
             const startNode = isBackward ? focusNode : anchorNode;
@@ -766,7 +775,6 @@ export function applyTableHandlers(
             const tableIndex = tableNode.getIndexWithinParent();
             const parentKey = tableNode.getParentOrThrow().getKey();
             isRangeSelectionHijacked = true;
-            tableSelection.disableHighlightStyle();
             (isBackward
               ? modifiedSelection.focus
               : modifiedSelection.anchor
@@ -784,30 +792,22 @@ export function applyTableHandlers(
               'element',
             );
             $setSelection(modifiedSelection);
-            $forEachGridCell(tableSelection.grid, (cell) => {
-              const elem = cell.elem;
-              cell.highlighted = true;
-              elem.style.setProperty('background-color', 'rgb(172, 206, 247)');
-              elem.style.setProperty('caret-color', 'transparent');
-            });
+            $addHighlightStyleToTable(tableSelection);
             return true;
           }
         }
 
-        if (isRangeSelectionHijacked && !tableNode.isSelected()) {
-          tableSelection.enableHighlightStyle();
-          $forEachGridCell(tableSelection.grid, (cell) => {
-            const elem = cell.elem;
-            cell.highlighted = false;
-            elem.style.removeProperty('background-color');
-            elem.style.removeProperty('caret-color');
-
-            if (!elem.getAttribute('style')) {
-              elem.removeAttribute('style');
-            }
-          });
+        if (
+          tableSelection.hasHijackedSelectionStyles &&
+          !tableNode.isSelected()
+        ) {
+          $removeHighlightStyleToTable(tableSelection);
           isRangeSelectionHijacked = false;
-          return true;
+        } else if (
+          !tableSelection.hasHijackedSelectionStyles &&
+          tableNode.isSelected()
+        ) {
+          $addHighlightStyleToTable(tableSelection);
         }
 
         return false;
@@ -947,8 +947,7 @@ export function $forEachGridCell(
     lexicalNode: LexicalNode,
     cords: {x: number, y: number},
   ) => void,
-): Array<Cell> {
-  const highlightedCells = [];
+) {
   const {cells} = grid;
   for (let y = 0; y < cells.length; y++) {
     const row = cells[y];
@@ -960,7 +959,29 @@ export function $forEachGridCell(
       }
     }
   }
-  return highlightedCells;
+}
+
+export function $addHighlightStyleToTable(tableSelection: TableSelection) {
+  tableSelection.disableHighlightStyle();
+  $forEachGridCell(tableSelection.grid, (cell) => {
+    const elem = cell.elem;
+    cell.highlighted = true;
+    elem.style.setProperty('background-color', 'rgb(172, 206, 247)');
+    elem.style.setProperty('caret-color', 'transparent');
+  });
+}
+
+export function $removeHighlightStyleToTable(tableSelection: TableSelection) {
+  tableSelection.enableHighlightStyle();
+  $forEachGridCell(tableSelection.grid, (cell) => {
+    const elem = cell.elem;
+    cell.highlighted = false;
+    elem.style.removeProperty('background-color');
+    elem.style.removeProperty('caret-color');
+    if (!elem.getAttribute('style')) {
+      elem.removeAttribute('style');
+    }
+  });
 }
 
 const selectGridNodeInDirection = (


### PR DESCRIPTION
This PR improves the UX for when an entire Table is selected. Now it'll show the entire table as selected rather vs using default range selection UI in the table cell text nodes.

Before:
https://user-images.githubusercontent.com/13852400/163275084-ff620f5f-45f6-438a-afdc-d0fd9ddf19fb.mov

After:
https://user-images.githubusercontent.com/13852400/163275096-a58b288b-8116-48eb-ae1e-08252882540f.mov



