### PR TITLE
Headless mode `@lexical/headless`

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -81,6 +81,7 @@ module.name_mapper='^@lexical/dragon/LexicalDragon' -> '<PROJECT_ROOT>/packages/
 module.name_mapper='^@lexical/history/LexicalHistory' -> '<PROJECT_ROOT>/packages/lexical-history/flow/LexicalHistory.js.flow'
 module.name_mapper='^@lexical/link/LexicalLink' -> '<PROJECT_ROOT>/packages/lexical-link/flow/LexicalLink.js.flow'
 module.name_mapper='^@lexical/markdown/LexicalMarkdown' -> '<PROJECT_ROOT>/packages/lexical-markdown/flow/LexicalMarkdown.js.flow'
+module.name_mapper='^@lexical/headless/LexicalHeadless' -> '<PROJECT_ROOT>/packages/lexical-markdown/flow/LexicalHeadless.js.flow'
 module.name_mapper='^@lexical/offset/LexicalOffset' -> '<PROJECT_ROOT>/packages/lexical-offset/flow/LexicalOffset.js.flow'
 module.name_mapper='^@lexical/overflow/LexicalOverflow' -> '<PROJECT_ROOT>/packages/lexical-overflow/flow/LexicalOverflow.js.flow'
 module.name_mapper='^@lexical/plain-text/LexicalPlainText' -> '<PROJECT_ROOT>/packages/lexical-plain-text/flow/LexicalPlainText.js.flow'

--- a/package-lock.json
+++ b/package-lock.json
@@ -4176,6 +4176,10 @@
       "resolved": "packages/lexical-hashtag",
       "link": true
     },
+    "node_modules/@lexical/headless": {
+      "resolved": "packages/lexical-headless",
+      "link": true
+    },
     "node_modules/@lexical/history": {
       "resolved": "packages/lexical-history",
       "link": true
@@ -26305,6 +26309,13 @@
         "lexical": "0.2.5"
       }
     },
+    "packages/lexical-headless": {
+      "version": "0.2.5",
+      "license": "MIT",
+      "peerDependencies": {
+        "lexical": "0.2.5"
+      }
+    },
     "packages/lexical-history": {
       "name": "@lexical/history",
       "version": "0.2.5",
@@ -30351,6 +30362,9 @@
       "requires": {
         "@lexical/utils": "0.2.5"
       }
+    },
+    "@lexical/headless": {
+      "version": "file:packages/lexical-headless"
     },
     "@lexical/history": {
       "version": "file:packages/lexical-history",

--- a/packages/lexical-headless/LexicalHeadless.d.ts
+++ b/packages/lexical-headless/LexicalHeadless.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {
+  LexicalEditor,
+  LexicalNode,
+  EditorState,
+  EditorThemeClasses,
+} from 'lexical';
+
+export function createHeadlessEditor(editorConfig?: {
+  namespace?: string;
+  editorState?: EditorState;
+  theme?: EditorThemeClasses;
+  parentEditor?: LexicalEditor;
+  nodes?: $ReadOnlyArray<Class<LexicalNode>>;
+  onError: (error: Error) => void;
+  disableEvents?: boolean;
+  readOnly?: boolean;
+}): LexicalEditor;

--- a/packages/lexical-headless/LexicalHeadless.js
+++ b/packages/lexical-headless/LexicalHeadless.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+module.exports = require('./dist/LexicalHeadless.js');

--- a/packages/lexical-headless/README.md
+++ b/packages/lexical-headless/README.md
@@ -1,0 +1,45 @@
+# `@lexical/headless`
+
+This package allows creating headless lexical editor (that does not rely on DOM, e.g. for Node.js environment), and use its
+main features like editor.update(), editor.registerNodeTransform(), editor.registerUpdateListener()
+to create, update or traverse state.
+
+```js
+const { createHeadlessEditor } = require('@lexical/headless');
+
+const editor = createHeadlessEditor({
+  nodes: [],
+  onError: () => {},
+});
+
+editor.update(() => {
+  $getRoot().append(
+    $createParagraphNode().append(
+      $createTextNode('Hello world')
+    )
+  )
+});
+```
+
+Any plugins that do not rely on DOM could also be used. Here's an example of how
+you can convert lexical editor state to markdown on server:
+```js
+const { createHeadlessEditor } = require('@lexical/headless');
+const { $convertToMarkdownString, TRANSFORMERS } = require('@lexical/markdown');
+
+app.get('article/:id/markdown', await (req, res) => {
+  const editor = createHeadlessEditor({
+    nodes: [],
+    onError: () => {},
+  });
+
+  const articleEditorStateJSON = await loadArticleBody(req.query.id);
+  editor.setEditorState(editor.parseEditorState(articleEditorStateJSON));  
+
+  editor.update(() => {
+    const markdown = $convertToMarkdownString(TRANSFORMERS);
+    res.send(markdown);
+  });
+});
+
+```

--- a/packages/lexical-headless/flow/LexicalHeadless.js.flow
+++ b/packages/lexical-headless/flow/LexicalHeadless.js.flow
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {
+  LexicalEditor,
+  LexicalNode,
+  EditorState,
+  EditorThemeClasses,
+} from 'lexical';
+
+declare export function createHeadlessEditor(editorConfig?: {
+  namespace?: string,
+  editorState?: EditorState,
+  theme?: EditorThemeClasses,
+  parentEditor?: LexicalEditor,
+  nodes?: $ReadOnlyArray<Class<LexicalNode>>,
+  onError: (error: Error) => void,
+  disableEvents?: boolean,
+  readOnly?: boolean,
+}): LexicalEditor;

--- a/packages/lexical-headless/package.json
+++ b/packages/lexical-headless/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@lexical/headless",
+  "description": "This package contains Headless helpers and functionality for Lexical.",
+  "keywords": [
+    "lexical",
+    "editor",
+    "rich-text",
+    "headless"
+  ],
+  "license": "MIT",
+  "version": "0.2.5",
+  "main": "LexicalHeadless.js",
+  "peerDependencies": {
+    "lexical": "0.2.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/lexical",
+    "directory": "packages/lexical-headless"
+  }
+}

