### PR TITLE
Confine character popup to rootElementRect

### DIFF
--- a/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/CharacterStylesPopupPlugin.tsx
@@ -37,10 +37,15 @@ function setPopupPosition(
   let top = rect.top - 8 + window.pageYOffset;
   let left =
     rect.left + 340 + window.pageXOffset - editor.offsetWidth + rect.width;
-  if (
-    rect.width >= rootElementRect.width - 20 ||
-    left > rootElementRect.width - 150
-  ) {
+  if (left + editor.offsetWidth > rootElementRect.right) {
+    left = rect.right - editor.offsetWidth;
+    top = rect.top - 50 + window.pageYOffset;
+  }
+  if (left < 0) {
+    left = rect.left;
+    top = rect.bottom + 20;
+  }
+  if (rect.width >= rootElementRect.width - 25) {
     left = rect.left;
     top = rect.top - 50 + window.pageYOffset;
   }


### PR DESCRIPTION
Fixes #2287 

https://user-images.githubusercontent.com/64399555/170713005-71aa49ee-71f1-4c06-a837-2122cf96a623.mp4

**Note:** Would require suggestions on how to handle the popup if the screen size is less than that of popup (or if we can ignore that case altogether)