### PR TITLE
Fix editor-state.md

### DIFF
--- a/packages/lexical-website-new/docs/concepts/editor-state.md
+++ b/packages/lexical-website-new/docs/concepts/editor-state.md
@@ -37,7 +37,7 @@ registerRichText(editor, initialEditorState);
 
 // Handler to store content (e.g. when user submits a form)
 const onSubmit = () => {
-  await saveContent(editor.getEditorState().toJSON());
+  await saveContent(JSON.stringify(editor.getEditorState()));
 }
 ```
 
@@ -52,7 +52,7 @@ const editorStateRef = useRef();
   <LexicalOnChangePlugin onChange={editorState => editorStateRef.current = editorState} />
   <Button label="Save" onPress={() => {
     if (editorStateRef.current) {
-      saveContent(editorStateRef.current.toJSON())
+      saveContent(JSON.stringify(editorStateRef.current))
     }
   }} />
 </LexicalComposer>


### PR DESCRIPTION
We should be recommending people to use `JSON.stringify(editorState)` directly.