### PR TITLE
Fix add/remove classes order

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.js
+++ b/packages/lexical-list/src/LexicalListItemNode.js
@@ -377,12 +377,11 @@ function $setListItemThemeClassNames(
     }
   }
 
-  if (classesToAdd.length > 0) {
-    addClassNamesToElement(dom, ...classesToAdd);
-  }
-
   if (classesToRemove.length > 0) {
     removeClassNamesFromElement(dom, ...classesToRemove);
+  }
+  if (classesToAdd.length > 0) {
+    addClassNamesToElement(dom, ...classesToAdd);
   }
 }
 

--- a/packages/lexical-list/src/LexicalListNode.js
+++ b/packages/lexical-list/src/LexicalListNode.js
@@ -177,11 +177,11 @@ function setListThemeClassNames(
     }
   }
 
-  if (classesToAdd.length > 0) {
-    addClassNamesToElement(dom, ...classesToAdd);
-  }
   if (classesToRemove.length > 0) {
     removeClassNamesFromElement(dom, ...classesToRemove);
+  }
+  if (classesToAdd.length > 0) {
+    addClassNamesToElement(dom, ...classesToAdd);
   }
 }
 


### PR DESCRIPTION
Added/removed styles might overlap (e.g. property-specific classes in stylex) so make sure we delete first and then add needed classes

```
existing classes = [a, d]
classes to add = [a, b, c]
classes to remove = [a, d]

existing classes should become [a, b, c]
```