### PR TITLE
Use isTokenOrInertOrSegmented in selection

### DIFF
--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -44,6 +44,7 @@ import {
   $getDecoratorNode,
   $getNodeByKey,
   $isTokenOrInert,
+  $isTokenOrInertOrSegmented,
   $setCompositionKey,
   doesContainGrapheme,
   getNodeFromDOM,
@@ -688,8 +689,7 @@ export class RangeSelection implements BaseSelection {
       let nextSibling = firstNode.getNextSibling();
       if (
         !$isTextNode(nextSibling) ||
-        $isTokenOrInert(nextSibling) ||
-        nextSibling.isSegmented()
+        $isTokenOrInertOrSegmented(nextSibling)
       ) {
         nextSibling = $createTextNode();
         if (!firstNodeParent.canInsertTextAfter()) {
@@ -715,8 +715,7 @@ export class RangeSelection implements BaseSelection {
       let prevSibling = firstNode.getPreviousSibling();
       if (
         !$isTextNode(prevSibling) ||
-        $isTokenOrInert(prevSibling) ||
-        prevSibling.isSegmented()
+        $isTokenOrInertOrSegmented(prevSibling)
       ) {
         prevSibling = $createTextNode();
         if (!firstNodeParent.canInsertTextBefore()) {


### PR DESCRIPTION
We have a `isTokenOrInertOrSegmented` method that we're not using in the selection logic. This adds it to a relevant conditionals to dedupe similar logic.