### PR TITLE
Use TS type predicates for $isXNode checks

### DIFF
--- a/packages/lexical-code/LexicalCode.d.ts
+++ b/packages/lexical-code/LexicalCode.d.ts
@@ -34,7 +34,9 @@ declare class CodeNode extends ElementNode {
   getLanguage(): string | void;
 }
 declare function $createCodeNode(): CodeNode;
-declare function $isCodeNode(node: null | undefined | LexicalNode): boolean;
+declare function $isCodeNode(
+  node: null | undefined | LexicalNode,
+): node is CodeNode;
 
 declare function getFirstCodeHighlightNodeOfLine(
   anchor: LexicalNode,
@@ -69,6 +71,8 @@ declare function $createCodeHighlightNode(
   text: string,
   highlightType?: string,
 ): CodeHighlightNode;
-declare function $isCodeHighlightNode(node: ?LexicalNode): boolean;
+declare function $isCodeHighlightNode(
+  node: ?LexicalNode,
+): node is CodeHighlightNode;
 
 declare function registerCodeHighlighting(editor: LexicalEditor): () => void;

--- a/packages/lexical-hashtag/LexicalHashtag.d.ts
+++ b/packages/lexical-hashtag/LexicalHashtag.d.ts
@@ -18,4 +18,6 @@ export declare class HashtagNode extends TextNode {
   isTextEntity(): true;
 }
 export function $createHashtagNode(text?: string): TextNode;
-export function $isHashtagNode(node: LexicalNode | null | undefined): boolean;
+export function $isHashtagNode(
+  node: LexicalNode | null | undefined,
+): node is HashtagNode;

--- a/packages/lexical-link/LexicalLink.d.ts
+++ b/packages/lexical-link/LexicalLink.d.ts
@@ -39,13 +39,13 @@ export declare class LinkNode extends ElementNode {
 }
 export function convertAnchorElement(domNode: Node): DOMConversionOutput;
 export function $createLinkNode(url: string): LinkNode;
-export function $isLinkNode(node: ?LexicalNode): boolean;
+export function $isLinkNode(node: ?LexicalNode): node is LinkNode;
 export declare class AutoLinkNode extends LinkNode {
   static getType(): string;
   static clone(node: AutoLinkNode): AutoLinkNode;
   insertNewAfter(selection: RangeSelection): null | ElementNode;
 }
 export function $createAutoLinkNode(url: string): AutoLinkNode;
-export function $isAutoLinkNode(node: ?LexicalNode): boolean;
+export function $isAutoLinkNode(node: ?LexicalNode): node is AutoLinkNode;
 
 export var TOGGLE_LINK_COMMAND: LexicalCommand<string | null>;

--- a/packages/lexical-list/LexicalList.d.ts
+++ b/packages/lexical-list/LexicalList.d.ts
@@ -20,8 +20,8 @@ export function $createListItemNode(): ListItemNode;
 export function $createListNode(tag: ListNodeTagType, start?: number): ListNode;
 export function $getListDepth(listNode: ListNode): number;
 export function $handleListInsertParagraph(): boolean;
-export function $isListItemNode(node?: LexicalNode): boolean;
-export function $isListNode(node?: LexicalNode): boolean;
+export function $isListItemNode(node?: LexicalNode): node is ListItemNode;
+export function $isListNode(node?: LexicalNode): node is ListNode;
 export function indentList(): boolean;
 export function insertList(editor: LexicalEditor, listType: 'ul' | 'ol'): void;
 export declare class ListItemNode extends ElementNode {

--- a/packages/lexical-overflow/LexicalOverflow.d.ts
+++ b/packages/lexical-overflow/LexicalOverflow.d.ts
@@ -18,4 +18,4 @@ export declare class OverflowNode extends ElementNode {
   excludeFromCopy(): boolean;
 }
 export function $createOverflowNode(): OverflowNode;
-export function $isOverflowNode(node: LexicalNode | null): boolean;
+export function $isOverflowNode(node: LexicalNode | null): node is OverflowNode;

--- a/packages/lexical-react/LexicalHorizontalRuleNode.d.ts
+++ b/packages/lexical-react/LexicalHorizontalRuleNode.d.ts
@@ -20,6 +20,6 @@ export declare class HorizontalRuleNode extends DecoratorNode<JSX.Element | null
 export function $createHorizontalRuleNode(): HorizontalRuleNode;
 export function $isHorizontalRuleNode(
   node: LexicalNode | null | undefined,
-): boolean;
+): node is HorizontalRuleNode;
 
 export var INSERT_HORIZONTAL_RULE_COMMAND: LexicalCommand<void>;

--- a/packages/lexical-rich-text/LexicalRichText.d.ts
+++ b/packages/lexical-rich-text/LexicalRichText.d.ts
@@ -28,7 +28,7 @@ export declare class QuoteNode extends ElementNode {
   collapseAtStart(): true;
 }
 export function $createQuoteNode(): QuoteNode;
-export function $isQuoteNode(node: ?LexicalNode): boolean;
+export function $isQuoteNode(node: ?LexicalNode): node is QuoteNode;
 export type HeadingTagType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
 export declare class HeadingNode extends ElementNode {
   __tag: HeadingTagType;
@@ -43,7 +43,7 @@ export declare class HeadingNode extends ElementNode {
   collapseAtStart(): true;
 }
 export function $createHeadingNode(headingTag: HeadingTagType): HeadingNode;
-export function $isHeadingNode(node: ?LexicalNode): boolean;
+export function $isHeadingNode(node: ?LexicalNode): node is HeadingNode;
 export function registerRichText(
   editor: LexicalEditor,
   initialEditorState?: InitialEditorStateType,

--- a/packages/lexical-table/LexicalTable.d.ts
+++ b/packages/lexical-table/LexicalTable.d.ts
@@ -66,7 +66,9 @@ export declare class TableCellNode extends ElementNode {
   canBeEmpty(): false;
 }
 export declare function $createTableCellNode(): TableCellNode;
-export declare function $isTableCellNode(node?: LexicalNode): boolean;
+export declare function $isTableCellNode(
+  node?: LexicalNode,
+): node is TableCellNode;
 
 /**
  * LexicalTableNode
@@ -91,7 +93,7 @@ export declare class TableNode extends ElementNode {
   canSelectBefore(): true;
 }
 declare function $createTableNode(): TableNode;
-declare function $isTableNode(node?: LexicalNode): boolean;
+declare function $isTableNode(node?: LexicalNode): node is TableNode;
 
 /**
  * LexicalTableRowNode
@@ -112,7 +114,7 @@ declare class TableRowNode extends ElementNode {
   collapseAtStart(): true;
 }
 declare function $createTableRowNode(): TableRowNode;
-declare function $isTableRowNode(node?: LexicalNode): boolean;
+declare function $isTableRowNode(node?: LexicalNode): node is TableRowNode;
 
 /**
  * LexicalTableSelectionHelpers

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -435,7 +435,9 @@ export declare class GridSelection {
   getNodes(): Array<LexicalNode>;
   getTextContent(): string;
 }
-export function $isGridSelection(x: unknown | null | undefined): boolean;
+export function $isGridSelection(
+  x: unknown | null | undefined,
+): x is GridSelection;
 export declare class NodeSelection {
   _nodes: Set<NodeKey>;
   dirty: boolean;
@@ -452,7 +454,9 @@ export declare class NodeSelection {
   getNodes(): Array<LexicalNode>;
   getTextContent(): string;
 }
-export function $isNodeSelection(x: unknown | null | undefined): boolean;
+export function $isNodeSelection(
+  x: unknown | null | undefined,
+): x is NodeSelection;
 export declare class RangeSelection {
   anchor: PointType;
   focus: PointType;
@@ -534,7 +538,9 @@ declare class _Point {
 export function $createRangeSelection(): RangeSelection;
 export function $createNodeSelection(): NodeSelection;
 export function $createGridSelection(): GridSelection;
-export function $isRangeSelection(x: unknown | null | undefined): boolean;
+export function $isRangeSelection(
+  x: unknown | null | undefined,
+): x is RangeSelection;
 export function $getSelection():
   | null
   | RangeSelection
@@ -612,7 +618,9 @@ export declare class TextNode extends LexicalNode {
   mergeWithSibling(target: TextNode): TextNode;
 }
 export function $createTextNode(text?: string): TextNode;
-export function $isTextNode(node: LexicalNode | null | undefined): boolean;
+export function $isTextNode(
+  node: LexicalNode | null | undefined,
+): node is TextNode;
 
 /**
  * LexicalLineBreakNode
@@ -626,7 +634,9 @@ export declare class LineBreakNode extends LexicalNode {
   updateDOM(): false;
 }
 export function $createLineBreakNode(): LineBreakNode;
-export function $isLineBreakNode(node: LexicalNode | null | undefined): boolean;
+export function $isLineBreakNode(
+  node: LexicalNode | null | undefined,
+): node is LineBreakNode;
 
 /**
  * LexicalRootNode
@@ -646,7 +656,9 @@ export declare class RootNode extends ElementNode {
   append(...nodesToAppend: Array<LexicalNode>): ElementNode;
   canBeEmpty(): false;
 }
-export function $isRootNode(node: LexicalNode | null | undefined): boolean;
+export function $isRootNode(
+  node: LexicalNode | null | undefined,
+): node is RootNode;
 
 /**
  * LexicalElementNode
@@ -702,7 +714,9 @@ export declare class ElementNode extends LexicalNode {
     nodesToInsert: Array<LexicalNode>,
   ): ElementNode;
 }
-export function $isElementNode(node: LexicalNode | null | undefined): boolean;
+export function $isElementNode(
+  node: LexicalNode | null | undefined,
+): node is ElementNode;
 
 /**
  * LexicalDecoratorNode
@@ -713,7 +727,9 @@ export declare class DecoratorNode<X> extends LexicalNode {
   isIsolated(): boolean;
   isTopLevel(): boolean;
 }
-export function $isDecoratorNode(node: LexicalNode | null | undefined): boolean;
+export function $isDecoratorNode(
+  node: LexicalNode | null | undefined,
+): node is DecoratorNode<unknown>;
 
 /**
  * LexicalHorizontalRuleNode
@@ -743,16 +759,24 @@ export declare class ParagraphNode extends ElementNode {
   collapseAtStart(): boolean;
 }
 export function $createParagraphNode(): ParagraphNode;
-export function $isParagraphNode(node: LexicalNode | null | undefined): boolean;
+export function $isParagraphNode(
+  node: LexicalNode | null | undefined,
+): node is ParagraphNode;
 export declare class GridNode extends ElementNode {}
-export function $isGridNode(node: LexicalNode | null | undefined): boolean;
+export function $isGridNode(
+  node: LexicalNode | null | undefined,
+): node is GridNode;
 export declare class GridRowNode extends ElementNode {}
-export function $isGridRowNode(node: LexicalNode | null | undefined): boolean;
+export function $isGridRowNode(
+  node: LexicalNode | null | undefined,
+): node is GridRowNode;
 export declare class GridCellNode extends ElementNode {
   __colSpan: number;
   constructor(colSpan: number, key?: NodeKey);
 }
-export function $isGridCellNode(node: LexicalNode | null | undefined): boolean;
+export function $isGridCellNode(
+  node: LexicalNode | null | undefined,
+): node is GridCellNode;
 
 /**
  * LexicalUtils


### PR DESCRIPTION
Uses TypeScript type predicates for `$isXNode` and `$isXSelection` checks in the `.d.ts` files. Looks like this is already happening in flow.