### PR TITLE
Fixes typo in README.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lexical-monorepo",
-  "description": "Lexical is an extensible text editor framework that provides excellent reliability, accessible and performance.",
+  "description": "Lexical is an extensible text editor framework that provides excellent reliability, accessibility and performance.",
   "version": "0.2.1",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Changes `accessible` to `accessibility` in the README.