### PR TITLE
Playground: allow custom collab endpoints

### DIFF
--- a/packages/lexical-playground/src/collaboration.ts
+++ b/packages/lexical-playground/src/collaboration.ts
@@ -11,7 +11,8 @@ import {Doc} from 'yjs';
 
 const url = new URL(window.location.href);
 const params = new URLSearchParams(url.search);
-const WEBSOCKET_ENDPOINT = params.get('collabEndpoint') || 'ws://localhost:1234';
+const WEBSOCKET_ENDPOINT =
+  params.get('collabEndpoint') || 'ws://localhost:1234';
 const WEBSOCKET_SLUG = 'playground';
 const WEBSOCKET_ID = params.get('collabId') || '0';
 

--- a/packages/lexical-playground/src/collaboration.ts
+++ b/packages/lexical-playground/src/collaboration.ts
@@ -11,7 +11,7 @@ import {Doc} from 'yjs';
 
 const url = new URL(window.location.href);
 const params = new URLSearchParams(url.search);
-const WEBSOCKET_ENDPOINT = 'ws://localhost:1234';
+const WEBSOCKET_ENDPOINT = params.get('collabEndpoint') || 'ws://localhost:1234';
 const WEBSOCKET_SLUG = 'playground';
 const WEBSOCKET_ID = params.get('collabId') || '0';
 


### PR DESCRIPTION
Tested locally and the yjs demo server works `?collabEndpoint=wss://demos.yjs.dev`