### PR TITLE
Remove default exports from synced packages

### DIFF
--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import LexicalComposer from '@lexical/react/LexicalComposer';
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
 import * as React from 'react';
 
 import {isDevPlayground} from './appSettings';

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -8,19 +8,19 @@
 
 import {$createLinkNode} from '@lexical/link';
 import {$createListItemNode, $createListNode} from '@lexical/list';
-import AutoFocusPlugin from '@lexical/react/LexicalAutoFocusPlugin';
-import AutoScrollPlugin from '@lexical/react/LexicalAutoScrollPlugin';
-import CharacterLimitPlugin from '@lexical/react/LexicalCharacterLimitPlugin';
-import CheckListPlugin from '@lexical/react/LexicalCheckListPlugin';
-import LexicalClearEditorPlugin from '@lexical/react/LexicalClearEditorPlugin';
+import {AutoFocusPlugin} from '@lexical/react/LexicalAutoFocusPlugin';
+import {AutoScrollPlugin} from '@lexical/react/LexicalAutoScrollPlugin';
+import {CharacterLimitPlugin} from '@lexical/react/LexicalCharacterLimitPlugin';
+import {CheckListPlugin} from '@lexical/react/LexicalCheckListPlugin';
+import {ClearEditorPlugin} from '@lexical/react/LexicalClearEditorPlugin';
 import {CollaborationPlugin} from '@lexical/react/LexicalCollaborationPlugin';
-import HashtagsPlugin from '@lexical/react/LexicalHashtagPlugin';
+import {HashtagPlugin} from '@lexical/react/LexicalHashtagPlugin';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
-import LinkPlugin from '@lexical/react/LexicalLinkPlugin';
-import ListPlugin from '@lexical/react/LexicalListPlugin';
-import PlainTextPlugin from '@lexical/react/LexicalPlainTextPlugin';
-import RichTextPlugin from '@lexical/react/LexicalRichTextPlugin';
-import TablesPlugin from '@lexical/react/LexicalTablePlugin';
+import {LinkPlugin} from '@lexical/react/LexicalLinkPlugin';
+import {ListPlugin} from '@lexical/react/LexicalListPlugin';
+import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {TablePlugin} from '@lexical/react/LexicalTablePlugin';
 import {$createHeadingNode, $createQuoteNode} from '@lexical/rich-text';
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
 import * as React from 'react';
