### PR TITLE
Fix npm run start command for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "engineStrict": true,
   "scripts": {
-    "start": "NODE_ENV=development concurrently \"npm:collab\" \"npm run dev --prefix packages/lexical-playground\"",
+    "start": "cross-env NODE_ENV=development concurrently \"npm:collab\" \"npm run dev --prefix packages/lexical-playground\"",
     "start:website": "npm run start --prefix packages/lexical-website-new -- --port 3001",
     "dev": "npm run dev --prefix packages/lexical-playground",
     "build": "npm run clean && node scripts/build.js",


### PR DESCRIPTION
Looks like a `cross-env` was missing!