### PR TITLE
Improve Lexical -> HTML and Lexical -> Lexical Copy and Paste Data Model Conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26259,17 +26259,8 @@
       "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
-<<<<<<< HEAD
-<<<<<<< HEAD
         "@lexical/selection": "0.2.5",
         "@lexical/utils": "0.2.5"
-=======
-        "@lexical/react": "0.2.4",
-=======
->>>>>>> 5f938144 (Remove package.json changes)
-        "@lexical/selection": "0.2.4",
-        "@lexical/utils": "0.2.4"
->>>>>>> 3ec050c0 (Add tests for clipboard)
       },
       "peerDependencies": {
         "lexical": "0.2.5"
@@ -30338,17 +30329,8 @@
     "@lexical/clipboard": {
       "version": "file:packages/lexical-clipboard",
       "requires": {
-<<<<<<< HEAD
-<<<<<<< HEAD
         "@lexical/selection": "0.2.5",
         "@lexical/utils": "0.2.5"
-=======
-        "@lexical/react": "0.2.4",
-=======
->>>>>>> 5f938144 (Remove package.json changes)
-        "@lexical/selection": "0.2.4",
-        "@lexical/utils": "0.2.4"
->>>>>>> 3ec050c0 (Add tests for clipboard)
       }
     },
     "@lexical/code": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26259,8 +26259,17 @@
       "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
+<<<<<<< HEAD
+<<<<<<< HEAD
         "@lexical/selection": "0.2.5",
         "@lexical/utils": "0.2.5"
+=======
+        "@lexical/react": "0.2.4",
+=======
+>>>>>>> 5f938144 (Remove package.json changes)
+        "@lexical/selection": "0.2.4",
+        "@lexical/utils": "0.2.4"
+>>>>>>> 3ec050c0 (Add tests for clipboard)
       },
       "peerDependencies": {
         "lexical": "0.2.5"
@@ -30329,8 +30338,17 @@
     "@lexical/clipboard": {
       "version": "file:packages/lexical-clipboard",
       "requires": {
+<<<<<<< HEAD
+<<<<<<< HEAD
         "@lexical/selection": "0.2.5",
         "@lexical/utils": "0.2.5"
+=======
+        "@lexical/react": "0.2.4",
+=======
+>>>>>>> 5f938144 (Remove package.json changes)
+        "@lexical/selection": "0.2.4",
+        "@lexical/utils": "0.2.4"
+>>>>>>> 3ec050c0 (Add tests for clipboard)
       }
     },
     "@lexical/code": {

--- a/packages/lexical-clipboard/LexicalClipboard.d.ts
+++ b/packages/lexical-clipboard/LexicalClipboard.d.ts
@@ -18,7 +18,7 @@ export function $insertDataTransferForRichText(
   editor: LexicalEditor,
 ): void;
 
-export function getHtmlContent(editor: LexicalEditor): string;
+export function $getHtmlContent(editor: LexicalEditor): string;
 export function $getLexicalContent(editor: LexicalEditor): string;
 
 /*

--- a/packages/lexical-clipboard/flow/LexicalClipboard.js.flow
+++ b/packages/lexical-clipboard/flow/LexicalClipboard.js.flow
@@ -19,7 +19,7 @@ declare export function $insertDataTransferForRichText(
   editor: LexicalEditor,
 ): void;
 
-declare export function getHtmlContent(editor: LexicalEditor): string;
+declare export function $getHtmlContent(editor: LexicalEditor): string;
 declare export function $getLexicalContent(editor: LexicalEditor): string;
 
 /*

--- a/packages/lexical-clipboard/package.json
+++ b/packages/lexical-clipboard/package.json
@@ -15,8 +15,18 @@
     "lexical": "0.2.5"
   },
   "dependencies": {
+<<<<<<< HEAD
     "@lexical/utils": "0.2.5",
     "@lexical/selection": "0.2.5"
+=======
+    "@lexical/utils": "0.2.4",
+<<<<<<< HEAD
+    "@lexical/selection": "0.2.4",
+    "@lexical/react": "0.2.4"
+>>>>>>> 3ec050c0 (Add tests for clipboard)
+=======
+    "@lexical/selection": "0.2.4"
+>>>>>>> 5f938144 (Remove package.json changes)
   },
   "repository": {
     "type": "git",

--- a/packages/lexical-clipboard/package.json
+++ b/packages/lexical-clipboard/package.json
@@ -15,18 +15,8 @@
     "lexical": "0.2.5"
   },
   "dependencies": {
-<<<<<<< HEAD
     "@lexical/utils": "0.2.5",
     "@lexical/selection": "0.2.5"
-=======
-    "@lexical/utils": "0.2.4",
-<<<<<<< HEAD
-    "@lexical/selection": "0.2.4",
-    "@lexical/react": "0.2.4"
->>>>>>> 3ec050c0 (Add tests for clipboard)
-=======
-    "@lexical/selection": "0.2.4"
->>>>>>> 5f938144 (Remove package.json changes)
   },
   "repository": {
     "type": "git",

--- a/packages/lexical-clipboard/src/__tests__/unit/clipboard.test.js
+++ b/packages/lexical-clipboard/src/__tests__/unit/clipboard.test.js
@@ -1,0 +1,418 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$createLinkNode, LinkNode} from '@lexical/link';
+import {$createListItemNode, $createListNode} from '@lexical/list';
+// import {$createHorizontalRuleNode} from '@lexical/react';
+import {$createTableNodeWithDimensions} from '@lexical/table';
+import {$dfs} from '@lexical/utils';
+import {
+  $createGridSelection,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $setSelection,
+} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+
+import {
+  $cloneSelectedLexicalContent,
+  $convertSelectedLexicalContentToHtml,
+  $generateNodes,
+  $generateNodesFromDOM,
+} from '../../clipboard';
+
+// No idea why we suddenly need to do this, but it fixes the tests
+// with latest experimental React version.
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+export function setAnchorPoint(point) {
+  let selection = $getSelection();
+  if (selection === null) {
+    const dummyTextNode = $createTextNode();
+    dummyTextNode.select();
+    selection = $getSelection();
+  }
+  const anchor = selection.anchor;
+  anchor.type = point.type;
+  anchor.offset = point.offset;
+  anchor.key = point.key;
+}
+
+export function setFocusPoint(point) {
+  let selection = $getSelection();
+  if (selection === null) {
+    const dummyTextNode = $createTextNode();
+    dummyTextNode.select();
+    selection = $getSelection();
+  }
+  const focus = selection.focus;
+  focus.type = point.type;
+  focus.offset = point.offset;
+  focus.key = point.key;
+}
+
+function expectMatchingOutput(editor, cloneState, htmlString) {
+  const parser = new DOMParser();
+  const dom = parser.parseFromString(htmlString, 'text/html');
+
+  const htmlToLexicalTreeRoot = $createParagraphNode();
+  htmlToLexicalTreeRoot.append(...$generateNodesFromDOM(dom, editor));
+
+  const lexicalToLexicalTreeRoot = $createParagraphNode();
+  lexicalToLexicalTreeRoot.append(...$generateNodes(cloneState));
+
+  const htmlToLexicalTreeNodes = $dfs(htmlToLexicalTreeRoot);
+  const lexicalToLexicalNodes = $dfs(lexicalToLexicalTreeRoot);
+
+  expect(htmlToLexicalTreeNodes.length).toBe(lexicalToLexicalNodes.length);
+
+  for (let i = 0; i < htmlToLexicalTreeNodes.length; i++) {
+    const htmlToLexicalNode = htmlToLexicalTreeNodes[i];
+    const lexicalToLexicalDFSNode = htmlToLexicalTreeNodes[i];
+
+    expect(htmlToLexicalNode.depth).toBe(lexicalToLexicalDFSNode.depth);
+
+    Object.keys(htmlToLexicalNode.node).forEach((property) => {
+      if (property !== '__key') {
+        expect(htmlToLexicalNode.node[property]).toBe(
+          lexicalToLexicalDFSNode.node[property],
+        );
+      }
+    });
+  }
+}
+
+const fillEditorWithComplexData = () => {
+  const root = $getRoot();
+
+  const paragraph = $createParagraphNode();
+  const nodesToInsert = [];
+
+  root.append(paragraph);
+
+  setAnchorPoint({
+    key: paragraph.getKey(),
+    offset: 0,
+    type: 'element',
+  });
+  setFocusPoint({
+    key: paragraph.getKey(),
+    offset: 0,
+    type: 'element',
+  });
+
+  const link = $createLinkNode('https://');
+  link.append($createTextNode('ello worl'));
+
+  nodesToInsert.push(
+    $createTextNode('h').toggleFormat('bold'),
+    link,
+    $createTextNode('d').toggleFormat('italic'),
+  );
+
+  const table = $createTableNodeWithDimensions(3, 3);
+  nodesToInsert.push(table);
+
+  const tableCell1TextNode = table.getFirstDescendant();
+  tableCell1TextNode.setTextContent('table cell text!');
+
+  const list = $createListNode('ul');
+
+  for (let i = 0; i < 4; i++) {
+    const listItemNode = $createListItemNode();
+    listItemNode.append(
+      $createTextNode(`${i + 1}: Lorem ipsum dolor sit amet`),
+    );
+    list.append(listItemNode);
+  }
+
+  nodesToInsert.push(list);
+
+  const selection = $getSelection();
+  selection.insertNodes(nodesToInsert);
+
+  return {list, paragraph, root, table};
+};
+
+describe('Clipboard tests', () => {
+  initializeUnitTest((testEnv) => {
+    test('Clone entire document', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const {root, paragraph, list, table} = fillEditorWithComplexData();
+        const firstRootTextChild = root.getFirstDescendant();
+        const lastRootTextChild = root.getLastDescendant();
+
+        setAnchorPoint({
+          key: firstRootTextChild.getKey(),
+          offset: 0,
+          type: 'text',
+        });
+
+        setFocusPoint({
+          key: lastRootTextChild.getKey(),
+          offset: lastRootTextChild.getTextContentSize() - 1,
+          type: 'text',
+        });
+
+        const selection = $getSelection();
+        const state = $cloneSelectedLexicalContent(editor, selection);
+        const rangeSet = new Set(state.range);
+        const nodeMap = new Map(state.nodeMap);
+        const selectedNodes = selection.getNodes();
+
+        selectedNodes.forEach((n) => {
+          expect(nodeMap.has(n.getKey())).toBe(true);
+        });
+
+        expect(rangeSet.size).toBe(3);
+        expect(rangeSet.has(paragraph.getKey()));
+        expect(rangeSet.has(list.getKey()));
+        expect(rangeSet.has(table.getKey()));
+        expect(nodeMap.size).toBe(selectedNodes.length);
+
+        const htmlString = $convertSelectedLexicalContentToHtml(
+          editor,
+          selection,
+        );
+
+        expect(htmlString).toBe(
+          '<p><strong>h</strong><a href="https://"><span>ello worl</span></a><em>d</em></p><table><colgroup><col><col><col></colgroup><tbody><tr><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><span>table cell text!</span></p></th><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><br><span></span></p></th><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><br><span></span></p></th></tr><tr><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><br><span></span></p></th><td style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start;"><p><br><span></span></p></td><td style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start;"><p><br><span></span></p></td></tr><tr><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><br><span></span></p></th><td style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start;"><p><br><span></span></p></td><td style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start;"><p><br><span></span></p></td></tr></tbody></table><ul><li value="1"><span>1: Lorem ipsum dolor sit amet</span></li><li value="2"><span>2: Lorem ipsum dolor sit amet</span></li><li value="3"><span>3: Lorem ipsum dolor sit amet</span></li><li value="4"><span>4: Lorem ipsum dolor sit ame</span></li></ul>',
+        );
+      });
+    });
+
+    test('$cloneSelectedLexicalContent: partial test selection including link', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const {paragraph} = fillEditorWithComplexData();
+
+        const [textNode1, linkNode] = paragraph.getChildren();
+
+        setAnchorPoint({
+          key: textNode1.getKey(),
+          offset: 0,
+          type: 'text',
+        });
+
+        const linkTextNode = linkNode.getFirstChild();
+        setFocusPoint({
+          key: linkTextNode.getKey(),
+          offset: linkTextNode.getTextContentSize() - 2,
+          type: 'text',
+        });
+
+        const selection = $getSelection();
+        const selectedNodes = selection.getNodes();
+
+        expect(selectedNodes.length).toBe(3);
+        expect(linkNode).toBeInstanceOf(LinkNode);
+
+        const state = $cloneSelectedLexicalContent(editor, selection);
+        const rangeSet = new Set(state.range);
+        const nodeMap = new Map(state.nodeMap);
+
+        expect(nodeMap.size).toBe(3);
+        expect(rangeSet.size).toBe(2);
+
+        selectedNodes.forEach((n) => {
+          expect(nodeMap.has(n.getKey())).toBe(true);
+        });
+
+        // Check if text is split on the cloned node.
+        expect(nodeMap.get(linkTextNode.getKey()).__text).toBe('ello wo');
+
+        const htmlString = $convertSelectedLexicalContentToHtml(
+          editor,
+          selection,
+        );
+
+        expect(htmlString).toBe(
+          '<strong>h</strong><a href="https://"><span>ello wo</span></a>',
+        );
+
+        expectMatchingOutput(editor, state, htmlString);
+      });
+    });
+
+    test('$cloneSelectedLexicalContent: partial test selection within list item', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const {list} = fillEditorWithComplexData();
+
+        const [listItem1] = list.getChildren();
+
+        const listItem1TextNode = listItem1.getFirstChild();
+        setAnchorPoint({
+          key: listItem1TextNode.getKey(),
+          offset: 1,
+          type: 'text',
+        });
+
+        setFocusPoint({
+          key: listItem1TextNode.getKey(),
+          offset: listItem1TextNode.getTextContentSize() - 5,
+          type: 'text',
+        });
+
+        const selection = $getSelection();
+        const selectedNodes = selection.getNodes();
+
+        expect(selectedNodes.length).toBe(1);
+
+        const state = $cloneSelectedLexicalContent(editor, selection);
+        const rangeSet = new Set(state.range);
+        const nodeMap = new Map(state.nodeMap);
+
+        expect(nodeMap.size).toBe(1);
+        expect(rangeSet.size).toBe(1);
+
+        // Check that only the text is selected and not the entire list item.
+        expect(nodeMap.has(listItem1.getKey())).toBe(false);
+        expect(rangeSet.has(listItem1.getKey())).toBe(false);
+        expect(nodeMap.has(listItem1TextNode.getKey())).toBe(true);
+        expect(rangeSet.has(listItem1TextNode.getKey())).toBe(true);
+
+        selectedNodes.forEach((n) => {
+          expect(nodeMap.has(n.getKey())).toBe(true);
+        });
+
+        // Check if text is split on the cloned node.
+        expect(nodeMap.get(listItem1TextNode.getKey()).__text).toBe(
+          ': Lorem ipsum dolor sit',
+        );
+
+        const htmlString = $convertSelectedLexicalContentToHtml(
+          editor,
+          selection,
+        );
+
+        expect(htmlString).toBe('<span>: Lorem ipsum dolor sit</span>');
+
+        expectMatchingOutput(editor, state, htmlString);
+      });
+    });
+
+    test('$cloneSelectedLexicalContent: two partial list items', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const {list} = fillEditorWithComplexData();
+
+        const [listItem1, listItem2] = list.getChildren();
+
+        const listItem1TextNode = listItem1.getFirstDescendant();
+        setAnchorPoint({
+          key: listItem1TextNode.getKey(),
+          offset: 1,
+          type: 'text',
+        });
+
+        const listItem2TextNode = listItem2.getFirstDescendant();
+        setFocusPoint({
+          key: listItem2TextNode.getKey(),
+          offset: listItem2TextNode.getTextContentSize() - 5,
+          type: 'text',
+        });
+
+        const selection = $getSelection();
+        const selectedNodes = selection.getNodes();
+
+        expect(selectedNodes.length).toBe(4);
+
+        const state = $cloneSelectedLexicalContent(editor, selection);
+        const rangeSet = new Set(state.range);
+        const nodeMap = new Map(state.nodeMap);
+
+        expect(nodeMap.size).toBe(5);
+        expect(rangeSet.size).toBe(1);
+
+        // We want to make sure that the list node is the top level and is included.
+        expect(rangeSet.has(list.getKey())).toBe(true);
+        expect(nodeMap.has(list.getKey())).toBe(true);
+
+        selectedNodes.forEach((n) => {
+          expect(nodeMap.has(n.getKey())).toBe(true);
+        });
+
+        // Check if text is split on the cloned node.
+        expect(nodeMap.get(listItem1TextNode.getKey()).__text).toBe(
+          ': Lorem ipsum dolor sit amet',
+        );
+
+        expect(nodeMap.get(listItem2TextNode.getKey()).__text).toBe(
+          '2: Lorem ipsum dolor sit',
+        );
+
+        const htmlString = $convertSelectedLexicalContentToHtml(
+          editor,
+          selection,
+        );
+
+        expect(htmlString).toBe(
+          '<ul><li value="1"><span>: Lorem ipsum dolor sit amet</span></li><li value="2"><span>2: Lorem ipsum dolor sit</span></li></ul>',
+        );
+
+        expectMatchingOutput(editor, state, htmlString);
+      });
+    });
+
+    test('$cloneSelectedLexicalContent: grid selection', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const {table} = fillEditorWithComplexData();
+
+        const [tableRow1, tableRow2] = table.getChildren();
+
+        const tableCell1x1 = tableRow1.getFirstChild();
+        const tableCell2x2 = tableRow2.getChildren()[1];
+
+        const selection = $createGridSelection();
+
+        selection.set(
+          table.getKey(),
+          tableCell1x1.getKey(),
+          tableCell2x2.getKey(),
+        );
+
+        $setSelection(selection);
+
+        const selectedNodes = selection.getNodes();
+
+        // (Text, Paragraph, Cell) x4, Row x2, 1x Grid
+        expect(selectedNodes.length).toBe(15);
+
+        const state = $cloneSelectedLexicalContent(editor, selection);
+        const rangeSet = new Set(state.range);
+        const nodeMap = new Map(state.nodeMap);
+
+        expect(nodeMap.size).toBe(15);
+        expect(rangeSet.size).toBe(1);
+
+        // Check that only the text is selected and not the entire list item.
+        expect(rangeSet.has(table.getKey())).toBe(true);
+
+        selectedNodes.forEach((n) => {
+          expect(nodeMap.has(n.getKey())).toBe(true);
+        });
+
+        const htmlString = $convertSelectedLexicalContentToHtml(
+          editor,
+          selection,
+        );
+
+        expect(htmlString).toBe(
+          '<table><colgroup><col><col><col></colgroup><tbody><tr><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><span>table cell text!</span></p></th><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><br><span></span></p></th></tr><tr><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><br><span></span></p></th><td style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start;"><p><br><span></span></p></td></tr></tbody></table>',
+        );
+
+        expectMatchingOutput(editor, state, htmlString);
+      });
+    });
+  });
+});

--- a/packages/lexical-clipboard/src/__tests__/unit/clipboard.test.js
+++ b/packages/lexical-clipboard/src/__tests__/unit/clipboard.test.js
@@ -22,8 +22,8 @@ import {
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 
 import {
-  $cloneSelectedLexicalContent,
-  $convertSelectedLexicalContentToHtml,
+  $cloneSelectedContent,
+  $convertSelectedContentToHtml,
   $generateNodes,
   $generateNodesFromDOM,
 } from '../../clipboard';
@@ -163,7 +163,7 @@ describe('Clipboard tests', () => {
         });
 
         const selection = $getSelection();
-        const state = $cloneSelectedLexicalContent(editor, selection);
+        const state = $cloneSelectedContent(editor, selection);
         const rangeSet = new Set(state.range);
         const nodeMap = new Map(state.nodeMap);
         const selectedNodes = selection.getNodes();
@@ -178,10 +178,7 @@ describe('Clipboard tests', () => {
         expect(rangeSet.has(table.getKey()));
         expect(nodeMap.size).toBe(selectedNodes.length);
 
-        const htmlString = $convertSelectedLexicalContentToHtml(
-          editor,
-          selection,
-        );
+        const htmlString = $convertSelectedContentToHtml(editor, selection);
 
         expect(htmlString).toBe(
           '<p><strong>h</strong><a href="https://"><span>ello worl</span></a><em>d</em></p><table><colgroup><col><col><col></colgroup><tbody><tr><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><span>table cell text!</span></p></th><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><br><span></span></p></th><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><br><span></span></p></th></tr><tr><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><br><span></span></p></th><td style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start;"><p><br><span></span></p></td><td style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start;"><p><br><span></span></p></td></tr><tr><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><br><span></span></p></th><td style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start;"><p><br><span></span></p></td><td style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start;"><p><br><span></span></p></td></tr></tbody></table><ul><li value="1"><span>1: Lorem ipsum dolor sit amet</span></li><li value="2"><span>2: Lorem ipsum dolor sit amet</span></li><li value="3"><span>3: Lorem ipsum dolor sit amet</span></li><li value="4"><span>4: Lorem ipsum dolor sit ame</span></li></ul>',
@@ -189,7 +186,7 @@ describe('Clipboard tests', () => {
       });
     });
 
-    test('$cloneSelectedLexicalContent: partial test selection including link', async () => {
+    test('$cloneSelectedContent: partial test selection including link', async () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const {paragraph} = fillEditorWithComplexData();
@@ -215,7 +212,7 @@ describe('Clipboard tests', () => {
         expect(selectedNodes.length).toBe(3);
         expect(linkNode).toBeInstanceOf(LinkNode);
 
-        const state = $cloneSelectedLexicalContent(editor, selection);
+        const state = $cloneSelectedContent(editor, selection);
         const rangeSet = new Set(state.range);
         const nodeMap = new Map(state.nodeMap);
 
@@ -229,10 +226,7 @@ describe('Clipboard tests', () => {
         // Check if text is split on the cloned node.
         expect(nodeMap.get(linkTextNode.getKey()).__text).toBe('ello wo');
 
-        const htmlString = $convertSelectedLexicalContentToHtml(
-          editor,
-          selection,
-        );
+        const htmlString = $convertSelectedContentToHtml(editor, selection);
 
         expect(htmlString).toBe(
           '<strong>h</strong><a href="https://"><span>ello wo</span></a>',
@@ -242,7 +236,7 @@ describe('Clipboard tests', () => {
       });
     });
 
-    test('$cloneSelectedLexicalContent: partial test selection within list item', async () => {
+    test('$cloneSelectedContent: partial test selection within list item', async () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const {list} = fillEditorWithComplexData();
@@ -267,7 +261,7 @@ describe('Clipboard tests', () => {
 
         expect(selectedNodes.length).toBe(1);
 
-        const state = $cloneSelectedLexicalContent(editor, selection);
+        const state = $cloneSelectedContent(editor, selection);
         const rangeSet = new Set(state.range);
         const nodeMap = new Map(state.nodeMap);
 
@@ -289,10 +283,7 @@ describe('Clipboard tests', () => {
           ': Lorem ipsum dolor sit',
         );
 
-        const htmlString = $convertSelectedLexicalContentToHtml(
-          editor,
-          selection,
-        );
+        const htmlString = $convertSelectedContentToHtml(editor, selection);
 
         expect(htmlString).toBe('<span>: Lorem ipsum dolor sit</span>');
 
@@ -300,7 +291,7 @@ describe('Clipboard tests', () => {
       });
     });
 
-    test('$cloneSelectedLexicalContent: two partial list items', async () => {
+    test('$cloneSelectedContent: two partial list items', async () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const {list} = fillEditorWithComplexData();
@@ -326,7 +317,7 @@ describe('Clipboard tests', () => {
 
         expect(selectedNodes.length).toBe(4);
 
-        const state = $cloneSelectedLexicalContent(editor, selection);
+        const state = $cloneSelectedContent(editor, selection);
         const rangeSet = new Set(state.range);
         const nodeMap = new Map(state.nodeMap);
 
@@ -350,10 +341,7 @@ describe('Clipboard tests', () => {
           '2: Lorem ipsum dolor sit',
         );
 
-        const htmlString = $convertSelectedLexicalContentToHtml(
-          editor,
-          selection,
-        );
+        const htmlString = $convertSelectedContentToHtml(editor, selection);
 
         expect(htmlString).toBe(
           '<ul><li value="1"><span>: Lorem ipsum dolor sit amet</span></li><li value="2"><span>2: Lorem ipsum dolor sit</span></li></ul>',
@@ -363,7 +351,7 @@ describe('Clipboard tests', () => {
       });
     });
 
-    test('$cloneSelectedLexicalContent: grid selection', async () => {
+    test('$cloneSelectedContent: grid selection', async () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const {table} = fillEditorWithComplexData();
@@ -388,7 +376,7 @@ describe('Clipboard tests', () => {
         // (Text, Paragraph, Cell) x4, Row x2, 1x Grid
         expect(selectedNodes.length).toBe(15);
 
-        const state = $cloneSelectedLexicalContent(editor, selection);
+        const state = $cloneSelectedContent(editor, selection);
         const rangeSet = new Set(state.range);
         const nodeMap = new Map(state.nodeMap);
 
@@ -402,10 +390,7 @@ describe('Clipboard tests', () => {
           expect(nodeMap.has(n.getKey())).toBe(true);
         });
 
-        const htmlString = $convertSelectedLexicalContentToHtml(
-          editor,
-          selection,
-        );
+        const htmlString = $convertSelectedContentToHtml(editor, selection);
 
         expect(htmlString).toBe(
           '<table><colgroup><col><col><col></colgroup><tbody><tr><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><span>table cell text!</span></p></th><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><br><span></span></p></th></tr><tr><th style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p><br><span></span></p></th><td style="border: 1px solid black; width: 233.33333333333334px; vertical-align: top; text-align: start;"><p><br><span></span></p></td></tr></tbody></table>',

--- a/packages/lexical-clipboard/src/__tests__/unit/clipboard.test.js
+++ b/packages/lexical-clipboard/src/__tests__/unit/clipboard.test.js
@@ -32,7 +32,7 @@ import {
 // with latest experimental React version.
 global.IS_REACT_ACT_ENVIRONMENT = true;
 
-export function setAnchorPoint(point) {
+function setAnchorPoint(point) {
   let selection = $getSelection();
   if (selection === null) {
     const dummyTextNode = $createTextNode();
@@ -45,7 +45,7 @@ export function setAnchorPoint(point) {
   anchor.key = point.key;
 }
 
-export function setFocusPoint(point) {
+function setFocusPoint(point) {
   let selection = $getSelection();
   if (selection === null) {
     const dummyTextNode = $createTextNode();

--- a/packages/lexical-clipboard/src/clipboard.js
+++ b/packages/lexical-clipboard/src/clipboard.js
@@ -57,7 +57,7 @@ export function $getHtmlContent(editor: LexicalEditor): string | null {
     return null;
   }
 
-  return $convertSelectedLexicalContentToHtml(editor, selection);
+  return $convertSelectedContentToHtml(editor, selection);
 }
 
 export function $appendSelectedNodesToHTML(
@@ -107,7 +107,7 @@ export function $appendSelectedNodesToHTML(
   return shouldInclude;
 }
 
-export function $convertSelectedLexicalContentToHtml(
+export function $convertSelectedContentToHtml(
   editor: LexicalEditor,
   selection: RangeSelection | NodeSelection | GridSelection,
 ): string {

--- a/packages/lexical-clipboard/src/clipboard.js
+++ b/packages/lexical-clipboard/src/clipboard.js
@@ -17,15 +17,16 @@ import type {
   NodeSelection,
   ParsedNodeMap,
   RangeSelection,
+  TextNode,
 } from 'lexical';
 
-import {$cloneContents} from '@lexical/selection';
+import {$cloneWithProperties} from '@lexical/selection';
 import {$findMatchingParent} from '@lexical/utils';
 import {
   $createGridSelection,
   $createNodeFromParse,
   $createParagraphNode,
-  $getNodeByKey,
+  $getRoot,
   $getSelection,
   $isElementNode,
   $isGridCellNode,
@@ -41,7 +42,7 @@ import invariant from 'shared/invariant';
 
 const IGNORE_TAGS = new Set(['STYLE']);
 
-export function getHtmlContent(editor: LexicalEditor): string | null {
+export function $getHtmlContent(editor: LexicalEditor): string | null {
   const selection = $getSelection();
 
   if (selection == null) {
@@ -56,115 +57,155 @@ export function getHtmlContent(editor: LexicalEditor): string | null {
     return null;
   }
 
-  const state = $cloneContents(selection);
-  return $convertSelectedLexicalContentToHtml(editor, selection, state);
+  return $convertSelectedLexicalContentToHtml(editor, selection);
 }
 
-export function $convertSelectedLexicalNodeToHTMLElement(
+export function $appendSelectedNodesToHTML(
   editor: LexicalEditor,
   selection: RangeSelection | NodeSelection | GridSelection,
-  node: LexicalNode,
-): ?HTMLElement {
-  let nodeToConvert = node;
-
-  if ($isRangeSelection(selection) || $isGridSelection(selection)) {
-    const anchorNode = selection.anchor.getNode();
-    const focusNode = selection.focus.getNode();
-    const isAnchor = node.is(anchorNode);
-    const isFocus = node.is(focusNode);
-
-    if ($isTextNode(node) && (isAnchor || isFocus)) {
-      const [anchorOffset, focusOffset] = selection.getCharacterOffsets();
-      const isBackward = selection.isBackward();
-
-      const isSame = anchorNode.is(focusNode);
-      const isFirst = node.is(isBackward ? focusNode : anchorNode);
-      const isLast = node.is(isBackward ? anchorNode : focusNode);
-
-      if (isSame) {
-        const startOffset =
-          anchorOffset > focusOffset ? focusOffset : anchorOffset;
-        const endOffset =
-          anchorOffset > focusOffset ? anchorOffset : focusOffset;
-        const splitNodes = node.splitText(startOffset, endOffset);
-        nodeToConvert = startOffset === 0 ? splitNodes[0] : splitNodes[1];
-      } else if (isFirst) {
-        const offset = isBackward ? focusOffset : anchorOffset;
-        const splitNodes = node.splitText(offset);
-        nodeToConvert = offset === 0 ? splitNodes[0] : splitNodes[1];
-      } else if (isLast) {
-        const offset = isBackward ? anchorOffset : focusOffset;
-        const splitNodes = node.splitText(offset);
-        nodeToConvert = splitNodes[0];
-      }
-    }
+  currentNode: LexicalNode,
+  parentElement: HTMLElement | DocumentFragment,
+): boolean {
+  let shouldInclude = currentNode.isSelected();
+  const shouldExclude =
+    $isElementNode(currentNode) && currentNode.excludeFromCopy();
+  let clone = $cloneWithProperties<LexicalNode>(currentNode);
+  clone = $isTextNode(clone) ? $splitClonedTextNode(selection, clone) : clone;
+  const children = $isElementNode(clone) ? clone.getChildren() : [];
+  const {element, after} = clone.exportDOM(editor);
+  if (!element) {
+    return false;
   }
-
-  const {element, after} = nodeToConvert.exportDOM(editor);
-  if (!element) return null;
-  const children = $isElementNode(nodeToConvert)
-    ? nodeToConvert.getChildren()
-    : [];
+  const fragment = new DocumentFragment();
   for (let i = 0; i < children.length; i++) {
     const childNode = children[i];
-
-    if (childNode.isSelected()) {
-      const newElement = $convertSelectedLexicalNodeToHTMLElement(
-        editor,
-        selection,
-        childNode,
-      );
-      if (newElement) element.append(newElement);
+    const shouldIncludeChild = $appendSelectedNodesToHTML(
+      editor,
+      selection,
+      childNode,
+      fragment,
+    );
+    if (
+      !shouldInclude &&
+      $isElementNode(currentNode) &&
+      shouldIncludeChild &&
+      currentNode.extractWithChild(childNode, selection)
+    ) {
+      shouldInclude = true;
     }
   }
-
-  return after ? after.call(nodeToConvert, element) : element;
+  if (shouldInclude && !shouldExclude) {
+    element.append(fragment);
+    parentElement.append(element);
+    if (after) {
+      const newElement = after.call(clone, element);
+      if (newElement) element.replaceWith(newElement);
+    }
+  } else {
+    parentElement.append(fragment);
+  }
+  return shouldInclude;
 }
 
 export function $convertSelectedLexicalContentToHtml(
   editor: LexicalEditor,
   selection: RangeSelection | NodeSelection | GridSelection,
-  state: {
-    nodeMap: Array<[NodeKey, LexicalNode]>,
-    range: Array<NodeKey>,
-  },
 ): string {
   const container = document.createElement('div');
-  for (let i = 0; i < state.range.length; i++) {
-    const nodeKey = state.range[i];
-    const node = $getNodeByKey(nodeKey);
-    if (node) {
-      const element = $convertSelectedLexicalNodeToHTMLElement(
-        editor,
-        selection,
-        node,
-      );
-      if (element) {
-        // It might be the case that the node is an element node
-        // and we're not directly selecting it, but we are selecting
-        // some of its children. So we'll need to extract that out
-        // separately.
-        if (node.isSelected()) {
-          container.append(element);
-        } else {
-          let childNode = element.firstChild;
-          while (childNode != null) {
-            const nextSibling = childNode.nextSibling;
-            container.append(childNode);
-            childNode = nextSibling;
-          }
-        }
-      }
-    }
+  const root = $getRoot();
+  const topLevelChildren = root.getChildren();
+  for (let i = 0; i < topLevelChildren.length; i++) {
+    const topLevelNode = topLevelChildren[i];
+    $appendSelectedNodesToHTML(editor, selection, topLevelNode, container);
   }
   return container.innerHTML;
+}
+
+export function $appendSelectedNodesToClone(
+  editor: LexicalEditor,
+  selection: RangeSelection | NodeSelection | GridSelection,
+  currentNode: LexicalNode,
+  nodeMap: Array<[NodeKey, LexicalNode]>,
+  range: Array<NodeKey>,
+  shouldIncludeInRange: boolean = true,
+): Array<NodeKey> {
+  let shouldInclude = currentNode.isSelected();
+  const shouldExclude =
+    $isElementNode(currentNode) && currentNode.excludeFromCopy();
+  let clone = $cloneWithProperties<LexicalNode>(currentNode);
+  clone = $isTextNode(clone) ? $splitClonedTextNode(selection, clone) : clone;
+  const children = $isElementNode(clone) ? clone.getChildren() : [];
+  const nodeKeys = [];
+  let shouldIncludeChildrenInRange = shouldIncludeInRange;
+  if (shouldIncludeInRange && shouldInclude) {
+    shouldIncludeChildrenInRange = false;
+  }
+  for (let i = 0; i < children.length; i++) {
+    const childNode = children[i];
+    const childNodeKeys = $appendSelectedNodesToClone(
+      editor,
+      selection,
+      childNode,
+      nodeMap,
+      range,
+      shouldIncludeChildrenInRange,
+    );
+    for (let j = 0; j < childNodeKeys.length; j++) {
+      const childNodeKey = childNodeKeys[j];
+      nodeKeys.push(childNodeKey);
+    }
+    if (
+      !shouldInclude &&
+      $isElementNode(currentNode) &&
+      nodeKeys.includes(childNode.getKey()) &&
+      currentNode.extractWithChild(childNode, selection)
+    ) {
+      shouldInclude = true;
+    }
+  }
+  if (shouldInclude && !shouldExclude) {
+    nodeMap.push([clone.getKey(), clone]);
+    if (shouldIncludeInRange) {
+      return [clone.getKey()];
+    }
+  }
+  return shouldIncludeChildrenInRange ? nodeKeys : [];
+}
+
+export function $cloneSelectedContent(
+  editor: LexicalEditor,
+  selection: RangeSelection | NodeSelection | GridSelection,
+): {
+  nodeMap: Array<[NodeKey, LexicalNode]>,
+  range: Array<NodeKey>,
+} {
+  const root = $getRoot();
+  const nodeMap = [];
+  const range = [];
+  const topLevelChildren = root.getChildren();
+  for (let i = 0; i < topLevelChildren.length; i++) {
+    const topLevelNode = topLevelChildren[i];
+    const childNodeKeys = $appendSelectedNodesToClone(
+      editor,
+      selection,
+      topLevelNode,
+      nodeMap,
+      range,
+      true,
+    );
+    for (let j = 0; j < childNodeKeys.length; j++) {
+      const childNodeKey = childNodeKeys[j];
+      range.push(childNodeKey);
+    }
+  }
+  return {nodeMap, range};
 }
 
 export function $getLexicalContent(editor: LexicalEditor): string | null {
   const selection = $getSelection();
   if (selection !== null) {
     const namespace = editor._config.namespace;
-    const state = $cloneContents(selection);
+    const state = $cloneSelectedContent(editor, selection);
     return JSON.stringify({namespace, state});
   }
   return null;
@@ -384,7 +425,7 @@ function $mergeGridNodesStrategy(
   }
 }
 
-function $generateNodes(nodeRange: {
+export function $generateNodes(nodeRange: {
   nodeMap: ParsedNodeMap,
   range: Array<NodeKey>,
 }): Array<LexicalNode> {
@@ -498,7 +539,7 @@ function $createNodesFromDOM(
   return lexicalNodes;
 }
 
-function $generateNodesFromDOM(
+export function $generateNodesFromDOM(
   dom: Document,
   editor: LexicalEditor,
 ): Array<LexicalNode> {
@@ -515,4 +556,45 @@ function $generateNodesFromDOM(
     }
   }
   return lexicalNodes;
+}
+
+export function $splitClonedTextNode(
+  selection: RangeSelection | GridSelection | NodeSelection,
+  clone: TextNode,
+): LexicalNode {
+  if (
+    clone.isSelected() &&
+    !clone.isSegmented() &&
+    !clone.isToken() &&
+    ($isRangeSelection(selection) || $isGridSelection(selection))
+  ) {
+    const anchorNode = selection.anchor.getNode();
+    const focusNode = selection.focus.getNode();
+    const isAnchor = clone.is(anchorNode);
+    const isFocus = clone.is(focusNode);
+    if (isAnchor || isFocus) {
+      const isBackward = selection.isBackward();
+      const [anchorOffset, focusOffset] = selection.getCharacterOffsets();
+      const isSame = anchorNode.is(focusNode);
+      const isFirst = clone.is(isBackward ? focusNode : anchorNode);
+      const isLast = clone.is(isBackward ? anchorNode : focusNode);
+      let startOffset = 0;
+      let endOffset = undefined;
+      if (isSame) {
+        startOffset = anchorOffset > focusOffset ? focusOffset : anchorOffset;
+        endOffset = anchorOffset > focusOffset ? anchorOffset : focusOffset;
+      } else if (isFirst) {
+        const offset = isBackward ? focusOffset : anchorOffset;
+        startOffset = offset;
+        endOffset = undefined;
+      } else if (isLast) {
+        const offset = isBackward ? anchorOffset : focusOffset;
+        startOffset = 0;
+        endOffset = offset;
+      }
+      clone.__text = clone.__text.slice(startOffset, endOffset);
+      return clone;
+    }
+  }
+  return clone;
 }

--- a/packages/lexical-clipboard/src/index.js
+++ b/packages/lexical-clipboard/src/index.js
@@ -8,15 +8,15 @@
  */
 
 import {
+  $getHtmlContent,
   $getLexicalContent,
   $insertDataTransferForPlainText,
   $insertDataTransferForRichText,
-  getHtmlContent,
 } from './clipboard';
 
 export {
+  $getHtmlContent,
   $getLexicalContent,
   $insertDataTransferForPlainText,
   $insertDataTransferForRichText,
-  getHtmlContent,
 };

--- a/packages/lexical-list/src/LexicalListItemNode.js
+++ b/packages/lexical-list/src/LexicalListItemNode.js
@@ -302,14 +302,10 @@ export class ListItemNode extends ElementNode {
     }
     const anchorNode = selection.anchor.getNode();
     const focusNode = selection.focus.getNode();
-    const isBackward = selection.isBackward();
-    const selectionLength = isBackward
-      ? selection.anchor.offset - selection.focus.offset
-      : selection.focus.offset - selection.anchor.offset;
     return (
       this.isParentOf(anchorNode) &&
       this.isParentOf(focusNode) &&
-      this.getTextContent().length === selectionLength
+      this.getTextContent().length === selection.getTextContent().length
     );
   }
 }

