### PR TITLE
Avoid preventDefault on pressing enter

### DIFF
--- a/packages/lexical-plain-text/src/index.js
+++ b/packages/lexical-plain-text/src/index.js
@@ -42,6 +42,7 @@ import {
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
 } from 'lexical';
+import {IS_IOS} from 'shared/environment';
 
 export type InitialEditorStateType = null | string | EditorState | (() => void);
 
@@ -310,6 +311,13 @@ export function registerPlainText(
           return false;
         }
         if (event !== null) {
+          // If we have beforeinput, then we can avoid blocking
+          // the default behavior. This ensures that the iOS can
+          // intercept that we're actually inserting a paragraph,
+          // and autocomplete, autocapitialize etc work as intended.
+          if (IS_IOS) {
+            return false;
+          }
           event.preventDefault();
         }
         return editor.dispatchCommand(INSERT_LINE_BREAK_COMMAND);

--- a/packages/lexical-rich-text/src/index.js
+++ b/packages/lexical-rich-text/src/index.js
@@ -68,6 +68,7 @@ import {
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
 } from 'lexical';
+import {CAN_USE_BEFORE_INPUT} from 'shared/environment';
 
 export type InitialEditorStateType = null | string | EditorState | (() => void);
 
@@ -605,6 +606,13 @@ export function registerRichText(
           return false;
         }
         if (event !== null) {
+          // If we have beforeinput, then we can avoid blocking
+          // the default behavior. This ensures that the browser/OS
+          // can intercept that we're actually inserting a paragraph,
+          // and autocomplete, autocapitialize etc work as intended.
+          if (CAN_USE_BEFORE_INPUT) {
+            return false;
+          }
           event.preventDefault();
           if (event.shiftKey) {
             return editor.dispatchCommand(INSERT_LINE_BREAK_COMMAND);

--- a/packages/lexical-rich-text/src/index.js
+++ b/packages/lexical-rich-text/src/index.js
@@ -68,7 +68,7 @@ import {
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
 } from 'lexical';
-import {CAN_USE_BEFORE_INPUT} from 'shared/environment';
+import {IS_IOS} from 'shared/environment';
 
 export type InitialEditorStateType = null | string | EditorState | (() => void);
 
@@ -607,10 +607,10 @@ export function registerRichText(
         }
         if (event !== null) {
           // If we have beforeinput, then we can avoid blocking
-          // the default behavior. This ensures that the browser/OS
-          // can intercept that we're actually inserting a paragraph,
+          // the default behavior. This ensures that the iOS can
+          // intercept that we're actually inserting a paragraph,
           // and autocomplete, autocapitialize etc work as intended.
-          if (CAN_USE_BEFORE_INPUT) {
+          if (IS_IOS) {
             return false;
           }
           event.preventDefault();


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/1849 and fixes https://github.com/facebook/lexical/issues/1846.

If we have support for `beforeinput`, we can use that event for signal rather than blocking the return/enter key press via `preventDefault()`. This allows iOS to function better – although it's a bit strange how this is the only platform that suffers from this issue :P