### PR TITLE
Further constrain DecoratorNode selection resolution logic

### DIFF
--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -2087,7 +2087,11 @@ function internalResolveSelectionPoints(
     // Ensure if we're selecting the content of a decorator that we
     // return null for this point, as it's not in the controlled scope
     // of Lexical.
-    if ($isDecoratorNode(anchorNode) && $isDecoratorNode(focusNode)) {
+    if (
+      $isDecoratorNode(anchorNode) &&
+      $isDecoratorNode(focusNode) &&
+      anchorNode.is(focusNode)
+    ) {
       return null;
     }
   }

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -2088,9 +2088,9 @@ function internalResolveSelectionPoints(
     // return null for this point, as it's not in the controlled scope
     // of Lexical.
     if (
+      anchorNode === focusNode &&
       $isDecoratorNode(anchorNode) &&
-      $isDecoratorNode(focusNode) &&
-      anchorNode.is(focusNode)
+      $isDecoratorNode(focusNode)
     ) {
       return null;
     }


### PR DESCRIPTION
We should only apply this heuristic when both anchorDOM is focusDOM, otherwise, the selection could be selecting a range over many decorators, which is valid.