### PR TITLE
Command priorities as constants

### DIFF
--- a/packages/lexical-code/src/index.js
+++ b/packages/lexical-code/src/index.js
@@ -54,6 +54,7 @@ import {
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_UP_COMMAND,
   OUTDENT_CONTENT_COMMAND,
+  COMMAND_PRIORITY_LOW,
 } from 'lexical';
 
 const DEFAULT_CODE_LANGUAGE = 'javascript';
@@ -871,22 +872,22 @@ export function registerCodeHighlighting(editor: LexicalEditor): () => void {
     editor.registerCommand(
       INDENT_CONTENT_COMMAND,
       (payload): boolean => handleMultilineIndent(INDENT_CONTENT_COMMAND),
-      1,
+      COMMAND_PRIORITY_LOW,
     ),
     editor.registerCommand(
       OUTDENT_CONTENT_COMMAND,
       (payload): boolean => handleMultilineIndent(OUTDENT_CONTENT_COMMAND),
-      1,
+      COMMAND_PRIORITY_LOW,
     ),
     editor.registerCommand(
       KEY_ARROW_UP_COMMAND,
       (payload): boolean => handleShiftLines(KEY_ARROW_UP_COMMAND, payload),
-      1,
+      COMMAND_PRIORITY_LOW,
     ),
     editor.registerCommand(
       KEY_ARROW_DOWN_COMMAND,
       (payload): boolean => handleShiftLines(KEY_ARROW_DOWN_COMMAND, payload),
-      1,
+      COMMAND_PRIORITY_LOW,
     ),
   );
 }

