### PR TITLE
Fix docs for typed commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ There are a few ways to update an editor instance:
 - Trigger an update with `editor.update()`
 - Setting the editor state via `editor.setEditorState()`
 - Applying a change as part of an existing update via `editor.registerNodeTransform()`
-- Using a command listener with `editor.registerCommand( () => {...}, priority)`
+- Using a command listener with `editor.registerCommand(EXAMPLE_COMMAND, () => {...}, priority)`
 
 The most common way to update the editor is to use `editor.update()`. Calling this function
 requires a function to be passed in that will provide access to mutate the underlying

--- a/examples/decorators.md
+++ b/examples/decorators.md
@@ -70,7 +70,7 @@ function VideoPlugin(): React$Node {
   useEffect(() => {
     // Similar with command listener, which returns unlisten callback
     const removeListener = editor.registerCommand(
-      CommandPayload,
+      INSERT_VIDEO_COMMAND,
       (payload) => {
         // Adding custom command that will be handled by this plugin
         editor.update(() => {

--- a/examples/decorators.md
+++ b/examples/decorators.md
@@ -59,13 +59,18 @@ As any other custom Lexical node, decorator nodes need to be registered _before_
 ```
 
 ```js
+// Create a custom command with a typed payload.
+type CommandPayload = string;
+export const INSERT_VIDEO_COMMAND: LexicalCommand<CommandPayload> =
+  createCommand();
+
 function VideoPlugin(): React$Node {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
     // Similar with command listener, which returns unlisten callback
     const removeListener = editor.registerCommand(
-      'insertVideo',
+      CommandPayload,
       (payload) => {
         // Adding custom command that will be handled by this plugin
         editor.update(() => {
@@ -94,12 +99,14 @@ function VideoPlugin(): React$Node {
 Then assuming we have a some UE insert a video into the editor:
 
 ```js
+import {INSERT_VIDEO_COMMAND} from 'VideoPlugin';
+
 function ToolbarVideoButton(): React$Node {
   const [editor] = useLexicalComposerContext();
   const insertVideo = useCallback(
     (url) => {
       // Executing command defined in a plugin
-      editor.dispatchCommand('insertVideo', url);
+      editor.dispatchCommand(INSERT_VIDEO_COMMAND, url);
     },
     [editor],
   );

--- a/packages/lexical-history/README.md
+++ b/packages/lexical-history/README.md
@@ -18,11 +18,13 @@ function registerHistory(
 
 ### Commands
 
-History package handles `undo`, `redo` and `clearHistory` commands. It also triggers `canUndo` and `canRedo` commands when history state is changed. These commands could be used to work with history state:
+History package handles `UNDO_COMMAND`, `REDO_COMMAND` and `CLEAR_HISTORY_COMMAND` commands. It also triggers `CAN_UNDO_COMMAND` and `CAN_REDO_COMMAND` commands when history state is changed. These commands could be used to work with history state:
 
 ```jsx
+import {UNDO_COMMAND, REDO_COMMAND} from 'lexical';
+
 <Toolbar>
-  <Button onClick={() => editor.dispatchCommand('undo')}>Undo</Button>
-  <Button onClick={() => editor.dispatchCommand('redo')}>Redo</Button>
-</Toolbar>
+  <Button onClick={() => editor.dispatchCommand(UNDO_COMMAND)}>Undo</Button>
+  <Button onClick={() => editor.dispatchCommand(REDO_COMMAND)}>Redo</Button>
+</Toolbar>;
 ```

--- a/packages/lexical/README.md
+++ b/packages/lexical/README.md
@@ -90,7 +90,7 @@ There are a few ways to update an editor instance:
 - Trigger an update with `editor.update()`
 - Setting the editor state via `editor.setEditorState()`
 - Applying a change as part of an existing update via `editor.registerNodeTransform()`
-- Using a command listener with `editor.registerCommand( () => {...}, priority)`
+- Using a command listener with `editor.registerCommand(EXAMPLE_COMMAND, () => {...}, priority)`
 
 The most common way to update the editor is to use `editor.update()`. Calling this function
 requires a function to be passed in that will provide access to mutate the underlying


### PR DESCRIPTION
We forgot to update various docs when we launched typed over string literal commands.