### PR TITLE
Remove line from README about starting collab server

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ editor.registerUpdateListener(({editorState}) => {
    - `npm run test-e2e:chromium` to run only chromium e2e tests
      - The server needs to be running for the e2e tests
 
+`npm run start` will start both the web server and collab server. If you don't need collab, use `npm run dev` to start just the web server.
+
 ### Optional but recommended, use VSCode for development
 
 1.  Download and install VSCode

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ editor.registerUpdateListener(({editorState}) => {
    - `npm run test-e2e:chromium` to run only chromium e2e tests
      - The server needs to be running for the e2e tests
 
-`npm run start` will start both the web server and collab server. If you don't need collab, use `npm run dev` to start just the web server.
+`npm run start` will start both the dev server and collab server. If you don't need collab, use `npm run dev` to start just the dev server.
 
 ### Optional but recommended, use VSCode for development
 

--- a/README.md
+++ b/README.md
@@ -304,8 +304,6 @@ editor.registerUpdateListener(({editorState}) => {
    - `npm run test-e2e:chromium` to run only chromium e2e tests
      - The server needs to be running for the e2e tests
 
-Note: for collaboration, ensure you start the websocket server separately with `npm run collab`.
-
 ### Optional but recommended, use VSCode for development
 
 1.  Download and install VSCode


### PR DESCRIPTION
The collab server appears to start with `npm run start` now. This line isn't needed anymore.