### PR TITLE
Track last event for when in Shadow DOM

### DIFF
--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -203,7 +203,8 @@ function onSelectionChange(
         // within the given time range – then attempt to use that format
         // instead of getting the format from the anchor node.
         const event = getActiveEvent();
-        const currentTimeStamp = event !== null ? event.timeStamp : Infinity;
+        const currentTimeStamp =
+          event !== null ? event.timeStamp : performance.now();
         const [lastFormat, lastOffset, lastKey, timeStamp] =
           collapsedSelectionFormat;
 

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -132,6 +132,7 @@ if (CAN_USE_BEFORE_INPUT) {
   rootElementEvents.push(['drop', PASS_THROUGH_COMMAND]);
 }
 
+let lastEvent: null | Event = null;
 let lastKeyDownTimeStamp = 0;
 let rootElementsRegistered = 0;
 let isSelectionChangeFromReconcile = false;
@@ -201,7 +202,8 @@ function onSelectionChange(
         // If we have marked a collapsed selection format, and we're
         // within the given time range – then attempt to use that format
         // instead of getting the format from the anchor node.
-        const currentTimeStamp = window.event.timeStamp;
+        const event = getActiveEvent();
+        const currentTimeStamp = event !== null ? event.timeStamp : Infinity;
         const [lastFormat, lastOffset, lastKey, timeStamp] =
           collapsedSelectionFormat;
 
@@ -782,6 +784,7 @@ export function addRootElementEvents(
       typeof onEvent === 'function'
         ? (event: Event) => {
             if (!editor.isReadOnly()) {
+              lastEvent = event;
               onEvent(event, editor);
             }
           }
@@ -865,4 +868,12 @@ export function markCollapsedSelectionFormat(
   timeStamp: number,
 ): void {
   collapsedSelectionFormat = [format, offset, key, timeStamp];
+}
+
+export function getActiveEvent(): Event | null {
+  const windowEvent = window.event;
+  if (windowEvent != null) {
+    return windowEvent;
+  }
+  return lastEvent;
 }

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -33,6 +33,7 @@ import {
   TextNode,
 } from '.';
 import {DOM_ELEMENT_TYPE, TEXT_TYPE_TO_FORMAT} from './LexicalConstants';
+import {getActiveEvent} from './LexicalEvents';
 import {getIsProcesssingMutations} from './LexicalMutations';
 import {
   getActiveEditor,
@@ -2185,11 +2186,6 @@ export function $createEmptyGridSelection(): GridSelection {
   return new GridSelection('root', anchor, focus);
 }
 
-function getActiveEventType(): string | void {
-  const event = window.event;
-  return event && event.type;
-}
-
 export function internalCreateSelection(
   editor: LexicalEditor,
 ): null | RangeSelection | NodeSelection | GridSelection {
@@ -2223,7 +2219,8 @@ function internalCreateRangeSelection(
   // reconciliation unless there are dirty nodes that need
   // reconciling.
 
-  const eventType = getActiveEventType();
+  const event = getActiveEvent();
+  const eventType = event === null ? null : event.type;
   const isSelectionChange = eventType === 'selectionchange';
   const useDOMSelection =
     !getIsProcesssingMutations() &&
@@ -2231,7 +2228,10 @@ function internalCreateRangeSelection(
       eventType === 'beforeinput' ||
       eventType === 'compositionstart' ||
       eventType === 'compositionend' ||
-      (eventType === 'click' && window.event.detail === 3) ||
+      (eventType === 'click' &&
+        event !== null &&
+        // $FlowFixMe: cast to mouse event
+        ((event: any): MouseEvent).detail === 3) ||
       eventType === undefined);
   let anchorDOM, focusDOM, anchorOffset, focusOffset;
 

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -2232,7 +2232,7 @@ function internalCreateRangeSelection(
         event !== null &&
         // $FlowFixMe: cast to mouse event
         ((event: any): MouseEvent).detail === 3) ||
-      eventType === undefined);
+      eventType === null);
   let anchorDOM, focusDOM, anchorOffset, focusOffset;
 
   if (!$isRangeSelection(lastSelection) || useDOMSelection) {

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -52,6 +52,7 @@ import {
   TEXT_TYPE_TO_FORMAT,
   ZERO_WIDTH_CHAR,
 } from './LexicalConstants';
+import {getActiveEvent} from './LexicalEvents';
 import {flushRootMutations} from './LexicalMutations';
 import {
   errorOnInfiniteTransforms,
@@ -999,8 +1000,9 @@ export function $getDecoratorNode(
 }
 
 export function isFirefoxClipboardEvents(): boolean {
-  const event = window.event;
-  const inputType = event && event.inputType;
+  const event = getActiveEvent();
+  // $FlowFixMe: intend to refine after
+  const inputType = event !== null && event.inputType;
   return (
     inputType === 'insertFromPaste' ||
     inputType === 'insertFromPasteAsQuotation'


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/2119. In the Shadow DOM, `window.event` returns `undefined`. In this case, we need to use the last known event that the Lexical event system knows of in order to get some heuristic working. I'm unsure of if this will work in all cases, so leaving as as draft for now.