### PR TITLE
Add aria-labels to toolbar and footer bar.

### DIFF
--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -544,17 +544,26 @@ export function html(partials, ...params) {
 }
 
 export async function selectFromFormatDropdown(page, selector) {
-  await click(page, '.toolbar-item[aria-label="Formatting Options"]');
+  await click(
+    page,
+    '.toolbar-item[aria-label="Formatting options for text style"]',
+  );
   await click(page, '.dropdown ' + selector);
 }
 
 export async function selectFromInsertDropdown(page, selector) {
-  await click(page, '.toolbar-item[aria-label="Insert"]');
+  await click(
+    page,
+    '.toolbar-item[aria-label="Insert specialized editor node"]',
+  );
   await click(page, '.dropdown ' + selector);
 }
 
 export async function selectFromAlignDropdown(page, selector) {
-  await click(page, '.toolbar-item[aria-label="Align"]');
+  await click(
+    page,
+    '.toolbar-item[aria-label="Formatting options for text alignment"]',
+  );
   await click(page, '.dropdown ' + selector);
 }
 

--- a/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
@@ -190,8 +190,8 @@ export default function ActionsPlugin({
             connected ? 'Disconnect' : 'Connect'
           } Collaborative Editing`}
           aria-label={`${
-            connected ? 'Disconnect' : 'Connect'
-          } from a collaborative editing server`}>
+            connected ? 'Disconnect from' : 'Connect to'
+          } a collaborative editing server`}>
           <i className={connected ? 'disconnect' : 'connect'} />
         </button>
       )}

--- a/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
@@ -129,7 +129,7 @@ export default function ActionsPlugin({
           title="Speect To Text"
           aria-label={`${
             isSpeechToText ? 'Enable' : 'Disable'
-          } speect to text assistive technology`}>
+          } speect to text`}>
           <i className="mic" />
         </button>
       )}
@@ -169,14 +169,14 @@ export default function ActionsPlugin({
         onClick={() => {
           editor.setReadOnly(!editor.isReadOnly());
         }}
-        title="Read-only mode"
+        title="Read-Only Mode"
         aria-label={`${isReadOnly ? 'Unlock' : 'Lock'} read-only mode`}>
         <i className={isReadOnly ? 'unlock' : 'lock'} />
       </button>
       <button
         className="action-button"
         onClick={handleMarkdownToggle}
-        title="Convert from markdown"
+        title="Convert From Markdown"
         aria-label="Convert from markdown">
         <i className="markdown" />
       </button>
@@ -188,7 +188,7 @@ export default function ActionsPlugin({
           }}
           title={`${
             connected ? 'Disconnect' : 'Connect'
-          } collaborative editing`}
+          } Collaborative Editing`}
           aria-label={`${
             connected ? 'Disconnect' : 'Connect'
           } from a collaborative editing server`}>

--- a/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
@@ -126,8 +126,10 @@ export default function ActionsPlugin({
             'action-button action-button-mic ' +
             (isSpeechToText ? 'active' : '')
           }
-          title="Mic"
-          aria-label="Mic">
+          title="Speect To Text"
+          aria-label={`${
+            isSpeechToText ? 'Enable' : 'Disable'
+          } speect to text assistive technology`}>
           <i className="mic" />
         </button>
       )}
@@ -135,7 +137,7 @@ export default function ActionsPlugin({
         className="action-button import"
         onClick={() => importFile(editor)}
         title="Import"
-        aria-label="Import">
+        aria-label="Import editor state from JSON">
         <i className="import" />
       </button>
       <button
@@ -147,7 +149,7 @@ export default function ActionsPlugin({
           })
         }
         title="Export"
-        aria-label="Export">
+        aria-label="Export editor state to JSON">
         <i className="export" />
       </button>
       <button
@@ -159,7 +161,7 @@ export default function ActionsPlugin({
           ));
         }}
         title="Clear"
-        aria-label="Clear">
+        aria-label="Clear editor contents">
         <i className="clear" />
       </button>
       <button
