### PR TITLE
Fix text/html copy regression

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.js
+++ b/packages/lexical-clipboard/src/clipboard.js
@@ -133,6 +133,10 @@ export function $convertSelectedLexicalContentToHtml(
         node,
       );
       if (element) {
+        // It might be the case that the node is an element node
+        // and we're not directly selecting it, but we are selecting
+        // some of its children. So we'll need to extract that out
+        // separately.
         if (node.isSelected()) {
           container.append(element);
         } else {

--- a/packages/lexical-website-new/src/components/CommunityLinks/index.js
+++ b/packages/lexical-website-new/src/components/CommunityLinks/index.js
@@ -21,7 +21,8 @@ const links = [
       <Translate
         id="pages.community.links.github.description"
         description="Description of Github community">
-        Want to add a new feature or get a bug fixed? Create a pull request or raise an issue.
+        Want to add a new feature or get a bug fixed? Create a pull request or
+        raise an issue.
       </Translate>
     ),
     image: (


### PR DESCRIPTION
This is a quick fix for the regression we're seeing with Lexical and copying of rich text content. Today, we're inserting an empty string into the clipboard, which is causing big issues for users on FF.