### PR TITLE
Fix toolbar active editor

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -44,13 +44,11 @@ test.describe('Images', () => {
           <span
             class="editor-image"
             contenteditable="false"
-            data-lexical-decorator="true"
-          >
+            data-lexical-decorator="true">
             <img
               src="${IMAGE_URL}"
               alt="Yellow flower in tilt shift lens"
-              style="height: inherit; max-width: 500px; width: inherit;"
-            />
+              style="height: inherit; max-width: 500px; width: inherit;" />
           </span>
           <br />
         </p>
@@ -107,14 +105,12 @@ test.describe('Images', () => {
           <span
             class="editor-image"
             contenteditable="false"
-            data-lexical-decorator="true"
-          >
+            data-lexical-decorator="true">
             <img
               src="${IMAGE_URL}"
               alt="Yellow flower in tilt shift lens"
               style="height: inherit; max-width: 500px; width: inherit;"
-              class="focused"
-            />
+              class="focused" />
             <button class="image-caption-button">Add Caption</button>
             <div class="image-resizer-ne"></div>
             <div class="image-resizer-se"></div>
@@ -151,13 +147,11 @@ test.describe('Images', () => {
           <span
             class="editor-image"
             contenteditable="false"
-            data-lexical-decorator="true"
-          >
+            data-lexical-decorator="true">
             <img
               src="${IMAGE_URL}"
               alt="Yellow flower in tilt shift lens"
-              style="height: inherit; max-width: 500px; width: inherit;"
-            />
+              style="height: inherit; max-width: 500px; width: inherit;" />
           </span>
           <br />
         </p>
@@ -211,24 +205,20 @@ test.describe('Images', () => {
           <span
             class="editor-image"
             contenteditable="false"
-            data-lexical-decorator="true"
-          >
+            data-lexical-decorator="true">
             <img
               src="${IMAGE_URL}"
               alt="Yellow flower in tilt shift lens"
-              style="height: inherit; max-width: 500px; width: inherit;"
-            />
+              style="height: inherit; max-width: 500px; width: inherit;" />
           </span>
           <span
             class="editor-image"
             contenteditable="false"
-            data-lexical-decorator="true"
-          >
+            data-lexical-decorator="true">
             <img
               src="${IMAGE_URL}"
               alt="Yellow flower in tilt shift lens"
-              style="height: inherit; max-width: 500px; width: inherit;"
-            />
+              style="height: inherit; max-width: 500px; width: inherit;" />
           </span>
           <br />
         </p>
@@ -249,13 +239,11 @@ test.describe('Images', () => {
           <span
             class="editor-image"
             contenteditable="false"
-            data-lexical-decorator="true"
-          >
+            data-lexical-decorator="true">
             <img
               src="${IMAGE_URL}"
               alt="Yellow flower in tilt shift lens"
-              style="height: inherit; max-width: 500px; width: inherit;"
-            />
+              style="height: inherit; max-width: 500px; width: inherit;" />
           </span>
           <br />
         </p>
@@ -295,30 +283,25 @@ test.describe('Images', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Test</span>
           <span
             class="editor-image"
             contenteditable="false"
-            data-lexical-decorator="true"
-          >
+            data-lexical-decorator="true">
             <img
               src="${IMAGE_URL}"
               alt="Yellow flower in tilt shift lens"
-              style="height: inherit; max-width: 500px; width: inherit;"
-            />
+              style="height: inherit; max-width: 500px; width: inherit;" />
           </span>
           <span
             class="editor-image"
             contenteditable="false"
-            data-lexical-decorator="true"
-          >
+            data-lexical-decorator="true">
             <img
               src="${IMAGE_URL}"
               alt="Yellow flower in tilt shift lens"
-              style="height: inherit; max-width: 500px; width: inherit;"
-            />
+              style="height: inherit; max-width: 500px; width: inherit;" />
           </span>
           <br />
         </p>
@@ -336,19 +319,16 @@ test.describe('Images', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Test</span>
           <span
             class="editor-image"
             contenteditable="false"
-            data-lexical-decorator="true"
-          >
+            data-lexical-decorator="true">
             <img
               src="${IMAGE_URL}"
               alt="Yellow flower in tilt shift lens"
-              style="height: inherit; max-width: 500px; width: inherit;"
-            />
+              style="height: inherit; max-width: 500px; width: inherit;" />
           </span>
           <br />
         </p>

--- a/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
@@ -40,26 +40,16 @@ test.describe('Toolbar', () => {
     await assertHTML(
       page,
       html`
-        <p class="PlaygroundEditorTheme__paragraph">
-          <span
-            class="editor-image"
-            contenteditable="false"
-            data-lexical-decorator="true">
-            <img
-              alt="Yellow flower in tilt shift lens"
-              src="${IMAGE_URL}"
-              style="height: inherit; max-width: 500px; width: inherit" />
-            <div class="image-caption-container">
+        <p>
+          <span contenteditable="false" data-lexical-decorator="true">
+            <img alt="Yellow flower in tilt shift lens" src="${IMAGE_URL}" />
+            <div>
               <div
-                class="ImageNode__contentEditable"
                 contenteditable="true"
                 role="textbox"
                 spellcheck="true"
-                style="user-select: text; white-space: pre-wrap; word-break: break-word"
                 data-lexical-editor="true">
-                <p
-                  class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                  dir="ltr">
+                <p dir="ltr">
                   <span data-lexical-text="true">
                     Yellow flower in tilt shift lens
                   </span>
@@ -70,6 +60,10 @@ test.describe('Toolbar', () => {
           <br />
         </p>
       `,
+      {
+        ignoreClasses: true,
+        ignoreInlineStyles: true,
+      },
     );
 
     // Delete image
@@ -78,8 +72,12 @@ test.describe('Toolbar', () => {
     await assertHTML(
       page,
       html`
-        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <p><br /></p>
       `,
+      {
+        ignoreClasses: true,
+        ignoreInlineStyles: true,
+      },
     );
 
     // Add table
@@ -89,107 +87,102 @@ test.describe('Toolbar', () => {
     await assertHTML(
       page,
       html`
-        <p class="PlaygroundEditorTheme__paragraph">
+        <p>
           <br />
         </p>
-        <table class="PlaygroundEditorTheme__table">
+        <table>
           <tr>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <th>
+              <p><br /></p>
             </th>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <th>
+              <p><br /></p>
             </th>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <th>
+              <p><br /></p>
             </th>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <th>
+              <p><br /></p>
             </th>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <th>
+              <p><br /></p>
             </th>
           </tr>
           <tr>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <th>
+              <p><br /></p>
             </th>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
           </tr>
           <tr>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <th>
+              <p><br /></p>
             </th>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
           </tr>
           <tr>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <th>
+              <p><br /></p>
             </th>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
           </tr>
           <tr>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <th>
+              <p><br /></p>
             </th>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <td>
+              <p><br /></p>
             </td>
           </tr>
         </table>
-        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <p><br /></p>
       `,
+      {
+        ignoreClasses: true,
+        ignoreInlineStyles: true,
+      },
     );
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
@@ -6,6 +6,7 @@
  *
  */
 
+import {selectAll} from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
   click,
@@ -67,7 +68,12 @@ test.describe('Toolbar', () => {
     );
 
     // Delete image
-    await click(page, '.editor-image img');
+    // TODO Revisit the a11y side of NestedEditors
+    await page.evaluate(() => {
+      const p = document.querySelector('[contenteditable="true"] p');
+      document.getSelection().setBaseAndExtent(p, 0, p, 0);
+    });
+    await selectAll(page);
     await page.keyboard.press('Delete');
     await assertHTML(
       page,

--- a/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  assertHTML,
+  click,
+  E2E_PORT,
+  focusEditor,
+  html,
+  initialize,
+  selectFromInsertDropdown,
+  test,
+} from '../utils/index.mjs';
+
+const IMAGE_URL =
+  E2E_PORT === 3000
+    ? '/src/images/yellow-flower.jpg'
+    : '/assets/yellow-flower.bf6d0400.jpg';
+
+test.describe('Toolbar', () => {
+  test.beforeEach(({isCollab, page}) =>
+    initialize({isCollab, page, showNestedEditorTreeView: false}),
+  );
+
+  test('Insert image caption + table', async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+
+    // Add caption
+    await selectFromInsertDropdown(page, '.image');
+    await click(page, '.editor-image img');
+    await click(page, '.image-caption-button');
+    await page.focus('.ImageNode__contentEditable');
+    await page.keyboard.type('Yellow flower in tilt shift lens');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <img
+              alt="Yellow flower in tilt shift lens"
+              src="${IMAGE_URL}"
+              style="height: inherit; max-width: 500px; width: inherit" />
+            <div class="image-caption-container">
+              <div
+                class="ImageNode__contentEditable"
+                contenteditable="true"
+                role="textbox"
+                spellcheck="true"
+                style="user-select: text; white-space: pre-wrap; word-break: break-word"
+                data-lexical-editor="true">
+                <p
+                  class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                  dir="ltr">
+                  <span data-lexical-text="true">
+                    Yellow flower in tilt shift lens
+                  </span>
+                </p>
+              </div>
+            </div>
+          </span>
+          <br />
+        </p>
+      `,
+    );
+
+    // Delete image
+    await click(page, '.editor-image img');
+    await page.keyboard.press('Delete');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    // Add table
+    await selectFromInsertDropdown(page, '.table');
+    await click(page, '[data-test-id="table-model-confirm-insert"] button');
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <br />
+        </p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+});

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -30,6 +30,7 @@ export async function initialize({
   isCollab,
   isCharLimit,
   isCharLimitUtf8,
+  showNestedEditorTreeView,
 }) {
   const appSettings = {};
   appSettings.isRichText = IS_RICH_TEXT;
@@ -39,7 +40,7 @@ export async function initialize({
     appSettings.isCollab = isCollab;
     appSettings.collabId = uuidv4();
   }
-  if (appSettings.showNestedEditorTreeView === undefined) {
+  if (showNestedEditorTreeView === undefined) {
     appSettings.showNestedEditorTreeView = true;
   }
   appSettings.isCharLimit = !!isCharLimit;

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -717,7 +717,7 @@ export default function ToolbarPlugin(): React$Node {
         COMMAND_PRIORITY_CRITICAL,
       ),
     );
-  }, [activeEditor, editor, updateToolbar]);
+  }, [activeEditor, updateToolbar]);
 
   const applyStyleText = useCallback(
     (styles: {[string]: string}) => {

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -47,6 +47,7 @@ import {
   $isRangeSelection,
   CAN_REDO_COMMAND,
   CAN_UNDO_COMMAND,
+  COMMAND_PRIORITY_CRITICAL,
   COMMAND_PRIORITY_LOW,
   ElementNode,
   FORMAT_ELEMENT_COMMAND,
@@ -688,7 +689,7 @@ export default function ToolbarPlugin(): React$Node {
         setActiveEditor(newEditor);
         return false;
       },
-      COMMAND_PRIORITY_LOW,
+      COMMAND_PRIORITY_CRITICAL,
     );
   }, [editor, updateToolbar]);
 
@@ -705,7 +706,7 @@ export default function ToolbarPlugin(): React$Node {
           setCanUndo(payload);
           return false;
         },
-        COMMAND_PRIORITY_LOW,
+        COMMAND_PRIORITY_CRITICAL,
       ),
       activeEditor.registerCommand(
         CAN_REDO_COMMAND,
@@ -713,10 +714,10 @@ export default function ToolbarPlugin(): React$Node {
           setCanRedo(payload);
           return false;
         },
-        COMMAND_PRIORITY_LOW,
+        COMMAND_PRIORITY_CRITICAL,
       ),
     );
-  }, [activeEditor, updateToolbar]);
+  }, [activeEditor, editor, updateToolbar]);
 
   const applyStyleText = useCallback(
     (styles: {[string]: string}) => {


### PR DESCRIPTION
Currently activeEditor was stuck on the nested editor once focused, this is because commands only bubble so once it's on the nested editor it needs manual correction.

This meant that once you had inserted an image caption the toolbar would no longer properly work for inserting any other node.

In this case I think the fix is pretty straightforward and we can just leverage bubbling and listening to the top editor instead.

- [x] E2E test