### PR TITLE
CodeHighlight setFormat do not mark dirty

### DIFF
--- a/packages/lexical-code/src/index.js
+++ b/packages/lexical-code/src/index.js
@@ -128,7 +128,7 @@ export class CodeHighlightNode extends TextNode {
 
   // Prevent formatting (bold, underline, etc)
   setFormat(format: number): this {
-    return this.getWritable();
+    return this;
   }
 }
 


### PR DESCRIPTION
If we're not changing node values, let's just not mark the node dirty which is more expensive? #1966 