### PR TITLE
Updating content of community links description

### DIFF
--- a/packages/lexical-website-new/src/components/CommunityLinks/index.js
+++ b/packages/lexical-website-new/src/components/CommunityLinks/index.js
@@ -21,8 +21,7 @@ const links = [
       <Translate
         id="pages.community.links.github.description"
         description="Description of Github community">
-        Some copy about stack overflow Some copy about stack overflowSome copy
-        about stack overflow
+        Want to add a new feature or get a bug fixed? Create a pull request or raise an issue.
       </Translate>
     ),
     image: (
@@ -45,8 +44,7 @@ const links = [
       <Translate
         id="pages.community.links.stackoverflow.description"
         description="Description of StackOverflow community">
-        Some copy about stack overflow Some copy about stack overflowSome copy
-        about stack overflow
+        Have trouble using Lexical? Just shoot a question.
       </Translate>
     ),
     image: (
@@ -69,8 +67,7 @@ const links = [
       <Translate
         id="pages.community.links.discord.description"
         description="Description of Discord community">
-        Some copy about stack overflow Some copy about stack overflowSome copy
-        about stack overflow
+        Let us discuss upcoming features and plan together.
       </Translate>
     ),
     image: (

--- a/packages/lexical-website-new/src/components/CommunityLinks/index.js
+++ b/packages/lexical-website-new/src/components/CommunityLinks/index.js
@@ -44,7 +44,7 @@ const links = [
       <Translate
         id="pages.community.links.stackoverflow.description"
         description="Description of StackOverflow community">
-        Have trouble using Lexical? Just shoot a question.
+        Having trouble using Lexical? Just shoot us a question.
       </Translate>
     ),
     image: (
@@ -67,7 +67,7 @@ const links = [
       <Translate
         id="pages.community.links.discord.description"
         description="Description of Discord community">
-        Let us discuss upcoming features and plan together.
+        Let's discuss upcoming features and plans together.
       </Translate>
     ),
     image: (


### PR DESCRIPTION
This would be an improvement from the current content

<img width="805" alt="image" src="https://user-images.githubusercontent.com/6573105/164614643-4fc72b4d-98bb-421f-9eb6-aa562965cab3.png">

There is always scope for improvement.