### PR TITLE
Fix Table can delete empty lines when there're text

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.js
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.js
@@ -628,7 +628,7 @@ export function applyTableHandlers(
           const paragraphNode = $findMatchingParent(
             selection.anchor.getNode(),
             (n) => $isParagraphNode(n),
-          )
+          );
 
           if (!$isParagraphNode(paragraphNode)) {
             return false;

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.js
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.js
@@ -625,10 +625,19 @@ export function applyTableHandlers(
             return false;
           }
 
+          const paragraphNode = $findMatchingParent(
+            selection.anchor.getNode(),
+            (n) => $isParagraphNode(n),
+          )
+
+          if (!$isParagraphNode(paragraphNode)) {
+            return false;
+          }
+
           if (
             selection.isCollapsed() &&
             selection.anchor.offset === 0 &&
-            selection.anchor.getNode().getPreviousSiblings().length === 0
+            paragraphNode.getPreviousSiblings().length === 0
           ) {
             return true;
           }


### PR DESCRIPTION

https://user-images.githubusercontent.com/377544/164468711-42ebe76d-156f-4734-96fb-1d1bfba168c5.mp4

When there're text `hello`, the `selection.anchor.getNode()` is `<span>`, not `<p>` anymore.