### PR TITLE
Remove useCallbacks in StickyNode

### DIFF
--- a/packages/lexical-playground/src/nodes/StickyNode.jsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.jsx
@@ -26,7 +26,7 @@ import {
   DecoratorNode,
 } from 'lexical';
 import * as React from 'react';
-import {useCallback, useEffect, useRef} from 'react';
+import {useEffect, useRef} from 'react';
 // $FlowFixMe
 import {createPortal} from 'react-dom';
 import useLayoutEffect from 'shared/useLayoutEffect';
@@ -146,7 +146,7 @@ function StickyComponent({
     }
   }, []);
 
-  const handlePointerMove = useCallback((event: PointerEvent) => {
+  const handlePointerMove = (event: PointerEvent) => {
     const stickyContainer = stickyContainerRef.current;
     const positioning = positioningRef.current;
     const rootElementRect = positioning.rootElementRect;
@@ -159,45 +159,42 @@ function StickyComponent({
       positioning.y = event.pageY - positioning.offsetY - rootElementRect.top;
       positionSticky(stickyContainer, positioning);
     }
-  }, []);
+  };
 
-  const handlePointerUp = useCallback(
-    (event: PointerEvent) => {
-      const stickyContainer = stickyContainerRef.current;
-      const positioning = positioningRef.current;
-      if (stickyContainer !== null) {
-        positioning.isDragging = false;
-        stickyContainer.classList.remove('dragging');
-        editor.update(() => {
-          const node = $getNodeByKey(nodeKey);
-          if ($isStickyNode(node)) {
-            node.setPosition(positioning.x, positioning.y);
-          }
-        });
-      }
-      document.removeEventListener('pointermove', handlePointerMove);
-      document.removeEventListener('pointerup', handlePointerUp);
-    },
-    [editor, handlePointerMove, nodeKey],
-  );
+  const handlePointerUp = (event: PointerEvent) => {
+    const stickyContainer = stickyContainerRef.current;
+    const positioning = positioningRef.current;
+    if (stickyContainer !== null) {
+      positioning.isDragging = false;
+      stickyContainer.classList.remove('dragging');
+      editor.update(() => {
+        const node = $getNodeByKey(nodeKey);
+        if ($isStickyNode(node)) {
+          node.setPosition(positioning.x, positioning.y);
+        }
+      });
+    }
+    document.removeEventListener('pointermove', handlePointerMove);
+    document.removeEventListener('pointerup', handlePointerUp);
+  };
 
-  const handleDelete = useCallback(() => {
+  const handleDelete = () => {
     editor.update(() => {
       const node = $getNodeByKey(nodeKey);
       if ($isStickyNode(node)) {
         node.remove();
       }
     });
-  }, [editor, nodeKey]);
+  };
 
-  const handleColorChange = useCallback(() => {
+  const handleColorChange = () => {
     editor.update(() => {
       const node = $getNodeByKey(nodeKey);
       if ($isStickyNode(node)) {
         node.toggleColor();
       }
     });
-  }, [editor, nodeKey]);
+  };
 
   const {historyState} = useSharedHistoryContext();
 


### PR DESCRIPTION
There is a common misconception about `useCallback` that it prevents function creation during render. It actually doesn't prevent it and when used for this goal, it decreases performance. `useCallback` is needed when referential equality matters, for exampled for memoized components props (`React.Memo()`) or when used in a hook dependency array. There is a very good article explaining it better than me in https://kentcdodds.com/blog/usememo-and-usecallback. 

In StickyNode this is not one of these cases where it's needed.
`handleDelete` and `handleColorChange` are both passed to a `<button>`, which is a host component and doesn't do any referential equality check. 
`handlePointerMove` and `handlePointerUp` are a bit more tricky. Referential equality **does** matter here as `removeEventListener` needs to be passed the same function that was passed in `addEventListener` to correctly remove the listener. But the functions will be the same even without `useCallback`. The function passed to `onPointerDown` will capture both `handlePointerMove` and `handlePointerUp` and when `handlePointerUp` is called, it will call `removeEventListener` with these captured functions, so they will be the same. **In short, in this case we need referential equality, but not across renders**. I hope this makes  sense.

After this I will look into unneeded `useCallback` in other files.
