### PR TITLE
Adjust octocat colors to match rest of background

### DIFF
--- a/packages/lexical-playground/src/App.jsx
+++ b/packages/lexical-playground/src/App.jsx
@@ -67,8 +67,8 @@ export default function PlaygroundApp(): React$Node {
           viewBox="0 0 250 250"
           style={{
             border: '0',
-            color: '#fff',
-            fill: '#151513',
+            color: '#eee',
+            fill: '#222',
             left: '0',
             position: 'absolute',
             top: '0',


### PR DESCRIPTION
Very important change:

Before 

<img width="118" alt="Screen Shot 2022-05-03 at 3 52 30 PM" src="https://user-images.githubusercontent.com/132642/166555118-fafa0747-156a-4b1a-8b64-58d180af06bc.png">

After 

<img width="114" alt="Screen Shot 2022-05-03 at 3 52 24 PM" src="https://user-images.githubusercontent.com/132642/166555117-99b8bf85-ae85-40c6-82e5-2f5b968fa481.png">

