### PR TITLE
Add non-intraword text formats

### DIFF
--- a/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
+++ b/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
@@ -38,6 +38,7 @@ export type ElementTransformer = {
 export type TextFormatTransformer = $ReadOnly<{
   format: $ReadOnlyArray<TextFormatType>,
   tag: string,
+  intraword?: boolean,
   type: 'text-format',
 }>;
 

--- a/packages/lexical-markdown/src/v2/MarkdownShortcuts.js
+++ b/packages/lexical-markdown/src/v2/MarkdownShortcuts.js
@@ -29,6 +29,8 @@ import {
 import {TRANSFORMERS} from '..';
 import {indexBy, transformersByType} from './utils';
 
+const PUNCTUATION_OR_SPACE = /[!-/:-@[-`{-~\s]/;
+
 function runElementTransformers(
   parentNode: ElementNode,
   anchorNode: TextNode,
@@ -150,6 +152,16 @@ function runTextFormatTransformers(
       continue;
     }
 
+    // Some tags can not be used within words, hence should have newline/space/punctuation after it
+    const afterCloseTagChar = textContent[closeTagEndIndex + 1];
+    if (
+      matcher.intraword === false &&
+      afterCloseTagChar &&
+      !PUNCTUATION_OR_SPACE.test(afterCloseTagChar)
+    ) {
+      continue;
+    }
+
     const closeNode = anchorNode;
     let openNode = closeNode;
 
@@ -196,6 +208,16 @@ function runTextFormatTransformers(
     if (
       openTagStartIndex > 0 &&
       prevOpenNodeText[openTagStartIndex - 1] === closeChar
+    ) {
+      continue;
+    }
+
+    // Some tags can not be used within words, hence should have newline/space/punctuation before it
+    const beforeOpenTagChar = prevOpenNodeText[openTagStartIndex - 1];
+    if (
+      matcher.intraword === false &&
+      beforeOpenTagChar &&
+      !PUNCTUATION_OR_SPACE.test(beforeOpenTagChar)
     ) {
       continue;
     }

--- a/packages/lexical-markdown/src/v2/MarkdownTransformers.js
+++ b/packages/lexical-markdown/src/v2/MarkdownTransformers.js
@@ -194,6 +194,7 @@ export const BOLD_ITALIC_STAR: TextFormatTransformer = {
 
 export const BOLD_ITALIC_UNDERSCORE: TextFormatTransformer = {
   format: ['bold', 'italic'],
+  intraword: false,
   tag: '___',
   type: 'text-format',
 };
@@ -206,6 +207,7 @@ export const BOLD_STAR: TextFormatTransformer = {
 
 export const BOLD_UNDERSCORE: TextFormatTransformer = {
   format: ['bold'],
+  intraword: false,
   tag: '__',
   type: 'text-format',
 };
@@ -224,6 +226,7 @@ export const ITALIC_STAR: TextFormatTransformer = {
 
 export const ITALIC_UNDERSCORE: TextFormatTransformer = {
   format: ['italic'],
+  intraword: false,
   tag: '_',
   type: 'text-format',
 };

--- a/packages/lexical-playground/__tests__/e2e/Markdown-v2.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown-v2.spec.mjs
@@ -6,7 +6,7 @@
  *
  */
 
-import {redo, undo} from '../keyboardShortcuts/index.mjs';
+import {moveLeft, redo, undo} from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
   clearEditor,
@@ -462,10 +462,10 @@ test.describe('Markdown', () => {
     await focusEditor(page);
     await pressToggleBold(page);
     await pressToggleUnderline(page);
-    await page.keyboard.type('h_e~~llo');
+    await page.keyboard.type('h*e~~llo');
     await pressToggleBold(page);
     await pressToggleUnderline(page);
-    await page.keyboard.type(' wo~~r_ld');
+    await page.keyboard.type(' wo~~r*ld');
     await assertHTML(
       page,
       html`
@@ -536,6 +536,36 @@ test.describe('Markdown', () => {
     await focusEditor(page);
     await page.keyboard.type(TYPED_MARKDOWN);
     await assertHTML(page, TYPED_MARKDOWN_HTML);
+  });
+
+  test('itraword text format', async ({page}) => {
+    await focusEditor(page);
+    await page.keyboard.type('he_llo_ world');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">he_llo_ world</span>
+        </p>
+      `,
+    );
+
+    await clearEditor(page);
+    await page.keyboard.type('_hello world');
+    await moveLeft(page, 3);
+    await page.keyboard.type('_');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">_hello wo_rld</span>
+        </p>
+      `,
+    );
   });
 });
 


### PR DESCRIPTION
`_` can not be used within words: `h_ell_o` should not be auto formatted into italic. In comparison `*` and `~` should be transformed in the same position