### PR TITLE
Ensure Babel plugins run for ts/tsx modules

### DIFF
--- a/packages/lexical-playground/vite.config.js
+++ b/packages/lexical-playground/vite.config.js
@@ -170,6 +170,7 @@ export default defineConfig({
       babelrc: false,
       configFile: false,
       exclude: '/**/node_modules/**',
+      extensions: ['jsx', 'js', 'ts', 'tsx', 'mjs'],
       plugins: [
         '@babel/plugin-transform-flow-strip-types',
         [


### PR DESCRIPTION
This should fix the invariant issue we've recently being seeing.