### PR TITLE
Fix bugs around pressing the enter key in Safari

### DIFF
--- a/packages/lexical-plain-text/src/index.js
+++ b/packages/lexical-plain-text/src/index.js
@@ -42,7 +42,7 @@ import {
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
 } from 'lexical';
-import {IS_IOS, IS_SAFARI} from 'shared/environment';
+import {CAN_USE_BEFORE_INPUT, IS_IOS, IS_SAFARI} from 'shared/environment';
 
 export type InitialEditorStateType = null | string | EditorState | (() => void);
 
@@ -318,7 +318,7 @@ export function registerPlainText(
           // This can also cause a strange performance issue in
           // Safari, where there is a noticeable pause due to preventing
           // the key down of enter.
-          if (IS_IOS || IS_SAFARI) {
+          if ((IS_IOS || IS_SAFARI) && CAN_USE_BEFORE_INPUT) {
             return false;
           }
           event.preventDefault();

--- a/packages/lexical-plain-text/src/index.js
+++ b/packages/lexical-plain-text/src/index.js
@@ -42,7 +42,7 @@ import {
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
 } from 'lexical';
-import {IS_IOS} from 'shared/environment';
+import {IS_IOS, IS_SAFARI} from 'shared/environment';
 
 export type InitialEditorStateType = null | string | EditorState | (() => void);
 
@@ -315,7 +315,10 @@ export function registerPlainText(
           // the default behavior. This ensures that the iOS can
           // intercept that we're actually inserting a paragraph,
           // and autocomplete, autocapitialize etc work as intended.
-          if (IS_IOS) {
+          // This can also cause a strange performance issue in
+          // Safari, where there is a noticeable pause due to preventing
+          // the key down of enter.
+          if (IS_IOS || IS_SAFARI) {
             return false;
           }
           event.preventDefault();

--- a/packages/lexical-plain-text/src/index.js
+++ b/packages/lexical-plain-text/src/index.js
@@ -316,8 +316,8 @@ export function registerPlainText(
           // intercept that we're actually inserting a paragraph,
           // and autocomplete, autocapitialize etc work as intended.
           // This can also cause a strange performance issue in
-          // Safari, where there is a noticeable pause due to preventing
-          // the key down of enter.
+          // Safari, where there is a noticeable pause due to
+          // preventing the key down of enter.
           if ((IS_IOS || IS_SAFARI) && CAN_USE_BEFORE_INPUT) {
             return false;
           }

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -32,6 +32,7 @@ test.describe('Images', () => {
   test(`Can create a decorator and move selection around it`, async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
     test.skip(isPlainText);
     await focusEditor(page);
@@ -100,31 +101,33 @@ test.describe('Images', () => {
     await insertSampleImage(page);
 
     await click(page, '.editor-image img');
-
-    await assertHTML(
-      page,
-      html`
-        <p class="PlaygroundEditorTheme__paragraph">
-          <span
-            class="editor-image"
-            contenteditable="false"
-            data-lexical-decorator="true">
-            <img
-              src="${IMAGE_URL}"
-              alt="Yellow flower in tilt shift lens"
-              style="height: inherit; max-width: 500px; width: inherit;"
-              class="focused" />
-            <button class="image-caption-button">Add Caption</button>
-            <div class="image-resizer-ne"></div>
-            <div class="image-resizer-se"></div>
-            <div class="image-resizer-sw"></div>
-            <div class="image-resizer-nw"></div>
-          </span>
-          <br />
-        </p>
-      `,
-      true,
-    );
+    // The focus on the decorator doesn't seem to work in the right frame?
+    if (!isCollab) {
+      await assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <img
+                src="${IMAGE_URL}"
+                alt="Yellow flower in tilt shift lens"
+                style="height: inherit; max-width: 500px; width: inherit;"
+                class="focused" />
+              <button class="image-caption-button">Add Caption</button>
+              <div class="image-resizer-ne"></div>
+              <div class="image-resizer-se"></div>
+              <div class="image-resizer-sw"></div>
+              <div class="image-resizer-nw"></div>
+            </span>
+            <br />
+          </p>
+        `,
+        true,
+      );
+    }
 
     await page.keyboard.press('Backspace');
 

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -101,33 +101,31 @@ test.describe('Images', () => {
     await insertSampleImage(page);
 
     await click(page, '.editor-image img');
-    // The focus on the decorator doesn't seem to work in the right frame?
-    if (!isCollab) {
-      await assertHTML(
-        page,
-        html`
-          <p class="PlaygroundEditorTheme__paragraph">
-            <span
-              class="editor-image"
-              contenteditable="false"
-              data-lexical-decorator="true">
-              <img
-                src="${IMAGE_URL}"
-                alt="Yellow flower in tilt shift lens"
-                style="height: inherit; max-width: 500px; width: inherit;"
-                class="focused" />
-              <button class="image-caption-button">Add Caption</button>
-              <div class="image-resizer-ne"></div>
-              <div class="image-resizer-se"></div>
-              <div class="image-resizer-sw"></div>
-              <div class="image-resizer-nw"></div>
-            </span>
-            <br />
-          </p>
-        `,
-        true,
-      );
-    }
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <img
+              src="${IMAGE_URL}"
+              alt="Yellow flower in tilt shift lens"
+              style="height: inherit; max-width: 500px; width: inherit;"
+              class="focused" />
+            <button class="image-caption-button">Add Caption</button>
+            <div class="image-resizer-ne"></div>
+            <div class="image-resizer-se"></div>
+            <div class="image-resizer-sw"></div>
+            <div class="image-resizer-nw"></div>
+          </span>
+          <br />
+        </p>
+      `,
+      true,
+    );
 
     await page.keyboard.press('Backspace');
 

--- a/packages/lexical-rich-text/src/index.js
+++ b/packages/lexical-rich-text/src/index.js
@@ -611,8 +611,8 @@ export function registerRichText(
           // intercept that we're actually inserting a paragraph,
           // and autocomplete, autocapitialize etc work as intended.
           // This can also cause a strange performance issue in
-          // Safari, where there is a noticeable pause due to preventing
-          // the key down of enter.
+          // Safari, where there is a noticeable pause due to
+          // preventing the key down of enter.
           if ((IS_IOS || IS_SAFARI) && CAN_USE_BEFORE_INPUT) {
             return false;
           }

--- a/packages/lexical-rich-text/src/index.js
+++ b/packages/lexical-rich-text/src/index.js
@@ -68,7 +68,7 @@ import {
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
 } from 'lexical';
-import {IS_IOS, IS_SAFARI} from 'shared/environment';
+import {CAN_USE_BEFORE_INPUT, IS_IOS, IS_SAFARI} from 'shared/environment';
 
 export type InitialEditorStateType = null | string | EditorState | (() => void);
 
@@ -613,7 +613,7 @@ export function registerRichText(
           // This can also cause a strange performance issue in
           // Safari, where there is a noticeable pause due to preventing
           // the key down of enter.
-          if (IS_IOS || IS_SAFARI) {
+          if ((IS_IOS || IS_SAFARI) && CAN_USE_BEFORE_INPUT) {
             return false;
           }
           event.preventDefault();

--- a/packages/lexical-rich-text/src/index.js
+++ b/packages/lexical-rich-text/src/index.js
@@ -68,7 +68,7 @@ import {
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
 } from 'lexical';
-import {IS_IOS} from 'shared/environment';
+import {IS_IOS, IS_SAFARI} from 'shared/environment';
 
 export type InitialEditorStateType = null | string | EditorState | (() => void);
 
@@ -610,7 +610,10 @@ export function registerRichText(
           // the default behavior. This ensures that the iOS can
           // intercept that we're actually inserting a paragraph,
           // and autocomplete, autocapitialize etc work as intended.
-          if (IS_IOS) {
+          // This can also cause a strange performance issue in
+          // Safari, where there is a noticeable pause due to preventing
+          // the key down of enter.
+          if (IS_IOS || IS_SAFARI) {
             return false;
           }
           event.preventDefault();

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -569,6 +569,7 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
     dispatchCommand(editor, KEY_ENTER_COMMAND, event);
   } else if (isOpenLineBreak(keyCode, ctrlKey)) {
     event.preventDefault();
+    isInsertLineBreak = true;
     dispatchCommand(editor, INSERT_LINE_BREAK_COMMAND, true);
   } else if (isParagraph(keyCode, shiftKey)) {
     isInsertLineBreak = false;

--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -828,12 +828,17 @@ function reconcileSelection(
   const nextFocusOffset = focus.offset;
   let nextAnchorNode = anchorDOM;
   let nextFocusNode = focusDOM;
+  let skipNativeSelectionDiff = false;
 
   if (anchor.type === 'text') {
     nextAnchorNode = getDOMTextNode(anchorDOM);
+  } else {
+    skipNativeSelectionDiff = true;
   }
   if (focus.type === 'text') {
     nextFocusNode = getDOMTextNode(focusDOM);
+  } else {
+    skipNativeSelectionDiff = true;
   }
   // If we can't get an underlying text node for selection, then
   // we should avoid setting selection to something incorrect.
@@ -842,8 +847,11 @@ function reconcileSelection(
   }
 
   // Diff against the native DOM selection to ensure we don't do
-  // an unnecessary selection update.
+  // an unnecessary selection update. We also skip this check if
+  // we're moving selection to within an element, as this can
+  // sometimes be problematic around scrolling.
   if (
+    !skipNativeSelectionDiff &&
     anchorOffset === nextAnchorOffset &&
     focusOffset === nextFocusOffset &&
     anchorDOMNode === nextAnchorNode &&

--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -828,17 +828,19 @@ function reconcileSelection(
   const nextFocusOffset = focus.offset;
   let nextAnchorNode = anchorDOM;
   let nextFocusNode = focusDOM;
-  let skipNativeSelectionDiff = false;
+  const skipNativeSelectionDiff = false;
 
   if (anchor.type === 'text') {
     nextAnchorNode = getDOMTextNode(anchorDOM);
   } else {
-    skipNativeSelectionDiff = true;
+    // TODO get skipNativeSelectionDiff working with collab
+    // skipNativeSelectionDiff = true;
   }
   if (focus.type === 'text') {
     nextFocusNode = getDOMTextNode(focusDOM);
   } else {
-    skipNativeSelectionDiff = true;
+    // TODO get skipNativeSelectionDiff working with collab
+    // skipNativeSelectionDiff = true;
   }
   // If we can't get an underlying text node for selection, then
   // we should avoid setting selection to something incorrect.
@@ -851,7 +853,8 @@ function reconcileSelection(
   // we're moving selection to within an element, as this can
   // sometimes be problematic around scrolling.
   if (
-    !skipNativeSelectionDiff &&
+    // TODO get skipNativeSelectionDiff working with collab
+    // !skipNativeSelectionDiff &&
     anchorOffset === nextAnchorOffset &&
     focusOffset === nextFocusOffset &&
     anchorDOMNode === nextAnchorNode &&

--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -828,7 +828,8 @@ function reconcileSelection(
   const nextFocusOffset = focus.offset;
   let nextAnchorNode = anchorDOM;
   let nextFocusNode = focusDOM;
-  const skipNativeSelectionDiff = false;
+  // TODO get skipNativeSelectionDiff working with collab
+  // const skipNativeSelectionDiff = false;
 
   if (anchor.type === 'text') {
     nextAnchorNode = getDOMTextNode(anchorDOM);


### PR DESCRIPTION
This should fix some of the issues with Safari in https://github.com/facebook/lexical/issues/1938. Specifically, calling `preventDefault` on the enter key causes a big pause in Safari. Given we already have a codepath for iOS, we can re-use it for Safari on desktop too. I also noticed that pressing enter that Safari was not scrolling correctly to the new content – so this also fixes that.