### PR TITLE
Fix lists backward compatibility & markdown typedefs

### DIFF
--- a/packages/lexical-code/LexicalCode.d.ts
+++ b/packages/lexical-code/LexicalCode.d.ts
@@ -33,7 +33,7 @@ declare class CodeNode extends ElementNode {
   setLanguage(language: string): void;
   getLanguage(): string | void;
 }
-declare function $createCodeNode(): CodeNode;
+declare function $createCodeNode(language?: string): CodeNode;
 declare function $isCodeNode(
   node: null | undefined | LexicalNode,
 ): node is CodeNode;

--- a/packages/lexical-code/flow/LexicalCode.js.flow
+++ b/packages/lexical-code/flow/LexicalCode.js.flow
@@ -33,7 +33,7 @@ declare export class CodeNode extends ElementNode {
   setLanguage(language: string): void;
   getLanguage(): string | void;
 }
-declare export function $createCodeNode(): CodeNode;
+declare export function $createCodeNode(language?: string): CodeNode;
 declare export function $isCodeNode(
   node: ?LexicalNode,
 ): boolean %checks(node instanceof CodeNode);

--- a/packages/lexical-list/src/LexicalListNode.js
+++ b/packages/lexical-list/src/LexicalListNode.js
@@ -39,7 +39,8 @@ export class ListNode extends ElementNode {
   }
 
   static clone(node: ListNode): ListNode {
-    return new ListNode(node.__listType, node.__start, node.__key);
+    const listType = node.__listType || TAG_TO_LIST_TYPE[node.__tag];
+    return new ListNode(listType, node.__start, node.__key);
   }
 
   constructor(listType: ListType, start: number, key?: NodeKey): void {

--- a/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.js
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.js
@@ -247,13 +247,31 @@ describe('LexicalListNode tests', () => {
       });
     });
 
-    test('$createListNode() with tag name', async () => {
+    test('$createListNode() with tag name (backward compatibility)', async () => {
       const {editor} = testEnv;
       await editor.update(() => {
         const numberList = $createListNode('ol', 1);
         const bulletList = $createListNode('ul', 1);
         expect(numberList.__listType).toBe('number');
         expect(bulletList.__listType).toBe('bullet');
+      });
+    });
+
+    test('ListNode.clone() without list type (backward compatibility)', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const olNode = ListNode.clone({
+          __key: '1',
+          __start: 1,
+          __tag: 'ol',
+        });
+        const ulNode = ListNode.clone({
+          __key: '1',
+          __start: 1,
+          __tag: 'ul',
+        });
+        expect(olNode.__listType).toBe('number');
+        expect(ulNode.__listType).toBe('bullet');
       });
     });
   });

--- a/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
+++ b/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
@@ -7,14 +7,52 @@
  * @flow strict
  */
 
-import type {LexicalEditor} from 'lexical';
 import type {
-  Transformer,
-  ElementTransformer,
-  TextFormatTransformer,
-  TextMatchTransformer,
-} from '../src';
+  LexicalEditor,
+  LexicalNode,
+  ElementNode,
+  TextFormatType,
+  TextNode,
+} from 'lexical';
 
+export type Transformer =
+  | ElementTransformer
+  | TextFormatTransformer
+  | TextMatchTransformer;
+
+export type ElementTransformer = {
+  export: (
+    node: LexicalNode,
+    traverseChildren: (node: ElementNode) => string,
+  ) => string | null,
+  regExp: RegExp,
+  replace: (
+    parentNode: ElementNode,
+    children: Array<LexicalNode>,
+    match: Array<string>,
+    isImport: boolean,
+  ) => void,
+  type: 'element',
+};
+
+export type TextFormatTransformer = $ReadOnly<{
+  format: $ReadOnlyArray<TextFormatType>,
+  tag: string,
+  type: 'text-format',
+}>;
+
+export type TextMatchTransformer = $ReadOnly<{
+  export: (
+    node: LexicalNode,
+    exportChildren: (node: ElementNode) => string,
+    exportFormat: (node: TextNode, textContent: string) => string,
+  ) => string | null,
+  importRegExp: RegExp,
+  regExp: RegExp,
+  replace: (node: TextNode, match: RegExp$matchResult) => void,
+  trigger: string,
+  type: 'text-match',
+}>;
 // TODO:
 // transformers should be required argument, breaking change
 declare export function registerMarkdownShortcuts(

--- a/packages/lexical-markdown/src/index.js
+++ b/packages/lexical-markdown/src/index.js
@@ -12,7 +12,7 @@ import type {
   TextFormatTransformer,
   TextMatchTransformer,
   Transformer,
-} from './v2/MarkdownTransformers';
+} from '../flow/LexicalMarkdown';
 
 import {createMarkdownExport} from './v2/MarkdownExport';
 import {createMarkdownImport} from './v2/MarkdownImport';

