### PR TITLE
Expose RootNode to be used in node transform

### DIFF
--- a/packages/lexical/src/index.js
+++ b/packages/lexical/src/index.js
@@ -52,7 +52,7 @@ import {
   $isParagraphNode,
   ParagraphNode,
 } from './nodes/LexicalParagraphNode';
-import {$isRootNode} from './nodes/LexicalRootNode';
+import {$isRootNode, RootNode} from './nodes/LexicalRootNode';
 import {$createTextNode, $isTextNode, TextNode} from './nodes/LexicalTextNode';
 
 export {
@@ -98,6 +98,7 @@ export {
   GridRowNode,
   LineBreakNode,
   ParagraphNode,
+  RootNode,
   TextNode,
   VERSION,
 };


### PR DESCRIPTION
This would be useful for cases where we want to use `RootNode` in a node transform.