### PR TITLE
Provide legacy editor conversion

### DIFF
--- a/packages/lexical-react/src/LexicalAutoFocusPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoFocusPlugin.ts
@@ -7,7 +7,6 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import { unsupported_convertLegacyJSONEditorState } from '@lexical/utils';
 import {useEffect} from 'react';
 
 export function AutoFocusPlugin(): null {
@@ -15,11 +14,6 @@ export function AutoFocusPlugin(): null {
 
   useEffect(() => {
     editor.focus();
-    return editor.registerUpdateListener(({editorState}) => {
-      const json = JSON.stringify(editorState);
-      const newEditorState = unsupported_convertLegacyJSONEditorState(editor, json);
-      console.log(newEditorState)
-    })
   }, [editor]);
 
   return null;

--- a/packages/lexical-react/src/LexicalAutoFocusPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoFocusPlugin.ts
@@ -7,6 +7,7 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import { unsupported_convertLegacyJSONEditorState } from '@lexical/utils';
 import {useEffect} from 'react';
 
 export function AutoFocusPlugin(): null {
@@ -14,6 +15,11 @@ export function AutoFocusPlugin(): null {
 
   useEffect(() => {
     editor.focus();
+    return editor.registerUpdateListener(({editorState}) => {
+      const json = JSON.stringify(editorState);
+      const newEditorState = unsupported_convertLegacyJSONEditorState(editor, json);
+      console.log(newEditorState)
+    })
   }, [editor]);
 
   return null;

--- a/packages/lexical-utils/LexicalUtils.d.ts
+++ b/packages/lexical-utils/LexicalUtils.d.ts
@@ -8,7 +8,7 @@
 
 import {Class} from 'utility-types';
 
-import type {LexicalNode, ElementNode, LexicalEditor} from 'lexical';
+import type {EditorState, LexicalNode, ElementNode, LexicalEditor} from 'lexical';
 
 export type DFSNode = Readonly<{
   depth: number;
@@ -54,3 +54,8 @@ declare function registerNestedElementResolver<N>(
   cloneNode: (from: N) => N,
   handleOverlap: (from: N, to: N) => void,
 ): () => void;
+
+export declare function unsupported_convertLegacyJSONEditorState(
+  editor: LexicalEditor,
+  maybeStringifiedEditorState: string,
+): EditorState;

--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -6,7 +6,7 @@
  *
  * @flow strict
  */
-import type {LexicalEditor, LexicalNode, ElementNode} from 'lexical';
+import type {EditorState, LexicalEditor, LexicalNode, ElementNode} from 'lexical';
 export type DFSNode = $ReadOnly<{
   depth: number,
   node: LexicalNode,
@@ -48,3 +48,8 @@ declare export function registerNestedElementResolver<N: ElementNode>(
   cloneNode: (from: N) => N,
   handleOverlap: (from: N, to: N) => void,
 ): () => void;
+
+declare export function unsupported_convertLegacyJSONEditorState(
+  editor: LexicalEditor,
+  maybeStringifiedEditorState: string,
+): EditorState;

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -6,9 +6,15 @@
  *
  */
 
-import type {ElementNode, LexicalEditor, LexicalNode} from 'lexical';
+import type {
+  EditorState,
+  ElementNode,
+  LexicalEditor,
+  LexicalNode,
+  NodeKey,
+} from 'lexical';
 
-import {$getRoot, $isElementNode} from 'lexical';
+import {$getRoot, $isElementNode, $isTextNode, createEditor} from 'lexical';
 import invariant from 'shared/invariant';
 import {Class} from 'utility-types';
 
@@ -232,4 +238,146 @@ export function registerNestedElementResolver<N extends ElementNode>(
   };
 
   return editor.registerNodeTransform(targetNode, elementNodeTransform);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ParseObject = any;
+
+function unsupported_internalCreateNodeFromParse(
+  parsedNode: ParseObject,
+  parsedNodeMap: Map<string, ParseObject>,
+  editor: LexicalEditor,
+  parentKey: null | NodeKey,
+  activeEditorState: EditorState,
+): LexicalNode {
+  const nodeType = parsedNode.__type;
+  const registeredNode = editor._nodes.get(nodeType);
+
+  if (registeredNode === undefined) {
+    invariant(false, 'createNodeFromParse: type "%s" + not found', nodeType);
+  }
+
+  // Check for properties that are editors
+  for (const property in parsedNode) {
+    const value = parsedNode[property];
+
+    if (value != null && typeof value === 'object') {
+      const parsedEditorState = value.editorState;
+
+      if (parsedEditorState != null) {
+        const nestedEditor = createEditor();
+        nestedEditor._nodes = editor._nodes;
+        nestedEditor._parentEditor = editor._parentEditor;
+        nestedEditor._pendingEditorState =
+          unsupported_convertLegacyJSONEditorState(
+            nestedEditor,
+            parsedEditorState,
+          );
+        parsedNode[property] = nestedEditor;
+      }
+    }
+  }
+
+  const NodeKlass = registeredNode.klass;
+  const parsedKey = parsedNode.__key;
+  // We set the parsedKey to undefined before calling clone() so that
+  // we get a new random key assigned.
+  parsedNode.__key = undefined;
+  // @ts-expect-error TODO Replace Class utility type with InstanceType
+  const node = NodeKlass.clone(parsedNode);
+  parsedNode.__key = parsedKey;
+  const key = node.__key;
+  activeEditorState._nodeMap.set(key, node);
+
+  node.__parent = parentKey;
+
+  // We will need to recursively handle the children in the case
+  // of a ElementNode.
+  if ($isElementNode(node)) {
+    const children = parsedNode.__children;
+
+    for (let i = 0; i < children.length; i++) {
+      const childKey = children[i];
+      const parsedChild = parsedNodeMap.get(childKey);
+
+      if (parsedChild !== undefined) {
+        const child = unsupported_internalCreateNodeFromParse(
+          parsedChild,
+          parsedNodeMap,
+          editor,
+          key,
+          activeEditorState,
+        );
+        const newChildKey = child.__key;
+
+        node.__children.push(newChildKey);
+      }
+    }
+
+    node.__indent = parsedNode.__indent;
+    node.__format = parsedNode.__format;
+    node.__dir = parsedNode.__dir;
+  } else if ($isTextNode(node)) {
+    node.__format = parsedNode.__format;
+    node.__style = parsedNode.__style;
+    node.__mode = parsedNode.__mode;
+    node.__detail = parsedNode.__detail;
+  }
+  return node;
+}
+
+function unsupported_parseEditorState(
+  parsedEditorState: ParseObject,
+  editor: LexicalEditor,
+): EditorState {
+  // This is hacky, do not do this!
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const EditorStateClass: any = editor._editorState.constructor;
+  const nodeMap = new Map();
+  const editorState = new EditorStateClass(nodeMap);
+  const parsedNodeMap: Map<string, ParseObject> = new Map(
+    parsedEditorState._nodeMap,
+  );
+  // root always exists in Map
+  const parsedRoot = parsedNodeMap.get('root');
+  const isUpdating = editor._updating;
+  try {
+    editor._updating = false;
+    editor.update(() => {
+      const dirtyElements = editor._dirtyElements;
+      const dirtyLeaves = editor._dirtyLeaves;
+      const dirtyType = editor._dirtyType;
+      editor._dirtyElements = new Map();
+      editor._dirtyLeaves = new Set();
+      editor._dirtyType = 0;
+      try {
+        unsupported_internalCreateNodeFromParse(
+          parsedRoot,
+          parsedNodeMap,
+          editor,
+          null,
+          editorState,
+        );
+      } finally {
+        editor._dirtyElements = dirtyElements;
+        editor._dirtyLeaves = dirtyLeaves;
+        editor._dirtyType = dirtyType;
+      }
+    });
+  } finally {
+    editor._updating = isUpdating;
+  }
+  editorState._readOnly = true;
+  return editorState;
+}
+
+export function unsupported_convertLegacyJSONEditorState(
+  editor: LexicalEditor,
+  maybeStringifiedEditorState: string,
+): EditorState {
+  const parsedEditorState =
+    typeof maybeStringifiedEditorState === 'string'
+      ? JSON.parse(maybeStringifiedEditorState)
+      : maybeStringifiedEditorState;
+  return unsupported_parseEditorState(parsedEditorState, editor);
 }


### PR DESCRIPTION
This PR introduces a legacy EditorState JSON -> `EditorState` conversion. Making it easier to upgrade and convert from the old data that people might have stored, into an EditorState, where they can do `JSON.stringify` and get the new format.

```js
import { unsupported_convertLegacyJSONEditorState } from '@lexical/utils';

// Put in legacyJsonEditorState, which is using the old format!
const editorState = unsupported_convertLegacyJSONEditorState(editor, legacyJsonEditorState);
console.log(JSON.stringify(newEditorState)); // New format!

```