### PR TITLE
Open a confirm modal on discard excalidraw

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.css
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.css
@@ -41,3 +41,7 @@
   align-items: center;
   background-color: #eee;
 }
+.ExcalidrawModal__discardModal {
+  margin-top: 20px;
+  text-align: center;
+}

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.jsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.jsx
@@ -15,6 +15,9 @@ import Excalidraw from '@excalidraw/excalidraw';
 import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
 
+import Button from '../../ui/Button';
+import Modal from '../../ui/Modal';
+
 type ExcalidrawElementFragment = {
   isDeleted?: boolean,
 };
@@ -55,6 +58,7 @@ export default function ExcalidrawModal({
   onDelete,
 }: Props): React.MixedElement | null {
   const excalidrawRef = useRef(null);
+  const [discardModalOpen, setDiscardModalOpen] = useState(false);
   const [elements, setElements] =
     useState<$ReadOnlyArray<ExcalidrawElementFragment>>(initialElements);
 
@@ -72,9 +76,38 @@ export default function ExcalidrawModal({
     if (elements.filter((el) => !el.isDeleted).length === 0) {
       // delete node if the scene is clear
       onDelete();
+    } else {
+      //Otherwise, show confirmation dialog before closing
+      setDiscardModalOpen(true);
     }
-    onHide();
   };
+
+  function ShowDiscardDialog(): React$Node {
+    return (
+      <Modal
+        title="Discard"
+        onClose={() => {
+          setDiscardModalOpen(false);
+        }}>
+        Are you sure you want to discard the changes?
+        <div className="ExcalidrawModal__discardModal">
+          <Button
+            onClick={() => {
+              setDiscardModalOpen(false);
+              onHide();
+            }}>
+            Discard
+          </Button>{' '}
+          <Button
+            onClick={() => {
+              setDiscardModalOpen(false);
+            }}>
+            Cancel
+          </Button>
+        </div>
+      </Modal>
+    );
+  }
 
   useEffect(() => {
     excalidrawRef?.current?.updateScene({elements: initialElements});
@@ -97,6 +130,7 @@ export default function ExcalidrawModal({
   return (
     <div className="ExcalidrawModal__modal">
       <div className="ExcalidrawModal__row">
+        {discardModalOpen && <ShowDiscardDialog />}
         <_Excalidraw
           onChange={onChange}
           initialData={{


### PR DESCRIPTION
Addresses #1811 

![image](https://user-images.githubusercontent.com/3740777/163814436-3f71e0cb-0f69-4c05-9523-45def402f8e9.png)

Modal does not appear in case you didin't make any change in excalidraw, it appears only in case there is something created with this tool.