### PR TITLE
Fix CI Caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,13 +95,13 @@ jobs:
         with:
           path: |
             node_modules
+            packages/playwright-core/node_modules
             ~/Library/Caches/ms-playwright
           key: ${{ runner.os }}-v4-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Download browsers
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npx playwright install
       - run: npm run test-e2e-ci:${{ matrix.browser }}
       - name: Upload Artifacts
@@ -140,13 +140,13 @@ jobs:
         with:
           path: |
             node_modules
+            packages/playwright-core/node_modules
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-v4-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Download browsers
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npx playwright install
       - run: npm run test-e2e-ci:${{ matrix.browser }}
       - name: Upload Artifacts
@@ -217,6 +217,7 @@ jobs:
         with:
           path: |
             node_modules
+            packages/playwright-core/node_modules
             ~/Library/Caches/ms-playwright
           key: ${{ runner.os }}-v4-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
@@ -257,6 +258,7 @@ jobs:
         with:
           path: |
             node_modules
+            packages/playwright-core/node_modules
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-v4-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           path: |
             node_modules
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -65,7 +65,7 @@ jobs:
           path: |
             node_modules
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -97,7 +97,7 @@ jobs:
             node_modules
             packages/playwright-core/node_modules
             ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -142,7 +142,7 @@ jobs:
             node_modules
             packages/playwright-core/node_modules
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -182,7 +182,7 @@ jobs:
       #     path: |
       #       node_modules
       #       C:\Users\runneradmin\AppData\Local\ms-playwright
-      #     key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      #     key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       # - name: Install dependencies
       #   if: steps.cache.outputs.cache-hit != 'true'
       - run: npm ci
@@ -219,7 +219,7 @@ jobs:
             node_modules
             packages/playwright-core/node_modules
             ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -260,7 +260,7 @@ jobs:
             node_modules
             packages/playwright-core/node_modules
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -296,7 +296,7 @@ jobs:
           path: |
             node_modules
             C:\Users\runneradmin\AppData\Local\ms-playwright
-          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         #   if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Download browsers
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npx playwright install
       - run: npm run test-e2e-ci:${{ matrix.browser }}
       - name: Upload Artifacts
@@ -145,6 +146,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Download browsers
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npx playwright install
       - run: npm run test-e2e-ci:${{ matrix.browser }}
       - name: Upload Artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           path: |
             node_modules
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -65,7 +65,7 @@ jobs:
           path: |
             node_modules
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -97,7 +97,7 @@ jobs:
             node_modules
             packages/playwright-core/node_modules
             ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -142,7 +142,7 @@ jobs:
             node_modules
             packages/playwright-core/node_modules
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -182,7 +182,7 @@ jobs:
       #     path: |
       #       node_modules
       #       C:\Users\runneradmin\AppData\Local\ms-playwright
-      #     key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      #     key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       # - name: Install dependencies
       #   if: steps.cache.outputs.cache-hit != 'true'
       - run: npm ci
@@ -219,7 +219,7 @@ jobs:
             node_modules
             packages/playwright-core/node_modules
             ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -260,7 +260,7 @@ jobs:
             node_modules
             packages/playwright-core/node_modules
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -296,7 +296,7 @@ jobs:
           path: |
             node_modules
             C:\Users\runneradmin\AppData\Local\ms-playwright
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         #   if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           path: |
             node_modules
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-v4-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -65,7 +65,7 @@ jobs:
           path: |
             node_modules
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-v4-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -97,7 +97,7 @@ jobs:
             node_modules
             packages/playwright-core/node_modules
             ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-v4-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -142,7 +142,7 @@ jobs:
             node_modules
             packages/playwright-core/node_modules
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-v4-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -182,7 +182,7 @@ jobs:
       #     path: |
       #       node_modules
       #       C:\Users\runneradmin\AppData\Local\ms-playwright
-      #     key: ${{ runner.os }}-v4-${{ hashFiles('package-lock.json') }}
+      #     key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       # - name: Install dependencies
       #   if: steps.cache.outputs.cache-hit != 'true'
       - run: npm ci
@@ -219,7 +219,7 @@ jobs:
             node_modules
             packages/playwright-core/node_modules
             ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-v4-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -260,7 +260,7 @@ jobs:
             node_modules
             packages/playwright-core/node_modules
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-v4-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -296,7 +296,7 @@ jobs:
           path: |
             node_modules
             C:\Users\runneradmin\AppData\Local\ms-playwright
-          key: ${{ runner.os }}-v4-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-{{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         #   if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.js
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.js
@@ -1743,7 +1743,7 @@ describe('LexicalSelection tests', () => {
         root.append(
           $createParagraphNode().append(
             text1,
-            $createLinkNode('http://lexical.dev').append(text2),
+            $createLinkNode('https://lexical.dev').append(text2),
             text3,
           ),
         );

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.js
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.js
@@ -1743,7 +1743,7 @@ describe('LexicalSelection tests', () => {
         root.append(
           $createParagraphNode().append(
             text1,
-            $createLinkNode('https://lexical.dev').append(text2),
+            $createLinkNode('http://lexical.dev').append(text2),
             text3,
           ),
         );


### PR DESCRIPTION
We only cache the node_modules in the project root. Before https://github.com/facebook/lexical/pull/2073 was merged, we depended on dangerjs, which had a dependency on https-proxy-agent, so by coincidence, playwright was able to resolve that module because it was there in the root node_modules as a dependency of dangerjs.

Since we use a fork of playwright locally in the packages directory, a different node_modules gets created in packages/playwright-core as part of the workspace install. We don't cache this, and we don't run an npm install on a cache hit, so https-proxy-agent isn't there when playwright needs it to download browsers.

This fixes that by caching the playwright-core local node_modules. 

It also adds a GitHub Secret to the cache key which can be used to manually bust the cache from the settings without making a code change.