### PR TITLE
move toggleLink to lexical/link

### DIFF
--- a/packages/lexical-link/LexicalLink.d.ts
+++ b/packages/lexical-link/LexicalLink.d.ts
@@ -54,3 +54,4 @@ export function $isAutoLinkNode(
 ): node is AutoLinkNode;
 
 export var TOGGLE_LINK_COMMAND: LexicalCommand<string | null>;
+export function toggleLink(url: null | string): void;

--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -52,3 +52,4 @@ declare export function $isAutoLinkNode(
 ): boolean %checks(node instanceof AutoLinkNode);
 
 declare export var TOGGLE_LINK_COMMAND: LexicalCommand<string | null>;
+declare export function toggleLink(url: null | string): void;

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -19,9 +19,15 @@ import type {
 } from 'lexical';
 
 import {addClassNamesToElement} from '@lexical/utils';
-import {$isElementNode, createCommand, ElementNode} from 'lexical';
-import {Spread} from 'libdefs/globals';
-import invariant from 'shared/invariant';
+import {Spread} from 'globals';
+import {
+  $getSelection,
+  $isElementNode,
+  $setSelection,
+  createCommand,
+  ElementNode,
+} from 'lexical';
+import invariant from 'shared-ts/invariant';
 
 export type SerializedLinkNode = Spread<
   {
@@ -210,3 +216,109 @@ export function $isAutoLinkNode(
 
 export const TOGGLE_LINK_COMMAND: LexicalCommand<string | null> =
   createCommand();
+
+export function toggleLink(url: null | string): void {
+  const selection = $getSelection();
+
+  if (selection !== null) {
+    $setSelection(selection);
+  }
+
+  const sel = $getSelection();
+
+  if (sel !== null) {
+    const nodes = sel.extract();
+
+    if (url === null) {
+      // Remove LinkNodes
+      nodes.forEach((node) => {
+        const parent = node.getParent();
+
+        if ($isLinkNode(parent)) {
+          const children = parent.getChildren();
+
+          for (let i = 0; i < children.length; i++) {
+            parent.insertBefore(children[i]);
+          }
+
+          parent.remove();
+        }
+      });
+    } else {
+      // Add or merge LinkNodes
+      if (nodes.length === 1) {
+        const firstNode = nodes[0];
+
+        // if the first node is a LinkNode or if its
+        // parent is a LinkNode, we update the URL.
+        if ($isLinkNode(firstNode)) {
+          firstNode.setURL(url);
+          return;
+        } else {
+          const parent = firstNode.getParent();
+
+          if ($isLinkNode(parent)) {
+            // set parent to be the current linkNode
+            // so that other nodes in the same parent
+            // aren't handled separately below.
+            parent.setURL(url);
+            return;
+          }
+        }
+      }
+
+      let prevParent = null;
+      let linkNode = null;
+
+      nodes.forEach((node) => {
+        const parent = node.getParent();
+
+        if (
+          parent === linkNode ||
+          parent === null ||
+          ($isElementNode(node) && !node.isInline())
+        ) {
+          return;
+        }
+
+        if ($isLinkNode(parent)) {
+          linkNode = parent;
+          parent.setURL(url);
+          return;
+        }
+
+        if (!parent.is(prevParent)) {
+          prevParent = parent;
+          linkNode = $createLinkNode(url);
+
+          if ($isLinkNode(parent)) {
+            if (node.getPreviousSibling() === null) {
+              parent.insertBefore(linkNode);
+            } else {
+              parent.insertAfter(linkNode);
+            }
+          } else {
+            node.insertBefore(linkNode);
+          }
+        }
+
+        if ($isLinkNode(node)) {
+          if (linkNode !== null) {
+            const children = node.getChildren();
+
+            for (let i = 0; i < children.length; i++) {
+              linkNode.append(children[i]);
+            }
+          }
+
+          node.remove();
+          return;
+        }
+
+        if (linkNode !== null) {
+          linkNode.append(node);
+        }
+      });
+    }
+  }
+}

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -27,7 +27,7 @@ import {
   createCommand,
   ElementNode,
 } from 'lexical';
-import invariant from 'shared-ts/invariant';
+import invariant from 'shared/invariant';
 
 export type SerializedLinkNode = Spread<
   {

--- a/packages/lexical-react/src/LexicalLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalLinkPlugin.ts
@@ -3,129 +3,13 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
  */
 
-import {
-  $createLinkNode,
-  $isLinkNode,
-  LinkNode,
-  TOGGLE_LINK_COMMAND,
-} from '@lexical/link';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {
-  $getSelection,
-  $isElementNode,
-  $setSelection,
-  COMMAND_PRIORITY_EDITOR,
-} from 'lexical';
+import {LinkNode, TOGGLE_LINK_COMMAND, toggleLink} from '@lexical/link';
+import {COMMAND_PRIORITY_EDITOR} from 'lexical';
 import {useEffect} from 'react';
 
-function toggleLink(url: null | string) {
-  const selection = $getSelection();
-
-  if (selection !== null) {
-    $setSelection(selection);
-  }
-
-  const sel = $getSelection();
-
-  if (sel !== null) {
-    const nodes = sel.extract();
-
-    if (url === null) {
-      // Remove LinkNodes
-      nodes.forEach((node) => {
-        const parent = node.getParent();
-
-        if ($isLinkNode(parent)) {
-          const children = parent.getChildren();
-
-          for (let i = 0; i < children.length; i++) {
-            parent.insertBefore(children[i]);
-          }
-
-          parent.remove();
-        }
-      });
-    } else {
-      // Add or merge LinkNodes
-      if (nodes.length === 1) {
-        const firstNode = nodes[0];
-
-        // if the first node is a LinkNode or if its
-        // parent is a LinkNode, we update the URL.
-        if ($isLinkNode(firstNode)) {
-          firstNode.setURL(url);
-          return;
-        } else {
-          const parent = firstNode.getParent();
-
-          if ($isLinkNode(parent)) {
-            // set parent to be the current linkNode
-            // so that other nodes in the same parent
-            // aren't handled separately below.
-            parent.setURL(url);
-            return;
-          }
-        }
-      }
-
-      let prevParent = null;
-      let linkNode = null;
-
-      nodes.forEach((node) => {
-        const parent = node.getParent();
-
-        if (
-          parent === linkNode ||
-          parent === null ||
-          ($isElementNode(node) && !node.isInline())
-        ) {
-          return;
-        }
-
-        if ($isLinkNode(parent)) {
-          linkNode = parent;
-          parent.setURL(url);
-          return;
-        }
-
-        if (!parent.is(prevParent)) {
-          prevParent = parent;
-          linkNode = $createLinkNode(url);
-
-          if ($isLinkNode(parent)) {
-            if (node.getPreviousSibling() === null) {
-              parent.insertBefore(linkNode);
-            } else {
-              parent.insertAfter(linkNode);
-            }
-          } else {
-            node.insertBefore(linkNode);
-          }
-        }
-
-        if ($isLinkNode(node)) {
-          if (linkNode !== null) {
-            const children = node.getChildren();
-
-            for (let i = 0; i < children.length; i++) {
-              linkNode.append(children[i]);
-            }
-          }
-
-          node.remove();
-          return;
-        }
-
-        if (linkNode !== null) {
-          linkNode.append(node);
-        }
-      });
-    }
-  }
-}
+import {useLexicalComposerContext} from './LexicalComposerContext';
 
 export function LinkPlugin(): null {
   const [editor] = useLexicalComposerContext();


### PR DESCRIPTION
`toggleLink` isn't a React specific function. As such I moved it to lexical/link so that it can be used by other frameworks