### PR TITLE
Add predicate to  $isLeafNode in .flow file

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -828,7 +828,9 @@ declare export function $getNearestNodeFromDOMNode(
 ): LexicalNode | null;
 declare export function $getNodeByKey<N: LexicalNode>(key: NodeKey): N | null;
 declare export function $getRoot(): RootNode;
-declare export function $isLeafNode(node: ?LexicalNode): boolean;
+export function $isLeafNode(node: ?LexicalNode): boolean %checks {
+  return $isTextNode(node) || $isLineBreakNode(node) || $isDecoratorNode(node);
+}
 declare export function $setCompositionKey(
   compositionKey: null | NodeKey,
 ): void;


### PR DESCRIPTION
Using $isLeafNode with Flow typing does not refine the type. This is because it's not declared as a predicate function (`%checks`). In order to have a predicate function, Flow needs the implementation. I suggest to add the function implementation in the flow file. This is not ideal as it duplicates things : the implementation in the flow file could get out of sync from the actual implementation, but in my opinion this is still an improvement.

I only do it for Flow here, as I am not very familiar with TypeScript 