### PR TITLE
Fix flow round II

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -349,8 +349,8 @@ declare export class LexicalNode {
   getIndexWithinParent(): number;
   getParent<T: ElementNode>(): T | null;
   getParentOrThrow<T: ElementNode>(): T;
-  getTopLevelElement(): ElementNode | this | null;
-  getTopLevelElementOrThrow(): ElementNode | this;
+  getTopLevelElement(): ElementNode | null;
+  getTopLevelElementOrThrow(): ElementNode;
   getParents<T: ElementNode>(): Array<T>;
   getParentKeys(): Array<NodeKey>;
   getPreviousSibling<T: LexicalNode>(): T | null;


### PR DESCRIPTION
These methods will always return an ElementNode, but the method itself is on LexicalNode, so adding "this" to the return type means that TextNode.getTopLevelElement() returns a union of TextNode or ElementNode, which is wrong and causes issues downstream.