### PR TITLE
Fix Firefox composition bug

### DIFF
--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -359,7 +359,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
       dispatchCommand(editor, DELETE_CHARACTER_COMMAND, true);
       // Fixes an Android bug where selection flickers when backspacing
       setTimeout(() => {
-        editor.update(() => {
+        updateEditor(editor, () => {
           $setCompositionKey(null);
         });
       }, ANDROID_COMPOSITION_LATENCY);

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -486,7 +486,8 @@ export function createUID(): string {
 
 export function $updateSelectedTextFromDOM(
   editor: LexicalEditor,
-  compositionEndEvent: null | CompositionEvent,
+  isCompositionEnd: boolean,
+  data?: ?string,
 ): void {
   // Update the text content with the latest composition text
   const domSelection = getDOMSelection();
@@ -499,7 +500,6 @@ export function $updateSelectedTextFromDOM(
     const node = $getNearestNodeFromDOMNode(anchorNode);
     if ($isTextNode(node)) {
       let textContent = anchorNode.nodeValue;
-      const data = compositionEndEvent !== null && compositionEndEvent.data;
 
       // Data is intentionally truthy, as we check for boolean, null and empty string.
       if (textContent === ZERO_WIDTH_CHAR && data) {
@@ -514,7 +514,7 @@ export function $updateSelectedTextFromDOM(
         textContent,
         anchorOffset,
         focusOffset,
-        compositionEndEvent !== null,
+        isCompositionEnd,
       );
     }
   }


### PR DESCRIPTION
We have reports of emojis being inserted multiple times on Windows + Firefox using the Windows emoji picker. We actually fixed this issue in the past: https://github.com/facebook/lexical/pull/738. However, we can't use setTimeout, as it means that we invalidate composition too late.

In order to make the composition sequence work the same in FF as it does in Chrome/Webkit – we can defer ending composition till the subsequent `input` event comes in. Thus making the sequence behave like `compositionstart` -> `input` -> `compositionend`, even though `input` occurs after `compositionend` in Firefox.