### PR TITLE
Fixing Placeholder Bug found on web

### DIFF
--- a/packages/lexical-react/src/shared/useCanShowPlaceholder.js
+++ b/packages/lexical-react/src/shared/useCanShowPlaceholder.js
@@ -21,6 +21,11 @@ export function useCanShowPlaceholder(editor: LexicalEditor): boolean {
   );
 
   useLayoutEffect(() => {
+    const isComposing = editor.isComposing();
+      const currentCanShowPlaceholder = editorState.getEditorState().read(
+        $canShowPlaceholderCurry(isComposing),
+      );
+      setCanShowPlaceholder(currentCanShowPlaceholder);
     return editor.registerUpdateListener(({editorState}) => {
       const isComposing = editor.isComposing();
       const currentCanShowPlaceholder = editorState.read(


### PR DESCRIPTION
Updating useLexicalCanShowPlaceholder to run the placeholder checking logic before the useLayoutEffect to solve for a very specific race condition.