### PR TITLE
docs : fix code typo in quick-start

### DIFF
--- a/packages/lexical-website-new/docs/getting-started/quick-start.md
+++ b/packages/lexical-website-new/docs/getting-started/quick-start.md
@@ -77,7 +77,7 @@ based on the changes from the update.
 Here's an example of how you can update an editor instance:
 
 ```js
-import {$getRoot, $getSelection, $createParagraphNode} from 'lexical';
+import {$getRoot, $getSelection, $createParagraphNode, $createTextNode} from 'lexical';
 
 // Inside the `editor.update` you can use special $ prefixed helper functions.
 // These functions cannot be used outside the closure, and will error if you try.


### PR DESCRIPTION
add $createTextNode in import code example.