--- a/packages/lexical-history/src/index.js
+++ b/packages/lexical-history/src/index.js
@@ -8,7 +8,6 @@
  */
 
 import type {
-  CommandListenerEditorPriority,
   EditorState,
   GridSelection,
   IntentionallyMarkedAsDirtyElement,
@@ -29,6 +28,7 @@ import {
   CAN_UNDO_COMMAND,
   CLEAR_EDITOR_COMMAND,
   CLEAR_HISTORY_COMMAND,
+  COMMAND_PRIORITY_EDITOR,
   REDO_COMMAND,
   UNDO_COMMAND,
 } from 'lexical';
@@ -44,8 +44,6 @@ const COMPOSING_CHARACTER = 1;
 const INSERT_CHARACTER_AFTER_SELECTION = 2;
 const DELETE_CHARACTER_BEFORE_SELECTION = 3;
 const DELETE_CHARACTER_AFTER_SELECTION = 4;
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 export type HistoryStateEntry = {
   editor: LexicalEditor,
@@ -376,7 +374,7 @@ export function registerHistory(
         undo(editor, historyState);
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       REDO_COMMAND,
@@ -384,7 +382,7 @@ export function registerHistory(
         redo(editor, historyState);
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       CLEAR_EDITOR_COMMAND,
@@ -392,7 +390,7 @@ export function registerHistory(
         clearHistory(historyState);
         return false;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       CLEAR_HISTORY_COMMAND,
@@ -400,7 +398,7 @@ export function registerHistory(
         clearHistory(historyState);
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerUpdateListener(applyChange),
   );

--- a/packages/lexical-plain-text/src/index.js
+++ b/packages/lexical-plain-text/src/index.js
@@ -23,6 +23,7 @@ import {
   $getRoot,
   $getSelection,
   $isRangeSelection,
+  COMMAND_PRIORITY_EDITOR,
   COPY_COMMAND,
   CUT_COMMAND,
   DELETE_CHARACTER_COMMAND,
@@ -155,7 +156,7 @@ export function registerPlainText(
         selection.deleteCharacter(isBackward);
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       DELETE_WORD_COMMAND,
@@ -167,7 +168,7 @@ export function registerPlainText(
         selection.deleteWord(isBackward);
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       DELETE_LINE_COMMAND,
@@ -179,7 +180,7 @@ export function registerPlainText(
         selection.deleteLine(isBackward);
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       INSERT_TEXT_COMMAND,
@@ -203,7 +204,7 @@ export function registerPlainText(
         }
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       REMOVE_TEXT_COMMAND,
@@ -215,7 +216,7 @@ export function registerPlainText(
         selection.removeText();
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       INSERT_LINE_BREAK_COMMAND,
@@ -227,7 +228,7 @@ export function registerPlainText(
         selection.insertLineBreak(selectStart);
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       INSERT_PARAGRAPH_COMMAND,
@@ -239,7 +240,7 @@ export function registerPlainText(
         selection.insertLineBreak();
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       KEY_ARROW_LEFT_COMMAND,
@@ -257,7 +258,7 @@ export function registerPlainText(
         }
         return false;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       KEY_ARROW_RIGHT_COMMAND,
@@ -275,7 +276,7 @@ export function registerPlainText(
         }
         return false;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       KEY_BACKSPACE_COMMAND,
@@ -287,7 +288,7 @@ export function registerPlainText(
         event.preventDefault();
         return editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       KEY_DELETE_COMMAND,
@@ -299,7 +300,7 @@ export function registerPlainText(
         event.preventDefault();
         return editor.dispatchCommand(DELETE_CHARACTER_COMMAND, false);
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       KEY_ENTER_COMMAND,
@@ -313,7 +314,7 @@ export function registerPlainText(
         }
         return editor.dispatchCommand(INSERT_LINE_BREAK_COMMAND);
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       COPY_COMMAND,
@@ -325,7 +326,7 @@ export function registerPlainText(
         onCopyForPlainText(event, editor);
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       CUT_COMMAND,
@@ -337,7 +338,7 @@ export function registerPlainText(
         onCutForPlainText(event, editor);
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       PASTE_COMMAND,
@@ -349,7 +350,7 @@ export function registerPlainText(
         onPasteForPlainText(event, editor);
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       DROP_COMMAND,
@@ -362,7 +363,7 @@ export function registerPlainText(
         event.preventDefault();
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       DRAGSTART_COMMAND,
@@ -375,7 +376,7 @@ export function registerPlainText(
         event.preventDefault();
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
   );
   initializeEditor(editor, initialEditorState);

--- a/packages/lexical-playground/src/nodes/EquationNode.jsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.jsx
@@ -7,17 +7,13 @@
  * @flow strict
  */
 
-import type {
-  CommandListenerHighPriority,
-  EditorConfig,
-  LexicalNode,
-  NodeKey,
-} from 'lexical';
+import type {EditorConfig, LexicalNode, NodeKey} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
+  COMMAND_PRIORITY_HIGH,
   DecoratorNode,
   KEY_ESCAPE_COMMAND,
   SELECTION_CHANGE_COMMAND,
@@ -27,8 +23,6 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 
 import EquationEditor from '../ui/EquationEditor';
 import KatexRenderer from '../ui/KatexRenderer';
-
-const HighPriority: CommandListenerHighPriority = 3;
 
 type EquationComponentProps = {
   equation: string,
@@ -75,7 +69,7 @@ function EquationComponent({
             }
             return false;
           },
-          HighPriority,
+          COMMAND_PRIORITY_HIGH,
         ),
         editor.registerCommand(
           KEY_ESCAPE_COMMAND,
@@ -88,7 +82,7 @@ function EquationComponent({
             }
             return false;
           },
-          HighPriority,
+          COMMAND_PRIORITY_HIGH,
         ),
       );
     }

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.jsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.jsx
@@ -7,13 +7,7 @@
  * @flow strict
  */
 
-import type {
-  CommandListenerLowPriority,
-  EditorConfig,
-  LexicalEditor,
-  LexicalNode,
-  NodeKey,
-} from 'lexical';
+import type {EditorConfig, LexicalEditor, LexicalNode, NodeKey} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import useLexicalNodeSelection from '@lexical/react/useLexicalNodeSelection';
@@ -23,6 +17,7 @@ import {
   $getSelection,
   $isNodeSelection,
   CLICK_COMMAND,
+  COMMAND_PRIORITY_LOW,
   DecoratorNode,
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
@@ -32,8 +27,6 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import ExcalidrawImage from './ExcalidrawImage';
 import ExcalidrawModal from './ExcalidrawModal';
-
-const LowPriority: CommandListenerLowPriority = 1;
 
 function ExcalidrawComponent({
   nodeKey,
@@ -87,10 +80,18 @@ function ExcalidrawComponent({
 
           return false;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
-      editor.registerCommand(KEY_DELETE_COMMAND, onDelete, LowPriority),
-      editor.registerCommand(KEY_BACKSPACE_COMMAND, onDelete, LowPriority),
+      editor.registerCommand(
+        KEY_DELETE_COMMAND,
+        onDelete,
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        KEY_BACKSPACE_COMMAND,
+        onDelete,
+        COMMAND_PRIORITY_LOW,
+      ),
     );
   }, [clearSelection, editor, isSelected, onDelete, setSelected]);
 
@@ -131,8 +132,7 @@ function ExcalidrawComponent({
       />
       <button
         ref={buttonRef}
-        className={`excalidraw-button ${isSelected ? 'selected' : ''}`}
-      >
+        className={`excalidraw-button ${isSelected ? 'selected' : ''}`}>
         <ExcalidrawImage className="image" elements={elements} />
       </button>
     </>

--- a/packages/lexical-playground/src/nodes/ImageNode.jsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.jsx
@@ -7,13 +7,7 @@
  * @flow strict
  */
 
-import type {
-  CommandListenerLowPriority,
-  EditorConfig,
-  LexicalEditor,
-  LexicalNode,
-  NodeKey,
-} from 'lexical';
+import type {EditorConfig, LexicalEditor, LexicalNode, NodeKey} from 'lexical';
 
 import './ImageNode.css';
 
@@ -35,6 +29,7 @@ import {
   $getSelection,
   $isNodeSelection,
   CLICK_COMMAND,
+  COMMAND_PRIORITY_LOW,
   createEditor,
   DecoratorNode,
   KEY_BACKSPACE_COMMAND,
@@ -54,8 +49,6 @@ import TableCellActionMenuPlugin from '../plugins/TableActionMenuPlugin';
 import TreeViewPlugin from '../plugins/TreeViewPlugin';
 import ContentEditable from '../ui/ContentEditable';
 import Placeholder from '../ui/Placeholder';
-
-const LowPriority: CommandListenerLowPriority = 1;
 
 const imageCache = new Set();
 
@@ -242,8 +235,7 @@ function ImageResizer({
           ref={buttonRef}
           onClick={() => {
             setShowCaption(!showCaption);
-          }}
-        >
+          }}>
           Add Caption
         </button>
       )}
@@ -346,10 +338,18 @@ function ImageComponent({
 
           return false;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
-      editor.registerCommand(KEY_DELETE_COMMAND, onDelete, LowPriority),
-      editor.registerCommand(KEY_BACKSPACE_COMMAND, onDelete, LowPriority),
+      editor.registerCommand(
+        KEY_DELETE_COMMAND,
+        onDelete,
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        KEY_BACKSPACE_COMMAND,
+        onDelete,
+        COMMAND_PRIORITY_LOW,
+      ),
     );
   }, [
     clearSelection,

--- a/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
@@ -7,8 +7,6 @@
  * @flow strict
  */
 
-import type {CommandListenerEditorPriority} from 'lexical';
-
 import {exportFile, importFile} from '@lexical/file';
 import {$convertFromMarkdownString} from '@lexical/markdown';
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationPlugin';
@@ -20,6 +18,7 @@ import {
   $getRoot,
   $isParagraphNode,
   CLEAR_EDITOR_COMMAND,
+  COMMAND_PRIORITY_EDITOR,
   READ_ONLY_COMMAND,
 } from 'lexical';
 import * as React from 'react';
@@ -29,8 +28,6 @@ import {
   SPEECT_TO_TEXT_COMMAND,
   SUPPORT_SPEECH_RECOGNITION,
 } from './SpeechToTextPlugin';
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 export default function ActionsPlugins({
   isRichText,
@@ -53,7 +50,7 @@ export default function ActionsPlugins({
           setIsReadyOnly(readOnly);
           return false;
         },
-        EditorPriority,
+        COMMAND_PRIORITY_EDITOR,
       ),
       editor.registerCommand(
         CONNECTED_COMMAND,
@@ -62,7 +59,7 @@ export default function ActionsPlugins({
           setConnected(isConnected);
           return false;
         },
-        EditorPriority,
+        COMMAND_PRIORITY_EDITOR,
       ),
     );
   }, [editor]);

--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
@@ -18,6 +18,7 @@ import {
   $getSelection,
   $isRangeSelection,
   $isTextNode,
+  COMMAND_PRIORITY_LOW,
   FORMAT_TEXT_COMMAND,
   SELECTION_CHANGE_COMMAND,
   TextNode,
@@ -117,7 +118,7 @@ function FloatingCharacterStylesEditor({
           updateCharacterStylesEditor();
           return false;
         },
-        1,
+        COMMAND_PRIORITY_LOW,
       ),
     );
   }, [editor, updateCharacterStylesEditor]);
@@ -129,8 +130,7 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
         }}
         className={'popup-item spaced ' + (isBold ? 'active' : '')}
-        aria-label="Format Bold"
-      >
+        aria-label="Format Bold">
         <i className="format bold" />
       </button>
       <button
@@ -138,8 +138,7 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
         }}
         className={'popup-item spaced ' + (isItalic ? 'active' : '')}
-        aria-label="Format Italics"
-      >
+        aria-label="Format Italics">
         <i className="format italic" />
       </button>
       <button
@@ -147,8 +146,7 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
         }}
         className={'popup-item spaced ' + (isUnderline ? 'active' : '')}
-        aria-label="Format Underline"
-      >
+        aria-label="Format Underline">
         <i className="format underline" />
       </button>
       <button
@@ -156,8 +154,7 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough');
         }}
         className={'popup-item spaced ' + (isStrikethrough ? 'active' : '')}
-        aria-label="Format Strikethrough"
-      >
+        aria-label="Format Strikethrough">
         <i className="format strikethrough" />
       </button>
       <button
@@ -165,15 +162,13 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
         }}
         className={'popup-item spaced ' + (isCode ? 'active' : '')}
-        aria-label="Insert Code"
-      >
+        aria-label="Insert Code">
         <i className="format code" />
       </button>
       <button
         onClick={insertLink}
         className={'popup-item spaced ' + (isLink ? 'active' : '')}
-        aria-label="Insert Link"
-      >
+        aria-label="Insert Link">
         <i className="format link" />
       </button>
     </div>

--- a/packages/lexical-playground/src/plugins/EquationsPlugin.js
+++ b/packages/lexical-playground/src/plugins/EquationsPlugin.js
@@ -7,18 +7,21 @@
  * @flow strict
  */
 
-import type {CommandListenerEditorPriority, LexicalCommand} from 'lexical';
+import type {LexicalCommand} from 'lexical';
 
 // $FlowFixMe
 import 'katex/dist/katex.css';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$getSelection, $isRangeSelection, createCommand} from 'lexical';
+import {
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_EDITOR,
+  createCommand,
+} from 'lexical';
 import {useEffect} from 'react';
 
 import {$createEquationNode, EquationNode} from '../nodes/EquationNode';
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 export const INSERT_EQUATION_COMMAND: LexicalCommand<{
   equation: string,
@@ -46,7 +49,7 @@ export default function EquationsPlugin(): React$Node {
         }
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     );
   }, [editor]);
   return null;

--- a/packages/lexical-playground/src/plugins/ExcalidrawPlugin.js
+++ b/packages/lexical-playground/src/plugins/ExcalidrawPlugin.js
@@ -7,15 +7,18 @@
  * @flow strict
  */
 
-import type {CommandListenerEditorPriority, LexicalCommand} from 'lexical';
+import type {LexicalCommand} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$getSelection, $isRangeSelection, createCommand} from 'lexical';
+import {
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_EDITOR,
+  createCommand,
+} from 'lexical';
 import {useEffect} from 'react';
 
 import {$createExcalidrawNode, ExcalidrawNode} from '../nodes/ExcalidrawNode';
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 export const INSERT_EXCALIDRAW_COMMAND: LexicalCommand<void> = createCommand();
 
@@ -39,7 +42,7 @@ export default function ExcalidrawPlugin(): React$Node {
         }
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     );
   }, [editor]);
   return null;

--- a/packages/lexical-playground/src/plugins/HorizontalRulePlugin.js
+++ b/packages/lexical-playground/src/plugins/HorizontalRulePlugin.js
@@ -7,17 +7,17 @@
  * @flow strict
  */
 
-import type {CommandListenerEditorPriority} from 'lexical';
-
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $createHorizontalRuleNode,
   INSERT_HORIZONTAL_RULE_COMMAND,
 } from '@lexical/react/LexicalHorizontalRuleNode';
