### PR TITLE
Fix getTopLevelElement shouldn't get the root node

### DIFF
--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -348,8 +348,8 @@ export declare class LexicalNode {
   getIndexWithinParent(): number;
   getParent<T extends ElementNode>(): T | null;
   getParentOrThrow<T extends ElementNode>(): T;
-  getTopLevelElement<T extends RootNode>(): T | null;
-  getTopLevelElementOrThrow<T extends RootNode>(): T;
+  getTopLevelElement(): ElementNode | null;
+  getTopLevelElementOrThrow(): ElementNode;
   getParents<T extends ElementNode>(): Array<T>;
   getParentKeys(): Array<NodeKey>;
   getPreviousSibling<T extends LexicalNode>(): T | null;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -348,8 +348,8 @@ declare export class LexicalNode {
   getIndexWithinParent(): number;
   getParent<T: ElementNode>(): T | null;
   getParentOrThrow<T: ElementNode>(): T;
-  getTopLevelElement<T: RootNode>(): T | null;
-  getTopLevelElementOrThrow<T: RootNode>(): T;
+  getTopLevelElement(): ElementNode | null;
+  getTopLevelElementOrThrow(): ElementNode;
   getParents<T: ElementNode>(): Array<T>;
   getParentKeys(): Array<NodeKey>;
   getPreviousSibling<T: LexicalNode>(): T | null;

--- a/packages/lexical/src/LexicalNode.js
+++ b/packages/lexical/src/LexicalNode.js
@@ -7,7 +7,6 @@
  * @flow strict
  */
 
-import type {RootNode} from '../flow/Lexical';
 import type {EditorConfig, LexicalEditor} from './LexicalEditor';
 import type {RangeSelection} from './LexicalSelection';
 
@@ -277,12 +276,11 @@ export class LexicalNode {
     return parent;
   }
 
-  getTopLevelElement<T: RootNode>(): T | null {
+  getTopLevelElement(): ElementNode | null {
     let node = this;
     while (node !== null) {
       const parent = node.getParent();
-      if ($isRootNode(parent)) {
-        // $FlowFixMe
+      if ($isRootNode(parent) && $isElementNode(node)) {
         return node;
       }
       node = parent;
@@ -290,7 +288,7 @@ export class LexicalNode {
     return null;
   }
 
-  getTopLevelElementOrThrow<T: RootNode>(): T {
+  getTopLevelElementOrThrow(): ElementNode {
     const parent = this.getTopLevelElement();
     if (parent === null) {
       invariant(


### PR DESCRIPTION
`getTopLevelElement` should get the top most nested element, not the root.