### PR TITLE
Fix bug in $createNodesFromDOM

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -213,7 +213,7 @@ function $createNodesFromDOM(
       ...$createNodesFromDOM(
         children[i],
         editor,
-        forChildMap,
+        new Map(forChildMap),
         currentLexicalNode,
       ),
     );


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/2274. We should ensure that we pass a clone of the `forChildMap` to children otherwise we'll be mutating the same Map between sub-trees.