-import {$getSelection, $isRangeSelection} from 'lexical';
+import {
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_EDITOR,
+} from 'lexical';
 import {useEffect} from 'react';
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 export default function HorizontalRulePlugin(): null {
   const [editor] = useLexicalComposerContext();
@@ -43,7 +43,7 @@ export default function HorizontalRulePlugin(): null {
 
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     );
   }, [editor]);
 

--- a/packages/lexical-playground/src/plugins/ImagesPlugin.js
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin.js
@@ -7,21 +7,20 @@
  * @flow strict
  */
 
-import type {CommandListenerEditorPriority, LexicalCommand} from 'lexical';
+import type {LexicalCommand} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $getSelection,
   $isRangeSelection,
   $isRootNode,
+  COMMAND_PRIORITY_EDITOR,
   createCommand,
 } from 'lexical';
 import {useEffect} from 'react';
 
 import yellowFlowerImage from '../images/yellow-flower.jpg';
 import {$createImageNode, ImageNode} from '../nodes/ImageNode';
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 export const INSERT_IMAGE_COMMAND: LexicalCommand<void> = createCommand();
 
@@ -50,7 +49,7 @@ export default function ImagesPlugin(): React$Node {
         }
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     );
   }, [editor]);
   return null;

--- a/packages/lexical-playground/src/plugins/ListMaxIndentLevelPlugin.js
+++ b/packages/lexical-playground/src/plugins/ListMaxIndentLevelPlugin.js
@@ -7,19 +7,16 @@
  * @flow strict
  */
 
