### PR TITLE
Add preserveEmptyParent param to LexicalNode.remove

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.js
+++ b/packages/lexical-list/src/LexicalListItemNode.js
@@ -139,7 +139,7 @@ export class ListItemNode extends ElementNode {
       );
     }
 
-    // Attempt to merge tables if the list is of the same type.
+    // Attempt to merge if the list is of the same type.
     if ($isListNode(node) && node.getTag() === listNode.getTag()) {
       let child = node;
       const children = node.getChildren();

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -22,6 +22,7 @@ import {
   html,
   initialize,
   selectFromAlignDropdown,
+  selectFromFormatDropdown,
   test,
   waitForSelector,
 } from '../utils/index.mjs';
@@ -275,8 +276,7 @@ test.describe('Nested List', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
         </p>
       `,
@@ -296,32 +296,27 @@ test.describe('Nested List', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">from</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">the</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">other</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">side</span>
         </p>
       `,
@@ -343,32 +338,27 @@ test.describe('Nested List', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">from</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">the</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">other</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">side</span>
         </p>
       `,
@@ -392,32 +382,27 @@ test.describe('Nested List', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">from</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">the</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">other</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">side</span>
         </p>
       `,
@@ -443,8 +428,7 @@ test.describe('Nested List', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">One two three</span>
         </p>
       `,
@@ -461,14 +445,12 @@ test.describe('Nested List', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">One</span>
           <a
             href="https://"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
-            dir="ltr"
-          >
+            dir="ltr">
             <span data-lexical-text="true">two</span>
           </a>
           <span data-lexical-text="true">three</span>
@@ -493,14 +475,12 @@ test.describe('Nested List', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">One</span>
           <a
             href="https://"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
-            dir="ltr"
-          >
+            dir="ltr">
             <span data-lexical-text="true">two</span>
           </a>
           <span data-lexical-text="true">three</span>
@@ -558,34 +538,29 @@ test.describe('Nested List', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">from</span>
         </p>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">the</span>
         </p>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">other</span>
         </p>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">side</span>
         </p>
       `,
@@ -873,38 +848,33 @@ test.describe('Nested List', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">Hello</span>
         </p>
         <ul class="PlaygroundEditorTheme__ul">
           <li
             class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
             dir="ltr"
-            value="1"
-          >
+            value="1">
             <span data-lexical-text="true">from</span>
           </li>
         </ul>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">the</span>
         </p>
         <ul class="PlaygroundEditorTheme__ul">
           <li
             class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
             dir="ltr"
-            value="1"
-          >
+            value="1">
             <span data-lexical-text="true">other</span>
           </li>
         </ul>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr"
-        >
+          dir="ltr">
           <span data-lexical-text="true">side</span>
         </p>
       `,
@@ -1034,6 +1004,118 @@ test.describe('Nested List', () => {
     await assertHTML(
       page,
       '<ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">a</span></li></ul><p class="PlaygroundEditorTheme__paragraph"><br></p>',
+    );
+  });
+
+  test(`Converts a List with one ListItem to a Paragraph when Normal is selected in the format menu`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await toggleBulletList(page);
+    await page.keyboard.type('a');
+    await assertHTML(
+      page,
+      html`
+        <ul>
+          <li value="1" dir="ltr">
+            <span data-lexical-text="true">a</span>
+          </li>
+        </ul>
+      `,
+      {ignoreClasses: true},
+    );
+    await selectFromFormatDropdown(page, '.paragraph');
+    await assertHTML(
+      page,
+      html`
+        <p dir="ltr"><span data-lexical-text="true">a</span></p>
+      `,
+      {ignoreClasses: true},
+    );
+  });
+
+  test(`Converts the last ListItem in a List with multiple ListItem to a Paragraph when Normal is selected in the format menu`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await toggleBulletList(page);
+    await page.keyboard.type('a');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('b');
+    await assertHTML(
+      page,
+      html`
+        <ul>
+          <li value="1" dir="ltr">
+            <span data-lexical-text="true">a</span>
+          </li>
+          <li value="2" dir="ltr">
+            <span data-lexical-text="true">b</span>
+          </li>
+        </ul>
+      `,
+      {ignoreClasses: true},
+    );
+    await selectFromFormatDropdown(page, '.paragraph');
+    await assertHTML(
+      page,
+      html`
+        <ul>
+          <li value="1" dir="ltr">
+            <span data-lexical-text="true">a</span>
+          </li>
+        </ul>
+        <p dir="ltr"><span data-lexical-text="true">b</span></p>
+      `,
+      {ignoreClasses: true},
+    );
+  });
+
+  test(`Converts the middle ListItem in a List with multiple ListItem to a Paragraph when Normal is selected in the format menu`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await toggleBulletList(page);
+    await page.keyboard.type('a');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('b');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('c');
+    await page.keyboard.press('ArrowUp');
+    await assertHTML(
+      page,
+      html`
+        <ul>
+          <li value="1" dir="ltr">
+            <span data-lexical-text="true">a</span>
+          </li>
+          <li value="2" dir="ltr">
+            <span data-lexical-text="true">b</span>
+          </li>
+          <li value="3" dir="ltr">
+            <span data-lexical-text="true">c</span>
+          </li>
+        </ul>
+      `,
+      {ignoreClasses: true},
+    );
+    await selectFromFormatDropdown(page, '.paragraph');
+    await assertHTML(
+      page,
+      html`
+        <ul>
+          <li value="1" dir="ltr">
+            <span data-lexical-text="true">a</span>
+          </li>
+        </ul>
+        <p dir="ltr"><span data-lexical-text="true">b</span></p>
+        <ul>
+          <li value="1" dir="ltr">
+            <span data-lexical-text="true">c</span>
+          </li>
+        </ul>
+      `,
+      {ignoreClasses: true},
     );
   });
 });

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -507,6 +507,11 @@ export function html(partials, ...params) {
   return output;
 }
 
+export async function selectFromFormatDropdown(page, selector) {
+  await click(page, '.toolbar-item[aria-label="Formatting Options"]');
+  await click(page, '.dropdown ' + selector);
+}
+
 export async function selectFromInsertDropdown(page, selector) {
   await click(page, '.toolbar-item[aria-label="Insert"]');
   await click(page, '.dropdown ' + selector);

--- a/packages/lexical-selection/src/index.js
+++ b/packages/lexical-selection/src/index.js
@@ -510,7 +510,7 @@ function $removeParentEmptyElements(startingNode: ElementNode): void {
     const latest = node.getLatest();
     const parentNode = node.getParent();
     if (latest.__children.length === 0) {
-      node.remove();
+      node.remove(true);
     }
     node = parentNode;
   }

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -144,7 +144,7 @@ export declare class LexicalEditor {
     klass: Class<T>,
     listener: Transform<T>,
   ): () => void;
-  dispatchCommand(type: string, payload: P): boolean;
+  dispatchCommand<P>(type: string, payload: P): boolean;
   hasNodes(nodes: Array<Class<LexicalNode>>): boolean;
   getDecorators<X>(): Record<NodeKey, X>;
   getRootElement(): null | HTMLElement;
@@ -292,8 +292,8 @@ export type DOMConversionFn = (
 ) => DOMConversionOutput;
 export type DOMChildConversion = (
   lexicalNode: LexicalNode,
-  parentLexicalNode: ?(LexicalNode | null),
-) => ?(LexicalNode | void | null);
+  parentLexicalNode: LexicalNode | null,
+) => LexicalNode | void | null;
 export type DOMConversionMap = Record<
   NodeName,
   (node: Node) => DOMConversion | null
@@ -305,7 +305,7 @@ export type DOMConversionOutput = {
   node: LexicalNode | null;
 };
 export type DOMExportOutput = {
-  after?: (generatedElement: ?HTMLElement) => ?HTMLElement;
+  after?: (generatedElement: HTMLElement | null) => HTMLElement | null;
   element: HTMLElement | null;
 };
 export type NodeKey = string;
@@ -360,7 +360,7 @@ export declare class LexicalNode {
     dom: HTMLElement,
     config: EditorConfig<EditorContext>,
   ): boolean;
-  remove(): void;
+  remove(preserveEmptyParent?: boolean): void;
   replace<N extends LexicalNode>(replaceWith: N): N;
   insertAfter(nodeToInsert: LexicalNode): LexicalNode;
   insertBefore(nodeToInsert: LexicalNode): LexicalNode;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -369,7 +369,7 @@ declare export class LexicalNode {
     dom: HTMLElement,
     config: EditorConfig<EditorContext>,
   ): boolean;
-  remove(): void;
+  remove(preserveEmptyParent?: boolean): void;
   replace<N: LexicalNode>(replaceWith: N): N;
   insertAfter(nodeToInsert: LexicalNode): LexicalNode;
   insertBefore(nodeToInsert: LexicalNode): LexicalNode;

--- a/packages/lexical/src/LexicalNode.js
+++ b/packages/lexical/src/LexicalNode.js
@@ -46,6 +46,7 @@ export type NodeMap = Map<NodeKey, LexicalNode>;
 export function removeNode(
   nodeToRemove: LexicalNode,
   restoreSelection: boolean,
+  preserveEmptyParent?: boolean,
 ): void {
   errorOnReadOnly();
   const key = nodeToRemove.__key;
@@ -95,6 +96,7 @@ export function removeNode(
     $updateElementSelectionOnCreateDeleteNode(selection, parent, index, -1);
   }
   if (
+    !preserveEmptyParent &&
     parent !== null &&
     !$isRootNode(parent) &&
     !parent.canBeEmpty() &&
@@ -617,9 +619,9 @@ export class LexicalNode {
 
   // Setters and mutators
 
-  remove(): void {
+  remove(preserveEmptyParent?: boolean): void {
     errorOnReadOnly();
-    removeNode(this, true);
+    removeNode(this, true, preserveEmptyParent);
   }
 
   replace(replaceWith: LexicalNode): LexicalNode {


### PR DESCRIPTION
Will add a test, just wanted to write the explanation while it's fresh:

The root cause of this issue is that, in $wrapLeafNodesInElements, we call [$removeParentEmptyElements](https://github.com/facebook/lexical/blame/0e159ecb6bf4002777c91305312bd4182ff94391/packages/lexical-selection/src/index.js#L507) to try to remove all the nodes that are empty after their former leaves are appended to their new parents (the "elements" in "$wrapLeafNodesInElements"). This function tries to crawl up the tree, removing newly-empty nodes as it goes (uses getLatest to access the pending state).

The problem with this is that the implementation of LexicalNode.remove() actually [removes the parent under certain conditions](https://github.com/facebook/lexical/blob/main/packages/lexical/src/LexicalNode.js#L98-L104). So, as we're crawling up a nested structure, we remove a node, and it's parent also gets removed at the same time, which effectively short-circuits $removeParentEmptyElements, since it correctly detects that the latest version of the current node it's on doesn't have a parent anymore.

I tried a few ways to fix this. The next best one was probably trying to crawl up the tree without removing any nodes until we got to the highest empty one, then just removing that one and thereby removing all it's children. The issue became actually detecting emptiness in that case, since we're not removing as we go anymore, it gets harder to tell if a node is truly empty without recursively checking all of the siblings.

At the end, I decided that having removeNode also remove the parent in some cases, while convenient, is also not necessarily obvious or semantically correct behavior. It is probably usually the right thing to do, but shouldn't we have some low-level API for *just* removing a node without the side-effect of removing it's parent as well?

As a compromise, I introduced an optional flag to condition this behavior on.

Fixes #1128 