### PR TITLE
Fix typo in playground: speect → speech

### DIFF
--- a/packages/lexical-playground/src/plugins/ActionsPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.tsx
@@ -123,10 +123,10 @@ export default function ActionsPlugin({
             'action-button action-button-mic ' +
             (isSpeechToText ? 'active' : '')
           }
-          title="Speect To Text"
+          title="Speech To Text"
           aria-label={`${
             isSpeechToText ? 'Enable' : 'Disable'
-          } speect to text`}>
+          } speech to text`}>
           <i className="mic" />
         </button>
       )}


### PR DESCRIPTION
Action button title/aria-label says 'speect' instead of 'speech'.