### PR TITLE
change test command to e2e command

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ editor.registerUpdateListener(({editorState}) => {
 
 3. Start local server and run tests
    - `npm run start`
-   - `npm run test`
+   - `npm run test-e2e:chromium` to run only chromium e2e tests
      - The server needs to be running for the e2e tests
 
 Note: for collaboration, ensure you start the websocket server separately with `npm run collab`.


### PR DESCRIPTION
There is a `npm run test` in the readme `contributing to lexical` section. So I've changed the command to run e2e test.