### PR TITLE
Fix syntax highlighting on transforms docs (#1691)

### DIFF
--- a/packages/lexical-website-new/docs/concepts/transforms.md
+++ b/packages/lexical-website-new/docs/concepts/transforms.md
@@ -10,7 +10,7 @@ For example:
 User types a character and you want to color the word blue if the word is now equal to "congrats".
 We programmatically add an `@Mention` to the editor, the `@Mention` is immediately next to another `@Mention` (`@Mention@Mention`). Since we believe this makes mentions hard to read, we want to destroy/replace both mentions and render them as plain TextNode's instead.
 
-```
+```js
 const removeTransform = editor.registerNodeTransform(TextNode, textNode => {
   if (textNode.getTextContent() === 'blue') {
     textNode.setTextContent('green');
@@ -20,7 +20,7 @@ const removeTransform = editor.registerNodeTransform(TextNode, textNode => {
 
 ## Syntax
 
-```
+```typescript
 editor.registerNodeTransform<T: LexicalNode>(Class<T>, T): () => void
 ```
 
@@ -36,7 +36,7 @@ In most cases, it is possible to achieve the same or very similar result through
 
 Additionally, each cycle creates a brand new EditorState object which can interfere with plugins like HistoryPlugin (undo-redo) if not handled correctly.
 
-```
+```js
 editor.addUpdateListener(()=> {
   editor.update(() => {
     // Don't do this
@@ -52,7 +52,7 @@ Transforms are designed to run when nodes have been modified (aka marking nodes 
 
 Hence, we have to make sure that the transforms do not mark the node dirty unnecessarily.
 
-```
+```js
 // When a TextNode changes (marked as dirty) make it bold
 editor.registerNodeTransform(TextNode, textNode => {
   // Important: Check current format state
@@ -64,7 +64,7 @@ editor.registerNodeTransform(TextNode, textNode => {
 
 But oftentimes, the order is not important. The below would always end up in the result of the two transforms:
 
-```
+```js
 // Plugin 1
 editor.registerNodeTransform(TextNode, textNode => {
   // This transform runs twice but does nothing the first time because it doesn't meet the preconditions
@@ -90,7 +90,7 @@ editor.addListener('update', ({editorState}) => {
 
 Transforms are very specific to a type of node. This applies to both the declaration (`registerNodeTransform(ImageNode)`) and the times it triggers during an update cycle.
 
-```
+```js
 // Won't trigger
 editor.addTransform(ParagraphNode, ..)
 // Will trigger as TextNode was marked dirty
@@ -106,7 +106,7 @@ You add a node to an ElementNode, the ElementNode and the newly added children a
 You remove a node, its parent is marked dirty, also the node's immediate siblings prior to being removed
 You move a node via `replace`, rules 2 and 1 are applied.
 
-```
+```js
 editor.addTransform(ParagraphNode, paragraph => {
  // Triggers
 });
@@ -122,7 +122,7 @@ It is common to have certain nodes that are created/destroyed based on their tex
 
 This is a perfectly valid case for transforms but we have gone ahead and already built a utility transform wrapper for you for this specific case:
 
-```
+```typescript
 registerLexicalTextEntity<N: TextNode>(
   editor: LexicalEditor,
   getMatch: (text: string) => null | EntityMatch,


### PR DESCRIPTION
## Before:

![before-image](https://user-images.githubusercontent.com/7663513/163285144-ab122dbb-05e7-4fcb-84af-afdc772610a9.png)

## After:

![image](https://user-images.githubusercontent.com/7663513/163285563-747bfcb5-d34e-403c-aa6e-1cfae2fd99cf.png)

## Questions

I used ` ```typescript` for TS files but ` ```ts ` can be used too. Should I use the short or the long form? 