--- a/packages/lexical-list/src/LexicalListItemNode.js
+++ b/packages/lexical-list/src/LexicalListItemNode.js
@@ -12,8 +12,10 @@ import type {
   DOMConversionOutput,
   EditorConfig,
   EditorThemeClasses,
+  GridSelection,
   LexicalNode,
   NodeKey,
+  NodeSelection,
   ParagraphNode,
   RangeSelection,
 } from 'lexical';
@@ -26,6 +28,7 @@ import {
   $createParagraphNode,
   $isElementNode,
   $isParagraphNode,
+  $isRangeSelection,
   ElementNode,
 } from 'lexical';
 import invariant from 'shared/invariant';
@@ -288,6 +291,26 @@ export class ListItemNode extends ElementNode {
 
   canMergeWith(node: LexicalNode): boolean {
     return $isParagraphNode(node) || $isListItemNode(node);
+  }
+
+  extractWithChild(
+    child: LexicalNode,
+    selection: RangeSelection | NodeSelection | GridSelection,
+  ): boolean {
+    if (!$isRangeSelection(selection)) {
+      return false;
+    }
+    const anchorNode = selection.anchor.getNode();
+    const focusNode = selection.focus.getNode();
+    const isBackward = selection.isBackward();
+    const selectionLength = isBackward
+      ? selection.anchor.offset - selection.focus.offset
+      : selection.focus.offset - selection.anchor.offset;
+    return (
+      this.isParentOf(anchorNode) &&
+      this.isParentOf(focusNode) &&
+      this.getTextContent().length === selectionLength
+    );
   }
 }
 

