### PR TITLE
Tune MaxLengthPlugin behavior for restoration

### DIFF
--- a/packages/lexical-utils/LexicalUtils.d.ts
+++ b/packages/lexical-utils/LexicalUtils.d.ts
@@ -64,3 +64,8 @@ export declare function unstable_convertLegacyJSONEditorState(
   editor: LexicalEditor,
   maybeStringifiedEditorState: string,
 ): EditorState;
+
+export declare function $restoreEditorState(
+  editor: LexicalEditor,
+  editorState: EditorState,
+): void;

--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -58,3 +58,8 @@ declare export function unstable_convertLegacyJSONEditorState(
   editor: LexicalEditor,
   maybeStringifiedEditorState: string,
 ): EditorState;
+
+declare export function $restoreEditorState(
+  editor: LexicalEditor,
+  editorState: EditorState,
+): void;

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -393,12 +393,11 @@ export function $restoreEditorState(
   editor: LexicalEditor,
   editorState: EditorState,
 ): void {
+  const FULL_RECONCILE = 2;
   const nodeMap = new Map(editorState._nodeMap);
   const activeEditorState = editor._pendingEditorState;
   activeEditorState._nodeMap = nodeMap;
-  for (const [, node] of nodeMap) {
-    node.markDirty();
-  }
+  editor._dirtyType = FULL_RECONCILE;
   const selection = editorState._selection;
   $setSelection(selection === null ? null : selection.clone());
 }

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -14,7 +14,13 @@ import type {
   NodeKey,
 } from 'lexical';
 
-import {$getRoot, $isElementNode, $isTextNode, createEditor} from 'lexical';
+import {
+  $getRoot,
+  $isElementNode,
+  $isTextNode,
+  $setSelection,
+  createEditor,
+} from 'lexical';
 import invariant from 'shared/invariant';
 import {Class} from 'utility-types';
 
@@ -381,4 +387,18 @@ export function unstable_convertLegacyJSONEditorState(
       ? JSON.parse(maybeStringifiedEditorState)
       : maybeStringifiedEditorState;
   return unstable_parseEditorState(parsedEditorState, editor);
+}
+
+export function $restoreEditorState(
+  editor: LexicalEditor,
+  editorState: EditorState,
+): void {
+  const nodeMap = new Map(editorState._nodeMap);
+  const activeEditorState = editor._pendingEditorState;
+  activeEditorState._nodeMap = nodeMap;
+  for (const [, node] of nodeMap) {
+    node.markDirty();
+  }
+  const selection = editorState._selection;
+  $setSelection(selection === null ? null : selection.clone());
 }


### PR DESCRIPTION
Based off further feedback from https://github.com/facebook/lexical/issues/2230#issuecomment-1137838765. We can actually apply a heuristic where if the last editor state content was already at the max length, we just try and restore that editor state entirely.