### PR TITLE
Fix window undefined issue when SSR

### DIFF
--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -543,6 +543,7 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
     const selection = $getSelection();
     const data = event.data;
     const possibleTextReplacement =
+      CAN_USE_DOM &&
       event.inputType === 'insertText' &&
       data != null &&
       data.length > 1 &&
@@ -562,7 +563,7 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
         isFirefoxEndingComposition = false;
       }
       dispatchCommand(editor, INSERT_TEXT_COMMAND, data);
-      if (possibleTextReplacement && CAN_USE_DOM) {
+      if (possibleTextReplacement) {
         // If the DOM selection offset is higher than the existing
         // offset, then restore the offset as it's likely correct
         // in the case of text replacements.

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -13,6 +13,7 @@ import type {RangeSelection} from './LexicalSelection';
 import type {ElementNode} from './nodes/LexicalElementNode';
 import type {TextNode} from './nodes/LexicalTextNode';
 
+import {CAN_USE_DOM} from 'shared/canUseDOM';
 import {
   CAN_USE_BEFORE_INPUT,
   IS_FIREFOX,
@@ -561,7 +562,7 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
         isFirefoxEndingComposition = false;
       }
       dispatchCommand(editor, INSERT_TEXT_COMMAND, data);
-      if (possibleTextReplacement) {
+      if (possibleTextReplacement && CAN_USE_DOM) {
         // If the DOM selection offset is higher than the existing
         // offset, then restore the offset as it's likely correct
         // in the case of text replacements.


### PR DESCRIPTION
#2203 is causing an internal Meta error that `window.getSelection()` is undefined when server-side rendered. 

I think we should be fine to bypass this check completely as we don't need it until the editor is loaded and interactable  