### PR TITLE
Markdown import

### DIFF
--- a/packages/lexical-markdown/src/autoFormatUtils.js
+++ b/packages/lexical-markdown/src/autoFormatUtils.js
@@ -32,6 +32,7 @@ import {
   getAllMarkdownCriteriaForTextNodes,
   getAllTriggers,
   getInitialScanningContext,
+  getParentElementNodeOrThrow,
   getPatternMatchResultsForCriteria,
   getTextNodeWithOffsetOrThrow,
   transformTextNodeForMarkdownCriteria,
@@ -93,6 +94,7 @@ function getCriteriaWithPatternMatchResults(
       const patternMatchResults = getPatternMatchResultsForCriteria(
         markdownCriteria,
         scanningContext,
+        getParentElementNodeOrThrow(scanningContext),
       );
       if (patternMatchResults != null) {
         return {

--- a/packages/lexical-markdown/src/convertFromPlainTextUtils.js
+++ b/packages/lexical-markdown/src/convertFromPlainTextUtils.js
@@ -33,6 +33,7 @@ import {
   getAllMarkdownCriteriaForTextNodes,
   getCodeBlockCriteria,
   getInitialScanningContext,
+  getParentElementNodeOrThrow,
   getPatternMatchResultsForCodeBlock,
   getPatternMatchResultsForCriteria,
   resetScanningContext,
@@ -193,6 +194,7 @@ function convertParagraphLevelMarkdown<T>(
         const patternMatchResults = getPatternMatchResultsForCriteria(
           criteria,
           scanningContext,
+          getParentElementNodeOrThrow(scanningContext),
         );
         if (patternMatchResults != null) {
           scanningContext.markdownCriteria = criteria;
@@ -254,8 +256,8 @@ function convertMarkdownForTextCriteria<T>(
   const allCriteria = getAllMarkdownCriteriaForTextNodes();
   const count = allCriteria.length;
 
-  const textContent = elementNode.getTextContent();
-  let done = textContent.length > 0;
+  let textContent = elementNode.getTextContent();
+  let done = textContent.length === 0;
   let startIndex = 0;
   while (!done) {
     done = true;
@@ -278,6 +280,7 @@ function convertMarkdownForTextCriteria<T>(
       const patternMatchResults = getPatternMatchResultsForCriteria(
         criteria,
         scanningContext,
+        elementNode,
       );
 
       if (patternMatchResults != null) {
@@ -305,6 +308,7 @@ function convertMarkdownForTextCriteria<T>(
         }
 
         // The text was changed. Perhaps there is another hit for the same criteria.
+        textContent = currentTextContent;
         startIndex = i;
         done = false;
         break;

--- a/packages/lexical-markdown/src/convertFromPlainTextUtils.js
+++ b/packages/lexical-markdown/src/convertFromPlainTextUtils.js
@@ -247,10 +247,7 @@ function convertMarkdownForTextCriteria<T>(
   elementNode: ElementNode,
   createHorizontalRuleNode: null | (() => DecoratorNode<T>),
 ) {
-  invariant(
-    scanningContext.textNodeWithOffset == null,
-    'Scanning context was not reset.',
-  );
+  resetScanningContext(scanningContext);
 
   // Cycle through all the criteria and convert all text patterns in the parent element.
   const allCriteria = getAllMarkdownCriteriaForTextNodes();

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -394,5 +394,50 @@ test.describe('Markdown', () => {
       'text/plain': text,
     });
     await click(page, 'i.markdown');
+    const html = `
+    <h1 class=\"PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr\" dir=\"ltr\">
+      <span data-lexical-text=\"true\">Heading</span>
+    </h1>
+    <ul class=\"PlaygroundEditorTheme__ul\">
+      <li
+        class=\"PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr\"
+        dir=\"ltr\"
+        value=\"1\">
+        <span data-lexical-text=\"true\">unordered list</span>
+      </li>
+      <li
+        class=\"PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem\"
+        value=\"2\">
+        <ul class=\"PlaygroundEditorTheme__ul\">
+          <li
+            class=\"PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr\"
+            dir=\"ltr\"
+            value=\"1\">
+            <span data-lexical-text=\"true\">nested</span>
+          </li>
+        </ul>
+      </li>
+    </ul>
+    <ol class=\"PlaygroundEditorTheme__ol1\">
+      <li
+        class=\"PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr\"
+        dir=\"ltr\"
+        value=\"1\">
+        <span data-lexical-text=\"true\">ordered list</span>
+      </li>
+      <li
+        class=\"PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem\"
+        value=\"2\">
+        <ol class=\"PlaygroundEditorTheme__ol2\">
+          <li
+            class=\"PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr\"
+            dir=\"ltr\"
+            value=\"1\">
+            <span data-lexical-text=\"true\">nested</span>
+          </li>
+        </ol>
+      </li>
+    </ol>`;
+    await assertHTML(page, html);
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -44,14 +44,20 @@ test.describe('Markdown', () => {
     {
       expectation:
         '<p class="PlaygroundEditorTheme__paragraph"><a href="http://www.test.com" class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">hello world</span></a><span data-lexical-text="true"> </span></p>',
+      importExpectation:
+        '<p class="PlaygroundEditorTheme__paragraph"><a class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr" dir="ltr" href="http://www.test.com"><span data-lexical-text="true">hello world</span></a></p>',
       isBlockTest: true,
+      markdownImport: '[hello world](http://www.test.com)',
       markdownText: '[hello world](http://www.test.com) ', // Link
       undoHTML: `<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">[hello world](http://www.test.com) </span></p>`,
     },
     {
       expectation:
         '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">x</span><strong class="PlaygroundEditorTheme__textBold" data-lexical-text="true">hello</strong><span data-lexical-text="true"> y</span></p>',
+      importExpectation:
+        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><strong class="PlaygroundEditorTheme__textBold" data-lexical-text="true">hello</strong></p>',
       isBlockTest: false,
+      markdownImport: '__hello__',
       markdownText: '__hello__',
       stylizedExpectation:
         '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true" class="PlaygroundEditorTheme__textUnderline">x</span><strong class="PlaygroundEditorTheme__textBold" data-lexical-text="true">hello</strong><span class="PlaygroundEditorTheme__textUnderline" data-lexical-text="true"> y</span></p>',
@@ -64,16 +70,18 @@ test.describe('Markdown', () => {
     },
     {
       expectation: '<h1 class="PlaygroundEditorTheme__h1"><br></h1>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '# ',
-
       undoHTML: '', // H1.
     },
     {
       expectation: '<h2 class="PlaygroundEditorTheme__h2"><br></h2>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '## ',
-
       undoHTML: '', // H2.
     },
     {
@@ -100,78 +108,93 @@ test.describe('Markdown', () => {
     {
       expectation:
         '<code class="PlaygroundEditorTheme__code" spellcheck="false" data-gutter="1" data-highlight-language="javascript"><br></code>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '``` ',
-
       undoHTML: '', // Code block.
     },
     {
       expectation:
         '<blockquote class="PlaygroundEditorTheme__quote"><br></blockquote>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '> ',
-
       undoHTML:
         '<p class="PlaygroundEditorTheme__paragraph"><span data-lexical-text="true">&gt;</span></p>', // Block quote.
     },
     {
       expectation:
         '<ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem"><br></li></ul>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '* ',
-
       undoHTML: '', // Unordered.
     },
     {
       expectation:
         '<ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem"><br></li></ul>',
+      importExpectation:
+        '<ul class="PlaygroundEditorTheme__ul"><li class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr" value="1"><span data-lexical-text="true">hello</span></li></ul>',
       isBlockTest: true,
+      markdownImport: '- hello',
       markdownText: '- ',
-
       undoHTML: '', // Unordered.
     },
     {
       expectation:
         '<ol start="321" class="PlaygroundEditorTheme__ol1"><li value="321" class="PlaygroundEditorTheme__listItem"><br></li></ol>',
+      importExpectation:
+        '<ol class="PlaygroundEditorTheme__ol1" start="321"><li class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr" value="321"><span data-lexical-text="true">hello</span></li></ol>',
       isBlockTest: true,
+      markdownImport: '', // '321. hello', Need to merge w/ Maksims changes first to get correct start number.
       markdownText: '321. ',
-
       undoHTML: '', // Ordered.
     },
     {
       expectation:
         '<div data-lexical-decorator="true" contenteditable="false" style="display: contents;"><hr></div><p class="PlaygroundEditorTheme__paragraph"><br></p>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '*** ',
-
       undoHTML: '', // HR rule.
     },
     {
       expectation:
         '<div data-lexical-decorator="true" contenteditable="false" style="display: contents;"><hr></div><p class="PlaygroundEditorTheme__paragraph"><br></p>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '--- ',
-
       undoHTML: '', // HR Rule.
     },
     {
       expectation:
         '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><strong class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough" data-lexical-text="true">test</strong><span data-lexical-text="true"></span></p>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '~~_**test**_~~ ',
       undoHTML: 'none', // strikethru, italic, bold
     },
     {
       expectation:
         '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><em class="PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough" data-lexical-text="true">test</em><span data-lexical-text="true"></span></p>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '~~_test_~~ ',
       undoHTML: 'none', // strikethru, italic
     },
     {
       expectation:
         '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><strong class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textStrikethrough" data-lexical-text="true">test</strong><span data-lexical-text="true"></span></p>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '~~**test**~~ ',
       undoHTML: 'none', // strikethru, bold
     },
@@ -179,7 +202,10 @@ test.describe('Markdown', () => {
     {
       expectation:
         '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><strong class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic" data-lexical-text="true">test</strong><span data-lexical-text="true"></span></p>',
+      importExpectation:
+        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"> <strong class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic" data-lexical-text="true">test</strong></p>',
       isBlockTest: true,
+      markdownImport: '_**test**_',
       markdownText: '_**test**_ ',
       undoHTML: 'none', // italic, bold
     },
@@ -328,6 +354,23 @@ test.describe('Markdown', () => {
           triggersAndExpectations[i].undoHTML || undoHTML,
           isCollab,
         );
+      });
+    }
+
+    if (triggersAndExpectations[i].markdownImport.length > 0) {
+      test(`Should test importing markdown (${markdownText}) trigger.`, async ({
+        page,
+        isPlainText,
+        isCollab,
+      }) => {
+        test.skip(isPlainText);
+        await focusEditor(page);
+
+        await page.keyboard.type(triggersAndExpectations[i].markdownImport);
+        await click(page, 'i.markdown');
+
+        const html = triggersAndExpectations[i].importExpectation;
+        await assertHTML(page, html);
       });
     }
   }

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -12,7 +12,6 @@ import {
   assertSelection,
   click,
   focusEditor,
-  html,
   initialize,
   keyDownCtrlOrMeta,
   keyUpCtrlOrMeta,
@@ -103,7 +102,7 @@ test.describe('Markdown', () => {
       isBlockTest: true,
       markdownText: '##### ',
 
-      undoHTML: '', // H5.
+      undoHTML: '', // H55.
     },
     {
       expectation:
@@ -392,56 +391,5 @@ test.describe('Markdown', () => {
       'text/plain': text,
     });
     await click(page, 'i.markdown');
-
-    await assertHTML(
-      page,
-      html`
-        <h1
-          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">Heading</span>
-        </h1>
-        <ul class="PlaygroundEditorTheme__ul">
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="1">
-            <span data-lexical-text="true">unordered list</span>
-          </li>
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"
-            value="2">
-            <ul class="PlaygroundEditorTheme__ul">
-              <li
-                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-                dir="ltr"
-                value="1">
-                <span data-lexical-text="true">nested</span>
-              </li>
-            </ul>
-          </li>
-        </ul>
-        <ol class="PlaygroundEditorTheme__ol1">
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="1">
-            <span data-lexical-text="true">ordered list</span>
-          </li>
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"
-            value="2">
-            <ol class="PlaygroundEditorTheme__ol2">
-              <li
-                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-                dir="ltr"
-                value="1">
-                <span data-lexical-text="true">nested</span>
-              </li>
-            </ol>
-          </li>
-        </ol>
-      `,
-    );
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -85,23 +85,26 @@ test.describe('Markdown', () => {
     },
     {
       expectation: '<h3 class="PlaygroundEditorTheme__h3"><br></h3>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '### ',
-
       undoHTML: '', // H3.
     },
     {
       expectation: '<h4 class="PlaygroundEditorTheme__h4"><br></h4>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '#### ',
-
       undoHTML: '', // H4.
     },
     {
       expectation: '<h5 class="PlaygroundEditorTheme__h5"><br></h5>',
+      importExpectation: '',
       isBlockTest: true,
+      markdownImport: '',
       markdownText: '##### ',
-
       undoHTML: '', // H55.
     },
     {

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -181,7 +181,6 @@ test.describe('Markdown', () => {
         '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><strong class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic" data-lexical-text="true">test</strong><span data-lexical-text="true"></span></p>',
       isBlockTest: true,
       markdownText: '_**test**_ ',
-
       undoHTML: 'none', // italic, bold
     },
   ];


### PR DESCRIPTION
With this PR, we now complete the markdown import code including:
1. importing paragraph markdown
2. importing text markdown like links and BIUS
3. importing codeblocks
4. unit tests for much of the above.