### PR TITLE
Remove root style from EditorThemeClasses

### DIFF
--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -187,7 +187,6 @@ type TextNodeThemeClasses = {
 export type EditorThemeClasses = {
   ltr?: EditorThemeClassName;
   rtl?: EditorThemeClassName;
-  root?: EditorThemeClassName;
   text?: TextNodeThemeClasses;
   paragraph?: EditorThemeClassName;
   image?: EditorThemeClassName;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -195,7 +195,6 @@ type TextNodeThemeClasses = {
 export type EditorThemeClasses = {
   ltr?: EditorThemeClassName,
   rtl?: EditorThemeClassName,
-  root?: EditorThemeClassName,
   text?: TextNodeThemeClasses,
   paragraph?: EditorThemeClassName,
   image?: EditorThemeClassName,


### PR DESCRIPTION
I doesn't look like this property is actually used anywhere (correct me if I am wrong). It seems that it has been supplanted by ContentEditable style.

----

We've briefly discussed if we should instead get rid of the ContentEditable style and move it to root. The reasons we are not going this way are
1. ContentEditable is already used for the "global styles" and this means people would have to migrate after this change
2. If you want small differences for the root style of a nested composer, you can just pass a different ContentEditable style as the theme will be inherited from the parent if you don't pass it. If we go with root style approach, you will have to merge it with the parent's theme ( `initialTheme={{...baseTheme, root: 'nestedTheme__root'}}`).
3. We would like to stick with the rule theme = nodes