### PR TITLE
Delete the excalidraw node from editor on discard changes

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.jsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.jsx
@@ -133,6 +133,8 @@ export default function ExcalidrawModal({
           <Button
             onClick={() => {
               setDiscardModalOpen(false);
+              // delete node
+              onDelete();
               onHide();
             }}>
             Discard


### PR DESCRIPTION
Removing the empty node from the editor on discard changes from excalidraw.

