### PR TITLE
feat: image plugin take arbitrary url

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -14,7 +14,7 @@ import {
   focusEditor,
   html,
   initialize,
-  selectFromInsertDropdown,
+  insertRandomImage,
   test,
   waitForSelector,
 } from '../utils/index.mjs';
@@ -33,7 +33,7 @@ test.describe('Images', () => {
     test.skip(isPlainText);
     await focusEditor(page);
 
-    await selectFromInsertDropdown(page, '.image');
+    await insertRandomImage(page);
 
     await waitForSelector(page, '.editor-image img');
 
@@ -94,7 +94,7 @@ test.describe('Images', () => {
       focusPath: [0],
     });
 
-    await selectFromInsertDropdown(page, '.image');
+    await insertRandomImage(page);
 
     await click(page, '.editor-image img');
 
@@ -134,7 +134,7 @@ test.describe('Images', () => {
 
     await click(page, 'div[contenteditable="true"]');
 
-    await selectFromInsertDropdown(page, '.image');
+    await insertRandomImage(page);
 
     await waitForSelector(page, '.editor-image img');
 
@@ -190,9 +190,9 @@ test.describe('Images', () => {
 
     await focusEditor(page);
 
-    await selectFromInsertDropdown(page, '.image');
+    await insertRandomImage(page);
 
-    await selectFromInsertDropdown(page, '.image');
+    await insertRandomImage(page);
 
     await focusEditor(page);
     await page.keyboard.press('ArrowLeft');
@@ -271,8 +271,8 @@ test.describe('Images', () => {
     });
 
     await page.keyboard.type('Test');
-    await selectFromInsertDropdown(page, '.image');
-    await selectFromInsertDropdown(page, '.image');
+    await insertRandomImage(page);
+    await insertRandomImage(page);
 
     await focusEditor(page);
     await page.keyboard.press('ArrowLeft');

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -14,7 +14,7 @@ import {
   focusEditor,
   html,
   initialize,
-  insertRandomImage,
+  insertSampleImage,
   test,
   waitForSelector,
 } from '../utils/index.mjs';
@@ -33,7 +33,7 @@ test.describe('Images', () => {
     test.skip(isPlainText);
     await focusEditor(page);
 
-    await insertRandomImage(page);
+    await insertSampleImage(page);
 
     await waitForSelector(page, '.editor-image img');
 
@@ -94,7 +94,7 @@ test.describe('Images', () => {
       focusPath: [0],
     });
 
-    await insertRandomImage(page);
+    await insertSampleImage(page);
 
     await click(page, '.editor-image img');
 
@@ -134,7 +134,7 @@ test.describe('Images', () => {
 
     await click(page, 'div[contenteditable="true"]');
 
-    await insertRandomImage(page);
+    await insertSampleImage(page);
 
     await waitForSelector(page, '.editor-image img');
 
@@ -190,9 +190,9 @@ test.describe('Images', () => {
 
     await focusEditor(page);
 
-    await insertRandomImage(page);
+    await insertSampleImage(page);
 
-    await insertRandomImage(page);
+    await insertSampleImage(page);
 
     await focusEditor(page);
     await page.keyboard.press('ArrowLeft');
@@ -271,8 +271,8 @@ test.describe('Images', () => {
     });
 
     await page.keyboard.type('Test');
-    await insertRandomImage(page);
-    await insertRandomImage(page);
+    await insertSampleImage(page);
+    await insertSampleImage(page);
 
     await focusEditor(page);
     await page.keyboard.press('ArrowLeft');

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -529,7 +529,7 @@ export async function insertRandomImage(page) {
   await selectFromInsertDropdown(page, '.image');
   await click(
     page,
-    '.ToolbarPlugin__dialogImageActions > .Button__root >> nth=0',
+    '.ToolbarPlugin__dialogButtonsList > .Button__root >> nth=0',
   );
 }
 

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -525,6 +525,14 @@ export async function insertTable(page) {
   );
 }
 
+export async function insertRandomImage(page) {
+  await selectFromInsertDropdown(page, '.image');
+  await click(
+    page,
+    '.ToolbarPlugin__dialogImageActions > .Button__root >> nth=0',
+  );
+}
+
 export async function enableCompositionKeyEvents(page) {
   const targetPage = IS_COLLAB ? await page.frame('left') : page;
   await targetPage.evaluate(() => {

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -525,7 +525,7 @@ export async function insertTable(page) {
   );
 }
 
-export async function insertRandomImage(page) {
+export async function insertSampleImage(page) {
   await selectFromInsertDropdown(page, '.image');
   await click(
     page,

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -527,10 +527,7 @@ export async function insertTable(page) {
 
 export async function insertSampleImage(page) {
   await selectFromInsertDropdown(page, '.image');
-  await click(
-    page,
-    '.ToolbarPlugin__dialogButtonsList > .Button__root >> nth=0',
-  );
+  await click(page, 'button[data-test-id="image-modal-option-sample"]');
 }
 
 export async function enableCompositionKeyEvents(page) {

--- a/packages/lexical-playground/src/plugins/ImagesPlugin.js
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin.js
@@ -19,12 +19,11 @@ import {
 } from 'lexical';
 import {useEffect} from 'react';
 
-import yellowFlowerImage from '../images/yellow-flower.jpg';
 import {$createImageNode, ImageNode} from '../nodes/ImageNode';
 
 export const INSERT_IMAGE_COMMAND: LexicalCommand<{
-  altText?: string,
-  src?: string,
+  altText: string,
+  src: string,
 }> = createCommand();
 
 export default function ImagesPlugin(): React$Node {
@@ -43,11 +42,7 @@ export default function ImagesPlugin(): React$Node {
           if ($isRootNode(selection.anchor.getNode())) {
             selection.insertParagraph();
           }
-          const imageNode = $createImageNode(
-            payload?.src || yellowFlowerImage,
-            payload?.altText || 'Yellow flower in tilt shift lens',
-            500,
-          );
+          const imageNode = $createImageNode(payload.src, payload.altText, 500);
           selection.insertNodes([imageNode]);
         }
         return true;

--- a/packages/lexical-playground/src/plugins/ImagesPlugin.js
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin.js
@@ -22,7 +22,10 @@ import {useEffect} from 'react';
 import yellowFlowerImage from '../images/yellow-flower.jpg';
 import {$createImageNode, ImageNode} from '../nodes/ImageNode';
 
-export const INSERT_IMAGE_COMMAND: LexicalCommand<void> = createCommand();
+export const INSERT_IMAGE_COMMAND: LexicalCommand<{
+  altText?: string,
+  src?: string,
+}> = createCommand();
 
 export default function ImagesPlugin(): React$Node {
   const [editor] = useLexicalComposerContext();
@@ -34,15 +37,15 @@ export default function ImagesPlugin(): React$Node {
 
     return editor.registerCommand(
       INSERT_IMAGE_COMMAND,
-      () => {
+      (payload) => {
         const selection = $getSelection();
         if ($isRangeSelection(selection)) {
           if ($isRootNode(selection.anchor.getNode())) {
             selection.insertParagraph();
           }
           const imageNode = $createImageNode(
-            yellowFlowerImage,
-            'Yellow flower in tilt shift lens',
+            payload?.src || yellowFlowerImage,
+            payload?.altText || 'Yellow flower in tilt shift lens',
             500,
           );
           selection.insertNodes([imageNode]);

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.css
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.css
@@ -12,3 +12,14 @@
   justify-content: right;
   margin-top: 20px;
 }
+
+.ToolbarPlugin__dialogImageActions {
+  display: flex;
+  flex-direction: column;
+  justify-content: right;
+  margin-top: 20px;
+}
+
+.ToolbarPlugin__dialogImageActions button {
+  margin-bottom: 20px;
+}

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.css
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.css
@@ -13,13 +13,13 @@
   margin-top: 20px;
 }
 
-.ToolbarPlugin__dialogImageActions {
+.ToolbarPlugin__dialogButtonsList {
   display: flex;
   flex-direction: column;
   justify-content: right;
   margin-top: 20px;
 }
 
-.ToolbarPlugin__dialogImageActions button {
+.ToolbarPlugin__dialogButtonsList button {
   margin-bottom: 20px;
 }

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -9,6 +9,8 @@
 
 import type {LexicalEditor, RangeSelection} from 'lexical';
 
+import './ToolbarPlugin.css';
+
 import {
   $createCodeNode,
   $isCodeNode,
@@ -270,6 +272,53 @@ function FloatingLinkEditor({editor}: {editor: LexicalEditor}): React$Node {
         </>
       )}
     </div>
+  );
+}
+
+function InsertImageDialog({
+  activeEditor,
+  onClose,
+}: {
+  activeEditor: LexicalEditor,
+  onClose: () => void,
+}): React$Node {
+  const [text, setText] = useState('');
+  const [mode, setMode] = useState<'url' | 'file' | ''>('');
+
+  const onClick = (payload) => () => {
+    activeEditor.dispatchCommand(INSERT_IMAGE_COMMAND, payload);
+    onClose();
+  };
+
+  const isDisabled = text === '';
+
+  return (
+    <>
+      {!mode && (
+        <div className="ToolbarPlugin__dialogImageActions">
+          <Button onClick={onClick()}>Sample</Button>
+          <Button onClick={() => setMode('url')}>URL</Button>
+          <Button disabled={true} onClick={() => setMode('file')}>
+            File
+          </Button>
+        </div>
+      )}
+      {mode === 'url' && (
+        <>
+          <Input
+            label="Image URL"
+            placeholder="i.e. https://source.unsplash.com/random"
+            onChange={setText}
+            value={text}
+          />
+          <div className="ToolbarPlugin__dialogActions">
+            <Button disabled={isDisabled} onClick={onClick({src: text})}>
+              Confirm
+            </Button>
+          </div>
+        </>
+      )}
+    </>
   );
 }
 
@@ -916,7 +965,13 @@ export default function ToolbarPlugin(): React$Node {
             </button>
             <button
               onClick={() => {
-                activeEditor.dispatchCommand(INSERT_IMAGE_COMMAND);
+                // activeEditor.dispatchCommand(INSERT_IMAGE_COMMAND);
+                showModal('Insert Image', (onClose) => (
+                  <InsertImageDialog
+                    activeEditor={activeEditor}
+                    onClose={onClose}
+                  />
+                ));
               }}
               className="item">
               <i className="icon image" />

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -328,6 +328,7 @@ function InsertImageDialog({
       {!mode && (
         <div className="ToolbarPlugin__dialogButtonsList">
           <Button
+            data-test-id="image-modal-option-sample"
             onClick={() =>
               onClick({
                 altText: 'Yellow flower in tilt shift lens',
@@ -336,7 +337,11 @@ function InsertImageDialog({
             }>
             Sample
           </Button>
-          <Button onClick={() => setMode('url')}>URL</Button>
+          <Button
+            data-test-id="image-modal-option-url"
+            onClick={() => setMode('url')}>
+            URL
+          </Button>
         </div>
       )}
       {mode === 'url' && <InsertImageUriDialogBody onClick={onClick} />}

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -295,7 +295,7 @@ function InsertImageDialog({
   return (
     <>
       {!mode && (
-        <div className="ToolbarPlugin__dialogImageActions">
+        <div className="ToolbarPlugin__dialogButtonsList">
           <Button onClick={onClick()}>Sample</Button>
           <Button onClick={() => setMode('url')}>URL</Button>
           <Button disabled={true} onClick={() => setMode('file')}>

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -67,6 +67,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 
 import useModal from '../hooks/useModal';
+import yellowFlowerImage from '../images/yellow-flower.jpg';
 import {$createStickyNode} from '../nodes/StickyNode';
 import Button from '../ui/Button';
 import DropDown from '../ui/DropDown';
@@ -275,6 +276,39 @@ function FloatingLinkEditor({editor}: {editor: LexicalEditor}): React$Node {
   );
 }
 
+function InsertImageUriDialogBody({
+  onClick,
+}: {
+  onClick: (payload: {altText: string, src: string}) => void,
+}) {
+  const [src, setSrc] = useState('');
+  const [altText, setAltText] = useState('');
+
+  const isDisabled = src === '';
+
+  return (
+    <>
+      <Input
+        label="Image URL"
+        placeholder="i.e. https://source.unsplash.com/random"
+        onChange={setSrc}
+        value={src}
+      />
+      <Input
+        label="Alt Text"
+        placeholder="Random unsplash image"
+        onChange={setAltText}
+        value={altText}
+      />
+      <div className="ToolbarPlugin__dialogActions">
+        <Button disabled={isDisabled} onClick={() => onClick({altText, src})}>
+          Confirm
+        </Button>
+      </div>
+    </>
+  );
+}
+
 function InsertImageDialog({
   activeEditor,
   onClose,
@@ -282,42 +316,30 @@ function InsertImageDialog({
   activeEditor: LexicalEditor,
   onClose: () => void,
 }): React$Node {
-  const [text, setText] = useState('');
-  const [mode, setMode] = useState<'url' | 'file' | ''>('');
+  const [mode, setMode] = useState<null | 'url' | 'file'>(null);
 
-  const onClick = (payload) => () => {
+  const onClick = (payload: {altText: string, src: string}) => {
     activeEditor.dispatchCommand(INSERT_IMAGE_COMMAND, payload);
     onClose();
   };
-
-  const isDisabled = text === '';
 
   return (
     <>
       {!mode && (
         <div className="ToolbarPlugin__dialogButtonsList">
-          <Button onClick={onClick()}>Sample</Button>
-          <Button onClick={() => setMode('url')}>URL</Button>
-          <Button disabled={true} onClick={() => setMode('file')}>
-            File
+          <Button
+            onClick={() =>
+              onClick({
+                altText: 'Yellow flower in tilt shift lens',
+                src: yellowFlowerImage,
+              })
+            }>
+            Sample
           </Button>
+          <Button onClick={() => setMode('url')}>URL</Button>
         </div>
       )}
-      {mode === 'url' && (
-        <>
-          <Input
-            label="Image URL"
-            placeholder="i.e. https://source.unsplash.com/random"
-            onChange={setText}
-            value={text}
-          />
-          <div className="ToolbarPlugin__dialogActions">
-            <Button disabled={isDisabled} onClick={onClick({src: text})}>
-              Confirm
-            </Button>
-          </div>
-        </>
-      )}
+      {mode === 'url' && <InsertImageUriDialogBody onClick={onClick} />}
     </>
   );
 }
@@ -965,7 +987,6 @@ export default function ToolbarPlugin(): React$Node {
             </button>
             <button
               onClick={() => {
-                // activeEditor.dispatchCommand(INSERT_IMAGE_COMMAND);
                 showModal('Insert Image', (onClose) => (
                   <InsertImageDialog
                     activeEditor={activeEditor}

--- a/packages/lexical-playground/src/ui/Button.jsx
+++ b/packages/lexical-playground/src/ui/Button.jsx
@@ -14,11 +14,13 @@ import * as React from 'react';
 import joinClasses from '../utils/join-classes';
 
 export default function Button({
+  'data-test-id': dataTestId,
   children,
   onClick,
   disabled,
   small,
 }: {
+  'data-test-id'?: string,
   children: React$Node,
   disabled?: boolean,
   onClick: () => void,
@@ -33,7 +35,7 @@ export default function Button({
         small && 'Button__small',
       )}
       onClick={onClick}
-    >
+      {...(dataTestId && {'data-test-id': dataTestId})}>
       {children}
     </button>
   );


### PR DESCRIPTION
### Description

Added modal for image plugin to allow option to add custom URI and files. 

~~File button is disabled, to be implemented later (or should I do it in this PR too?).~~
Upload file feature to be implemented in another PR.

part of #1799

### Screenshots
![image](https://user-images.githubusercontent.com/97230812/163712043-dcce90ad-069a-4cce-853e-393986bc67db.png)

![image](https://user-images.githubusercontent.com/97230812/163711298-495a6aee-5b17-46e7-ab8b-074b51868426.png)

![image](https://user-images.githubusercontent.com/97230812/163708487-33308754-5c89-4100-b4a7-e34b4d231d39.png)

### Issues

Encountered a few issues, not sure if should be addressed in this PR.

1. Image cannot be added if current selection is null.
2. Random image added using https://source.unsplash.com/random are cached by `useSuspenseImage`. 