### PR TITLE
fix: editor theme class name type for list

### DIFF
--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -213,7 +213,14 @@ export type EditorThemeClasses = {
     h5?: EditorThemeClassName;
   };
   // Handle other generic values
-  [key: string]: EditorThemeClassName | Record<string, EditorThemeClassName | Array<EditorThemeClassName> | Record<string, EditorThemeClassName>>;
+  [key: string]:
+    | EditorThemeClassName
+    | Record<
+        string,
+        | EditorThemeClassName
+        | Array<EditorThemeClassName>
+        | Record<string, EditorThemeClassName>
+      >;
 };
 export type EditorConfig = {
   namespace: string;

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -185,7 +185,6 @@ export type EditorThemeClasses = {
   text?: TextNodeThemeClasses;
   paragraph?: EditorThemeClassName;
   image?: EditorThemeClassName;
-  //@ts-expect-error
   list?: {
     ul?: EditorThemeClassName;
     ulDepth?: Array<EditorThemeClassName>;
@@ -214,7 +213,7 @@ export type EditorThemeClasses = {
     h5?: EditorThemeClassName;
   };
   // Handle other generic values
-  [key: string]: EditorThemeClassName | Record<string, EditorThemeClassName>;
+  [key: string]: EditorThemeClassName | Record<string, EditorThemeClassName | Array<EditorThemeClassName> | Record<string, EditorThemeClassName>>;
 };
 export type EditorConfig = {
   namespace: string;


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/1885

```typescript
type EditorThemeClasses = {
  list?: {...};
  // Handle other generic values
  [key: string]:
    | EditorThemeClassName
    | Record<
        string,
        | EditorThemeClassName
        | Array<EditorThemeClassName>
        | Record<string, EditorThemeClassName>
      >;
}
```

This only handles the current structure for `list` key. If we want it recursive I can update it to

```typescript
type EditorThemeRecursiveClassName = {
  [key: string]: EditorThemeClassName | Array<EditorThemeClassName> | EditorThemeRecursiveClassName
}

type EditorThemeClasses = {
  list?: {...};
  [key: string]: EditorThemeClassName | EditorThemeRecursiveClassName;
}
```