### PR TITLE
Remove useCallbacks in ImageNode and EquationEditor

### DIFF
--- a/packages/lexical-playground/src/nodes/ImageNode.jsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.jsx
@@ -193,44 +193,41 @@ function ImageComponent({
     setSelected,
   ]);
 
-  const setShowCaption = useCallback(() => {
+  const setShowCaption = () => {
     editor.update(() => {
       const node = $getNodeByKey(nodeKey);
       if ($isImageNode(node)) {
         node.setShowCaption(true);
       }
     });
-  }, [editor, nodeKey]);
+  };
 
-  const onResizeEnd = useCallback(
-    (nextWidth, nextHeight) => {
-      const rootElement = editor.getRootElement();
-      if (rootElement !== null) {
-        rootElement.style.setProperty('cursor', 'default');
+  const onResizeEnd = (nextWidth, nextHeight) => {
+    const rootElement = editor.getRootElement();
+    if (rootElement !== null) {
+      rootElement.style.setProperty('cursor', 'default');
+    }
+
+    // Delay hiding the resize bars for click case
+    setTimeout(() => {
+      setIsResizing(false);
+    }, 200);
+
+    editor.update(() => {
+      const node = $getNodeByKey(nodeKey);
+      if ($isImageNode(node)) {
+        node.setWidthAndHeight(nextWidth, nextHeight);
       }
+    });
+  };
 
-      // Delay hiding the resize bars for click case
-      setTimeout(() => {
-        setIsResizing(false);
-      }, 200);
-
-      editor.update(() => {
-        const node = $getNodeByKey(nodeKey);
-        if ($isImageNode(node)) {
-          node.setWidthAndHeight(nextWidth, nextHeight);
-        }
-      });
-    },
-    [editor, nodeKey],
-  );
-
-  const onResizeStart = useCallback(() => {
+  const onResizeStart = () => {
     const rootElement = editor.getRootElement();
     if (rootElement !== null) {
       rootElement.style.setProperty('cursor', 'nwse-resize', 'important');
     }
     setIsResizing(true);
-  }, [editor]);
+  };
 
   const {historyState} = useSharedHistoryContext();
   const {

--- a/packages/lexical-playground/src/ui/EquationEditor.jsx
+++ b/packages/lexical-playground/src/ui/EquationEditor.jsx
@@ -9,7 +9,7 @@
 
 import './EquationEditor.css';
 
-import React, {useCallback} from 'react';
+import React from 'react';
 
 type BaseEquationEditorProps = {
   equation: string,
@@ -24,12 +24,9 @@ export default function EquationEditor({
   inline,
   inputRef,
 }: BaseEquationEditorProps): React$Node {
-  const onChange = useCallback(
-    (event) => {
-      setEquation(event.target.value);
-    },
-    [setEquation],
-  );
+  const onChange = (event) => {
+    setEquation(event.target.value);
+  };
 
   const props = {
     equation,


### PR DESCRIPTION
Follow up on #1935.
 
ImageNode : `setShowCaption`, `onResizeStart` and `onResizeEnd` are all three passed to `ImageResizer` which does not do any referential equality check. 
`onDelete` however is in the dependency array of a useEffect. I wonder if this is needed as this useEffect needs to be run at first render only, but linters would probably complain if all dependencies are not listed.

 EquationEditor : `onChange` is passed to an `<input>`
