### PR TITLE
Skip reconciled selection changes

### DIFF
--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
@@ -243,7 +243,7 @@ function useCharacterStylesPopup(editor: LexicalEditor): React$Node {
     });
   }, [editor]);
 
-  if (!isText) {
+  if (!isText || !isLink) {
     return null;
   }
 

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -215,6 +215,12 @@ function FloatingLinkEditor({editor}: {editor: LexicalEditor}): React$Node {
   }, [editor, updateLinkEditor]);
 
   useEffect(() => {
+    editor.getEditorState().read(() => {
+      updateLinkEditor();
+    });
+  }, [editor, updateLinkEditor])
+
+  useEffect(() => {
     if (isEditMode && inputRef.current) {
       inputRef.current.focus();
     }

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -289,8 +289,7 @@ function InsertTableDialog({
       <Input label="No of columns" onChange={setColumns} value={columns} />
       <div
         className="ToolbarPlugin__dialogActions"
-        data-test-id="table-model-confirm-insert"
-      >
+        data-test-id="table-model-confirm-insert">
         <Button onClick={onClick}>Confirm</Button>
       </div>
     </>
@@ -519,8 +518,7 @@ function BlockFormatDropDown({
       buttonClassName="toolbar-item block-controls"
       buttonIconClassName={'icon block-type ' + blockType}
       buttonLabel={blockTypeToBlockName[blockType]}
-      buttonAriaLabel="Formatting Options"
-    >
+      buttonAriaLabel="Formatting Options">
       <button className="item" onClick={formatParagraph}>
         <span className="icon paragraph" />
         <span className="text">Normal</span>
@@ -659,16 +657,13 @@ export default function ToolbarPlugin(): React$Node {
   }, [activeEditor]);
 
   useEffect(() => {
-    return activeEditor.registerUpdateListener(({editorState}) => {
-      editorState.read(() => {
-        updateToolbar();
-      });
-    });
-  }, [activeEditor, updateToolbar]);
-
-  useEffect(() => {
     return mergeRegister(
-      editor.registerCommand(
+      activeEditor.registerUpdateListener(({editorState}) => {
+        editorState.read(() => {
+          updateToolbar();
+        });
+      }),
+      activeEditor.registerCommand(
         SELECTION_CHANGE_COMMAND,
         (_payload, newEditor) => {
           updateToolbar();
@@ -677,7 +672,7 @@ export default function ToolbarPlugin(): React$Node {
         },
         LowPriority,
       ),
-      editor.registerCommand(
+      activeEditor.registerCommand(
         CAN_UNDO_COMMAND,
         (payload) => {
           setCanUndo(payload);
@@ -685,7 +680,7 @@ export default function ToolbarPlugin(): React$Node {
         },
         LowPriority,
       ),
-      editor.registerCommand(
+      activeEditor.registerCommand(
         CAN_REDO_COMMAND,
         (payload) => {
           setCanRedo(payload);
@@ -694,7 +689,7 @@ export default function ToolbarPlugin(): React$Node {
         LowPriority,
       ),
     );
-  }, [editor, updateToolbar]);
+  }, [activeEditor, updateToolbar]);
 
   const applyStyleText = useCallback(
     (styles: {[string]: string}) => {
@@ -753,8 +748,7 @@ export default function ToolbarPlugin(): React$Node {
           activeEditor.dispatchCommand(UNDO_COMMAND);
         }}
         className="toolbar-item spaced"
-        aria-label="Undo"
-      >
+        aria-label="Undo">
         <i className="format undo" />
       </button>
       <button
@@ -763,8 +757,7 @@ export default function ToolbarPlugin(): React$Node {
           activeEditor.dispatchCommand(REDO_COMMAND);
         }}
         className="toolbar-item"
-        aria-label="Redo"
-      >
+        aria-label="Redo">
         <i className="format redo" />
       </button>
       <Divider />
@@ -829,8 +822,7 @@ export default function ToolbarPlugin(): React$Node {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
             }}
             className={'toolbar-item spaced ' + (isBold ? 'active' : '')}
-            aria-label="Format Bold"
-          >
+            aria-label="Format Bold">
             <i className="format bold" />
           </button>
           <button
@@ -838,8 +830,7 @@ export default function ToolbarPlugin(): React$Node {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
             }}
             className={'toolbar-item spaced ' + (isItalic ? 'active' : '')}
-            aria-label="Format Italics"
-          >
+            aria-label="Format Italics">
             <i className="format italic" />
           </button>
           <button
@@ -847,8 +838,7 @@ export default function ToolbarPlugin(): React$Node {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
             }}
             className={'toolbar-item spaced ' + (isUnderline ? 'active' : '')}
-            aria-label="Format Underline"
-          >
+            aria-label="Format Underline">
             <i className="format underline" />
           </button>
           <button
@@ -861,8 +851,7 @@ export default function ToolbarPlugin(): React$Node {
             className={
               'toolbar-item spaced ' + (isStrikethrough ? 'active' : '')
             }
-            aria-label="Format Strikethrough"
-          >
+            aria-label="Format Strikethrough">
             <i className="format strikethrough" />
           </button>
           <button
@@ -870,15 +859,13 @@ export default function ToolbarPlugin(): React$Node {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
             }}
             className={'toolbar-item spaced ' + (isCode ? 'active' : '')}
-            aria-label="Insert Code"
-          >
+            aria-label="Insert Code">
             <i className="format code" />
           </button>
           <button
             onClick={insertLink}
             className={'toolbar-item spaced ' + (isLink ? 'active' : '')}
-            aria-label="Insert Link"
-          >
+            aria-label="Insert Link">
             <i className="format link" />
           </button>
           {isLink &&
@@ -890,14 +877,12 @@ export default function ToolbarPlugin(): React$Node {
           <DropDown
             buttonClassName="toolbar-item spaced"
             buttonLabel="Insert"
-            buttonIconClassName="icon plus"
-          >
+            buttonIconClassName="icon plus">
             <button
               onClick={() => {
                 activeEditor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND);
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon horizontal-rule" />
               <span className="text">Horizontal Rule</span>
             </button>
@@ -905,8 +890,7 @@ export default function ToolbarPlugin(): React$Node {
               onClick={() => {
                 activeEditor.dispatchCommand(INSERT_IMAGE_COMMAND);
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon image" />
               <span className="text">Image</span>
             </button>
@@ -914,8 +898,7 @@ export default function ToolbarPlugin(): React$Node {
               onClick={() => {
                 activeEditor.dispatchCommand(INSERT_EXCALIDRAW_COMMAND);
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon diagram-2" />
               <span className="text">Excalidraw</span>
             </button>
@@ -928,8 +911,7 @@ export default function ToolbarPlugin(): React$Node {
                   />
                 ));
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon table" />
               <span className="text">Table</span>
             </button>
@@ -942,8 +924,7 @@ export default function ToolbarPlugin(): React$Node {
                   />
                 ));
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon poll" />
               <span className="text">Poll</span>
             </button>
@@ -956,8 +937,7 @@ export default function ToolbarPlugin(): React$Node {
                   />
                 ));
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon tweet" />
               <span className="text">Tweet</span>
             </button>
@@ -970,8 +950,7 @@ export default function ToolbarPlugin(): React$Node {
                   />
                 ));
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon youtube" />
               <span className="text">YouTube Video</span>
             </button>
@@ -984,8 +963,7 @@ export default function ToolbarPlugin(): React$Node {
                   />
                 ));
               }}
-              className="item"
-            >
+              className="item">
               <i className="icon equation" />
               <span className="text">Equation</span>
             </button>
@@ -996,14 +974,12 @@ export default function ToolbarPlugin(): React$Node {
       <DropDown
         buttonLabel="Align"
         buttonIconClassName="icon left-align"
-        buttonClassName="toolbar-item spaced"
-      >
+        buttonClassName="toolbar-item spaced">
         <button
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left');
           }}
-          className="item"
-        >
+          className="item">
           <i className="icon left-align" />
           <span className="text">Left Align</span>
         </button>
@@ -1011,8 +987,7 @@ export default function ToolbarPlugin(): React$Node {
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'center');
           }}
-          className="item"
-        >
+          className="item">
           <i className="icon center-align" />
           <span className="text">Center Align</span>
         </button>
@@ -1020,8 +995,7 @@ export default function ToolbarPlugin(): React$Node {
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'right');
           }}
-          className="item"
-        >
+          className="item">
           <i className="icon right-align" />
           <span className="text">Right Align</span>
         </button>
@@ -1029,8 +1003,7 @@ export default function ToolbarPlugin(): React$Node {
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'justify');
           }}
-          className="item"
-        >
+          className="item">
           <i className="icon justify-align" />
           <span className="text">Justify Align</span>
         </button>
@@ -1039,8 +1012,7 @@ export default function ToolbarPlugin(): React$Node {
           onClick={() => {
             activeEditor.dispatchCommand(OUTDENT_CONTENT_COMMAND);
           }}
-          className="item"
-        >
+          className="item">
           <i className={'icon ' + (isRTL ? 'indent' : 'outdent')} />
           <span className="text">Outdent</span>
         </button>
@@ -1048,8 +1020,7 @@ export default function ToolbarPlugin(): React$Node {
           onClick={() => {
             activeEditor.dispatchCommand(INDENT_CONTENT_COMMAND);
           }}
-          className="item"
-        >
+          className="item">
           <i className={'icon ' + (isRTL ? 'outdent' : 'indent')} />
           <span className="text">Indent</span>
         </button>

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -52,6 +52,7 @@ import {
   SELECTION_CHANGE_COMMAND,
   UNDO_COMMAND,
 } from '.';
+import {DOM_ELEMENT_TYPE} from './LexicalConstants';
 import {updateEditor} from './LexicalUpdates';
 import {
   $flushMutations,
@@ -135,7 +136,18 @@ function onSelectionChange(
 ): void {
   if (isSelectionChangeFromReconcile) {
     isSelectionChangeFromReconcile = false;
-    return;
+    const {anchorNode, focusNode} = domSelection;
+    // If native DOM selection is on a DOM element, then
+    // we should continue as usual, as Lexical's selection
+    // may have normalized to a better child.
+    if (
+      anchorNode !== null &&
+      focusNode !== null &&
+      anchorNode.nodeType !== DOM_ELEMENT_TYPE &&
+      focusNode.nodeType !== DOM_ELEMENT_TYPE
+    ) {
+      return;
+    }
   }
   updateEditor(editor, () => {
     // Non-active editor don't need any extra logic for selection, it only needs update

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -126,12 +126,17 @@ if (CAN_USE_BEFORE_INPUT) {
 
 let lastKeyDownTimeStamp = 0;
 let rootElementsRegistered = 0;
+let isSelectionChangeFromReconcile = false;
 
 function onSelectionChange(
   domSelection: Selection,
   editor: LexicalEditor,
   isActive: boolean,
 ): void {
+  if (isSelectionChangeFromReconcile) {
+    isSelectionChangeFromReconcile = false;
+    return;
+  }
   updateEditor(editor, () => {
     // Non-active editor don't need any extra logic for selection, it only needs update
     // to reconcile selection (set it to null) to ensure that only one editor has non-null selection.
@@ -714,4 +719,8 @@ function cleanActiveNestedEditorsMap(editor: LexicalEditor) {
     // For top-level editors cleanup map
     activeNestedEditorsMap.delete(editor._key);
   }
+}
+
+export function markSelectionChangeFromReconcile(): void {
+  isSelectionChangeFromReconcile = true;
 }

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -52,7 +52,7 @@ import {
   SELECTION_CHANGE_COMMAND,
   UNDO_COMMAND,
 } from '.';
-import {DOM_ELEMENT_TYPE} from './LexicalConstants';
+import {DOM_TEXT_TYPE} from './LexicalConstants';
 import {updateEditor} from './LexicalUpdates';
 import {
   $flushMutations,
@@ -139,12 +139,14 @@ function onSelectionChange(
     const {anchorNode, focusNode} = domSelection;
     // If native DOM selection is on a DOM element, then
     // we should continue as usual, as Lexical's selection
-    // may have normalized to a better child.
+    // may have normalized to a better child. If the DOM
+    // element is a text node, we can safely apply this
+    // optimization and skip the selection change entirely.
     if (
       anchorNode !== null &&
       focusNode !== null &&
-      anchorNode.nodeType !== DOM_ELEMENT_TYPE &&
-      focusNode.nodeType !== DOM_ELEMENT_TYPE
+      anchorNode.nodeType === DOM_TEXT_TYPE &&
+      focusNode.nodeType === DOM_TEXT_TYPE
     ) {
       return;
     }

--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -43,6 +43,7 @@ import {
   IS_ALIGN_RIGHT,
 } from './LexicalConstants';
 import {EditorState} from './LexicalEditorState';
+import {markSelectionChangeFromReconcile} from './LexicalEvents';
 import {
   cloneDecorators,
   getDOMTextNode,
@@ -871,6 +872,7 @@ function reconcileSelection(
     if (nextSelection.isCollapsed() && rootElement === activeElement) {
       scrollIntoViewIfNeeded(editor, nextAnchorNode, rootElement);
     }
+    markSelectionChangeFromReconcile();
   } catch (error) {
     // If we encounter an error, continue. This can sometimes
     // occur with FF and there's no good reason as to why it


### PR DESCRIPTION
If we reconcile a selection change, in most cases we should attempt to "ignore" the subsequent incoming selection change event, as it won't give us any real value. Plus this can avoid issues around changing format part way through text.