### PR TITLE
fix: Toolbar e2e test fail on adding image

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
@@ -16,6 +16,7 @@ import {
   focusEditor,
   html,
   initialize,
+  insertSampleImage,
   selectFromAlignDropdown,
   selectFromInsertDropdown,
   test,
@@ -36,7 +37,7 @@ test.describe('Toolbar', () => {
     await focusEditor(page);
 
     // Add caption
-    await selectFromInsertDropdown(page, '.image');
+    await insertSampleImage(page);
     await click(page, '.editor-image img');
     await click(page, '.image-caption-button');
     await focus(page, '.ImageNode__contentEditable');
@@ -199,7 +200,7 @@ test.describe('Toolbar', () => {
     test.skip(isPlainText);
     await focusEditor(page);
 
-    await selectFromInsertDropdown(page, '.image');
+    await insertSampleImage(page);
     await click(page, '.editor-image img');
     await assertHTML(
       page,


### PR DESCRIPTION
Broke e2e test Toolbar in #1817, modified test to use `insertSampleImage` to add images.
(my bad)
