### PR TITLE
Unexpected language change for code block is fixed #2271

### DIFF
--- a/packages/lexical-code/src/index.ts
+++ b/packages/lexical-code/src/index.ts
@@ -64,6 +64,7 @@ import {
 import {Spread} from 'libdefs/globals';
 
 const DEFAULT_CODE_LANGUAGE = 'javascript';
+let selectedLanguage: string;
 
 type SerializedCodeNode = Spread<
   {
@@ -400,6 +401,7 @@ export class CodeNode extends ElementNode {
   }
 
   setLanguage(language: string): void {
+    selectedLanguage = language;
     const writable = this.getWritable();
     writable.__language = mapToPrismLanguage(language);
   }
@@ -600,7 +602,7 @@ function convertDivElement(domNode: Node): DOMConversionOutput {
       }
       return childLexicalNodes;
     },
-    node: isCodeElement(div) ? $createCodeNode() : null,
+    node: isCodeElement(div) ? $createCodeNode(selectedLanguage) : null,
   };
 }
 


### PR DESCRIPTION
As the issue points, whenever you paste a new block of code when the code block is empt even though you have selected a different language for selector, it returns back to the javascript mode, which is the default language. I have created a new variable to store the selected language and then use it in the node creation process.