### PR TITLE
Remove useCallback from decorators.md

### DIFF
--- a/examples/decorators.md
+++ b/examples/decorators.md
@@ -103,13 +103,11 @@ import {INSERT_VIDEO_COMMAND} from 'VideoPlugin';
 
 function ToolbarVideoButton(): React$Node {
   const [editor] = useLexicalComposerContext();
-  const insertVideo = useCallback(
-    (url) => {
+  const insertVideo = url => {
       // Executing command defined in a plugin
       editor.dispatchCommand(INSERT_VIDEO_COMMAND, url);
-    },
-    [editor],
-  );
+    };
+   
   const showDialog = useVideoDialog({onSubmit: insertVideo});
   return <button onClick={showDialog}>Add video</button>;
 }


### PR DESCRIPTION
Follow up on #1935

To stop the bleeding,  I think the first step is to remove it from the documentation.
We could argue that there is no implementation of `useVideoDialog` provided and it's left to the imagination of the reader. So we don't actually know if there is a referential equality check done with `onSubmit` inside the hook, but the most probable case is that there is none as `onSubmit` will be likely passed to a `<button>`.

