### PR TITLE
Fix decorator content selection bug

### DIFF
--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -1913,6 +1913,15 @@ function internalResolveSelectionPoint(
           resolvedOffset++;
         }
       } else {
+        // Ensure if we're selecting the content of a decorator that we
+        // return null for this point, as it's not in the controlled scope
+        // of Lexical.
+        if (
+          (resolvedNode === null || $isDecoratorNode(resolvedNode)) &&
+          $isDecoratorNode(getNodeFromDOM(dom))
+        ) {
+          return null;
+        }
         const index = resolvedElement.getIndexWithinParent();
         // When selecting decorators, there can be some selection issues when using resolvedOffset,
         // and instead we should be checking if we're using the offset


### PR DESCRIPTION
When selection is within the content of a DecoratorNode, selection should be `null`.