### PR TITLE
Fix boundary selection issues

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.js
+++ b/packages/lexical-clipboard/src/clipboard.js
@@ -67,8 +67,7 @@ export function $convertSelectedLexicalNodeToHTMLElement(
     const isFocus = node.is(focus);
 
     if ($isTextNode(node) && (isAnchor || isFocus)) {
-      const anchorOffset = selection.anchor.getCharacterOffset();
-      const focusOffset = selection.focus.getCharacterOffset();
+      const [anchorOffset, focusOffset] = selection.getCharacterOffsets();
       const isBackward = selection.isBackward();
 
       const isSame = anchor.is(focus);

--- a/packages/lexical-playground/__tests__/e2e/Keywords.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Keywords.spec.mjs
@@ -320,21 +320,12 @@ test.describe('Keywords', () => {
         </p>
       `,
     );
-    if (browserName === 'firefox') {
-      await assertSelection(page, {
-        anchorOffset: 8,
-        anchorPath: [0, 0, 0],
-        focusOffset: 8,
-        focusPath: [0, 0, 0],
-      });
-    } else {
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [0, 1, 0],
-        focusOffset: 0,
-        focusPath: [0, 1, 0],
-      });
-    }
+    await assertSelection(page, {
+      anchorOffset: 8,
+      anchorPath: [0, 0, 0],
+      focusOffset: 8,
+      focusPath: [0, 0, 0],
+    });
 
     await page.keyboard.press('Space');
 

--- a/packages/lexical-playground/__tests__/e2e/Keywords.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Keywords.spec.mjs
@@ -320,12 +320,21 @@ test.describe('Keywords', () => {
         </p>
       `,
     );
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [0, 1, 0],
-      focusOffset: 0,
-      focusPath: [0, 1, 0],
-    });
+    if (browserName === 'firefox') {
+      await assertSelection(page, {
+        anchorOffset: 8,
+        anchorPath: [0, 0, 0],
+        focusOffset: 8,
+        focusPath: [0, 0, 0],
+      });
+    } else {
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0, 1, 0],
+        focusOffset: 0,
+        focusPath: [0, 1, 0],
+      });
+    }
 
     await page.keyboard.press('Space');
 

