### PR TITLE
Fix formatting on embeds

### DIFF
--- a/packages/lexical-playground/src/nodes/TweetNode.jsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.jsx
@@ -98,7 +98,7 @@ export class TweetNode extends DecoratorBlockNode<React$Node> {
     return new TweetNode(node.__id, node.__format, node.__key);
   }
 
-  constructor(id: string, format?: ElementFormatType, key?: NodeKey) {
+  constructor(id: string, format?: ?ElementFormatType, key?: NodeKey) {
     super(format, key);
     this.__id = id;
   }

--- a/packages/lexical-playground/src/nodes/TweetNode.jsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.jsx
@@ -95,12 +95,11 @@ export class TweetNode extends DecoratorBlockNode<React$Node> {
   }
 
   static clone(node: TweetNode): TweetNode {
-    return new TweetNode(node.__id, node.__key);
+    return new TweetNode(node.__id, node.__format, node.__key);
   }
 
-  constructor(id: string, key?: NodeKey) {
-    super(key);
-
+  constructor(id: string, format?: ElementFormatType, key?: NodeKey) {
+    super(format, key);
     this.__id = id;
   }
 
@@ -113,11 +112,6 @@ export class TweetNode extends DecoratorBlockNode<React$Node> {
         tweetID={this.__id}
       />
     );
-  }
-
-  setFormat(format: ElementFormatType): void {
-    const self = this.getWritable();
-    self.__format = format;
   }
 }
 

--- a/packages/lexical-playground/src/nodes/YouTubeNode.jsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.jsx
@@ -46,7 +46,7 @@ export class YouTubeNode extends DecoratorBlockNode<React$Node> {
     return new YouTubeNode(node.__id, node.__format, node.__key);
   }
 
-  constructor(id: string, format?: ElementFormatType, key?: NodeKey) {
+  constructor(id: string, format?: ?ElementFormatType, key?: NodeKey) {
     super(format, key);
     this.__id = id;
   }

--- a/packages/lexical-playground/src/nodes/YouTubeNode.jsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.jsx
@@ -43,11 +43,11 @@ export class YouTubeNode extends DecoratorBlockNode<React$Node> {
   }
 
   static clone(node: YouTubeNode): YouTubeNode {
-    return new YouTubeNode(node.__id, node.__key);
+    return new YouTubeNode(node.__id, node.__format, node.__key);
   }
 
-  constructor(id: string, key?: NodeKey) {
-    super(key);
+  constructor(id: string, format?: ElementFormatType, key?: NodeKey) {
+    super(format, key);
     this.__id = id;
   }
 

--- a/packages/lexical-react/flow/LexicalDecoratorBlockNode.js.flow
+++ b/packages/lexical-react/flow/LexicalDecoratorBlockNode.js.flow
@@ -17,8 +17,8 @@ import type {
 import {DecoratorNode} from 'lexical';
 
 declare export class DecoratorBlockNode<T> extends DecoratorNode<T> {
-  __format: ElementFormatType;
-  constructor(format?: ElementFormatType, key?: NodeKey): void;
+  __format: ?ElementFormatType;
+  constructor(format?: ?ElementFormatType, key?: NodeKey): void;
   createDOM(): HTMLElement;
   setFormat(format: ElementFormatType): void;
 }

--- a/packages/lexical-react/flow/LexicalDecoratorBlockNode.js.flow
+++ b/packages/lexical-react/flow/LexicalDecoratorBlockNode.js.flow
@@ -7,17 +7,22 @@
  * @flow strict
  */
 
-import type {ElementFormatType, LexicalNode, LexicalCommand} from 'lexical';
+import type {
+  ElementFormatType,
+  LexicalNode,
+  LexicalCommand,
+  NodeKey,
+} from 'lexical';
 
 import {DecoratorNode} from 'lexical';
 
 declare export class DecoratorBlockNode<T> extends DecoratorNode<T> {
-  __format: ?ElementFormatType;
+  __format: ElementFormatType;
+  constructor(format?: ElementFormatType, key?: NodeKey): void;
   createDOM(): HTMLElement;
   setFormat(format: ElementFormatType): void;
 }
 
-declare export function $createDecoratorBlockNode<T>(): DecoratorBlockNode<T>;
 declare export function $isDecoratorBlockNode(
   node: ?LexicalNode,
 ): boolean %checks(node instanceof DecoratorBlockNode);

--- a/packages/lexical-react/src/LexicalDecoratorBlockNode.js
+++ b/packages/lexical-react/src/LexicalDecoratorBlockNode.js
@@ -7,12 +7,17 @@
  * @flow strict
  */
 
-import type {ElementFormatType, LexicalNode} from 'lexical';
+import type {ElementFormatType, LexicalNode, NodeKey} from 'lexical';
 
 import {DecoratorNode} from 'lexical';
 
 export class DecoratorBlockNode extends DecoratorNode<React$Node> {
-  __format: ?ElementFormatType;
+  __format: ElementFormatType;
+
+  constructor(format?: ElementFormatType, key?: NodeKey) {
+    super(key);
+    this.__format = format || 'left';
+  }
 
   createDOM(): HTMLElement {
     return document.createElement('div');
@@ -27,11 +32,6 @@ export class DecoratorBlockNode extends DecoratorNode<React$Node> {
     self.__format = format;
   }
 }
-
-export function $createDecoratorBlockNode(): DecoratorBlockNode {
-  return new DecoratorBlockNode();
-}
-
 export function $isDecoratorBlockNode(node: ?LexicalNode): boolean %checks {
   return node instanceof DecoratorBlockNode;
 }

--- a/packages/lexical-react/src/LexicalDecoratorBlockNode.js
+++ b/packages/lexical-react/src/LexicalDecoratorBlockNode.js
@@ -12,11 +12,11 @@ import type {ElementFormatType, LexicalNode, NodeKey} from 'lexical';
 import {DecoratorNode} from 'lexical';
 
 export class DecoratorBlockNode extends DecoratorNode<React$Node> {
-  __format: ElementFormatType;
+  __format: ?ElementFormatType;
 
-  constructor(format?: ElementFormatType, key?: NodeKey) {
+  constructor(format?: ?ElementFormatType, key?: NodeKey) {
     super(key);
-    this.__format = format || 'left';
+    this.__format = format;
   }
 
   createDOM(): HTMLElement {


### PR DESCRIPTION
Embed nodes do not correctly update. It turned out that the format logic was missing from the constructor and the clone methods, which was why it was never being kept on the node.