### PR TITLE
Add KEY_MODIFIER_COMMAND

### DIFF
--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -36,6 +36,7 @@ export var KEY_BACKSPACE_COMMAND: LexicalCommand<KeyboardEvent>;
 export var KEY_ESCAPE_COMMAND: LexicalCommand<KeyboardEvent>;
 export var KEY_DELETE_COMMAND: LexicalCommand<KeyboardEvent>;
 export var KEY_TAB_COMMAND: LexicalCommand<KeyboardEvent>;
+export var KEY_MODIFIER_COMMAND: LexicalCommand<KeyboardEvent>;
 export var INDENT_CONTENT_COMMAND: LexicalCommand<void>;
 export var OUTDENT_CONTENT_COMMAND: LexicalCommand<void>;
 export var DROP_COMMAND: LexicalCommand<DragEvent>;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -35,6 +35,7 @@ declare export var KEY_BACKSPACE_COMMAND: LexicalCommand<KeyboardEvent>;
 declare export var KEY_ESCAPE_COMMAND: LexicalCommand<KeyboardEvent>;
 declare export var KEY_DELETE_COMMAND: LexicalCommand<KeyboardEvent>;
 declare export var KEY_TAB_COMMAND: LexicalCommand<KeyboardEvent>;
+declare export var KEY_MODIFIER_COMMAND: LexicalCommand<KeyboardEvent>;
 declare export var INDENT_CONTENT_COMMAND: LexicalCommand<void>;
 declare export var OUTDENT_CONTENT_COMMAND: LexicalCommand<void>;
 declare export var DROP_COMMAND: LexicalCommand<DragEvent>;

--- a/packages/lexical/src/LexicalCommands.js
+++ b/packages/lexical/src/LexicalCommands.js
@@ -61,3 +61,5 @@ export const CAN_REDO_COMMAND: LexicalCommand<boolean> = createCommand();
 export const CAN_UNDO_COMMAND: LexicalCommand<boolean> = createCommand();
 export const FOCUS_COMMAND: LexicalCommand<FocusEvent> = createCommand();
 export const BLUR_COMMAND: LexicalCommand<FocusEvent> = createCommand();
+export const KEY_MODIFIER_COMMAND: LexicalCommand<KeyboardEvent> =
+  createCommand();

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -52,6 +52,7 @@ import {
   SELECTION_CHANGE_COMMAND,
   UNDO_COMMAND,
 } from '.';
+import {KEY_MODIFIER_COMMAND} from './LexicalCommands';
 import {DOM_TEXT_TYPE} from './LexicalConstants';
 import {updateEditor} from './LexicalUpdates';
 import {
@@ -79,6 +80,7 @@ import {
   isFirefoxClipboardEvents,
   isItalic,
   isLineBreak,
+  isModifier,
   isMoveBackward,
   isMoveDown,
   isMoveForward,
@@ -599,6 +601,10 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
   } else if (isRedo(keyCode, shiftKey, metaKey, ctrlKey)) {
     event.preventDefault();
     dispatchCommand(editor, REDO_COMMAND);
+  }
+
+  if (isModifier(ctrlKey, shiftKey, altKey, metaKey)) {
+    dispatchCommand(editor, KEY_MODIFIER_COMMAND, event);
   }
 }
 

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -839,6 +839,15 @@ export function isMoveDown(
   return isArrowDown(keyCode) && !ctrlKey && !metaKey;
 }
 
+export function isModifier(
+  ctrlKey: boolean,
+  shiftKey: boolean,
+  altKey: boolean,
+  metaKey: boolean,
+): boolean {
+  return ctrlKey || shiftKey || altKey || metaKey;
+}
+
 export function controlOrMeta(metaKey: boolean, ctrlKey: boolean): boolean {
   if (IS_APPLE) {
     return metaKey;


### PR DESCRIPTION
Adding a command that will be dispatched on keyDown with any of the modifier keys (cmd/ctr/shift/alt) which will simplify adding editor shortcuts (and help getting rid of root listener)