--- a/packages/lexical-playground/__tests__/e2e/Keywords.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Keywords.spec.mjs
@@ -321,10 +321,10 @@ test.describe('Keywords', () => {
       `,
     );
     await assertSelection(page, {
-      anchorOffset: 8,
-      anchorPath: [0, 0, 0],
-      focusOffset: 8,
-      focusPath: [0, 0, 0],
+      anchorOffset: 0,
+      anchorPath: [0, 1, 0],
+      focusOffset: 0,
+      focusPath: [0, 1, 0],
     });
 
     await page.keyboard.press('Space');

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -375,6 +375,107 @@ test.describe('Links', () => {
     );
   });
 
+  test(`Can create a link then replace it with plain text`, async ({page}) => {
+    await focusEditor(page);
+    await page.keyboard.type(' abc ');
+
+    await moveLeft(page, 1);
+    await selectCharacters(page, 'left', 3);
+
+    // link
+    await click(page, '.link');
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://">
+            <span data-lexical-text="true">abc</span>
+          </a>
+          <span data-lexical-text="true"></span>
+        </p>
+      `,
+    );
+
+    await page.keyboard.type('a');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">a</span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Can create a link then replace it with plain text #2`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type(' abc ');
+
+    await moveLeft(page, 1);
+    await selectCharacters(page, 'left', 3);
+
+    // link
+    await click(page, '.link');
+
+    await selectCharacters(page, 'left', 1);
+    await page.keyboard.type('a');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">a</span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Can create a link then partly replace it with plain text`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type(' abc ');
+
+    await moveLeft(page, 1);
+    await selectCharacters(page, 'left', 3);
+
+    // link
+    await click(page, '.link');
+
+    await selectCharacters(page, 'right', 1);
+    await page.keyboard.type('a');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://">
+            <span data-lexical-text="true">a</span>
+          </a>
+          <span data-lexical-text="true">a</span>
+        </p>
+      `,
+    );
+  });
+
   test(`Can convert multi-formatted text into a link and then modify text after`, async ({
     page,
   }) => {
@@ -686,8 +787,8 @@ test.describe('Links', () => {
       });
     } else {
       await assertSelection(page, {
-        anchorOffset: 6,
-        anchorPath: [0, 0, 0],
+        anchorOffset: 0,
+        anchorPath: [0, 1],
         focusOffset: 5,
         focusPath: [0, 1, 0, 0],
       });
@@ -805,8 +906,8 @@ test.describe('Links', () => {
       await assertSelection(page, {
         anchorOffset: 5,
         anchorPath: [0, 1, 0, 0],
-        focusOffset: 6,
-        focusPath: [0, 0, 0],
+        focusOffset: 0,
+        focusPath: [0, 1],
       });
     }
 

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -23,6 +23,8 @@ import {
   focusEditor,
   html,
   initialize,
+  keyDownCtrlOrMeta,
+  keyUpCtrlOrMeta,
   test,
   waitForSelector,
 } from '../utils/index.mjs';
@@ -126,6 +128,378 @@ test.describe('Links', () => {
       anchorPath: [0, 0, 0],
       focusOffset: 5,
       focusPath: [0, 0, 0],
+    });
+  });
+
+  test(`Can convert multi-formatted text into a link (backward)`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type(' abc');
+
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('b');
+    await keyUpCtrlOrMeta(page);
+
+    await page.keyboard.type('def');
+
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('b');
+    await keyUpCtrlOrMeta(page);
+
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('i');
+    await keyUpCtrlOrMeta(page);
+
+    await page.keyboard.type('ghi');
+
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('i');
+    await keyUpCtrlOrMeta(page);
+
+    await page.keyboard.type(' ');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">abc</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            def
+          </strong>
+          <em
+            class="PlaygroundEditorTheme__textItalic"
+            data-lexical-text="true">
+            ghi
+          </em>
+          <span data-lexical-text="true"></span>
+        </p>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 1,
+      anchorPath: [0, 3, 0],
+      focusOffset: 1,
+      focusPath: [0, 3, 0],
+    });
+
+    await moveLeft(page, 1);
+    await selectCharacters(page, 'left', 9);
+
+    // link
+    await click(page, '.link');
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://">
+            <span data-lexical-text="true">abc</span>
+            <strong
+              class="PlaygroundEditorTheme__textBold"
+              data-lexical-text="true">
+              def
+            </strong>
+            <em
+              class="PlaygroundEditorTheme__textItalic"
+              data-lexical-text="true">
+              ghi
+            </em>
+          </a>
+          <span data-lexical-text="true"></span>
+        </p>
+      `,
+    );
+
+    // set url
+    await click(page, '.link-edit');
+    await focus(page, '.link-input');
+    await page.keyboard.type('facebook.com');
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://facebook.com">
+            <span data-lexical-text="true">abc</span>
+            <strong
+              class="PlaygroundEditorTheme__textBold"
+              data-lexical-text="true">
+              def
+            </strong>
+            <em
+              class="PlaygroundEditorTheme__textItalic"
+              data-lexical-text="true">
+              ghi
+            </em>
+          </a>
+          <span data-lexical-text="true"></span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Can convert multi-formatted text into a link (forward)`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type(' abc');
+
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('b');
+    await keyUpCtrlOrMeta(page);
+
+    await page.keyboard.type('def');
+
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('b');
+    await keyUpCtrlOrMeta(page);
+
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('i');
+    await keyUpCtrlOrMeta(page);
+
+    await page.keyboard.type('ghi');
+
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('i');
+    await keyUpCtrlOrMeta(page);
+
+    await page.keyboard.type(' ');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">abc</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            def
+          </strong>
+          <em
+            class="PlaygroundEditorTheme__textItalic"
+            data-lexical-text="true">
+            ghi
+          </em>
+          <span data-lexical-text="true"></span>
+        </p>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 1,
+      anchorPath: [0, 3, 0],
+      focusOffset: 1,
+      focusPath: [0, 3, 0],
+    });
+
+    await moveLeft(page, 10);
+    await selectCharacters(page, 'right', 9);
+
+    // link
+    await click(page, '.link');
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://">
+            <span data-lexical-text="true">abc</span>
+            <strong
+              class="PlaygroundEditorTheme__textBold"
+              data-lexical-text="true">
+              def
+            </strong>
+            <em
+              class="PlaygroundEditorTheme__textItalic"
+              data-lexical-text="true">
+              ghi
+            </em>
+          </a>
+          <span data-lexical-text="true"></span>
+        </p>
+      `,
+    );
+
+    // set url
+    await click(page, '.link-edit');
+    await focus(page, '.link-input');
+    await page.keyboard.type('facebook.com');
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://facebook.com">
+            <span data-lexical-text="true">abc</span>
+            <strong
+              class="PlaygroundEditorTheme__textBold"
+              data-lexical-text="true">
+              def
+            </strong>
+            <em
+              class="PlaygroundEditorTheme__textItalic"
+              data-lexical-text="true">
+              ghi
+            </em>
+          </a>
+          <span data-lexical-text="true"></span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Can convert multi-formatted text into a link and then modify text after`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type(' abc');
+
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('b');
+    await keyUpCtrlOrMeta(page);
+
+    await page.keyboard.type('def');
+
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('b');
+    await keyUpCtrlOrMeta(page);
+
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('i');
+    await keyUpCtrlOrMeta(page);
+
+    await page.keyboard.type('ghi');
+
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('i');
+    await keyUpCtrlOrMeta(page);
+
+    await page.keyboard.type(' ');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">abc</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            def
+          </strong>
+          <em
+            class="PlaygroundEditorTheme__textItalic"
+            data-lexical-text="true">
+            ghi
+          </em>
+          <span data-lexical-text="true"></span>
+        </p>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 1,
+      anchorPath: [0, 3, 0],
+      focusOffset: 1,
+      focusPath: [0, 3, 0],
+    });
+
+    await moveLeft(page, 1);
+    await selectCharacters(page, 'left', 9);
+
+    // link
+    await click(page, '.link');
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://">
+            <span data-lexical-text="true">abc</span>
+            <strong
+              class="PlaygroundEditorTheme__textBold"
+              data-lexical-text="true">
+              def
+            </strong>
+            <em
+              class="PlaygroundEditorTheme__textItalic"
+              data-lexical-text="true">
+              ghi
+            </em>
+          </a>
+          <span data-lexical-text="true"></span>
+        </p>
+      `,
+    );
+
+    await moveRight(page, 1);
+    await selectCharacters(page, 'right', 1);
+    await page.keyboard.type('a');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://">
+            <span data-lexical-text="true">abc</span>
+            <strong
+              class="PlaygroundEditorTheme__textBold"
+              data-lexical-text="true">
+              def
+            </strong>
+            <em
+              class="PlaygroundEditorTheme__textItalic"
+              data-lexical-text="true">
+              ghi
+            </em>
+          </a>
+          <span data-lexical-text="true">a</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 1,
+      anchorPath: [0, 2, 0],
+      focusOffset: 1,
+      focusPath: [0, 2, 0],
     });
   });
 

