### PR TITLE
add default error handler in createEditor config

### DIFF
--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -253,7 +253,7 @@ export function createEditor<EditorContext>(editorConfig?: {
     ParagraphNode,
     ...(config.nodes || []),
   ];
-  const onError = config.onError;
+  const onError = config.onError || console.warn;
   const isReadOnly = config.readOnly || false;
 
   const registeredNodes = new Map();


### PR DESCRIPTION
add default error handler when user don't put onError in createEditor config.