-import type {
-  CommandListenerHighPriority,
-  ElementNode,
-  RangeSelection,
-} from 'lexical';
-
 import {$getListDepth, $isListItemNode, $isListNode} from '@lexical/list';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $getSelection,
   $isElementNode,
   $isRangeSelection,
+  COMMAND_PRIORITY_CRITICAL,
+  ElementNode,
   INDENT_CONTENT_COMMAND,
+  RangeSelection,
 } from 'lexical';
 import {useEffect} from 'react';
 
@@ -43,8 +40,6 @@ function getElementNodesInSelection(
     nodesInSelection.map((n) => ($isElementNode(n) ? n : n.getParentOrThrow())),
   );
 }
-
-const highPriority: CommandListenerHighPriority = 3;
 
 function isIndentPermitted(maxDepth: number): boolean {
   const selection = $getSelection();
@@ -83,7 +78,7 @@ export default function ListMaxIndentLevelPlugin({maxDepth}: Props): null {
     return editor.registerCommand(
       INDENT_CONTENT_COMMAND,
       () => !isIndentPermitted(maxDepth ?? 7),
-      highPriority,
+      COMMAND_PRIORITY_CRITICAL,
     );
   }, [editor, maxDepth]);
 

--- a/packages/lexical-playground/src/plugins/MentionsPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/MentionsPlugin.jsx
@@ -7,11 +7,7 @@
  * @flow strict
  */
 
-import type {
-  CommandListenerLowPriority,
-  LexicalEditor,
-  RangeSelection,
-} from 'lexical';
+import type {LexicalEditor, RangeSelection} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
@@ -19,6 +15,7 @@ import {
   $getSelection,
   $isRangeSelection,
   $isTextNode,
+  COMMAND_PRIORITY_LOW,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_UP_COMMAND,
   KEY_ENTER_COMMAND,
@@ -112,8 +109,6 @@ const AtSignMentionsRegexAliasRegex = new RegExp(
     '})' +
     ')$',
 );
-
-const LowPriority: CommandListenerLowPriority = 1;
 
 // At most, 5 suggestions are shown in the popup.
 const SUGGESTION_LIST_LENGTH_LIMIT = 5;
@@ -704,7 +699,7 @@ function MentionsTypeahead({
           }
           return true;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         KEY_ARROW_UP_COMMAND,
@@ -719,7 +714,7 @@ function MentionsTypeahead({
           }
           return true;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         KEY_ESCAPE_COMMAND,
@@ -733,7 +728,7 @@ function MentionsTypeahead({
           close();
           return true;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         KEY_TAB_COMMAND,
@@ -747,7 +742,7 @@ function MentionsTypeahead({
           applyCurrentSelected();
           return true;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         KEY_ENTER_COMMAND,
@@ -762,7 +757,7 @@ function MentionsTypeahead({
           applyCurrentSelected();
           return true;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
     );
   }, [

--- a/packages/lexical-playground/src/plugins/PollPlugin.js
+++ b/packages/lexical-playground/src/plugins/PollPlugin.js
@@ -7,20 +7,19 @@
  * @flow strict
  */
 
-import type {CommandListenerEditorPriority, LexicalCommand} from 'lexical';
+import type {LexicalCommand} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $getSelection,
   $isRangeSelection,
   $isRootNode,
+  COMMAND_PRIORITY_EDITOR,
   createCommand,
 } from 'lexical';
 import {useEffect} from 'react';
 
 import {$createPollNode, PollNode} from '../nodes/PollNode';
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 export const INSERT_POLL_COMMAND: LexicalCommand<string> = createCommand();
 
@@ -45,7 +44,7 @@ export default function PollPlugin(): React$Node {
         }
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     );
   }, [editor]);
   return null;

--- a/packages/lexical-playground/src/plugins/SpeechToTextPlugin.js
+++ b/packages/lexical-playground/src/plugins/SpeechToTextPlugin.js
@@ -7,26 +7,22 @@
  * @flow strict
  */
 
-import type {
-  CommandListenerEditorPriority,
-  LexicalCommand,
-  LexicalEditor,
-  RangeSelection,
-} from 'lexical';
+import type {LexicalCommand} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $getSelection,
   $isRangeSelection,
+  COMMAND_PRIORITY_EDITOR,
   createCommand,
+  LexicalEditor,
+  RangeSelection,
   REDO_COMMAND,
   UNDO_COMMAND,
 } from 'lexical';
 import {useEffect, useRef, useState} from 'react';
 
 import useReport from '../hooks/useReport';
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 export const SPEECT_TO_TEXT_COMMAND: LexicalCommand<boolean> = createCommand();
 
@@ -110,7 +106,7 @@ function SpeechToTextPlugin(): null {
         setIsEnabled(_isEnabled);
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     );
   }, [editor]);
 

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -7,11 +7,7 @@
  * @flow strict
  */
 
-import type {
-  CommandListenerLowPriority,
-  LexicalEditor,
-  RangeSelection,
-} from 'lexical';
+import type {LexicalEditor, RangeSelection} from 'lexical';
 
 import {
   $createCodeNode,
@@ -51,6 +47,7 @@ import {
   $isRangeSelection,
   CAN_REDO_COMMAND,
   CAN_UNDO_COMMAND,
+  COMMAND_PRIORITY_LOW,
   ElementNode,
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
@@ -79,8 +76,6 @@ import {INSERT_IMAGE_COMMAND} from './ImagesPlugin';
 import {INSERT_POLL_COMMAND} from './PollPlugin';
 import {INSERT_TWEET_COMMAND} from './TwitterPlugin';
 import {INSERT_YOUTUBE_COMMAND} from './YouTubePlugin';
-
-const LowPriority: CommandListenerLowPriority = 1;
 
 const supportedBlockTypes = new Set([
   'paragraph',
@@ -212,7 +207,7 @@ function FloatingLinkEditor({editor}: {editor: LexicalEditor}): React$Node {
           updateLinkEditor();
           return true;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
     );
   }, [editor, updateLinkEditor]);
@@ -699,7 +694,7 @@ export default function ToolbarPlugin(): React$Node {
           setActiveEditor(newEditor);
           return false;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
       activeEditor.registerCommand(
         CAN_UNDO_COMMAND,
@@ -707,7 +702,7 @@ export default function ToolbarPlugin(): React$Node {
           setCanUndo(payload);
           return false;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
       activeEditor.registerCommand(
         CAN_REDO_COMMAND,
@@ -715,7 +710,7 @@ export default function ToolbarPlugin(): React$Node {
           setCanRedo(payload);
           return false;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
     );
   }, [activeEditor, updateToolbar]);

--- a/packages/lexical-playground/src/plugins/TwitterPlugin.js
+++ b/packages/lexical-playground/src/plugins/TwitterPlugin.js
@@ -7,20 +7,19 @@
  * @flow strict
  */
 
-import type {CommandListenerEditorPriority, LexicalCommand} from 'lexical';
+import type {LexicalCommand} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $createParagraphNode,
   $getSelection,
   $isRangeSelection,
+  COMMAND_PRIORITY_EDITOR,
   createCommand,
 } from 'lexical';
 import {useEffect} from 'react';
 
 import {$createTweetNode, TweetNode} from '../nodes/TweetNode.jsx';
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 export const INSERT_TWEET_COMMAND: LexicalCommand<string> = createCommand();
 
@@ -51,7 +50,7 @@ export default function TwitterPlugin(): React$Node {
         }
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     );
   }, [editor]);
   return null;

--- a/packages/lexical-playground/src/plugins/YouTubePlugin.js
+++ b/packages/lexical-playground/src/plugins/YouTubePlugin.js
@@ -7,20 +7,19 @@
  * @flow strict
  */
 
-import type {CommandListenerEditorPriority, LexicalCommand} from 'lexical';
+import type {LexicalCommand} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $createParagraphNode,
   $getSelection,
   $isRangeSelection,
+  COMMAND_PRIORITY_EDITOR,
   createCommand,
 } from 'lexical';
 import {useEffect} from 'react';
 
 import {$createYouTubeNode, YouTubeNode} from '../nodes/YouTubeNode.jsx';
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 export const INSERT_YOUTUBE_COMMAND: LexicalCommand<string> = createCommand();
 
