### PR TITLE
fix: docs site codesandbox

### DIFF
--- a/packages/lexical-website-new/src/components/HomepageExamples/styles.module.css
+++ b/packages/lexical-website-new/src/components/HomepageExamples/styles.module.css
@@ -13,6 +13,6 @@
 
 .codesandbox {
   height: 500px;
-  width: 750px;
+  width: 100%;
   overflow: hidden;
 }


### PR DESCRIPTION
The docs site codesandbox is kinda overflowing in mobile and tablet view. Seems like it was due to the explicit 750px given although its parent had `col--8`.


Before | After |
--- | --- | 
<img width="318" alt="Screenshot 2022-04-14 at 9 56 32 AM" src="https://user-images.githubusercontent.com/32865581/163313562-c24dff85-5aa7-4a63-a11f-13ea4ff5b533.png"> | <img width="322" alt="Screenshot 2022-04-14 at 9 56 53 AM" src="https://user-images.githubusercontent.com/32865581/163313590-3373541c-3331-4272-acb6-710bd959822b.png"> |