### PR TITLE
editorUpdate -> skipRootElementFocus

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/SkipSelection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/SkipSelection.spec.mjs
@@ -11,7 +11,6 @@ import {
   assertHTML,
   click,
   focusEditor,
-  hasFocus,
   html,
   initialize,
   repeat,
@@ -29,7 +28,10 @@ test.describe('Placeholder', () => {
   }) => {
     await focusEditor(page);
 
-    await repeat(10, async () => await click(page, '.skip-selection-button'));
+    await repeat(
+      10,
+      async () => await click(page, '.skip-selection-type-button'),
+    );
     await assertHTML(
       page,
       html`
@@ -42,12 +44,10 @@ test.describe('Placeholder', () => {
     );
     await assertFocus(page, false);
 
-    // For some reason, the browser moves the selection to the beginning when calling editor.focus()
-    let focused = false;
-    while (!focused) {
-      await page.keyboard.press('Tab');
-      focused = await hasFocus(page);
-    }
+    // For some reason, some browsers don't trigger a focus event on editorElement.focus() so let's
+    // use editor.focus() for the sake of the test
+    // with
+    await click(page, '.skip-selection-focus-button');
 
     await page.keyboard.type('bar');
     await assertHTML(

--- a/packages/lexical-playground/__tests__/e2e/SkipSelection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/SkipSelection.spec.mjs
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  assertHTML,
+  assertSelection,
+  expect,
+  focusEditor,
+  html,
+  initialize,
+  test,
+  textContent,
+} from '../utils/index.mjs';
+
+test.describe('Placeholder', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+  test(`Shows foo 10 times, editor is not focused`, async ({
+    page,
+    isRichText,
+    isCollab,
+  }) => {
+    await focusEditor(page);
+    const content = await textContent(page, '.Placeholder__root');
+    if (isCollab) {
+      expect(content).toBe('Enter some collaborative rich text...');
+    } else if (isRichText) {
+      expect(content).toBe('Enter some rich text...');
+    } else {
+      expect(content).toBe('Enter some plain text...');
+    }
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0],
+      focusOffset: 0,
+      focusPath: [0],
+    });
+  });
+});

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -157,15 +157,11 @@ export async function assertHTML(
 }
 
 export async function assertFocus(pageOrFrame, expected = true) {
-  const contentEditableHasFocus = await hasFocus(pageOrFrame);
-  return contentEditableHasFocus === expected;
-}
-
-export async function hasFocus(pageOrFrame) {
-  return await pageOrFrame.evaluate(() => {
+  const contentEditableHasFocus = await pageOrFrame.evaluate(() => {
     const editor = document.querySelector('div[contenteditable="true"]');
     return editor === document.activeElement;
   });
+  return contentEditableHasFocus === expected;
 }
 
 async function retryAsync(page, fn, attempts) {

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -31,11 +31,13 @@ export async function initialize({
   isCharLimit,
   isCharLimitUtf8,
   showNestedEditorTreeView,
+  testSkipSelection,
 }) {
   const appSettings = {};
   appSettings.isRichText = IS_RICH_TEXT;
   appSettings.emptyEditor = true;
   appSettings.disableBeforeInput = LEGACY_EVENTS;
+  appSettings.testSkipSelection = testSkipSelection;
   if (isCollab) {
     appSettings.isCollab = isCollab;
     appSettings.collabId = uuidv4();
@@ -152,6 +154,18 @@ export async function assertHTML(
       ignoreInlineStyles,
     );
   }
+}
+
+export async function assertFocus(pageOrFrame, expected = true) {
+  const contentEditableHasFocus = await hasFocus(pageOrFrame);
+  return contentEditableHasFocus === expected;
+}
+
+export async function hasFocus(pageOrFrame) {
+  return await pageOrFrame.evaluate(() => {
+    const editor = document.querySelector('div[contenteditable="true"]');
+    return editor === document.activeElement;
+  });
 }
 
 async function retryAsync(page, fn, attempts) {

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -50,6 +50,7 @@ import SpeechToTextPlugin from './plugins/SpeechToTextPlugin';
 import TabFocusPlugin from './plugins/TabFocusPlugin';
 import TableCellActionMenuPlugin from './plugins/TableActionMenuPlugin';
 import TableCellResizer from './plugins/TableCellResizer';
+import TestSkipSelectionPlugin from './plugins/TestSkipSelectionPlugin';
 import ToolbarPlugin from './plugins/ToolbarPlugin';
 import TreeViewPlugin from './plugins/TreeViewPlugin';
 import TwitterPlugin from './plugins/TwitterPlugin';
@@ -152,6 +153,7 @@ export default function Editor(): JSX.Element {
       isRichText,
       showTreeView,
       emptyEditor,
+      testSkipSelection,
     },
   } = useSettings();
   const text = isCollab
@@ -234,6 +236,7 @@ export default function Editor(): JSX.Element {
         <ActionsPlugin isRichText={isRichText} />
       </div>
       {showTreeView && <TreeViewPlugin />}
+      {testSkipSelection && <TestSkipSelectionPlugin />}
     </>
   );
 }

--- a/packages/lexical-playground/src/appSettings.ts
+++ b/packages/lexical-playground/src/appSettings.ts
@@ -16,7 +16,8 @@ export type SettingName =
   | 'isAutocomplete'
   | 'showTreeView'
   | 'showNestedEditorTreeView'
-  | 'emptyEditor';
+  | 'emptyEditor'
+  | 'testSkipSelection';
 
 export type Settings = Record<SettingName, boolean>;
 
@@ -36,4 +37,5 @@ export const DEFAULT_SETTINGS: Settings = {
   measureTypingPerf: false,
   showNestedEditorTreeView: false,
   showTreeView: true,
+  testSkipSelection: false,
 };

--- a/packages/lexical-playground/src/plugins/TestSkipSelectionPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TestSkipSelectionPlugin.tsx
@@ -14,7 +14,7 @@ import * as React from 'react';
 export default function TestSkipSelectionPlugin(): JSX.Element {
   const [editor] = useLexicalComposerContext();
 
-  const clickHandler = () => {
+  const typeHandler = () => {
     editor.update(
       () => {
         const selection = $getSelection();
@@ -26,9 +26,18 @@ export default function TestSkipSelectionPlugin(): JSX.Element {
     );
   };
 
+  const focusHandler = () => {
+    editor.focus();
+  };
+
   return (
-    <button className="skip-selection-button" onClick={clickHandler}>
-      Type foo
-    </button>
+    <>
+      <button className="skip-selection-type-button" onClick={typeHandler}>
+        Type foo
+      </button>
+      <button className="skip-selection-focus-button" onClick={focusHandler}>
+        Focus
+      </button>
+    </>
   );
 }

--- a/packages/lexical-playground/src/plugins/TestSkipSelectionPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TestSkipSelectionPlugin.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$getSelection, $isRangeSelection} from 'lexical';
+import * as React from 'react';
+
+export default function TestSkipSelectionPlugin(): JSX.Element {
+  const [editor] = useLexicalComposerContext();
+
+  const clickHandler = () => {
+    editor.update(
+      () => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          selection.insertText('foo');
+        }
+      },
+      {skipRootElementFocus: true},
+    );
+  };
+
+  return (
+    <button className="skip-selection-button" onClick={clickHandler}>
+      Type foo
+    </button>
+  );
+}

--- a/packages/lexical-react/src/shared/PlainRichTextUtils.js
+++ b/packages/lexical-react/src/shared/PlainRichTextUtils.js
@@ -20,6 +20,7 @@ const setEditorOptions: {
 } = options;
 const updateOptions: {
   onUpdate?: () => void,
+  skipRootElementFocus?: true,
   skipTransforms?: true,
   tag?: string,
 } = options;

--- a/packages/lexical-yjs/src/SyncEditorStates.js
+++ b/packages/lexical-yjs/src/SyncEditorStates.js
@@ -160,6 +160,7 @@ export function syncYjsChangesToLexical(
       onUpdate: () => {
         syncCursorPositions(binding, provider);
       },
+      skipRootElementFocus: true,
       skipTransforms: true,
       tag: 'collaboration',
     },

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -125,6 +125,7 @@ export declare class LexicalEditor {
   _dirtyElements: Map<NodeKey, IntentionallyMarkedAsDirtyElement>;
   _normalizedNodes: Set<NodeKey>;
   _updateTags: Set<string>;
+  _skipRootElementFocus: boolean;
   _observer: null | MutationObserver;
   _key: string;
   _readOnly: boolean;
@@ -170,6 +171,7 @@ type EditorUpdateOptions = {
   onUpdate?: () => void;
   tag?: string;
   skipTransforms?: true;
+  skipRootElementFocus?: true;
 };
 type EditorSetOptions = {
   tag?: string;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -129,6 +129,7 @@ declare export class LexicalEditor {
   _dirtyElements: Map<NodeKey, IntentionallyMarkedAsDirtyElement>;
   _normalizedNodes: Set<NodeKey>;
   _updateTags: Set<string>;
+  _skipRootElementFocus: boolean;
   _observer: null | MutationObserver;
   _key: string;
   _readOnly: boolean;
@@ -176,6 +177,7 @@ type EditorUpdateOptions = {
   onUpdate?: () => void,
   tag?: string,
   skipTransforms?: true,
+  skipRootElementFocus?: true,
 };
 type EditorSetOptions = {
   tag?: string,

--- a/packages/lexical/src/LexicalEditor.js
+++ b/packages/lexical/src/LexicalEditor.js
@@ -48,6 +48,7 @@ export type TextNodeThemeClasses = {
 
 export type EditorUpdateOptions = {|
   onUpdate?: () => void,
+  skipRootElementFocus?: true,
   skipTransforms?: true,
   tag?: string,
 |};
@@ -309,6 +310,7 @@ export class LexicalEditor {
   _dirtyElements: Map<NodeKey, IntentionallyMarkedAsDirtyElement>;
   _normalizedNodes: Set<NodeKey>;
   _updateTags: Set<string>;
+  _skipRootElementFocus: boolean;
   _observer: null | MutationObserver;
   _key: string;
   _onError: ErrorHandler;
@@ -363,6 +365,7 @@ export class LexicalEditor {
     this._dirtyElements = new Map();
     this._normalizedNodes = new Set();
     this._updateTags = new Set();
+    this._skipRootElementFocus = false;
     // Handling of DOM mutations
     this._observer = null;
     // Used for identifying owning editors

--- a/packages/lexical/src/LexicalReconciler.js
+++ b/packages/lexical/src/LexicalReconciler.js
@@ -812,15 +812,13 @@ function reconcileSelection(
   const focusOffset = domSelection.focusOffset;
   const activeElement = document.activeElement;
   const rootElement = editor._rootElement;
-  // TODO: make this not hard-coded, and add another config option
-  // that makes this configurable.
-  if (
-    editor._updateTags.has('collaboration') &&
-    activeElement !== rootElement
-  ) {
+  const rootElementHasFocus =
+    rootElement !== null &&
+    activeElement !== null &&
+    rootElement.contains(activeElement);
+  if (!rootElementHasFocus && editor._skipRootElementFocus) {
     return;
   }
-
   if (!$isRangeSelection(nextSelection)) {
     // We don't remove selection if the prevSelection is null because
     // of editor.setRootElement(). If this occurs on init when the
@@ -881,10 +879,6 @@ function reconcileSelection(
     );
   }
 
-  // Diff against the native DOM selection to ensure we don't do
-  // an unnecessary selection update. We also skip this check if
-  // we're moving selection to within an element, as this can
-  // sometimes be problematic around scrolling.
   if (
     anchorOffset === nextAnchorOffset &&
     focusOffset === nextFocusOffset &&
@@ -894,10 +888,7 @@ function reconcileSelection(
     !(domSelection.type === 'Range' && isCollapsed)
   ) {
     // If the root element does not have focus, ensure it has focus
-    if (
-      rootElement !== null &&
-      (activeElement === null || !rootElement.contains(activeElement))
-    ) {
+    if (rootElement !== null && !rootElementHasFocus) {
       rootElement.focus({preventScroll: true});
     }
     // In Safari/iOS if we have selection on an element, then we also

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -2100,11 +2100,7 @@ function internalResolveSelectionPoints(
   editor: LexicalEditor,
   lastSelection: null | RangeSelection | NodeSelection | GridSelection,
 ): null | [PointType, PointType] {
-  if (
-    anchorDOM === null ||
-    focusDOM === null ||
-    !isSelectionWithinEditor(editor, anchorDOM, focusDOM)
-  ) {
+  if (anchorDOM === null || focusDOM === null) {
     return null;
   }
   const resolvedAnchorPoint = internalResolveSelectionPoint(
@@ -2243,6 +2239,12 @@ function internalCreateRangeSelection(
     focusDOM = domSelection.focusNode;
     anchorOffset = domSelection.anchorOffset;
     focusOffset = domSelection.focusOffset;
+    if (
+      $isRangeSelection(lastSelection) &&
+      !isSelectionWithinEditor(editor, anchorDOM, focusDOM)
+    ) {
+      return lastSelection.clone();
+    }
   } else {
     return lastSelection.clone();
   }

--- a/packages/lexical/src/LexicalUpdates.js
+++ b/packages/lexical/src/LexicalUpdates.js
@@ -575,6 +575,8 @@ function beginUpdate(
     }
     skipTransforms = options.skipTransforms;
   }
+  editor._skipRootElementFocus =
+    (options !== undefined && options.skipRootElementFocus) || false;
   if (onUpdate) {
     editor._deferred.push(onUpdate);
   }


### PR DESCRIPTION
All updates (except readonly and `collaboration`) are forced selection reconciliation. This is not ideal when the user programmatically wants to update the content without forcing focus.

This PR adds an optional update flag, `skipRootElementFocus`, that will skip the root element focus when passed as true.

It is worth noting that the use of the flags is unideal for a11y reasons. For example, when you add an image you want to refocus the content to understand the changes but there may be edge cases where it's still suitable (and also was a demanded feature).
