### PR TITLE
Append additional newline when exporting Quote node as Markdown

### DIFF
--- a/packages/lexical-markdown/src/v2/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/v2/MarkdownImport.ts
@@ -75,6 +75,7 @@ function importBlocks(
   textFormatTransformersIndex: TextFormatTransformersIndex,
   textMatchTransformers: Array<TextMatchTransformer>,
 ) {
+  if (lineText === '') return
   const textNode = $createTextNode(lineText);
   const elementNode = $createParagraphNode();
   elementNode.append(textNode);

--- a/packages/lexical-markdown/src/v2/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/v2/MarkdownTransformers.ts
@@ -124,7 +124,7 @@ export const HEADING: ElementTransformer = {
 
 export const QUOTE: ElementTransformer = {
   export: (node, exportChildren) => {
-    return $isQuoteNode(node) ? '> ' + exportChildren(node) : null;
+    return $isQuoteNode(node) ? '> ' + exportChildren(node) + '\n' : null;
   },
   regExp: /^>\s/,
   replace: replaceWithBlock(() => $createQuoteNode()),


### PR DESCRIPTION
No idea if there is a better way to do this, but I believe this is right.

closes #2247


--

Hmmm, may need a more contextual solution, this naively _always_ appends new lines, (flipping back and forth between content & markdown results in a growing markdown tab)