### PR TITLE
Fix PlaygroundPopupPositioning For Various Edge Cases top and left position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31577,7 +31577,7 @@
         "open": "^8.3.0",
         "pirates": "^4.0.1",
         "pixelmatch": "^5.2.1",
-        "playwright-core": "1.16.0-next-alpha-trueadm-fork",
+        "playwright-core": "=1.17.0-next-alpha-nov-5-2021",
         "pngjs": "^5.0.0",
         "rimraf": "^3.0.2",
         "source-map-support": "^0.4.18",

--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
@@ -33,9 +33,9 @@ function setPopupPosition(editor, rect) {
     editor.style.left = '-1000px';
   } else {
     editor.style.opacity = '1';
-    editor.style.top = `${rect.top - 45 + window.pageYOffset}px`;
+    editor.style.top = `${rect.top - 8 + window.pageYOffset}px`;
     editor.style.left = `${
-      rect.left + window.pageXOffset - editor.offsetWidth / 2 + rect.width / 2
+      rect.left + 245 + window.pageXOffset - editor.offsetWidth + rect.width / 2
     }px`;
   }
 }
@@ -129,7 +129,8 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
         }}
         className={'popup-item spaced ' + (isBold ? 'active' : '')}
-        aria-label="Format Bold">
+        aria-label="Format Bold"
+      >
         <i className="format bold" />
       </button>
       <button
@@ -137,7 +138,8 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
         }}
         className={'popup-item spaced ' + (isItalic ? 'active' : '')}
-        aria-label="Format Italics">
+        aria-label="Format Italics"
+      >
         <i className="format italic" />
       </button>
       <button
@@ -145,7 +147,8 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
         }}
         className={'popup-item spaced ' + (isUnderline ? 'active' : '')}
-        aria-label="Format Underline">
+        aria-label="Format Underline"
+      >
         <i className="format underline" />
       </button>
       <button
@@ -153,7 +156,8 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough');
         }}
         className={'popup-item spaced ' + (isStrikethrough ? 'active' : '')}
-        aria-label="Format Strikethrough">
+        aria-label="Format Strikethrough"
+      >
         <i className="format strikethrough" />
       </button>
       <button
@@ -161,13 +165,15 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
         }}
         className={'popup-item spaced ' + (isCode ? 'active' : '')}
-        aria-label="Insert Code">
+        aria-label="Insert Code"
+      >
         <i className="format code" />
       </button>
       <button
         onClick={insertLink}
         className={'popup-item spaced ' + (isLink ? 'active' : '')}
-        aria-label="Insert Link">
+        aria-label="Insert Link"
+      >
         <i className="format link" />
       </button>
     </div>

--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
@@ -35,7 +35,7 @@ function setPopupPosition(editor, rect) {
     editor.style.opacity = '1';
     editor.style.top = `${rect.top - 8 + window.pageYOffset}px`;
     editor.style.left = `${
-      rect.left + 245 + window.pageXOffset - editor.offsetWidth + rect.width / 2
+      rect.left + 230 + window.pageXOffset - editor.offsetWidth + rect.width / 2
     }px`;
   }
 }


### PR DESCRIPTION
Fixes  #1704
This PR fixes the Playground Popup Positioning to Handle Various Edge Cases top, left  and right position 

Before:
https://user-images.githubusercontent.com/22450188/163326237-b65f071b-5b1d-4e6c-b55a-e3ee9744ceb8.png
https://user-images.githubusercontent.com/22450188/163326356-74214cff-00ef-4e4f-a413-19181afa7ebc.png
https://user-images.githubusercontent.com/22450188/163326498-47f0516a-0e84-402e-b8d5-3de718bb7cd6.png

After:
https://user-images.githubusercontent.com/35562131/163366694-0eb71c18-f746-4c08-bfb1-80cdb75826e7.png
https://user-images.githubusercontent.com/35562131/163366784-118e31f2-1315-432d-980b-7da3e54dc1f0.png
https://user-images.githubusercontent.com/35562131/163367031-8786caf4-3cbc-49d2-9ac5-50b21f7b337e.png