### PR TITLE
Fix small segmented node bug on backspace

### DIFF
--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -1797,7 +1797,7 @@ function $removeSegment(
       break;
     }
   }
-  const nextTextContent = split.join('');
+  const nextTextContent = split.join('').trim();
 
   if (nextTextContent === '') {
     textNode.remove();

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -1774,7 +1774,7 @@ function $removeSegment(
 ): void {
   const textNode = node;
   const textContent = textNode.getTextContent();
-  const split = textContent.split(/\s/g);
+  const split = textContent.split(/(?=\s)/g);
   const splitLength = split.length;
   let segmentOffset = 0;
   let restoreOffset = 0;
@@ -1797,7 +1797,7 @@ function $removeSegment(
       break;
     }
   }
-  const nextTextContent = split.join(' ');
+  const nextTextContent = split.join('');
 
   if (nextTextContent === '') {
     textNode.remove();


### PR DESCRIPTION
If your carat is focused at the start of a segmented TextNode segment and press backspace, we remove the subsequent segment, rather than what should probably be the preceding segment. A small Regex adjustment fixes this issue.

### Before
https://user-images.githubusercontent.com/7748470/165857212-e4e9aebd-2e07-42d7-b624-3dc6832705a4.mov
### After
https://user-images.githubusercontent.com/7748470/165857096-71c33ff9-0b4b-4b20-bdc9-9b6b290281f9.mov

