### PR TITLE
Fix memory leak with EditorContext

### DIFF
--- a/examples/decorators.md
+++ b/examples/decorators.md
@@ -21,7 +21,7 @@ export class VideoNode extends DecoratorNode {
     this.__url = url;
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const div = document.createElement('div');
     div.style.display = 'contents';
     return div;

--- a/packages/lexical-code/flow/LexicalCode.js.flow
+++ b/packages/lexical-code/flow/LexicalCode.js.flow
@@ -23,7 +23,7 @@ declare export class CodeNode extends ElementNode {
   static getType(): string;
   static clone(node: CodeNode): CodeNode;
   constructor(key?: NodeKey): void;
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: CodeNode, dom: HTMLElement): boolean;
   insertNewAfter(
     selection: RangeSelection,
@@ -54,12 +54,12 @@ declare export class CodeHighlightNode extends TextNode {
   constructor(text: string, highlightType?: string, key?: NodeKey): void;
   static getType(): string;
   static clone(node: CodeHighlightNode): CodeHighlightNode;
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
-  updateDOM<EditorContext>(
+  createDOM(config: EditorConfig): HTMLElement;
+  updateDOM(
     // $FlowFixMe
     prevNode: CodeHighlightNode,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean;
   setFormat(format: number): this;
 }

--- a/packages/lexical-code/src/index.js
+++ b/packages/lexical-code/src/index.js
@@ -90,7 +90,7 @@ export class CodeHighlightNode extends TextNode {
     );
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const element = super.createDOM(config);
     const className = getHighlightThemeClass(
       config.theme,
@@ -100,11 +100,11 @@ export class CodeHighlightNode extends TextNode {
     return element;
   }
 
-  updateDOM<EditorContext>(
+  updateDOM(
     // $FlowFixMe
     prevNode: CodeHighlightNode,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean {
     const update = super.updateDOM(prevNode, dom, config);
     const prevClassName = getHighlightThemeClass(
@@ -174,7 +174,7 @@ export class CodeNode extends ElementNode {
   }
 
   // View
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const element = document.createElement('code');
     addClassNamesToElement(element, config.theme.code);
     element.setAttribute('spellcheck', 'false');

--- a/packages/lexical-hashtag/LexicalHashtag.d.ts
+++ b/packages/lexical-hashtag/LexicalHashtag.d.ts
@@ -13,7 +13,7 @@ export declare class HashtagNode extends TextNode {
   static getType(): string;
   static clone(node: HashtagNode): HashtagNode;
   constructor(text: string, key?: NodeKey);
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   canInsertTextBefore(): boolean;
   isTextEntity(): true;
 }

--- a/packages/lexical-hashtag/flow/LexicalHashtag.js.flow
+++ b/packages/lexical-hashtag/flow/LexicalHashtag.js.flow
@@ -15,7 +15,7 @@ declare export class HashtagNode extends TextNode {
   static getType(): string;
   static clone(node: HashtagNode): HashtagNode;
   constructor(text: string, key?: NodeKey): void;
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   canInsertTextBefore(): boolean;
   isTextEntity(): true;
 }

--- a/packages/lexical-hashtag/src/LexicalHashtagNode.js
+++ b/packages/lexical-hashtag/src/LexicalHashtagNode.js
@@ -25,7 +25,7 @@ export class HashtagNode extends TextNode {
     super(text, key);
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const element = super.createDOM(config);
     addClassNamesToElement(element, config.theme.hashtag);
     return element;

--- a/packages/lexical-link/LexicalLink.d.ts
+++ b/packages/lexical-link/LexicalLink.d.ts
@@ -22,11 +22,11 @@ export declare class LinkNode extends ElementNode {
   static getType(): string;
   static clone(node: LinkNode): LinkNode;
   constructor(url: string, key?: NodeKey);
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
-  updateDOM<EditorContext>(
+  createDOM(config: EditorConfig): HTMLElement;
+  updateDOM(
     prevNode: LinkNode,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean;
   static importDOM(): DOMConversionMap | null;
   getURL(): string;

--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -21,11 +21,11 @@ declare export class LinkNode extends ElementNode {
   static getType(): string;
   static clone(node: LinkNode): LinkNode;
   constructor(url: string, key?: NodeKey): void;
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
-  updateDOM<EditorContext>(
+  createDOM(config: EditorConfig): HTMLElement;
+  updateDOM(
     prevNode: LinkNode,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean;
   static importDOM(): DOMConversionMap | null;
   getURL(): string;

--- a/packages/lexical-link/src/index.js
+++ b/packages/lexical-link/src/index.js
@@ -36,18 +36,18 @@ export class LinkNode extends ElementNode {
     this.__url = url;
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const element = document.createElement('a');
     element.href = this.__url;
     addClassNamesToElement(element, config.theme.link);
     return element;
   }
 
-  updateDOM<EditorContext>(
+  updateDOM(
     // $FlowFixMe: not sure how to fix this
     prevNode: LinkNode,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean {
     // $FlowFixMe: not sure how to fix this
     const anchor: HTMLAnchorElement = dom;

--- a/packages/lexical-list/src/LexicalListItemNode.js
+++ b/packages/lexical-list/src/LexicalListItemNode.js
@@ -48,17 +48,17 @@ export class ListItemNode extends ElementNode {
 
   // View
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const element = document.createElement('li');
     element.value = getListItemValue(this);
     $setListItemThemeClassNames(element, config.theme, this);
     return element;
   }
 
-  updateDOM<EditorContext>(
+  updateDOM(
     prevNode: ListItemNode,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean {
     //$FlowFixMe - this is always HTMLListItemElement
     dom.value = getListItemValue(this);

--- a/packages/lexical-list/src/LexicalListNode.js
+++ b/packages/lexical-list/src/LexicalListNode.js
@@ -55,7 +55,7 @@ export class ListNode extends ElementNode {
 
   // View
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const tag = this.__tag;
     const dom = document.createElement(tag);
     if (this.__start !== 1) {
@@ -65,10 +65,10 @@ export class ListNode extends ElementNode {
     return dom;
   }
 
-  updateDOM<EditorContext>(
+  updateDOM(
     prevNode: ListNode,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean {
     if (prevNode.__tag !== this.__tag) {
       return true;

--- a/packages/lexical-overflow/LexicalOverflow.d.ts
+++ b/packages/lexical-overflow/LexicalOverflow.d.ts
@@ -12,7 +12,7 @@ export declare class OverflowNode extends ElementNode {
   static getType(): string;
   static clone(node: OverflowNode): OverflowNode;
   constructor(key?: NodeKey);
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: OverflowNode, dom: HTMLElement): boolean;
   insertNewAfter(selection: RangeSelection): null | LexicalNode;
   excludeFromCopy(): boolean;

--- a/packages/lexical-overflow/flow/LexicalOverflow.js.flow
+++ b/packages/lexical-overflow/flow/LexicalOverflow.js.flow
@@ -12,7 +12,7 @@ declare export class OverflowNode extends ElementNode {
   static getType(): string;
   static clone(node: OverflowNode): OverflowNode;
   constructor(key?: NodeKey): void;
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: OverflowNode, dom: HTMLElement): boolean;
   insertNewAfter(selection: RangeSelection): null | LexicalNode;
   excludeFromCopy(): boolean;

--- a/packages/lexical-overflow/src/index.js
+++ b/packages/lexical-overflow/src/index.js
@@ -25,7 +25,7 @@ export class OverflowNode extends ElementNode {
     this.__type = 'overflow';
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const div = document.createElement('span');
     const className = config.theme.characterLimit;
     if (typeof className === 'string') {

--- a/packages/lexical-playground/src/nodes/EmojiNode.jsx
+++ b/packages/lexical-playground/src/nodes/EmojiNode.jsx
@@ -27,7 +27,7 @@ export class EmojiNode extends TextNode {
     this.__className = className;
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const dom = document.createElement('span');
     const inner = super.createDOM(config);
     dom.className = this.__className;
@@ -36,10 +36,10 @@ export class EmojiNode extends TextNode {
     return dom;
   }
 
-  updateDOM<EditorContext>(
+  updateDOM(
     prevNode: TextNode,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean {
     // $FlowFixMe: this will always be an element or null
     const inner: null | HTMLElement = dom.firstChild;

--- a/packages/lexical-playground/src/nodes/EquationNode.jsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.jsx
@@ -128,7 +128,7 @@ export class EquationNode extends DecoratorNode<React$Node> {
     this.__inline = inline ?? false;
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     return document.createElement(this.__inline ? 'span' : 'div');
   }
 

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.jsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.jsx
@@ -177,7 +177,7 @@ export class ExcalidrawNode extends DecoratorNode<React$Node> {
   }
 
   // View
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const span = document.createElement('span');
     const theme = config.theme;
     const className = theme.image;

--- a/packages/lexical-playground/src/nodes/ImageNode.jsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.jsx
@@ -531,7 +531,7 @@ export class ImageNode extends DecoratorNode<React$Node> {
 
   // View
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const span = document.createElement('span');
     const theme = config.theme;
     const className = theme.image;

--- a/packages/lexical-playground/src/nodes/KeywordNode.js
+++ b/packages/lexical-playground/src/nodes/KeywordNode.js
@@ -20,7 +20,7 @@ export class KeywordNode extends TextNode {
     return new KeywordNode(node.__text, node.__key);
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const dom = super.createDOM(config);
     dom.style.cursor = 'default';
     dom.className = 'keyword';

--- a/packages/lexical-playground/src/nodes/MentionNode.js
+++ b/packages/lexical-playground/src/nodes/MentionNode.js
@@ -29,7 +29,7 @@ export class MentionNode extends TextNode {
     this.__mention = mentionName;
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const dom = super.createDOM(config);
     dom.style.cssText = mentionStyle;
     dom.className = 'mention';

--- a/packages/lexical-playground/src/nodes/StickyNode.jsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.jsx
@@ -291,7 +291,7 @@ export class StickyNode extends DecoratorNode<React$Node> {
     this.__color = color;
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const div = document.createElement('div');
     div.style.display = 'contents';
     return div;

--- a/packages/lexical-playground/src/nodes/TypeaheadNode.js
+++ b/packages/lexical-playground/src/nodes/TypeaheadNode.js
@@ -20,7 +20,7 @@ export class TypeaheadNode extends TextNode {
     return 'typeahead';
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const dom = super.createDOM(config);
     dom.style.cssText = 'color: #ccc;';
     return dom;

--- a/packages/lexical-react/src/DEPRECATED_useLexical.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexical.js
@@ -19,8 +19,7 @@ import {useMemo} from 'react';
 
 import useLexicalEditor from './DEPRECATED_useLexicalEditor';
 
-export default function useLexical<EditorContext>(editorConfig: {
-  context?: EditorContext,
+export default function useLexical(editorConfig: {
   disableEvents?: boolean,
   editorState?: EditorState,
   namespace?: string,

--- a/packages/lexical-react/src/LexicalComposer.jsx
+++ b/packages/lexical-react/src/LexicalComposer.jsx
@@ -51,8 +51,7 @@ export default function LexicalComposer({
       let editor = initialEditor || null;
 
       if (editor === null) {
-        const newEditor = createEditor<LexicalComposerContextType>({
-          context,
+        const newEditor = createEditor({
           namespace,
           nodes,
           onError: (error) => onError(error, newEditor),

--- a/packages/lexical-rich-text/LexicalRichText.d.ts
+++ b/packages/lexical-rich-text/LexicalRichText.d.ts
@@ -15,14 +15,13 @@ import type {
   LexicalEditor,
 } from 'lexical';
 import {ElementNode} from 'lexical';
-
 export type InitialEditorStateType = null | string | EditorState | (() => void);
 
 export declare class QuoteNode extends ElementNode {
   static getType(): string;
   static clone(node: QuoteNode): QuoteNode;
   constructor(key?: NodeKey);
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: QuoteNode, dom: HTMLElement): boolean;
   insertNewAfter(): ParagraphNode;
   collapseAtStart(): true;
@@ -36,7 +35,7 @@ export declare class HeadingNode extends ElementNode {
   static clone(node: HeadingNode): HeadingNode;
   constructor(tag: HeadingTagType, key?: NodeKey);
   getTag(): HeadingTagType;
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: HeadingNode, dom: HTMLElement): boolean;
   static importDOM(): DOMConversionMap | null;
   insertNewAfter(): ParagraphNode;

--- a/packages/lexical-rich-text/flow/LexicalRichText.js.flow
+++ b/packages/lexical-rich-text/flow/LexicalRichText.js.flow
@@ -22,7 +22,7 @@ declare export class QuoteNode extends ElementNode {
   static getType(): string;
   static clone(node: QuoteNode): QuoteNode;
   constructor(key?: NodeKey): void;
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: QuoteNode, dom: HTMLElement): boolean;
   insertNewAfter(): ParagraphNode;
   collapseAtStart(): true;
@@ -38,7 +38,7 @@ declare export class HeadingNode extends ElementNode {
   static clone(node: HeadingNode): HeadingNode;
   constructor(tag: HeadingTagType, key?: NodeKey): void;
   getTag(): HeadingTagType;
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: HeadingNode, dom: HTMLElement): boolean;
   static importDOM(): DOMConversionMap | null;
   insertNewAfter(): ParagraphNode;

--- a/packages/lexical-rich-text/src/index.js
+++ b/packages/lexical-rich-text/src/index.js
@@ -98,7 +98,7 @@ export class QuoteNode extends ElementNode {
 
   // View
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const element = document.createElement('blockquote');
     addClassNamesToElement(element, config.theme.quote);
     return element;
@@ -158,7 +158,7 @@ export class HeadingNode extends ElementNode {
 
   // View
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const tag = this.__tag;
     const element = document.createElement(tag);
     const theme = config.theme;

--- a/packages/lexical-table/LexicalTable.d.ts
+++ b/packages/lexical-table/LexicalTable.d.ts
@@ -47,7 +47,7 @@ export declare class TableCellNode extends ElementNode {
     width?: ?number,
     key?: NodeKey,
   );
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: TableCellNode, dom: HTMLElement): boolean;
   insertNewAfter(
     selection: RangeSelection,
@@ -78,7 +78,7 @@ export declare class TableNode extends ElementNode {
   static getType(): string;
   static clone(node: TableNode): TableNode;
   constructor(grid?: Grid, key?: NodeKey);
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: TableNode, dom: HTMLElement): boolean;
   insertNewAfter(selection: RangeSelection): null | ParagraphNode | TableNode;
   canInsertTab(): true;
@@ -103,7 +103,7 @@ declare class TableRowNode extends ElementNode {
   static getType(): string;
   static clone(node: TableRowNode): TableRowNode;
   constructor(key?: NodeKey, height?: ?number);
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: TableRowNode, dom: HTMLElement): boolean;
   insertNewAfter(
     selection: RangeSelection,

--- a/packages/lexical-table/LexicalTable.d.ts
+++ b/packages/lexical-table/LexicalTable.d.ts
@@ -15,6 +15,8 @@ import type {
   RangeSelection,
   ElementNode,
   LexicalEditor,
+  TextFormatType,
+  LexicalCommand,
 } from 'lexical';
 import {TableSelection} from './src/TableSelection';
 
@@ -210,7 +212,7 @@ declare function $deleteTableColumn(
 /**
  * LexicalTableSelection.js
  */
-declare class TableSelection {
+export declare class TableSelection {
   currentX: number;
   currentY: number;
   listenersToRemove: Set<() => void>;
@@ -222,7 +224,7 @@ declare class TableSelection {
   startY: number;
   nodeKey: string;
   editor: LexicalEditor;
-  constructor(editor: LexicalEditor, nodeKey: string): void;
+  constructor(editor: LexicalEditor, nodeKey: string);
   getGrid(): Grid;
   removeListeners(): void;
   trackTableGrid(): void;

--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -43,7 +43,7 @@ declare export class TableCellNode extends ElementNode {
     key?: NodeKey,
   ): void;
   __headerState: TableCellHeaderState;
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: TableCellNode, dom: HTMLElement): boolean;
   insertNewAfter(
     selection: RangeSelection,
@@ -78,7 +78,7 @@ declare export class TableNode extends ElementNode {
   static getType(): string;
   static clone(node: TableNode): TableNode;
   constructor(grid: ?Grid, key?: NodeKey): void;
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: TableNode, dom: HTMLElement): boolean;
   insertNewAfter(selection: RangeSelection): null | ParagraphNode | TableNode;
   canInsertTab(): true;
@@ -108,7 +108,7 @@ declare export class TableRowNode extends ElementNode {
   static getType(): string;
   static clone(node: TableRowNode): TableRowNode;
   constructor(height?: ?number, key?: NodeKey): void;
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: TableRowNode, dom: HTMLElement): boolean;
   setHeight(height: number): ?number;
   getHeight(): ?number;

--- a/packages/lexical-table/src/LexicalTableCellNode.js
+++ b/packages/lexical-table/src/LexicalTableCellNode.js
@@ -75,7 +75,7 @@ export class TableCellNode extends GridCellNode {
     this.__width = width;
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const element = document.createElement(this.getTag());
 
     if (this.__width) {

--- a/packages/lexical-table/src/LexicalTableNode.js
+++ b/packages/lexical-table/src/LexicalTableNode.js
@@ -51,10 +51,7 @@ export class TableNode extends GridNode {
     super(key);
   }
 
-  createDOM<EditorContext>(
-    config: EditorConfig<EditorContext>,
-    editor: LexicalEditor,
-  ): HTMLElement {
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     const tableElement = document.createElement('table');
 
     addClassNamesToElement(tableElement, config.theme.table);

--- a/packages/lexical-table/src/LexicalTableRowNode.js
+++ b/packages/lexical-table/src/LexicalTableRowNode.js
@@ -43,7 +43,7 @@ export class TableRowNode extends GridRowNode {
     this.__height = height;
   }
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const element = document.createElement('tr');
 
     if (this.__height) {

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -116,7 +116,7 @@ export declare class LexicalEditor {
   _onError: ErrorHandler;
   _decorators: Record<NodeKey, unknown>;
   _pendingDecorators: null | Record<NodeKey, unknown>;
-  _config: EditorConfig<{}>;
+  _config: EditorConfig;
   _dirtyType: 0 | 1 | 2;
   _cloneNotNeeded: Set<NodeKey>;
   _dirtyLeaves: Set<NodeKey>;
@@ -216,10 +216,9 @@ export type EditorThemeClasses = {
   // Handle other generic values
   [key: string]: EditorThemeClassName | Record<string, EditorThemeClassName>;
 };
-export type EditorConfig<EditorContext> = {
+export type EditorConfig = {
   namespace: string;
   theme: EditorThemeClasses;
-  context: EditorContext;
   disableEvents?: boolean;
 };
 export type CommandListenerPriority = 0 | 1 | 2 | 3 | 4;
@@ -229,11 +228,10 @@ export const COMMAND_PRIORITY_NORMAL = 2;
 export const COMMAND_PRIORITY_HIGH = 3;
 export const COMMAND_PRIORITY_CRITICAL = 4;
 export type IntentionallyMarkedAsDirtyElement = boolean;
-export function createEditor<EditorContext>(editorConfig?: {
+export function createEditor(editorConfig?: {
   namespace?: string;
   editorState?: EditorState;
   theme?: EditorThemeClasses;
-  context?: EditorContext;
   parentEditor?: LexicalEditor;
   nodes?: Array<Class<LexicalNode>>;
   onError: (error: Error) => void;
@@ -350,16 +348,14 @@ export declare class LexicalNode {
     includeDirectionless?: false,
   ): number;
   exportDOM(editor: LexicalEditor): DOMExportOutput;
-  // $FlowFixMe
-  createDOM<EditorContext extends Record<string, any>>(
-    config: EditorConfig<EditorContext>,
+  createDOM(
+    config: EditorConfig,
     editor: LexicalEditor,
   ): HTMLElement;
-  // $FlowFixMe
-  updateDOM<EditorContext extends Record<string, any>>( // $FlowFixMe
+  updateDOM(
     prevNode: any,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean;
   remove(preserveEmptyParent?: boolean): void;
   replace<N extends LexicalNode>(replaceWith: N): N;
@@ -585,14 +581,12 @@ export declare class TextNode extends LexicalNode {
   getTextContent(includeInert?: boolean, includeDirectionless?: false): string;
   getFormatFlags(type: TextFormatType, alignWithFormat: null | number): number;
   // $FlowFixMe
-  createDOM<EditorContext extends Record<string, any>>(
-    config: EditorConfig<EditorContext>,
-  ): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   // $FlowFixMe
-  updateDOM<EditorContext extends Record<string, any>>(
+  updateDOM(
     prevNode: TextNode,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean;
   selectionTransform(
     prevSelection: null | RangeSelection | NodeSelection | GridSelection,
@@ -753,7 +747,7 @@ export declare class ParagraphNode extends ElementNode {
   getType(): string;
   clone(node: ParagraphNode): ParagraphNode;
   constructor(key?: NodeKey);
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: ParagraphNode, dom: HTMLElement): boolean;
   insertNewAfter(): ParagraphNode;
   collapseAtStart(): boolean;

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -348,15 +348,8 @@ export declare class LexicalNode {
     includeDirectionless?: false,
   ): number;
   exportDOM(editor: LexicalEditor): DOMExportOutput;
-  createDOM(
-    config: EditorConfig,
-    editor: LexicalEditor,
-  ): HTMLElement;
-  updateDOM(
-    prevNode: any,
-    dom: HTMLElement,
-    config: EditorConfig,
-  ): boolean;
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement;
+  updateDOM(prevNode: any, dom: HTMLElement, config: EditorConfig): boolean;
   remove(preserveEmptyParent?: boolean): void;
   replace<N extends LexicalNode>(replaceWith: N): N;
   insertAfter(nodeToInsert: LexicalNode): LexicalNode;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -222,10 +222,9 @@ export type EditorThemeClasses = {
   // Handle other generic values
   [string]: EditorThemeClassName | {[string]: EditorThemeClassName},
 };
-export type EditorConfig<EditorContext> = {
+export type EditorConfig = {
   namespace: string,
   theme: EditorThemeClasses,
-  context: EditorContext,
   disableEvents?: boolean,
 };
 export type CommandListenerPriority = 0 | 1 | 2 | 3 | 4;
@@ -236,11 +235,10 @@ export const COMMAND_PRIORITY_HIGH = 3;
 export const COMMAND_PRIORITY_CRITICAL = 4;
 
 export type IntentionallyMarkedAsDirtyElement = boolean;
-declare export function createEditor<EditorContext>(editorConfig?: {
+declare export function createEditor(editorConfig?: {
   namespace?: string,
   editorState?: EditorState,
   theme?: EditorThemeClasses,
-  context?: EditorContext,
   parentEditor?: LexicalEditor,
   nodes?: $ReadOnlyArray<Class<LexicalNode>>,
   onError: (error: Error) => void,
@@ -358,17 +356,12 @@ declare export class LexicalNode {
     includeInert?: boolean,
     includeDirectionless?: false,
   ): number;
-  // $FlowFixMe
-  createDOM<EditorContext: Object>(
-    config: EditorConfig<EditorContext>,
-    editor: LexicalEditor,
-  ): HTMLElement;
-  // $FlowFixMe
-  updateDOM<EditorContext: Object>(
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement;
+  updateDOM(
     // $FlowFixMe
     prevNode: any,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean;
   remove(preserveEmptyParent?: boolean): void;
   replace<N: LexicalNode>(replaceWith: N): N;
@@ -617,15 +610,11 @@ declare export class TextNode extends LexicalNode {
   isSimpleText(): boolean;
   getTextContent(includeInert?: boolean, includeDirectionless?: false): string;
   getFormatFlags(type: TextFormatType, alignWithFormat: null | number): number;
-  // $FlowFixMe
-  createDOM<EditorContext: Object>(
-    config: EditorConfig<EditorContext>,
-  ): HTMLElement;
-  // $FlowFixMe
-  updateDOM<EditorContext: Object>(
+  createDOM(config: EditorConfig): HTMLElement;
+  updateDOM(
     prevNode: TextNode,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean;
   selectionTransform(
     prevSelection: null | RangeSelection | NodeSelection | GridSelection,
@@ -788,7 +777,7 @@ declare export class ParagraphNode extends ElementNode {
   static getType(): string;
   static clone(node: ParagraphNode): ParagraphNode;
   constructor(key?: NodeKey): void;
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement;
+  createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: ParagraphNode, dom: HTMLElement): boolean;
   insertNewAfter(): ParagraphNode;
   collapseAtStart(): boolean;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -120,7 +120,7 @@ declare export class LexicalEditor {
   _pendingDecorators: null | {
     [NodeKey]: mixed,
   };
-  _config: EditorConfig<{...}>;
+  _config: EditorConfig;
   _dirtyType: 0 | 1 | 2;
   _cloneNotNeeded: Set<NodeKey>;
   _dirtyLeaves: Set<NodeKey>;

--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -94,8 +94,7 @@ export type EditorThemeClasses = {
   [string]: EditorThemeClassName | {[string]: EditorThemeClassName},
 };
 
-export type EditorConfig<EditorContext> = {
-  context: EditorContext,
+export type EditorConfig = {
   disableEvents?: boolean,
   namespace: string,
   theme: EditorThemeClasses,
@@ -227,8 +226,7 @@ function initializeConversionCache(nodes: RegisteredNodes): DOMConversionCache {
   return conversionCache;
 }
 
-export function createEditor<EditorContext>(editorConfig?: {
-  context?: EditorContext,
+export function createEditor(editorConfig?: {
   disableEvents?: boolean,
   editorState?: EditorState,
   namespace?: string,
@@ -241,7 +239,6 @@ export function createEditor<EditorContext>(editorConfig?: {
   const config = editorConfig || {};
   const namespace = config.namespace || createUID();
   const theme = config.theme || {};
-  const context = config.context || {};
   const parentEditor = config.parentEditor || null;
   const disableEvents = config.disableEvents || false;
   const editorState = createEmptyEditorState();
@@ -272,8 +269,6 @@ export function createEditor<EditorContext>(editorConfig?: {
     parentEditor,
     registeredNodes,
     {
-      // $FlowFixMe: we use our internal type to simpify the generics
-      context,
       disableEvents,
       namespace,
       theme,
@@ -304,7 +299,7 @@ export class LexicalEditor {
   _nodes: RegisteredNodes;
   _decorators: {[NodeKey]: mixed};
   _pendingDecorators: null | {[NodeKey]: mixed};
-  _config: EditorConfig<{...}>;
+  _config: EditorConfig;
   _dirtyType: 0 | 1 | 2;
   _cloneNotNeeded: Set<NodeKey>;
   _dirtyLeaves: Set<NodeKey>;
@@ -321,7 +316,7 @@ export class LexicalEditor {
     editorState: EditorState,
     parentEditor: null | LexicalEditor,
     nodes: RegisteredNodes,
-    config: EditorConfig<{...}>,
+    config: EditorConfig,
     onError: ErrorHandler,
     htmlConversions: DOMConversionCache,
     readOnly: boolean,

--- a/packages/lexical/src/LexicalNode.js
+++ b/packages/lexical/src/LexicalNode.js
@@ -583,24 +583,18 @@ export class LexicalNode {
 
   // View
 
-  // $FlowFixMe: Revise typings for EditorContext
-  createDOM<EditorContext: Object>(
-    config: EditorConfig<EditorContext>,
-    editor: LexicalEditor,
-  ): HTMLElement {
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     invariant(false, 'createDOM: base method not extended');
   }
-  // $FlowFixMe: Revise typings for EditorContext
-  updateDOM<EditorContext: Object>(
+
+  updateDOM(
     // $FlowFixMe: TODO
     prevNode: any,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean {
     invariant(false, 'updateDOM: base method not extended');
   }
-
-  // $FlowFixMe: Revise typings for EditorContext
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
     if ($isDecoratorNode(this)) {

--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -55,7 +55,7 @@ import {
 let subTreeTextContent = '';
 let subTreeDirectionedTextContent = '';
 let editorTextContent = '';
-let activeEditorConfig: EditorConfig<{...}>;
+let activeEditorConfig: EditorConfig;
 let activeEditor: LexicalEditor;
 let activeEditorNodes: RegisteredNodes;
 let treatAllNodesAsDirty: boolean = false;

--- a/packages/lexical/src/nodes/LexicalParagraphNode.js
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.js
@@ -34,7 +34,7 @@ export class ParagraphNode extends ElementNode {
 
   // View
 
-  createDOM<EditorContext>(config: EditorConfig<EditorContext>): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const dom = document.createElement('p');
     const classNames = getCachedClassNameArray<EditorThemeClasses>(
       config.theme,

--- a/packages/lexical/src/nodes/LexicalTextNode.js
+++ b/packages/lexical/src/nodes/LexicalTextNode.js
@@ -213,13 +213,13 @@ function setTextContent(
   }
 }
 
-function createTextInnerDOM<EditorContext>(
+function createTextInnerDOM(
   innerDOM: HTMLElement,
   node: TextNode,
   innerTag: string,
   format: number,
   text: string,
-  config: EditorConfig<EditorContext>,
+  config: EditorConfig,
 ): void {
   setTextContent(text, innerDOM, node);
   const theme = config.theme;
@@ -318,10 +318,7 @@ export class TextNode extends LexicalNode {
 
   // View
 
-  // $FlowFixMe: Revise typings for EditorContext
-  createDOM<EditorContext: Object>(
-    config: EditorConfig<EditorContext>,
-  ): HTMLElement {
+  createDOM(config: EditorConfig): HTMLElement {
     const format = this.__format;
     const outerTag = getElementOuterTag(this, format);
     const innerTag = getElementInnerTag(this, format);
@@ -340,11 +337,11 @@ export class TextNode extends LexicalNode {
     }
     return dom;
   }
-  // $FlowFixMe: Revise typings for EditorContext
-  updateDOM<EditorContext: Object>(
+
+  updateDOM(
     prevNode: TextNode,
     dom: HTMLElement,
-    config: EditorConfig<EditorContext>,
+    config: EditorConfig,
   ): boolean {
     const nextText = this.__text;
     const prevFormat = prevNode.__format;


### PR DESCRIPTION
We have a strange memory leak that seems to stem from `LexicalContext` which is passed to the editor. It seems to be a cyclical retained reference which means the GC never properly clears up some types of node that make use of context.

This PR removes the `context` field from the editor and thus removes the need to pass `<LexicalContext>` to almost all the `updateDOM`/`createDOM` methods. I wonder too, given that we no longer need to pass around the context, should we even be passing `EditorConfig` to all the nodes? Can we not just pass the theme directly?

I'm a bit worried that we might make use of this context internally, so maybe @acywatson @tylerjbainbridge @fantactuka can help with their respective surfaces that may have used this.