### PR TITLE
Show excalidraw nodes only in case elements have been created

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.jsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.jsx
@@ -133,8 +133,6 @@ export default function ExcalidrawModal({
           <Button
             onClick={() => {
               setDiscardModalOpen(false);
-              // delete node
-              onDelete();
               onHide();
             }}>
             Discard

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.jsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.jsx
@@ -170,25 +170,27 @@ function ExcalidrawComponent({
         }}
         closeOnClickOutside={true}
       />
-      <button
-        ref={buttonRef}
-        className={`excalidraw-button ${isSelected ? 'selected' : ''}`}>
-        <ExcalidrawImage
-          imageContainerRef={imageContainerRef}
-          className="image"
-          elements={elements}
-        />
-        {(isSelected || isResizing) && (
-          <ImageResizer
-            showCaption={true}
-            setShowCaption={() => {}}
-            imageRef={imageContainerRef}
-            editor={editor}
-            onResizeStart={onResizeStart}
-            onResizeEnd={onResizeEnd}
+      {elements.length > 0 && (
+        <button
+          ref={buttonRef}
+          className={`excalidraw-button ${isSelected ? 'selected' : ''}`}>
+          <ExcalidrawImage
+            imageContainerRef={imageContainerRef}
+            className="image"
+            elements={elements}
           />
-        )}
-      </button>
+          {(isSelected || isResizing) && (
+            <ImageResizer
+              showCaption={true}
+              setShowCaption={() => {}}
+              imageRef={imageContainerRef}
+              editor={editor}
+              onResizeStart={onResizeStart}
+              onResizeEnd={onResizeEnd}
+            />
+          )}
+        </button>
+      )}
     </>
   );
 }


### PR DESCRIPTION
Only include the modal on open excalidraw. The rest of the elements include them only in case something has been already created with the tool.