### PR TITLE
Fix text replacement event handling

### DIFF
--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -77,6 +77,7 @@ import {
   $updateSelectedTextFromDOM,
   $updateTextNodeFromDOMContent,
   dispatchCommand,
+  doesContainGrapheme,
   getDOMTextNode,
   getEditorsToPropagate,
   getNearestEditorFromDOMNode,
@@ -531,7 +532,10 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
     const selection = $getSelection();
     const data = event.data;
     const possibleTextReplacement =
-      event.inputType === 'insertText' && data != null && data.length > 1;
+      event.inputType === 'insertText' &&
+      data != null &&
+      data.length > 1 &&
+      !doesContainGrapheme(data);
 
     if (
       data != null &&

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -621,6 +621,12 @@ function $shouldInsertTextAfterOrBeforeTextNode(
   return shouldInsertTextBefore || shouldInsertTextAfter;
 }
 
+// This function is used to determine if Lexical should attempt to override
+// the default browser behavior for insertion of text and use its own internal
+// heuristics. This is an extremely important function, and makes much of Lexical
+// work as intended between different browsers and across word, line and character
+// boundary/formats. It also is important for text replacement, node schemas and
+// composition mechanics.
 export function $shouldPreventDefaultAndInsertText(
   selection: RangeSelection,
   text: string,
@@ -638,8 +644,10 @@ export function $shouldPreventDefaultAndInsertText(
     anchorKey !== focus.key ||
     // If we're working with a non-text node.
     !$isTextNode(anchorNode) ||
-    // If we are replacing a range with a single character.
-    (textLength < 2 && anchor.offset !== focus.offset) ||
+    // If we are replacing a range with a single character, and not composing.
+    (textLength < 2 &&
+      anchor.offset !== focus.offset &&
+      !anchorNode.isComposing()) ||
     // Any non standard text node.
     $isTokenOrInertOrSegmented(anchorNode) ||
     // If the text length is more than a single character and we're either

--- a/packages/lexical/src/LexicalUtils.js
+++ b/packages/lexical/src/LexicalUtils.js
@@ -660,8 +660,6 @@ export function $shouldPreventDefaultAndInsertText(
       domAnchorNode !== getDOMTextNode(backingAnchorElement)) ||
     // Check if we're changing from bold to italics, or some other format.
     anchorNode.getFormat() !== selection.format ||
-    // If we detect graphemes, it's safer to insert.
-    doesContainGrapheme(text) ||
     // One last set of heuristics to check against.
     $shouldInsertTextAfterOrBeforeTextNode(selection, anchorNode)
   );


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/2199. When handling text replacements, we need to handle the logic at a later stage than beforeinput. That's because we don't know what the selection should be after the replacement.