### PR TITLE
Make markdown transformers optional

### DIFF
--- a/packages/lexical-markdown/LexicalMarkdown.d.ts
+++ b/packages/lexical-markdown/LexicalMarkdown.d.ts
@@ -10,6 +10,7 @@ import type {
   LexicalEditor,
   ElementNode,
   LexicalNode,
+  TextNode,
   TextFormatType,
 } from 'lexical';
 
@@ -33,13 +34,13 @@ export type ElementTransformer = {
   type: 'element';
 };
 
-export type TextFormatTransformer = $ReadOnly<{
-  format: $ReadOnlyArray<TextFormatType>;
+export type TextFormatTransformer = {
+  format: Array<TextFormatType>;
   tag: string;
   type: 'text-format';
-}>;
+};
 
-export type TextMatchTransformer = $ReadOnly<{
+export type TextMatchTransformer = {
   export: (
     node: LexicalNode,
     exportChildren: (node: ElementNode) => string,
@@ -47,10 +48,10 @@ export type TextMatchTransformer = $ReadOnly<{
   ) => string | null;
   importRegExp: RegExp;
   regExp: RegExp;
-  replace: (node: TextNode, match: RegExp$matchResult) => void;
+  replace: (node: TextNode, match: RegExpMatchArray) => void;
   trigger: string;
   type: 'text-match';
-}>;
+};
 
 // TODO:
 // transformers should be required argument, breaking change

--- a/packages/lexical-markdown/src/v2/MarkdownShortcuts.js
+++ b/packages/lexical-markdown/src/v2/MarkdownShortcuts.js
@@ -26,6 +26,7 @@ import {
   $setSelection,
 } from 'lexical';
 
+import {TRANSFORMERS} from '..';
 import {indexBy, transformersByType} from './utils';
 
 function runElementTransformers(
@@ -286,7 +287,7 @@ function isEqualSubString(
 
 export function registerMarkdownShortcuts(
   editor: LexicalEditor,
-  transformers: Array<Transformer>,
+  transformers: Array<Transformer> = TRANSFORMERS,
 ): () => void {
   const byType = transformersByType(transformers);
   const textFormatTransformersIndex = indexBy(

--- a/packages/lexical-react/LexicalMarkdownShortcutPlugin.d.ts
+++ b/packages/lexical-react/LexicalMarkdownShortcutPlugin.d.ts
@@ -6,4 +6,6 @@
  *
  */
 
-export default function LexicalMarkdownShortcutPlugin(): JSX.Element | null;
+export default function LexicalMarkdownShortcutPlugin(arg0: {
+  transformers: Array<Transformer>;
+}): JSX.Element | null;


### PR DESCRIPTION
- Make `transformers` prop optional for `<LexicalMarkdownShortcutsPlugin>` (as it was before)
- Add Horizontal Rule as a part of default transformers (as it was before)