### PR TITLE
Fix relative imports in @lexical/react

### DIFF
--- a/packages/lexical-react/src/LexicalAutoFocusPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoFocusPlugin.ts
@@ -6,9 +6,8 @@
  *
  */
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
 
 export function AutoFocusPlugin(): null {
   const [editor] = useLexicalComposerContext();

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -14,6 +14,7 @@ import {
   $isLinkNode,
   AutoLinkNode,
 } from '@lexical/link';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
 import {
   $createTextNode,
@@ -24,8 +25,6 @@ import {
 } from 'lexical';
 import {useEffect} from 'react';
 import invariant from 'shared-ts/invariant';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
 
 type ChangeHandler = (url: string | null, prevUrl: string | null) => void;
 

--- a/packages/lexical-react/src/LexicalAutoScrollPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoScrollPlugin.ts
@@ -6,10 +6,9 @@
  *
  */
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$getSelection, $isRangeSelection} from 'lexical';
 import useLayoutEffect from 'shared-ts/useLayoutEffect';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
 
 type Props = Readonly<{
   scrollRef: {

--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -8,6 +8,9 @@
 
 import type {ElementFormatType, NodeKey} from 'lexical';
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$isDecoratorBlockNode} from '@lexical/react/LexicalDecoratorBlockNode';
+import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {
   $getNearestBlockElementAncestorOrThrow,
   mergeRegister,
@@ -26,10 +29,6 @@ import {
 } from 'lexical';
 import * as React from 'react';
 import {useCallback, useEffect, useRef} from 'react';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
-import {$isDecoratorBlockNode} from './LexicalDecoratorBlockNode';
-import {useLexicalNodeSelection} from './useLexicalNodeSelection';
 
 type Props = Readonly<{
   children: JSX.Element;

--- a/packages/lexical-react/src/LexicalCharacterLimitPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCharacterLimitPlugin.tsx
@@ -6,10 +6,10 @@
  *
  */
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
 import {useMemo, useState} from 'react';
 
-import {useLexicalComposerContext} from './LexicalComposerContext';
 import {useCharacterLimit} from './shared/useCharacterLimit';
 
 const CHARACTER_LIMIT = 5;

--- a/packages/lexical-react/src/LexicalCheckListPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCheckListPlugin.tsx
@@ -15,6 +15,7 @@ import {
   INSERT_CHECK_LIST_COMMAND,
   insertList,
 } from '@lexical/list';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
   $getNearestNodeFromDOMNode,
@@ -29,8 +30,6 @@ import {
   KEY_SPACE_COMMAND,
 } from 'lexical';
 import {useEffect} from 'react';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
 
 export function CheckListPlugin(): null {
   const [editor] = useLexicalComposerContext();

--- a/packages/lexical-react/src/LexicalClearEditorPlugin.ts
+++ b/packages/lexical-react/src/LexicalClearEditorPlugin.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $createParagraphNode,
   $getRoot,
@@ -14,8 +15,6 @@ import {
   COMMAND_PRIORITY_EDITOR,
 } from 'lexical';
 import useLayoutEffect from 'shared-ts/useLayoutEffect';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
 
 type Props = Readonly<{
   onClear?: () => void;

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.ts
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.ts
@@ -9,9 +9,9 @@
 import type {Provider} from '@lexical/yjs';
 import type {Doc} from 'yjs';
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {createContext, useContext, useMemo} from 'react';
 
-import {useLexicalComposerContext} from './LexicalComposerContext';
 import {
   useYjsCollaboration,
   useYjsFocusTracking,

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -6,19 +6,18 @@
  *
  */
 
-import type {LexicalComposerContextType} from './LexicalComposerContext';
+import type {LexicalComposerContextType} from '@lexical/react/LexicalComposerContext';
 import type {EditorThemeClasses, LexicalEditor, LexicalNode} from 'lexical';
 
+import {
+  createLexicalComposerContext,
+  LexicalComposerContext,
+} from '@lexical/react/LexicalComposerContext';
 import {createEditor} from 'lexical';
 import {useMemo} from 'react';
 import * as React from 'react';
 import useLayoutEffect from 'shared-ts/useLayoutEffect';
 import {Class} from 'utility-types';
-
-import {
-  createLexicalComposerContext,
-  LexicalComposerContext,
-} from './LexicalComposerContext';
 
 type Props = {
   children: JSX.Element | string | (JSX.Element | string)[];

--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -6,11 +6,10 @@
  *
  */
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
 import {CSSProperties, useCallback, useState} from 'react';
 import useLayoutEffect from 'shared-ts/useLayoutEffect';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
 
 export type Props = Readonly<{
   ariaActiveDescendantID?: string;

--- a/packages/lexical-react/src/LexicalHashtagPlugin.ts
+++ b/packages/lexical-react/src/LexicalHashtagPlugin.ts
@@ -9,10 +9,9 @@
 import type {TextNode} from 'lexical';
 
 import {$createHashtagNode, HashtagNode} from '@lexical/hashtag';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalTextEntity} from '@lexical/react/useLexicalTextEntity';
 import {useCallback, useEffect} from 'react';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
-import {useLexicalTextEntity} from './useLexicalTextEntity';
 
 function getHashtagRegexStringChars(): Readonly<{
   alpha: string;

--- a/packages/lexical-react/src/LexicalHistoryPlugin.ts
+++ b/packages/lexical-react/src/LexicalHistoryPlugin.ts
@@ -8,7 +8,8 @@
 
 import type {HistoryState} from '@lexical/history';
 
-import {useLexicalComposerContext} from './LexicalComposerContext';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+
 import {useHistory} from './shared/useHistory';
 
 export {createEmptyHistoryState} from '@lexical/history';

--- a/packages/lexical-react/src/LexicalLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalLinkPlugin.ts
@@ -12,6 +12,7 @@ import {
   LinkNode,
   TOGGLE_LINK_COMMAND,
 } from '@lexical/link';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $getSelection,
   $isElementNode,
@@ -19,8 +20,6 @@ import {
   COMMAND_PRIORITY_EDITOR,
 } from 'lexical';
 import {useEffect} from 'react';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
 
 function toggleLink(url: null | string) {
   const selection = $getSelection();

--- a/packages/lexical-react/src/LexicalListPlugin.ts
+++ b/packages/lexical-react/src/LexicalListPlugin.ts
@@ -7,9 +7,9 @@
  */
 
 import {ListItemNode, ListNode} from '@lexical/list';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
 
-import {useLexicalComposerContext} from './LexicalComposerContext';
 import {useList} from './shared/useList';
 
 export function ListPlugin(): null {

--- a/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.tsx
+++ b/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.tsx
@@ -10,13 +10,12 @@ import type {ElementTransformer, Transformer} from '@lexical/markdown';
 import type {LexicalNode} from 'lexical';
 
 import {registerMarkdownShortcuts, TRANSFORMERS} from '@lexical/markdown';
-import {useEffect} from 'react';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $createHorizontalRuleNode,
   $isHorizontalRuleNode,
-} from './LexicalHorizontalRuleNode';
+} from '@lexical/react/LexicalHorizontalRuleNode';
+import {useEffect} from 'react';
 
 const HR: ElementTransformer = {
   export: (node: LexicalNode) => {

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -6,18 +6,17 @@
  *
  */
 
-import type {LexicalComposerContextType} from './LexicalComposerContext';
+import type {LexicalComposerContextType} from '@lexical/react/LexicalComposerContext';
 import type {EditorThemeClasses, LexicalEditor} from 'lexical';
 
-import * as React from 'react';
-import {useContext, useMemo} from 'react';
-import invariant from 'shared-ts/invariant';
-
-import {useCollaborationContext} from './LexicalCollaborationPlugin';
+import {useCollaborationContext} from '@lexical/react/LexicalCollaborationPlugin';
 import {
   createLexicalComposerContext,
   LexicalComposerContext,
-} from './LexicalComposerContext';
+} from '@lexical/react/LexicalComposerContext';
+import * as React from 'react';
+import {useContext, useMemo} from 'react';
+import invariant from 'shared-ts/invariant';
 
 export function LexicalNestedComposer({
   initialEditor,

--- a/packages/lexical-react/src/LexicalOnChangePlugin.ts
+++ b/packages/lexical-react/src/LexicalOnChangePlugin.ts
@@ -8,9 +8,8 @@
 
 import type {EditorState, LexicalEditor} from 'lexical';
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import useLayoutEffect from 'shared-ts/useLayoutEffect';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
 
 export function OnChangePlugin({
   ignoreInitialChange = true,

--- a/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
@@ -8,9 +8,9 @@
 
 import type {InitialEditorStateType} from './shared/PlainRichTextUtils';
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
 
-import {useLexicalComposerContext} from './LexicalComposerContext';
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 import {useDecorators} from './shared/useDecorators';
 import {usePlainTextSetup} from './shared/usePlainTextSetup';

--- a/packages/lexical-react/src/LexicalRichTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalRichTextPlugin.tsx
@@ -8,9 +8,9 @@
 
 import type {InitialEditorStateType} from './shared/PlainRichTextUtils';
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
 
-import {useLexicalComposerContext} from './LexicalComposerContext';
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 import {useDecorators} from './shared/useDecorators';
 import {useRichTextSetup} from './shared/useRichTextSetup';

--- a/packages/lexical-react/src/LexicalTablePlugin.ts
+++ b/packages/lexical-react/src/LexicalTablePlugin.ts
@@ -9,6 +9,7 @@
 import type {InsertTableCommandPayload, TableSelection} from '@lexical/table';
 import type {ElementNode, NodeKey} from 'lexical';
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $createTableNodeWithDimensions,
   applyTableHandlers,
@@ -27,8 +28,6 @@ import {
 } from 'lexical';
 import {useEffect} from 'react';
 import invariant from 'shared-ts/invariant';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
 
 export function TablePlugin(): JSX.Element {
   const [editor] = useLexicalComposerContext();

--- a/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
@@ -6,12 +6,12 @@
  *
  */
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 
 import {LexicalComposer} from '../../LexicalComposer';
-import {useLexicalComposerContext} from '../../LexicalComposerContext';
 
 describe('LexicalNodeHelpers tests', () => {
   let container = null;

--- a/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
@@ -11,6 +11,7 @@ import {HashtagNode} from '@lexical/hashtag';
 import {AutoLinkNode, LinkNode} from '@lexical/link';
 import {ListItemNode, ListNode} from '@lexical/list';
 import {OverflowNode} from '@lexical/overflow';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
 import {$rootTextContentCurry} from '@lexical/text';
@@ -26,7 +27,6 @@ import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 
 import {LexicalComposer} from '../../LexicalComposer';
-import {useLexicalComposerContext} from '../../LexicalComposerContext';
 import {ContentEditable} from '../../LexicalContentEditable';
 import {PlainTextPlugin} from '../../LexicalPlainTextPlugin';
 import {RichTextPlugin} from '../../LexicalRichTextPlugin';

--- a/packages/lexical-react/src/__tests__/unit/utils.tsx
+++ b/packages/lexical-react/src/__tests__/unit/utils.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {LexicalEditor} from 'lexical';
 import * as React from 'react';
 import {createRoot, Root} from 'react-dom/client';
@@ -17,7 +18,6 @@ import {
   useCollaborationContext,
 } from '../../LexicalCollaborationPlugin';
 import {LexicalComposer} from '../../LexicalComposer';
-import {useLexicalComposerContext} from '../../LexicalComposerContext';
 import {ContentEditable} from '../../LexicalContentEditable';
 import {RichTextPlugin} from '../../LexicalRichTextPlugin';
 

--- a/packages/lexical-react/src/useLexicalNodeSelection.ts
+++ b/packages/lexical-react/src/useLexicalNodeSelection.ts
@@ -8,6 +8,7 @@
 
 import type {LexicalEditor, NodeKey} from 'lexical';
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $createNodeSelection,
   $getNodeByKey,
@@ -16,8 +17,6 @@ import {
   $setSelection,
 } from 'lexical';
 import {useCallback, useEffect, useState} from 'react';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
 
 function isNodeSelected(editor: LexicalEditor, key: NodeKey): boolean {
   return editor.getEditorState().read(() => {

--- a/packages/lexical-react/src/useLexicalTextEntity.ts
+++ b/packages/lexical-react/src/useLexicalTextEntity.ts
@@ -9,12 +9,11 @@
 import type {EntityMatch} from '@lexical/text';
 import type {TextNode} from 'lexical';
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {registerLexicalTextEntity} from '@lexical/text';
 import {mergeRegister} from '@lexical/utils';
 import {useEffect} from 'react';
 import {Class} from 'utility-types';
-
-import {useLexicalComposerContext} from './LexicalComposerContext';
 
 export function useLexicalTextEntity<N extends TextNode>(
   getMatch: (text: string) => null | EntityMatch,

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -79,8 +79,9 @@ const lexicalReactModules = fs
   );
 
 const lexicalReactModuleExternals = lexicalReactModules.map((module) => {
-  const external = `@lexical/react/${module}`;
-  wwwMappings[external] = module;
+  const basename = path.basename(path.basename(module, '.ts'), '.tsx');
+  const external = `@lexical/react/${basename}`;
+  wwwMappings[external] = basename;
   return external;
 });
 


### PR DESCRIPTION
The recent refactor of `@lexical/react` to TS has caused some the imports to be incorrectly re-written. If relative imports are used, then we inline the module. We only want to do this for shared modules, otherwise this will cause major issues for npm/www releases.