--- a/packages/lexical-markdown/src/v2/MarkdownExport.js
+++ b/packages/lexical-markdown/src/v2/MarkdownExport.js
@@ -12,7 +12,7 @@ import type {
   TextFormatTransformer,
   TextMatchTransformer,
   Transformer,
-} from './MarkdownTransformers';
+} from '../../flow/LexicalMarkdown';
 import type {ElementNode, LexicalNode, TextFormatType, TextNode} from 'lexical';
 
 import {$getRoot, $isElementNode, $isLineBreakNode, $isTextNode} from 'lexical';

--- a/packages/lexical-markdown/src/v2/MarkdownImport.js
+++ b/packages/lexical-markdown/src/v2/MarkdownImport.js
@@ -12,7 +12,7 @@ import type {
   TextFormatTransformer,
   TextMatchTransformer,
   Transformer,
-} from './MarkdownTransformers';
+} from '../../flow/LexicalMarkdown';
 import type {CodeNode} from '@lexical/code';
 import type {RootNode, TextNode} from 'lexical';
 

--- a/packages/lexical-markdown/src/v2/MarkdownShortcuts.js
+++ b/packages/lexical-markdown/src/v2/MarkdownShortcuts.js
@@ -12,7 +12,7 @@ import type {
   TextFormatTransformer,
   TextMatchTransformer,
   Transformer,
-} from './MarkdownTransformers';
+} from '../../flow/LexicalMarkdown';
 import type {ElementNode, LexicalEditor, TextNode} from 'lexical';
 
 import {$isCodeNode} from '@lexical/code';

--- a/packages/lexical-markdown/src/v2/MarkdownTransformers.js
+++ b/packages/lexical-markdown/src/v2/MarkdownTransformers.js
@@ -7,9 +7,14 @@
  * @flow strict
  */
 
+import type {
+  ElementTransformer,
+  TextFormatTransformer,
+  TextMatchTransformer,
+} from '../../flow/LexicalMarkdown';
 import type {ListNode, ListType} from '@lexical/list';
 import type {HeadingTagType} from '@lexical/rich-text';
-import type {ElementNode, LexicalNode, TextFormatType, TextNode} from 'lexical';
+import type {ElementNode, LexicalNode} from 'lexical';
 
 import {$createCodeNode, $isCodeNode} from '@lexical/code';
 import {$createLinkNode, $isLinkNode} from '@lexical/link';
@@ -26,45 +31,6 @@ import {
   $isQuoteNode,
 } from '@lexical/rich-text';
 import {$createTextNode, $isTextNode} from 'lexical';
-
-export type Transformer =
-  | ElementTransformer
-  | TextFormatTransformer
-  | TextMatchTransformer;
-
-export type ElementTransformer = {
-  export: (
-    node: LexicalNode,
-    traverseChildren: (node: ElementNode) => string,
-  ) => string | null,
-  regExp: RegExp,
-  replace: (
-    parentNode: ElementNode,
-    children: Array<LexicalNode>,
-    match: Array<string>,
-    isImport: boolean,
-  ) => void,
-  type: 'element',
-};
-
-export type TextFormatTransformer = $ReadOnly<{
-  format: $ReadOnlyArray<TextFormatType>,
-  tag: string,
-  type: 'text-format',
-}>;
-
-export type TextMatchTransformer = $ReadOnly<{
-  export: (
-    node: LexicalNode,
-    exportChildren: (node: ElementNode) => string,
-    exportFormat: (node: TextNode, textContent: string) => string,
-  ) => string | null,
-  importRegExp: RegExp,
-  regExp: RegExp,
-  replace: (node: TextNode, match: RegExp$matchResult) => void,
-  trigger: string,
-  type: 'text-match',
-}>;
 
 const replaceWithBlock = (
   createNode: (match: Array<string>) => ElementNode,

--- a/packages/lexical-markdown/src/v2/utils.js
+++ b/packages/lexical-markdown/src/v2/utils.js
@@ -12,7 +12,7 @@ import type {
   TextFormatTransformer,
   TextMatchTransformer,
   Transformer,
-} from './MarkdownTransformers';
+} from '../../flow/LexicalMarkdown';
 
 export function indexBy<T>(
   list: Array<T>,


### PR DESCRIPTION
- Update `ListNode.clone()` to be backward compatible if passing tag instead of listType
- Move markdown transformer types from .js to .flow
- Fix `$createCodeNode()` to accept optional highlighting language