### PR TITLE
Fix @lexical/rich-text package.json

### DIFF
--- a/packages/lexical-rich-text/package.json
+++ b/packages/lexical-rich-text/package.json
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "version": "0.2.8",
-  "main": "LexicalRichText.ts",
+  "main": "LexicalRichText.js",
   "peerDependencies": {
     "lexical": "0.2.8",
     "@lexical/selection": "0.2.8",


### PR DESCRIPTION
The latest version 0.2.8 doesn't work for me, I assume it's because LexicalRichText.ts doesn't exist in the bundle