### PR TITLE
Add forEachChild to ElementNode

### DIFF
--- a/packages/lexical-list/src/formatList.js
+++ b/packages/lexical-list/src/formatList.js
@@ -202,7 +202,7 @@ export function $handleIndent(listItemNodes: Array<ListItemNode>): void {
           nextSibling.remove();
           removed.add(nextSibling.getKey());
         }
-        innerList.getChildren().forEach((child) => child.markDirty());
+        innerList.forEachChild((child) => child.markDirty());
       }
     } else if (isNestedListNode(nextSibling)) {
       // if the ListItemNode is next to a nested ListNode, merge them
@@ -212,13 +212,13 @@ export function $handleIndent(listItemNodes: Array<ListItemNode>): void {
         if (firstChild !== null) {
           firstChild.insertBefore(listItemNode);
         }
-        innerList.getChildren().forEach((child) => child.markDirty());
+        innerList.forEachChild((child) => child.markDirty());
       }
     } else if (isNestedListNode(previousSibling)) {
       const innerList = previousSibling.getFirstChild();
       if ($isListNode(innerList)) {
         innerList.append(listItemNode);
-        innerList.getChildren().forEach((child) => child.markDirty());
+        innerList.forEachChild((child) => child.markDirty());
       }
     } else {
       // otherwise, we need to create a new nested ListNode
@@ -237,7 +237,7 @@ export function $handleIndent(listItemNodes: Array<ListItemNode>): void {
       }
     }
     if ($isListNode(parent)) {
-      parent.getChildren().forEach((child) => child.markDirty());
+      parent.forEachChild((child) => child.markDirty());
     }
   });
 }
@@ -294,8 +294,8 @@ export function $handleOutdent(listItemNodes: Array<ListItemNode>): void {
         // replace the grandparent list item (now between the siblings) with the outdented list item.
         grandparentListItem.replace(listItemNode);
       }
-      parentList.getChildren().forEach((child) => child.markDirty());
-      greatGrandparentList.getChildren().forEach((child) => child.markDirty());
+      parentList.forEachChild((child) => child.markDirty());
+      greatGrandparentList.forEachChild((child) => child.markDirty());
     }
   });
 }

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -933,7 +933,7 @@ test.describe('Links', () => {
     });
   });
 
-  test.only(`Can convert part of a text node into a link and change block type`, async ({
+  test(`Can convert part of a text node into a link and change block type`, async ({
     page,
     browserName,
   }) => {

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -933,7 +933,7 @@ test.describe('Links', () => {
     });
   });
 
-  test(`Can convert part of a text node into a link and change block type`, async ({
+  test.only(`Can convert part of a text node into a link and change block type`, async ({
     page,
     browserName,
   }) => {

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin.jsx
@@ -272,7 +272,7 @@ function TableActionMenu({
           throw new Error('Expected table row');
         }
 
-        tableRow.getChildren().forEach((tableCell) => {
+        tableRow.forEachChild((tableCell) => {
           if (!$isTableCellNode(tableCell)) {
             throw new Error('Expected table cell');
           }

--- a/packages/lexical-selection/src/index.js
+++ b/packages/lexical-selection/src/index.js
@@ -589,7 +589,7 @@ export function $wrapLeafNodesInElements(
 
         // Move node and its siblings to the new
         // element.
-        parent.getChildren().forEach((child) => {
+        parent.forEachChild((child) => {
           targetElement.append(child);
           movedLeafNodes.add(child.getKey());
         });

--- a/packages/lexical-table/src/LexicalTableSelection.js
+++ b/packages/lexical-table/src/LexicalTableSelection.js
@@ -359,7 +359,7 @@ export class TableSelection {
           paragraphNode.append(textNode);
           cellNode.append(paragraphNode);
 
-          cellNode.getChildren().forEach((child) => {
+          cellNode.forEachChild((child) => {
             if (child !== paragraphNode) {
               child.remove();
             }

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -670,6 +670,7 @@ export declare class ElementNode extends LexicalNode {
   constructor(key?: NodeKey);
   getFormat(): number;
   getIndent(): number;
+  forEachChild(cb: (node: LexicalNode, index: number) => void): void;
   getChildren(): Array<LexicalNode>;
   getChildrenKeys(): Array<NodeKey>;
   getChildrenSize(): number;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -698,6 +698,7 @@ declare export class ElementNode extends LexicalNode {
   constructor(key?: NodeKey): void;
   getFormat(): number;
   getIndent(): number;
+  forEachChild(cb: (node: LexicalNode, index: number) => void): void;
   getChildren(): Array<LexicalNode>;
   getChildrenKeys(): Array<NodeKey>;
   getChildrenSize(): number;

--- a/packages/lexical/src/nodes/LexicalElementNode.js
+++ b/packages/lexical/src/nodes/LexicalElementNode.js
@@ -53,11 +53,9 @@ export class ElementNode extends LexicalNode {
     return self.__indent;
   }
   forEachChild(cb: (node: LexicalNode, index: number) => void): void {
-    for (
-      let i = 0, children;
-      i < (children = this.getLatest().__children).length;
-      i++
-    ) {
+    const self = this.getLatest();
+    const children = self.__children;
+    for (let i = 0; i < children.length; i++) {
       const childNode = $getNodeByKey<LexicalNode>(children[i]);
       if (childNode !== null) {
         cb(childNode, i);

--- a/packages/lexical/src/nodes/LexicalElementNode.js
+++ b/packages/lexical/src/nodes/LexicalElementNode.js
@@ -53,9 +53,11 @@ export class ElementNode extends LexicalNode {
     return self.__indent;
   }
   forEachChild(cb: (node: LexicalNode, index: number) => void): void {
-    const self = this.getLatest();
-    const children = self.__children;
-    for (let i = 0; i < children.length; i++) {
+    for (
+      let i = 0, children;
+      i < (children = this.getLatest().__children).length;
+      i++
+    ) {
       const childNode = $getNodeByKey<LexicalNode>(children[i]);
       if (childNode !== null) {
         cb(childNode, i);

--- a/packages/lexical/src/nodes/LexicalElementNode.js
+++ b/packages/lexical/src/nodes/LexicalElementNode.js
@@ -52,6 +52,16 @@ export class ElementNode extends LexicalNode {
     const self = this.getLatest();
     return self.__indent;
   }
+  forEachChild(cb: (node: LexicalNode, index: number) => void): void {
+    const self = this.getLatest();
+    const children = self.__children;
+    for (let i = 0; i < children.length; i++) {
+      const childNode = $getNodeByKey<LexicalNode>(children[i]);
+      if (childNode !== null) {
+        cb(childNode, i);
+      }
+    }
+  }
   getChildren(): Array<LexicalNode> {
     const self = this.getLatest();
     const children = self.__children;


### PR DESCRIPTION
This is a nice utility function that improves the computation without needing a second O(n) traversal of the element's children.