### PR TITLE
Update Lexical.d.ts#dispatchCommand type

### DIFF
--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -148,7 +148,7 @@ export declare class LexicalEditor {
     klass: Class<T>,
     listener: Transform<T>,
   ): () => void;
-  dispatchCommand<P>(type: LexicalCommand<P>, payload: P): boolean;
+  dispatchCommand<P>(type: LexicalCommand<P>, payload?: P): boolean;
   hasNodes(nodes: Array<Class<LexicalNode>>): boolean;
   getKey(): string;
   getDecorators<X>(): Record<NodeKey, X>;


### PR DESCRIPTION
This PR corrects the `dispatchCommand` type, making payload optional

This allows consumers to not explicitly pass in undefined which seems like a reasonable DX improvement.

i.e. https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx#L624

Feel free to close if I'm missing something!