### PR TITLE
Excalidraw fixes

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.jsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.jsx
@@ -49,6 +49,16 @@ type Props = {
 // We don't want them to be used in open source
 const removeStyleFromSvg_HACK = (svg) => {
   const styleTag = svg?.firstElementChild?.firstElementChild;
+
+  // Generated SVG is getting double-sized by height and width attributes
+  // We want to match the real size of the SVG element
+  const viewBox = svg.getAttribute('viewBox');
+  if (viewBox != null) {
+    const viewBoxDimentions = viewBox.split(' ');
+    svg.setAttribute('width', viewBoxDimentions[2]);
+    svg.setAttribute('height', viewBoxDimentions[3]);
+  }
+
   if (styleTag && styleTag.tagName === 'style') {
     styleTag.remove();
   }

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.css
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.css
@@ -32,8 +32,8 @@
 }
 .ExcalidrawModal__modal {
   position: fixed;
-  z-index: 2;
-  top: 10px;
+  z-index: 10;
+  top: 50px;
   width: 100%;
   left: 0;
   display: flex;
@@ -42,6 +42,6 @@
   background-color: #eee;
 }
 .ExcalidrawModal__discardModal {
-  margin-top: 20px;
+  margin-top: 60px;
   text-align: center;
 }

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.jsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.jsx
@@ -14,11 +14,13 @@ import './ExcalidrawModal.css';
 import Excalidraw from '@excalidraw/excalidraw';
 import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
+// $FlowFixMe: Flow doesn't see react-dom module
+import {createPortal} from 'react-dom';
 
 import Button from '../../ui/Button';
 import Modal from '../../ui/Modal';
 
-type ExcalidrawElementFragment = {
+export type ExcalidrawElementFragment = {
   isDeleted?: boolean,
 };
 
@@ -56,7 +58,7 @@ export default function ExcalidrawModal({
   isShown = false,
   onHide,
   onDelete,
-}: Props): React.MixedElement | null {
+}: Props): React.Portal | null {
   const excalidrawRef = useRef(null);
   const [discardModalOpen, setDiscardModalOpen] = useState(false);
   const [elements, setElements] =
@@ -127,7 +129,7 @@ export default function ExcalidrawModal({
   const _Excalidraw =
     Excalidraw.$$typeof != null ? Excalidraw : Excalidraw.default;
 
-  return (
+  return createPortal(
     <div className="ExcalidrawModal__modal">
       <div className="ExcalidrawModal__row">
         {discardModalOpen && <ShowDiscardDialog />}
@@ -147,6 +149,7 @@ export default function ExcalidrawModal({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.jsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.jsx
@@ -37,9 +37,8 @@ function ExcalidrawComponent({
   nodeKey: NodeKey,
 }): React.Node {
   const [editor] = useLexicalComposerContext();
-  const shouldModalOpenInitially = data === '[]' && !editor.isReadOnly();
   const [isModalOpen, setModalOpen] = useState<boolean>(
-    shouldModalOpenInitially,
+    data === '[]' && !editor.isReadOnly(),
   );
   const buttonRef = useRef<HTMLElement | null>(null);
   const [isSelected, setSelected, clearSelection] =

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.jsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.jsx
@@ -7,6 +7,7 @@
  * @flow strict
  */
 
+import type {ExcalidrawElementFragment} from './ExcalidrawModal';
 import type {EditorConfig, LexicalEditor, LexicalNode, NodeKey} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -35,8 +36,11 @@ function ExcalidrawComponent({
   data: string,
   nodeKey: NodeKey,
 }): React.Node {
-  const [isModalOpen, setModalOpen] = useState<boolean>(data === '[]');
   const [editor] = useLexicalComposerContext();
+  const shouldModalOpenInitially = data === '[]' && !editor.isReadOnly();
+  const [isModalOpen, setModalOpen] = useState<boolean>(
+    shouldModalOpenInitially,
+  );
   const buttonRef = useRef<HTMLElement | null>(null);
   const [isSelected, setSelected, clearSelection] =
     useLexicalNodeSelection(nodeKey);
@@ -58,6 +62,13 @@ function ExcalidrawComponent({
     },
     [editor, isSelected, nodeKey, setSelected],
   );
+
+  // Set editor to readOnly if excalidraw is open to prevent unwanted changes
+  useEffect(() => {
+    if (isModalOpen) {
+      editor.setReadOnly(true);
+    }
+  }, [isModalOpen, editor]);
 
   useEffect(() => {
     return mergeRegister(
@@ -105,11 +116,18 @@ function ExcalidrawComponent({
   }, [editor, nodeKey]);
 
   const setData = useCallback(
-    (newData: string) => {
+    (newData: $ReadOnlyArray<ExcalidrawElementFragment>) => {
+      if (editor.isReadOnly()) {
+        return;
+      }
       return editor.update(() => {
         const node = $getNodeByKey(nodeKey);
         if ($isExcalidrawNode(node)) {
-          node.setData(newData);
+          if (newData.length > 0) {
+            node.setData(JSON.stringify(newData));
+          } else {
+            node.remove();
+          }
         }
       });
     },
@@ -124,9 +142,13 @@ function ExcalidrawComponent({
         initialElements={elements}
         isShown={isModalOpen}
         onDelete={deleteNode}
-        onHide={() => setModalOpen(false)}
+        onHide={() => {
+          editor.setReadOnly(false);
+          setModalOpen(false);
+        }}
         onSave={(newData) => {
-          setData(JSON.stringify(newData));
+          editor.setReadOnly(false);
+          setData(newData);
           setModalOpen(false);
         }}
       />


### PR DESCRIPTION
- Set readOnly mode when Excalidraw is open to avoid unnecessary updates
- Move Excalidraw Modal to a portal to avoid interacting with Lexical and other wrappers event listeneners
- Fix Excalidraw image size
- Remove Excalidraw Node if the content of the saved drawing is empty