### PR TITLE
Fix bug with skipTransforms

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Composition.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Composition.spec.mjs
@@ -535,10 +535,6 @@ test.describe('Composition', () => {
     }) => {
       // We don't yet support FF.
       test.skip(browserName === 'firefox');
-      test.fixme(
-        isCollab,
-        'Some extra characters are appended to the right hand frame in collab.',
-      );
 
       await focusEditor(page);
       await enableCompositionKeyEvents(page);

--- a/packages/lexical-yjs/src/CollabElementNode.js
+++ b/packages/lexical-yjs/src/CollabElementNode.js
@@ -140,10 +140,10 @@ export class CollabElementNode {
             children.splice(nodeIndex, 1);
             deletionSize -= 1;
           } else if (node instanceof CollabTextNode) {
-            const delCount = Math.min(deletionSize, length);
             const prevCollabNode =
               nodeIndex !== 0 ? children[nodeIndex - 1] : null;
             const nodeSize = node.getSize();
+            let delCount = Math.min(deletionSize, length);
 
             if (
               offset === 0 &&
@@ -161,6 +161,14 @@ export class CollabElementNode {
               // The entire thing needs removing
               children.splice(nodeIndex, 1);
             } else {
+              const diff = node._text.length - (delCount + offset);
+              // If the value is more than the string length, then deduct it
+              // from the delCount. TBH this is likely something we need to
+              // fix in getPositionFromElementAndOffset, but I'm unsure at
+              // this point.
+              if (diff !== 0) {
+                delCount += diff;
+              }
               node._text = spliceString(node._text, offset, delCount, '');
             }
             deletionSize -= delCount;

--- a/packages/lexical-yjs/src/CollabElementNode.js
+++ b/packages/lexical-yjs/src/CollabElementNode.js
@@ -140,10 +140,10 @@ export class CollabElementNode {
             children.splice(nodeIndex, 1);
             deletionSize -= 1;
           } else if (node instanceof CollabTextNode) {
+            const delCount = Math.min(deletionSize, length);
             const prevCollabNode =
               nodeIndex !== 0 ? children[nodeIndex - 1] : null;
             const nodeSize = node.getSize();
-            const delCount = Math.min(deletionSize, length);
 
             if (
               offset === 0 &&

--- a/packages/lexical-yjs/src/CollabElementNode.js
+++ b/packages/lexical-yjs/src/CollabElementNode.js
@@ -143,7 +143,7 @@ export class CollabElementNode {
             const prevCollabNode =
               nodeIndex !== 0 ? children[nodeIndex - 1] : null;
             const nodeSize = node.getSize();
-            let delCount = Math.min(deletionSize, length);
+            const delCount = Math.min(deletionSize, length);
 
             if (
               offset === 0 &&
@@ -161,14 +161,6 @@ export class CollabElementNode {
               // The entire thing needs removing
               children.splice(nodeIndex, 1);
             } else {
-              const diff = node._text.length - (delCount + offset);
-              // If the value is more than the string length, then deduct it
-              // from the delCount. TBH this is likely something we need to
-              // fix in getPositionFromElementAndOffset, but I'm unsure at
-              // this point.
-              if (diff !== 0) {
-                delCount += diff;
-              }
               node._text = spliceString(node._text, offset, delCount, '');
             }
             deletionSize -= delCount;

--- a/packages/lexical-yjs/src/Utils.js
+++ b/packages/lexical-yjs/src/Utils.js
@@ -344,7 +344,7 @@ export function getPositionFromElementAndOffset(
       if (textOffset < 0) {
         textOffset = 0;
       }
-      const diffLength = size - textOffset;
+      const diffLength = index - offset;
       return {
         length: diffLength,
         node: child,

--- a/packages/lexical/src/LexicalUpdates.js
+++ b/packages/lexical/src/LexicalUpdates.js
@@ -143,7 +143,12 @@ function $normalizeAllDirtyTextNodes(
   const nodeMap = editorState._nodeMap;
   for (const nodeKey of dirtyLeaves) {
     const node = nodeMap.get(nodeKey);
-    if ($isTextNode(node) && node.isSimpleText() && !node.isUnmergeable()) {
+    if (
+      $isTextNode(node) &&
+      node.isAttached() &&
+      node.isSimpleText() &&
+      !node.isUnmergeable()
+    ) {
       $normalizeTextNode(node);
     }
   }
@@ -182,7 +187,12 @@ function $applyAllTransforms(
       editor._dirtyLeaves = new Set();
       for (const nodeKey of untransformedDirtyLeaves) {
         const node = nodeMap.get(nodeKey);
-        if ($isTextNode(node) && node.isSimpleText() && !node.isUnmergeable()) {
+        if (
+          $isTextNode(node) &&
+          node.isAttached() &&
+          node.isSimpleText() &&
+          !node.isUnmergeable()
+        ) {
           $normalizeTextNode(node);
         }
         if (
@@ -513,9 +523,12 @@ function triggerDeferredUpdateCallbacks(editor: LexicalEditor): void {
   }
 }
 
-function processNestedUpdates(editor: LexicalEditor): boolean {
+function processNestedUpdates(
+  editor: LexicalEditor,
+  initialSkipTransforms?: boolean,
+): boolean {
   const queuedUpdates = editor._updates;
-  let skipTransforms = false;
+  let skipTransforms = initialSkipTransforms || false;
   // Updates might grow as we process them, we so we'll need
   // to handle each update as we go until the updates array is
   // empty.
@@ -587,7 +600,7 @@ function beginUpdate(
     }
     const startingCompositionKey = editor._compositionKey;
     updateFn();
-    skipTransforms = processNestedUpdates(editor);
+    skipTransforms = processNestedUpdates(editor, skipTransforms);
     applySelectionTransforms(pendingEditorState, editor);
     if (editor._dirtyType !== NO_DIRTY_NODES) {
       if (skipTransforms) {

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -289,17 +289,19 @@ export function $setCompositionKey(compositionKey: null | NodeKey): void {
   errorOnReadOnly();
   const editor = getActiveEditor();
   const previousCompositionKey = editor._compositionKey;
-  editor._compositionKey = compositionKey;
-  if (previousCompositionKey !== null) {
-    const node = $getNodeByKey(previousCompositionKey);
-    if (node !== null) {
-      node.getWritable();
+  if (compositionKey !== previousCompositionKey) {
+    editor._compositionKey = compositionKey;
+    if (previousCompositionKey !== null) {
+      const node = $getNodeByKey(previousCompositionKey);
+      if (node !== null) {
+        node.getWritable();
+      }
     }
-  }
-  if (compositionKey !== null) {
-    const node = $getNodeByKey(compositionKey);
-    if (node !== null) {
-      node.getWritable();
+    if (compositionKey !== null) {
+      const node = $getNodeByKey(compositionKey);
+      if (node !== null) {
+        node.getWritable();
+      }
     }
   }
 }


### PR DESCRIPTION
Turns out that `skipTransforms` never worked properly because we also reset the value (wrongly) back to `false`. I also noticed we can improve perf by checking if nodes were attached or not before calling the transform on them too!