### PR TITLE
Rename $rootTextContentCurry -> $rootTextContent

### DIFF
--- a/packages/lexical-playground/src/plugins/AutocompletePlugin.tsx
+++ b/packages/lexical-playground/src/plugins/AutocompletePlugin.tsx
@@ -9,7 +9,7 @@
 import type {LexicalEditor, NodeKey} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$rootTextContentCurry} from '@lexical/text';
+import {$rootTextContent} from '@lexical/text';
 import {
   $getNodeByKey,
   $getRoot,
@@ -26,7 +26,7 @@ import {$createTypeaheadNode, TypeaheadNode} from '../nodes/TypeaheadNode';
 function useTypeahead(editor: LexicalEditor): void {
   const typeaheadNodeKey = useRef<NodeKey | null>(null);
   const [text, setText] = useState<string>(
-    editor.getEditorState().read($rootTextContentCurry),
+    editor.getEditorState().read($rootTextContent),
   );
   const [selectionCollapsed, $setSelectionCollapsed] = useState<boolean>(false);
   const server = useMemo(() => new TypeaheadServer(), []);

--- a/packages/lexical-playground/src/plugins/CommentPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin.tsx
@@ -32,7 +32,7 @@ import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
 import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
 import {createDOMRange, createRectsFromDOMRange} from '@lexical/selection';
-import {$isRootTextContentEmpty, $rootTextContentCurry} from '@lexical/text';
+import {$isRootTextContentEmpty, $rootTextContent} from '@lexical/text';
 import {mergeRegister, registerNestedElementResolver} from '@lexical/utils';
 import {
   $getNodeByKey,
@@ -188,7 +188,7 @@ function useOnChange(setContent, setCanSubmit) {
   return useCallback(
     (editorState: EditorState, _editor: LexicalEditor) => {
       editorState.read(() => {
-        setContent($rootTextContentCurry());
+        setContent($rootTextContent());
         setCanSubmit(!$isRootTextContentEmpty(_editor.isComposing(), true));
       });
     },

--- a/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
@@ -14,7 +14,7 @@ import {OverflowNode} from '@lexical/overflow';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
-import {$rootTextContentCurry} from '@lexical/text';
+import {$rootTextContent} from '@lexical/text';
 import {
   $createParagraphNode,
   $createTextNode,
@@ -113,8 +113,7 @@ describe('LexicalNodeHelpers tests', () => {
         reactRoot.render(<App />);
       });
 
-      const text = editor.getEditorState().read($rootTextContentCurry);
-
+      const text = editor.getEditorState().read($rootTextContent);
       expect(text).toBe('foo');
     });
   }
@@ -227,7 +226,7 @@ describe('LexicalNodeHelpers tests', () => {
       });
 
       await editor.getEditorState().read(() => {
-        expect($rootTextContentCurry()).toBe('foo');
+        expect($rootTextContent()).toBe('foo');
 
         const selection = $getSelection();
 

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -13,7 +13,7 @@ import {
   $isOverflowNode,
   OverflowNode,
 } from '@lexical/overflow';
-import {$rootTextContentCurry} from '@lexical/text';
+import {$rootTextContent} from '@lexical/text';
 import {$dfs, mergeRegister} from '@lexical/utils';
 import {
   $getSelection,
@@ -53,7 +53,7 @@ export function useCharacterLimit(
   }, [editor]);
 
   useEffect(() => {
-    let text = editor.getEditorState().read($rootTextContentCurry);
+    let text = editor.getEditorState().read($rootTextContent);
     let lastComputedTextLength = 0;
 
     return mergeRegister(

--- a/packages/lexical-text/LexicalText.d.ts
+++ b/packages/lexical-text/LexicalText.d.ts
@@ -39,7 +39,7 @@ export function $isRootTextContentEmptyCurry(
   isEditorComposing: boolean,
   trim?: boolean,
 ): () => boolean;
-export function $rootTextContentCurry(): string;
+export function $rootTextContent(): string;
 export function $canShowPlaceholder(isComposing: boolean): boolean;
 export function $canShowPlaceholderCurry(
   isEditorComposing: boolean,

--- a/packages/lexical-text/flow/LexicalText.js.flow
+++ b/packages/lexical-text/flow/LexicalText.js.flow
@@ -37,7 +37,7 @@ declare export function $isRootTextContentEmptyCurry(
   isEditorComposing: boolean,
   trim?: boolean,
 ): () => boolean;
-declare export function $rootTextContentCurry(): string;
+declare export function $rootTextContent(): string;
 declare export function $canShowPlaceholder(isComposing: boolean): boolean;
 declare export function $canShowPlaceholderCurry(
   isEditorComposing: boolean,

--- a/packages/lexical-text/src/index.ts
+++ b/packages/lexical-text/src/index.ts
@@ -180,7 +180,8 @@ export function $isRootTextContentEmpty(
   if (isEditorComposing) {
     return false;
   }
-  let text = $rootTextContentCurry();
+
+  let text = $rootTextContent();
 
   if (trim) {
     text = text.trim();
@@ -196,7 +197,7 @@ export function $isRootTextContentEmptyCurry(
   return () => $isRootTextContentEmpty(isEditorComposing, trim);
 }
 
-export function $rootTextContentCurry(): string {
+export function $rootTextContent(): string {
   const root = $getRoot();
 
   return root.getTextContent();

--- a/packages/lexical-utils/src/__tests__/unit/LexicalRootHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalRootHelpers.test.ts
@@ -9,7 +9,7 @@
 import {
   $isRootTextContentEmpty,
   $isRootTextContentEmptyCurry,
-  $rootTextContentCurry,
+  $rootTextContent,
 } from '@lexical/text';
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
@@ -19,7 +19,7 @@ describe('LexicalRootHelpers tests', () => {
     it('textContent', async () => {
       const editor = testEnv.editor;
 
-      expect(editor.getEditorState().read($rootTextContentCurry)).toBe('');
+      expect(editor.getEditorState().read($rootTextContent)).toBe('');
 
       await editor.update(() => {
         const root = $getRoot();
@@ -28,10 +28,10 @@ describe('LexicalRootHelpers tests', () => {
         root.append(paragraph);
         paragraph.append(text);
 
-        expect($rootTextContentCurry()).toBe('foo');
+        expect($rootTextContent()).toBe('foo');
       });
 
-      expect(editor.getEditorState().read($rootTextContentCurry)).toBe('foo');
+      expect(editor.getEditorState().read($rootTextContent)).toBe('foo');
     });
 
     it('isBlank', async () => {


### PR DESCRIPTION
The idea behind the curry suffix was to be able to provide an alternative that worked immediately on the read clause. For $textContent, which is widely used, the curry suffix is unnecessary (it doesn't take any parameter) and seemed confusing (maybe more now because someone killed the alternative function). So just cleaning this up and making it a single function without the suffix