### PR TITLE
Rename insert text command

### DIFF
--- a/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.js
+++ b/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.js
@@ -19,7 +19,7 @@ import {
   $createTextNode,
   $getRoot,
   COMMAND_PRIORITY_NORMAL,
-  INSERT_TEXT_COMMAND,
+  CONTROLLED_TEXT_INSERTION_COMMAND,
   ParagraphNode,
 } from 'lexical';
 
@@ -118,7 +118,7 @@ describe('LexicalHeadlessEditor', () => {
 
     editor.registerUpdateListener(onUpdate);
     editor.registerCommand(
-      INSERT_TEXT_COMMAND,
+      CONTROLLED_TEXT_INSERTION_COMMAND,
       onCommand,
       COMMAND_PRIORITY_NORMAL,
     );
@@ -132,7 +132,7 @@ describe('LexicalHeadlessEditor', () => {
           $createTextNode('world'),
         ),
       );
-      editor.dispatchCommand(INSERT_TEXT_COMMAND, 'foo');
+      editor.dispatchCommand(CONTROLLED_TEXT_INSERTION_COMMAND, 'foo');
     });
 
     expect(onUpdate).toBeCalled();

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -23,6 +23,7 @@ import {
   $getSelection,
   $isRangeSelection,
   COMMAND_PRIORITY_EDITOR,
+  CONTROLLED_TEXT_INSERTION_COMMAND,
   COPY_COMMAND,
   CUT_COMMAND,
   DELETE_CHARACTER_COMMAND,
@@ -32,7 +33,6 @@ import {
   DROP_COMMAND,
   INSERT_LINE_BREAK_COMMAND,
   INSERT_PARAGRAPH_COMMAND,
-  INSERT_TEXT_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
   KEY_BACKSPACE_COMMAND,
@@ -201,7 +201,7 @@ export function registerPlainText(
       COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand<InputEvent | string>(
-      INSERT_TEXT_COMMAND,
+      CONTROLLED_TEXT_INSERTION_COMMAND,
       (eventOrText) => {
         const selection = $getSelection();
 

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -45,6 +45,7 @@ import {
   $isTextNode,
   CLICK_COMMAND,
   COMMAND_PRIORITY_EDITOR,
+  CONTROLLED_TEXT_INSERTION_COMMAND,
   COPY_COMMAND,
   CUT_COMMAND,
   DELETE_CHARACTER_COMMAND,
@@ -58,7 +59,6 @@ import {
   INDENT_CONTENT_COMMAND,
   INSERT_LINE_BREAK_COMMAND,
   INSERT_PARAGRAPH_COMMAND,
-  INSERT_TEXT_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
   KEY_BACKSPACE_COMMAND,
@@ -470,7 +470,7 @@ export function registerRichText(
       COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand<InputEvent | string>(
-      INSERT_TEXT_COMMAND,
+      CONTROLLED_TEXT_INSERTION_COMMAND,
       (eventOrText) => {
         const selection = $getSelection();
 
@@ -569,7 +569,7 @@ export function registerRichText(
       () => {
         handleIndentAndOutdent(
           () => {
-            editor.dispatchCommand(INSERT_TEXT_COMMAND, '\t');
+            editor.dispatchCommand(CONTROLLED_TEXT_INSERTION_COMMAND, '\t');
           },
           (block) => {
             const indent = block.getIndent();

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -29,10 +29,10 @@ import {
   $isRangeSelection,
   $setSelection,
   COMMAND_PRIORITY_CRITICAL,
+  CONTROLLED_TEXT_INSERTION_COMMAND,
   DELETE_CHARACTER_COMMAND,
   FOCUS_COMMAND,
   FORMAT_TEXT_COMMAND,
-  INSERT_TEXT_COMMAND,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
@@ -710,7 +710,7 @@ export function applyTableHandlers(
 
   tableSelection.listenersToRemove.add(
     editor.registerCommand(
-      INSERT_TEXT_COMMAND,
+      CONTROLLED_TEXT_INSERTION_COMMAND,
       (payload) => {
         const selection = $getSelection();
 

--- a/packages/lexical-website-new/docs/concepts/commands.md
+++ b/packages/lexical-website-new/docs/concepts/commands.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Commands
 
-Commands are a very powerful feature of Lexical that lets you register listeners for events like `INSERT_TEXT_COMMAND` or `KEY_TAB_COMMAND` and contextually react to them _wherever_ & _however_ you'd like.
+Commands are a very powerful feature of Lexical that lets you register listeners for events like `KEY_ENTER_COMMAND` or `KEY_TAB_COMMAND` and contextually react to them _wherever_ & _however_ you'd like.
 
 This is pattern is useful for building [`Toolbars`](https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/plugins/ToolbarPlugin.jsx) or complex `Plugins` and `Nodes` such as the [`TablePlugin`](https://github.com/facebook/lexical/tree/main/packages/lexical-table) which require special handling for `selection`, `keyboard events`, and more.
 

--- a/packages/lexical-website-new/docs/faq.md
+++ b/packages/lexical-website-new/docs/faq.md
@@ -36,3 +36,18 @@ editor.getEditorState().read(...);
 If you've used React Hooks before, you can think of `$` functions as being something that follows a similar pattern. These are functions that show their intent as to where and where they cannot be used. This makes it possible for a developer to create their own functions that give the same signal, by simply prefixing the function with the dollar.
 
 Internally, we've found this scales really well and developers get to grips with it in almost no time at all.
+
+## How do I listen for user text insertions?
+
+Listening to text insertion events is problematic with content editables in general. It's a common source of bugs due to how
+different browsers and third-party extensions interact with the DOM. Whilst it's possible to use DOM events like `input` and
+`beforeinput` to gauge some of the possible cases where a user has inserted text, these are hardly reliable and also don't
+take into account edge-cases. Instead, Lexical prefers to consider any change as a possible user input, and as such doesn't
+make a distinction between the cases. This is important for tools like spellcheck, browser extensions, IME, speech-to-text,
+screen readers and other external tools that often don't reliably trigger a reliable event sequence (some don't even trigger
+any events at all!).
+
+For those wanting to react to a text change and possibly block/alter the intent, the recommended approach is to use a node
+transform. This also plays nicely with other sub-systems at play that might also be looking to do the same thing as you.
+
+For those who just want to know of the changes, this can be achieved using a text content listener or an editor update listener.

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -20,7 +20,9 @@ export var CLICK_COMMAND: LexicalCommand<MouseEvent>;
 export var DELETE_CHARACTER_COMMAND: LexicalCommand<boolean>;
 export var INSERT_LINE_BREAK_COMMAND: LexicalCommand<boolean>;
 export var INSERT_PARAGRAPH_COMMAND: LexicalCommand<void>;
-export var CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<InputEvent | string>;
+export var CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<
+  InputEvent | string
+>;
 export var PASTE_COMMAND: LexicalCommand<ClipboardEvent>;
 export var REMOVE_TEXT_COMMAND: LexicalCommand<void>;
 export var DELETE_WORD_COMMAND: LexicalCommand<boolean>;

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -20,7 +20,7 @@ export var CLICK_COMMAND: LexicalCommand<MouseEvent>;
 export var DELETE_CHARACTER_COMMAND: LexicalCommand<boolean>;
 export var INSERT_LINE_BREAK_COMMAND: LexicalCommand<boolean>;
 export var INSERT_PARAGRAPH_COMMAND: LexicalCommand<void>;
-export var INSERT_TEXT_COMMAND: LexicalCommand<InputEvent | string>;
+export var CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<InputEvent | string>;
 export var PASTE_COMMAND: LexicalCommand<ClipboardEvent>;
 export var REMOVE_TEXT_COMMAND: LexicalCommand<void>;
 export var DELETE_WORD_COMMAND: LexicalCommand<boolean>;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -18,7 +18,7 @@ declare export var CLICK_COMMAND: LexicalCommand<MouseEvent>;
 declare export var DELETE_CHARACTER_COMMAND: LexicalCommand<boolean>;
 declare export var INSERT_LINE_BREAK_COMMAND: LexicalCommand<boolean>;
 declare export var INSERT_PARAGRAPH_COMMAND: LexicalCommand<void>;
-declare export var INSERT_TEXT_COMMAND: LexicalCommand<string>;
+declare export var CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<string>;
 declare export var PASTE_COMMAND: LexicalCommand<ClipboardEvent>;
 declare export var REMOVE_TEXT_COMMAND: LexicalCommand<void>;
 declare export var DELETE_WORD_COMMAND: LexicalCommand<boolean>;

--- a/packages/lexical/src/LexicalCommands.js
+++ b/packages/lexical/src/LexicalCommands.js
@@ -21,7 +21,8 @@ export const DELETE_CHARACTER_COMMAND: LexicalCommand<boolean> =
 export const INSERT_LINE_BREAK_COMMAND: LexicalCommand<boolean> =
   createCommand();
 export const INSERT_PARAGRAPH_COMMAND: LexicalCommand<void> = createCommand();
-export const CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<string> = createCommand();
+export const CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<string> =
+  createCommand();
 export const PASTE_COMMAND: LexicalCommand<ClipboardEvent> = createCommand();
 export const REMOVE_TEXT_COMMAND: LexicalCommand<void> = createCommand();
 export const DELETE_WORD_COMMAND: LexicalCommand<boolean> = createCommand();

--- a/packages/lexical/src/LexicalCommands.js
+++ b/packages/lexical/src/LexicalCommands.js
@@ -21,7 +21,7 @@ export const DELETE_CHARACTER_COMMAND: LexicalCommand<boolean> =
 export const INSERT_LINE_BREAK_COMMAND: LexicalCommand<boolean> =
   createCommand();
 export const INSERT_PARAGRAPH_COMMAND: LexicalCommand<void> = createCommand();
-export const INSERT_TEXT_COMMAND: LexicalCommand<string> = createCommand();
+export const CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<string> = createCommand();
 export const PASTE_COMMAND: LexicalCommand<ClipboardEvent> = createCommand();
 export const REMOVE_TEXT_COMMAND: LexicalCommand<void> = createCommand();
 export const DELETE_WORD_COMMAND: LexicalCommand<boolean> = createCommand();

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -350,7 +350,11 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
             const prevTextContent = prevNode.getTextContent();
             if (composedText.indexOf(prevTextContent) === 0) {
               const insertedText = composedText.slice(prevTextContent.length);
-              dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, insertedText);
+              dispatchCommand(
+                editor,
+                CONTROLLED_TEXT_INSERTION_COMMAND,
+                insertedText,
+              );
               setTimeout(() => {
                 updateEditor(editor, () => {
                   node.select();
@@ -618,7 +622,11 @@ function onCompositionStart(
         // to get inserted into the new node we create. If
         // we don't do this, Safari will fail on us because
         // there is no text node matching the selection.
-        dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, COMPOSITION_START_CHAR);
+        dispatchCommand(
+          editor,
+          CONTROLLED_TEXT_INSERTION_COMMAND,
+          COMPOSITION_START_CHAR,
+        );
       }
     }
   });

--- a/packages/lexical/src/LexicalEvents.js
+++ b/packages/lexical/src/LexicalEvents.js
@@ -33,6 +33,7 @@ import {
   $setCompositionKey,
   BLUR_COMMAND,
   CLICK_COMMAND,
+  CONTROLLED_TEXT_INSERTION_COMMAND,
   COPY_COMMAND,
   CUT_COMMAND,
   DELETE_CHARACTER_COMMAND,
@@ -46,7 +47,6 @@ import {
   FORMAT_TEXT_COMMAND,
   INSERT_LINE_BREAK_COMMAND,
   INSERT_PARAGRAPH_COMMAND,
-  INSERT_TEXT_COMMAND,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
@@ -350,7 +350,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
             const prevTextContent = prevNode.getTextContent();
             if (composedText.indexOf(prevTextContent) === 0) {
               const insertedText = composedText.slice(prevTextContent.length);
-              dispatchCommand(editor, INSERT_TEXT_COMMAND, insertedText);
+              dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, insertedText);
               setTimeout(() => {
                 updateEditor(editor, () => {
                   node.select();
@@ -425,7 +425,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
         $shouldPreventDefaultAndInsertText(selection, data)
       ) {
         event.preventDefault();
-        dispatchCommand(editor, INSERT_TEXT_COMMAND, data);
+        dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, data);
       }
       return;
     }
@@ -439,13 +439,13 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
       case 'insertFromYank':
       case 'insertFromDrop':
       case 'insertReplacementText': {
-        dispatchCommand(editor, INSERT_TEXT_COMMAND, event);
+        dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, event);
         break;
       }
       case 'insertFromComposition': {
         // This is the end of composition
         $setCompositionKey(null);
-        dispatchCommand(editor, INSERT_TEXT_COMMAND, event);
+        dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, event);
         break;
       }
       case 'insertLineBreak': {
@@ -562,7 +562,7 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
         onCompositionEndImpl(editor, data);
         isFirefoxEndingComposition = false;
       }
-      dispatchCommand(editor, INSERT_TEXT_COMMAND, data);
+      dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, data);
       if (possibleTextReplacement) {
         // If the DOM selection offset is higher than the existing
         // offset, then restore the offset as it's likely correct
@@ -618,7 +618,7 @@ function onCompositionStart(
         // to get inserted into the new node we create. If
         // we don't do this, Safari will fail on us because
         // there is no text node matching the selection.
-        dispatchCommand(editor, INSERT_TEXT_COMMAND, COMPOSITION_START_CHAR);
+        dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, COMPOSITION_START_CHAR);
       }
     }
   });


### PR DESCRIPTION
The `INSERT_TEXT_COMMAND` is misleading. It appears to be a signal for a user to detect some user text insertion, and allowing them to override it or change what is coming in. Actually, this couldn't be further from the truth – it's actually an internal signal used to let plugins know of a controlled text insertion, rather than a non-controlled text insertion (we let the browser do it and do not override). This PR renames it to `CONTROLLED_TEXT_INSERTION` to better communicate intent.

I also added a piece in the FAQ to explain how to go about listening for text insertions the correct way – using node transforms.