### PR TITLE
Do not reconcile selection during readOnly

### DIFF
--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -735,6 +735,7 @@ export function updateEditorState(
 
   const domSelection = getDOMSelection();
   if (
+    !editor._readOnly &&
     domSelection !== null &&
     (needsUpdate || pendingSelection === null || pendingSelection.dirty)
   ) {


### PR DESCRIPTION
If the editor is in a read only mode, do not attempt to reconcile selection.