### PR TITLE
Improve DEV warnings for node methods

### DIFF
--- a/packages/lexical-playground/src/nodes/EmojiNode.tsx
+++ b/packages/lexical-playground/src/nodes/EmojiNode.tsx
@@ -14,6 +14,7 @@ import type {
 } from 'lexical';
 
 import {TextNode} from 'lexical';
+import {Spread} from 'libdefs/globals';
 
 export type SerializedEmojiNode = Spread<
   {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -323,9 +323,7 @@ export function createEditor(
         ['getType', 'clone'].forEach((method) => {
           // eslint-disable-next-line no-prototype-builtins
           if (!klass.hasOwnProperty(method)) {
-            console.warn(
-              `${name} must implement static "${method}" method`,
-            );
+            console.warn(`${name} must implement static "${method}" method`);
           }
         });
         if (proto instanceof DecoratorNode || proto instanceof ElementNode) {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -324,7 +324,7 @@ export function createEditor(
           // eslint-disable-next-line no-prototype-builtins
           if (!klass.hasOwnProperty(method)) {
             console.warn(
-              `${klass.name} must implement static "${method}" method`,
+              `${name} must implement static "${method}" method`,
             );
           }
         });

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -35,6 +35,8 @@ import {
   generateRandomKey,
   markAllNodesAsDirty,
 } from './LexicalUtils';
+import {DecoratorNode} from './nodes/LexicalDecoratorNode';
+import {ElementNode} from './nodes/LexicalElementNode';
 import {LineBreakNode} from './nodes/LexicalLineBreakNode';
 import {ParagraphNode} from './nodes/LexicalParagraphNode';
 import {RootNode} from './nodes/LexicalRootNode';
@@ -312,6 +314,42 @@ export function createEditor(
 
   for (let i = 0; i < nodes.length; i++) {
     const klass = nodes[i];
+    // Ensure custom nodes implement required methods.
+    // @ts-ignore
+    if (__DEV__) {
+      const name = klass.name;
+      if (name !== 'RootNode') {
+        const proto = klass.prototype;
+        ['getType', 'clone'].forEach((method) => {
+          // eslint-disable-next-line no-prototype-builtins
+          if (!klass.hasOwnProperty(method)) {
+            console.warn(
+              `${klass.name} must implement static "${method}" method`,
+            );
+          }
+        });
+        if (proto instanceof DecoratorNode || proto instanceof ElementNode) {
+          // eslint-disable-next-line no-prototype-builtins
+          if (!klass.hasOwnProperty('importDOM')) {
+            console.warn(
+              `${name} should implement "importDOM" method to ensure HTML serialization (important for copy & paste) works as expected`,
+            );
+          }
+        }
+        // eslint-disable-next-line no-prototype-builtins
+        if (!klass.hasOwnProperty('importJSON')) {
+          console.warn(
+            `${name} should implement "importJSON" method to ensure JSON serialization works as expected`,
+          );
+        }
+        // eslint-disable-next-line no-prototype-builtins
+        if (!proto.hasOwnProperty('exportJSON')) {
+          console.warn(
+            `${name} should implement "exportJSON" method to ensure JSON serialization works as expected`,
+          );
+        }
+      }
+    }
     // @ts-expect-error TODO Replace Class utility type with InstanceType
     const type = klass.getType();
     registeredNodes.set(type, {

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -195,18 +195,8 @@ export class LexicalNode {
     this.__parent = null;
     $setNodeKey(this, key);
 
-    // Ensure custom nodes implement required methods.
     // @ts-ignore
     if (__DEV__) {
-      const proto = Object.getPrototypeOf(this);
-      ['getType', 'clone'].forEach((method) => {
-        // eslint-disable-next-line no-prototype-builtins
-        if (!proto.constructor.hasOwnProperty(method)) {
-          console.warn(
-            `${this.constructor.name} must implement static "${method}" method`,
-          );
-        }
-      });
       if (this.__type !== 'root') {
         errorOnReadOnly();
         errorOnTypeKlassMismatch(


### PR DESCRIPTION
We're missing a bunch of warnings and we're also missing the opportunity to do it on creation of the editor rather than at creation of node.