### PR TITLE
Persist collapsed formats across selection updates

### DIFF
--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -8,6 +8,7 @@
  */
 
 import type {LexicalEditor} from './LexicalEditor';
+import type {NodeKey} from './LexicalNode';
 import type {RangeSelection} from './LexicalSelection';
 import type {ElementNode} from './nodes/LexicalElementNode';
 import type {TextNode} from './nodes/LexicalTextNode';
@@ -132,24 +133,23 @@ let lastKeyDownTimeStamp = 0;
 let rootElementsRegistered = 0;
 let isSelectionChangeFromReconcile = false;
 let isInsertLineBreak = false;
+let collapsedSelectionFormat: [number, number, NodeKey, number] = [
+  0,
+  0,
+  'root',
+  0,
+];
 
-function isEmptyElementOrTextNotAtBoundary(
+function isElementOrTextNotAtBoundary(
   domNode: null | Node,
   offset: number,
 ): boolean {
   if (domNode === null) {
     return false;
   }
-  const firstChild = domNode.firstChild;
   const nodeType = domNode.nodeType;
-  if (
-    nodeType === DOM_ELEMENT_TYPE &&
-    firstChild != null &&
-    firstChild === domNode.lastChild &&
-    firstChild.nodeName === 'BR'
-  ) {
-    // Empty element
-    return true;
+  if (nodeType === DOM_ELEMENT_TYPE) {
+    return false;
   }
   return (
     nodeType === DOM_TEXT_TYPE &&
@@ -175,8 +175,8 @@ function onSelectionChange(
     // because in this case, we might need to normalize to a
     // sibling instead.
     if (
-      isEmptyElementOrTextNotAtBoundary(anchorNode, anchorOffset) &&
-      isEmptyElementOrTextNotAtBoundary(focusNode, focusOffset)
+      isElementOrTextNotAtBoundary(anchorNode, anchorOffset) &&
+      isElementOrTextNotAtBoundary(focusNode, focusOffset)
     ) {
       return;
     }
@@ -200,10 +200,25 @@ function onSelectionChange(
         if (domSelection.type === 'Range') {
           selection.dirty = true;
         }
-        if (anchor.type === 'text') {
-          selection.format = anchorNode.getFormat();
-        } else if (anchor.type === 'element') {
-          selection.format = 0;
+        // If we have marked a collapsed selection format, and we're
+        // within the given time range – then attempt to use that format
+        // instead of getting the format from the anchor node.
+        const currentTimeStamp = window.event.timeStamp;
+        const [lastFormat, lastOffset, lastKey, timeStamp] =
+          collapsedSelectionFormat;
+
+        if (
+          currentTimeStamp < timeStamp + 200 &&
+          anchor.offset === lastOffset &&
+          anchor.key === lastKey
+        ) {
+          selection.format = lastFormat;
+        } else {
+          if (anchor.type === 'text') {
+            selection.format = anchorNode.getFormat();
+          } else if (anchor.type === 'element') {
+            selection.format = 0;
+          }
         }
       } else {
         const focus = selection.focus;
@@ -812,4 +827,13 @@ function cleanActiveNestedEditorsMap(editor: LexicalEditor) {
 
 export function markSelectionChangeFromReconcile(): void {
   isSelectionChangeFromReconcile = true;
+}
+
+export function markCollapsedSelectionFormat(
+  format: number,
+  offset: number,
+  key: NodeKey,
+  timeStamp: number,
+): void {
+  collapsedSelectionFormat = [format, offset, key, timeStamp];
 }

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -55,7 +55,7 @@ import {
   UNDO_COMMAND,
 } from '.';
 import {KEY_MODIFIER_COMMAND} from './LexicalCommands';
-import {DOM_ELEMENT_TYPE, DOM_TEXT_TYPE} from './LexicalConstants';
+import {DOM_TEXT_TYPE} from './LexicalConstants';
 import {updateEditor} from './LexicalUpdates';
 import {
   $flushMutations,
@@ -140,19 +140,13 @@ let collapsedSelectionFormat: [number, number, NodeKey, number] = [
   0,
 ];
 
-function isElementOrTextNotAtBoundary(
+function shouldSkipSelectionChange(
   domNode: null | Node,
   offset: number,
 ): boolean {
-  if (domNode === null) {
-    return false;
-  }
-  const nodeType = domNode.nodeType;
-  if (nodeType === DOM_ELEMENT_TYPE) {
-    return false;
-  }
   return (
-    nodeType === DOM_TEXT_TYPE &&
+    domNode !== null &&
+    domNode.nodeType === DOM_TEXT_TYPE &&
     offset !== 0 &&
     offset !== domNode.nodeValue.length
   );
@@ -175,8 +169,8 @@ function onSelectionChange(
     // because in this case, we might need to normalize to a
     // sibling instead.
     if (
-      isElementOrTextNotAtBoundary(anchorNode, anchorOffset) &&
-      isElementOrTextNotAtBoundary(focusNode, focusOffset)
+      shouldSkipSelectionChange(anchorNode, anchorOffset) &&
+      shouldSkipSelectionChange(focusNode, focusOffset)
     ) {
       return;
     }

--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -43,7 +43,10 @@ import {
   IS_ALIGN_RIGHT,
 } from './LexicalConstants';
 import {EditorState} from './LexicalEditorState';
-import {markSelectionChangeFromReconcile} from './LexicalEvents';
+import {
+  markCollapsedSelectionFormat,
+  markSelectionChangeFromReconcile,
+} from './LexicalEvents';
 import {
   cloneDecorators,
   getDOMTextNode,
@@ -844,6 +847,16 @@ function reconcileSelection(
   // we should avoid setting selection to something incorrect.
   if (nextAnchorNode === null || nextFocusNode === null) {
     return;
+  }
+  const nextFormat = nextSelection.format;
+
+  if (prevSelection === null || prevSelection.format !== nextFormat) {
+    markCollapsedSelectionFormat(
+      nextFormat,
+      nextAnchorOffset,
+      anchorKey,
+      performance.now(),
+    );
   }
 
   // Diff against the native DOM selection to ensure we don't do


### PR DESCRIPTION
This better revises formatting that was introduced in https://github.com/facebook/lexical/pull/1962. Specifically, we try to persist selection formats for collapsed selection if we're on the same offset and key within the given threshold.