### PR TITLE
Add a cache for selection.getNodes()

### DIFF
--- a/packages/lexical-playground/src/plugins/TabFocusPlugin.jsx
+++ b/packages/lexical-playground/src/plugins/TabFocusPlugin.jsx
@@ -53,9 +53,7 @@ export default function TabFocusPlugin(): null {
             lastTabKeyDownTimestamp + TAB_TO_FOCUS_INTERVAL >
             event.timeStamp
           ) {
-            const clonedSelection = selection.clone();
-            clonedSelection.dirty = true;
-            $setSelection(clonedSelection);
+            $setSelection(selection.clone());
           }
         }
         return false;

--- a/packages/lexical-rich-text/src/index.js
+++ b/packages/lexical-rich-text/src/index.js
@@ -550,7 +550,6 @@ export function registerRichText(
           (block) => {
             const indent = block.getIndent();
             if (indent !== 0) {
-              debugger;
               block.setIndent(indent - 1);
             }
           },

--- a/packages/lexical-rich-text/src/index.js
+++ b/packages/lexical-rich-text/src/index.js
@@ -550,6 +550,7 @@ export function registerRichText(
           (block) => {
             const indent = block.getIndent();
             if (indent !== 0) {
+              debugger;
               block.setIndent(indent - 1);
             }
           },

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.js
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.js
@@ -90,61 +90,77 @@ describe('LexicalSelectionHelpers tests', () => {
       setupTestCase((selection, state) => {
         selection.insertText('Test');
         expect($getNodeByKey('a').getTextContent()).toBe('Testa');
-        expect(selection.anchor).toEqual({
-          key: 'a',
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: 'a',
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // insertNodes
       setupTestCase((selection, element) => {
         selection.insertNodes([$createTextNode('foo')]);
-        expect(selection.anchor).toEqual({
-          key: element.getFirstChild().getKey(),
-          offset: 3,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: element.getFirstChild().getKey(),
-          offset: 3,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: element.getFirstChild().getKey(),
+            offset: 3,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: element.getFirstChild().getKey(),
+            offset: 3,
+            type: 'text',
+          }),
+        );
       });
 
       // insertParagraph
       setupTestCase((selection) => {
         selection.insertParagraph();
-        expect(selection.anchor).toEqual({
-          key: 'a',
-          offset: 0,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: 'a',
-          offset: 0,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 0,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 0,
+            type: 'text',
+          }),
+        );
       });
 
       // insertLineBreak
       setupTestCase((selection, element) => {
         selection.insertLineBreak(true);
-        expect(selection.anchor).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
-        expect(selection.focus).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
       });
 
       // Format text
@@ -152,16 +168,20 @@ describe('LexicalSelectionHelpers tests', () => {
         selection.formatText('bold');
         selection.insertText('Test');
         expect(element.getFirstChild().getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: element.getFirstChild().getKey(),
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: element.getFirstChild().getKey(),
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: element.getFirstChild().getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: element.getFirstChild().getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
         expect(element.getFirstChild().getNextSibling().getTextContent()).toBe(
           'a',
         );
@@ -222,16 +242,20 @@ describe('LexicalSelectionHelpers tests', () => {
 
       editor.getEditorState().read(() => {
         const selection = $getSelection();
-        expect(selection.anchor).toEqual({
-          key: 'a',
-          offset: 2,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: 'a',
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 2,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
     });
 
@@ -271,16 +295,20 @@ describe('LexicalSelectionHelpers tests', () => {
 
       editor.getEditorState().read(() => {
         const selection = $getSelection();
-        expect(selection.anchor).toEqual({
-          key: 'a',
-          offset: 0,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: 'a',
-          offset: 3,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 0,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 3,
+            type: 'text',
+          }),
+        );
       });
     });
 
@@ -315,16 +343,20 @@ describe('LexicalSelectionHelpers tests', () => {
 
       editor.getEditorState().read(() => {
         const selection = $getSelection();
-        expect(selection.anchor).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
-        expect(selection.focus).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
       });
     });
 
@@ -362,16 +394,20 @@ describe('LexicalSelectionHelpers tests', () => {
 
       editor.getEditorState().read(() => {
         const selection = $getSelection();
-        expect(selection.anchor).toEqual({
-          key: 'b',
-          offset: 1,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: 'b',
-          offset: 1,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: 'b',
+            offset: 1,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: 'b',
+            offset: 1,
+            type: 'text',
+          }),
+        );
       });
     });
 
@@ -411,16 +447,20 @@ describe('LexicalSelectionHelpers tests', () => {
 
       editor.getEditorState().read(() => {
         const selection = $getSelection();
-        expect(selection.anchor).toEqual({
-          key: 'c',
-          offset: 2,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: 'c',
-          offset: 2,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: 'c',
+            offset: 2,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: 'c',
+            offset: 2,
+            type: 'text',
+          }),
+        );
       });
     });
 
@@ -460,16 +500,20 @@ describe('LexicalSelectionHelpers tests', () => {
 
       editor.getEditorState().read(() => {
         const selection = $getSelection();
-        expect(selection.anchor).toEqual({
-          key: 'c',
-          offset: 2,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: 'c',
-          offset: 2,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: 'c',
+            offset: 2,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: 'c',
+            offset: 2,
+            type: 'text',
+          }),
+        );
       });
     });
 
@@ -511,47 +555,59 @@ describe('LexicalSelectionHelpers tests', () => {
         selection.insertText('Test');
         const firstChild = element.getFirstChild();
         expect(firstChild.getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // insertParagraph
       setupTestCase((selection, element) => {
         selection.insertParagraph();
         const nextElement = element.getNextSibling();
-        expect(selection.anchor).toEqual({
-          key: nextElement.getKey(),
-          offset: 0,
-          type: 'element',
-        });
-        expect(selection.focus).toEqual({
-          key: nextElement.getKey(),
-          offset: 0,
-          type: 'element',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: nextElement.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: nextElement.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
       });
 
       // insertLineBreak
       setupTestCase((selection, element) => {
         selection.insertLineBreak(true);
-        expect(selection.anchor).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
-        expect(selection.focus).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
       });
 
       // Format text
@@ -560,16 +616,20 @@ describe('LexicalSelectionHelpers tests', () => {
         selection.insertText('Test');
         const firstChild = element.getFirstChild();
         expect(firstChild.getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // Extract selection
@@ -628,47 +688,59 @@ describe('LexicalSelectionHelpers tests', () => {
         selection.insertText('Test');
         const firstChild = element.getFirstChild();
         expect(firstChild.getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // insertParagraph
       setupTestCase((selection, element) => {
         selection.insertParagraph();
         const firstChild = element;
-        expect(selection.anchor).toEqual({
-          key: firstChild.getKey(),
-          offset: 0,
-          type: 'element',
-        });
-        expect(selection.focus).toEqual({
-          key: firstChild.getKey(),
-          offset: 0,
-          type: 'element',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
       });
 
       // insertLineBreak
       setupTestCase((selection, element) => {
         selection.insertLineBreak(true);
-        expect(selection.anchor).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
-        expect(selection.focus).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
       });
 
       // Format text
@@ -677,16 +749,20 @@ describe('LexicalSelectionHelpers tests', () => {
         selection.insertText('Test');
         const firstChild = element.getFirstChild();
         expect(firstChild.getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // Extract selection
@@ -748,48 +824,60 @@ describe('LexicalSelectionHelpers tests', () => {
         selection.insertText('Test');
         const lastChild = element.getLastChild();
         expect(lastChild.getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: lastChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: lastChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: lastChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: lastChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // insertParagraph
       setupTestCase((selection, element) => {
         selection.insertParagraph();
         const nextSibling = element.getNextSibling();
-        expect(selection.anchor).toEqual({
-          key: nextSibling.getKey(),
-          offset: 0,
-          type: 'element',
-        });
-        expect(selection.focus).toEqual({
-          key: nextSibling.getKey(),
-          offset: 0,
-          type: 'element',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: nextSibling.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: nextSibling.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
       });
 
       // insertLineBreak
       setupTestCase((selection, element) => {
         selection.insertLineBreak(true);
         const thirdChild = $getNodeByKey('c');
-        expect(selection.anchor).toEqual({
-          key: thirdChild.getKey(),
-          offset: 1,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: thirdChild.getKey(),
-          offset: 1,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: thirdChild.getKey(),
+            offset: 1,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: thirdChild.getKey(),
+            offset: 1,
+            type: 'text',
+          }),
+        );
       });
 
       // Format text
@@ -798,16 +886,20 @@ describe('LexicalSelectionHelpers tests', () => {
         selection.insertText('Test');
         const lastChild = element.getLastChild();
         expect(lastChild.getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: lastChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: lastChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: lastChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: lastChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // Extract selection
@@ -858,16 +950,20 @@ describe('LexicalSelectionHelpers tests', () => {
 
       editor.getEditorState().read(() => {
         const selection = $getSelection();
-        expect(selection.anchor).toEqual({
-          key: 'a',
-          offset: 2,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: 'a',
-          offset: 2,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 2,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 2,
+            type: 'text',
+          }),
+        );
       });
     });
 
@@ -902,16 +998,20 @@ describe('LexicalSelectionHelpers tests', () => {
 
       editor.getEditorState().read(() => {
         const selection = $getSelection();
-        expect(selection.anchor).toEqual({
-          key: 'a',
-          offset: 3,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: 'a',
-          offset: 3,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 3,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 3,
+            type: 'text',
+          }),
+        );
       });
     });
   });
@@ -961,61 +1061,77 @@ describe('LexicalSelectionHelpers tests', () => {
       setupTestCase((selection, state) => {
         selection.insertText('Test');
         expect($getNodeByKey('a').getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: 'a',
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: 'a',
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: 'a',
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // insertNodes
       setupTestCase((selection, element) => {
         selection.insertNodes([$createTextNode('foo')]);
-        expect(selection.anchor).toEqual({
-          key: element.getFirstChild().getKey(),
-          offset: 3,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: element.getFirstChild().getKey(),
-          offset: 3,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: element.getFirstChild().getKey(),
+            offset: 3,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: element.getFirstChild().getKey(),
+            offset: 3,
+            type: 'text',
+          }),
+        );
       });
 
       // insertParagraph
       setupTestCase((selection) => {
         selection.insertParagraph();
-        expect(selection.anchor).toEqual({
-          key: 'b',
-          offset: 0,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: 'b',
-          offset: 0,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: 'b',
+            offset: 0,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: 'b',
+            offset: 0,
+            type: 'text',
+          }),
+        );
       });
 
       // insertLineBreak
       setupTestCase((selection, element) => {
         selection.insertLineBreak(true);
-        expect(selection.anchor).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
-        expect(selection.focus).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
       });
 
       // Format text
@@ -1023,16 +1139,20 @@ describe('LexicalSelectionHelpers tests', () => {
         selection.formatText('bold');
         selection.insertText('Test');
         expect(element.getFirstChild().getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: element.getFirstChild().getKey(),
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: element.getFirstChild().getKey(),
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: element.getFirstChild().getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: element.getFirstChild().getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // Extract selection
@@ -1098,47 +1218,59 @@ describe('LexicalSelectionHelpers tests', () => {
         selection.insertText('Test');
         const firstChild = element.getFirstChild();
         expect(firstChild.getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // insertParagraph
       setupTestCase((selection, element) => {
         selection.insertParagraph();
         const firstChild = element.getFirstChild();
-        expect(selection.anchor).toEqual({
-          key: firstChild.getKey(),
-          offset: 0,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: firstChild.getKey(),
-          offset: 0,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 0,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 0,
+            type: 'text',
+          }),
+        );
       });
 
       // insertLineBreak
       setupTestCase((selection, element) => {
         selection.insertLineBreak(true);
-        expect(selection.anchor).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
-        expect(selection.focus).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
       });
 
       // Format text
@@ -1147,16 +1279,20 @@ describe('LexicalSelectionHelpers tests', () => {
         selection.insertText('Test');
         const firstChild = element.getFirstChild();
         expect(firstChild.getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // Extract selection
@@ -1230,47 +1366,59 @@ describe('LexicalSelectionHelpers tests', () => {
         selection.insertText('Test');
         const firstChild = element.getFirstChild();
         expect(firstChild.getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // insertParagraph
       setupTestCase((selection, element) => {
         selection.insertParagraph();
         const nextElement = element.getNextSibling();
-        expect(selection.anchor).toEqual({
-          key: nextElement.getKey(),
-          offset: 0,
-          type: 'element',
-        });
-        expect(selection.focus).toEqual({
-          key: nextElement.getKey(),
-          offset: 0,
-          type: 'element',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: nextElement.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: nextElement.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
       });
 
       // insertLineBreak
       setupTestCase((selection, element) => {
         selection.insertLineBreak(true);
-        expect(selection.anchor).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
-        expect(selection.focus).toEqual({
-          key: element.getKey(),
-          offset: 0,
-          type: 'element',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: element.getKey(),
+            offset: 0,
+            type: 'element',
+          }),
+        );
       });
 
       // Format text
@@ -1279,16 +1427,20 @@ describe('LexicalSelectionHelpers tests', () => {
         selection.insertText('Test');
         const firstChild = element.getFirstChild();
         expect(firstChild.getTextContent()).toBe('Test');
-        expect(selection.anchor).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
-        expect(selection.focus).toEqual({
-          key: firstChild.getKey(),
-          offset: 4,
-          type: 'text',
-        });
+        expect(selection.anchor).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
+        expect(selection.focus).toEqual(
+          expect.objectContaining({
+            key: firstChild.getKey(),
+            offset: 4,
+            type: 'text',
+          }),
+        );
       });
 
       // Extract selection

--- a/packages/lexical-selection/src/index.js
+++ b/packages/lexical-selection/src/index.js
@@ -648,9 +648,7 @@ export function $wrapLeafNodesInElements(
     isPointAttached(prevSelection.anchor) &&
     isPointAttached(prevSelection.focus)
   ) {
-    const clonedSelection = prevSelection.clone();
-    clonedSelection.dirty = true;
-    $setSelection(clonedSelection);
+    $setSelection(prevSelection.clone());
   } else {
     selection.dirty = true;
   }

--- a/packages/lexical/src/LexicalNode.js
+++ b/packages/lexical/src/LexicalNode.js
@@ -537,6 +537,10 @@ export class LexicalNode {
     const latestNode = this.getLatest();
     const parent = latestNode.__parent;
     const cloneNotNeeded = editor._cloneNotNeeded;
+    const selection = $getSelection();
+    if (selection !== null) {
+      selection._cachedNodes = null;
+    }
     if (cloneNotNeeded.has(key)) {
       // Transforms clear the dirty node set on each iteration to keep track on newly dirty nodes
       internalMarkNodeAsDirty(latestNode);
@@ -631,9 +635,6 @@ export class LexicalNode {
     removeNode(this, false);
     internalMarkSiblingsAsDirty(writableReplaceWith);
     const selection = $getSelection();
-    if (selection !== null) {
-      selection._nodesCache = null;
-    }
     if ($isRangeSelection(selection)) {
       const anchor = selection.anchor;
       const focus = selection.focus;

--- a/packages/lexical/src/LexicalNode.js
+++ b/packages/lexical/src/LexicalNode.js
@@ -631,6 +631,9 @@ export class LexicalNode {
     removeNode(this, false);
     internalMarkSiblingsAsDirty(writableReplaceWith);
     const selection = $getSelection();
+    if (selection !== null) {
+      selection._nodesCache = null;
+    }
     if ($isRangeSelection(selection)) {
       const anchor = selection.anchor;
       const focus = selection.focus;

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -529,16 +529,20 @@ export class RangeSelection implements BaseSelection {
     if ($isElementNode(lastNode)) {
       lastNode = lastNode.getDescendantByIndex(focus.offset);
     }
+    let nodes;
+
     if (firstNode.is(lastNode)) {
       if (
         $isElementNode(firstNode) &&
         (firstNode.getChildrenSize() > 0 || firstNode.excludeFromCopy())
       ) {
-        return [];
+        nodes = [];
+      } else {
+        nodes = [firstNode];
       }
-      return [firstNode];
+    } else {
+      nodes = firstNode.getNodesBetween(lastNode);
     }
-    const nodes = firstNode.getNodesBetween(lastNode);
     if (!isCurrentlyReadOnlyMode()) {
       this._cachedNodes = nodes;
     }

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -133,7 +133,7 @@ class Point {
         selection !== null &&
         (selection.anchor === this || selection.focus === this)
       ) {
-        selection._nodesCache = null;
+        selection._cachedNodes = null;
         selection.dirty = true;
       }
     }
@@ -229,12 +229,12 @@ interface BaseSelection {
 export class NodeSelection implements BaseSelection {
   _nodes: Set<NodeKey>;
   dirty: boolean;
-  _nodesCache: null | Array<LexicalNode>;
+  _cachedNodes: null | Array<LexicalNode>;
 
   constructor(objects: Set<NodeKey>) {
     this.dirty = false;
     this._nodes = objects;
-    this._nodesCache = null;
+    this._cachedNodes = null;
   }
 
   is(
@@ -251,19 +251,19 @@ export class NodeSelection implements BaseSelection {
   add(key: NodeKey): void {
     this.dirty = true;
     this._nodes.add(key);
-    this._nodesCache = null;
+    this._cachedNodes = null;
   }
 
   delete(key: NodeKey): void {
     this.dirty = true;
     this._nodes.delete(key);
-    this._nodesCache = null;
+    this._cachedNodes = null;
   }
 
   clear(): void {
     this.dirty = true;
     this._nodes.clear();
-    this._nodesCache = null;
+    this._cachedNodes = null;
   }
 
   has(key: NodeKey): boolean {
@@ -287,9 +287,9 @@ export class NodeSelection implements BaseSelection {
   }
 
   getNodes(): Array<LexicalNode> {
-    const nodesCache = this._nodesCache;
-    if (nodesCache !== null) {
-      return nodesCache;
+    const cachedNodes = this._cachedNodes;
+    if (cachedNodes !== null) {
+      return cachedNodes;
     }
     const objects = this._nodes;
     const nodes = [];
@@ -300,7 +300,7 @@ export class NodeSelection implements BaseSelection {
       }
     }
     if (!isCurrentlyReadOnlyMode()) {
-      this._nodesCache = nodes;
+      this._cachedNodes = nodes;
     }
     return nodes;
   }
@@ -331,14 +331,14 @@ export class GridSelection implements BaseSelection {
   anchor: PointType;
   focus: PointType;
   dirty: boolean;
-  _nodesCache: null | Array<LexicalNode>;
+  _cachedNodes: null | Array<LexicalNode>;
 
   constructor(gridKey: NodeKey, anchor: PointType, focus: PointType): void {
     this.gridKey = gridKey;
     this.anchor = anchor;
     this.focus = focus;
     this.dirty = false;
-    this._nodesCache = null;
+    this._cachedNodes = null;
   }
 
   is(
@@ -355,7 +355,7 @@ export class GridSelection implements BaseSelection {
     this.gridKey = gridKey;
     this.anchor.key = anchorCellKey;
     this.focus.key = focusCellKey;
-    this._nodesCache = null;
+    this._cachedNodes = null;
   }
 
   clone(): GridSelection {
@@ -416,9 +416,9 @@ export class GridSelection implements BaseSelection {
   }
 
   getNodes(): Array<LexicalNode> {
-    const nodesCache = this._nodesCache;
-    if (nodesCache !== null) {
-      return nodesCache;
+    const cachedNodes = this._cachedNodes;
+    if (cachedNodes !== null) {
+      return cachedNodes;
     }
     const nodesSet = new Set();
     const {fromX, fromY, toX, toY} = this.getShape();
@@ -458,7 +458,7 @@ export class GridSelection implements BaseSelection {
     }
     const nodes = Array.from(nodesSet);
     if (!isCurrentlyReadOnlyMode()) {
-      this._nodesCache = nodes;
+      this._cachedNodes = nodes;
     }
     return nodes;
   }
@@ -482,14 +482,14 @@ export class RangeSelection implements BaseSelection {
   focus: PointType;
   dirty: boolean;
   format: number;
-  _nodesCache: null | Array<LexicalNode>;
+  _cachedNodes: null | Array<LexicalNode>;
 
   constructor(anchor: PointType, focus: PointType, format: number): void {
     this.anchor = anchor;
     this.focus = focus;
     this.dirty = false;
     this.format = format;
-    this._nodesCache = null;
+    this._cachedNodes = null;
   }
 
   is(
@@ -514,9 +514,9 @@ export class RangeSelection implements BaseSelection {
   }
 
   getNodes(): Array<LexicalNode> {
-    const nodesCache = this._nodesCache;
-    if (nodesCache !== null) {
-      return nodesCache;
+    const cachedNodes = this._cachedNodes;
+    if (cachedNodes !== null) {
+      return cachedNodes;
     }
     const anchor = this.anchor;
     const focus = this.focus;
@@ -540,7 +540,7 @@ export class RangeSelection implements BaseSelection {
     }
     const nodes = firstNode.getNodesBetween(lastNode);
     if (!isCurrentlyReadOnlyMode()) {
-      this._nodesCache = nodes;
+      this._cachedNodes = nodes;
     }
     return nodes;
   }

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -94,7 +94,6 @@ class Point {
   }
   is(point: PointType): boolean {
     return (
-      this._selection === point._selection &&
       this.key === point.key &&
       this.offset === point.offset &&
       this.type === point.type

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -251,16 +251,19 @@ export class NodeSelection implements BaseSelection {
   add(key: NodeKey): void {
     this.dirty = true;
     this._nodes.add(key);
+    this._nodesCache = null;
   }
 
   delete(key: NodeKey): void {
     this.dirty = true;
     this._nodes.delete(key);
+    this._nodesCache = null;
   }
 
   clear(): void {
     this.dirty = true;
     this._nodes.clear();
+    this._nodesCache = null;
   }
 
   has(key: NodeKey): boolean {
@@ -345,6 +348,7 @@ export class GridSelection implements BaseSelection {
     this.gridKey = gridKey;
     this.anchor.key = anchorCellKey;
     this.focus.key = focusCellKey;
+    this._nodesCache = null;
   }
 
   clone(): GridSelection {

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -412,7 +412,7 @@ export function $setSelection(
       );
     }
     selection.dirty = true;
-    selection._nodesCache = null;
+    selection._cachedNodes = null;
   }
   editorState._selection = selection;
 }

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -404,10 +404,15 @@ export function $setSelection(
   selection: null | RangeSelection | NodeSelection | GridSelection,
 ): void {
   const editorState = getActiveEditorState();
-  if (__DEV__ && selection !== null && Object.isFrozen(selection)) {
-    console.warn(
-      '$setSelection called on frozen selection object. Ensure selection is cloned before passing in.',
-    );
+  if (selection !== null) {
+    if (Object.isFrozen(selection)) {
+      invariant(
+        false,
+        '$setSelection called on frozen selection object. Ensure selection is cloned before passing in.',
+      );
+    }
+    selection.dirty = true;
+    selection._nodesCache = null;
   }
   editorState._selection = selection;
 }


### PR DESCRIPTION
Today, we call `selection.getNodes()` a lot. One such case is when you do `node.isSelected()`. If you do this in a hot path, it can cause a lot of slow-down. We can however apply a caching heuristic to `selection.getNodes()`. Upon the first pass we can cache the return value on the selection object. We just need to ensure we invalidate this cache correctly so we don't wrongly use the cache when something might have changed. My heuristic is:

- When calling `set` on a point, or add/clear/delete, thus "mutation" the selection.
- When calling `$setSelection`
- When mutating a node, via `getWritable()`

I might have missed some cases but let's see how this works out. In perf testing this dramatically improves performance in some cases.