### PR TITLE
Fix Listeners

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -601,8 +601,7 @@ export function triggerListeners(
   editor._updating = isCurrentlyEnqueuingUpdates;
 
   try {
-    const listeners = [...editor._listeners[type]];
-
+    const listeners = [...editor._listeners[type].values()];
     for (let i = 0; i < listeners.length; i++) {
       listeners[i].apply(null, payload);
     }


### PR DESCRIPTION
Spreads are loosely transpiled internally and only work with Arrays, not Sets.