### PR TITLE
Expose $parseSerializedNode

### DIFF
--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -832,7 +832,18 @@ export type EventHandler = (event: Event, editor: LexicalEditor) => void;
  */
 export declare var VERSION: string;
 
-// Serialization
+/**
+ *  Serialization/Deserialization
+ * */
+interface InternalSerializedNode {
+  children?: Array<InternalSerializedNode>;
+  type: string;
+  version: number;
+}
+
+export function $parseSerializedNode<
+  SerializedNode extends InternalSerializedNode,
+>(serializedNode: SerializedNode): LexicalNode;
 
 export type SerializedLexicalNode = {
   type: string;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -861,7 +861,19 @@ export type EventHandler = (event: Event, editor: LexicalEditor) => void;
  */
 declare export var VERSION: string;
 
-// Serialization
+/**
+ * Serialization/Deserialization
+ * */
+
+type InternalSerializedNode = {
+  children?: Array<InternalSerializedNode>,
+  type: string,
+  version: number,
+};
+
+declare export function $parseSerializedNode(
+  serializedNode: InternalSerializedNode,
+): LexicalNode;
 
 export type SerializedLexicalNode = {
   type: string,

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -309,9 +309,9 @@ export function parseEditorState(
 }
 
 export interface InternalSerializedNode {
-  children?: Array<InternalSerializedNode>,
-  type: string,
-  version: number,
+  children?: Array<InternalSerializedNode>;
+  type: string;
+  version: number;
 }
 
 export function $parseSerializedNode(
@@ -325,7 +325,9 @@ export function $parseSerializedNode(
   );
 }
 
-function $parseSerializedNodeImpl<SerializedNode extends InternalSerializedNode>(
+function $parseSerializedNodeImpl<
+  SerializedNode extends InternalSerializedNode,
+>(
   serializedNode: SerializedNode,
   registeredNodes: RegisteredNodes,
 ): LexicalNode {

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -18,7 +18,7 @@ import type {
   ParsedEditorState,
   SerializedEditorState,
 } from './LexicalEditorState';
-import type {LexicalNode} from './LexicalNode';
+import type {LexicalNode, SerializedLexicalNode} from './LexicalNode';
 import type {NodeParserState, ParsedNode} from './LexicalParsing';
 
 import invariant from 'shared/invariant';
@@ -307,13 +307,25 @@ export function parseEditorState(
   );
   return editorState;
 }
-type InternalSerializedNode = {
-  children?: Array<InternalSerializedNode>;
-  type: string;
-  version: number;
-};
 
-function parseSerializedNode<SerializedNode extends InternalSerializedNode>(
+export interface InternalSerializedNode {
+  children?: Array<InternalSerializedNode>,
+  type: string,
+  version: number,
+}
+
+export function $parseSerializedNode(
+  serializedNode: SerializedLexicalNode,
+): LexicalNode {
+  // $FlowFixMe: intentional cast to our internal type
+  const internalSerializedNode: InternalSerializedNode = serializedNode;
+  return $parseSerializedNodeImpl(
+    internalSerializedNode,
+    getActiveEditor()._nodes,
+  );
+}
+
+function $parseSerializedNodeImpl<SerializedNode extends InternalSerializedNode>(
   serializedNode: SerializedNode,
   registeredNodes: RegisteredNodes,
 ): LexicalNode {
@@ -342,7 +354,7 @@ function parseSerializedNode<SerializedNode extends InternalSerializedNode>(
   if ($isElementNode(node) && Array.isArray(children)) {
     for (let i = 0; i < children.length; i++) {
       const serializedJSONChildNode = children[i];
-      const childNode = parseSerializedNode(
+      const childNode = $parseSerializedNodeImpl(
         serializedJSONChildNode,
         registeredNodes,
       );
@@ -369,8 +381,7 @@ export function unstable_parseEditorState(
   try {
     const registeredNodes = editor._nodes;
     const serializedNode = serializedEditorState.root;
-    parseSerializedNode(serializedNode, registeredNodes);
-
+    $parseSerializedNodeImpl(serializedNode, registeredNodes);
     if (updateFn) {
       updateFn();
     }

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -26,6 +26,7 @@ import {
   $getRoot,
   $getSelection,
   $isTextNode,
+  $parseSerializedNode,
   $setCompositionKey,
   $setSelection,
   COMMAND_PRIORITY_EDITOR,
@@ -1337,6 +1338,33 @@ describe('LexicalEditor tests', () => {
         expect(parsedSelection.anchor.key).toEqual(parsedText.__key);
         expect(parsedSelection.focus.key).toEqual(parsedText.__key);
       });
+    });
+  });
+
+  describe('$parseSerializedNode()', () => {
+    it('parses serialized nodes', async () => {
+      const expectedTextContent = 'Hello world\n\nHello world';
+      let actualTextContent;
+      let root;
+      await update(() => {
+        root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode('Hello world'));
+        root.append(paragraph);
+      });
+      const stringifiedEditorState = JSON.stringify(
+        editor.getEditorState().unstable_toJSON(),
+      );
+      const parsedEditorStateJson = JSON.parse(stringifiedEditorState);
+      const rootJson = parsedEditorStateJson.root;
+      await update(() => {
+        const children = rootJson.children.map($parseSerializedNode);
+        root = $getRoot();
+        root.append(...children);
+        actualTextContent = root.getTextContent();
+      });
+      expect(actualTextContent).toEqual(expectedTextContent);
     });
   });
 

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -25,6 +25,7 @@ import {
   $isNodeSelection,
   $isRangeSelection,
 } from './LexicalSelection';
+import {$parseSerializedNode} from './LexicalUpdates';
 import {
   $getDecoratorNode,
   $getNearestNodeFromDOMNode,
@@ -82,6 +83,7 @@ export {
   $isRootNode,
   $isTextNode,
   $nodesOfType,
+  $parseSerializedNode,
   $setCompositionKey,
   $setSelection,
   COMMAND_PRIORITY_CRITICAL,


### PR DESCRIPTION
The use case for this is taking a previously saved editor state and inserting it into an active editor state. In order to do this, we need the parsed nodes we want to insert to be in the activeEditorState, which is not the case if we just use the unstable_parseEditorState API and pass them in. Previously, we exported $createNodeFromParse for this.