### PR TITLE
Improve insertText handling of inline elements

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -375,6 +375,92 @@ test.describe('Links', () => {
     );
   });
 
+  test(`Can create a link with some text after, insert paragraph, then backspace, it should merge correctly`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type(' abc def ');
+    await moveLeft(page, 5);
+    await selectCharacters(page, 'left', 3);
+
+    // link
+    await click(page, '.link');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://">
+            <span data-lexical-text="true">abc</span>
+          </a>
+          <span data-lexical-text="true">def</span>
+        </p>
+      `,
+    );
+
+    await moveLeft(page, 1);
+    await moveRight(page, 2);
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://">
+            <span data-lexical-text="true">ab</span>
+          </a>
+        </p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://">
+            <span data-lexical-text="true">c</span>
+          </a>
+          <span data-lexical-text="true">def</span>
+        </p>
+      `,
+    );
+
+    await page.keyboard.press('Backspace');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true"></span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://">
+            <span data-lexical-text="true">ab</span>
+          </a>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://">
+            <span data-lexical-text="true">c</span>
+          </a>
+          <span data-lexical-text="true">def</span>
+        </p>
+      `,
+    );
+  });
+
   test(`Can create a link then replace it with plain text`, async ({page}) => {
     await focusEditor(page);
     await page.keyboard.type(' abc ');

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -808,8 +808,6 @@ export class RangeSelection implements BaseSelection {
       let lastElement = $isElementNode(lastNode)
         ? lastNode
         : lastNode.getParentOrThrow();
-      const shouldInsertAfterFirstElement =
-        firstElement.isInline() && firstNode.getNextSibling() === null;
       let lastElementWasInline = false;
 
       // If the last element is inline, we should instead look at getting
@@ -869,9 +867,10 @@ export class RangeSelection implements BaseSelection {
       // we will incorrectly merge into the starting parent element.
       // TODO: should we keep on traversing parents if we're inside another
       // nested inline element?
-      const insertionTarget = shouldInsertAfterFirstElement
-        ? firstElement
-        : firstNode;
+      const insertionTarget =
+        firstElement.isInline() && firstNode.getNextSibling() === null
+          ? firstElement
+          : firstNode;
 
       for (let i = lastNodeChildren.length - 1; i >= 0; i--) {
         const lastNodeChild = lastNodeChildren[i];
@@ -887,6 +886,11 @@ export class RangeSelection implements BaseSelection {
           if (
             !selectedNodesSet.has(lastNodeChild) ||
             lastNodeChild.is(lastNode) ||
+            // If the last node parent element was an inline element, then we're
+            // using the last node's grand parent. This means that the above
+            // heuristics for checking if the lastNodeChild.is(lastNode) can never
+            // happen. Instead, we should check the lastNode's parent, which will
+            // correctly correlate to the right node.
             (lastElementWasInline &&
               lastNodeChild.is(lastNode.getParentOrThrow()))
           ) {

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -800,12 +800,27 @@ export class RangeSelection implements BaseSelection {
         ...firstNode.getParentKeys(),
         ...lastNode.getParentKeys(),
       ]);
+      // We have to get the parent elements before the next section,
+      // as in that section we might mutate the lastNode.
       const firstElement = $isElementNode(firstNode)
         ? firstNode
         : firstNode.getParentOrThrow();
-      const lastElement = $isElementNode(lastNode)
+      let lastElement = $isElementNode(lastNode)
         ? lastNode
         : lastNode.getParentOrThrow();
+      const shouldInsertAfterFirstElement =
+        firstElement.isInline() && firstNode.getNextSibling() === null;
+      let lastElementWasInline = false;
+
+      // If the last element is inline, we should instead look at getting
+      // the nodes of its parent, rather than itself. This behavior will
+      // then better match how text node insertions work.
+      // TODO: should we keep on traversing parents if we're inside another
+      // nested inline element?
+      if (!firstElement.is(lastElement) && lastElement.isInline()) {
+        lastElementWasInline = true;
+        lastElement = lastElement.getParentOrThrow();
+      }
 
       // Handle mutations to the last node.
       if (
@@ -847,56 +862,61 @@ export class RangeSelection implements BaseSelection {
       const lastNodeChildren = lastElement.getChildren();
       const selectedNodesSet = new Set(selectedNodes);
       const firstAndLastElementsAreEqual = firstElement.is(lastElement);
+      
+      // We choose a target to insert all nodes after. In the case of having
+      // and inline starting parent element with a starting node that has no
+      // siblings, we should insert after the starting parent element, otherwise
+      // we will incorrectly merge into the starting parent element.
+      // TODO: should we keep on traversing parents if we're inside another
+      // nested inline element?
+      const insertionTarget = shouldInsertAfterFirstElement
+        ? firstElement
+        : firstNode;
 
-      // If the last element is an "inline" element, don't move it's text nodes to the first node.
-      // Instead, preserve the "inline" element's children and append to the first element.
-      if (!lastElement.canBeEmpty() && firstElement !== lastElement) {
-        firstElement.append(lastElement);
-      } else {
-        for (let i = lastNodeChildren.length - 1; i >= 0; i--) {
-          const lastNodeChild = lastNodeChildren[i];
+      for (let i = lastNodeChildren.length - 1; i >= 0; i--) {
+        const lastNodeChild = lastNodeChildren[i];
 
-          if (
-            lastNodeChild.is(firstNode) ||
-            ($isElementNode(lastNodeChild) &&
-              lastNodeChild.isParentOf(firstNode))
-          ) {
-            break;
-          }
-
-          if (lastNodeChild.isAttached()) {
-            if (
-              !selectedNodesSet.has(lastNodeChild) ||
-              lastNodeChild.is(lastNode)
-            ) {
-              if (!firstAndLastElementsAreEqual) {
-                firstNode.insertAfter(lastNodeChild);
-              }
-            } else {
-              lastNodeChild.remove();
-            }
-          }
+        if (
+          lastNodeChild.is(firstNode) ||
+          ($isElementNode(lastNodeChild) && lastNodeChild.isParentOf(firstNode))
+        ) {
+          break;
         }
 
-        if (!firstAndLastElementsAreEqual) {
-          // Check if we have already moved out all the nodes of the
-          // last parent, and if so, traverse the parent tree and mark
-          // them all as being able to deleted too.
-          let parent = lastElement;
-          let lastRemovedParent = null;
-
-          while (parent !== null) {
-            const children = parent.getChildren();
-            const childrenLength = children.length;
-            if (
-              childrenLength === 0 ||
-              children[childrenLength - 1].is(lastRemovedParent)
-            ) {
-              markedNodeKeysForKeep.delete(parent.__key);
-              lastRemovedParent = parent;
+        if (lastNodeChild.isAttached()) {
+          if (
+            !selectedNodesSet.has(lastNodeChild) ||
+            lastNodeChild.is(lastNode) ||
+            (lastElementWasInline &&
+              lastNodeChild.is(lastNode.getParentOrThrow()))
+          ) {
+            if (!firstAndLastElementsAreEqual) {
+              insertionTarget.insertAfter(lastNodeChild);
             }
-            parent = parent.getParent();
+          } else {
+            lastNodeChild.remove();
           }
+        }
+      }
+
+      if (!firstAndLastElementsAreEqual) {
+        // Check if we have already moved out all the nodes of the
+        // last parent, and if so, traverse the parent tree and mark
+        // them all as being able to deleted too.
+        let parent = lastElement;
+        let lastRemovedParent = null;
+
+        while (parent !== null) {
+          const children = parent.getChildren();
+          const childrenLength = children.length;
+          if (
+            childrenLength === 0 ||
+            children[childrenLength - 1].is(lastRemovedParent)
+          ) {
+            markedNodeKeysForKeep.delete(parent.__key);
+            lastRemovedParent = parent;
+          }
+          parent = parent.getParent();
         }
       }
 

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -862,7 +862,7 @@ export class RangeSelection implements BaseSelection {
       const lastNodeChildren = lastElement.getChildren();
       const selectedNodesSet = new Set(selectedNodes);
       const firstAndLastElementsAreEqual = firstElement.is(lastElement);
-      
+
       // We choose a target to insert all nodes after. In the case of having
       // and inline starting parent element with a starting node that has no
       // siblings, we should insert after the starting parent element, otherwise


### PR DESCRIPTION
This improves on the heuristics of `insertText`, so that it better handles inline elements. Working with @acywatson on this, so it might need some further work.