### PR TITLE
Fix inlines in insertParagraph

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -8,9 +8,12 @@
 
 import {
   moveLeft,
+  moveRight,
+  moveToLineBeginning,
   moveToLineEnd,
   selectAll,
   selectCharacters,
+  toggleBold,
 } from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
@@ -41,8 +44,7 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
         </p>
       `,
@@ -56,13 +58,11 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <a
             href="https://"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
-            dir="ltr"
-          >
+            dir="ltr">
             <span data-lexical-text="true">Hello</span>
           </a>
         </p>
@@ -90,13 +90,11 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <a
             href="https://facebook.com"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
-            dir="ltr"
-          >
+            dir="ltr">
             <span data-lexical-text="true">Hello</span>
           </a>
         </p>
@@ -118,8 +116,7 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
         </p>
       `,
@@ -144,8 +141,7 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
         </p>
       `,
@@ -159,8 +155,7 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
         </p>
       `,
@@ -183,8 +178,7 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">An Awesome Website</span>
         </p>
       `,
@@ -196,13 +190,11 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <a
             href="https://"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
-            dir="ltr"
-          >
+            dir="ltr">
             <span data-lexical-text="true">An Awesome Website</span>
           </a>
         </p>
@@ -219,14 +211,12 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hey, check this out:</span>
           <a
             href="https://"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
-            dir="ltr"
-          >
+            dir="ltr">
             <span data-lexical-text="true">An Awesome Website</span>
           </a>
           <span data-lexical-text="true">!</span>
@@ -247,8 +237,7 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello world</span>
         </p>
       `,
@@ -265,14 +254,12 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
           <a
             href="https://"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
-            dir="ltr"
-          >
+            dir="ltr">
             <span data-lexical-text="true">world</span>
           </a>
         </p>
@@ -305,14 +292,12 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
           <a
             href="https://facebook.com"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
-            dir="ltr"
-          >
+            dir="ltr">
             <span data-lexical-text="true">world</span>
           </a>
         </p>
@@ -343,8 +328,7 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello world</span>
         </p>
       `,
@@ -370,8 +354,7 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello world</span>
         </p>
       `,
@@ -387,14 +370,12 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
           <a
             href="https://"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
-            dir="ltr"
-          >
+            dir="ltr">
             <span data-lexical-text="true">world</span>
           </a>
         </p>
@@ -428,14 +409,12 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
           <a
             href="https://facebook.com"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
-            dir="ltr"
-          >
+            dir="ltr">
             <span data-lexical-text="true">world</span>
           </a>
         </p>
@@ -466,8 +445,7 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello world</span>
         </p>
       `,
@@ -499,14 +477,12 @@ test.describe('Links', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
           <a
             href="https://"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
-            dir="ltr"
-          >
+            dir="ltr">
             <span data-lexical-text="true">world</span>
           </a>
         </p>
@@ -523,14 +499,12 @@ test.describe('Links', () => {
       html`
         <h1
           class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
           <a
             href="https://"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
-            dir="ltr"
-          >
+            dir="ltr">
             <span data-lexical-text="true">world</span>
           </a>
         </h1>
