### PR TITLE
Add missing type to DecoratorNode

### DIFF
--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -711,6 +711,7 @@ export declare class DecoratorNode<X> extends LexicalNode {
   constructor(key?: NodeKey);
   decorate(editor: LexicalEditor): X;
   isIsolated(): boolean;
+  isTopLevel(): boolean;
 }
 export function $isDecoratorNode(node: LexicalNode | null | undefined): boolean;
 

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -762,6 +762,7 @@ declare export class DecoratorNode<X> extends LexicalNode {
   constructor(key?: NodeKey): void;
   decorate(editor: LexicalEditor): X;
   isIsolated(): boolean;
+  isTopLevel(): boolean;
 }
 declare export function $isDecoratorNode(
   node: ?LexicalNode,


### PR DESCRIPTION
Type missing from DecoratorNode `isTopLevel`. 