### PR TITLE
Fix flow

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -607,7 +607,7 @@ declare export class TextNode extends LexicalNode {
   __mode: 0 | 1 | 2 | 3;
   __detail: number;
   static getType(): string;
-  static clone(node: TextNode): TextNode;
+  static clone(node: $FlowFixMe): TextNode;
   constructor(text: string, key?: NodeKey): void;
   getFormat(): number;
   getStyle(): string;


### PR DESCRIPTION
If we specify the type of the argument in clone, it makes the subclass method signature incompatible. This is similar to the problem with importJSON, and could be solved the same way, but for now I'm just reverting this change to unblock.