@@ -51,7 +50,7 @@ export default function YouTubePlugin(): React$Node {
         }
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     );
   }, [editor]);
   return null;

--- a/packages/lexical-react/src/LexicalClearEditorPlugin.js
+++ b/packages/lexical-react/src/LexicalClearEditorPlugin.js
@@ -13,6 +13,7 @@ import {
   $getRoot,
   $getSelection,
   CLEAR_EDITOR_COMMAND,
+  COMMAND_PRIORITY_EDITOR,
 } from 'lexical';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
@@ -42,7 +43,7 @@ export default function LexicalClearEditorPlugin({onClear}: Props): React$Node {
         });
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     );
   }, [editor, onClear]);
 

--- a/packages/lexical-react/src/LexicalLinkPlugin.js
+++ b/packages/lexical-react/src/LexicalLinkPlugin.js
@@ -7,8 +7,6 @@
  * @flow strict
  */
 
-import type {CommandListenerEditorPriority} from 'lexical';
-
 import {
   $createLinkNode,
   $isLinkNode,
@@ -16,10 +14,13 @@ import {
   TOGGLE_LINK_COMMAND,
 } from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$getSelection, $isElementNode, $setSelection} from 'lexical';
+import {
+  $getSelection,
+  $isElementNode,
+  $setSelection,
+  COMMAND_PRIORITY_EDITOR,
+} from 'lexical';
 import {useEffect} from 'react';
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 function toggleLink(url: null | string) {
   const selection = $getSelection();
@@ -122,7 +123,7 @@ export default function LinkPlugin(): null {
         toggleLink(url);
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     );
   }, [editor]);
 

--- a/packages/lexical-react/src/LexicalTablePlugin.js
+++ b/packages/lexical-react/src/LexicalTablePlugin.js
@@ -8,7 +8,7 @@
  */
 
 import type {TableSelection} from '@lexical/table';
-import type {NodeKey} from 'lexical';
+import type {ElementNode, NodeKey} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
@@ -26,7 +26,6 @@ import {
   $isRangeSelection,
   $isRootNode,
   COMMAND_PRIORITY_EDITOR,
-  ElementNode,
 } from 'lexical';
 import {useEffect} from 'react';
 import invariant from 'shared/invariant';

--- a/packages/lexical-react/src/LexicalTablePlugin.js
+++ b/packages/lexical-react/src/LexicalTablePlugin.js
@@ -8,11 +8,7 @@
  */
 
 import type {TableSelection} from '@lexical/table';
-import type {
-  CommandListenerEditorPriority,
-  ElementNode,
-  NodeKey,
-} from 'lexical';
+import type {NodeKey} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
@@ -29,11 +25,11 @@ import {
   $getSelection,
   $isRangeSelection,
   $isRootNode,
+  COMMAND_PRIORITY_EDITOR,
+  ElementNode,
 } from 'lexical';
 import {useEffect} from 'react';
 import invariant from 'shared/invariant';
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 export default function TablePlugin(): React$Node {
   const [editor] = useLexicalComposerContext();
@@ -81,7 +77,7 @@ export default function TablePlugin(): React$Node {
         }
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     );
   }, [editor]);
 

