### PR TITLE
Fix collab selections possibly doubling up when spanning text nodes

### DIFF
--- a/packages/lexical-yjs/src/SyncCursors.js
+++ b/packages/lexical-yjs/src/SyncCursors.js
@@ -296,7 +296,6 @@ function updateCursor(
         prevRect.top === selectionRect.top &&
         prevRect.left === selectionRect.left &&
         prevRect.width === selectionRect.width &&
-        prevRect.height === selectionRect.height &&
         prevRect.height === selectionRect.height
       ) {
         selectionRects.splice(i--, 1);

--- a/packages/lexical-yjs/src/SyncCursors.js
+++ b/packages/lexical-yjs/src/SyncCursors.js
@@ -283,6 +283,8 @@ function updateCursor(
   let selectionRectsLength = selectionRects.length;
   const selectionsLength = selections.length;
 
+  let prevRect;
+
   for (let i = 0; i < selectionRectsLength; i++) {
     const selectionRect = selectionRects[i];
 
@@ -290,26 +292,25 @@ function updateCursor(
     // the same rect twice for some elements. A more sophisticated thing to do here is to
     // merge all the rects together into a set of rects that don't overlap, so we don't
     // generate backgrounds that are too dark.
-    if (i > 0) {
-      const prevRect = selectionRects[i - 1];
-      if (
-        prevRect.top === selectionRect.top &&
-        prevRect.left === selectionRect.left &&
-        prevRect.width === selectionRect.width &&
-        prevRect.height === selectionRect.height
-      ) {
-        selectionRects.splice(i--, 1);
-        selectionRectsLength--;
-        continue;
-      }
-    }
+    const isDuplicateRect =
+      prevRect &&
+      prevRect.top === selectionRect.top &&
+      prevRect.left === selectionRect.left &&
+      prevRect.width === selectionRect.width &&
+      prevRect.height === selectionRect.height;
 
-    if (selectionRect.width + rootPadding === rootRect.width) {
-      // Exclude selections that span the entire element
+    // Exclude selections that span the entire element
+    const selectionSpansElement =
+      selectionRect.width + rootPadding === rootRect.width;
+
+    if (isDuplicateRect || selectionSpansElement) {
       selectionRects.splice(i--, 1);
       selectionRectsLength--;
       continue;
     }
+
+    prevRect = selectionRect;
+
     let selection = selections[i];
     if (selection === undefined) {
       selection = document.createElement('span');

--- a/packages/lexical-yjs/src/SyncCursors.js
+++ b/packages/lexical-yjs/src/SyncCursors.js
@@ -285,6 +285,26 @@ function updateCursor(
 
   for (let i = 0; i < selectionRectsLength; i++) {
     const selectionRect = selectionRects[i];
+
+    // Exclude a rect that is the exact same as the last rect. getClientRects() can return
+    // the same rect twice for some elements. A more sophisticated thing to do here is to
+    // merge all the rects together into a set of rects that don't overlap, so we don't
+    // generate backgrounds that are too dark.
+    if (i > 0) {
+      const prevRect = selectionRects[i - 1];
+      if (
+        prevRect.top === selectionRect.top &&
+        prevRect.left === selectionRect.left &&
+        prevRect.width === selectionRect.width &&
+        prevRect.height === selectionRect.height &&
+        prevRect.height === selectionRect.height
+      ) {
+        selectionRects.splice(i--, 1);
+        selectionRectsLength--;
+        continue;
+      }
+    }
+
     if (selectionRect.width + rootPadding === rootRect.width) {
       // Exclude selections that span the entire element
       selectionRects.splice(i--, 1);


### PR DESCRIPTION
I noticed while playing with collaboration that if a user highlighted multiple adjacent text blocks, then the remote user would see blocks in the middle double-highlighted. (See screenshot). This turned out to be because the DOM function `getClientRects()` can return multiple identical rects for some elements. The fix is just to ignore duplicate rects.

<img width="768" alt="Screen Shot 2022-04-18 at 10 07 08 AM" src="https://user-images.githubusercontent.com/4167/163867525-9ffdcebc-336d-4bfd-9b41-f80b5ce58e54.png">