### PR TITLE
fix: 404 on 'edit this page' link

### DIFF
--- a/packages/lexical-website-new/docusaurus.config.js
+++ b/packages/lexical-website-new/docusaurus.config.js
@@ -38,7 +38,7 @@ const config = {
           showReadingTime: true, // TODO: Update when directory finalized
         },
         docs: {
-          editUrl: `${GITHUB_REPO_URL}/tree/main/packages/lexical-website-new/docs/`,
+          editUrl: `${GITHUB_REPO_URL}/tree/main/packages/lexical-website-new/`,
           remarkPlugins: [importPlugin],
           // TODO: Update when directory finalized
           sidebarPath: require.resolve('./sidebars.js'),


### PR DESCRIPTION
Hi there again,

I am not familiar with docusaurus so feel free to reject this PR if the fix is wrong.
Edit page call-to-action links to a 404 due to a double "docs" slug in the URL.

<img width="778" alt="Capture d’écran 2022-04-27 à 18 03 39" src="https://user-images.githubusercontent.com/5717515/165562267-14189c8b-6d09-4296-b097-6ac2013fc9e0.png">
