### PR TITLE
Revert "Fix window undefined issue when SSR"

### DIFF
--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -13,7 +13,6 @@ import type {RangeSelection} from './LexicalSelection';
 import type {ElementNode} from './nodes/LexicalElementNode';
 import type {TextNode} from './nodes/LexicalTextNode';
 
-import {CAN_USE_DOM} from 'shared/canUseDOM';
 import {
   CAN_USE_BEFORE_INPUT,
   IS_FIREFOX,
@@ -543,7 +542,6 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
     const selection = $getSelection();
     const data = event.data;
     const possibleTextReplacement =
-      CAN_USE_DOM &&
       event.inputType === 'insertText' &&
       data != null &&
       data.length > 1 &&


### PR DESCRIPTION
Reverts facebook/lexical#2229

Come to think of it, I'm not sure this is the right fix. @thegreatercurve this code path is on a DOM event listener, which means there must be a window present for it to fire to begin with?