### PR TITLE
Adjust selection to be after decorator node when moving selection to the end of decorator/linebreak

### DIFF
--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -155,7 +155,7 @@ function $createPoint(
 }
 
 function selectPointOnNode(point: PointType, node: LexicalNode): void {
-  const key = node.__key;
+  let key = node.__key;
   let offset = point.offset;
   let type = 'element';
   if ($isTextNode(node)) {
@@ -163,6 +163,18 @@ function selectPointOnNode(point: PointType, node: LexicalNode): void {
     const textContentLength = node.getTextContentSize();
     if (offset > textContentLength) {
       offset = textContentLength;
+    }
+  } else if (!$isElementNode(node)) {
+    const nextSibling = node.getNextSibling();
+    if ($isTextNode(nextSibling)) {
+      key = nextSibling.__key;
+      offset = 0;
+    } else {
+      const parentNode = node.getParent();
+      if (parentNode) {
+        key = parentNode.__key;
+        offset = node.getIndexWithinParent() + 1;
+      }
     }
   }
   point.set(key, offset, type);
@@ -179,7 +191,7 @@ export function $moveSelectionPointToEnd(
     } else {
       selectPointOnNode(point, node);
     }
-  } else if ($isTextNode(node)) {
+  } else {
     selectPointOnNode(point, node);
   }
 }


### PR DESCRIPTION
Replacing selected node with decorator/linebreak does not adjust selection properly. It supposed to move selection to the end of newly inserted node, which didn't happen for non-text/element nodes

Fix #2161