### PR TITLE
Base markdown export & import/export toggle for the playground

### DIFF
--- a/packages/lexical-markdown/LexicalMarkdown.d.ts
+++ b/packages/lexical-markdown/LexicalMarkdown.d.ts
@@ -16,3 +16,4 @@ export function $convertFromMarkdownString(
   markdownString: string,
   editor: LexicalEditor,
 ): void;
+export function $convertToMarkdownString(): string;

--- a/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
+++ b/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
@@ -17,3 +17,4 @@ declare export function $convertFromMarkdownString(
   markdownString: string,
   editor: LexicalEditor,
 ): void;
+declare export function $convertToMarkdownString(): string;

--- a/packages/lexical-markdown/src/convertToMarkdown.js
+++ b/packages/lexical-markdown/src/convertToMarkdown.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {ElementNode, LexicalNode, TextFormatType, TextNode} from 'lexical';
+
+import {$isLinkNode} from '@lexical/link';
+import {$getRoot, $isElementNode, $isLineBreakNode, $isTextNode} from 'lexical';
+
+import {
+  getAllMarkdownCriteriaForParagraphs,
+  getAllMarkdownCriteriaForTextNodes,
+} from './utils';
+
+export function $convertToMarkdownString(): string {
+  const output = [];
+  const children = $getRoot().getChildren();
+
+  for (const child of children) {
+    const result = exportTopLevelElementOrDecorator(child);
+    if (result != null) {
+      output.push(result);
+    }
+  }
+
+  return output.join('\n');
+}
+
+function exportTopLevelElementOrDecorator(node: LexicalNode): string | null {
+  const blockTransformers = getAllMarkdownCriteriaForParagraphs();
+  for (const transformer of blockTransformers) {
+    if (transformer.export != null) {
+      const result = transformer.export(node, (_node) => exportChildren(_node));
+      if (result != null) {
+        return result;
+      }
+    }
+  }
+
+  return $isElementNode(node) ? exportChildren(node) : null;
+}
+
+function exportChildren(node: ElementNode): string {
+  const output = [];
+  const children = node.getChildren();
+  for (const child of children) {
+    if ($isLineBreakNode(child)) {
+      output.push('\n');
+    } else if ($isTextNode(child)) {
+      output.push(exportTextNode(child, child.getTextContent(), node));
+    } else if ($isLinkNode(child)) {
+      const linkContent = `[${child.getTextContent()}](${child.getURL()})`;
+      const firstChild = child.getFirstChild();
+      // Add text styles only if link has single text node inside. If it's more
+      // then one we either ignore it and have single <a> to cover whole link,
+      // or process them, but then have link cut into multiple <a>.
+      // For now chosing the first option.
+      if (child.getChildrenSize() === 1 && $isTextNode(firstChild)) {
+        output.push(exportTextNode(firstChild, linkContent, child));
+      } else {
+        output.push(linkContent);
+      }
+    } else if ($isElementNode(child)) {
+      output.push(exportChildren(child));
+    }
+  }
+
+  return output.join('');
+}
+
+function exportTextNode(
+  node: TextNode,
+  textContent: string,
+  parentNode: ElementNode,
+): string {
+  let output = textContent;
+  const applied = new Set();
+  const textTransformers = getAllMarkdownCriteriaForTextNodes();
+  for (const transformer of textTransformers) {
+    const {
+      exportFormat: format,
+      exportTag: tag,
+      exportTagClose: tagClose = tag,
+    } = transformer;
+    if (
+      format != null &&
+      tag != null &&
+      tagClose != null &&
+      hasFormat(node, format) &&
+      !applied.has(format)
+    ) {
+      // Multiple tags might be used for the same format (*, _)
+      applied.add(format);
+
+      // Prevent adding extra wrapping tags if it's already
+      // added by a previous sibling (or will be closed by the next one)
+      const previousNode = getTextSibling(node, true);
+      if (!hasFormat(previousNode, format)) {
+        output = tag + output;
+      }
+
+      const nextNode = getTextSibling(node, false);
+      if (!hasFormat(nextNode, format)) {
+        output += tagClose;
+      }
+    }
+  }
+  return output;
+}
+
+// Finds text sibling including cases for inline elements
+function getTextSibling(node: TextNode, backward: boolean): TextNode | null {
+  let sibling = backward ? node.getPreviousSibling() : node.getNextSibling();
+
+  if (!sibling) {
+    const parent = node.getParentOrThrow();
+    if (parent.isInline()) {
+      sibling = backward
+        ? parent.getPreviousSibling()
+        : parent.getNextSibling();
+    }
+  }
+
+  while (sibling) {
+    if ($isElementNode(sibling)) {
+      if (!sibling.isInline()) {
+        break;
+      }
+      const descendant = backward
+        ? sibling.getLastDescendant()
+        : sibling.getFirstDescendant();
+
+      if ($isTextNode(descendant)) {
+        return descendant;
+      } else {
+        sibling = backward
+          ? sibling.getPreviousSibling()
+          : sibling.getNextSibling();
+      }
+    }
+
+    if ($isTextNode(sibling)) {
+      return sibling;
+    }
+  }
+
+  return null;
+}
+
+function hasFormat(node: LexicalNode | null, format: TextFormatType): boolean {
+  return $isTextNode(node) && node.hasFormat(format);
+}

--- a/packages/lexical-markdown/src/index.js
+++ b/packages/lexical-markdown/src/index.js
@@ -57,3 +57,5 @@ export function $convertFromMarkdownString<T>(
     convertMarkdownForElementNodes(editor, createHorizontalRuleNode);
   }
 }
+
+export {$convertToMarkdownString} from './convertToMarkdown';

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -10,6 +10,7 @@ import {
   moveLeft,
   moveRight,
   redo,
+  selectAll,
   selectCharacters,
   toggleUnderline,
   undo,
@@ -21,6 +22,8 @@ import {
   focusEditor,
   initialize,
   pasteFromClipboard,
+  selectFromFormatDropdown,
+  selectOption,
   test,
 } from '../utils/index.mjs';
 
@@ -346,14 +349,23 @@ test.describe('Markdown', () => {
         test.skip(isPlainText);
         await focusEditor(page);
 
-        await page.keyboard.type(triggersAndExpectations[i].markdownImport);
+        await page.keyboard.type(
+          '```markdown ' + triggersAndExpectations[i].markdownImport,
+        );
         await click(page, 'i.markdown');
 
         const html = triggersAndExpectations[i].importExpectation;
         await assertHTML(page, html);
+
+        // Click on markdow toggle twice to run import -> export loop and then
+        // validate that it's the same rich text after full cycle
+        await click(page, 'i.markdown');
+        await click(page, 'i.markdown');
+        await assertHTML(page, html);
       });
     }
   }
+
   test(`Should test markdown conversion from plain text to Lexical.`, async ({
     page,
     isPlainText,
@@ -371,6 +383,9 @@ test.describe('Markdown', () => {
     await pasteFromClipboard(page, {
       'text/plain': text,
     });
+    await selectAll(page);
+    await selectFromFormatDropdown(page, '.code');
+    await selectOption(page, '.code-language', {value: 'markdown'});
     await click(page, 'i.markdown');
     const html = `
     <h1 class=\"PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr\" dir=\"ltr\">


### PR DESCRIPTION
- Some basic markdown exporting
- Updated md button in the playground to be a bit more functional: toggling editor content between its markdown representation within code block and back to rich text.

https://user-images.githubusercontent.com/132642/164358063-5adc98bd-19eb-40d1-baf9-7e9ae05329f2.mov