@@ -167,15 +169,15 @@ export default function ActionsPlugin({
         onClick={() => {
           editor.setReadOnly(!editor.isReadOnly());
         }}
-        title={isReadOnly ? 'Unlock' : 'Lock'}
-        aria-label={isReadOnly ? 'Unlock' : 'Lock'}>
+        title="Read-only mode"
+        aria-label={`${isReadOnly ? 'Unlock' : 'Lock'} read-only mode`}>
         <i className={isReadOnly ? 'unlock' : 'lock'} />
       </button>
       <button
         className="action-button"
         onClick={handleMarkdownToggle}
-        title="Markdown"
-        aria-label="Markdown">
+        title="Convert from markdown"
+        aria-label="Convert from markdown">
         <i className="markdown" />
       </button>
       {isCollab && (
@@ -184,8 +186,12 @@ export default function ActionsPlugin({
           onClick={() => {
             editor.dispatchCommand(TOGGLE_CONNECT_COMMAND, !connected);
           }}
-          title={connected ? 'Disconnect' : 'Connect'}
-          aria-label={connected ? 'Disconnect' : 'Connect'}>
+          title={`${
+            connected ? 'Disconnect' : 'Connect'
+          } collaborative editing`}
+          aria-label={`${
+            connected ? 'Disconnect' : 'Connect'
+          } from a collaborative editing server`}>
           <i className={connected ? 'disconnect' : 'connect'} />
         </button>
       )}

--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
@@ -130,7 +130,7 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
         }}
         className={'popup-item spaced ' + (isBold ? 'active' : '')}
-        aria-label="Format text to bold">
+        aria-label="Format text as bold">
         <i className="format bold" />
       </button>
       <button
@@ -138,7 +138,7 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
         }}
         className={'popup-item spaced ' + (isItalic ? 'active' : '')}
-        aria-label="Format text to italics">
+        aria-label="Format text as italics">
         <i className="format italic" />
       </button>
       <button
@@ -146,7 +146,7 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
         }}
         className={'popup-item spaced ' + (isUnderline ? 'active' : '')}
-        aria-label="Format text to underline">
+        aria-label="Format text to underlined">
         <i className="format underline" />
       </button>
       <button
@@ -154,7 +154,7 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough');
         }}
         className={'popup-item spaced ' + (isStrikethrough ? 'active' : '')}
-        aria-label="Format text to strikethrough">
+        aria-label="Format text with a strikethrough">
         <i className="format strikethrough" />
       </button>
       <button

--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
@@ -130,7 +130,7 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
         }}
         className={'popup-item spaced ' + (isBold ? 'active' : '')}
-        aria-label="Format Bold">
+        aria-label="Format text to bold">
         <i className="format bold" />
       </button>
       <button
@@ -138,7 +138,7 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
         }}
         className={'popup-item spaced ' + (isItalic ? 'active' : '')}
-        aria-label="Format Italics">
+        aria-label="Format text to italics">
         <i className="format italic" />
       </button>
       <button
@@ -146,7 +146,7 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
         }}
         className={'popup-item spaced ' + (isUnderline ? 'active' : '')}
-        aria-label="Format Underline">
+        aria-label="Format text to underline">
         <i className="format underline" />
       </button>
       <button
@@ -154,7 +154,7 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough');
         }}
         className={'popup-item spaced ' + (isStrikethrough ? 'active' : '')}
-        aria-label="Format Strikethrough">
+        aria-label="Format text to strikethrough">
         <i className="format strikethrough" />
       </button>
       <button
@@ -162,13 +162,15 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
         }}
         className={'popup-item spaced ' + (isCode ? 'active' : '')}
-        aria-label="Insert Code">
+        aria-label="Insert code block"
+        type="Insert code block">
         <i className="format code" />
       </button>
       <button
         onClick={insertLink}
         className={'popup-item spaced ' + (isLink ? 'active' : '')}
-        aria-label="Insert Link">
+        aria-label="Insert link"
+        type="Insert link">
         <i className="format link" />
       </button>
     </div>

--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.jsx
@@ -162,15 +162,13 @@ function FloatingCharacterStylesEditor({
           editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
         }}
         className={'popup-item spaced ' + (isCode ? 'active' : '')}
-        aria-label="Insert code block"
-        type="Insert code block">
+        aria-label="Insert code block">
         <i className="format code" />
       </button>
       <button
         onClick={insertLink}
         className={'popup-item spaced ' + (isLink ? 'active' : '')}