--- a/packages/lexical-react/src/shared/useList.js
+++ b/packages/lexical-react/src/shared/useList.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import type {CommandListenerLowPriority, LexicalEditor} from 'lexical';
+import type {LexicalEditor} from 'lexical';
 
 import {
   $handleListInsertParagraph,
@@ -21,13 +21,12 @@ import {
 } from '@lexical/list';
 import {mergeRegister} from '@lexical/utils';
 import {
+  COMMAND_PRIORITY_LOW,
   INDENT_CONTENT_COMMAND,
   INSERT_PARAGRAPH_COMMAND,
   OUTDENT_CONTENT_COMMAND,
 } from 'lexical';
 import {useEffect} from 'react';
-
-const LowPriority: CommandListenerLowPriority = 1;
 
 export default function useList(editor: LexicalEditor): void {
   useEffect(() => {
@@ -41,7 +40,7 @@ export default function useList(editor: LexicalEditor): void {
           }
           return false;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         OUTDENT_CONTENT_COMMAND,
@@ -52,7 +51,7 @@ export default function useList(editor: LexicalEditor): void {
           }
           return false;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         INSERT_ORDERED_LIST_COMMAND,
@@ -60,7 +59,7 @@ export default function useList(editor: LexicalEditor): void {
           insertList(editor, 'ol');
           return true;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         INSERT_UNORDERED_LIST_COMMAND,
@@ -68,7 +67,7 @@ export default function useList(editor: LexicalEditor): void {
           insertList(editor, 'ul');
           return true;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         REMOVE_LIST_COMMAND,
@@ -76,7 +75,7 @@ export default function useList(editor: LexicalEditor): void {
           removeList(editor);
           return true;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         INSERT_PARAGRAPH_COMMAND,
@@ -87,7 +86,7 @@ export default function useList(editor: LexicalEditor): void {
           }
           return false;
         },
-        LowPriority,
+        COMMAND_PRIORITY_LOW,
       ),
     );
   }, [editor]);

--- a/packages/lexical-react/src/shared/useYjsCollaboration.jsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.jsx
@@ -8,7 +8,7 @@
  */
 
 import type {Binding, Provider} from '@lexical/yjs';
-import type {CommandListenerEditorPriority, LexicalEditor} from 'lexical';
+import type {LexicalEditor} from 'lexical';
 import type {Doc} from 'yjs';
 
 import {mergeRegister} from '@lexical/utils';
@@ -28,6 +28,7 @@ import {
   $getRoot,
   $getSelection,
   BLUR_COMMAND,
+  COMMAND_PRIORITY_EDITOR,
   FOCUS_COMMAND,
   REDO_COMMAND,
   UNDO_COMMAND,
@@ -36,8 +37,6 @@ import * as React from 'react';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 // $FlowFixMe
 import {createPortal} from 'react-dom';
-
-const EditorPriority: CommandListenerEditorPriority = 0;
 
 export function useYjsCollaboration(
   editor: LexicalEditor,
@@ -194,7 +193,7 @@ export function useYjsCollaboration(
         }
         return true;
       },
-      EditorPriority,
+      COMMAND_PRIORITY_EDITOR,
     );
   }, [connect, disconnect, editor]);
 
@@ -215,7 +214,7 @@ export function useYjsFocusTracking(
           setLocalStateFocus(provider, name, color, true);
           return true;
         },
-        EditorPriority,
+        COMMAND_PRIORITY_EDITOR,
       ),
       editor.registerCommand(
         BLUR_COMMAND,
@@ -223,7 +222,7 @@ export function useYjsFocusTracking(
           setLocalStateFocus(provider, name, color, false);
           return true;
         },
-        EditorPriority,
+        COMMAND_PRIORITY_EDITOR,
       ),
     );
   }, [color, editor, name, provider]);
@@ -253,7 +252,7 @@ export function useYjsHistory(
           undo();
           return true;
         },
-        EditorPriority,
+        COMMAND_PRIORITY_EDITOR,
       ),
       editor.registerCommand(
         REDO_COMMAND,
@@ -261,7 +260,7 @@ export function useYjsHistory(
           redo();
           return true;
         },
-        EditorPriority,
+        COMMAND_PRIORITY_EDITOR,
       ),
     );
   });

