### PR TITLE
include heading 4 and 5 in lexical markdown

### DIFF
--- a/packages/lexical-markdown/src/utils.js
+++ b/packages/lexical-markdown/src/utils.js
@@ -71,6 +71,8 @@ export type MarkdownFormatKind =
   | 'paragraphH1'
   | 'paragraphH2'
   | 'paragraphH3'
+  | 'paragraphH4'
+  | 'paragraphH5'
   | 'paragraphBlockQuote'
   | 'paragraphUnorderedList'
   | 'paragraphOrderedList'
@@ -199,11 +201,24 @@ const markdownHeader2: MarkdownCriteria = {
 
 const markdownHeader3: MarkdownCriteria = {
   ...paragraphStartBase,
-  markdownFormatKind: 'paragraphH2',
+  markdownFormatKind: 'paragraphH3',
   regEx: /^(?:### )/,
   regExForAutoFormatting: /^(?:### )/,
 };
 
+const markdownHeader4: MarkdownCriteria = {
+  ...paragraphStartBase,
+  markdownFormatKind: 'paragraphH4',
+  regEx: /^(?:#### )/,
+  regExForAutoFormatting: /^(?:#### )/,
+};
+
+const markdownHeader5: MarkdownCriteria = {
+  ...paragraphStartBase,
+  markdownFormatKind: 'paragraphH5',
+  regEx: /^(?:##### )/,
+  regExForAutoFormatting: /^(?:##### )/,
+};
 const markdownBlockQuote: MarkdownCriteria = {
   ...paragraphStartBase,
   markdownFormatKind: 'paragraphBlockQuote',
@@ -366,6 +381,8 @@ export const allMarkdownCriteria: MarkdownCriteriaArray = [
   markdownHeader1,
   markdownHeader2,
   markdownHeader3,
+  markdownHeader4,
+  markdownHeader5,
   markdownBlockQuote,
   markdownUnorderedListDash,
   markdownUnorderedListAsterisk,
@@ -582,6 +599,16 @@ function getNewNodeForCriteria<T>(
       }
       case 'paragraphH3': {
         newNode = $createHeadingNode('h3');
+        newNode.append(...children);
+        return {newNode, shouldDelete};
+      }
+      case 'paragraphH4': {
+        newNode = $createHeadingNode('h4');
+        newNode.append(...children);
+        return {newNode, shouldDelete};
+      }
+      case 'paragraphH5': {
+        newNode = $createHeadingNode('h5');
         newNode.append(...children);
         return {newNode, shouldDelete};
       }


### PR DESCRIPTION
I've included h4 and h5 in the lexical markdown so that we'd be able to handle them in the markdown mode. Also fixes h3 which was converted to h2 previously. 

Also we might want to include them inside the dropdown too?
But the name small heading and large heading is quite confusing thoughts?

<img width="237" alt="Screenshot 2022-04-14 at 4 40 46 PM" src="https://user-images.githubusercontent.com/32865581/163379612-117acffc-38af-433b-8b6f-0f79a731b959.png">


Fixes: 
- https://github.com/facebook/lexical/issues/1628