--- a/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.js
+++ b/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.js
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment node
+ */
+
+// Jest environment should be at the very top of the file. Overridding environment for this test
+// to ensure that headless editor works within node environment
+// https://jestjs.io/docs/configuration#testenvironment-string
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  COMMAND_PRIORITY_NORMAL,
+  INSERT_TEXT_COMMAND,
+  ParagraphNode,
+} from 'lexical';
+
+import {createHeadlessEditor} from '../../';
+
+describe('LexicalHeadlessEditor', () => {
+  let editor;
+
+  async function update(callback) {
+    return new Promise((resolve) => {
+      editor.update(callback, {onUpdate: resolve});
+    });
+  }
+
+  function assertEditorState(editorState, nodes) {
+    const nodesFromState = Array.from(editorState._nodeMap).map(
+      (pair) => pair[1],
+    );
+    expect(nodesFromState).toEqual(
+      nodes.map((node) => expect.objectContaining(node)),
+    );
+  }
+
+  beforeEach(() => {
+    editor = createHeadlessEditor();
+  });
+
+  it('should be headless environment', async () => {
+    expect(typeof window === 'undefined').toBe(true);
+    expect(typeof document === 'undefined').toBe(true);
+    expect(typeof navigator === 'undefined').toBe(true);
+  });
+
+  it('can update editor', async () => {
+    await update(() => {
+      $getRoot().append(
+        $createParagraphNode().append(
+          $createTextNode('Hello').toggleFormat('bold'),
+          $createTextNode('world'),
+        ),
+      );
+    });
+
+    assertEditorState(editor.getEditorState(), [
+      {
+        __key: 'root',
+      },
+      {
+        __type: 'paragraph',
+      },
+      {
+        __format: 1,
+        __text: 'Hello',
+        __type: 'text',
+      },
+      {
+        __format: 0,
+        __text: 'world',
+        __type: 'text',
+      },
+    ]);
+  });
+
+  it('can set editor state from json', async () => {
+    editor.setEditorState(
+      editor.parseEditorState(
+        '{"_nodeMap":[["root",{"__children":["1"],"__dir":null,"__format":0,"__indent":0,"__key":"root","__parent":null,"__type":"root"}],["1",{"__type":"paragraph","__parent":"root","__key":"1","__children":["2","3"],"__format":0,"__indent":0,"__dir":null}],["2",{"__type":"text","__parent":"1","__key":"2","__text":"Hello","__format":1,"__style":"","__mode":0,"__detail":0}],["3",{"__type":"text","__parent":"1","__key":"3","__text":"world","__format":0,"__style":"","__mode":0,"__detail":0}]],"_selection":null}',
+      ),
+    );
+
+    assertEditorState(editor.getEditorState(), [
+      {
+        __key: 'root',
+      },
+      {
+        __type: 'paragraph',
+      },
+      {
+        __format: 1,
+        __text: 'Hello',
+        __type: 'text',
+      },
+      {
+        __format: 0,
+        __text: 'world',
+        __type: 'text',
+      },
+    ]);
+  });
+
+  it('can register listeners', async () => {
+    const onUpdate = jest.fn();
+    const onCommand = jest.fn();
+    const onTransform = jest.fn();
+    const onTextContent = jest.fn();
+
+    editor.registerUpdateListener(onUpdate);
+    editor.registerCommand(
+      INSERT_TEXT_COMMAND,
+      onCommand,
+      COMMAND_PRIORITY_NORMAL,
+    );
+    editor.registerNodeTransform(ParagraphNode, onTransform);
+    editor.registerTextContentListener(onTextContent);
+
+    await update(() => {
+      $getRoot().append(
+        $createParagraphNode().append(
+          $createTextNode('Hello').toggleFormat('bold'),
+          $createTextNode('world'),
+        ),
+      );
+      editor.dispatchCommand(INSERT_TEXT_COMMAND, 'foo');
+    });
+
+    expect(onUpdate).toBeCalled();
+    expect(onCommand).toBeCalledWith('foo', expect.anything());
+    expect(onTransform).toBeCalledWith(
+      expect.objectContaining({__type: 'paragraph'}),
+    );
+    expect(onTextContent).toBeCalledWith('Helloworld');
+  });
+});

