### PR TITLE
Trim whitespace before applying text formatting during markdown export

### DIFF
--- a/packages/lexical-markdown/src/v2/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/v2/MarkdownExport.ts
@@ -123,7 +123,13 @@ function exportTextFormat(
   textContent: string,
   textTransformers: Array<TextFormatTransformer>,
 ): string {
-  let output = textContent;
+  // This function handles the case of a string looking like this: "   foo   "
+  // Where it would be invalid markdown to generate: "**   foo   **"
+  // We instead want to trim the whitespace out, apply formatting, and then
+  // bring the whitespace back. So our returned string looks like this: "   **foo**   "
+  const frozenString = textContent.trim();
+  let output = frozenString;
+
   const applied = new Set();
 
   for (const transformer of textTransformers) {
@@ -149,7 +155,8 @@ function exportTextFormat(
     }
   }
 
-  return output;
+  // Replace trimmed version of textContent ensuring surrounding whitespace is not modified
+  return textContent.replace(frozenString, output);
 }
 
 // Get next or previous text sibling a text node, including cases


### PR DESCRIPTION
When typing and combining different text-format's on text nodes, i.e. "**bold** _italic_" it's easy to break the markdown export as it currently applies the formatting characters around included whitespace.

i.e. `"  foo  "` becomes `"**  foo  **"` when we actually want it to be `"   **foo**   "`

This PR fixes that

---

Before:
![Screen Recording 2022-05-23 at 2 48 10 PM](https://user-images.githubusercontent.com/2148168/169911150-f3392f9b-a70b-4f8e-a65c-d1b10bb30290.gif)

After:
![Screen Recording 2022-05-23 at 2 50 05 PM](https://user-images.githubusercontent.com/2148168/169911349-43ceee83-61f1-43ff-9770-8de12f3a83b2.gif)


closes #2250