### PR TITLE
Capitalize 'tweet' in Playground Insert Menu

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -959,7 +959,7 @@ export default function ToolbarPlugin(): React$Node {
               className="item"
             >
               <i className="icon tweet" />
-              <span className="text">tweet</span>
+              <span className="text">Tweet</span>
             </button>
             <button
               onClick={() => {


### PR DESCRIPTION
"Tweet" was the only option not capitalized in the insert menu, now it is.

<img width="252" alt="image" src="https://user-images.githubusercontent.com/13852400/163276479-347d9f2d-3742-4fbf-b5bb-6744ad17c547.png">