--- a/packages/lexical-list/src/LexicalListNode.js
+++ b/packages/lexical-list/src/LexicalListNode.js
@@ -116,6 +116,9 @@ export class ListNode extends ElementNode {
     }
     return this;
   }
+  extractWithChild(child: LexicalNode): boolean {
+    return $isListItemNode(child);
+  }
 }
 
 function setListThemeClassNames(

--- a/packages/lexical-plain-text/src/index.js
+++ b/packages/lexical-plain-text/src/index.js
@@ -10,8 +10,8 @@
 import type {EditorState, LexicalEditor} from 'lexical';
 
 import {
+  $getHtmlContent,
   $insertDataTransferForPlainText,
-  getHtmlContent,
 } from '@lexical/clipboard';
 import {
   $moveCharacter,
@@ -67,7 +67,7 @@ function onCopyForPlainText(
     const selection = $getSelection();
     if (selection !== null) {
       if (clipboardData != null) {
-        const htmlString = getHtmlContent(editor);
+        const htmlString = $getHtmlContent(editor);
         if (htmlString !== null) {
           clipboardData.setData('text/html', htmlString);
         }

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -169,9 +169,9 @@ test.describe('Nested List', () => {
       html`
         <ul class="PlaygroundEditorTheme__ul">
           <li
+            value="1"
             class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="1">
+            dir="ltr">
             <span data-lexical-text="true">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
               venenatis risus ac cursus efficitur. Cras efficitur magna odio,
@@ -186,14 +186,11 @@ test.describe('Nested List', () => {
             </span>
           </li>
         </ul>
-        <ul class="PlaygroundEditorTheme__ul">
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="1">
-            <span data-lexical-text="true">ipsum dolor</span>
-          </li>
-        </ul>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">ipsum dolor</span>
+        </p>
       `,
     );
   });

--- a/packages/lexical-playground/src/nodes/EquationNode.jsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.jsx
@@ -7,7 +7,12 @@
  * @flow strict
  */
 
-import type {EditorConfig, LexicalNode, NodeKey} from 'lexical';
+import type {
+  DOMExportOutput,
+  EditorConfig,
+  LexicalNode,
+  NodeKey,
+} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
@@ -126,6 +131,12 @@ export class EquationNode extends DecoratorNode<React$Node> {
     super(key);
     this.__equation = equation;
     this.__inline = inline ?? false;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement(this.__inline ? 'span' : 'div');
+    element.innerText = this.__equation;
+    return {element};
   }
 
   createDOM(config: EditorConfig): HTMLElement {

--- a/packages/lexical-playground/src/nodes/ImageNode.jsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.jsx
@@ -7,7 +7,13 @@
  * @flow strict
  */
 
-import type {EditorConfig, LexicalEditor, LexicalNode, NodeKey} from 'lexical';
+import type {
+  DOMExportOutput,
+  EditorConfig,
+  LexicalEditor,
+  LexicalNode,
+  NodeKey,
+} from 'lexical';
 
 import './ImageNode.css';
 
@@ -334,6 +340,13 @@ export class ImageNode extends DecoratorNode<React$Node> {
     this.__height = height || 'inherit';
     this.__showCaption = showCaption || false;
     this.__caption = caption || createEditor();
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement('img');
+    element.setAttribute('src', this.__src);
+    element.setAttribute('alt', this.__altText);
+    return {element};
   }
 
   setWidthAndHeight(

--- a/packages/lexical-rich-text/src/index.js
+++ b/packages/lexical-rich-text/src/index.js
@@ -21,9 +21,9 @@ import type {
 } from 'lexical';
 
 import {
+  $getHtmlContent,
   $getLexicalContent,
   $insertDataTransferForRichText,
-  getHtmlContent,
 } from '@lexical/clipboard';
 import {
   $moveCharacter,
@@ -218,6 +218,10 @@ export class HeadingNode extends ElementNode {
     this.replace(paragraph);
     return true;
   }
+
+  extractWithChild(): boolean {
+    return true;
+  }
 }
 
 function convertHeadingElement(domNode: Node): DOMConversionOutput {
@@ -308,7 +312,7 @@ function onCopyForRichText(event: ClipboardEvent, editor: LexicalEditor): void {
     const selection = $getSelection();
     if (selection !== null) {
       if (clipboardData != null) {
-        const htmlString = getHtmlContent(editor);
+        const htmlString = $getHtmlContent(editor);
         const lexicalString = $getLexicalContent(editor);
         if (htmlString !== null) {
           clipboardData.setData('text/html', htmlString);

--- a/packages/lexical-selection/LexicalSelection.d.ts
+++ b/packages/lexical-selection/LexicalSelection.d.ts
@@ -21,6 +21,9 @@ export function $cloneContents(
   nodeMap: Array<[NodeKey, LexicalNode]>;
   range: Array<NodeKey>;
 };
+export function $cloneWithProperties<LexicalNode>(
+  node: LexicalNode,
+): LexicalNode;
 export function getStyleObjectFromCSS(css: string): {
   [key: string]: string;
 } | null;

--- a/packages/lexical-selection/flow/LexicalSelection.js.flow
+++ b/packages/lexical-selection/flow/LexicalSelection.js.flow
@@ -21,6 +21,7 @@ declare export function $cloneContents(
   nodeMap: Array<[NodeKey, LexicalNode]>,
   range: Array<NodeKey>,
 };
+declare export function $cloneWithProperties<T: LexicalNode>(node: T): T;
 declare export function getStyleObjectFromCSS(css: string): {
   [string]: string,
 } | null;

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.js
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.js
@@ -8,6 +8,7 @@
 
 import type {State} from 'lexical';
 
+import {$createLinkNode} from '@lexical/link';
 import {$createHeadingNode} from '@lexical/rich-text';
 import {$cloneContents} from '@lexical/selection';
 import {
@@ -1506,6 +1507,43 @@ describe('LexicalSelectionHelpers tests', () => {
 
         expect(element.innerHTML).toBe(
           '<p dir="ltr"><span data-lexical-text="true">foobar</span></p>',
+        );
+      });
+
+      test('link insertion without parent element', async () => {
+        const editor = createTestEditor();
+        const element = document.createElement('div');
+        editor.setRootElement(element);
+
+        await editor.update((state: State) => {
+          const root = $getRoot();
+          const paragraph = $createParagraphNode();
+          root.append(paragraph);
+
+          setAnchorPoint({
+            key: paragraph.getKey(),
+            offset: 0,
+            type: 'element',
+          });
+          setFocusPoint({
+            key: paragraph.getKey(),
+            offset: 0,
+            type: 'element',
+          });
+          const selection = $getSelection();
+
+          const link = $createLinkNode('https://');
+          link.append($createTextNode('ello worl'));
+
+          selection.insertNodes([
+            $createTextNode('h'),
+            link,
+            $createTextNode('d'),
+          ]);
+        });
+
+        expect(element.innerHTML).toBe(
+          '<p dir="ltr"><span data-lexical-text="true">h</span><a href="https://" dir="ltr"><span data-lexical-text="true">ello worl</span></a><span data-lexical-text="true">d</span></p>',
         );
       });
 

--- a/packages/lexical-selection/src/index.js
+++ b/packages/lexical-selection/src/index.js
@@ -71,7 +71,7 @@ function $getParentAvoidingExcludedElements(
   node: LexicalNode,
 ): ElementNode | null {
   let parent = node.getParent();
-  while (parent !== null && parent.excludeFromCopy()) {
+  while (parent !== null && parent.excludeFromCopy('clone')) {
     parent = parent.getParent();
   }
   return parent;
@@ -92,7 +92,7 @@ function $copyLeafNodeBranchToRoot(
     if (parent === null) {
       break;
     }
-    if (!$isElementNode(node) || !node.excludeFromCopy()) {
+    if (!$isElementNode(node) || !node.excludeFromCopy('clone')) {
       const key = node.getKey();
       let clone = nodeMap.get(key);
       const needsClone = clone === undefined;
@@ -221,7 +221,7 @@ function $cloneContentsImpl(
       const key = node.getKey();
       if (
         !nodeMap.has(key) &&
-        (!$isElementNode(node) || !node.excludeFromCopy())
+        (!$isElementNode(node) || !node.excludeFromCopy('clone'))
       ) {
         const clone = $cloneWithProperties<LexicalNode>(node);
         if ($isRootNode(node.getParent())) {

--- a/packages/lexical-selection/src/index.js
+++ b/packages/lexical-selection/src/index.js
@@ -35,7 +35,7 @@ import invariant from 'shared/invariant';
 
 const cssToStyles: Map<string, {[string]: string}> = new Map();
 
-function $cloneWithProperties<T: LexicalNode>(node: T): T {
+export function $cloneWithProperties<T: LexicalNode>(node: T): T {
   const latest = node.getLatest();
   const constructor = latest.constructor;
   const clone = constructor.clone(latest);

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -694,7 +694,7 @@ export declare class ElementNode extends LexicalNode {
   canInsertTab(): boolean;
   canIndent(): boolean;
   collapseAtStart(selection: RangeSelection): boolean;
-  excludeFromCopy(): boolean;
+  excludeFromCopy(destination: 'clone' | 'html'): boolean;
   canExtractContents(): boolean;
   canReplaceWith(replacement: LexicalNode): boolean;
   canInsertAfter(node: LexicalNode): boolean;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -725,6 +725,10 @@ declare export class ElementNode extends LexicalNode {
   canExtractContents(): boolean;
   canReplaceWith(replacement: LexicalNode): boolean;
   canInsertAfter(node: LexicalNode): boolean;
+  extractWithChild(
+    child: LexicalNode,
+    selection: RangeSelection | NodeSelection | GridSelection,
+  ): boolean;
   canBeEmpty(): boolean;
   canInsertTextBefore(): boolean;
   canInsertTextAfter(): boolean;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -721,13 +721,14 @@ declare export class ElementNode extends LexicalNode {
   canInsertTab(): boolean;
   canIndent(): boolean;
   collapseAtStart(selection: RangeSelection): boolean;
-  excludeFromCopy(): boolean;
+  excludeFromCopy(destination: 'clone' | 'html'): boolean;
   canExtractContents(): boolean;
   canReplaceWith(replacement: LexicalNode): boolean;
   canInsertAfter(node: LexicalNode): boolean;
   extractWithChild(
     child: LexicalNode,
     selection: RangeSelection | NodeSelection | GridSelection,
+    destination: 'clone' | 'html',
   ): boolean;
   canBeEmpty(): boolean;
   canInsertTextBefore(): boolean;

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -1154,8 +1154,7 @@ export class RangeSelection implements BaseSelection {
     // Time to insert the nodes!
     for (let i = 0; i < nodes.length; i++) {
       const node = nodes[i];
-
-      if ($isElementNode(node)) {
+      if ($isElementNode(node) && !node.isInline()) {
         // -----
         // Heuristics for the replacment or merging of elements
         // -----
@@ -1249,7 +1248,7 @@ export class RangeSelection implements BaseSelection {
         );
       }
       didReplaceOrMerge = false;
-      if ($isElementNode(target)) {
+      if ($isElementNode(target) && !target.isInline()) {
         lastNodeInserted = node;
         if ($isDecoratorNode(node) && node.isTopLevel()) {
           target = target.insertAfter(node);
@@ -1279,6 +1278,7 @@ export class RangeSelection implements BaseSelection {
         }
       } else if (
         !$isElementNode(node) ||
+        ($isElementNode(node) && node.isInline()) ||
         ($isDecoratorNode(target) && target.isTopLevel())
       ) {
         lastNodeInserted = node;

--- a/packages/lexical/src/nodes/LexicalElementNode.js
+++ b/packages/lexical/src/nodes/LexicalElementNode.js
@@ -6,9 +6,13 @@
  *
  * @flow strict
  */
-
 import type {NodeKey} from '../LexicalNode';
-import type {PointType, RangeSelection} from '../LexicalSelection';
+import type {
+  GridSelection,
+  NodeSelection,
+  PointType,
+  RangeSelection,
+} from '../LexicalSelection';
 
 import invariant from 'shared/invariant';
 
@@ -446,6 +450,12 @@ export class ElementNode extends LexicalNode {
     return false;
   }
   canMergeWith(node: ElementNode): boolean {
+    return false;
+  }
+  extractWithChild(
+    child: LexicalNode,
+    selection: RangeSelection | NodeSelection | GridSelection,
+  ): boolean {
     return false;
   }
 }

--- a/packages/lexical/src/nodes/LexicalElementNode.js
+++ b/packages/lexical/src/nodes/LexicalElementNode.js
@@ -455,6 +455,7 @@ export class ElementNode extends LexicalNode {
   extractWithChild(
     child: LexicalNode,
     selection: RangeSelection | NodeSelection | GridSelection,
+    destination: 'clone' | 'html',
   ): boolean {
     return false;
   }

--- a/packages/lexical/src/nodes/LexicalParagraphNode.js
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  */
-
 import type {
   EditorConfig,
   EditorThemeClasses,


### PR DESCRIPTION
Solves the problems described in #1957 and the `Lexical -> HTML` & `Lexical -> Lexical (Clone)` conversion functions now have identical outputs, which will make debugging issues in the future much easier.

This PR also adds an `extractWithChild` method to `ElementNodes` that can be used to ensure there's a tightly coupled relationship between parent and child. This is useful situations where the `ElementNode` provides important context for its children e.g. `Heading -> TextNode` or `List -> ListItem`.

NOTE: Most of the line count is from the new tests in `clipboard.test.js`. 

`Lexical -> Lexical (Clone)` and `Lexical -> HTML` are tested individually and then they're both ran through the same processing code and compared to each other ensure the end output is the same.

https://user-images.githubusercontent.com/13852400/165403382-c8b326f9-bbce-4789-8d88-f9392f252fe7.mov

