### PR TITLE
Update LexicalMarkdownShortcutPlugin.d.ts

### DIFF
--- a/packages/lexical-react/LexicalMarkdownShortcutPlugin.d.ts
+++ b/packages/lexical-react/LexicalMarkdownShortcutPlugin.d.ts
@@ -9,5 +9,5 @@
 import type {Transformer} from '@lexical/markdown';
 
 export default function LexicalMarkdownShortcutPlugin(arg0: {
-  transformers: Array<Transformer>;
+  transformers?: Array<Transformer>;
 }): JSX.Element | null;

--- a/packages/lexical-react/flow/LexicalMarkdownShortcutPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalMarkdownShortcutPlugin.js.flow
@@ -10,5 +10,5 @@
 import type {Transformer} from '@lexical/markdown';
 
 declare export default function LexicalMarkdownShortcutPlugin({
-  transformers: Array<Transformer>,
+  transformers?: Array<Transformer>,
 }): React$Node;

--- a/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.jsx
+++ b/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.jsx
@@ -43,7 +43,7 @@ const DEFAULT_TRANSFORMERS = [HR, ...TRANSFORMERS];
 
 export default function LexicalMarkdownShortcutPlugin({
   transformers = DEFAULT_TRANSFORMERS,
-}: $ReadOnly<{transformers: Array<Transformer>}>): null {
+}: $ReadOnly<{transformers?: Array<Transformer>}>): null {
   const [editor] = useLexicalComposerContext();
   useEffect(() => {
     return registerMarkdownShortcuts(editor, transformers);


### PR DESCRIPTION
In https://github.com/facebook/lexical/pull/2124 the `transformers` prop was made optional, but the type was never made optional. This fixes that!