### PR TITLE
Ensure selection is not prematurely nulled out on blur

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Focus.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Focus.spec.mjs
@@ -6,7 +6,14 @@
  *
  */
 
-import {expect, focusEditor, initialize, test} from '../utils/index.mjs';
+import {
+  click,
+  evaluate,
+  expect,
+  focusEditor,
+  initialize,
+  test,
+} from '../utils/index.mjs';
 
 test.describe('Focus', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
@@ -20,5 +27,41 @@ test.describe('Focus', () => {
     });
 
     expect(isEditorFocused).toBe(false);
+  });
+
+  test(`selection remains internally when clicking outside the editor`, async ({
+    page,
+    isCollab,
+  }) => {
+    test.skip(isCollab);
+    const getInternalSelection = async () =>
+      await evaluate(page, () => {
+        return document
+          .querySelector(`div[contenteditable="true"]`)
+          .__lexicalEditor.getEditorState()._selection;
+      });
+    await focusEditor(page);
+    await page.keyboard.type('Hello world');
+    expect(await getInternalSelection()).toEqual(
+      expect.objectContaining({
+        anchor: expect.objectContaining({
+          offset: 11,
+        }),
+        focus: expect.objectContaining({
+          offset: 11,
+        }),
+      }),
+    );
+    await click(page, '.tree-view-output');
+    expect(await getInternalSelection()).toEqual(
+      expect.objectContaining({
+        anchor: expect.objectContaining({
+          offset: 11,
+        }),
+        focus: expect.objectContaining({
+          offset: 11,
+        }),
+      }),
+    );
   });
 });

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -101,6 +101,7 @@ import {
   isOpenLineBreak,
   isParagraph,
   isRedo,
+  isSelectionWithinEditor,
   isSpace,
   isTab,
   isUnderline,
@@ -170,9 +171,14 @@ function onSelectionChange(
   editor: LexicalEditor,
   isActive: boolean,
 ): void {
+  const {
+    anchorNode: anchorDOM,
+    anchorOffset,
+    focusNode: focusDOM,
+    focusOffset,
+  } = domSelection;
   if (isSelectionChangeFromReconcile) {
     isSelectionChangeFromReconcile = false;
-    const {anchorNode, anchorOffset, focusNode, focusOffset} = domSelection;
     // If native DOM selection is on a DOM element, then
     // we should continue as usual, as Lexical's selection
     // may have normalized to a better child. If the DOM
@@ -182,8 +188,8 @@ function onSelectionChange(
     // because in this case, we might need to normalize to a
     // sibling instead.
     if (
-      shouldSkipSelectionChange(anchorNode, anchorOffset) &&
-      shouldSkipSelectionChange(focusNode, focusOffset)
+      shouldSkipSelectionChange(anchorDOM, anchorOffset) &&
+      shouldSkipSelectionChange(focusDOM, focusOffset)
     ) {
       return;
     }
@@ -193,6 +199,9 @@ function onSelectionChange(
     // to reconcile selection (set it to null) to ensure that only one editor has non-null selection.
     if (!isActive) {
       $setSelection(null);
+      return;
+    }
+    if (!isSelectionWithinEditor(editor, anchorDOM, focusDOM)) {
       return;
     }
 

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -2244,6 +2244,13 @@ function internalCreateRangeSelection(
     focusDOM = domSelection.focusNode;
     anchorOffset = domSelection.anchorOffset;
     focusOffset = domSelection.focusOffset;
+    if (
+      isSelectionChange &&
+      $isRangeSelection(lastSelection) &&
+      !isSelectionWithinEditor(editor, anchorDOM, focusDOM)
+    ) {
+      return lastSelection.clone();
+    }
   } else {
     return lastSelection.clone();
   }


### PR DESCRIPTION
When the user moves selection outside the editor, we should aim to keep the selection object the same within the editor.