### PR TITLE
Ensure window.event is valid

### DIFF
--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -201,7 +201,10 @@ function onSelectionChange(
         // If we have marked a collapsed selection format, and we're
         // within the given time range – then attempt to use that format
         // instead of getting the format from the anchor node.
-        const currentTimeStamp = window.event.timeStamp;
+        const windowEvent = window.event;
+        const currentTimeStamp = windowEvent
+          ? windowEvent.timeStamp
+          : performance.now();
         const [lastFormat, lastOffset, lastKey, timeStamp] =
           collapsedSelectionFormat;
 

--- a/packages/lexical/src/LexicalSelection.js
+++ b/packages/lexical/src/LexicalSelection.js
@@ -2190,11 +2190,6 @@ export function $createEmptyGridSelection(): GridSelection {
   return new GridSelection('root', anchor, focus);
 }
 
-function getActiveEventType(): string | void {
-  const event = window.event;
-  return event && event.type;
-}
-
 export function internalCreateSelection(
   editor: LexicalEditor,
 ): null | RangeSelection | NodeSelection | GridSelection {
@@ -2228,7 +2223,8 @@ function internalCreateRangeSelection(
   // reconciliation unless there are dirty nodes that need
   // reconciling.
 
-  const eventType = getActiveEventType();
+  const windowEvent = window.event;
+  const eventType = windowEvent ? windowEvent.type : undefined;
   const isSelectionChange = eventType === 'selectionchange';
   const useDOMSelection =
     !getIsProcesssingMutations() &&
@@ -2236,7 +2232,7 @@ function internalCreateRangeSelection(
       eventType === 'beforeinput' ||
       eventType === 'compositionstart' ||
       eventType === 'compositionend' ||
-      (eventType === 'click' && window.event.detail === 3) ||
+      (eventType === 'click' && windowEvent && windowEvent.detail === 3) ||
       eventType === undefined);
   let anchorDOM, focusDOM, anchorOffset, focusOffset;
 


### PR DESCRIPTION
We should be validating `window.event` is valid before attempting to use it.