### PR TITLE
Feat: Add clear formatting button to playground

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -310,6 +310,10 @@ i.italic {
   background-image: url(images/icons/type-italic.svg);
 }
 
+i.clear {
+  background-image: url(images/icons/trash.svg);
+}
+
 i.code {
   background-image: url(images/icons/code.svg);
 }
@@ -988,10 +992,6 @@ select.font-family {
 
 .actions i.table {
   background-image: url(images/icons/table.svg);
-}
-
-.actions i.clear {
-  background-image: url(images/icons/trash.svg);
 }
 
 .actions i.unlock {

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
@@ -852,7 +852,7 @@ export default function ToolbarPlugin(): JSX.Element {
           }
         }
       }
-      // Hande buttons
+      // Handle buttons
       setFontSize(
         $getSelectionStyleValueForProperty(selection, 'font-size', '15px'),
       );

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
@@ -930,12 +930,8 @@ export default function ToolbarPlugin(): JSX.Element {
         selection.getNodes().forEach((node) => {
           if ($isTextNode(node)) {
             node.setFormat(0);
+            node.setStyle('');
           }
-        });
-        $patchStyleText(selection, {
-          'background-color': '#fff',
-          color: '#000',
-          'font-family': 'Arial',
         });
       }
       activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left');

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
@@ -936,11 +936,8 @@ export default function ToolbarPlugin(): JSX.Element {
           'background-color': '#fff',
           color: '#000',
           'font-family': 'Arial',
-          'font-size': '15px',
         });
-        $wrapLeafNodesInElements(selection, () => $createParagraphNode());
       }
-      activeEditor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
       activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left');
     });
   }, [activeEditor]);
@@ -1002,9 +999,9 @@ export default function ToolbarPlugin(): JSX.Element {
     <div className="toolbar">
       <button
         onClick={clearFormatting}
-        title="Clear Formatting"
+        title="Clear text formatting"
         className="toolbar-item spaced"
-        aria-label="Clear">
+        aria-label="Clear all text formatting">
         <i className="format clear" />
       </button>
       <button

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
@@ -998,13 +998,6 @@ export default function ToolbarPlugin(): JSX.Element {
   return (
     <div className="toolbar">
       <button
-        onClick={clearFormatting}
-        title="Clear text formatting"
-        className="toolbar-item spaced"
-        aria-label="Clear all text formatting">
-        <i className="format clear" />
-      </button>
-      <button
         disabled={!canUndo}
         onClick={() => {
           activeEditor.dispatchCommand(UNDO_COMMAND, undefined);
@@ -1197,6 +1190,14 @@ export default function ToolbarPlugin(): JSX.Element {
               aria-label="Format text with a superscript">
               <i className="icon superscript" />
               <span className="text">Superscript</span>
+            </DropDownItem>
+            <DropDownItem
+              onClick={clearFormatting}
+              className="item"
+              title="Clear text formatting"
+              aria-label="Clear all text formatting">
+              <i className="icon clear" />
+              <span className="text">Clear Formatting</span>
             </DropDownItem>
           </DropDown>
           <Divider />


### PR DESCRIPTION
Closes #2190

https://user-images.githubusercontent.com/64399555/170961978-128faa38-23e9-4cdb-8e03-63e5f64d8f11.mp4

**Note:** Is it okay to leave the hashtag as is? Because lexical changes the node from text to hashtag whenever a string starts with "#". But due to changing the background color to default, the light blue background of the hashtag is being removed.