### PR TITLE
fix: dispatchCommand payload typescript type

### DIFF
--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -146,7 +146,7 @@ export declare class LexicalEditor {
     klass: Class<T>,
     listener: Transform<T>,
   ): () => void;
-  dispatchCommand<P>(type: string, payload: P): boolean;
+  dispatchCommand<P>(type: string, payload?: P): boolean;
   hasNodes(nodes: Array<Class<LexicalNode>>): boolean;
   getDecorators<X>(): Record<NodeKey, X>;
   getRootElement(): null | HTMLElement;


### PR DESCRIPTION
payload is optional, so that `editor.dispatchCommand(command)` won't show a type error in typescript.

<img width="833" alt="Screen Shot 2022-05-03 at 18 00 21" src="https://user-images.githubusercontent.com/377544/166435592-248200ca-d48e-4c93-8765-04d7c650a541.png">
