### PR TITLE
Deduplicate code langs in a toolbar, prevent setting unknown language

### DIFF
--- a/packages/lexical-code/src/index.js
+++ b/packages/lexical-code/src/index.js
@@ -59,6 +59,12 @@ import {
 
 const DEFAULT_CODE_LANGUAGE = 'javascript';
 
+const mapToPrismLanguage = (language: ?string): string | void => {
+  return language != null && Prism.languages.hasOwnProperty(language)
+    ? language
+    : undefined;
+};
+
 export const getDefaultCodeLanguage = (): string => DEFAULT_CODE_LANGUAGE;
 
 export const getCodeLanguages = (): Array<string> =>
@@ -170,7 +176,7 @@ export class CodeNode extends ElementNode {
 
   constructor(language?: string, key?: NodeKey): void {
     super(key);
-    this.__language = language;
+    this.__language = mapToPrismLanguage(language);
   }
 
   // View
@@ -321,7 +327,7 @@ export class CodeNode extends ElementNode {
 
   setLanguage(language: string): void {
     const writable = this.getWritable();
-    writable.__language = language;
+    writable.__language = mapToPrismLanguage(language);
   }
 
   getLanguage(): string | void {

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1195,8 +1195,7 @@ button.action-button:disabled {
 }
 
 .toolbar select.code-language {
-  text-transform: capitalize;
-  width: 130px;
+  width: 150px;
 }
 
 .toolbar .toolbar-item .text {

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx
@@ -12,12 +12,7 @@ import type {LexicalEditor, RangeSelection} from 'lexical';
 
 import './ToolbarPlugin.css';
 
-import {
-  $createCodeNode,
-  $isCodeNode,
-  getCodeLanguages,
-  getDefaultCodeLanguage,
-} from '@lexical/code';
+import {$createCodeNode, $isCodeNode} from '@lexical/code';
 import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {
   $isListNode,
@@ -63,7 +58,7 @@ import {
   UNDO_COMMAND,
 } from 'lexical';
 import * as React from 'react';
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 // $FlowFixMe
 import {createPortal} from 'react-dom';
 import {IS_APPLE} from 'shared/environment';
@@ -107,6 +102,31 @@ const blockTypeToBlockName = {
   paragraph: 'Normal',
   quote: 'Quote',
   ul: 'Bulleted List',
+};
+
+const CODE_LANGUAGE_OPTIONS = [
+  ['', '- Select language -'],
+  ['c', 'C'],
+  ['clike', 'C-like'],
+  ['css', 'CSS'],
+  ['html', 'HTML'],
+  ['js', 'JavaScript'],
+  ['markdown', 'Markdown'],
+  ['objc', 'Objective-C'],
+  ['plain', 'Plain Text'],
+  ['py', 'Python'],
+  ['rust', 'Rust'],
+  ['sql', 'SQL'],
+  ['swift', 'Swift'],
+  ['xml', 'XML'],
+];
+
+const CODE_LANGUAGE_MAP = {
+  javascript: 'js',
+  md: 'markdown',
+  plaintext: 'plain',
+  python: 'py',
+  text: 'plain',
 };
 
 function getSelectedNode(selection: RangeSelection): TextNode | ElementNode {
@@ -717,15 +737,14 @@ function Select({
 }: {
   className: string,
   onChange: (event: {target: {value: string}}) => void,
-  options: Array<string>,
+  options: Array<[string, string]>,
   value: string,
 }): React$Node {
   return (
     <select className={className} onChange={onChange} value={value}>
-      <option hidden={true} value="" />
-      {options.map((option) => (
+      {options.map(([option, text]) => (
         <option key={option} value={option}>
-          {option}
+          {text}
         </option>
       ))}
     </select>
@@ -791,7 +810,10 @@ export default function ToolbarPlugin(): React$Node {
             : element.getType();
           setBlockType(type);
           if ($isCodeNode(element)) {
-            setCodeLanguage(element.getLanguage() || getDefaultCodeLanguage());
+            const language = element.getLanguage();
+            setCodeLanguage(
+              language ? CODE_LANGUAGE_MAP[language] || language : '',
+            );
             return;
           }
         }
@@ -878,7 +900,6 @@ export default function ToolbarPlugin(): React$Node {
     }
   }, [editor, isLink]);
 
-  const codeLanguges = useMemo(() => getCodeLanguages(), []);
   const onCodeLanguageSelect = useCallback(
     (e) => {
       activeEditor.update(() => {
@@ -930,7 +951,7 @@ export default function ToolbarPlugin(): React$Node {
           <Select
             className="toolbar-item code-language"
             onChange={onCodeLanguageSelect}
-            options={codeLanguges}
+            options={CODE_LANGUAGE_OPTIONS}
             value={codeLanguage}
           />
           <i className="chevron-down inside" />
@@ -942,12 +963,12 @@ export default function ToolbarPlugin(): React$Node {
               className="toolbar-item font-family"
               onChange={onFontFamilySelect}
               options={[
-                'Arial',
-                'Courier New',
-                'Georgia',
-                'Times New Roman',
-                'Trebuchet MS',
-                'Verdana',
+                ['Arial', 'Arial'],
+                ['Courier New', 'Courier New'],
+                ['Georgia', 'Georgia'],
+                ['Times New Roman', 'Times New Roman'],
+                ['Trebuchet MS', 'Trebuchet MS'],
+                ['Verdana', 'Verdana'],
               ]}
               value={fontFamily}
             />
@@ -958,17 +979,17 @@ export default function ToolbarPlugin(): React$Node {
               className="toolbar-item font-size"
               onChange={onFontSizeSelect}
               options={[
-                '10px',
-                '11px',
-                '12px',
-                '13px',
-                '14px',
-                '15px',
-                '16px',
-                '17px',
-                '18px',
-                '19px',
-                '20px',
+                ['10px', '10px'],
+                ['11px', '11px'],
+                ['12px', '12px'],
+                ['13px', '13px'],
+                ['14px', '14px'],
+                ['15px', '15px'],
+                ['16px', '16px'],
+                ['17px', '17px'],
+                ['18px', '18px'],
+                ['19px', '19px'],
+                ['20px', '20px'],
               ]}
               value={fontSize}
             />


### PR DESCRIPTION
- Remove duplicates from language dropdown (but keep mappings like 'py' => 'python', 'js' => 'javascript')
- Prevent setting unknown language to a code node
- Manual labeling langues (it's less dynamic than before, but looks way nicer)

Before
<img width="161" alt="Screen Shot 2022-04-25 at 10 55 59 AM" src="https://user-images.githubusercontent.com/132642/165123066-7a6cb864-ce0d-4ca0-b47a-df3f6744eea4.png">

After
<img width="199" alt="Screen Shot 2022-04-25 at 11 34 17 AM" src="https://user-images.githubusercontent.com/132642/165123069-b66d5bd4-4391-4fcd-9293-ec3bb6536a2c.png">