@@ -171,10 +171,10 @@ export default function Editor(): JSX.Element {
         }`}
         ref={scrollRef}>
         <AutoFocusPlugin />
-        <LexicalClearEditorPlugin />
+        <ClearEditorPlugin />
         <MentionsPlugin />
         <EmojisPlugin />
-        <HashtagsPlugin />
+        <HashtagPlugin />
         <KeywordsPlugin />
         <SpeechToTextPlugin />
         <AutoLinkPlugin />
@@ -203,7 +203,7 @@ export default function Editor(): JSX.Element {
             <ListPlugin />
             <CheckListPlugin />
             <ListMaxIndentLevelPlugin maxDepth={7} />
-            <TablesPlugin />
+            <TablePlugin />
             <TableCellActionMenuPlugin />
             <TableCellResizer />
             <ImagesPlugin />

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -10,7 +10,7 @@ import type {ExcalidrawElementFragment} from './ExcalidrawModal';
 import type {EditorConfig, LexicalEditor, LexicalNode, NodeKey} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import useLexicalNodeSelection from '@lexical/react/useLexicalNodeSelection';
+import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -21,13 +21,13 @@ import {
   useCollaborationContext,
 } from '@lexical/react/LexicalCollaborationPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import HashtagsPlugin from '@lexical/react/LexicalHashtagPlugin';
+import {HashtagPlugin} from '@lexical/react/LexicalHashtagPlugin';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
-import LinkPlugin from '@lexical/react/LexicalLinkPlugin';
-import LexicalNestedComposer from '@lexical/react/LexicalNestedComposer';
-import RichTextPlugin from '@lexical/react/LexicalRichTextPlugin';
-import TablesPlugin from '@lexical/react/LexicalTablePlugin';
-import useLexicalNodeSelection from '@lexical/react/useLexicalNodeSelection';
+import {LinkPlugin} from '@lexical/react/LexicalLinkPlugin';
+import {LexicalNestedComposer} from '@lexical/react/LexicalNestedComposer';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {TablePlugin} from '@lexical/react/LexicalTablePlugin';
+import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
@@ -246,12 +246,12 @@ function ImageComponent({
           <div className="image-caption-container">
             <LexicalNestedComposer initialEditor={caption}>
               <MentionsPlugin />
-              <TablesPlugin />
+              <TablePlugin />
               <TableCellActionMenuPlugin />
               <ImagesPlugin />
               <LinkPlugin />
               <EmojisPlugin />
-              <HashtagsPlugin />
+              <HashtagPlugin />
               <KeywordsPlugin />
               {isCollab ? (
                 <CollaborationPlugin

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -16,8 +16,8 @@ import {
 } from '@lexical/react/LexicalCollaborationPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
-import LexicalNestedComposer from '@lexical/react/LexicalNestedComposer';
-import PlainTextPlugin from '@lexical/react/LexicalPlainTextPlugin';
+import {LexicalNestedComposer} from '@lexical/react/LexicalNestedComposer';
+import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
 import {
   $getNodeByKey,
   $setSelection,

--- a/packages/lexical-playground/src/plugins/AutoLinkPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/AutoLinkPlugin.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import LexicalAutoLinkPlugin from '@lexical/react/LexicalAutoLinkPlugin';
+import {AutoLinkPlugin} from '@lexical/react/LexicalAutoLinkPlugin';
 import * as React from 'react';
 
 const URL_MATCHER =
@@ -40,6 +40,6 @@ const MATCHERS = [
   },
 ];
 
-export default function AutoLinkPlugin(): JSX.Element {
-  return <LexicalAutoLinkPlugin matchers={MATCHERS} />;
+export default function LexicalAutoLinkPlugin(): JSX.Element {
+  return <AutoLinkPlugin matchers={MATCHERS} />;
 }

--- a/packages/lexical-playground/src/plugins/CommentPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin.tsx
@@ -24,13 +24,13 @@ import {
   $wrapSelectionInMarkNode,
   MarkNode,
 } from '@lexical/mark';
-import AutoFocusPlugin from '@lexical/react/LexicalAutoFocusPlugin';
-import LexicalClearEditorPlugin from '@lexical/react/LexicalClearEditorPlugin';
-import LexicalComposer from '@lexical/react/LexicalComposer';
+import {AutoFocusPlugin} from '@lexical/react/LexicalAutoFocusPlugin';
+import {ClearEditorPlugin} from '@lexical/react/LexicalClearEditorPlugin';
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
-import LexicalOnChangePlugin from '@lexical/react/LexicalOnChangePlugin';
-import PlainTextPlugin from '@lexical/react/LexicalPlainTextPlugin';
+import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
+import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
 import {createDOMRange, createRectsFromDOMRange} from '@lexical/selection';
 import {$isRootTextContentEmpty, $rootTextContentCurry} from '@lexical/text';
 import {mergeRegister, registerNestedElementResolver} from '@lexical/utils';
@@ -173,11 +173,11 @@ function PlainTextEditor({
           contentEditable={<ContentEditable className={className} />}
           placeholder={<Placeholder>{placeholder}</Placeholder>}
         />
-        <LexicalOnChangePlugin onChange={onChange} />
+        <OnChangePlugin onChange={onChange} />
         <HistoryPlugin />
         {autoFocus !== false && <AutoFocusPlugin />}
         <EscapeHandlerPlugin onEscape={onEscape} />
-        <LexicalClearEditorPlugin />
+        <ClearEditorPlugin />
         {editorRef !== undefined && <EditorRefPlugin editorRef={editorRef} />}
       </div>
     </LexicalComposer>

--- a/packages/lexical-playground/src/plugins/KeywordsPlugin.ts
+++ b/packages/lexical-playground/src/plugins/KeywordsPlugin.ts
@@ -9,7 +9,7 @@
 import type {TextNode} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import useLexicalTextEntity from '@lexical/react/useLexicalTextEntity';
+import {useLexicalTextEntity} from '@lexical/react/useLexicalTextEntity';
 import {useCallback, useEffect} from 'react';
 
 import {$createKeywordNode, KeywordNode} from '../nodes/KeywordNode';

--- a/packages/lexical-playground/src/plugins/MarkdownShortcutPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/MarkdownShortcutPlugin.tsx
@@ -6,13 +6,11 @@
  *
  */
 
-import LexicalMarkdownShortcutPlugin from '@lexical/react/LexicalMarkdownShortcutPlugin';
+import {MarkdownShortcutPlugin} from '@lexical/react/LexicalMarkdownShortcutPlugin';
 import * as React from 'react';
 
 import {PLAYGROUND_TRANSFORMERS} from './MarkdownTransformers';
 
 export default function MarkdownPlugin(): JSX.Element {
-  return (
-    <LexicalMarkdownShortcutPlugin transformers={PLAYGROUND_TRANSFORMERS} />
-  );
+  return <MarkdownShortcutPlugin transformers={PLAYGROUND_TRANSFORMERS} />;
 }

--- a/packages/lexical-playground/src/plugins/TreeViewPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TreeViewPlugin.tsx
@@ -7,13 +7,13 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import LexicalTreeView from '@lexical/react/LexicalTreeView';
+import {TreeView} from '@lexical/react/LexicalTreeView';
 import * as React from 'react';
 
 export default function TreeViewPlugin(): JSX.Element {
   const [editor] = useLexicalComposerContext();
   return (
-    <LexicalTreeView
+    <TreeView
       viewClassName="tree-view-output"
       timeTravelPanelClassName="debug-timetravel-panel"
       timeTravelButtonClassName="debug-timetravel-button"

--- a/packages/lexical-playground/src/ui/ContentEditable.tsx
+++ b/packages/lexical-playground/src/ui/ContentEditable.tsx
@@ -8,15 +8,13 @@
 
 import './ContentEditable.css';
 
-import LexicalContentEditable from '@lexical/react/LexicalContentEditable';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import * as React from 'react';
 
-export default function ContentEditable({
+export default function LexicalContentEditable({
   className,
 }: {
   className?: string;
 }): JSX.Element {
-  return (
-    <LexicalContentEditable className={className || 'ContentEditable__root'} />
-  );
+  return <ContentEditable className={className || 'ContentEditable__root'} />;
 }

--- a/packages/lexical-react/LexicalAutoFocusPlugin.d.ts
+++ b/packages/lexical-react/LexicalAutoFocusPlugin.d.ts
@@ -6,4 +6,4 @@
  *
  */
 
-export default function LexicalAutoFocusPlugin(): null;
+export function AutoFocusPlugin(): null;

--- a/packages/lexical-react/LexicalAutoLinkPlugin.d.ts
+++ b/packages/lexical-react/LexicalAutoLinkPlugin.d.ts
@@ -14,7 +14,7 @@ type LinkMatcherResult = {
   index: number;
 };
 export type LinkMatcher = (text: string) => LinkMatcherResult | null;
-export default function LexicalAutoLinkPlugin(props: {
+export function AutoLinkPlugin(props: {
   matchers: Array<LinkMatcher>;
   onChange?: ChangeHandler;
 }): JSX.Element | null;

--- a/packages/lexical-react/LexicalAutoScrollPlugin.d.ts
+++ b/packages/lexical-react/LexicalAutoScrollPlugin.d.ts
@@ -9,4 +9,4 @@
 type Props = Readonly<{
   scrollRef: {current: HTMLElement | null};
 }>;
-export default function LexicalAutoScrollPlugin(props: Props): null;
+export function AutoScrollPlugin(props: Props): null;

--- a/packages/lexical-react/LexicalCharacterLimitPlugin.d.ts
+++ b/packages/lexical-react/LexicalCharacterLimitPlugin.d.ts
@@ -6,6 +6,6 @@
  *
  */
 
-export default function LexicalCharacterLimitPlugin(props: {
+export function CharacterLimitPlugin(props: {
   charset: 'UTF-8' | 'UTF-16';
 }): JSX.Element | null;

--- a/packages/lexical-react/LexicalCheckListPlugin.d.ts
+++ b/packages/lexical-react/LexicalCheckListPlugin.d.ts
@@ -6,4 +6,4 @@
  *
  */
 
-export default function LexicalCheckListPlugin(): null;
+export function CheckListPlugin(): null;

--- a/packages/lexical-react/LexicalClearEditorPlugin.d.ts
+++ b/packages/lexical-react/LexicalClearEditorPlugin.d.ts
@@ -11,6 +11,4 @@ import {$ReadOnly} from 'utility-types';
 type Props = $ReadOnly<{
   onClear?: () => void;
 }>;
-export default function LexicalClearEditorPlugin(
-  arg0: Props,
-): JSX.Element | null;
+export function ClearEditorPlugin(arg0: Props): JSX.Element | null;

--- a/packages/lexical-react/LexicalComposer.d.ts
+++ b/packages/lexical-react/LexicalComposer.d.ts
@@ -19,4 +19,4 @@ type Props = {
   };
   children: JSX.Element | JSX.Element[] | null;
 };
-export default function LexicalComposer(arg0: Props): JSX.Element | null;
+export function LexicalComposer(arg0: Props): JSX.Element | null;

--- a/packages/lexical-react/LexicalContentEditable.d.ts
+++ b/packages/lexical-react/LexicalContentEditable.d.ts
@@ -29,6 +29,4 @@ export type Props = $ReadOnly<{
   tabIndex?: number;
   testid?: string;
 }>;
-export default function LexicalContentEditable(
-  props: Props,
-): JSX.Element | null;
+export function ContentEditable(props: Props): JSX.Element | null;

--- a/packages/lexical-react/LexicalHashtagPlugin.d.ts
+++ b/packages/lexical-react/LexicalHashtagPlugin.d.ts
@@ -6,4 +6,4 @@
  *
  */
 
-export default function LexicalHashtagPlugin(): JSX.Element | null;
+export function HashtagPlugin(): JSX.Element | null;

--- a/packages/lexical-react/LexicalLinkPlugin.d.ts
+++ b/packages/lexical-react/LexicalLinkPlugin.d.ts
@@ -6,4 +6,4 @@
  *
  */
 
-export default function LexicalLinkPlugin(): null;
+export function LinkPlugin(): null;

--- a/packages/lexical-react/LexicalListPlugin.d.ts
+++ b/packages/lexical-react/LexicalListPlugin.d.ts
@@ -6,4 +6,4 @@
  *
  */
 
-export default function ListPlugin(): null;
+export function ListPlugin(): null;

--- a/packages/lexical-react/LexicalMarkdownShortcutPlugin.d.ts
+++ b/packages/lexical-react/LexicalMarkdownShortcutPlugin.d.ts
@@ -8,6 +8,6 @@
 
 import type {Transformer} from '@lexical/markdown';
 
-export default function LexicalMarkdownShortcutPlugin(arg0: {
+export function MarkdownShortcutPlugin(arg0: {
   transformers?: Array<Transformer>;
 }): JSX.Element | null;

--- a/packages/lexical-react/LexicalNestedComposer.d.ts
+++ b/packages/lexical-react/LexicalNestedComposer.d.ts
@@ -8,7 +8,7 @@
 
 import type {LexicalEditor, EditorThemeClasses} from 'lexical';
 
-export default function LexicalNestedComposer(arg0: {
+export function LexicalNestedComposer(arg0: {
   initialEditor: LexicalEditor;
   initialTheme?: EditorThemeClasses;
   children: JSX.Element | (JSX.Element | string | null)[] | null;

--- a/packages/lexical-react/LexicalOnChangePlugin.d.ts
+++ b/packages/lexical-react/LexicalOnChangePlugin.d.ts
@@ -7,7 +7,7 @@
  */
 
 import type {EditorState, LexicalEditor} from 'lexical';
-export default function OnChangePlugin(arg0: {
+export function OnChangePlugin(arg0: {
   ignoreInitialChange?: boolean;
   ignoreSelectionChange?: boolean;
   onChange: (editorState: EditorState, editor: LexicalEditor) => void;

--- a/packages/lexical-react/LexicalPlainTextPlugin.d.ts
+++ b/packages/lexical-react/LexicalPlainTextPlugin.d.ts
@@ -8,7 +8,7 @@
 
 import type {EditorState} from 'lexical';
 type InitialEditorStateType = null | string | EditorState | (() => void);
-export default function PlainTextPlugin(arg0: {
+export function PlainTextPlugin(arg0: {
   contentEditable: JSX.Element | null;
   initialEditorState?: InitialEditorStateType;
   placeholder: JSX.Element | null;

--- a/packages/lexical-react/LexicalRichTextPlugin.d.ts
+++ b/packages/lexical-react/LexicalRichTextPlugin.d.ts
@@ -8,7 +8,7 @@
 
 import type {EditorState} from 'lexical';
 type InitialEditorStateType = null | string | EditorState | (() => void);
-export default function RichTextPlugin(arg0: {
+export function RichTextPlugin(arg0: {
   contentEditable: JSX.Element | null;
   initialEditorState?: InitialEditorStateType;
   placeholder: JSX.Element | null;

--- a/packages/lexical-react/LexicalTablePlugin.d.ts
+++ b/packages/lexical-react/LexicalTablePlugin.d.ts
@@ -6,4 +6,4 @@
  *
  */
 
-export default function LexicalTablePlugin(): null;
+export function TablePlugin(): null;

--- a/packages/lexical-react/LexicalTreeView.d.ts
+++ b/packages/lexical-react/LexicalTreeView.d.ts
@@ -7,7 +7,7 @@
  */
 
 import type {LexicalEditor} from 'lexical';
-export default function TreeView(props: {
+export function TreeView(props: {
   timeTravelPanelClassName: string;
   timeTravelPanelSliderClassName: string;
   timeTravelPanelButtonClassName: string;

--- a/packages/lexical-react/flow/LexicalAutoFocusPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalAutoFocusPlugin.js.flow
@@ -7,4 +7,4 @@
  * @flow strict
  */
 
-declare export default function LexicalAutoFocusPlugin(): null;
+declare export function AutoFocusPlugin(): null;

--- a/packages/lexical-react/flow/LexicalAutoLinkPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalAutoLinkPlugin.js.flow
@@ -17,7 +17,7 @@ type LinkMatcherResult = {
 };
 export type LinkMatcher = (text: string) => LinkMatcherResult | null;
 
-declare export default function LexicalAutoLinkPlugin(props: {
+declare export function AutoLinkPlugin(props: {
   matchers: Array<LinkMatcher>,
   onChange?: ChangeHandler,
 }): React$Node;

--- a/packages/lexical-react/flow/LexicalAutoScrollPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalAutoScrollPlugin.js.flow
@@ -9,6 +9,4 @@
 type Props = $ReadOnly<{
   scrollRef: {current: HTMLElement | null},
 }>;
-declare export default function LexicalAutoScrollPlugin(
-  props: Props,
-): React$Node;
+declare export function AutoScrollPlugin(props: Props): React$Node;

--- a/packages/lexical-react/flow/LexicalCharacterLimitPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalCharacterLimitPlugin.js.flow
@@ -7,6 +7,6 @@
  * @flow strict
  */
 
-declare export default function LexicalCharacterLimitPlugin(props: {
+declare export function CharacterLimitPlugin(props: {
   charset: 'UTF-8' | 'UTF-16',
 }): React$Node;

--- a/packages/lexical-react/flow/LexicalCheckListPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalCheckListPlugin.js.flow
@@ -7,4 +7,4 @@
  * @flow strict
  */
 
-declare export default function LexicalCheckListPlugin(): null;
+declare export function CheckListPlugin(): null;

--- a/packages/lexical-react/flow/LexicalClearEditorPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalClearEditorPlugin.js.flow
@@ -11,4 +11,4 @@ type Props = $ReadOnly<{
   onClear?: () => void,
 }>;
 
-declare export default function LexicalClearEditorPlugin(Props): React$Node;
+declare export function ClearEditorPlugin(Props): React$Node;

--- a/packages/lexical-react/flow/LexicalComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalComposer.js.flow
@@ -21,4 +21,4 @@ type Props = {
   children: React$Node,
 };
 
-declare export default function LexicalComposer(Props): React$MixedElement;
+declare export function LexicalComposer(Props): React$MixedElement;

--- a/packages/lexical-react/flow/LexicalContentEditable.js.flow
+++ b/packages/lexical-react/flow/LexicalContentEditable.js.flow
@@ -30,6 +30,4 @@ export type Props = $ReadOnly<{
   testid?: string,
 }>;
 
-declare export default function LexicalContentEditable(
-  props: Props,
-): React$Node;
+declare export function ContentEditable(props: Props): React$Node;

--- a/packages/lexical-react/flow/LexicalHashtagPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalHashtagPlugin.js.flow
@@ -7,4 +7,4 @@
  * @flow strict
  */
 
-declare export default function LexicalHashtagPlugin(): React$Node;
+declare export function HashtagPlugin(): React$Node;

--- a/packages/lexical-react/flow/LexicalLinkPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalLinkPlugin.js.flow
@@ -7,4 +7,4 @@
  * @flow strict
  */
 
-declare export default function LexicalLinkPlugin(): null;
+declare export function LinkPlugin(): null;

--- a/packages/lexical-react/flow/LexicalListPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalListPlugin.js.flow
@@ -7,4 +7,4 @@
  * @flow strict
  */
 
-declare export default function ListPlugin(): null;
+declare export function ListPlugin(): null;

--- a/packages/lexical-react/flow/LexicalMarkdownShortcutPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalMarkdownShortcutPlugin.js.flow
@@ -9,6 +9,6 @@
 
 import type {Transformer} from '@lexical/markdown';
 
-declare export default function LexicalMarkdownShortcutPlugin({
+declare export function MarkdownShortcutPlugin({
   transformers?: Array<Transformer>,
 }): React$Node;

--- a/packages/lexical-react/flow/LexicalNestedComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalNestedComposer.js.flow
@@ -9,7 +9,7 @@
 
 import type {LexicalEditor, EditorThemeClasses, LexicalNode} from 'lexical';
 
-declare export default function LexicalNestedComposer({
+declare export function LexicalNestedComposer({
   children: React$Node,
   initialEditor: LexicalEditor,
   initialTheme?: EditorThemeClasses,

--- a/packages/lexical-react/flow/LexicalOnChangePlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalOnChangePlugin.js.flow
@@ -9,7 +9,7 @@
 
 import type {EditorState, LexicalEditor} from 'lexical';
 
-declare export default function OnChangePlugin({
+declare export function OnChangePlugin({
   ignoreInitialChange?: boolean,
   ignoreSelectionChange?: boolean,
   onChange: (editorState: EditorState, editor: LexicalEditor) => void,

--- a/packages/lexical-react/flow/LexicalPlainTextPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalPlainTextPlugin.js.flow
@@ -11,7 +11,7 @@ import type {EditorState} from 'lexical';
 
 type InitialEditorStateType = null | string | EditorState | (() => void);
 
-declare export default function PlainTextPlugin({
+declare export function PlainTextPlugin({
   contentEditable: React$Node,
   initialEditorState?: InitialEditorStateType,
   placeholder: React$Node,

--- a/packages/lexical-react/flow/LexicalRichTextPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalRichTextPlugin.js.flow
@@ -11,7 +11,7 @@ import type {EditorState} from 'lexical';
 
 type InitialEditorStateType = null | string | EditorState | (() => void);
 
-declare export default function RichTextPlugin({
+declare export function RichTextPlugin({
   contentEditable: React$Node,
   initialEditorState?: InitialEditorStateType,
   placeholder: React$Node,

--- a/packages/lexical-react/flow/LexicalTablePlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalTablePlugin.js.flow
@@ -7,4 +7,4 @@
  * @flow strict
  */
 
-declare export default function LexicalTablePlugin(): null;
+declare export function TablePlugin(): null;

--- a/packages/lexical-react/flow/LexicalTreeView.js.flow
+++ b/packages/lexical-react/flow/LexicalTreeView.js.flow
@@ -9,7 +9,7 @@
 
 import type {LexicalEditor} from 'lexical';
 
-declare export default function TreeView(props: {
+declare export function TreeView(props: {
   timeTravelPanelClassName: string,
   timeTravelPanelSliderClassName: string,
   timeTravelPanelButtonClassName: string,

--- a/packages/lexical-react/flow/useLexicalIsTextContentEmpty.js.flow
+++ b/packages/lexical-react/flow/useLexicalIsTextContentEmpty.js.flow
@@ -9,7 +9,7 @@
 
 import type {LexicalEditor} from 'lexical';
 
-declare export default function useLexicalIsTextContentEmpty(
+declare export function useLexicalIsTextContentEmpty(
   editor: LexicalEditor,
   trim?: boolean,
 ): boolean;

--- a/packages/lexical-react/flow/useLexicalNodeSelection.js.flow
+++ b/packages/lexical-react/flow/useLexicalNodeSelection.js.flow
@@ -9,6 +9,6 @@
 
 import type {NodeKey} from 'lexical';
 
-declare export default function useLexicalNodeSelection(
+declare export function useLexicalNodeSelection(
   key: NodeKey,
 ): [boolean, (boolean) => void, () => void];

--- a/packages/lexical-react/flow/useLexicalTextEntity.js.flow
+++ b/packages/lexical-react/flow/useLexicalTextEntity.js.flow
@@ -11,7 +11,7 @@ import type {TextNode} from 'lexical';
 
 export type EntityMatch = {end: number, start: number};
 
-declare export default function useLexicalTextEntity<N: TextNode>(
+declare export function useLexicalTextEntity<N: TextNode>(
   getMatch: (text: string) => null | EntityMatch,
   targetNode: Class<N>,
   createNode: (textNode: TextNode) => N,

--- a/packages/lexical-react/src/DEPRECATED_useLexical.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexical.js
@@ -17,9 +17,9 @@ import type {
 import {createEditor} from 'lexical';
 import {useMemo} from 'react';
 
-import useLexicalEditor from './DEPRECATED_useLexicalEditor';
+import {useLexicalEditor} from './DEPRECATED_useLexicalEditor';
 
-export default function useLexical(editorConfig: {
+export function useLexical(editorConfig: {
   disableEvents?: boolean,
   editorState?: EditorState,
   namespace?: string,

--- a/packages/lexical-react/src/DEPRECATED_useLexicalAutoFormatter.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalAutoFormatter.js
@@ -12,7 +12,7 @@ import type {LexicalEditor} from 'lexical';
 import {registerMarkdownShortcuts, TRANSFORMERS} from '@lexical/markdown';
 import {useEffect} from 'react';
 
-export default function useLexicalAutoFormatter(editor: LexicalEditor): void {
+export function useLexicalAutoFormatter(editor: LexicalEditor): void {
   useEffect(() => {
     return registerMarkdownShortcuts(editor, TRANSFORMERS);
   }, [editor]);

--- a/packages/lexical-react/src/DEPRECATED_useLexicalCanShowPlaceholder.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalCanShowPlaceholder.js
@@ -9,10 +9,8 @@
 
 import type {LexicalEditor} from 'lexical';
 
-import useCanShowPlaceholder from './shared/useCanShowPlaceholder';
+import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 
-export default function useLexicalCanShowPlaceholder(
-  editor: LexicalEditor,
-): boolean {
+export function useLexicalCanShowPlaceholder(editor: LexicalEditor): boolean {
   return useCanShowPlaceholder(editor);
 }

--- a/packages/lexical-react/src/DEPRECATED_useLexicalDecorators.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalDecorators.js
@@ -9,10 +9,8 @@
 
 import type {LexicalEditor} from 'lexical';
 
-import useDecorators from './shared/useDecorators';
+import {useDecorators} from './shared/useDecorators';
 
-export default function useLexicalDecorators(
-  editor: LexicalEditor,
-): Array<React$Node> {
+export function useLexicalDecorators(editor: LexicalEditor): Array<React$Node> {
   return useDecorators(editor);
 }

--- a/packages/lexical-react/src/DEPRECATED_useLexicalEditor.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalEditor.js
@@ -9,10 +9,10 @@
 
 import type {LexicalEditor} from 'lexical';
 
-import useLexicalCanShowPlaceholder from '@lexical/react/DEPRECATED_useLexicalCanShowPlaceholder';
+import {useLexicalCanShowPlaceholder} from '@lexical/react/DEPRECATED_useLexicalCanShowPlaceholder';
 import {useCallback} from 'react';
 
-export default function useLexicalEditor(
+export function useLexicalEditor(
   editor: LexicalEditor,
 ): [(null | HTMLElement) => void, boolean] {
   const showPlaceholder = useLexicalCanShowPlaceholder(editor);

--- a/packages/lexical-react/src/DEPRECATED_useLexicalEditorEvents.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalEditorEvents.js
@@ -10,9 +10,9 @@
 import type {InputEvents} from './shared/useEditorEvents';
 import type {LexicalEditor} from 'lexical';
 
-import useEditorEvents from './shared/useEditorEvents';
+import {useEditorEvents} from './shared/useEditorEvents';
 
-export default function useLexicalEditorEvents(
+export function useLexicalEditorEvents(
   events: InputEvents,
   editor: LexicalEditor,
 ): void {

--- a/packages/lexical-react/src/DEPRECATED_useLexicalList.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalList.js
@@ -9,8 +9,8 @@
 
 import type {LexicalEditor} from 'lexical';
 
-import useList from './shared/useList';
+import {useList} from './shared/useList';
 
-export default function useLexicalList(editor: LexicalEditor): void {
+export function useLexicalList(editor: LexicalEditor): void {
   useList(editor);
 }

--- a/packages/lexical-react/src/DEPRECATED_useLexicalPlainText.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalPlainText.js
@@ -11,9 +11,9 @@ import type {HistoryState} from './DEPRECATED_useLexicalHistory';
 import type {EditorState, LexicalEditor} from 'lexical';
 
 import {useLexicalHistory} from './DEPRECATED_useLexicalHistory';
-import usePlainTextSetup from './shared/usePlainTextSetup';
+import {usePlainTextSetup} from './shared/usePlainTextSetup';
 
-export default function useLexicalPlainText(
+export function useLexicalPlainText(
   editor: LexicalEditor,
   externalHistoryState?: HistoryState,
   initialEditorState?: null | string | EditorState | (() => void),

--- a/packages/lexical-react/src/DEPRECATED_useLexicalRichText.js
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalRichText.js
@@ -11,9 +11,9 @@ import type {HistoryState} from './DEPRECATED_useLexicalHistory';
 import type {EditorState, LexicalEditor} from 'lexical';
 
 import {useLexicalHistory} from './DEPRECATED_useLexicalHistory';
-import useRichTextSetup from './shared/useRichTextSetup';
+import {useRichTextSetup} from './shared/useRichTextSetup';
 
-export default function useLexicalRichText(
+export function useLexicalRichText(
   editor: LexicalEditor,
   externalHistoryState?: HistoryState,
   initialEditorState?: null | string | EditorState | (() => void),

--- a/packages/lexical-react/src/LexicalAutoFocusPlugin.js
+++ b/packages/lexical-react/src/LexicalAutoFocusPlugin.js
@@ -10,7 +10,7 @@
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
 
-export default function LexicalAutoFocusPlugin(): null {
+export function AutoFocusPlugin(): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.js
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.js
@@ -240,7 +240,7 @@ function useAutoLink(
   }, [editor, matchers, onChange]);
 }
 
-export default function AutoLinkPlugin({
+export function AutoLinkPlugin({
   matchers,
   onChange,
 }: {

--- a/packages/lexical-react/src/LexicalAutoScrollPlugin.js
+++ b/packages/lexical-react/src/LexicalAutoScrollPlugin.js
@@ -15,9 +15,7 @@ type Props = $ReadOnly<{
   scrollRef: {current: HTMLElement | null},
 }>;
 
-export default function LexicalAutoScrollPlugin({
-  scrollRef,
-}: Props): React$Node {
+export function AutoScrollPlugin({scrollRef}: Props): React$Node {
   const [editor] = useLexicalComposerContext();
   useLayoutEffect(() => {
     return editor.registerUpdateListener(({tags, editorState}) => {

--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.jsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.jsx
@@ -11,7 +11,7 @@ import type {ElementFormatType, NodeKey} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$isDecoratorBlockNode} from '@lexical/react/LexicalDecoratorBlockNode';
-import useLexicalNodeSelection from '@lexical/react/useLexicalNodeSelection';
+import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {
   $getNearestBlockElementAncestorOrThrow,
   mergeRegister,

--- a/packages/lexical-react/src/LexicalCharacterLimitPlugin.jsx
+++ b/packages/lexical-react/src/LexicalCharacterLimitPlugin.jsx
@@ -36,7 +36,7 @@ function utf8Length(text: string) {
   return currentTextEncoder.encode(text).length;
 }
 
-export default function CharacterLimitPlugin({
+export function CharacterLimitPlugin({
   charset = 'UTF-16',
 }: {
   charset: 'UTF-8' | 'UTF-16',

--- a/packages/lexical-react/src/LexicalCheckListPlugin.jsx
+++ b/packages/lexical-react/src/LexicalCheckListPlugin.jsx
@@ -32,7 +32,7 @@ import {
 } from 'lexical';
 import {useEffect} from 'react';
 
-export default function ListPlugin(): null {
+export function CheckListPlugin(): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {

--- a/packages/lexical-react/src/LexicalClearEditorPlugin.js
+++ b/packages/lexical-react/src/LexicalClearEditorPlugin.js
@@ -21,7 +21,7 @@ type Props = $ReadOnly<{
   onClear?: () => void,
 }>;
 
-export default function LexicalClearEditorPlugin({onClear}: Props): React$Node {
+export function ClearEditorPlugin({onClear}: Props): React$Node {
   const [editor] = useLexicalComposerContext();
   useLayoutEffect(() => {
     return editor.registerCommand(

--- a/packages/lexical-react/src/LexicalComposer.jsx
+++ b/packages/lexical-react/src/LexicalComposer.jsx
@@ -30,7 +30,7 @@ type Props = {
   }>,
 };
 
-export default function LexicalComposer({
+export function LexicalComposer({
   initialConfig,
   children,
 }: Props): React$MixedElement {

--- a/packages/lexical-react/src/LexicalContentEditable.jsx
+++ b/packages/lexical-react/src/LexicalContentEditable.jsx
@@ -36,7 +36,7 @@ export type Props = $ReadOnly<{
   testid?: string,
 }>;
 
-export default function LexicalContentEditable({
+export function ContentEditable({
   ariaActiveDescendantID,
   ariaAutoComplete,
   ariaControls,

--- a/packages/lexical-react/src/LexicalHashtagPlugin.js
+++ b/packages/lexical-react/src/LexicalHashtagPlugin.js
@@ -11,7 +11,7 @@ import type {TextNode} from 'lexical';
 
 import {$createHashtagNode, HashtagNode} from '@lexical/hashtag';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import useLexicalTextEntity from '@lexical/react/useLexicalTextEntity';
+import {useLexicalTextEntity} from '@lexical/react/useLexicalTextEntity';
 import {useCallback, useEffect} from 'react';
 
 function getHashtagRegexStringChars(): $ReadOnly<{
@@ -247,7 +247,7 @@ function getHashtagRegexString(): string {
 
 const REGEX = new RegExp(getHashtagRegexString(), 'i');
 
-export default function HashtagPlugin(): React$Node {
+export function HashtagPlugin(): React$Node {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {

--- a/packages/lexical-react/src/LexicalLinkPlugin.js
+++ b/packages/lexical-react/src/LexicalLinkPlugin.js
@@ -111,7 +111,7 @@ function toggleLink(url: null | string) {
   }
 }
 
-export default function LinkPlugin(): null {
+export function LinkPlugin(): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {

--- a/packages/lexical-react/src/LexicalListPlugin.js
+++ b/packages/lexical-react/src/LexicalListPlugin.js
@@ -9,9 +9,9 @@
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
-import useList from './shared/useList';
+import {useList} from './shared/useList';
 
-export default function ListPlugin(): null {
+export function ListPlugin(): null {
   const [editor] = useLexicalComposerContext();
   useList(editor);
 

--- a/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.jsx
+++ b/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.jsx
@@ -41,7 +41,7 @@ const HR: ElementTransformer = {
 
 const DEFAULT_TRANSFORMERS = [HR, ...TRANSFORMERS];
 
-export default function LexicalMarkdownShortcutPlugin({
+export function MarkdownShortcutPlugin({
   transformers = DEFAULT_TRANSFORMERS,
 }: $ReadOnly<{transformers?: Array<Transformer>}>): null {
   const [editor] = useLexicalComposerContext();

--- a/packages/lexical-react/src/LexicalNestedComposer.jsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.jsx
@@ -19,7 +19,7 @@ import * as React from 'react';
 import {useContext, useMemo} from 'react';
 import invariant from 'shared/invariant';
 
-export default function LexicalNestedComposer({
+export function LexicalNestedComposer({
   initialEditor,
   children,
   initialTheme,

--- a/packages/lexical-react/src/LexicalOnChangePlugin.js
+++ b/packages/lexical-react/src/LexicalOnChangePlugin.js
@@ -12,7 +12,7 @@ import type {EditorState, LexicalEditor} from 'lexical';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
-export default function OnChangePlugin({
+export function OnChangePlugin({
   ignoreInitialChange = true,
   ignoreSelectionChange = false,
   onChange,

--- a/packages/lexical-react/src/LexicalPlainTextPlugin.jsx
+++ b/packages/lexical-react/src/LexicalPlainTextPlugin.jsx
@@ -12,11 +12,11 @@ import type {InitialEditorStateType} from './shared/PlainRichTextUtils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
 
-import useCanShowPlaceholder from './shared/useCanShowPlaceholder';
-import useDecorators from './shared/useDecorators';
-import usePlainTextSetup from './shared/usePlainTextSetup';
+import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
+import {useDecorators} from './shared/useDecorators';
+import {usePlainTextSetup} from './shared/usePlainTextSetup';
 
-export default function PlainTextPlugin({
+export function PlainTextPlugin({
   contentEditable,
   placeholder,
   initialEditorState,

--- a/packages/lexical-react/src/LexicalRichTextPlugin.jsx
+++ b/packages/lexical-react/src/LexicalRichTextPlugin.jsx
@@ -12,11 +12,11 @@ import type {InitialEditorStateType} from './shared/PlainRichTextUtils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
 
-import useCanShowPlaceholder from './shared/useCanShowPlaceholder';
-import useDecorators from './shared/useDecorators';
-import useRichTextSetup from './shared/useRichTextSetup';
+import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
+import {useDecorators} from './shared/useDecorators';
+import {useRichTextSetup} from './shared/useRichTextSetup';
 
-export default function RichTextPlugin({
+export function RichTextPlugin({
   contentEditable,
   placeholder,
   initialEditorState,

--- a/packages/lexical-react/src/LexicalTablePlugin.js
+++ b/packages/lexical-react/src/LexicalTablePlugin.js
@@ -30,7 +30,7 @@ import {
 import {useEffect} from 'react';
 import invariant from 'shared/invariant';
 
-export default function TablePlugin(): React$Node {
+export function TablePlugin(): React$Node {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {

--- a/packages/lexical-react/src/LexicalTreeView.jsx
+++ b/packages/lexical-react/src/LexicalTreeView.jsx
@@ -47,7 +47,7 @@ const SYMBOLS = Object.freeze({
   selectedLine: '>',
 });
 
-export default function TreeView({
+export function TreeView({
   timeTravelButtonClassName,
   timeTravelPanelSliderClassName,
   timeTravelPanelButtonClassName,

--- a/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.js
+++ b/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.js
@@ -11,7 +11,7 @@ import React from 'react';
 import {createRoot} from 'react-dom/client';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import LexicalComposer from '../../../src/LexicalComposer';
+import {LexicalComposer} from '../../../src/LexicalComposer';
 import {useLexicalComposerContext} from '../../LexicalComposerContext';
 
 // No idea why we suddenly need to do this, but it fixes the tests

--- a/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.js
+++ b/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.js
@@ -12,7 +12,7 @@ import {HashtagNode} from '@lexical/hashtag';
 import {AutoLinkNode, LinkNode} from '@lexical/link';
 import {ListItemNode, ListNode} from '@lexical/list';
 import {OverflowNode} from '@lexical/overflow';
-import LexicalContentEditable from '@lexical/react/LexicalContentEditable';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
 import {$rootTextContentCurry} from '@lexical/text';
@@ -26,9 +26,9 @@ import React from 'react';
 import {createRoot} from 'react-dom/client';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import LexicalComposer from '../../../src/LexicalComposer';
-import PlainTextPlugin from '../../../src/LexicalPlainTextPlugin';
-import RichTextPlugin from '../../../src/LexicalRichTextPlugin';
+import {LexicalComposer} from '../../../src/LexicalComposer';
+import {PlainTextPlugin} from '../../../src/LexicalPlainTextPlugin';
+import {RichTextPlugin} from '../../../src/LexicalRichTextPlugin';
 import {useLexicalComposerContext} from '../../LexicalComposerContext';
 
 // No idea why we suddenly need to do this, but it fixes the tests
@@ -94,12 +94,12 @@ describe('LexicalNodeHelpers tests', () => {
             <GrabEditor />
             {plugin === 'PlainTextPlugin' ? (
               <PlainTextPlugin
-                contentEditable={<LexicalContentEditable />}
+                contentEditable={<ContentEditable />}
                 initialEditorState={$initialEditorState}
               />
             ) : (
               <RichTextPlugin
-                contentEditable={<LexicalContentEditable />}
+                contentEditable={<ContentEditable />}
                 initialEditorState={$initialEditorState}
               />
             )}
@@ -202,12 +202,12 @@ describe('LexicalNodeHelpers tests', () => {
             <GrabEditor />
             {plugin === 'PlainTextPlugin' ? (
               <PlainTextPlugin
-                contentEditable={<LexicalContentEditable />}
+                contentEditable={<ContentEditable />}
                 initialEditorState={initialEditorStateJson}
               />
             ) : (
               <RichTextPlugin
-                contentEditable={<LexicalContentEditable />}
+                contentEditable={<ContentEditable />}
                 initialEditorState={initialEditorStateJson}
               />
             )}

--- a/packages/lexical-react/src/__tests__/unit/useLexicalIsTextContentEmpty.test.js
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalIsTextContentEmpty.test.js
@@ -18,7 +18,7 @@ import React from 'react';
 import {createRoot} from 'react-dom/client';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import useLexicalIsTextContentEmpty from '../../useLexicalIsTextContentEmpty';
+import {useLexicalIsTextContentEmpty} from '../../useLexicalIsTextContentEmpty';
 
 // No idea why we suddenly need to do this, but it fixes the tests
 // with latest experimental React version.

--- a/packages/lexical-react/src/__tests__/unit/utils.js
+++ b/packages/lexical-react/src/__tests__/unit/utils.js
@@ -8,7 +8,7 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import LexicalContentEditable from '@lexical/react/LexicalContentEditable';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import * as React from 'react';
 import {createRoot} from 'react-dom/client';
 import ReactTestUtils from 'react-dom/test-utils';
@@ -18,8 +18,8 @@ import {
   CollaborationPlugin,
   useCollaborationContext,
 } from '../../LexicalCollaborationPlugin';
-import LexicalComposer from '../../LexicalComposer';
-import LexicalRichTextPlugin from '../../LexicalRichTextPlugin';
+import {LexicalComposer} from '../../LexicalComposer';
+import {RichTextPlugin} from '../../LexicalRichTextPlugin';
 
 function Editor({doc, provider, setEditor}) {
   const {yjsDocMap} = useCollaborationContext();
@@ -36,8 +36,8 @@ function Editor({doc, provider, setEditor}) {
         providerFactory={() => provider}
         shouldBootstrap={true}
       />
-      <LexicalRichTextPlugin
-        contentEditable={<LexicalContentEditable />}
+      <RichTextPlugin
+        contentEditable={<ContentEditable />}
         placeholder={null}
       />
     </>

--- a/packages/lexical-react/src/shared/useCanShowPlaceholder.js
+++ b/packages/lexical-react/src/shared/useCanShowPlaceholder.js
@@ -13,9 +13,7 @@ import {$canShowPlaceholderCurry} from '@lexical/text';
 import {useState} from 'react';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
-export default function useLexicalCanShowPlaceholder(
-  editor: LexicalEditor,
-): boolean {
+export function useCanShowPlaceholder(editor: LexicalEditor): boolean {
   const [canShowPlaceholder, setCanShowPlaceholder] = useState(
     editor
       .getEditorState()

--- a/packages/lexical-react/src/shared/useDecorators.js
+++ b/packages/lexical-react/src/shared/useDecorators.js
@@ -15,9 +15,7 @@ import {useMemo, useState} from 'react';
 import {createPortal, flushSync} from 'react-dom';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
-export default function useDecorators(
-  editor: LexicalEditor,
-): Array<React.Node> {
+export function useDecorators(editor: LexicalEditor): Array<React.Node> {
   const [decorators, setDecorators] = useState<{[string]: React.Node}>(() =>
     editor.getDecorators<React.Node>(),
   );

--- a/packages/lexical-react/src/shared/useEditorEvents.js
+++ b/packages/lexical-react/src/shared/useEditorEvents.js
@@ -27,7 +27,7 @@ function isRootEditable(editor: LexicalEditor): boolean {
   return rootElement !== null && rootElement.contentEditable === 'true';
 }
 
-export default function useEditorEvents(
+export function useEditorEvents(
   events: InputEvents,
   editor: LexicalEditor,
 ): void {

--- a/packages/lexical-react/src/shared/useList.js
+++ b/packages/lexical-react/src/shared/useList.js
@@ -28,7 +28,7 @@ import {
 } from 'lexical';
 import {useEffect} from 'react';
 
-export default function useList(editor: LexicalEditor): void {
+export function useList(editor: LexicalEditor): void {
   useEffect(() => {
     return mergeRegister(
       editor.registerCommand(

--- a/packages/lexical-react/src/shared/usePlainTextSetup.js
+++ b/packages/lexical-react/src/shared/usePlainTextSetup.js
@@ -15,7 +15,7 @@ import {registerPlainText} from '@lexical/plain-text';
 import {mergeRegister} from '@lexical/utils';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
-export default function usePlainTextSetup(
+export function usePlainTextSetup(
   editor: LexicalEditor,
   initialEditorState?: InitialEditorStateType,
 ): void {

--- a/packages/lexical-react/src/shared/useRichTextSetup.js
+++ b/packages/lexical-react/src/shared/useRichTextSetup.js
@@ -15,7 +15,7 @@ import {registerRichText} from '@lexical/rich-text';
 import {mergeRegister} from '@lexical/utils';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
-export default function useRichTextSetup(
+export function useRichTextSetup(
   editor: LexicalEditor,
   initialEditorState?: InitialEditorStateType,
 ): void {

--- a/packages/lexical-react/src/useLexicalIsTextContentEmpty.js
+++ b/packages/lexical-react/src/useLexicalIsTextContentEmpty.js
@@ -13,7 +13,7 @@ import {$isRootTextContentEmptyCurry} from '@lexical/text';
 import {useState} from 'react';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
-export default function useLexicalIsTextContentEmpty(
+export function useLexicalIsTextContentEmpty(
   editor: LexicalEditor,
   trim?: boolean,
 ): boolean {

--- a/packages/lexical-react/src/useLexicalNodeSelection.js
+++ b/packages/lexical-react/src/useLexicalNodeSelection.js
@@ -29,7 +29,7 @@ function isNodeSelected(editor: LexicalEditor, key: NodeKey): boolean {
   });
 }
 
-export default function useLexicalNodeSelection(
+export function useLexicalNodeSelection(
   key: NodeKey,
 ): [boolean, (boolean) => void, () => void] {
   const [editor] = useLexicalComposerContext();

--- a/packages/lexical-react/src/useLexicalTextEntity.js
+++ b/packages/lexical-react/src/useLexicalTextEntity.js
@@ -15,7 +15,7 @@ import {registerLexicalTextEntity} from '@lexical/text';
 import {mergeRegister} from '@lexical/utils';
 import {useEffect} from 'react';
 
-export default function useLexicalTextEntity<N: TextNode>(
+export function useLexicalTextEntity<N: TextNode>(
   getMatch: (text: string) => null | EntityMatch,
   targetNode: Class<N>,
   createNode: (textNode: TextNode) => N,

--- a/packages/lexical-react/useLexicalIsTextContentEmpty.d.ts
+++ b/packages/lexical-react/useLexicalIsTextContentEmpty.d.ts
@@ -7,7 +7,7 @@
  */
 
 import type {LexicalEditor} from 'lexical';
-export default function useLexicalIsTextContentEmpty(
+export function useLexicalIsTextContentEmpty(
   editor: LexicalEditor,
   trim?: boolean,
 ): boolean;

--- a/packages/lexical-react/useLexicalNodeSelection.d.ts
+++ b/packages/lexical-react/useLexicalNodeSelection.d.ts
@@ -7,6 +7,6 @@
  */
 
 import type {NodeKey} from 'lexical';
-export default function useLexicalNodeSelection(
+export function useLexicalNodeSelection(
   key: NodeKey,
 ): [boolean, (arg0: boolean) => void, () => void];

--- a/packages/lexical-react/useLexicalTextEntity.d.ts
+++ b/packages/lexical-react/useLexicalTextEntity.d.ts
@@ -12,7 +12,7 @@ export type EntityMatch = {
   end: number;
   start: number;
 };
-export default function useLexicalTextEntity<N extends TextNode>(
+export function useLexicalTextEntity<N extends TextNode>(
   getMatch: (text: string) => null | EntityMatch,
   targetNode: Class<N>,
   createNode: (textNode: TextNode) => N,

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.js
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.js
@@ -9,9 +9,9 @@
 import {$createLinkNode} from '@lexical/link';
 import {$createListItemNode, $createListNode} from '@lexical/list';
 import {useLexicalComposerContext} from '@lexical/react/src/LexicalComposerContext';
-import LexicalContentEditable from '@lexical/react/src/LexicalContentEditable';
+import {ContentEditable} from '@lexical/react/src/LexicalContentEditable';
 import {HistoryPlugin} from '@lexical/react/src/LexicalHistoryPlugin';
-import RichTextPlugin from '@lexical/react/src/LexicalRichTextPlugin';
+import {RichTextPlugin} from '@lexical/react/src/LexicalRichTextPlugin';
 import {
   $createLineBreakNode,
   $createParagraphNode,
@@ -128,7 +128,7 @@ describe('LexicalSelection tests', () => {
           <RichTextPlugin
             contentEditable={
               // eslint-disable-next-line jsx-a11y/aria-role
-              <LexicalContentEditable role={null} spellCheck={null} />
+              <ContentEditable role={null} spellCheck={null} />
             }
           />
           <HistoryPlugin />

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.js
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.js
@@ -13,8 +13,8 @@ import {AutoLinkNode, LinkNode} from '@lexical/link';
 import {ListItemNode, ListNode} from '@lexical/list';
 import {OverflowNode} from '@lexical/overflow';
 import {useLexicalComposerContext} from '@lexical/react/src/LexicalComposerContext';
-import LexicalContentEditable from '@lexical/react/src/LexicalContentEditable';
-import RichTextPlugin from '@lexical/react/src/LexicalRichTextPlugin';
+import {ContentEditable} from '@lexical/react/src/LexicalContentEditable';
+import {RichTextPlugin} from '@lexical/react/src/LexicalRichTextPlugin';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {
   applySelectionInputs,
@@ -114,7 +114,7 @@ describe('LexicalEventHelpers', () => {
           <RichTextPlugin
             contentEditable={
               // eslint-disable-next-line jsx-a11y/aria-role
-              <LexicalContentEditable role={null} spellCheck={null} />
+              <ContentEditable role={null} spellCheck={null} />
             }
           />
           <TestPlugin />

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.js
@@ -7,8 +7,8 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import ContentEditable from '@lexical/react/src/LexicalContentEditable';
-import RichTextPlugin from '@lexical/react/src/LexicalRichTextPlugin';
+import {ContentEditable} from '@lexical/react/src/LexicalContentEditable';
+import {RichTextPlugin} from '@lexical/react/src/LexicalRichTextPlugin';
 import {
   $createTableCellNode,
   $createTableNode,

--- a/packages/lexical/src/__tests__/utils/index.js
+++ b/packages/lexical/src/__tests__/utils/index.js
@@ -13,7 +13,7 @@ import {HashtagNode} from '@lexical/hashtag';
 import {AutoLinkNode, LinkNode} from '@lexical/link';
 import {ListItemNode, ListNode} from '@lexical/list';
 import {OverflowNode} from '@lexical/overflow';
-import LexicalComposer from '@lexical/react/src/LexicalComposer';
+import {LexicalComposer} from '@lexical/react/src/LexicalComposer';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
 import {createEditor, DecoratorNode, ElementNode, TextNode} from 'lexical';


### PR DESCRIPTION
This is a breaking change, as this now means many packages now need to be made named exports – however it provides two clear benefits:

- Default exports can be messy. If you want to introduce named exports, you shouldn't mix them with default exports. So this makes it hard to expand a module in the future with further exports.
- Named exports make tree shaking really simple.
- We can move forward with support for ESM modules in combination to our existing CJS modules using our current Rollup + Closure Compiler pipeline.