--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
@@ -34,7 +34,7 @@ function setPopupPosition(editor, rect) {
     editor.style.left = '-1000px';
   } else {
     editor.style.opacity = '1';
-    editor.style.top = `${rect.top - 40 + window.pageYOffset}px`;
+    editor.style.top = `${rect.top - 8 + window.pageYOffset}px`;
     editor.style.left = `${
       rect.left + 230 + window.pageXOffset - editor.offsetWidth + rect.width / 2
     }px`;

--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
@@ -34,7 +34,7 @@ function setPopupPosition(editor, rect) {
     editor.style.left = '-1000px';
   } else {
     editor.style.opacity = '1';
-    editor.style.top = `${rect.top - 8 + window.pageYOffset}px`;
+    editor.style.top = `${rect.top - 40 + window.pageYOffset}px`;
     editor.style.left = `${
       rect.left + 230 + window.pageXOffset - editor.offsetWidth + rect.width / 2
     }px`;
@@ -238,7 +238,7 @@ function useCharacterStylesPopup(editor: LexicalEditor): React$Node {
     });
   }, [editor]);
 
-  if (!isText || !isLink) {
+  if (!isText || isLink) {
     return null;
   }
 

--- a/packages/lexical-react/src/LexicalLinkPlugin.js
+++ b/packages/lexical-react/src/LexicalLinkPlugin.js
@@ -75,6 +75,11 @@ function toggleLink(url: null | string) {
         ) {
           return;
         }
+        if ($isLinkNode(parent)) {
+          linkNode = parent;
+          parent.setURL(url);
+          return;
+        }
         if (!parent.is(prevParent)) {
           prevParent = parent;
           linkNode = $createLinkNode(url);

--- a/packages/lexical-react/src/LexicalTreeView.jsx
+++ b/packages/lexical-react/src/LexicalTreeView.jsx
@@ -225,7 +225,7 @@ function printObjectSelection(selection: NodeSelection): string {
 }
 
 function printGridSelection(selection: GridSelection): string {
-  return `: grid\n  └ { grid: ${selection.gridKey}, anchorCell: ${selection.anchorCellKey}, focusCell: ${selection.focusCellKey} }`;
+  return `: grid\n  └ { grid: ${selection.gridKey}, anchorCell: ${selection.anchor.key}, focusCell: ${selection.focus.key} }`;
 }
 
 function generateContent(editorState: EditorState): string {

--- a/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.js
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.js
@@ -162,7 +162,7 @@ describe('LexicalNodeHelpers tests', () => {
             expect(selection.anchor.key).toBe(text2Key);
             expect(selection.anchor.offset).toBe(0);
             expect(selection.focus.key).toBe(text4Key);
-            expect(selection.anchor.offset).toBe(0);
+            expect(selection.focus.offset).toBe(0);
           });
         });
       });

