### PR TITLE
Update prettier config option name

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,7 +3,7 @@
 module.exports = {
   bracketSpacing: false,
   singleQuote: true,
-  jsxBracketSameLine: true,
+  bracketSameLine: true,
   printWidth: 80,
   trailingComma: 'all',
   htmlWhitespaceSensitivity: 'ignore',

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -486,6 +486,7 @@ export function prettifyHTML(string, {ignoreClasses, ignoreInlineStyles} = {}) {
     .format(output, {
       attributeGroups: ['$DEFAULT', '^data-'],
       attributeSort: 'ASC',
+      bracketSameLine: true,
       htmlWhitespaceSensitivity: 'ignore',
       parser: 'html',
     })


### PR DESCRIPTION
Prettier renamed `jsxBracketSameLine` to `bracketSameLine` and depending on VSCode's prettier version people will have old name ignored or supported causing different formatting.