### PR TITLE
feat: added title and aria-label to playground editor buttons

### DIFF
--- a/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
@@ -106,13 +106,17 @@ export default function ActionsPlugins({
           className={
             'action-button action-button-mic ' +
             (isSpeechToText ? 'active' : '')
-          }>
+          }
+          title="Mic"
+          aria-label="Mic">
           <i className="mic" />
         </button>
       )}
       <button
         className="action-button import"
-        onClick={() => importFile(editor)}>
+        onClick={() => importFile(editor)}
+        title="Import"
+        aria-label="Import">
         <i className="import" />
       </button>
       <button
@@ -122,7 +126,9 @@ export default function ActionsPlugins({
             fileName: `Playground ${new Date().toISOString()}`,
             source: 'Playground',
           })
-        }>
+        }
+        title="Export"
+        aria-label="Export">
         <i className="export" />
       </button>
       <button
@@ -130,17 +136,25 @@ export default function ActionsPlugins({
         onClick={() => {
           editor.dispatchCommand(CLEAR_EDITOR_COMMAND);
           editor.focus();
-        }}>
+        }}
+        title="Clear"
+        aria-label="Clear">
         <i className="clear" />
       </button>
       <button
         className="action-button lock"
         onClick={() => {
           editor.setReadOnly(!editor.isReadOnly());
-        }}>
+        }}
+        title={isReadOnly ? 'Unlock' : 'Lock'}
+        aria-label={isReadOnly ? 'Unlock' : 'Lock'}>
         <i className={isReadOnly ? 'unlock' : 'lock'} />
       </button>
-      <button className="action-button" onClick={convertFromMarkdown}>
+      <button
+        className="action-button"
+        onClick={convertFromMarkdown}
+        title="Markdown"
+        aria-label="Markdown">
         <i className="markdown" />
       </button>
       {isCollab && (
@@ -148,7 +162,9 @@ export default function ActionsPlugins({
           className="action-button connect"
           onClick={() => {
             editor.dispatchCommand(TOGGLE_CONNECT_COMMAND, !connected);
-          }}>
+          }}
+          title={connected ? 'Disconnect' : 'Connect'}
+          aria-label={connected ? 'Disconnect' : 'Connect'}>
           <i className={connected ? 'disconnect' : 'connect'} />
         </button>
       )}


### PR DESCRIPTION
Added `title` and `aria-label` attributes to the playground editor.