### PR TITLE
Fixed dropdown position in playground example

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -598,7 +598,7 @@ select.font-family {
 .dropdown {
   z-index: 10;
   display: block;
-  position: absolute;
+  position: fixed;
   box-shadow: 0 12px 28px 0 rgba(0, 0, 0, 0.2), 0 2px 4px 0 rgba(0, 0, 0, 0.1),
     inset 0 0 0 1px rgba(255, 255, 255, 0.5);
   border-radius: 8px;


### PR DESCRIPTION
In the playground, if page scroll is present then position of dropdown is not correct.