### PR TITLE
Type Fix: export "registerDragonSupport" as named not default.

### DIFF
--- a/packages/lexical-dragon/LexicalDragon.d.ts
+++ b/packages/lexical-dragon/LexicalDragon.d.ts
@@ -8,6 +8,6 @@
 
 import type {LexicalEditor} from 'lexical';
 
-export default function registerDragonSupport(
+export function registerDragonSupport(
   editor: LexicalEditor,
 ): () => void;


### PR DESCRIPTION
"registerDragonSupport" is a named export but the type declaration file for dragon lists it as a default export.