### PR TITLE
Add intraword format support for Markdown import

### DIFF
--- a/packages/lexical-markdown/src/v2/MarkdownShortcuts.js
+++ b/packages/lexical-markdown/src/v2/MarkdownShortcuts.js
@@ -27,9 +27,7 @@ import {
 } from 'lexical';
 
 import {TRANSFORMERS} from '..';
-import {indexBy, transformersByType} from './utils';
-
-const PUNCTUATION_OR_SPACE = /[!-/:-@[-`{-~\s]/;
+import {indexBy, PUNCTUATION_OR_SPACE, transformersByType} from './utils';
 
 function runElementTransformers(
   parentNode: ElementNode,

--- a/packages/lexical-markdown/src/v2/utils.js
+++ b/packages/lexical-markdown/src/v2/utils.js
@@ -47,3 +47,5 @@ export function transformersByType(
     textMatch: byType['text-match'],
   };
 }
+
+export const PUNCTUATION_OR_SPACE: RegExp = /[!-/:-@[-`{-~\s]/;

--- a/packages/lexical-playground/__tests__/e2e/Markdown-v2.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown-v2.spec.mjs
@@ -766,6 +766,7 @@ const IMPORTED_MARKDOWN = `# Markdown Import
 This is *italic*, _italic_, **bold**, __bold__, ~~strikethrough~~ text
 This is *__~~bold italic strikethrough~~__* text, ___~~this one too~~___
 It ~~___works [with links](https://lexical.io)___~~ too
+Links [with underscores](https://lexical.io/tag_here_and__here__and___here___too)
 *Nested **stars tags** are handled too*
 ### Headings
 # h1 Heading
@@ -866,6 +867,17 @@ const IMPORTED_MARKDOWN_HTML = html`
       </strong>
     </a>
     <span data-lexical-text="true">too</span>
+  </p>
+  <p
+    class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <span data-lexical-text="true">Links</span>
+    <a
+      href="https://lexical.io/tag_here_and__here__and___here___too"
+      class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+      dir="ltr">
+      <span data-lexical-text="true">with underscores</span>
+    </a>
   </p>
   <p
     class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"

--- a/packages/lexical-playground/src/plugins/MarkdownTransformers.ts
+++ b/packages/lexical-playground/src/plugins/MarkdownTransformers.ts
@@ -31,6 +31,7 @@ import {
   $isTableRowNode,
   TableCellHeaderStates,
   TableCellNode,
+  TableNode,
 } from '@lexical/table';
 import {
   $createParagraphNode,
@@ -102,23 +103,21 @@ export const EQUATION: TextMatchTransformer = {
   type: 'text-match',
 };
 
-export const TWEET: TextMatchTransformer = {
-  export: (node, exportChildren, exportFormat) => {
+export const TWEET: ElementTransformer = {
+  export: (node) => {
     if (!$isTweetNode(node)) {
       return null;
     }
 
     return `<tweet id="${node.getId()}" />`;
   },
-  importRegExp: /<tweet id="([^"]+?)"\s?\/>/,
-  regExp: /<tweet id="([^"]+?)"\s?\/>$/,
-  replace: (textNode, match) => {
+  regExp: /<tweet id="([^"]+?)"\s?\/>\s?$/,
+  replace: (textNode, _1, match) => {
     const [, id] = match;
     const tweetNode = $createTweetNode(id);
     textNode.replace(tweetNode);
   },
-  trigger: '>',
-  type: 'text-match',
+  type: 'element',
 };
 
 // Very primitive table setup
@@ -203,11 +202,26 @@ export const TABLE: ElementTransformer = {
       }
     }
 
-    parentNode.replace(table);
+    const previousSibling = parentNode.getPreviousSibling();
+    if (
+      $isTableNode(previousSibling) &&
+      getTableColumnsSize(previousSibling) === maxCells
+    ) {
+      previousSibling.append(...table.getChildren());
+      parentNode.remove();
+    } else {
+      parentNode.replace(table);
+    }
+
     table.selectEnd();
   },
   type: 'element',
 };
+
+function getTableColumnsSize(table: TableNode) {
+  const row = table.getFirstChild();
+  return $isTableRowNode(row) ? row.getChildrenSize() : 0;
+}
 
 const createTableCell = (
   textContent: string | null | undefined,


### PR DESCRIPTION
- Similar to #2136 which added intraword into markdown shortcuts (`_` should not be converted into italic if not surrounded with space/punctuation/newline), handling it during markdown import
- Couple fixes for playground transformers (table & tweet)

Fix #2159