### PR TITLE
fix: incorrect import in lexical-rich-text types

### DIFF
--- a/packages/lexical-rich-text/LexicalRichText.d.ts
+++ b/packages/lexical-rich-text/LexicalRichText.d.ts
@@ -12,7 +12,7 @@ import type {
   LexicalNode,
   NodeKey,
   ParagraphNode,
-  HeadingNode,
+  LexicalEditor,
 } from 'lexical';
 import {ElementNode} from 'lexical';
 


### PR DESCRIPTION
replaces `HeadingNode` import to `LexicalEditor`

Reference https://github.com/facebook/lexical/blob/main/packages/lexical-rich-text/flow/LexicalRichText.js.flow#L16