### PR TITLE
feat: added confirmation modal before clear text

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Clear.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Clear.spec.mjs
@@ -26,22 +26,36 @@ test.describe('Clear', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">foo</span>
         </p>
       `,
     );
 
     await click(page, '.action-button.clear');
+
+    await page.click('text=Cancel');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">foo</span>
+        </p>
+      `,
+    );
+
+    await click(page, '.action-button.clear');
+    await page.click('button:has-text("Clear")');
+
     await page.keyboard.type('bar');
     await assertHTML(
       page,
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">bar</span>
         </p>
       `,

--- a/packages/lexical-playground/__tests__/e2e/Clear.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Clear.spec.mjs
@@ -34,7 +34,7 @@ test.describe('Clear', () => {
 
     await click(page, '.action-button.clear');
 
-    await page.click('text=Cancel');
+    await click(page, 'button:has-text("Cancel")');
     await assertHTML(
       page,
       html`
@@ -47,8 +47,8 @@ test.describe('Clear', () => {
     );
 
     await click(page, '.action-button.clear');
-    await page.click('button:has-text("Clear")');
 
+    await click(page, 'button:has-text("Clear")');
     await page.keyboard.type('bar');
     await assertHTML(
       page,

--- a/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
@@ -7,6 +7,8 @@
  * @flow strict
  */
 
+import type {LexicalEditor} from 'lexical';
+
 import {exportFile, importFile} from '@lexical/file';
 import {$convertFromMarkdownString} from '@lexical/markdown';
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationPlugin';
@@ -23,6 +25,8 @@ import {
 import * as React from 'react';
 import {useCallback, useEffect, useState} from 'react';
 
+import useModal from '../hooks/useModal';
+import Button from '../ui/Button';
 import {
   SPEECH_TO_TEXT_COMMAND,
   SUPPORT_SPEECH_RECOGNITION,
@@ -37,6 +41,7 @@ export default function ActionsPlugins({
   const [isReadOnly, setIsReadyOnly] = useState(() => editor.isReadOnly());
   const [isSpeechToText, setIsSpeechToText] = useState(false);
   const [connected, setConnected] = useState(false);
+  const [modal, showModal] = useModal();
   const {yjsDocMap} = useCollaborationContext();
   const isCollab = yjsDocMap.get('main') !== undefined;
 
@@ -124,8 +129,9 @@ export default function ActionsPlugins({
       <button
         className="action-button clear"
         onClick={() => {
-          editor.dispatchCommand(CLEAR_EDITOR_COMMAND);
-          editor.focus();
+          showModal('Clear editor', (onClose) => (
+            <ShowClearDialog editor={editor} onClose={onClose} />
+          ));
         }}
         title="Clear"
         aria-label="Clear">
@@ -158,6 +164,38 @@ export default function ActionsPlugins({
           <i className={connected ? 'disconnect' : 'connect'} />
         </button>
       )}
+      {modal}
     </div>
+  );
+}
+
+function ShowClearDialog({
+  editor,
+  onClose,
+}: {
+  editor: LexicalEditor,
+  onClose: () => void,
+}): React$Node {
+  return (
+    <>
+      Are you sure you want to clear the editor?
+      <div className="Modal__content">
+        <Button
+          onClick={() => {
+            editor.dispatchCommand(CLEAR_EDITOR_COMMAND);
+            editor.focus();
+            onClose();
+          }}>
+          Clear
+        </Button>{' '}
+        <Button
+          onClick={() => {
+            editor.focus();
+            onClose();
+          }}>
+          Cancel
+        </Button>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
Added confirmation modal for clear text in playground.

this commit resolves #1794.