### PR TITLE
anotate onError is not optional type for who use vanilla-js in docs

### DIFF
--- a/packages/lexical-website-new/docs/getting-started/quick-start.md
+++ b/packages/lexical-website-new/docs/getting-started/quick-start.md
@@ -21,6 +21,7 @@ const config = {
   theme: {
     ...
   },
+  onError : console.warn // onError is not optional type
 };
 
 const editor = createEditor(config);

--- a/packages/lexical-website-new/docs/getting-started/quick-start.md
+++ b/packages/lexical-website-new/docs/getting-started/quick-start.md
@@ -21,7 +21,7 @@ const config = {
   theme: {
     ...
   },
-  onError : console.warn // onError is not optional type
+  onError: console.error
 };
 
 const editor = createEditor(config);


### PR DESCRIPTION
Instead of setting default onError on config  in createEditor.  i edit some docs for who use vanilla-js that onError is not optional. so include onError on config.