### PR TITLE
Fix Firefox composition bug with emojis

### DIFF
--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -359,7 +359,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
       dispatchCommand(editor, DELETE_CHARACTER_COMMAND, true);
       // Fixes an Android bug where selection flickers when backspacing
       setTimeout(() => {
-        editor.update(() => {
+        updateEditor(editor, () => {
           $setCompositionKey(null);
         });
       }, ANDROID_COMPOSITION_LATENCY);
@@ -525,23 +525,23 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
     ) {
       // Given we're over-riding the default behavior, we will need
       // to ensure to disable composition before dispatching the
-      // insertText command.
+      // insertText command for when changing the sequence for FF.
       if (isFirefoxEndingComposition) {
+        onCompositionEndImpl(editor, data);
         isFirefoxEndingComposition = false;
-        $setCompositionKey(null);
       }
       dispatchCommand(editor, INSERT_TEXT_COMMAND, data);
-      // For Android
+      // This ensures consistency on Android.
       if (editor._compositionKey !== null) {
         lastKeyDownTimeStamp = 0;
         $setCompositionKey(null);
       }
     } else {
-      $updateSelectedTextFromDOM(editor, null);
-      // onInput always fires after onCompositionEnd for FF
+      $updateSelectedTextFromDOM(editor, false);
+      // onInput always fires after onCompositionEnd for FF.
       if (isFirefoxEndingComposition) {
+        onCompositionEndImpl(editor, data);
         isFirefoxEndingComposition = false;
-        $setCompositionKey(null);
       }
     }
     // Also flush any other mutations that might have occurred
@@ -579,49 +579,60 @@ function onCompositionStart(
   });
 }
 
+function onCompositionEndImpl(editor: LexicalEditor, data: ?string): void {
+  const compositionKey = editor._compositionKey;
+  $setCompositionKey(null);
+  // Handle termination of composition.
+  if (compositionKey !== null && data != null) {
+    // Composition can sometimes move to an adjacent DOM node when backspacing.
+    // So check for the empty case.
+    if (data === '') {
+      const node = $getNodeByKey(compositionKey);
+      const textNode = getDOMTextNode(editor.getElementByKey(compositionKey));
+      if (textNode !== null && $isTextNode(node)) {
+        $updateTextNodeFromDOMContent(
+          node,
+          textNode.nodeValue,
+          null,
+          null,
+          true,
+        );
+      }
+      return;
+    }
+    // Composition can sometimes be that of a new line. In which case, we need to
+    // handle that accordingly.
+    if (data[data.length - 1] === '\n') {
+      const selection = $getSelection();
+      if ($isRangeSelection(selection)) {
+        // If the last character is a line break, we also need to insert
+        // a line break.
+        const focus = selection.focus;
+        selection.anchor.set(focus.key, focus.offset, focus.type);
+        dispatchCommand(editor, KEY_ENTER_COMMAND, null);
+        return;
+      }
+    }
+  }
+  $updateSelectedTextFromDOM(editor, true, data);
+}
+
 function onCompositionEnd(
   event: CompositionEvent,
   editor: LexicalEditor,
 ): void {
-  updateEditor(editor, () => {
-    const compositionKey = editor._compositionKey;
-    if (IS_FIREFOX) {
-      isFirefoxEndingComposition = true;
-    } else {
-      $setCompositionKey(null);
-    }
-    const data = event.data;
-    // Handle termination of composition.
-    if (compositionKey !== null && data != null) {
-      // It can sometimes move to an adjacent DOM node when backspacing.
-      // So check for the empty case.
-      if (data === '') {
-        const node = $getNodeByKey(compositionKey);
-        const textNode = getDOMTextNode(editor.getElementByKey(compositionKey));
-        if (textNode !== null && $isTextNode(node)) {
-          $updateTextNodeFromDOMContent(
-            node,
-            textNode.nodeValue,
-            null,
-            null,
-            true,
-          );
-        }
-        return;
-      } else if (data[data.length - 1] === '\n') {
-        const selection = $getSelection();
-        if ($isRangeSelection(selection)) {
-          // If the last character is a line break, we also need to insert
-          // a line break.
-          const focus = selection.focus;
-          selection.anchor.set(focus.key, focus.offset, focus.type);
-          dispatchCommand(editor, KEY_ENTER_COMMAND, null);
-          return;
-        }
-      }
-    }
-    $updateSelectedTextFromDOM(editor, event);
-  });
+  // Firefox fires onCompositionEnd before onInput, but Chrome/Webkit,
+  // fire onInput before onCompositionEnd. To ensure the sequence works
+  // like Chrome/Webkit we use the isFirefoxEndingComposition flag to
+  // defer handling of onCompositionEnd in Firefox till we have processed
+  // the logic in onInput.
+  if (IS_FIREFOX) {
+    isFirefoxEndingComposition = true;
+  } else {
+    updateEditor(editor, () => {
+      onCompositionEndImpl(editor, event.data);
+    });
+  }
 }
 
 function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -486,7 +486,8 @@ export function createUID(): string {
 
 export function $updateSelectedTextFromDOM(
   editor: LexicalEditor,
-  compositionEndEvent: null | CompositionEvent,
+  isCompositionEnd: boolean,
+  data?: ?string,
 ): void {
   // Update the text content with the latest composition text
   const domSelection = getDOMSelection();
@@ -499,7 +500,6 @@ export function $updateSelectedTextFromDOM(
     const node = $getNearestNodeFromDOMNode(anchorNode);
     if ($isTextNode(node)) {
       let textContent = anchorNode.nodeValue;
-      const data = compositionEndEvent !== null && compositionEndEvent.data;
 
       // Data is intentionally truthy, as we check for boolean, null and empty string.
       if (textContent === ZERO_WIDTH_CHAR && data) {
@@ -514,7 +514,7 @@ export function $updateSelectedTextFromDOM(
         textContent,
         anchorOffset,
         focusOffset,
-        compositionEndEvent !== null,
+        isCompositionEnd,
       );
     }
   }


### PR DESCRIPTION
We have reports of emojis being inserted multiple times on Windows + Firefox using the Windows emoji picker. We actually fixed this issue in the past: https://github.com/facebook/lexical/pull/738. However, we can't use setTimeout, as it means that we invalidate composition too late.

In order to make the composition sequence work the same in FF as it does in Chrome/Webkit – we can defer ending composition till the subsequent `input` event comes in. Thus making the sequence behave like `compositionstart` -> `input` -> `compositionend`, even though `input` occurs after `compositionend` in Firefox.