-        aria-label="Insert link"
-        type="Insert link">
+        aria-label="Insert link">
         <i className="format link" />
       </button>
     </div>

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -660,7 +660,7 @@ function BlockFormatDropDown({
       buttonClassName="toolbar-item block-controls"
       buttonIconClassName={'icon block-type ' + blockType}
       buttonLabel={blockTypeToBlockName[blockType]}
-      buttonAriaLabel="Formatting Options">
+      buttonAriaLabel="Formatting options for text style">
       <button className="item" onClick={formatParagraph}>
         <span className="icon paragraph" />
         <span className="text">Normal</span>
@@ -981,7 +981,9 @@ export default function ToolbarPlugin(): React$Node {
             }}
             className={'toolbar-item spaced ' + (isBold ? 'active' : '')}
             title={IS_APPLE ? 'Bold (⌘B)' : 'Bold (Ctrl+B)'}
-            aria-label="Format Bold">
+            aria-label={`Format text as bold. Shortcut: ${
+              IS_APPLE ? '⌘B' : 'Ctrl+B'
+            }`}>
             <i className="format bold" />
           </button>
           <button
@@ -990,7 +992,9 @@ export default function ToolbarPlugin(): React$Node {
             }}
             className={'toolbar-item spaced ' + (isItalic ? 'active' : '')}
             title={IS_APPLE ? 'Italic (⌘I)' : 'Italic (Ctrl+I)'}
-            aria-label="Format Italics">
+            aria-label={`Format text as italics. Shortcut: ${
+              IS_APPLE ? '⌘I' : 'Ctrl+I'
+            }`}>
             <i className="format italic" />
           </button>
           <button
@@ -999,7 +1003,9 @@ export default function ToolbarPlugin(): React$Node {
             }}
             className={'toolbar-item spaced ' + (isUnderline ? 'active' : '')}
             title={IS_APPLE ? 'Underline (⌘U)' : 'Underline (Ctrl+U)'}
-            aria-label="Format Underline">
+            aria-label={`Format text to underlined. Shortcut: ${
+              IS_APPLE ? '⌘U' : 'Ctrl+U'
+            }`}>
             <i className="format underline" />
           </button>
           <button
@@ -1013,7 +1019,7 @@ export default function ToolbarPlugin(): React$Node {
               'toolbar-item spaced ' + (isStrikethrough ? 'active' : '')
             }
             title="Strikethrough"
-            aria-label="Format Strikethrough">
+            aria-label="Format text with a strikethrough">
             <i className="format strikethrough" />
           </button>
           <button
@@ -1021,15 +1027,15 @@ export default function ToolbarPlugin(): React$Node {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
             }}
             className={'toolbar-item spaced ' + (isCode ? 'active' : '')}
-            title="Code"
-            aria-label="Insert Code">
+            title="Insert code block"
+            aria-label="Insert code block">
             <i className="format code" />
           </button>
           <button
             onClick={insertLink}
             className={'toolbar-item spaced ' + (isLink ? 'active' : '')}
-            title="Insert Link"
-            aria-label="Insert Link">
+            aria-label="Insert link"
+            type="Insert link">
             <i className="format link" />
           </button>
           {isLink &&
@@ -1041,6 +1047,7 @@ export default function ToolbarPlugin(): React$Node {
           <DropDown
             buttonClassName="toolbar-item spaced"
             buttonLabel="Insert"
+            buttonAriaLabel="Insert specialized editor node"
             buttonIconClassName="icon plus">
             <button
               onClick={() => {
@@ -1166,7 +1173,8 @@ export default function ToolbarPlugin(): React$Node {
       <DropDown
         buttonLabel="Align"
         buttonIconClassName="icon left-align"
-        buttonClassName="toolbar-item spaced">
+        buttonClassName="toolbar-item spaced"
+        buttonAriaLabel="Formatting options for text alignment">
         <button
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left');

--- a/packages/lexical-playground/src/ui/Modal.jsx
+++ b/packages/lexical-playground/src/ui/Modal.jsx
@@ -51,6 +51,7 @@ function PortalImpl({
         <button
           className="Modal__closeButton"
           aria-label="Close modal"
+          type="Close"
           onClick={onClose}>
           X
         </button>


### PR DESCRIPTION
Add descriptive `aria-labels` to all buttons in the toolbar and in the actions footer bar, which just show an icon.  

This should be used as the default button label by screen readers, overwriting the shortened `title` attribute introduced in #1924, 

The `title` attribute also has some accessibility shortcomings, highlighted in #1726.