### PR TITLE
Tests, playground usage, table/image/hr/tweet transformers

### DIFF
--- a/packages/lexical-markdown/src/index.js
+++ b/packages/lexical-markdown/src/index.js
@@ -19,6 +19,7 @@ import {
   convertMarkdownForElementNodes,
   convertStringToLexical,
 } from './convertFromPlainTextUtils.js';
+import * as v2 from './v2';
 
 export function registerMarkdownShortcuts<T>(
   editor: LexicalEditor,
@@ -59,3 +60,9 @@ export function $convertFromMarkdownString<T>(
 }
 
 export {$convertToMarkdownString} from './convertToMarkdown';
+export {v2};
+export type {
+  BlockTransformer,
+  TextFormatTransformer,
+  TextMatchTransformer,
+} from './v2/MarkdownTransformers';

--- a/packages/lexical-markdown/src/v2/MarkdownExport.js
+++ b/packages/lexical-markdown/src/v2/MarkdownExport.js
@@ -18,12 +18,12 @@ import {$getRoot, $isElementNode, $isLineBreakNode, $isTextNode} from 'lexical';
 
 export function createMarkdownExport(
   blockTransformers: Array<BlockTransformer>,
-  textFormatTransformers_: Array<TextFormatTransformer>,
+  _textFormatTransformers: Array<TextFormatTransformer>,
   textMatchTransformers: Array<TextMatchTransformer>,
 ): () => string {
   // Export only uses text formats that are responsible for single format
   // e.g. it will filter out *** (bold, italic) and instead use separate ** and *
-  const textFormatTransformers = textFormatTransformers_.filter(
+  const textFormatTransformers = _textFormatTransformers.filter(
     (transformer) => transformer.format.length === 1,
   );
   return () => {

--- a/packages/lexical-markdown/src/v2/MarkdownShortcuts.js
+++ b/packages/lexical-markdown/src/v2/MarkdownShortcuts.js
@@ -356,7 +356,7 @@ export function registerMarkdownShortcuts(
       if (
         !$isTextNode(anchorNode) ||
         !dirtyLeaves.has(anchorKey) ||
-        anchorOffset !== prevSelection.anchor.offset + 1
+        (anchorOffset !== 1 && anchorOffset !== prevSelection.anchor.offset + 1)
       ) {
         return;
       }

--- a/packages/lexical-markdown/src/v2/MarkdownTransformers.js
+++ b/packages/lexical-markdown/src/v2/MarkdownTransformers.js
@@ -193,56 +193,83 @@ export const ORDERED_LIST: BlockTransformer = {
   type: 'block-match',
 };
 
-export const BLOCK_TRANSFORMERS: Array<BlockTransformer> = [
-  HEADING,
-  QUOTE,
-  CODE,
-  UNORDERED_LIST,
-  ORDERED_LIST,
-];
+export const INLINE_CODE: TextFormatTransformer = {
+  format: ['code'],
+  tag: '`',
+  type: 'format',
+};
+
+export const BOLD_ITALIC_STAR: TextFormatTransformer = {
+  format: ['bold', 'italic'],
+  tag: '***',
+  type: 'format',
+};
+
+export const BOLD_ITALIC_UNDERSCORE: TextFormatTransformer = {
+  format: ['bold', 'italic'],
+  tag: '___',
+  type: 'format',
+};
+
+export const BOLD_STAR: TextFormatTransformer = {
+  format: ['bold'],
+  tag: '**',
+  type: 'format',
+};
+
+export const BOLD_UNDERSCORE: TextFormatTransformer = {
+  format: ['bold'],
+  tag: '__',
+  type: 'format',
+};
+
+export const STRIKETHROUGH: TextFormatTransformer = {
+  format: ['strikethrough'],
+  tag: '~~',
+  type: 'format',
+};
+
+export const ITALIC_STAR: TextFormatTransformer = {
+  format: ['italic'],
+  tag: '*',
+  type: 'format',
+};
+
+export const ITALIC_UNDERSCORE: TextFormatTransformer = {
+  format: ['italic'],
+  tag: '_',
+  type: 'format',
+};
 
 // Order of text transformers matters:
 //
 // - code should go first as it prevents any transformations inside
 // - then longer tags match (e.g. ** or __ should go before * or _)
-export const TEXT_FORMAT_TRANSFORMERS: Array<TextFormatTransformer> = [
-  {format: ['code'], tag: '`', type: 'format'},
-  {format: ['bold', 'italic'], tag: '***', type: 'format'},
-  {format: ['bold', 'italic'], tag: '___', type: 'format'},
-  {format: ['bold'], tag: '**', type: 'format'},
-  {format: ['bold'], tag: '__', type: 'format'},
-  {format: ['strikethrough'], tag: '~~', type: 'format'},
-  {format: ['italic'], tag: '*', type: 'format'},
-  {format: ['italic'], tag: '_', type: 'format'},
-];
-
-export const TEXT_MATCH_TRANSFORMERS: Array<TextMatchTransformer> = [
-  {
-    export: (node, exportChildren, exportFormat) => {
-      if (!$isLinkNode(node)) {
-        return null;
-      }
-      const linkContent = `[${node.getTextContent()}](${node.getURL()})`;
-      const firstChild = node.getFirstChild();
-      // Add text styles only if link has single text node inside. If it's more
-      // then one we ignore it as markdown does not support nested styles for links
-      if (node.getChildrenSize() === 1 && $isTextNode(firstChild)) {
-        return exportFormat(firstChild, linkContent);
-      } else {
-        return linkContent;
-      }
-    },
-    importRegExp: /(?:\[([^[]+)\])(?:\(([^(]+)\))/,
-    regExp: /(?:\[([^[]+)\])(?:\(([^(]+)\))$/,
-    replace: (textNode, match) => {
-      const [, linkText, linkUrl] = match;
-      const linkNode = $createLinkNode(linkUrl);
-      const linkTextNode = $createTextNode(linkText);
-      linkTextNode.setFormat(textNode.getFormat());
-      linkNode.append(linkTextNode);
-      textNode.replace(linkNode);
-    },
-    trigger: ')',
-    type: 'text-match',
+export const LINK: TextMatchTransformer = {
+  export: (node, exportChildren, exportFormat) => {
+    if (!$isLinkNode(node)) {
+      return null;
+    }
+    const linkContent = `[${node.getTextContent()}](${node.getURL()})`;
+    const firstChild = node.getFirstChild();
+    // Add text styles only if link has single text node inside. If it's more
+    // then one we ignore it as markdown does not support nested styles for links
+    if (node.getChildrenSize() === 1 && $isTextNode(firstChild)) {
+      return exportFormat(firstChild, linkContent);
+    } else {
+      return linkContent;
+    }
   },
-];
+  importRegExp: /(?:\[([^[]+)\])(?:\(([^(]+)\))/,
+  regExp: /(?:\[([^[]+)\])(?:\(([^(]+)\))$/,
+  replace: (textNode, match) => {
+    const [, linkText, linkUrl] = match;
+    const linkNode = $createLinkNode(linkUrl);
+    const linkTextNode = $createTextNode(linkText);
+    linkTextNode.setFormat(textNode.getFormat());
+    linkNode.append(linkTextNode);
+    textNode.replace(linkNode);
+  },
+  trigger: ')',
+  type: 'text-match',
+};

--- a/packages/lexical-markdown/src/v2/index.js
+++ b/packages/lexical-markdown/src/v2/index.js
@@ -7,26 +7,83 @@
  * @flow strict
  */
 
+import type {
+  BlockTransformer,
+  TextFormatTransformer,
+  TextMatchTransformer,
+} from './MarkdownTransformers';
+import type {Array} from 'yjs';
+
 import {createMarkdownExport} from './MarkdownExport';
 import {createMarkdownImport} from './MarkdownImport';
 import {registerMarkdownShortcuts} from './MarkdownShortcuts';
 import {
-  BLOCK_TRANSFORMERS,
-  TEXT_FORMAT_TRANSFORMERS,
-  TEXT_MATCH_TRANSFORMERS,
+  BOLD_ITALIC_STAR,
+  BOLD_ITALIC_UNDERSCORE,
+  BOLD_STAR,
+  BOLD_UNDERSCORE,
+  CODE,
+  HEADING,
+  INLINE_CODE,
+  ITALIC_STAR,
+  ITALIC_UNDERSCORE,
+  LINK,
+  ORDERED_LIST,
+  QUOTE,
+  STRIKETHROUGH,
+  UNORDERED_LIST,
 } from './MarkdownTransformers';
 
-const DEFAULT_TRANSFORMERS = [
-  BLOCK_TRANSFORMERS,
-  TEXT_FORMAT_TRANSFORMERS,
-  TEXT_MATCH_TRANSFORMERS,
+const BLOCK_TRANSFORMERS: Array<BlockTransformer> = [
+  HEADING,
+  QUOTE,
+  CODE,
+  UNORDERED_LIST,
+  ORDERED_LIST,
 ];
+
+const TEXT_FORMAT_TRANSFORMERS: Array<TextFormatTransformer> = [
+  // Order of text format transformers matters:
+  //
+  // - code should go first as it prevents any transformations inside
+  // - then longer tags match (e.g. ** or __ should go before * or _)
+  INLINE_CODE,
+  BOLD_ITALIC_STAR,
+  BOLD_ITALIC_UNDERSCORE,
+  BOLD_STAR,
+  BOLD_UNDERSCORE,
+  ITALIC_STAR,
+  ITALIC_UNDERSCORE,
+  STRIKETHROUGH,
+];
+
+const TEXT_MATCH_TRANSFORMERS: Array<TextMatchTransformer> = [LINK];
+
+const TRANSFORMERS: [
+  Array<BlockTransformer>,
+  Array<TextFormatTransformer>,
+  Array<TextMatchTransformer>,
+] = [BLOCK_TRANSFORMERS, TEXT_FORMAT_TRANSFORMERS, TEXT_MATCH_TRANSFORMERS];
 
 export {
   BLOCK_TRANSFORMERS,
-  DEFAULT_TRANSFORMERS,
+  BOLD_ITALIC_STAR,
+  BOLD_ITALIC_UNDERSCORE,
+  BOLD_STAR,
+  BOLD_UNDERSCORE,
+  CODE,
+  HEADING,
+  INLINE_CODE,
+  ITALIC_STAR,
+  ITALIC_UNDERSCORE,
+  LINK,
+  ORDERED_LIST,
+  QUOTE,
+  STRIKETHROUGH,
   TEXT_FORMAT_TRANSFORMERS,
   TEXT_MATCH_TRANSFORMERS,
+  TRANSFORMERS,
+  UNORDERED_LIST,
 };
 
 export {createMarkdownExport, createMarkdownImport, registerMarkdownShortcuts};

--- a/packages/lexical-playground/__tests__/e2e/Markdown-v2.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown-v2.spec.mjs
@@ -1,0 +1,1023 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {redo, undo} from '../keyboardShortcuts/index.mjs';
+import {
+  assertHTML,
+  clearEditor,
+  click,
+  focusEditor,
+  getHTML,
+  html,
+  initialize,
+  LEGACY_EVENTS,
+  pasteFromClipboard,
+  pressToggleBold,
+  pressToggleUnderline,
+  test,
+} from '../utils/index.mjs';
+
+async function assertMarkdownImportExport(
+  page,
+  textToImport,
+  expectedHTML,
+  ignoreClasses,
+) {
+  // Clear the editor from previous content
+  await clearEditor(page);
+
+  // Create code block that will be imported as a markdown into editor
+  await page.keyboard.type('```markdown ');
+  await page.keyboard.type(textToImport);
+  await click(page, '.action-button .markdown');
+  await assertHTML(page, expectedHTML, {ignoreClasses});
+
+  // Cycle through import-export to verify it produces the same result
+  await click(page, '.action-button .markdown');
+  await click(page, '.action-button .markdown');
+  await assertHTML(page, expectedHTML);
+}
+
+test.describe('Markdown', () => {
+  test.beforeEach(({isCollab, isPlainText, page}) => {
+    test.skip(isPlainText);
+    initialize({isCollab, page});
+  });
+
+  const BASE_BLOCK_SHORTCUTS = [
+    {
+      html: html`
+        <h1><br /></h1>
+      `,
+      text: '# ',
+    },
+    {
+      html: html`
+        <h2><br /></h2>
+      `,
+      text: '## ',
+    },
+    {
+      html: html`
+        <ol>
+          <li value="1"><br /></li>
+        </ol>
+      `,
+      text: '1. ',
+    },
+    {
+      html: html`
+        <ol start="25">
+          <li value="25"><br /></li>
+        </ol>
+      `,
+      text: '25. ',
+    },
+    {
+      html: html`
+        <ol>
+          <li value="1">
+            <ol>
+              <li value="1"><br /></li>
+            </ol>
+          </li>
+        </ol>
+      `,
+      text: '    1. ',
+    },
+    {
+      html: html`
+        <ul>
+          <li value="1"><br /></li>
+        </ul>
+      `,
+      text: '- ',
+    },
+    {
+      html: html`
+        <ul>
+          <li value="1">
+            <ul>
+              <li value="1"><br /></li>
+            </ul>
+          </li>
+        </ul>
+      `,
+      text: '    - ',
+    },
+    {
+      html: html`
+        <ul>
+          <li value="1"><br /></li>
+        </ul>
+      `,
+      text: '* ',
+    },
+    {
+      html: html`
+        <ul>
+          <li value="1">
+            <ul>
+              <li value="1"><br /></li>
+            </ul>
+          </li>
+        </ul>
+      `,
+      text: '    * ',
+    },
+    {
+      html: html`
+        <ul>
+          <li value="1">
+            <ul>
+              <li value="1"><br /></li>
+            </ul>
+          </li>
+        </ul>
+      `,
+      text: '      * ',
+    },
+    {
+      html: html`
+        <ul>
+          <li value="1">
+            <ul>
+              <li value="1">
+                <ul>
+                  <li value="1">
+                    <br />
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      `,
+      text: '        * ',
+    },
+    {
+      html: html`
+        <div
+          contenteditable="false"
+          style="display: contents;"
+          data-lexical-decorator="true">
+          <hr />
+        </div>
+        <p><br /></p>
+      `,
+      text: '--- ',
+    },
+    {
+      html: html`
+        <div
+          contenteditable="false"
+          style="display: contents;"
+          data-lexical-decorator="true">
+          <hr />
+        </div>
+        <p><br /></p>
+      `,
+      text: '*** ',
+    },
+  ];
+
+  const SIMPLE_TEXT_FORMAT_SHORTCUTS = [
+    {
+      html: html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">hello</span>
+          <em
+            class="PlaygroundEditorTheme__textItalic"
+            data-lexical-text="true">
+            world
+          </em>
+          <span data-lexical-text="true">!</span>
+        </p>
+      `,
+      text: 'hello *world*!',
+    },
+    {
+      html: html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">hello</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            world
+          </strong>
+          <span data-lexical-text="true">!</span>
+        </p>
+      `,
+      text: 'hello **world**!',
+    },
+    {
+      html: html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">hello</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+            data-lexical-text="true">
+            world
+          </strong>
+          <span data-lexical-text="true">!</span>
+        </p>
+      `,
+      text: 'hello ***world***!',
+    },
+    {
+      html: html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">hello</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+            data-lexical-text="true">
+            world
+          </strong>
+          <span data-lexical-text="true">!</span>
+        </p>
+      `,
+      text: 'hello ___world___!',
+    },
+    {
+      html: html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">hello</span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://www.test.com">
+            <span data-lexical-text="true">world</span>
+          </a>
+          <span data-lexical-text="true">!</span>
+        </p>
+      `,
+      text: 'hello [world](https://www.test.com)!',
+    },
+  ];
+
+  const NESTED_TEXT_FORMAT_SHORTCUTS = [
+    {
+      html: html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <strong
+            class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
+            data-lexical-text="true">
+            hello world
+          </strong>
+          <span data-lexical-text="true">!</span>
+        </p>
+      `,
+      text: '~~_**hello world**_~~!',
+    },
+    {
+      html: html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <em
+            class="PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
+            data-lexical-text="true">
+            hello world
+          </em>
+          <span data-lexical-text="true">!</span>
+        </p>
+      `,
+      text: '~~_hello world_~~!',
+    },
+    {
+      html: html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <strong
+            class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textStrikethrough"
+            data-lexical-text="true">
+            hello world
+          </strong>
+          <span data-lexical-text="true">!</span>
+        </p>
+      `,
+      text: '~~**hello world**~~!',
+    },
+    {
+      html: html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <strong
+            class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+            data-lexical-text="true">
+            hello world
+          </strong>
+          <span data-lexical-text="true">!</span>
+        </p>
+      `,
+      text: '_**hello world**_!',
+    },
+  ];
+
+  BASE_BLOCK_SHORTCUTS.forEach((testCase) => {
+    test(`can convert "${testCase.text}" shortcut`, async ({
+      page,
+      isCollab,
+    }) => {
+      await focusEditor(page);
+      await page.keyboard.type(testCase.text);
+      await assertHTML(page, testCase.html, {ignoreClasses: true});
+
+      if (!isCollab) {
+        const escapedText = testCase.text.replace('>', '&gt;');
+        await undo(page);
+        await assertHTML(
+          page,
+          `<p><span data-lexical-text="true">${escapedText}</span></p>`,
+          {ignoreClasses: true},
+        );
+        await redo(page);
+        await assertHTML(page, testCase.html, {ignoreClasses: true});
+      }
+    });
+  });
+
+  SIMPLE_TEXT_FORMAT_SHORTCUTS.forEach((testCase) => {
+    test(`can convert "${testCase.text}" shortcut`, async ({
+      page,
+      isCollab,
+    }) => {
+      await focusEditor(page);
+      await page.keyboard.type(testCase.text, {
+        delay: LEGACY_EVENTS ? 50 : 0,
+      });
+      await assertHTML(page, testCase.html, {ignoreClasses: false});
+      await assertMarkdownImportExport(page, testCase.text, testCase.html);
+    });
+  });
+
+  NESTED_TEXT_FORMAT_SHORTCUTS.forEach((testCase) => {
+    test(`can convert "${testCase.text}" shortcut`, async ({page}) => {
+      await focusEditor(page);
+      await page.keyboard.type(testCase.text, {
+        delay: LEGACY_EVENTS ? 50 : 0,
+      });
+      await assertHTML(page, testCase.html, {ignoreClasses: false});
+      await assertMarkdownImportExport(page, testCase.text, testCase.html);
+    });
+  });
+
+  test('can undo/redo nested transformations', async ({page, isCollab}) => {
+    await focusEditor(page);
+    await page.keyboard.type('~~_**hello world**_~~');
+
+    const BOLD_ITALIC_STRIKETHROUGH = html`
+      <p
+        class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+        dir="ltr">
+        <strong
+          class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
+          data-lexical-text="true">
+          hello world
+        </strong>
+      </p>
+    `;
+    const BOLD_ITALIC = html`
+      <p
+        class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+        dir="ltr">
+        <span data-lexical-text="true">~~</span>
+        <strong
+          class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+          data-lexical-text="true">
+          hello world
+        </strong>
+        <span data-lexical-text="true">~~</span>
+      </p>
+    `;
+    const BOLD = html`
+      <p
+        class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+        dir="ltr">
+        <span data-lexical-text="true">~~_</span>
+        <strong
+          class="PlaygroundEditorTheme__textBold"
+          data-lexical-text="true">
+          hello world
+        </strong>
+        <span data-lexical-text="true">_</span>
+      </p>
+    `;
+    const PLAIN = html`
+      <p
+        class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+        dir="ltr">
+        <span data-lexical-text="true">~~_**hello world**</span>
+      </p>
+    `;
+
+    await assertHTML(page, BOLD_ITALIC_STRIKETHROUGH);
+
+    if (isCollab) {
+      return;
+    }
+
+    await undo(page); // Undo last transformation
+    await assertHTML(page, BOLD_ITALIC);
+    await undo(page); // Undo transformation & its text typing
+    await undo(page);
+    await assertHTML(page, BOLD);
+    await undo(page); // Undo transformation & its text typing
+    await undo(page);
+    await assertHTML(page, PLAIN);
+    await redo(page); // Redo transformation & its text typing
+    await redo(page);
+    await assertHTML(page, BOLD);
+    await redo(page); // Redo transformation & its text typing
+    await redo(page);
+    await assertHTML(page, BOLD_ITALIC);
+    await redo(page); // Redo transformation
+    await assertHTML(page, BOLD_ITALIC_STRIKETHROUGH);
+  });
+
+  test('can convert already styled text (overlapping ranges)', async ({
+    page,
+  }) => {
+    // type partially bold/underlined text, add opening markdown tag within bold/underline part
+    // and add closing within plain text
+    await focusEditor(page);
+    await pressToggleBold(page);
+    await pressToggleUnderline(page);
+    await page.keyboard.type('h_e~~llo');
+    await pressToggleBold(page);
+    await pressToggleUnderline(page);
+    await page.keyboard.type(' wo~~r_ld');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <strong
+            class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textUnderline"
+            data-lexical-text="true">
+            h
+          </strong>
+          <strong
+            class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textUnderline"
+            data-lexical-text="true">
+            e
+          </strong>
+          <strong
+            class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+            data-lexical-text="true">
+            llo
+          </strong>
+          <em
+            class="PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
+            data-lexical-text="true">
+            wo
+          </em>
+          <em
+            class="PlaygroundEditorTheme__textItalic"
+            data-lexical-text="true">
+            r
+          </em>
+          <span data-lexical-text="true">ld</span>
+        </p>
+      `,
+    );
+  });
+
+  test('can convert markdown text into rich text', async ({page, isCollab}) => {
+    await focusEditor(page);
+    await page.keyboard.type('```markdown ');
+    await pasteFromClipboard(page, {
+      'text/plain': IMPORTED_MARKDOWN,
+    });
+
+    const originalHTML = await getHTML(page);
+
+    // Import from current markdown codeblock content
+    await click(page, '.action-button .markdown');
+    await assertHTML(page, IMPORTED_MARKDOWN_HTML);
+
+    if (!isCollab) {
+      await undo(page);
+      await assertHTML(page, originalHTML);
+      await redo(page);
+      await assertHTML(page, IMPORTED_MARKDOWN_HTML);
+
+      // Click again to run export/import cycle twice to make sure
+      // no extra nodes (e.g. newlines) are created
+      await click(page, '.action-button .markdown');
+      await click(page, '.action-button .markdown');
+      await click(page, '.action-button .markdown');
+      await click(page, '.action-button .markdown');
+      await assertHTML(page, IMPORTED_MARKDOWN_HTML);
+    }
+  });
+
+  test('can type text with markdown', async ({page}) => {
+    await focusEditor(page);
+    await page.keyboard.type(TYPED_MARKDOWN);
+    await assertHTML(page, TYPED_MARKDOWN_HTML);
+  });
+});
+
+const TYPED_MARKDOWN = `# Markdown Shortcuts
+This is *italic*, _italic_, **bold**, __bold__, ~~strikethrough~~ text
+This is *__~~bold italic strikethrough~~__* text, ___~~this one too~~___
+It ~~___works [with links](https://lexical.io) too___~~
+*Nested **stars tags** are handled too*
+# Title
+## Subtitle
+> Quote
+--- - List here
+
+    - Nested one
+
+
+\`\`\`sql Code block
+
+
+Done`;
+
+const TYPED_MARKDOWN_HTML = html`
+  <h1 class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">Markdown Shortcuts</span>
+  </h1>
+  <p
+    class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <span data-lexical-text="true">This is</span>
+    <em class="PlaygroundEditorTheme__textItalic" data-lexical-text="true">
+      italic
+    </em>
+    <span data-lexical-text="true">,</span>
+    <em class="PlaygroundEditorTheme__textItalic" data-lexical-text="true">
+      italic
+    </em>
+    <span data-lexical-text="true">,</span>
+    <strong class="PlaygroundEditorTheme__textBold" data-lexical-text="true">
+      bold
+    </strong>
+    <span data-lexical-text="true">,</span>
+    <strong class="PlaygroundEditorTheme__textBold" data-lexical-text="true">
+      bold
+    </strong>
+    <span data-lexical-text="true">,</span>
+    <span
+      class="PlaygroundEditorTheme__textStrikethrough"
+      data-lexical-text="true">
+      strikethrough
+    </span>
+    <span data-lexical-text="true">text</span>
+  </p>
+  <p
+    class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <span data-lexical-text="true">This is</span>
+    <strong
+      class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textStrikethrough PlaygroundEditorTheme__textItalic"
+      data-lexical-text="true">
+      bold italic strikethrough
+    </strong>
+    <span data-lexical-text="true">text,</span>
+    <strong
+      class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
+      data-lexical-text="true">
+      this one too
+    </strong>
+  </p>
+  <p
+    class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <span data-lexical-text="true">It</span>
+    <strong
+      class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
+      data-lexical-text="true">
+      works
+    </strong>
+    <a
+      href="https://lexical.io"
+      class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+      dir="ltr">
+      <strong
+        class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
+        data-lexical-text="true">
+        with links
+      </strong>
+    </a>
+    <strong
+      class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
+      data-lexical-text="true">
+      too
+    </strong>
+  </p>
+  <p
+    class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <em class="PlaygroundEditorTheme__textItalic" data-lexical-text="true">
+      Nested
+    </em>
+    <strong
+      class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+      data-lexical-text="true">
+      stars tags
+    </strong>
+    <em class="PlaygroundEditorTheme__textItalic" data-lexical-text="true">
+      are handled too
+    </em>
+  </p>
+  <h1 class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">Title</span>
+  </h1>
+  <h2 class="PlaygroundEditorTheme__h2 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">Subtitle</span>
+  </h2>
+  <blockquote
+    class="PlaygroundEditorTheme__quote PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <span data-lexical-text="true">Quote</span>
+  </blockquote>
+  <div
+    contenteditable="false"
+    style="display: contents;"
+    data-lexical-decorator="true">
+    <hr />
+  </div>
+  <ul class="PlaygroundEditorTheme__ul">
+    <li
+      value="1"
+      class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+      dir="ltr">
+      <span data-lexical-text="true">List here</span>
+    </li>
+    <li
+      value="2"
+      class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
+      <ul class="PlaygroundEditorTheme__ul">
+        <li
+          value="1"
+          class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Nested one</span>
+        </li>
+      </ul>
+    </li>
+  </ul>
+  <code
+    class="PlaygroundEditorTheme__code PlaygroundEditorTheme__ltr"
+    spellcheck="false"
+    dir="ltr"
+    data-highlight-language="sql"
+    data-gutter="1">
+    <span data-lexical-text="true">Code block</span>
+  </code>
+  <p
+    class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <span data-lexical-text="true">Done</span>
+  </p>
+`;
+
+const IMPORTED_MARKDOWN = `# Markdown Import
+### Formatting
+This is *italic*, _italic_, **bold**, __bold__, ~~strikethrough~~ text
+This is *__~~bold italic strikethrough~~__* text, ___~~this one too~~___
+It ~~___works [with links](https://lexical.io)___~~ too
+*Nested **stars tags** are handled too*
+### Headings
+# h1 Heading
+## h2 Heading
+### h3 Heading
+#### h4 Heading
+##### h5 Heading
+###### h6 Heading
+### Horizontal Rules
+---
+### Blockquotes
+> Blockquotes text goes here
+### Unordered lists
+- Create a list with \`+\`, \`-\`, or \`*\`
+    - Lists can be indented with 2 spaces
+        - Very easy
+### Ordered lists
+1. Oredered lists started with numbers as \`1.\`
+    1. And can be nested as well
+
+31. Have any starting number
+### Inline code
+Inline \`code\` format which also \`preserves **_~~any markdown-like~~_** text\` within
+### Code blocks
+\`\`\`javascript
+// Some comments
+1 + 1 = 2;
+**_~~1~~_**
+\`\`\``;
+
+const IMPORTED_MARKDOWN_HTML = html`
+  <h1 class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">Markdown Import</span>
+  </h1>
+  <h3 class="PlaygroundEditorTheme__h3 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">Formatting</span>
+  </h3>
+  <p
+    class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <span data-lexical-text="true">This is</span>
+    <em class="PlaygroundEditorTheme__textItalic" data-lexical-text="true">
+      italic
+    </em>
+    <span data-lexical-text="true">,</span>
+    <em class="PlaygroundEditorTheme__textItalic" data-lexical-text="true">
+      italic
+    </em>
+    <span data-lexical-text="true">,</span>
+    <strong class="PlaygroundEditorTheme__textBold" data-lexical-text="true">
+      bold
+    </strong>
+    <span data-lexical-text="true">,</span>
+    <strong class="PlaygroundEditorTheme__textBold" data-lexical-text="true">
+      bold
+    </strong>
+    <span data-lexical-text="true">,</span>
+    <span
+      class="PlaygroundEditorTheme__textStrikethrough"
+      data-lexical-text="true">
+      strikethrough
+    </span>
+    <span data-lexical-text="true">text</span>
+  </p>
+  <p
+    class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <span data-lexical-text="true">This is</span>
+    <strong
+      class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
+      data-lexical-text="true">
+      bold italic strikethrough
+    </strong>
+    <span data-lexical-text="true">text,</span>
+    <strong
+      class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
+      data-lexical-text="true">
+      this one too
+    </strong>
+  </p>
+  <p
+    class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <span data-lexical-text="true">It</span>
+    <strong
+      class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
+      data-lexical-text="true">
+      works
+    </strong>
+    <a
+      href="https://lexical.io"
+      class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+      dir="ltr">
+      <strong
+        class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
+        data-lexical-text="true">
+        with links
+      </strong>
+    </a>
+    <span data-lexical-text="true">too</span>
+  </p>
+  <p
+    class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <em class="PlaygroundEditorTheme__textItalic" data-lexical-text="true">
+      Nested
+    </em>
+    <strong
+      class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+      data-lexical-text="true">
+      stars tags
+    </strong>
+    <em class="PlaygroundEditorTheme__textItalic" data-lexical-text="true">
+      are handled too
+    </em>
+  </p>
+  <h3 class="PlaygroundEditorTheme__h3 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">Headings</span>
+  </h3>
+  <h1 class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">h1 Heading</span>
+  </h1>
+  <h2 class="PlaygroundEditorTheme__h2 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">h2 Heading</span>
+  </h2>
+  <h3 class="PlaygroundEditorTheme__h3 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">h3 Heading</span>
+  </h3>
+  <h4 class="PlaygroundEditorTheme__h4 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">h4 Heading</span>
+  </h4>
+  <h5 class="PlaygroundEditorTheme__h5 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">h5 Heading</span>
+  </h5>
+  <h6 class="PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">h6 Heading</span>
+  </h6>
+  <h3 class="PlaygroundEditorTheme__h3 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">Horizontal Rules</span>
+  </h3>
+  <div
+    contenteditable="false"
+    style="display: contents;"
+    data-lexical-decorator="true">
+    <hr />
+  </div>
+  <h3 class="PlaygroundEditorTheme__h3 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">Blockquotes</span>
+  </h3>
+  <blockquote
+    class="PlaygroundEditorTheme__quote PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <span data-lexical-text="true">Blockquotes text goes here</span>
+  </blockquote>
+  <h3 class="PlaygroundEditorTheme__h3 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">Unordered lists</span>
+  </h3>
+  <ul class="PlaygroundEditorTheme__ul">
+    <li
+      value="1"
+      class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+      dir="ltr">
+      <span data-lexical-text="true">Create a list with</span>
+      <code data-lexical-text="true">
+        <span class="PlaygroundEditorTheme__textCode">+</span>
+      </code>
+      <span data-lexical-text="true">,</span>
+      <code data-lexical-text="true">
+        <span class="PlaygroundEditorTheme__textCode">-</span>
+      </code>
+      <span data-lexical-text="true">, or</span>
+      <code data-lexical-text="true">
+        <span class="PlaygroundEditorTheme__textCode">*</span>
+      </code>
+    </li>
+    <li
+      value="2"
+      class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
+      <ul class="PlaygroundEditorTheme__ul">
+        <li
+          value="1"
+          class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">
+            Lists can be indented with 2 spaces
+          </span>
+        </li>
+        <li
+          value="2"
+          class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
+          <ul class="PlaygroundEditorTheme__ul">
+            <li
+              value="1"
+              class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+              dir="ltr">
+              <span data-lexical-text="true">Very easy</span>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>
+  <h3 class="PlaygroundEditorTheme__h3 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">Ordered lists</span>
+  </h3>
+  <ol class="PlaygroundEditorTheme__ol1">
+    <li
+      value="1"
+      class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+      dir="ltr">
+      <span data-lexical-text="true">
+        Oredered lists started with numbers as
+      </span>
+      <code data-lexical-text="true">
+        <span class="PlaygroundEditorTheme__textCode">1.</span>
+      </code>
+    </li>
+    <li
+      value="2"
+      class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
+      <ol class="PlaygroundEditorTheme__ol2">
+        <li
+          value="1"
+          class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">And can be nested as well</span>
+        </li>
+      </ol>
+    </li>
+  </ol>
+  <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+  <ol start="31" class="PlaygroundEditorTheme__ol1">
+    <li
+      value="31"
+      class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+      dir="ltr">
+      <span data-lexical-text="true">Have any starting number</span>
+    </li>
+  </ol>
+  <h3 class="PlaygroundEditorTheme__h3 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">Inline code</span>
+  </h3>
+  <p
+    class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <span data-lexical-text="true">Inline</span>
+    <code data-lexical-text="true">
+      <span class="PlaygroundEditorTheme__textCode">code</span>
+    </code>
+    <span data-lexical-text="true">format which also</span>
+    <code data-lexical-text="true">
+      <span class="PlaygroundEditorTheme__textCode">
+        preserves **_~~any markdown-like~~_** text
+      </span>
+    </code>
+    <span data-lexical-text="true">within</span>
+  </p>
+  <h3 class="PlaygroundEditorTheme__h3 PlaygroundEditorTheme__ltr" dir="ltr">
+    <span data-lexical-text="true">Code blocks</span>
+  </h3>
+  <code
+    class="PlaygroundEditorTheme__code PlaygroundEditorTheme__ltr"
+    spellcheck="false"
+    dir="ltr"
+    data-highlight-language="javascript"
+    data-gutter="123">
+    <span class="PlaygroundEditorTheme__tokenComment" data-lexical-text="true">
+      // Some comments
+    </span>
+    <br />
+    <span class="PlaygroundEditorTheme__tokenProperty" data-lexical-text="true">
+      1
+    </span>
+    <span data-lexical-text="true"></span>
+    <span class="PlaygroundEditorTheme__tokenOperator" data-lexical-text="true">
+      +
+    </span>
+    <span data-lexical-text="true"></span>
+    <span class="PlaygroundEditorTheme__tokenProperty" data-lexical-text="true">
+      1
+    </span>
+    <span data-lexical-text="true"></span>
+    <span class="PlaygroundEditorTheme__tokenOperator" data-lexical-text="true">
+      =
+    </span>
+    <span data-lexical-text="true"></span>
+    <span class="PlaygroundEditorTheme__tokenProperty" data-lexical-text="true">
+      2
+    </span>
+    <span
+      class="PlaygroundEditorTheme__tokenPunctuation"
+      data-lexical-text="true">
+      ;
+    </span>
+    <br />
+    <span class="PlaygroundEditorTheme__tokenOperator" data-lexical-text="true">
+      **
+    </span>
+    <span data-lexical-text="true">_</span>
+    <span class="PlaygroundEditorTheme__tokenOperator" data-lexical-text="true">
+      ~
+    </span>
+    <span class="PlaygroundEditorTheme__tokenOperator" data-lexical-text="true">
+      ~
+    </span>
+    <span class="PlaygroundEditorTheme__tokenProperty" data-lexical-text="true">
+      1
+    </span>
+    <span class="PlaygroundEditorTheme__tokenOperator" data-lexical-text="true">
+      ~
+    </span>
+    <span class="PlaygroundEditorTheme__tokenOperator" data-lexical-text="true">
+      ~
+    </span>
+    <span data-lexical-text="true">_</span>
+    <span class="PlaygroundEditorTheme__tokenOperator" data-lexical-text="true">
+      **
+    </span>
+  </code>
+`;

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -10,7 +10,6 @@ import {
   moveLeft,
   moveRight,
   redo,
-  selectAll,
   selectCharacters,
   toggleUnderline,
   undo,
@@ -21,9 +20,6 @@ import {
   click,
   focusEditor,
   initialize,
-  pasteFromClipboard,
-  selectFromFormatDropdown,
-  selectOption,
   test,
 } from '../utils/index.mjs';
 
@@ -47,33 +43,6 @@ async function checkHTMLExpectationsIncludingUndoRedo(
 test.describe('Markdown', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
   const triggersAndExpectations = [
-    {
-      expectation:
-        '<p class="PlaygroundEditorTheme__paragraph"><a href="http://www.test.com" class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">hello world</span></a><span data-lexical-text="true"> </span></p>',
-      importExpectation:
-        '<p class="PlaygroundEditorTheme__paragraph"><a class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr" dir="ltr" href="http://www.test.com"><span data-lexical-text="true">hello world</span></a></p>',
-      isBlockTest: true,
-      markdownImport: '[hello world](http://www.test.com)',
-      markdownText: '[hello world](http://www.test.com) ', // Link
-      undoHTML: `<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">[hello world](http://www.test.com) </span></p>`,
-    },
-    {
-      expectation:
-        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">x</span><strong class="PlaygroundEditorTheme__textBold" data-lexical-text="true">hello</strong><span data-lexical-text="true"> y</span></p>',
-      importExpectation:
-        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><strong class="PlaygroundEditorTheme__textBold" data-lexical-text="true">hello</strong></p>',
-      isBlockTest: false,
-      markdownImport: '__hello__',
-      markdownText: '__hello__',
-      stylizedExpectation:
-        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true" class="PlaygroundEditorTheme__textUnderline">x</span><strong class="PlaygroundEditorTheme__textBold" data-lexical-text="true">hello</strong><span class="PlaygroundEditorTheme__textUnderline" data-lexical-text="true"> y</span></p>',
-      // bold.
-      stylizedUndoHTML:
-        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true" class="PlaygroundEditorTheme__textUnderline">x_</span><span data-lexical-text="true">_hello_</span><span class="PlaygroundEditorTheme__textUnderline" data-lexical-text="true">_ y</span></p>',
-
-      undoHTML:
-        '<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">x__hello__ y</span></p>',
-    },
     {
       expectation: '<h1 class="PlaygroundEditorTheme__h1"><br></h1>',
       importExpectation: '',
@@ -365,72 +334,4 @@ test.describe('Markdown', () => {
       });
     }
   }
-
-  test(`Should test markdown conversion from plain text to Lexical.`, async ({
-    page,
-    isPlainText,
-    isCollab,
-  }) => {
-    test.skip(isPlainText);
-    await focusEditor(page);
-    const text = [
-      '# Heading',
-      '- unordered list',
-      '    - nested',
-      '1. ordered list',
-      '    1. nested',
-    ].join('\n');
-    await pasteFromClipboard(page, {
-      'text/plain': text,
-    });
-    await selectAll(page);
-    await selectFromFormatDropdown(page, '.code');
-    await selectOption(page, '.code-language', {value: 'markdown'});
-    await click(page, 'i.markdown');
-    const html = `
-    <h1 class=\"PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr\" dir=\"ltr\">
-      <span data-lexical-text=\"true\">Heading</span>
-    </h1>
-    <ul class=\"PlaygroundEditorTheme__ul\">
-      <li
-        class=\"PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr\"
-        dir=\"ltr\"
-        value=\"1\">
-        <span data-lexical-text=\"true\">unordered list</span>
-      </li>
-      <li
-        class=\"PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem\"
-        value=\"2\">
-        <ul class=\"PlaygroundEditorTheme__ul\">
-          <li
-            class=\"PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr\"
-            dir=\"ltr\"
-            value=\"1\">
-            <span data-lexical-text=\"true\">nested</span>
-          </li>
-        </ul>
-      </li>
-    </ul>
-    <ol class=\"PlaygroundEditorTheme__ol1\">
-      <li
-        class=\"PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr\"
-        dir=\"ltr\"
-        value=\"1\">
-        <span data-lexical-text=\"true\">ordered list</span>
-      </li>
-      <li
-        class=\"PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem\"
-        value=\"2\">
-        <ol class=\"PlaygroundEditorTheme__ol2\">
-          <li
-            class=\"PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr\"
-            dir=\"ltr\"
-            value=\"1\">
-            <span data-lexical-text=\"true\">nested</span>
-          </li>
-        </ol>
-      </li>
-    </ol>`;
-    await assertHTML(page, html);
-  });
 });

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -23,7 +23,7 @@ export const IS_COLLAB =
   process.env.E2E_EDITOR_MODE === 'rich-text-with-collab';
 const IS_RICH_TEXT = process.env.E2E_EDITOR_MODE !== 'plain-text';
 const IS_PLAIN_TEXT = process.env.E2E_EDITOR_MODE === 'plain-text';
-const LEGACY_EVENTS = process.env.E2E_EVENTS_MODE === 'legacy-events';
+export const LEGACY_EVENTS = process.env.E2E_EVENTS_MODE === 'legacy-events';
 
 export async function initialize({
   page,
@@ -89,7 +89,6 @@ export async function clickSelectors(page, selectors) {
 }
 
 async function assertHTMLOnPageOrFrame(
-  page,
   pageOrFrame,
   expectedHtml,
   ignoreClasses,
@@ -122,7 +121,6 @@ export async function assertHTML(
       async () => {
         const leftFrame = await page.frame('left');
         return assertHTMLOnPageOrFrame(
-          page,
           leftFrame,
           expectedHtml,
           ignoreClasses,
@@ -137,7 +135,6 @@ export async function assertHTML(
         async () => {
           const rightFrame = await page.frame('right');
           return assertHTMLOnPageOrFrame(
-            page,
             rightFrame,
             expectedHtml,
             ignoreClasses,
@@ -149,7 +146,6 @@ export async function assertHTML(
     }
   } else {
     await assertHTMLOnPageOrFrame(
-      page,
       page,
       expectedHtml,
       ignoreClasses,
@@ -382,6 +378,13 @@ export async function focusEditor(page, parentSelector = '.editor-shell') {
   } else {
     await page.focus(selector);
   }
+}
+
+export async function getHTML(page, selector = 'div[contenteditable="true"]') {
+  const pageOrFrame = IS_COLLAB ? await page.frame('left') : page;
+  await pageOrFrame.waitForSelector(selector);
+  const element = await pageOrFrame.$(selector);
+  return element.innerHTML();
 }
 
 export async function getEditorElement(page, parentSelector = '.editor-shell') {
@@ -638,4 +641,22 @@ export async function enableCompositionKeyEvents(page) {
       true,
     );
   });
+}
+
+export async function pressToggleBold(page) {
+  await keyDownCtrlOrMeta(page);
+  await page.keyboard.press('b');
+  await keyUpCtrlOrMeta(page);
+}
+
+export async function pressToggleItalic(page) {
+  await keyDownCtrlOrMeta(page);
+  await page.keyboard.press('b');
+  await keyUpCtrlOrMeta(page);
+}
+
+export async function pressToggleUnderline(page) {
+  await keyDownCtrlOrMeta(page);
+  await page.keyboard.press('u');
+  await keyUpCtrlOrMeta(page);
 }

--- a/packages/lexical-playground/src/Editor.jsx
+++ b/packages/lexical-playground/src/Editor.jsx
@@ -18,7 +18,6 @@ import HashtagsPlugin from '@lexical/react/LexicalHashtagPlugin';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import LinkPlugin from '@lexical/react/LexicalLinkPlugin';
 import ListPlugin from '@lexical/react/LexicalListPlugin';
-import LexicalMarkdownShortcutPlugin from '@lexical/react/LexicalMarkdownShortcutPlugin';
 import PlainTextPlugin from '@lexical/react/LexicalPlainTextPlugin';
 import RichTextPlugin from '@lexical/react/LexicalRichTextPlugin';
 import TablesPlugin from '@lexical/react/LexicalTablePlugin';
@@ -43,6 +42,7 @@ import HorizontalRulePlugin from './plugins/HorizontalRulePlugin';
 import ImagesPlugin from './plugins/ImagesPlugin';
 import KeywordsPlugin from './plugins/KeywordsPlugin';
 import ListMaxIndentLevelPlugin from './plugins/ListMaxIndentLevelPlugin';
+import MarkdownShortcutPlugin from './plugins/MarkdownShortcutPlugin';
 import MentionsPlugin from './plugins/MentionsPlugin';
 import PollPlugin from './plugins/PollPlugin';
 import SpeechToTextPlugin from './plugins/SpeechToTextPlugin';
@@ -198,7 +198,7 @@ export default function Editor(): React$Node {
                 isCollab ? null : emptyEditor ? undefined : prepopulatedRichText
               }
             />
-            <LexicalMarkdownShortcutPlugin />
+            <MarkdownShortcutPlugin />
             <CodeHighlightPlugin />
             <ListPlugin />
             <ListMaxIndentLevelPlugin maxDepth={7} />

--- a/packages/lexical-playground/src/Settings.jsx
+++ b/packages/lexical-playground/src/Settings.jsx
@@ -27,6 +27,7 @@ export default function Settings(): React$Node {
       isAutocomplete,
       showTreeView,
       showNestedEditorTreeView,
+      disableBeforeInput,
     },
   } = useSettings();
   const [showSettings, setShowSettings] = useState(false);
@@ -109,6 +110,14 @@ export default function Settings(): React$Node {
             onClick={() => setOption('isAutocomplete', !isAutocomplete)}
             checked={isAutocomplete}
             text="Autocomplete"
+          />
+          <Switch
+            onClick={() => {
+              setOption('disableBeforeInput', !disableBeforeInput);
+              setTimeout(() => window.location.reload(), 500);
+            }}
+            checked={disableBeforeInput}
+            text="Legacy Events"
           />
         </div>
       ) : null}

--- a/packages/lexical-playground/src/nodes/EquationNode.jsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.jsx
@@ -137,6 +137,10 @@ export class EquationNode extends DecoratorNode<React$Node> {
     return this.__inline !== prevNode.__inline;
   }
 
+  getEquation(): string {
+    return this.__equation;
+  }
+
   setEquation(equation: string): void {
     const writable = this.getWritable();
     writable.__equation = equation;

--- a/packages/lexical-playground/src/nodes/ImageNode.jsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.jsx
@@ -366,6 +366,14 @@ export class ImageNode extends DecoratorNode<React$Node> {
     return false;
   }
 
+  getSrc(): string {
+    return this.__src;
+  }
+
+  getAltText(): string {
+    return this.__altText;
+  }
+
   decorate(): React$Node {
     return (
       <ImageComponent

--- a/packages/lexical-playground/src/nodes/TweetNode.jsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.jsx
@@ -103,6 +103,10 @@ export class TweetNode extends DecoratorBlockNode<React$Node> {
     this.__id = id;
   }
 
+  getId(): string {
+    return this.__id;
+  }
+
   decorate(): React$Node {
     return (
       <TweetComponent

--- a/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.jsx
@@ -11,13 +11,9 @@ import type {LexicalEditor} from 'lexical';
 
 import {$createCodeNode, $isCodeNode} from '@lexical/code';
 import {exportFile, importFile} from '@lexical/file';
-import {
-  $convertFromMarkdownString,
-  $convertToMarkdownString,
-} from '@lexical/markdown';
+import {v2} from '@lexical/markdown';
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$createHorizontalRuleNode} from '@lexical/react/LexicalHorizontalRuleNode';
 import {mergeRegister} from '@lexical/utils';
 import {CONNECTED_COMMAND, TOGGLE_CONNECT_COMMAND} from '@lexical/yjs';
 import {
@@ -32,10 +28,16 @@ import {useCallback, useEffect, useState} from 'react';
 
 import useModal from '../hooks/useModal';
 import Button from '../ui/Button';
+import {TRANSFORMERS} from './MarkdownTransformers';
 import {
   SPEECH_TO_TEXT_COMMAND,
   SUPPORT_SPEECH_RECOGNITION,
 } from './SpeechToTextPlugin';
+
+const {createMarkdownExport, createMarkdownImport} = v2;
+
+const importMarkdown = createMarkdownImport(...TRANSFORMERS);
+const exportMarkdown = createMarkdownExport(...TRANSFORMERS);
 
 export default function ActionsPlugin({
   isRichText,
@@ -92,18 +94,10 @@ export default function ActionsPlugin({
     editor.update(() => {
       const root = $getRoot();
       const firstChild = root.getFirstChild();
-      if (
-        root.getChildrenSize() === 1 &&
-        $isCodeNode(firstChild) &&
-        firstChild.getLanguage() === 'markdown'
-      ) {
-        $convertFromMarkdownString(
-          firstChild.getTextContent(),
-          editor,
-          $createHorizontalRuleNode,
-        );
+      if ($isCodeNode(firstChild) && firstChild.getLanguage() === 'markdown') {
+        importMarkdown(firstChild.getTextContent());
       } else {
-        const markdown = $convertToMarkdownString();
+        const markdown = exportMarkdown();
         root
           .clear()
           .append(

--- a/packages/lexical-playground/src/plugins/MarkdownShortcutPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/MarkdownShortcutPlugin.jsx
@@ -1,19 +1,26 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
  *
  * @flow strict
  */
 
+import {v2} from '@lexical/markdown';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useEffect} from 'react';
 
-import useMarkdownShortcuts from './shared/useMarkdownShortcuts';
+import {TRANSFORMERS} from './MarkdownTransformers';
 
-export default function LexicalMarkdownShortcutPlugin(): React$Node {
+const {registerMarkdownShortcuts} = v2;
+
+export default function MarkdownPlugin(): React$Node {
   const [editor] = useLexicalComposerContext();
-  useMarkdownShortcuts(editor);
+
+  useEffect(() => {
+    return registerMarkdownShortcuts(editor, ...TRANSFORMERS);
+  }, [editor]);
 
   return null;
 }

--- a/packages/lexical-playground/src/plugins/MarkdownTransformers.js
+++ b/packages/lexical-playground/src/plugins/MarkdownTransformers.js
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {TextFormatTransformer} from '../../../lexical-markdown/src/v2/MarkdownTransformers';
+import type {BlockTransformer, TextMatchTransformer} from '@lexical/markdown';
+import type {ElementNode, LexicalNode} from 'lexical';
+
+import {v2} from '@lexical/markdown';
+import {
+  $createHorizontalRuleNode,
+  $isHorizontalRuleNode,
+} from '@lexical/react/LexicalHorizontalRuleNode';
+import {
+  $createTableCellNode,
+  $createTableNode,
+  $createTableRowNode,
+  $isTableNode,
+  $isTableRowNode,
+  TableCellHeaderStates,
+  TableCellNode,
+} from '@lexical/table';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $isElementNode,
+  $isParagraphNode,
+  $isTextNode,
+} from 'lexical';
+
+import {$createEquationNode, $isEquationNode} from '../nodes/EquationNode.jsx';
+import {$createImageNode, $isImageNode} from '../nodes/ImageNode.jsx';
+import {$createTweetNode, $isTweetNode} from '../nodes/TweetNode.jsx';
+
+export const HR: BlockTransformer = {
+  export: (node: LexicalNode) => {
+    return $isHorizontalRuleNode(node) ? '***' : null;
+  },
+  regExp: /^(---|\*\*\*|___)\s?$/,
+  replace: (parentNode, _1, _2, isImport) => {
+    const line = $createHorizontalRuleNode();
+    // TODO: Get rid of isImport flag
+    if (isImport || parentNode.getNextSibling() != null) {
+      parentNode.replace(line);
+    } else {
+      parentNode.insertBefore(line);
+    }
+    line.selectNext();
+  },
+  type: 'block-match',
+};
+
+export const IMAGE: TextMatchTransformer = {
+  export: (node, exportChildren, exportFormat) => {
+    if (!$isImageNode(node)) {
+      return null;
+    }
+    return `![${node.getAltText()}](${node.getSrc()})`;
+  },
+  importRegExp: /!(?:\[([^[]*)\])(?:\(([^(]+)\))/,
+  regExp: /!(?:\[([^[]*)\])(?:\(([^(]+)\))$/,
+  replace: (textNode, match) => {
+    const [, altText, src] = match;
+    const imageNode = $createImageNode(src, altText, 800);
+    textNode.replace(imageNode);
+  },
+  trigger: ')',
+  type: 'text-match',
+};
+
+export const EQUATION: TextMatchTransformer = {
+  export: (node, exportChildren, exportFormat) => {
+    if (!$isEquationNode(node)) {
+      return null;
+    }
+
+    return `$${node.getEquation()}$`;
+  },
+  importRegExp: /\$([^$].+?)\$/,
+  regExp: /\$([^$].+?)\$$/,
+  replace: (textNode, match) => {
+    const [, equation] = match;
+    const equationNode = $createEquationNode(equation, true);
+    textNode.replace(equationNode);
+  },
+  trigger: '$',
+  type: 'text-match',
+};
+
+export const TWEET: TextMatchTransformer = {
+  export: (node, exportChildren, exportFormat) => {
+    if (!$isTweetNode(node)) {
+      return null;
+    }
+
+    return `<tweet id="${node.getId()}" />`;
+  },
+  importRegExp: /<tweet id="([^"]+?)"\s?\/>/,
+  regExp: /<tweet id="([^"]+?)"\s?\/>$/,
+  replace: (textNode, match) => {
+    const [, id] = match;
+    const tweetNode = $createTweetNode(id);
+    textNode.replace(tweetNode);
+  },
+  trigger: '>',
+  type: 'text-match',
+};
+
+// Very primitive table setup
+const TABLE_ROW_REG_EXP = /^(?:\|)(.+)(?:\|)\s?$/;
+
+export const TABLE: BlockTransformer = {
+  export: (
+    node: LexicalNode,
+    exportChildren: (node: ElementNode) => string,
+  ) => {
+    if (!$isTableNode(node)) {
+      return null;
+    }
+
+    const output = [];
+    for (const row of node.getChildren()) {
+      const rowOutput = [];
+
+      if ($isTableRowNode(row)) {
+        for (const cell of row.getChildren()) {
+          // It's TableCellNode (hence ElementNode) so it's just to make flow happy
+          if ($isElementNode(cell)) {
+            rowOutput.push(exportChildren(cell));
+          }
+        }
+      }
+
+      output.push(`| ${rowOutput.join(' | ')} |`);
+    }
+
+    return output.join('\n');
+  },
+  regExp: TABLE_ROW_REG_EXP,
+  replace: (parentNode, _1, match) => {
+    const matchCells = mapToTableCells(match[0]);
+    if (matchCells == null) {
+      return;
+    }
+
+    const rows = [matchCells];
+    let sibling = parentNode.getPreviousSibling();
+    let maxCells = matchCells.length;
+    while (sibling) {
+      if (!$isParagraphNode(sibling)) {
+        break;
+      }
+
+      if (sibling.getChildrenSize() !== 1) {
+        break;
+      }
+
+      const firstChild = sibling.getFirstChild();
+      if (!$isTextNode(firstChild)) {
+        break;
+      }
+
+      const cells = mapToTableCells(firstChild.getTextContent());
+      if (cells == null) {
+        break;
+      }
+
+      maxCells = Math.max(maxCells, cells.length);
+      rows.unshift(cells);
+      const previousSibling = sibling.getPreviousSibling();
+      sibling.remove();
+      sibling = previousSibling;
+    }
+
+    const table = $createTableNode();
+    for (const cells of rows) {
+      const tableRow = $createTableRowNode();
+      table.append(tableRow);
+      for (let i = 0; i < maxCells; i++) {
+        tableRow.append(i < cells.length ? cells[i] : createTableCell());
+      }
+    }
+
+    parentNode.replace(table);
+    table.selectEnd();
+  },
+  type: 'block-match',
+};
+
+const createTableCell = (textContent: ?string): TableCellNode => {
+  const cell = $createTableCellNode(TableCellHeaderStates.NO_STATUS);
+  const paragraph = $createParagraphNode();
+  if (textContent != null) {
+    paragraph.append($createTextNode(textContent.trim()));
+  }
+  cell.append(paragraph);
+  return cell;
+};
+
+const mapToTableCells = (textContent: string): Array<TableCellNode> | null => {
+  // TODO:
+  // For now plain text, single node. Can be expanded to more complex content
+  // including formatted text
+  const match = textContent.match(TABLE_ROW_REG_EXP);
+  if (!match || !match[1]) {
+    return null;
+  }
+
+  return match[1].split('|').map((text) => createTableCell(text));
+};
+
+const {BLOCK_TRANSFORMERS, TEXT_FORMAT_TRANSFORMERS, TEXT_MATCH_TRANSFORMERS} =
+  v2;
+
+export const TRANSFORMERS: [
+  Array<BlockTransformer>,
+  Array<TextFormatTransformer>,
+  Array<TextMatchTransformer>,
+] = [
+  [TABLE, HR, ...BLOCK_TRANSFORMERS],
+  TEXT_FORMAT_TRANSFORMERS,
+  [IMAGE, EQUATION, TWEET, ...TEXT_MATCH_TRANSFORMERS],
+];

--- a/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.jsx
+++ b/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.jsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+
+import useMarkdownShortcuts from './shared/useMarkdownShortcuts';
+
+export default function LexicalMarkdownShortcutPlugin(): null {
+  const [editor] = useLexicalComposerContext();
+  useMarkdownShortcuts(editor);
+
+  return null;
+}


### PR DESCRIPTION
Playground use with custom markdown transformers: 
- Image
- Katex equation
- Table (extremely basic, lots to improve)
- Tweet (more for a demo purpose and no real usage, although markdown allows html-like tags to be used so it can be a legal way to allow embeds within markdown)

https://user-images.githubusercontent.com/132642/165447693-3a01b590-603b-4928-af92-dd3e405669a5.mov


