### PR TITLE
fix: missing types in LexicalCode

### DIFF
--- a/packages/lexical-code/LexicalCode.d.ts
+++ b/packages/lexical-code/LexicalCode.d.ts
@@ -44,6 +44,9 @@ declare function getLastCodeHighlightNodeOfLine(
   anchor: LexicalNode,
 ): null | undefined | CodeHighlightNode;
 
+declare function getDefaultCodeLanguage(): string;
+declare function getCodeLanguages(): Array<string>;
+
 declare class CodeHighlightNode extends TextNode {
   __highlightType: null | undefined | string;
   constructor(text: string, highlightType?: string, key?: NodeKey);

--- a/packages/lexical-code/flow/LexicalCode.js.flow
+++ b/packages/lexical-code/flow/LexicalCode.js.flow
@@ -46,6 +46,9 @@ declare export function getLastCodeHighlightNodeOfLine(
   anchor: LexicalNode,
 ): ?CodeHighlightNode;
 
+declare export function getDefaultCodeLanguage(): string;
+declare export function getCodeLanguages(): Array<string>;
+
 declare export class CodeHighlightNode extends TextNode {
   __highlightType: ?string;
   constructor(text: string, highlightType?: string, key?: NodeKey): void;


### PR DESCRIPTION
Adds types of `getCodeLanguages` and `getDefaultCodeLanguage` in `@lexical/code`