### PR TITLE
Migrate EditorState doc to typescript

### DIFF
--- a/packages/lexical-website-new/docs/concepts/editor-state.md
+++ b/packages/lexical-website-new/docs/concepts/editor-state.md
@@ -45,7 +45,7 @@ For React it could be something following:
 
 ```jsx
 const initialEditorState = await loadContent();
-const editorStateRef = useRef();
+const editorStateRef = useRef<EditorState | null>(null);
 
 <LexicalComposer ...>
   <LexicalRichTextPlugin initialEditorState={initialEditorState} />


### PR DESCRIPTION
Since the lexical team is migrating to typescript I thought it would be appropriate to convert examples to typescript. Is it something you are interested in? I can work on it. either JS/TS or all in ts