### PR TITLE
Improve StickyNode styling

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1245,18 +1245,25 @@ button.action-button:disabled {
   margin: 0 4px;
 }
 
+.sticky-note-container {
+  position: absolute;
+  z-index: 20;
+  width: 120px;
+  display: inline-block;
+}
+
 .sticky-note {
   line-height: 1;
   text-align: left;
   width: 120px;
   margin: 25px;
   padding: 20px 10px;
-  position: absolute;
+  position: relative;
   border: 1px solid #e8e8e8;
   font-family: 'Reenie Beanie';
   font-size: 24px;
   border-bottom-right-radius: 60px 5px;
-  display: inline-block;
+  display: block;
   cursor: move;
 }
 
@@ -1295,7 +1302,7 @@ button.action-button:disabled {
   );
 }
 
-.sticky-note.dragging {
+.sticky-note-container.dragging {
   transition: none !important;
 }
 

--- a/packages/lexical-playground/src/nodes/StickyNode.jsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.jsx
@@ -199,57 +199,63 @@ function StickyComponent({
   const {historyState} = useSharedHistoryContext();
 
   return (
-    <div
-      ref={stickyContainerRef}
-      className={`sticky-note ${color}`}
-      onPointerDown={(event) => {
-        if (event.button === 2 || event.target !== stickyContainerRef.current) {
-          // Right click or click on editor should not work
-          return;
-        }
-        const stickContainer = stickyContainerRef.current;
-        const positioning = positioningRef.current;
-        if (stickContainer !== null) {
-          const {top, left} = stickContainer.getBoundingClientRect();
-          positioning.offsetX = event.clientX - left + 30;
-          positioning.offsetY = event.clientY - top + 20;
-          positioning.isDragging = true;
-          stickContainer.classList.add('dragging');
-          document.addEventListener('pointermove', handlePointerMove);
-          document.addEventListener('pointerup', handlePointerUp);
-          event.preventDefault();
-        }
-      }}>
-      <button onClick={handleDelete} className="delete">
-        X
-      </button>
-      <button onClick={handleColorChange} className="color">
-        <i className="bucket" />
-      </button>
-      <LexicalNestedComposer
-        initialEditor={caption}
-        initialTheme={StickyEditorTheme}>
-        {isCollab ? (
-          <CollaborationPlugin
-            id={caption.getKey()}
-            providerFactory={createWebsocketProvider}
-            shouldBootstrap={true}
+    <div ref={stickyContainerRef} className="sticky-note-container">
+      <div
+        className={`sticky-note ${color}`}
+        onPointerDown={(event) => {
+          const stickyContainer = stickyContainerRef.current;
+          if (
+            stickyContainer == null ||
+            event.button === 2 ||
+            event.target !== stickyContainer.firstChild
+          ) {
+            // Right click or click on editor should not work
+            return;
+          }
+          const stickContainer = stickyContainer;
+          const positioning = positioningRef.current;
+          if (stickContainer !== null) {
+            const {top, left} = stickContainer.getBoundingClientRect();
+            positioning.offsetX = event.clientX - left;
+            positioning.offsetY = event.clientY - top;
+            positioning.isDragging = true;
+            stickContainer.classList.add('dragging');
+            document.addEventListener('pointermove', handlePointerMove);
+            document.addEventListener('pointerup', handlePointerUp);
+            event.preventDefault();
+          }
+        }}>
+        <button onClick={handleDelete} className="delete">
+          X
+        </button>
+        <button onClick={handleColorChange} className="color">
+          <i className="bucket" />
+        </button>
+        <LexicalNestedComposer
+          initialEditor={caption}
+          initialTheme={StickyEditorTheme}>
+          {isCollab ? (
+            <CollaborationPlugin
+              id={caption.getKey()}
+              providerFactory={createWebsocketProvider}
+              shouldBootstrap={true}
+            />
+          ) : (
+            <HistoryPlugin externalHistoryState={historyState} />
+          )}
+          <PlainTextPlugin
+            contentEditable={
+              <ContentEditable className="StickyNode__contentEditable" />
+            }
+            placeholder={
+              <Placeholder className="StickyNode__placeholder">
+                What's up?
+              </Placeholder>
+            }
+            initialEditorState={null}
           />
-        ) : (
-          <HistoryPlugin externalHistoryState={historyState} />
-        )}
-        <PlainTextPlugin
-          contentEditable={
-            <ContentEditable className="StickyNode__contentEditable" />
-          }
-          placeholder={
-            <Placeholder className="StickyNode__placeholder">
-              What's up?
-            </Placeholder>
-          }
-          initialEditorState={null}
-        />
-      </LexicalNestedComposer>
+        </LexicalNestedComposer>
+      </div>
     </div>
   );
 }

--- a/packages/lexical-playground/src/nodes/StickyNode.jsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.jsx
@@ -228,7 +228,7 @@ function StickyComponent({
         <button onClick={handleDelete} className="delete" aria-label="Delete sticky note" type="Delete">
           X
         </button>
-        <button onClick={handleColorChange} className="color">
+        <button onClick={handleColorChange} className="color" aria-label="Change sticky note color" type="Color">
           <i className="bucket" />
         </button>
         <LexicalNestedComposer

--- a/packages/lexical-playground/src/nodes/StickyNode.jsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.jsx
@@ -225,7 +225,7 @@ function StickyComponent({
             event.preventDefault();
           }
         }}>
-        <button onClick={handleDelete} className="delete">
+        <button onClick={handleDelete} className="delete" aria-label="Delete sticky note" type="Delete">
           X
         </button>
         <button onClick={handleColorChange} className="color">


### PR DESCRIPTION
The z-index can be off at times for StickyNode, so we need to wrap the `<div>` in a container to be able to apply z-index.