### PR TITLE
Better fix for decorator content selection bug

### DIFF
--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -1913,15 +1913,6 @@ function internalResolveSelectionPoint(
           resolvedOffset++;
         }
       } else {
-        // Ensure if we're selecting the content of a decorator that we
-        // return null for this point, as it's not in the controlled scope
-        // of Lexical.
-        if (
-          (resolvedNode === null || $isDecoratorNode(resolvedNode)) &&
-          $isDecoratorNode(getNodeFromDOM(dom))
-        ) {
-          return null;
-        }
         const index = resolvedElement.getIndexWithinParent();
         // When selecting decorators, there can be some selection issues when using resolvedOffset,
         // and instead we should be checking if we're using the offset
@@ -2082,6 +2073,19 @@ function internalResolveSelectionPoints(
   );
   if (resolvedFocusPoint === null) {
     return null;
+  }
+  if (
+    resolvedAnchorPoint.type === 'element' &&
+    resolvedFocusPoint.type === 'element'
+  ) {
+    const anchorNode = getNodeFromDOM(anchorDOM);
+    const focusNode = getNodeFromDOM(focusDOM);
+    // Ensure if we're selecting the content of a decorator that we
+    // return null for this point, as it's not in the controlled scope
+    // of Lexical.
+    if ($isDecoratorNode(anchorNode) && $isDecoratorNode(focusNode)) {
+      return null;
+    }
   }
 
   // Handle normalization of selection when it is at the boundaries.


### PR DESCRIPTION
A follow up to https://github.com/facebook/lexical/pull/2063, that applies a better heuristic for collapsed selection in a decorator.