### PR TITLE
Expose $getUpdateTags and $addUpdateTag

### DIFF
--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -809,6 +809,8 @@ export function $isGridCellNode(
 /**
  * LexicalUtils
  */
+export function $getUpdateTags(): Set<string>;
+export function $addUpdateTag(tag: string): void;
 export function $getNearestNodeFromDOMNode(
   startingDOM: Node,
 ): LexicalNode | null;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -832,6 +832,8 @@ declare export function $isGridCellNode(
 /**
  * LexicalUtils
  */
+declare export function $getUpdateTags(): Set<string>;
+declare export function $addUpdateTag(tag: string): void;
 declare export function $getNearestNodeFromDOMNode(
   startingDOM: Node,
 ): LexicalNode | null;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1110,3 +1110,14 @@ export function scrollIntoViewIfNeeded(
     tags.add('scroll-into-view');
   }
 }
+
+export function $getUpdateTags(): Set<string> {
+  const editor = getActiveEditor();
+  return editor._updateTags;
+}
+
+export function $addUpdateTag(tag: string): void {
+  errorOnReadOnly();
+  const editor = getActiveEditor();
+  editor._updateTags.add(tag);
+}


### PR DESCRIPTION
This PR exposes two new update based utility functions:

- `$getUpdateTags`
- `$addUpdateTag`

These allow you to access any update tags that might existing the current update cycle. It also allows you to add an update tag to the given update too.