--- a/packages/lexical-rich-text/src/index.js
+++ b/packages/lexical-rich-text/src/index.js
@@ -42,6 +42,7 @@ import {
   $isNodeSelection,
   $isRangeSelection,
   CLICK_COMMAND,
+  COMMAND_PRIORITY_EDITOR,
   COPY_COMMAND,
   CUT_COMMAND,
   DELETE_CHARACTER_COMMAND,
@@ -354,7 +355,7 @@ export function registerRichText(
         selection.deleteCharacter(isBackward);
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       DELETE_WORD_COMMAND,
@@ -367,7 +368,7 @@ export function registerRichText(
         selection.deleteWord(isBackward);
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       DELETE_LINE_COMMAND,
@@ -380,7 +381,7 @@ export function registerRichText(
         selection.deleteLine(isBackward);
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       INSERT_TEXT_COMMAND,
@@ -406,7 +407,7 @@ export function registerRichText(
         }
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       REMOVE_TEXT_COMMAND,
@@ -418,7 +419,7 @@ export function registerRichText(
         selection.removeText();
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       FORMAT_TEXT_COMMAND,
@@ -431,7 +432,7 @@ export function registerRichText(
         selection.formatText(format);
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       FORMAT_ELEMENT_COMMAND,
@@ -447,7 +448,7 @@ export function registerRichText(
         }
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       INSERT_LINE_BREAK_COMMAND,
@@ -460,7 +461,7 @@ export function registerRichText(
         selection.insertLineBreak(selectStart);
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       INSERT_PARAGRAPH_COMMAND,
@@ -472,7 +473,7 @@ export function registerRichText(
         selection.insertParagraph();
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       INDENT_CONTENT_COMMAND,
@@ -495,7 +496,7 @@ export function registerRichText(
         }
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       OUTDENT_CONTENT_COMMAND,
@@ -523,7 +524,7 @@ export function registerRichText(
         }
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       KEY_ARROW_LEFT_COMMAND,
@@ -541,7 +542,7 @@ export function registerRichText(
         }
         return false;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       KEY_ARROW_RIGHT_COMMAND,
@@ -559,7 +560,7 @@ export function registerRichText(
         }
         return false;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       KEY_BACKSPACE_COMMAND,
@@ -581,7 +582,7 @@ export function registerRichText(
         }
         return editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       KEY_DELETE_COMMAND,
@@ -594,7 +595,7 @@ export function registerRichText(
         event.preventDefault();
         return editor.dispatchCommand(DELETE_CHARACTER_COMMAND, false);
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       KEY_ENTER_COMMAND,
@@ -611,7 +612,7 @@ export function registerRichText(
         }
         return editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND);
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       KEY_TAB_COMMAND,
@@ -626,7 +627,7 @@ export function registerRichText(
           event.shiftKey ? OUTDENT_CONTENT_COMMAND : INDENT_CONTENT_COMMAND,
         );
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       KEY_ESCAPE_COMMAND,
@@ -638,7 +639,7 @@ export function registerRichText(
         editor.blur();
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       DROP_COMMAND,
@@ -651,7 +652,7 @@ export function registerRichText(
         event.preventDefault();
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       DRAGSTART_COMMAND,
@@ -665,7 +666,7 @@ export function registerRichText(
         event.preventDefault();
         return true;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       COPY_COMMAND,
@@ -678,7 +679,7 @@ export function registerRichText(
         }
         return false;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       CUT_COMMAND,
@@ -691,7 +692,7 @@ export function registerRichText(
         }
         return false;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand(
       PASTE_COMMAND,
@@ -703,7 +704,7 @@ export function registerRichText(
         }
         return false;
       },
-      0,
+      COMMAND_PRIORITY_EDITOR,
     ),
   );
   initializeEditor(editor, initialEditorState);

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.js
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.js
@@ -9,14 +9,6 @@
 
 import type {TableNode} from './LexicalTableNode';
 import type {Cell, Cells, Grid} from './LexicalTableSelection';
-import type {
-  CommandListenerCriticalPriority,
-  GridSelection,
-  LexicalEditor,
-  LexicalNode,
-  NodeSelection,
-  RangeSelection,
-} from 'lexical';
 
 import {$findMatchingParent} from '@lexical/utils';
 import {
@@ -28,9 +20,11 @@ import {
   $isParagraphNode,
   $isRangeSelection,
   $setSelection,
+  COMMAND_PRIORITY_CRITICAL,
   DELETE_CHARACTER_COMMAND,
   FOCUS_COMMAND,
   FORMAT_TEXT_COMMAND,
+  GridSelection,
   INSERT_TEXT_COMMAND,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
@@ -38,13 +32,15 @@ import {
   KEY_ARROW_UP_COMMAND,
   KEY_BACKSPACE_COMMAND,
   KEY_TAB_COMMAND,
+  LexicalEditor,
+  LexicalNode,
+  NodeSelection,
+  RangeSelection,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 
 import {$isTableCellNode} from './LexicalTableCellNode';
 import {TableSelection} from './LexicalTableSelection';
-
-const CriticalPriority: CommandListenerCriticalPriority = 4;
 
 const LEXICAL_ELEMENT_KEY = '__lexicalTableSelection';
 
@@ -288,7 +284,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      CriticalPriority,
+      COMMAND_PRIORITY_CRITICAL,
     ),
   );
   tableSelection.listenersToRemove.add(
@@ -395,7 +391,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      CriticalPriority,
+      COMMAND_PRIORITY_CRITICAL,
     ),
   );
   tableSelection.listenersToRemove.add(
@@ -496,7 +492,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      CriticalPriority,
+      COMMAND_PRIORITY_CRITICAL,
     ),
   );
   tableSelection.listenersToRemove.add(
@@ -601,7 +597,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      CriticalPriority,
+      COMMAND_PRIORITY_CRITICAL,
     ),
   );
   tableSelection.listenersToRemove.add(
@@ -638,7 +634,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      CriticalPriority,
+      COMMAND_PRIORITY_CRITICAL,
     ),
   );
   tableSelection.listenersToRemove.add(
@@ -671,7 +667,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      CriticalPriority,
+      COMMAND_PRIORITY_CRITICAL,
     ),
   );
   tableSelection.listenersToRemove.add(
@@ -700,7 +696,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      CriticalPriority,
+      COMMAND_PRIORITY_CRITICAL,
     ),
   );
   tableSelection.listenersToRemove.add(
@@ -729,7 +725,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      CriticalPriority,
+      COMMAND_PRIORITY_CRITICAL,
     ),
   );
   tableSelection.listenersToRemove.add(
@@ -775,7 +771,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      CriticalPriority,
+      COMMAND_PRIORITY_CRITICAL,
     ),
   );
 
@@ -785,7 +781,7 @@ export function applyTableHandlers(
       (payload) => {
         return tableNode.isSelected();
       },
-      CriticalPriority,
+      COMMAND_PRIORITY_CRITICAL,
     ),
   );
 
@@ -845,7 +841,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      CriticalPriority,
+      COMMAND_PRIORITY_CRITICAL,
     ),
   );
   return tableSelection;

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -222,17 +222,12 @@ export type EditorConfig<EditorContext> = {
   context: EditorContext;
   disableEvents?: boolean;
 };
