### PR TITLE
[Lexical Playground]: Fixes Excalidraw saved scenes rendering

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
@@ -85,10 +85,6 @@ export default function ExcalidrawImage({
 
   useEffect(() => {
     const setContent = async () => {
-      if (!appState) {
-        return;
-      }
-
       const svg: Element = await exportToSvg({
         appState,
         elements,


### PR DESCRIPTION
Hi there, Excalidraw core team member here 👋🏽

I was just playing around with the playground and realized that the saved scenes weren't being rendered because of the `appState` props null checking, we don't really need the `appState` when rendering the scenes.

<img width="1050" alt="Capture d’écran 2022-05-14 à 22 55 30" src="https://user-images.githubusercontent.com/23306911/168447977-ddc0a223-45b3-48f1-a386-13bdd54b441a.png">

