### PR TITLE
Adds disabled state css for action items

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1038,6 +1038,11 @@ i.chevron-down {
 .action-button-mic.active {
   animation: mic-pulsate-color 3s infinite;
 }
+button.action-button:disabled {
+  opacity: 0.6;
+  background: #eee;
+  cursor: not-allowed;
+}
 
 @keyframes mic-pulsate-color {
   0% {


### PR DESCRIPTION
Although the button was disabled it was kinda not very different from other buttons. So this might actually be better
Before: 
<img width="1011" alt="Screenshot 2022-04-18 at 1 38 36 PM" src="https://user-images.githubusercontent.com/32865581/163777973-27c66c30-ca4a-4a65-812d-a171c78c9784.png">

After: 
<img width="1004" alt="Screenshot 2022-04-18 at 1 38 53 PM" src="https://user-images.githubusercontent.com/32865581/163778038-113868b5-1f9e-4cb0-99e4-156d43f6f563.png">