-export type CommandListenerEditorPriority = 0;
-export type CommandListenerLowPriority = 1;
-export type CommandListenerNormalPriority = 2;
-export type CommandListenerHighPriority = 3;
-export type CommandListenerCriticalPriority = 4;
-type CommandListenerPriority =
-  | CommandListenerEditorPriority
-  | CommandListenerLowPriority
-  | CommandListenerNormalPriority
-  | CommandListenerHighPriority
-  | CommandListenerCriticalPriority;
+export type CommandListenerPriority = 0 | 1 | 2 | 3 | 4;
+export const COMMAND_PRIORITY_EDITOR = 0;
+export const COMMAND_PRIORITY_LOW = 1;
+export const COMMAND_PRIORITY_NORMAL = 2;
+export const COMMAND_PRIORITY_HIGH = 3;
+export const COMMAND_PRIORITY_CRITICAL = 4;
 export type IntentionallyMarkedAsDirtyElement = boolean;
 export function createEditor<EditorContext>(editorConfig?: {
   namespace?: string;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -228,17 +228,12 @@ export type EditorConfig<EditorContext> = {
   context: EditorContext,
   disableEvents?: boolean,
 };
-export type CommandListenerEditorPriority = 0;
-export type CommandListenerLowPriority = 1;
-export type CommandListenerNormalPriority = 2;
-export type CommandListenerHighPriority = 3;
-export type CommandListenerCriticalPriority = 4;
-type CommandListenerPriority =
-  | CommandListenerEditorPriority
-  | CommandListenerLowPriority
-  | CommandListenerNormalPriority
-  | CommandListenerHighPriority
-  | CommandListenerCriticalPriority;
+export type CommandListenerPriority = 0 | 1 | 2 | 3 | 4;
+export const COMMAND_PRIORITY_EDITOR = 0;
+export const COMMAND_PRIORITY_LOW = 1;
+export const COMMAND_PRIORITY_NORMAL = 2;
+export const COMMAND_PRIORITY_HIGH = 3;
+export const COMMAND_PRIORITY_CRITICAL = 4;
 
 export type IntentionallyMarkedAsDirtyElement = boolean;
 declare export function createEditor<EditorContext>(editorConfig?: {

--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -131,18 +131,12 @@ export type MutationListener = (nodes: Map<NodeKey, NodeMutation>) => void;
 export type CommandListener<P> = (payload: P, editor: LexicalEditor) => boolean;
 export type ReadOnlyListener = (readOnly: boolean) => void;
 
-export type CommandListenerEditorPriority = 0;
-export type CommandListenerLowPriority = 1;
-export type CommandListenerNormalPriority = 2;
-export type CommandListenerHighPriority = 3;
-export type CommandListenerCriticalPriority = 4;
-
-export type CommandListenerPriority =
-  | CommandListenerEditorPriority
-  | CommandListenerLowPriority
-  | CommandListenerNormalPriority
-  | CommandListenerHighPriority
-  | CommandListenerCriticalPriority;
+export type CommandListenerPriority = 0 | 1 | 2 | 3 | 4;
+export const COMMAND_PRIORITY_EDITOR = 0;
+export const COMMAND_PRIORITY_LOW = 1;
+export const COMMAND_PRIORITY_NORMAL = 2;
+export const COMMAND_PRIORITY_HIGH = 3;
+export const COMMAND_PRIORITY_CRITICAL = 4;
 
 // eslint-disable-next-line no-unused-vars
 export type LexicalCommand<T> = $ReadOnly<{}>;

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
@@ -6,8 +6,6 @@
  *
  */
 
-import type {LexicalEditor} from 'lexical';
-
 import DEPRECATED__useLexicalRichText from '@lexical/react/DEPRECATED_useLexicalRichText';
 import {
   $createTableCellNode,
@@ -28,7 +26,9 @@ import {
   $isTextNode,
   $setCompositionKey,
   $setSelection,
+  COMMAND_PRIORITY_EDITOR,
   ElementNode,
+  LexicalEditor,
   ParagraphNode,
   TextNode,
 } from 'lexical';
@@ -1485,7 +1485,7 @@ describe('LexicalEditor tests', () => {
     const removeCommandListener = editor.registerCommand(
       command,
       commandListener,
-      0,
+      COMMAND_PRIORITY_EDITOR,
     );
     editor.dispatchCommand(command, payload);
     editor.dispatchCommand(command, payload);
@@ -1508,12 +1508,12 @@ describe('LexicalEditor tests', () => {
     const removeCommandListener = editor.registerCommand(
       command,
       commandListener,
-      0,
+      COMMAND_PRIORITY_EDITOR,
     );
     const removeCommandListenerTwo = editor.registerCommand(
       command,
       commandListenerTwo,
-      0,
+      COMMAND_PRIORITY_EDITOR,
     );
     expect(editor._commands).toEqual(
       new Map([

--- a/packages/lexical/src/index.js
+++ b/packages/lexical/src/index.js
@@ -7,7 +7,14 @@
  * @flow strict
  */
 
-import {createEditor} from './LexicalEditor';
+import {
+  COMMAND_PRIORITY_CRITICAL,
+  COMMAND_PRIORITY_EDITOR,
+  COMMAND_PRIORITY_HIGH,
+  COMMAND_PRIORITY_LOW,
+  COMMAND_PRIORITY_NORMAL,
+  createEditor,
+} from './LexicalEditor';
 import {$createNodeFromParse} from './LexicalParsing';
 import {
   $createEmptyGridSelection as $createGridSelection,
@@ -77,6 +84,11 @@ export {
   $nodesOfType,
   $setCompositionKey,
   $setSelection,
+  COMMAND_PRIORITY_CRITICAL,
+  COMMAND_PRIORITY_EDITOR,
+  COMMAND_PRIORITY_HIGH,
+  COMMAND_PRIORITY_LOW,
+  COMMAND_PRIORITY_NORMAL,
   createEditor,
   DecoratorNode,
   ElementNode,


### PR DESCRIPTION
Unlikely HTML conversion we have always labeled priorities in code: CRITICAL, HIGH etc.

Priorities are traditionally numbers and to do so requires to have a cast around listener like `(0: EditorPriority)` or similar. This is not quite ergonomic and tends to lead to either:
1. No type cast at all - just a number on the listener
2. In some places we have abstracted this number into the same constant I'm proposing in this PR

For this reason, I'm proposing to standarize this into the core.

A very similar strategy would be to ship an object with these values but 5 constants will be way lighter than shipping an object with values, which will pay off in larger apps.