### PR TITLE
@lexical/link: Fix missing import in LexicalLink.d.ts

### DIFF
--- a/packages/lexical-link/LexicalLink.d.ts
+++ b/packages/lexical-link/LexicalLink.d.ts
@@ -15,6 +15,7 @@ import type {
   RangeSelection,
   LexicalCommand,
 } from 'lexical';
+import {ElementNode} from 'lexical';
 
 export declare class LinkNode extends ElementNode {
   __url: string;


### PR DESCRIPTION
Fixes missing `ElementNode` import in `LexicalLink.d.ts`