### PR TITLE
Remove unused ref in Playground ToolbarPlugin

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
@@ -163,7 +163,6 @@ function positionEditorElement(editor, rect) {
 function FloatingLinkEditor({editor}: {editor: LexicalEditor}): JSX.Element {
   const editorRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef(null);
-  const mouseDownRef = useRef(false);
   const [linkUrl, setLinkUrl] = useState('');
   const [isEditMode, setEditMode] = useState(false);
   const [lastSelection, setLastSelection] = useState(null);
@@ -208,9 +207,7 @@ function FloatingLinkEditor({editor}: {editor: LexicalEditor}): JSX.Element {
         rect = domRange.getBoundingClientRect();
       }
 
-      if (!mouseDownRef.current) {
-        positionEditorElement(editorElem, rect);
-      }
+      positionEditorElement(editorElem, rect);
       setLastSelection(selection);
     } else if (!activeElement || activeElement.className !== 'link-input') {
       positionEditorElement(editorElem, null);


### PR DESCRIPTION
This PR cleans up the Toolbar from the Playground, removing a ref that's never set.

Feel free to close this, if `mouseDownRef` is needed, but on master it's never actually used which caused me some confusion as I was replicating the Toolbar