### PR TITLE
Add h3 to dropdown and add tests for h4 and h5

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -77,6 +77,27 @@ test.describe('Markdown', () => {
       undoHTML: '', // H2.
     },
     {
+      expectation: '<h3 class="PlaygroundEditorTheme__h3"><br></h3>',
+      isBlockTest: true,
+      markdownText: '### ',
+
+      undoHTML: '', // H3.
+    },
+    {
+      expectation: '<h4 class="PlaygroundEditorTheme__h4"><br></h4>',
+      isBlockTest: true,
+      markdownText: '#### ',
+
+      undoHTML: '', // H4.
+    },
+    {
+      expectation: '<h5 class="PlaygroundEditorTheme__h5"><br></h5>',
+      isBlockTest: true,
+      markdownText: '##### ',
+
+      undoHTML: '', // H5.
+    },
+    {
       expectation:
         '<code class="PlaygroundEditorTheme__code" spellcheck="false" data-gutter="1" data-highlight-language="javascript"><br></code>',
       isBlockTest: true,
@@ -335,28 +356,24 @@ test.describe('Markdown', () => {
       html`
         <h1
           class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Heading</span>
         </h1>
         <ul class="PlaygroundEditorTheme__ul">
           <li
             class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
             dir="ltr"
-            value="1"
-          >
+            value="1">
             <span data-lexical-text="true">unordered list</span>
           </li>
           <li
             class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"
-            value="2"
-          >
+            value="2">
             <ul class="PlaygroundEditorTheme__ul">
               <li
                 class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
                 dir="ltr"
-                value="1"
-              >
+                value="1">
                 <span data-lexical-text="true">nested</span>
               </li>
             </ul>
@@ -366,20 +383,17 @@ test.describe('Markdown', () => {
           <li
             class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
             dir="ltr"
-            value="1"
-          >
+            value="1">
             <span data-lexical-text="true">ordered list</span>
           </li>
           <li
             class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"
-            value="2"
-          >
+            value="2">
             <ol class="PlaygroundEditorTheme__ol2">
               <li
                 class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
                 dir="ltr"
-                value="1"
-              >
+                value="1">
                 <span data-lexical-text="true">nested</span>
               </li>
             </ol>

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -663,14 +663,16 @@ select.font-family {
   background-image: url(images/icons/text-paragraph.svg);
 }
 
-.icon.large-heading,
 .icon.h1 {
   background-image: url(images/icons/type-h1.svg);
 }
 
-.icon.small-heading,
 .icon.h2 {
   background-image: url(images/icons/type-h2.svg);
+}
+
+.icon.h3 {
+  background-image: url(images/icons/type-h3.svg);
 }
 
 .icon.bullet-list,

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -86,17 +86,18 @@ const supportedBlockTypes = new Set([
   'code',
   'h1',
   'h2',
+  'h3',
   'ul',
   'ol',
 ]);
 
 const blockTypeToBlockName = {
   code: 'Code Block',
-  h1: 'Large Heading',
-  h2: 'Small Heading',
-  h3: 'Heading',
-  h4: 'Heading',
-  h5: 'Heading',
+  h1: 'Heading 1',
+  h2: 'Heading 2',
+  h3: 'Heading 3',
+  h4: 'Heading 4',
+  h5: 'Heading 5',
   ol: 'Numbered List',
   paragraph: 'Normal',
   quote: 'Quote',
@@ -289,8 +290,7 @@ function InsertTableDialog({
       <Input label="No of columns" onChange={setColumns} value={columns} />
       <div
         className="ToolbarPlugin__dialogActions"
-        data-test-id="table-model-confirm-insert"
-      >
+        data-test-id="table-model-confirm-insert">
         <Button onClick={onClick}>Confirm</Button>
       </div>
     </>
@@ -466,6 +466,18 @@ function BlockFormatDropDown({
     }
   };
 
+  const formatVerySmallHeading = () => {
+    if (blockType !== 'h3') {
+      editor.update(() => {
+        const selection = $getSelection();
+
+        if ($isRangeSelection(selection)) {
+          $wrapLeafNodesInElements(selection, () => $createHeadingNode('h3'));
+        }
+      });
+    }
+  };
+
   const formatBulletList = () => {
     if (blockType !== 'ul') {
       editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND);
@@ -519,22 +531,26 @@ function BlockFormatDropDown({
       buttonClassName="toolbar-item block-controls"
       buttonIconClassName={'icon block-type ' + blockType}
       buttonLabel={blockTypeToBlockName[blockType]}
-      buttonAriaLabel="Formatting Options"
-    >
+      buttonAriaLabel="Formatting Options">
       <button className="item" onClick={formatParagraph}>
         <span className="icon paragraph" />
         <span className="text">Normal</span>
         {blockType === 'paragraph' && <span className="active" />}
       </button>
       <button className="item" onClick={formatLargeHeading}>
-        <span className="icon large-heading" />
-        <span className="text">Large Heading</span>
+        <span className="icon h1" />
+        <span className="text">Heading 1</span>
         {blockType === 'h1' && <span className="active" />}
       </button>
       <button className="item" onClick={formatSmallHeading}>
-        <span className="icon small-heading" />
-        <span className="text">Small Heading</span>
+        <span className="icon h2" />
+        <span className="text">Heading 2</span>
         {blockType === 'h2' && <span className="active" />}
+      </button>
+      <button className="item" onClick={formatVerySmallHeading}>
+        <span className="icon h3" />
+        <span className="text">Heading 3</span>
+        {blockType === 'h3' && <span className="active" />}
       </button>
       <button className="item" onClick={formatBulletList}>
         <span className="icon bullet-list" />
@@ -753,8 +769,7 @@ export default function ToolbarPlugin(): React$Node {
           activeEditor.dispatchCommand(UNDO_COMMAND);
         }}
         className="toolbar-item spaced"
-        aria-label="Undo"
-      >
+        aria-label="Undo">
         <i className="format undo" />
       </button>
       <button
@@ -763,8 +778,7 @@ export default function ToolbarPlugin(): React$Node {
           activeEditor.dispatchCommand(REDO_COMMAND);
         }}
         className="toolbar-item"
-        aria-label="Redo"
-      >
+        aria-label="Redo">
         <i className="format redo" />
       </button>
       <Divider />
@@ -829,8 +843,7 @@ export default function ToolbarPlugin(): React$Node {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
             }}
             className={'toolbar-item spaced ' + (isBold ? 'active' : '')}
-            aria-label="Format Bold"
-          >
+            aria-label="Format Bold">
             <i className="format bold" />
           </button>
           <button
@@ -838,8 +851,7 @@ export default function ToolbarPlugin(): React$Node {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
             }}
             className={'toolbar-item spaced ' + (isItalic ? 'active' : '')}
-            aria-label="Format Italics"
-          >
+            aria-label="Format Italics">
             <i className="format italic" />
           </button>
           <button
@@ -847,8 +859,7 @@ export default function ToolbarPlugin(): React$Node {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
             }}
             className={'toolbar-item spaced ' + (isUnderline ? 'active' : '')}
-            aria-label="Format Underline"
-          >
+            aria-label="Format Underline">
             <i className="format underline" />
           </button>
           <button
@@ -861,8 +872,7 @@ export default function ToolbarPlugin(): React$Node {
             className={
               'toolbar-item spaced ' + (isStrikethrough ? 'active' : '')
             }
-            aria-label="Format Strikethrough"
-          >
+            aria-label="Format Strikethrough">
             <i className="format strikethrough" />
           </button>
           <button
@@ -870,15 +880,13 @@ export default function ToolbarPlugin(): React$Node {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
             }}
             className={'toolbar-item spaced ' + (isCode ? 'active' : '')}
-            aria-label="Insert Code"
-          >
+            aria-label="Insert Code">
             <i className="format code" />
           </button>
           <button
             onClick={insertLink}
             className={'toolbar-item spaced ' + (isLink ? 'active' : '')}
-            aria-label="Insert Link"
-          >
+            aria-label="Insert Link">
             <i className="format link" />
           </button>
           {isLink &&
@@ -890,14 +898,12 @@ export default function ToolbarPlugin(): React$Node {
           <DropDown
             buttonClassName="toolbar-item spaced"
             buttonLabel="Insert"
-            buttonIconClassName="icon plus"
-          >
+            buttonIconClassName="icon plus">
             <button
               onClick={() => {
                 activeEditor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND);
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon horizontal-rule" />
               <span className="text">Horizontal Rule</span>
             </button>
@@ -905,8 +911,7 @@ export default function ToolbarPlugin(): React$Node {
               onClick={() => {
                 activeEditor.dispatchCommand(INSERT_IMAGE_COMMAND);
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon image" />
               <span className="text">Image</span>
             </button>
@@ -914,8 +919,7 @@ export default function ToolbarPlugin(): React$Node {
               onClick={() => {
                 activeEditor.dispatchCommand(INSERT_EXCALIDRAW_COMMAND);
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon diagram-2" />
               <span className="text">Excalidraw</span>
             </button>
@@ -928,8 +932,7 @@ export default function ToolbarPlugin(): React$Node {
                   />
                 ));
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon table" />
               <span className="text">Table</span>
             </button>
@@ -942,8 +945,7 @@ export default function ToolbarPlugin(): React$Node {
                   />
                 ));
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon poll" />
               <span className="text">Poll</span>
             </button>
@@ -956,8 +958,7 @@ export default function ToolbarPlugin(): React$Node {
                   />
                 ));
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon tweet" />
               <span className="text">Tweet</span>
             </button>
@@ -970,8 +971,7 @@ export default function ToolbarPlugin(): React$Node {
                   />
                 ));
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon youtube" />
               <span className="text">YouTube Video</span>
             </button>
@@ -984,8 +984,7 @@ export default function ToolbarPlugin(): React$Node {
                   />
                 ));
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon equation" />
               <span className="text">Equation</span>
             </button>
@@ -996,14 +995,12 @@ export default function ToolbarPlugin(): React$Node {
       <DropDown
         buttonLabel="Align"
         buttonIconClassName="icon left-align"
-        buttonClassName="toolbar-item spaced"
-      >
+        buttonClassName="toolbar-item spaced">
         <button
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left');
           }}
-          className="item"
-        >
+          className="item">
           <i className="icon left-align" />
           <span className="text">Left Align</span>
         </button>
@@ -1011,8 +1008,7 @@ export default function ToolbarPlugin(): React$Node {
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'center');
           }}
-          className="item"
-        >
+          className="item">
           <i className="icon center-align" />
           <span className="text">Center Align</span>
         </button>
@@ -1020,8 +1016,7 @@ export default function ToolbarPlugin(): React$Node {
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'right');
           }}
-          className="item"
-        >
+          className="item">
           <i className="icon right-align" />
           <span className="text">Right Align</span>
         </button>
@@ -1029,8 +1024,7 @@ export default function ToolbarPlugin(): React$Node {
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'justify');
           }}
-          className="item"
-        >
+          className="item">
           <i className="icon justify-align" />
           <span className="text">Justify Align</span>
         </button>
@@ -1039,8 +1033,7 @@ export default function ToolbarPlugin(): React$Node {
           onClick={() => {
             activeEditor.dispatchCommand(OUTDENT_CONTENT_COMMAND);
           }}
-          className="item"
-        >
+          className="item">
           <i className={'icon ' + (isRTL ? 'indent' : 'outdent')} />
           <span className="text">Outdent</span>
         </button>
@@ -1048,8 +1041,7 @@ export default function ToolbarPlugin(): React$Node {
           onClick={() => {
             activeEditor.dispatchCommand(INDENT_CONTENT_COMMAND);
           }}
-          className="item"
-        >
+          className="item">
           <i className={'icon ' + (isRTL ? 'outdent' : 'indent')} />
           <span className="text">Indent</span>
         </button>

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -48,6 +48,13 @@
   padding: 0;
   text-transform: uppercase;
 }
+.PlaygroundEditorTheme__h3 {
+  font-size: 12px;
+  margin: 0;
+  margin-top: 10px;
+  padding: 0;
+  text-transform: uppercase;
+}
 .PlaygroundEditorTheme__textBold {
   font-weight: bold;
 }

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.js
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.js
@@ -50,6 +50,9 @@ const theme: EditorThemeClasses = {
   heading: {
     h1: 'PlaygroundEditorTheme__h1',
     h2: 'PlaygroundEditorTheme__h2',
+    h3: 'PlaygroundEditorTheme__h3',
+    h4: 'PlaygroundEditorTheme__h4',
+    h5: 'PlaygroundEditorTheme__h5',
   },
   image: 'editor-image',
   link: 'PlaygroundEditorTheme__link',


### PR DESCRIPTION
This PR introduces 
- one new menu item to the toolbar (H3) 
- Adds h4 and h5 in markdown spec
- Adds separate classes in case if want to use it for overriding style
- Changes block name from large heading to heading 1, small heading to heading 2

<img width="237" alt="Screenshot 2022-04-15 at 12 26 29 AM" src="https://user-images.githubusercontent.com/32865581/163458026-5d24c8f3-1951-433d-aa2a-7e1d54855d0c.png">