--- a/packages/lexical-headless/src/index.js
+++ b/packages/lexical-headless/src/index.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {
+  EditorState,
+  EditorThemeClasses,
+  LexicalEditor,
+  LexicalNode,
+} from 'lexical';
+
+import {createEditor} from 'lexical';
+
+export function createHeadlessEditor(editorConfig?: {
+  disableEvents?: boolean,
+  editorState?: EditorState,
+  namespace?: string,
+  nodes?: $ReadOnlyArray<Class<LexicalNode>>,
+  onError: (error: Error) => void,
+  parentEditor?: LexicalEditor,
+  readOnly?: boolean,
+  theme?: EditorThemeClasses,
+}): LexicalEditor {
+  const editor = createEditor(editorConfig);
+  editor._headless = true;
+
+  [
+    'registerDecoratorListener',
+    'registerRootListener',
+    'registerMutationListeners',
+    'getRootElement',
+    'setRootElement',
+    'getElementByKey',
+    'focus',
+    'blur',
+  ].forEach((method) => {
+    // $FlowFixMe
+    editor[method] = () => {
+      throw new Error(`${method} is not supported in headless mode`);
+    };
+  });
+
+  return editor;
+}

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -131,6 +131,7 @@ declare export class LexicalEditor {
   _observer: null | MutationObserver;
   _key: string;
   _readOnly: boolean;
+  _headless: boolean;
   isComposing(): boolean;
   registerUpdateListener(listener: UpdateListener): () => void;
   registerRootListener(listener: RootListener): () => void;

--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -286,6 +286,7 @@ export function createEditor(editorConfig?: {
 }
 
 export class LexicalEditor {
+  _headless: boolean;
   _parentEditor: null | LexicalEditor;
   _rootElement: null | HTMLElement;
   _editorState: EditorState;
@@ -368,6 +369,7 @@ export class LexicalEditor {
     this._onError = onError;
     this._htmlConversions = htmlConversions;
     this._readOnly = false;
+    this._headless = false;
   }
   isComposing(): boolean {
     return this._compositionKey != null;

--- a/packages/lexical/src/LexicalUpdates.js
+++ b/packages/lexical/src/LexicalUpdates.js
@@ -324,7 +324,8 @@ function handleDEVOnlyPendingUpdateGuarantees(
 export function commitPendingUpdates(editor: LexicalEditor): void {
   const pendingEditorState = editor._pendingEditorState;
   const rootElement = editor._rootElement;
-  if (rootElement === null || pendingEditorState === null) {
+  const headless = editor._headless;
+  if ((rootElement === null && !headless) || pendingEditorState === null) {
     return;
   }
   const currentEditorState = editor._editorState;
@@ -345,22 +346,24 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
   editor._updating = true;
 
   try {
-    const mutatedNodes = updateEditorState(
-      rootElement,
-      currentEditorState,
-      pendingEditorState,
-      currentSelection,
-      pendingSelection,
-      needsUpdate,
-      editor,
-    );
-    if (mutatedNodes !== null) {
-      triggerMutationListeners(
-        editor,
+    if (!headless && rootElement !== null) {
+      const mutatedNodes = updateEditorState(
+        rootElement,
         currentEditorState,
         pendingEditorState,
-        mutatedNodes,
+        currentSelection,
+        pendingSelection,
+        needsUpdate,
+        editor,
       );
+      if (mutatedNodes !== null) {
+        triggerMutationListeners(
+          editor,
+          currentEditorState,
+          pendingEditorState,
+          mutatedNodes,
+        );
+      }
     }
   } catch (error) {
     // Report errors
@@ -595,7 +598,7 @@ function beginUpdate(
   activeEditor = editor;
 
   try {
-    if (editorStateWasCloned) {
+    if (editorStateWasCloned && !editor._headless) {
       pendingEditorState._selection = internalCreateSelection(editor);
     }
     const startingCompositionKey = editor._compositionKey;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -50,6 +50,7 @@ const wwwMappings = {
   '@lexical/dragon': 'LexicalDragon',
   '@lexical/file': 'LexicalFile',
   '@lexical/hashtag': 'LexicalHashtag',
+  '@lexical/headless': 'LexicalHeadless',
   '@lexical/history': 'LexicalHistory',
   '@lexical/link': 'LexicalLink',
   '@lexical/list': 'LexicalList',
@@ -489,6 +490,17 @@ const packages = [
     name: 'Lexical Markdown',
     outputPath: './packages/lexical-markdown/dist/',
     sourcePath: './packages/lexical-markdown/src/',
+  },
+  {
+    modules: [
+      {
+        outputFileName: 'LexicalHeadless',
+        sourceFileName: 'index.js',
+      },
+    ],
+    name: 'Lexical Headless',
+    outputPath: './packages/lexical-headless/dist/',
+    sourcePath: './packages/lexical-headless/src/',
   },
   {
     modules: lexicalShared.map((module) => ({

--- a/scripts/www/rewriteImports.js
+++ b/scripts/www/rewriteImports.js
@@ -44,6 +44,7 @@ glob('packages/**/flow/*.flow', options, function (error1, files) {
         .replace(/from '@lexical\/link\'/g, "from 'LexicalLink'")
         .replace(/from '@lexical\/list\'/g, "from 'LexicalList'")
         .replace(/from '@lexical\/markdown\'/g, "from 'LexicalMarkdown'")
+        .replace(/from '@lexical\/headless\'/g, "from 'LexicalHeadless'")
         .replace(/from '@lexical\/offset\'/g, "from 'LexicalOffset'")
         .replace(/from '@lexical\/overflow\'/g, "from 'LexicalOverflow'")
         .replace(/from '@lexical\/plain\'/g, "from': 'LexicalPlainText'")


### PR DESCRIPTION
- Adds `@lexical/headless` with `createHeadlessEditor`
- Adds `_headless` to editor
- Skips reconciler and dom selection sync if is headless
- Unit tests are running in node environment to check `editor.update`, `editor.setEditorState` and `editor.register***`

E.g. can run markdown import/export from node:

<img width="407" alt="Screen Shot 2022-04-30 at 7 45 54 AM" src="https://user-images.githubusercontent.com/132642/166123913-94ee97e7-5193-4a7f-a8eb-4c24ef0c95b1.png">
