### PR TITLE
Fix overflow in select toolbar

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1212,6 +1212,7 @@ button.action-button:disabled {
   background: none;
   border-radius: 10px;
   padding: 8px;
+  padding-right: 24px;
   vertical-align: middle;
   -webkit-appearance: none;
   -moz-appearance: none;


### PR DESCRIPTION
The Font Family overflows a bit behind the dropdown arrow.

Before:
![Screenshot from 2022-05-27 17-00-39](https://user-images.githubusercontent.com/64399555/170692650-87a78461-3878-4715-a7ee-c35bd7127699.png)

After:
![Screenshot from 2022-05-27 17-00-59](https://user-images.githubusercontent.com/64399555/170692664-1a76ad1c-4edd-4880-a1d7-8dd30b17f7fb.png)