### PR TITLE
Show preview instead of editor by default

### DIFF
--- a/packages/lexical-website-new/src/components/HomepageExamples/index.js
+++ b/packages/lexical-website-new/src/components/HomepageExamples/index.js
@@ -26,7 +26,7 @@ const EXAMPLES = [
     ),
     id: 'example-feature-1',
     label: 'Simple Setup',
-    src: 'https://codesandbox.io/embed/lexical-plain-text-example-g932e?fontsize=12&hidenavigation=1&module=%2Fsrc%2FEditor.js&theme=dark&view=editor',
+    src: 'https://codesandbox.io/embed/lexical-plain-text-example-g932e?fontsize=12&hidenavigation=1&module=%2Fsrc%2FEditor.js&theme=dark',
   },
   {
     content: (
@@ -41,7 +41,7 @@ const EXAMPLES = [
     ),
     id: 'example-feature-2',
     label: 'Powerful Features',
-    src: 'https://codesandbox.io/embed/lexical-rich-text-example-5tncvy?fontsize=12&hidenavigation=1&module=%2Fsrc%2FEditor.js&theme=dark&view=editor',
+    src: 'https://codesandbox.io/embed/lexical-rich-text-example-5tncvy?fontsize=12&hidenavigation=1&module=%2Fsrc%2FEditor.js&theme=dark',
   },
   {
     content: (


### PR DESCRIPTION
There has been a lot of confusion caused by the fact that there are code editors on the landing page, which leads people to believe that Lexical is a code editor and these editors are implemented with Lexical. In fact, they are CodeSandbox embeds demonstrating Lexical Code. This should clarify things for now.