### PR TITLE
Better handling of siblings in md export

### DIFF
--- a/packages/lexical-markdown/src/v2/MarkdownExport.js
+++ b/packages/lexical-markdown/src/v2/MarkdownExport.js
@@ -175,12 +175,12 @@ function getTextSibling(node: TextNode, backward: boolean): TextNode | null {
       }
     }
 
-    if ($isLineBreakNode(sibling)) {
-      return null;
-    }
-
     if ($isTextNode(sibling)) {
       return sibling;
+    }
+
+    if (!$isElementNode(sibling)) {
+      return null;
     }
   }
 


### PR DESCRIPTION
This should be a better fix: instead of checking for linebreaks and decorators, all we care is to see if sibling is element (then traverse inside) or if it's a text node (then return)