@@ -567,6 +541,133 @@ test.describe('Links', () => {
           <a dir="ltr" href="https://">
             <span data-lexical-text="true">Hello world</span>
           </a>
+        </p>
+      `,
+      {ignoreClasses: true},
+    );
+  });
+
+  test('Can handle pressing Enter inside a Link', async ({page}) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello awesome');
+    await selectAll(page);
+    await click(page, '.link');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.type('world');
+
+    await moveToLineBeginning(page);
+    await moveRight(page, 6);
+
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <p dir="ltr">
+          <a dir="ltr" href="https://">
+            <span data-lexical-text="true">Hello</span>
+          </a>
+        </p>
+        <p dir="ltr">
+          <a dir="ltr" href="https://">
+            <span data-lexical-text="true">awesome</span>
+          </a>
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+      {ignoreClasses: true},
+    );
+  });
+
+  test('Can handle pressing Enter inside a Link containing multiple TextNodes', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello ');
+    await toggleBold(page);
+    await page.keyboard.type('awe');
+    await toggleBold(page);
+    await page.keyboard.type('some');
+    await selectAll(page);
+    await click(page, '.link');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.type(' world');
+
+    await moveToLineBeginning(page);
+    await moveRight(page, 6);
+
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <p dir="ltr">
+          <a dir="ltr" href="https://">
+            <span data-lexical-text="true">Hello</span>
+          </a>
+        </p>
+        <p dir="ltr">
+          <a dir="ltr" href="https://">
+            <strong data-lexical-text="true">awe</strong>
+            <span data-lexical-text="true">some</span>
+          </a>
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+      {ignoreClasses: true},
+    );
+  });
+
+  test('Can handle pressing Enter at the beginning of a Link', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello awesome');
+    await selectAll(page);
+    await click(page, '.link');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.type(' world');
+
+    await moveToLineBeginning(page);
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <p><br /></p>
+        <p dir="ltr">
+          <a dir="ltr" href="https://">
+            <span data-lexical-text="true">Hello awesome</span>
+          </a>
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+      {ignoreClasses: true},
+    );
+  });
+
+  test('Can handle pressing Enter at the end of a Link', async ({page}) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello awesome');
+    await selectAll(page);
+    await click(page, '.link');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.type(' world');
+
+    await moveLeft(page, 6);
+
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <p dir="ltr">
+          <a dir="ltr" href="https://">
+            <span data-lexical-text="true">Hello awesome</span>
+          </a>
+        </p>
+        <p dir="ltr">
+          <span data-lexical-text="true">world</span>
         </p>
       `,
       {ignoreClasses: true},

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -1336,10 +1336,10 @@ export class RangeSelection implements BaseSelection {
       const textContent = anchorNode.getTextContent();
       const textContentLength = textContent.length;
       currentElement = anchorNode.getParentOrThrow();
+      const isInline = currentElement.isInline();
       if (anchorOffset === 0) {
         nodesToMove.push(anchorNode);
       } else {
-        const isInline = currentElement.isInline();
         if (isInline) {
           // For inline nodes, we want to move all the siblings to the new paragraph
           // if selection is at the end, we just move the siblings. Otherwise, we also
@@ -1394,7 +1394,7 @@ export class RangeSelection implements BaseSelection {
           if (firstChild === null) {
             if (isInline) {
               // For inline nodes, we start with the nodes that were previously in the parent
-              newElement?.getParentOrThrow().append(nodeToMove);
+              newElement.getParentOrThrow().append(nodeToMove);
             } else {
               newElement.append(nodeToMove);
             }

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -1385,8 +1385,12 @@ export class RangeSelection implements BaseSelection {
       this.insertLineBreak();
     } else if ($isElementNode(newElement)) {
       // If we're at the beginning of the current element, move the new element to be before the current element
+      const currentElementFirstChild = currentElement.getFirstChild();
       const isBeginning =
-        anchorOffset === 0 && currentElement.getFirstChildOrThrow().is(anchor);
+        anchorOffset === 0 &&
+        (currentElement.is(anchor.getNode()) ||
+          (currentElementFirstChild &&
+            currentElementFirstChild.is(anchor.getNode())));
       if (isBeginning && nodesToMoveLength > 0) {
         currentElement.insertBefore(newElement);
         return;

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -1370,20 +1370,24 @@ export class RangeSelection implements BaseSelection {
       }
       nodesToMove = currentElement.getChildren().slice(anchorOffset).reverse();
     }
-    if (anchorOffset === 0 && nodesToMove.length > 0) {
-      if (currentElement.isInline()) {
-        currentElement.getParentOrThrow().insertBefore($createParagraphNode());
-        return;
-      }
+    const nodesToMoveLength = nodesToMove.length;
+    if (
+      anchorOffset === 0 &&
+      nodesToMoveLength > 0 &&
+      currentElement.isInline()
+    ) {
+      currentElement.getParentOrThrow().insertBefore($createParagraphNode());
+      return;
     }
     const newElement = currentElement.insertNewAfter(this);
     if (newElement === null) {
       // Handle as a line break insertion
       this.insertLineBreak();
     } else if ($isElementNode(newElement)) {
-      const nodesToMoveLength = nodesToMove.length;
-      // Move the new element to be before the current element
-      if (anchorOffset === 0 && nodesToMoveLength > 0) {
+      // If we're at the beginning of the current element, move the new element to be before the current element
+      const isBeginning =
+        anchorOffset === 0 && currentElement.getFirstChildOrThrow().is(anchor);
+      if (isBeginning && nodesToMoveLength > 0) {
         currentElement.insertBefore(newElement);
         return;
       }


### PR DESCRIPTION
Fixes #1678 

~~I'm not sure this is actually the right way to handle this though. The logic in this function is sort of messy, and this change certainly doesn't help things. It's also pretty specific to LinkNodes (the only thing implementing isInline right now) in that it basically assumes that the inline element has just a TextNode in it.~~

This function might be something we need to think about refactoring or totally rethinking. I want to add some tests here to catch weird behavior.

EDIT:

I was able to implement a solution that I think it more robust and should handle most cases of inline elements. Still thing we might be able to refactor this function, but I'm concerned about bloating core if we add a bunch of sub-functions to make it more readable.