### PR TITLE
Replace isHovered with isSelected in mentions typeahead

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -253,10 +253,6 @@ pre::-webkit-scrollbar-thumb {
   background: #eee;
 }
 
-#mentions-typeahead ul li.hovered {
-  background: #ddd;
-}
-
 .link-editor {
   position: absolute;
   z-index: 10;

--- a/packages/lexical-playground/src/plugins/MentionsPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/MentionsPlugin.tsx
@@ -557,19 +557,15 @@ function useMentionLookupService(mentionString) {
 
 function MentionsTypeaheadItem({
   index,
-  isHovered,
   isSelected,
   onClick,
   onMouseEnter,
-  onMouseLeave,
   result,
 }: {
   index: number;
-  isHovered: boolean;
   isSelected: boolean;
   onClick: () => void;
   onMouseEnter: () => void;
-  onMouseLeave: () => void;
   result: string;
 }) {
   const liRef = useRef(null);
@@ -577,9 +573,6 @@ function MentionsTypeaheadItem({
   let className = 'item';
   if (isSelected) {
     className += ' selected';
-  }
-  if (isHovered) {
-    className += ' hovered';
   }
 
   return (
@@ -592,7 +585,6 @@ function MentionsTypeaheadItem({
       aria-selected={isSelected}
       id={'typeahead-item-' + index}
       onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
       onClick={onClick}>
       {result}
     </li>
@@ -612,7 +604,6 @@ function MentionsTypeahead({
   const match = resolution.match;
   const results = useMentionLookupService(match.matchingString);
   const [selectedIndex, setSelectedIndex] = useState<null | number>(null);
-  const [hoveredIndex, setHoveredIndex] = useState(null);
 
   useEffect(() => {
     const div = divRef.current;
@@ -776,17 +767,13 @@ function MentionsTypeahead({
         {results.slice(0, SUGGESTION_LIST_LENGTH_LIMIT).map((result, i) => (
           <MentionsTypeaheadItem
             index={i}
-            isHovered={i === hoveredIndex}
             isSelected={i === selectedIndex}
             onClick={() => {
               setSelectedIndex(i);
               applyCurrentSelected();
             }}
             onMouseEnter={() => {
-              setHoveredIndex(i);
-            }}
-            onMouseLeave={() => {
-              setHoveredIndex(null);
+              setSelectedIndex(i);
             }}
             key={result}
             result={result}


### PR DESCRIPTION
Fixes Issue #2217 

Instead of tracking both an `isSelected` and an `isHovered` state, this PR moves to a single piece of state to represent both (isSelected). This results in clearer UX, where only one item in the dropdown is highlighted at a time. More importantly, it fixes a bug where clicking on a hovered item does not insert the correct item.

Now any focus interaction can be paired with any selection action. Some examples:
- Use your keyboard to navigate + select a mention
- Use your mouse to hover + select a mention
- Use your mouse to hover over a mention, then keyboard (enter or tab) to select it
- Use your mouse to hover over a mention, then keyboard to navigate to another, then keyboard to select it

Hope this helps!