### PR TITLE
Add TabFocusPlugin

### DIFF
--- a/packages/lexical-playground/src/Editor.jsx
+++ b/packages/lexical-playground/src/Editor.jsx
@@ -48,6 +48,7 @@ import MarkdownShortcutPlugin from './plugins/MarkdownShortcutPlugin';
 import MentionsPlugin from './plugins/MentionsPlugin';
 import PollPlugin from './plugins/PollPlugin';
 import SpeechToTextPlugin from './plugins/SpeechToTextPlugin';
+import TabFocusPlugin from './plugins/TabFocusPlugin';
 import TableCellActionMenuPlugin from './plugins/TableActionMenuPlugin';
 import TableCellResizer from './plugins/TableCellResizer';
 import ToolbarPlugin from './plugins/ToolbarPlugin';
@@ -215,6 +216,7 @@ export default function Editor(): React$Node {
             <CharacterStylesPopupPlugin />
             <EquationsPlugin />
             <ExcalidrawPlugin />
+            <TabFocusPlugin />
           </>
         ) : (
           <>

--- a/packages/lexical-playground/src/plugins/TabFocusPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/TabFocusPlugin.jsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {
+  $getSelection,
+  $isRangeSelection,
+  $setSelection,
+  FOCUS_COMMAND,
+} from 'lexical';
+import {useEffect} from 'react';
+
+const COMMAND_PRIORITY_LOW = 1;
+const TAB_TO_FOCUS_INTERVAL = 100;
+
+let lastTabKeyDownTimestamp = 0;
+let hasRegisteredKeyDownListener = false;
+
+function registerKeyTimeStampTracker() {
+  window.addEventListener(
+    'keydown',
+    (event: KeyboardEvent) => {
+      // Tab
+      if (event.keyCode === 9) {
+        lastTabKeyDownTimestamp = event.timeStamp;
+      }
+    },
+    true,
+  );
+}
+
+export default function TabFocusPlugin(): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    if (!hasRegisteredKeyDownListener) {
+      registerKeyTimeStampTracker();
+      hasRegisteredKeyDownListener = true;
+    }
+
+    return editor.registerCommand(
+      FOCUS_COMMAND,
+      (event: FocusEvent) => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          if (
+            lastTabKeyDownTimestamp + TAB_TO_FOCUS_INTERVAL >
+            event.timeStamp
+          ) {
+            const clonedSelection = selection.clone();
+            clonedSelection.dirty = true;
+            $setSelection(clonedSelection);
+          }
+        }
+        return false;
+      },
+      COMMAND_PRIORITY_LOW,
+    );
+  }, [editor]);
+
+  return null;
+}


### PR DESCRIPTION
This plugin will attempt to restore selection to the previous location in an editor when you tab focus back into the editor.