### PR TITLE
Fix trying to remove unexisting element after composition

### DIFF
--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -541,6 +541,9 @@ export function $updateTextNodeFromDOMContent(
           const editor = getActiveEditor();
           setTimeout(() => {
             editor.update(() => {
+              if (!node.isAttached()) {
+                return;
+              }
               node.remove();
             });
           }, 20);


### PR DESCRIPTION
Bit blinded by the fact it's async but my hunch is that the OS somehow has already removed the node we're trying to remove, consequently error'ing when trying to do a `getParent` as the node is no longer registered

This would usually work fine but the fact it's a setTimeout means the EditorState can have taken a completely different shape in the meantime