--- a/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.js
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.js
@@ -90,7 +90,7 @@ describe('LexicalNodeHelpers tests', () => {
           const editor: LexicalEditor = testEnv.editor;
           const [overflowLeftKey, overflowRightKey] =
             await initializeEditorWithLeftRightOverflowNodes();
-          let text2Key: NodeKey;
+          let text1Key: NodeKey;
           await editor.update(() => {
             const overflowLeft = $getNodeByKey(overflowLeftKey);
             const overflowRight = $getNodeByKey(overflowRightKey);
@@ -98,7 +98,7 @@ describe('LexicalNodeHelpers tests', () => {
             const text2 = $createTextNode('2');
             const text3 = $createTextNode('3');
             const text4 = $createTextNode('4');
-            text2Key = text2.getKey();
+            text1Key = text1.getKey();
             overflowLeft.append(text1, text2);
             text2.toggleFormat('bold'); // Prevent merging with text1
             overflowRight.append(text3, text4);
@@ -116,10 +116,10 @@ describe('LexicalNodeHelpers tests', () => {
             if (selection === null) {
               throw new Error('Lost selection');
             }
-            expect(selection.anchor.key).toBe(text2Key);
-            expect(selection.anchor.offset).toBe(0);
-            expect(selection.focus.key).toBe(text2Key);
-            expect(selection.anchor.offset).toBe(0);
+            expect(selection.anchor.key).toBe(text1Key);
+            expect(selection.anchor.offset).toBe(1);
+            expect(selection.focus.key).toBe(text1Key);
+            expect(selection.anchor.offset).toBe(1);
           });
         });
 

--- a/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.js
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.js
@@ -128,7 +128,7 @@ describe('LexicalNodeHelpers tests', () => {
           const [overflowLeftKey, overflowRightKey] =
             await initializeEditorWithLeftRightOverflowNodes();
           let text2Key: NodeKey;
-          let text4Key: NodeKey;
+          let text3Key: NodeKey;
           await editor.update(() => {
             const overflowLeft = $getNodeByKey(overflowLeftKey);
             const overflowRight = $getNodeByKey(overflowRightKey);
@@ -137,7 +137,7 @@ describe('LexicalNodeHelpers tests', () => {
             const text3 = $createTextNode('3');
             const text4 = $createTextNode('4');
             text2Key = text2.getKey();
-            text4Key = text4.getKey();
+            text3Key = text3.getKey();
             overflowLeft.append(text1);
             overflowLeft.append(text2);
             text2.toggleFormat('bold'); // Prevent merging with text1
@@ -161,8 +161,8 @@ describe('LexicalNodeHelpers tests', () => {
             }
             expect(selection.anchor.key).toBe(text2Key);
             expect(selection.anchor.offset).toBe(0);
-            expect(selection.focus.key).toBe(text4Key);
-            expect(selection.focus.offset).toBe(0);
+            expect(selection.focus.key).toBe(text3Key);
+            expect(selection.focus.offset).toBe(1);
           });
         });
       });

--- a/packages/lexical-selection/src/index.js
+++ b/packages/lexical-selection/src/index.js
@@ -167,8 +167,7 @@ function $cloneContentsImpl(
   if ($isRangeSelection(selection)) {
     const anchor = selection.anchor;
     const focus = selection.focus;
-    const anchorOffset = anchor.getCharacterOffset();
-    const focusOffset = focus.getCharacterOffset();
+    const [anchorOffset, focusOffset] = selection.getCharacterOffsets();
     const nodes = selection.getNodes();
     if (nodes.length === 0) {
       return {nodeMap: [], range: []};

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -407,15 +407,14 @@ export type GridSelectionShape = {
 };
 export declare class GridSelection {
   gridKey: NodeKey;
-  anchorCellKey: NodeKey;
   anchor: PointType;
-  focusCellKey: NodeKey;
   focus: PointType;
   dirty: boolean;
-  constructor(gridKey: NodeKey, anchorCellKey: NodeKey, focusCellKey: NodeKey);
+  constructor(gridKey: NodeKey, anchor: PointType, focus: PointType);
   is(selection: null | RangeSelection | NodeSelection | GridSelection): boolean;
   set(gridKey: NodeKey, anchorCellKey: NodeKey, focusCellKey: NodeKey): void;
   clone(): GridSelection;
+  getCharacterOffsets(): [number, number];
   extract(): Array<LexicalNode>;
   isCollapsed(): boolean;
   isBackward(): boolean;
@@ -476,6 +475,7 @@ export declare class RangeSelection {
   insertNodes(nodes: Array<LexicalNode>, selectStart?: boolean): boolean;
   insertParagraph(): void;
   insertLineBreak(selectStart?: boolean): void;
+  getCharacterOffsets(): [number, number];
   extract(): Array<LexicalNode>;
   modify(
     alter: 'move' | 'extend',
@@ -507,7 +507,6 @@ type ElementPointType = {
   isBefore: (arg0: PointType) => boolean;
   getNode: () => ElementNode;
   set: (key: NodeKey, offset: number, type: 'text' | 'element') => void;
-  getCharacterOffset: () => number;
   isAtNodeEnd: () => boolean;
 };
 export type Point = PointType;
@@ -520,7 +519,6 @@ declare class _Point {
   constructor(key: NodeKey, offset: number, type: 'text' | 'element');
   is(point: PointType): boolean;
   isBefore(b: PointType): boolean;
-  getCharacterOffset(): number;
   getNode(): LexicalNode;
   set(key: NodeKey, offset: number, type: 'text' | 'element'): void;
 }

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -417,19 +417,14 @@ export type GridSelectionShape = {
 };
 declare export class GridSelection implements BaseSelection {
   gridKey: NodeKey;
-  anchorCellKey: NodeKey;
   anchor: PointType;
-  focusCellKey: NodeKey;
   focus: PointType;
   dirty: boolean;
-  constructor(
-    gridKey: NodeKey,
-    anchorCellKey: NodeKey,
-    focusCellKey: NodeKey,
-  ): void;
+  constructor(gridKey: NodeKey, anchor: PointType, focus: PointType): void;
   is(selection: null | RangeSelection | NodeSelection | GridSelection): boolean;
   set(gridKey: NodeKey, anchorCellKey: NodeKey, focusCellKey: NodeKey): void;
   clone(): GridSelection;
+  getCharacterOffsets(): [number, number];
   extract(): Array<LexicalNode>;
   insertRawText(): void;
   insertText(): void;
@@ -506,6 +501,7 @@ declare export class RangeSelection implements BaseSelection {
   insertNodes(nodes: Array<LexicalNode>, selectStart?: boolean): boolean;
   insertParagraph(): void;
   insertLineBreak(selectStart?: boolean): void;
+  getCharacterOffsets(): [number, number];
   extract(): Array<LexicalNode>;
   modify(
     alter: 'move' | 'extend',
@@ -537,7 +533,6 @@ type ElementPointType = {
   isBefore: (PointType) => boolean,
   getNode: () => ElementNode,
   set: (key: NodeKey, offset: number, type: 'text' | 'element') => void,
-  getCharacterOffset: () => number,
   isAtNodeEnd: () => boolean,
 };
 export type Point = PointType;
@@ -549,7 +544,6 @@ declare class _Point {
   constructor(key: NodeKey, offset: number, type: 'text' | 'element'): void;
   is(point: PointType): boolean;
   isBefore(b: PointType): boolean;
-  getCharacterOffset(): number;
   getNode(): LexicalNode;
   set(key: NodeKey, offset: number, type: 'text' | 'element'): void;
 }

--- a/packages/lexical/src/LexicalEditorState.js
+++ b/packages/lexical/src/LexicalEditorState.js
@@ -116,8 +116,16 @@ export class EditorState {
           }
         : $isGridSelection(selection)
         ? {
-            anchorCellKey: selection.anchorCellKey,
-            focusCellKey: selection.focusCellKey,
+            anchor: {
+              key: selection.anchor.key,
+              offset: selection.anchor.offset,
+              type: selection.anchor.type,
+            },
+            focus: {
+              key: selection.focus.key,
+              offset: selection.focus.offset,
+              type: selection.focus.type,
+            },
             gridKey: selection.gridKey,
             type: 'grid',
           }

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -138,17 +138,24 @@ function onSelectionChange(
 ): void {
   if (isSelectionChangeFromReconcile) {
     isSelectionChangeFromReconcile = false;
-    const {anchorNode, focusNode} = domSelection;
+    const {anchorNode, anchorOffset, focusNode, focusOffset} = domSelection;
     // If native DOM selection is on a DOM element, then
     // we should continue as usual, as Lexical's selection
     // may have normalized to a better child. If the DOM
     // element is a text node, we can safely apply this
     // optimization and skip the selection change entirely.
+    // We also need to check if the offset is at the boundary,
+    // because in this case, we might need to normalize to a
+    // sibling instead.
     if (
       anchorNode !== null &&
       focusNode !== null &&
+      anchorOffset !== 0 &&
+      focusOffset !== 0 &&
       anchorNode.nodeType === DOM_TEXT_TYPE &&
-      focusNode.nodeType === DOM_TEXT_TYPE
+      focusNode.nodeType === DOM_TEXT_TYPE &&
+      anchorOffset !== anchorNode.nodeValue.length &&
+      focusOffset !== focusNode.nodeValue.length
     ) {
       return;
     }

--- a/packages/lexical/src/LexicalParsing.js
+++ b/packages/lexical/src/LexicalParsing.js
@@ -70,8 +70,16 @@ export type ParsedNodeSelection = {
 };
 
 export type ParsedGridSelection = {
-  anchorCellKey: NodeKey,
-  focusCellKey: NodeKey,
+  anchor: {
+    key: string,
+    offset: number,
+    type: 'text' | 'element',
+  },
+  focus: {
+    key: string,
+    offset: number,
+    type: 'text' | 'element',
+  },
   gridKey: NodeKey,
   type: 'grid',
 };
@@ -208,8 +216,8 @@ export function internalCreateNodeFromParse(
       }
     } else if (originalSelection.type === 'grid') {
       const gridKey = originalSelection.gridKey;
-      const anchorCellKey = originalSelection.anchorCellKey;
-      const focusCellKey = originalSelection.focusCellKey;
+      const anchorCellKey = originalSelection.anchor.key;
+      const focusCellKey = originalSelection.focus.key;
       if (
         remappedSelection == null &&
         (gridKey === parsedKey ||
@@ -226,10 +234,10 @@ export function internalCreateNodeFromParse(
           remappedSelection.gridKey = key;
         }
         if (anchorCellKey === parsedKey) {
-          remappedSelection.anchorCellKey = key;
+          remappedSelection.anchor.key = key;
         }
         if (focusCellKey === parsedKey) {
-          remappedSelection.focusCellKey = key;
+          remappedSelection.focus.key = key;
         }
       }
     }

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
@@ -1214,11 +1214,11 @@ describe('LexicalEditor tests', () => {
 
       it('Remaps the selection keys of a stringified editor state', async () => {
         expect(parsedSelection.gridKey).not.toEqual(originalText.__key);
-        expect(parsedSelection.anchorCellKey).not.toEqual(originalText.__key);
-        expect(parsedSelection.focusCellKey).not.toEqual(originalText.__key);
+        expect(parsedSelection.anchor.key).not.toEqual(originalText.__key);
+        expect(parsedSelection.focus.key).not.toEqual(originalText.__key);
         expect(parsedSelection.gridKey).toEqual(parsedText.__key);
-        expect(parsedSelection.anchorCellKey).toEqual(parsedText.__key);
-        expect(parsedSelection.focusCellKey).toEqual(parsedText.__key);
+        expect(parsedSelection.anchor.key).toEqual(parsedText.__key);
+        expect(parsedSelection.focus.key).toEqual(parsedText.__key);
       });
     });
   });

--- a/packages/lexical/src/__tests__/unit/LexicalEditorState.test.js
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorState.test.js
@@ -133,7 +133,7 @@ describe('LexicalEditorState tests', () => {
       });
 
       expect(JSON.stringify(editor.getEditorState().toJSON())).toEqual(
-        '{"_nodeMap":[["root",{"__children":["1"],"__dir":null,"__format":0,"__indent":0,"__key":"root","__parent":null,"__type":"root"}],["1",{"__type":"table","__parent":"root","__key":"1","__children":["2"],"__format":0,"__indent":0,"__dir":null}],["2",{"__type":"tablerow","__parent":"1","__key":"2","__children":["3"],"__format":0,"__indent":0,"__dir":null}],["3",{"__type":"tablecell","__parent":"2","__key":"3","__children":[],"__format":0,"__indent":0,"__dir":null,"__headerState":0}]],"_selection":{"anchorCellKey":"3","focusCellKey":"3","gridKey":"1","type":"grid"}}',
+        '{"_nodeMap":[["root",{"__children":["1"],"__dir":null,"__format":0,"__indent":0,"__key":"root","__parent":null,"__type":"root"}],["1",{"__type":"table","__parent":"root","__key":"1","__children":["2"],"__format":0,"__indent":0,"__dir":null}],["2",{"__type":"tablerow","__parent":"1","__key":"2","__children":["3"],"__format":0,"__indent":0,"__dir":null}],["3",{"__type":"tablecell","__parent":"2","__key":"3","__children":[],"__format":0,"__indent":0,"__dir":null,"__headerState":0}]],"_selection":{"anchor":{"key":"3","offset":0,"type":"element"},"focus":{"key":"3","offset":0,"type":"element"},"gridKey":"1","type":"grid"}}',
       );
     });
 


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/1904. This was an interesting one. Logically, we were missing some selection resolution code around the handling of inline elements – but by fixing that, it also made it clear that some of the logic for handling links and character offset resolution was also a bit loose. This PR fixes that and adds a regression test to capture that main issue.