### PR TITLE
Don’t create empty paragraphs for new lines in Markdown

### DIFF
--- a/packages/lexical-markdown/src/convertFromPlainTextUtils.js
+++ b/packages/lexical-markdown/src/convertFromPlainTextUtils.js
@@ -53,8 +53,6 @@ export function convertStringToLexical(
   for (let i = 0; i < splitLinesCount; i++) {
     if (splitLines[i].length > 0) {
       nodes.push($createParagraphNode().append($createTextNode(splitLines[i])));
-    } else {
-      nodes.push($createParagraphNode());
     }
   }
   if (nodes.length) {


### PR DESCRIPTION
**Work in progress. Need to test a bit more. Also, maybe implement `<br>` for two blank spaces at the end of a line and ensure that linebreaks mid-paragraph don’t create `<br>` or new paragraphs.**

Using `$convertFromMarkdownString` from `@lexical/markdown`. Given this:

```markdown
# Hello, I am a heading

Hello I am a paragraph. The space above me should not become an empty paragraph.
```

The conversion translates that to something roughly like this:

```html
<h1>Hello, I am a heading</h1>
<p><br></p>
<p>Hello I am a paragraph. The space above me should not become an empty paragraph.</p>
```

I expect this:

```html
<h1>Hello, I am a heading</h1>
<p>Hello I am a paragraph. The space above me should not become an empty paragraph.</p>
```

See:
- <https://daringfireball.net/projects/markdown/syntax#p>
- <https://spec.commonmark.org/0.30/#paragraphs>