### PR TITLE
Stop link clicking exception

### DIFF
--- a/packages/lexical-playground/src/plugins/ClickableLinkPlugin.js
+++ b/packages/lexical-playground/src/plugins/ClickableLinkPlugin.js
@@ -81,10 +81,14 @@ export default function ClickableLinkPlugin({
         return;
       }
 
-      window.open(
-        href,
-        newTab || event.metaKey || event.ctrlKey ? '_blank' : '_self',
-      );
+      try {
+        window.open(
+          href,
+          newTab || event.metaKey || event.ctrlKey ? '_blank' : '_self',
+        );
+      } catch {
+        // It didn't work, which is better than throwing an exception!
+      }
     }
 
     return editor.registerRootListener(


### PR DESCRIPTION
Clicking a link node that has an invalid href causes a frustrating error to throw. Let's swallow the error instead.