### PR TITLE
Add includeHeaders argument to INSERT_TABLE_COMMAND

### DIFF
--- a/packages/lexical-react/src/LexicalTablePlugin.ts
+++ b/packages/lexical-react/src/LexicalTablePlugin.ts
@@ -42,7 +42,7 @@ export function TablePlugin(): JSX.Element {
 
     return editor.registerCommand<InsertTableCommandPayload>(
       INSERT_TABLE_COMMAND,
-      ({columns, rows}) => {
+      ({columns, rows, includeHeaders}) => {
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -56,6 +56,7 @@ export function TablePlugin(): JSX.Element {
           const tableNode = $createTableNodeWithDimensions(
             Number(rows),
             Number(columns),
+            includeHeaders,
           );
 
           if ($isRootNode(focusNode)) {

--- a/packages/lexical-table/LexicalTable.d.ts
+++ b/packages/lexical-table/LexicalTable.d.ts
@@ -224,5 +224,6 @@ export declare class TableSelection {
 export type InsertTableCommandPayload = Readonly<{
   columns: string;
   rows: string;
+  includeHeaders?: boolean;
 }>;
 export const INSERT_TABLE_COMMAND: LexicalCommand<InsertTableCommandPayload>;

--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -240,4 +240,5 @@ declare export class TableSelection {
 declare export var INSERT_TABLE_COMMAND: LexicalCommand<{
   rows: string,
   columns: string,
+  includeHeaders?: string,
 }>;

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -77,6 +77,7 @@ export {
 export type InsertTableCommandPayload = Readonly<{
   columns: string;
   rows: string;
+  includeHeaders?: boolean;
 }>;
 
 export const INSERT_TABLE_COMMAND: LexicalCommand<InsertTableCommandPayload> =

--- a/packages/lexical/Lexical.d.ts
+++ b/packages/lexical/Lexical.d.ts
@@ -61,6 +61,7 @@ export var BLUR_COMMAND: LexicalCommand<FocusEvent>;
 export var INSERT_TABLE_COMMAND: LexicalCommand<{
   rows: string;
   columns: string;
+  includeHeaders?: boolean;
 }>;
 
 export declare function createCommand<T>(): LexicalCommand<T>;


### PR DESCRIPTION
`$createTableNodeWithDimensions` has an option to toggle headers on table cells. 
`INSERT_TABLE_COMMAND` enabled by LexicalTablePlugin should also accept this option (to disable marking first row/column as headers).