### PR TITLE
Remove HorizontalRuleNode from lexical types

### DIFF
--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -716,21 +716,6 @@ export declare class DecoratorNode<X> extends LexicalNode {
 export function $isDecoratorNode(node: LexicalNode | null | undefined): boolean;
 
 /**
- * LexicalHorizontalRuleNode
- */
-export declare class HorizontalRuleNode extends LexicalNode {
-  static getType(): string;
-  static clone(node: HorizontalRuleNode): HorizontalRuleNode;
-  constructor(key?: NodeKey);
-  createDOM(): HTMLElement;
-  updateDOM(): false;
-}
-export function $createHorizontalRuleNode(): HorizontalRuleNode;
-export function $isHorizontalRuleNode(
-  node: LexicalNode | null | undefined,
-): boolean;
-
-/**
  * LexicalParagraphNode
  */
 export declare class ParagraphNode extends ElementNode {

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -769,19 +769,6 @@ declare export function $isDecoratorNode(
 ): boolean %checks(node instanceof DecoratorNode);
 
 /**
- * LexicalHorizontalRuleNode
- */
-declare export class HorizontalRuleNode extends LexicalNode {
-  static getType(): string;
-  static clone(node: HorizontalRuleNode): HorizontalRuleNode;
-  constructor(key?: NodeKey): void;
-  createDOM(): HTMLElement;
-  updateDOM(): false;
-}
-declare export function $createHorizontalRuleNode(): HorizontalRuleNode;
-declare export function $isHorizontalRuleNode(node: ?LexicalNode): boolean;
-
-/**
  * LexicalParagraphNode
  */
 declare export class ParagraphNode extends ElementNode {


### PR DESCRIPTION
Removes `HorizontalRuleNode` and associated functions from `lexical` as these exports are not present in `lexical`.