### PR TITLE
Add MaxLengthPlugin

### DIFF
--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -44,6 +44,7 @@ import ImagesPlugin from './plugins/ImagesPlugin';
 import KeywordsPlugin from './plugins/KeywordsPlugin';
 import ListMaxIndentLevelPlugin from './plugins/ListMaxIndentLevelPlugin';
 import MarkdownShortcutPlugin from './plugins/MarkdownShortcutPlugin';
+import {MaxLengthPlugin} from './plugins/MaxLengthPlugin';
 import MentionsPlugin from './plugins/MentionsPlugin';
 import PollPlugin from './plugins/PollPlugin';
 import SpeechToTextPlugin from './plugins/SpeechToTextPlugin';
@@ -147,6 +148,7 @@ export default function Editor(): JSX.Element {
     settings: {
       isCollab,
       isAutocomplete,
+      isMaxLength,
       isCharLimit,
       isCharLimitUtf8,
       isRichText,
@@ -170,6 +172,7 @@ export default function Editor(): JSX.Element {
           !isRichText ? 'plain-text' : ''
         }`}
         ref={scrollRef}>
+        {isMaxLength && <MaxLengthPlugin maxLength={30} />}
         <AutoFocusPlugin />
         <ClearEditorPlugin />
         <MentionsPlugin />

--- a/packages/lexical-playground/src/Settings.tsx
+++ b/packages/lexical-playground/src/Settings.tsx
@@ -21,6 +21,7 @@ export default function Settings(): JSX.Element {
       measureTypingPerf,
       isCollab,
       isRichText,
+      isMaxLength,
       isCharLimit,
       isCharLimitUtf8,
       isAutocomplete,
@@ -104,6 +105,11 @@ export default function Settings(): JSX.Element {
             onClick={() => setOption('isCharLimitUtf8', !isCharLimitUtf8)}
             checked={isCharLimitUtf8}
             text="Char Limit (UTF-8)"
+          />
+          <Switch
+            onClick={() => setOption('isMaxLength', !isMaxLength)}
+            checked={isMaxLength}
+            text="Max Length"
           />
           <Switch
             onClick={() => setOption('isAutocomplete', !isAutocomplete)}

--- a/packages/lexical-playground/src/appSettings.ts
+++ b/packages/lexical-playground/src/appSettings.ts
@@ -12,6 +12,7 @@ export type SettingName =
   | 'isRichText'
   | 'isCollab'
   | 'isCharLimit'
+  | 'isMaxLength'
   | 'isCharLimitUtf8'
   | 'isAutocomplete'
   | 'showTreeView'
@@ -32,6 +33,7 @@ export const DEFAULT_SETTINGS: Settings = {
   isCharLimit: false,
   isCharLimitUtf8: false,
   isCollab: false,
+  isMaxLength: false,
   isRichText: true,
   measureTypingPerf: false,
   showNestedEditorTreeView: false,

--- a/packages/lexical-playground/src/plugins/MaxLengthPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/MaxLengthPlugin.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {trimTextContentFromAnchor} from '@lexical/selection';
+import {$getSelection, $isRangeSelection, RootNode} from 'lexical';
+import {useEffect} from 'react';
+
+export function MaxLengthPlugin({maxLength}: {maxLength: number}): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return editor.registerNodeTransform(RootNode, (rootNode: RootNode) => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+        return;
+      }
+      const prevTextContent = editor
+        .getEditorState()
+        .read(() => rootNode.getTextContent());
+      const textContent = rootNode.getTextContent();
+      if (prevTextContent !== textContent) {
+        const textLength = textContent.length;
+        const delCount = textLength - maxLength;
+        const anchor = selection.anchor;
+
+        if (delCount > 0) {
+          trimTextContentFromAnchor(editor, anchor, delCount);
+        }
+      }
+    });
+  }, [editor, maxLength]);
+
+  return null;
+}

--- a/packages/lexical-selection/LexicalSelection.d.ts
+++ b/packages/lexical-selection/LexicalSelection.d.ts
@@ -62,7 +62,7 @@ export function $shouldOverrideDefaultCharacterSelection(
   isBackward: boolean,
 ): boolean;
 
-declare function createDOMRange(
+export declare function createDOMRange(
   editor: LexicalEditor,
   anchorNode: LexicalNode,
   anchorOffset: number,
@@ -70,7 +70,13 @@ declare function createDOMRange(
   focusOffset: number,
 ): Range | null;
 
-declare function createRectsFromDOMRange(
+export declare function createRectsFromDOMRange(
   editor: LexicalEditor,
   range: Range,
 ): Array<ClientRect>;
+
+export declare function trimTextContentFromAnchor(
+  editor: LexicalEditor,
+  anchor: Point,
+  delCount: number,
+): void;

--- a/packages/lexical-selection/flow/LexicalSelection.js.flow
+++ b/packages/lexical-selection/flow/LexicalSelection.js.flow
@@ -73,3 +73,9 @@ declare export function createRectsFromDOMRange(
   editor: LexicalEditor,
   range: Range,
 ): Array<ClientRect>;
+
+declare export function trimTextContentFromAnchor(
+  editor: LexicalEditor,
+  anchor: Point,
+  delCount: number,
+): void;

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -240,8 +240,7 @@ function $applyAllTransforms(
     for (const currentUntransformedDirtyElement of untransformedDirtyElements) {
       const nodeKey = currentUntransformedDirtyElement[0];
       const intentionallyMarkedAsDirty = currentUntransformedDirtyElement[1];
-
-      if (nodeKey === 'root' || !intentionallyMarkedAsDirty) {
+      if (nodeKey !== 'root' && !intentionallyMarkedAsDirty) {
         continue;
       }
 

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -159,13 +159,15 @@ export class ElementNode extends LexicalNode {
       const resolvedNode = children[childrenLength - 1];
       return (
         ($isElementNode(resolvedNode) && resolvedNode.getLastDescendant()) ||
-        resolvedNode
+        resolvedNode ||
+        null
       );
     }
     const resolvedNode = children[index];
     return (
       ($isElementNode(resolvedNode) && resolvedNode.getFirstDescendant()) ||
-      resolvedNode
+      resolvedNode ||
+      null
     );
   }
   getFirstChild<T extends LexicalNode>(): null | T {


### PR DESCRIPTION
This PR adds a MaxLengthPlugin, and an associated `@lexical/selection` helper function `trimTextContentFromAnchor` to make all the logic work well. Internally, we expose `RootNode` to be treated always as a dirty element if any of its children are dirty too.