### PR TITLE
Fix: text alignment in clear formatting

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  selectAll,
+  toggleBold,
+  toggleItalic,
+  toggleUnderline,
+} from '../keyboardShortcuts/index.mjs';
+import {
+  assertHTML,
+  clearEditor,
+  focusEditor,
+  html,
+  initialize,
+  pasteFromClipboard,
+  selectFromAdditionalStylesDropdown,
+  selectFromBackgroundColorPicker,
+  selectFromColorPicker,
+  test,
+  waitForSelector,
+} from '../utils/index.mjs';
+
+test.describe('Clear All Formatting', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+  test(`Can clear BIU formatting`, async ({page}) => {
+    await focusEditor(page);
+
+    await page.keyboard.type('Hello');
+    await toggleBold(page);
+    await page.keyboard.type(' World');
+    await toggleItalic(page);
+    await toggleUnderline(page);
+    await page.keyboard.type(' Test');
+    await selectFromAdditionalStylesDropdown(page, '.clear');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello World Test</span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Should preserve the default styling of links and quoted text`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    const clipboard = {
+      'text/html': '<a href="https://facebook.com">Facebook!</a>',
+    };
+
+    await pasteFromClipboard(page, clipboard);
+    await selectAll(page);
+    await toggleBold(page);
+    await toggleItalic(page);
+    await toggleUnderline(page);
+    await selectFromColorPicker(page);
+    await selectFromAdditionalStylesDropdown(page, '.clear');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            href="https://facebook.com"
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Facebook!</span>
+          </a>
+        </p>
+      `,
+    );
+
+    await clearEditor(page);
+
+    await page.keyboard.type('> Testing for quote node');
+    await selectAll(page);
+    await toggleBold(page);
+    await toggleItalic(page);
+    await toggleUnderline(page);
+    await selectFromBackgroundColorPicker(page);
+    await selectFromColorPicker(page);
+    await selectFromAdditionalStylesDropdown(page, '.clear');
+    await assertHTML(
+      page,
+      html`
+        <blockquote
+          class="PlaygroundEditorTheme__quote PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Testing for quote node</span>
+        </blockquote>
+      `,
+    );
+  });
+
+  test(`Should preserve the default styling of hashtags and mentions`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    await page.keyboard.type('#facebook testing');
+    await selectAll(page);
+    await toggleItalic(page);
+    await selectFromBackgroundColorPicker(page);
+    await selectFromColorPicker(page);
+    await selectFromAdditionalStylesDropdown(page, '.clear');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #facebook
+          </span>
+          <span data-lexical-text="true">testing</span>
+        </p>
+      `,
+    );
+
+    await clearEditor(page);
+
+    await page.keyboard.type('Luke');
+
+    await waitForSelector(page, '#mentions-typeahead ul li');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Luke</span>
+        </p>
+      `,
+    );
+
+    await page.keyboard.press('Enter');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span
+            class="mention"
+            style="background-color: rgba(24, 119, 232, 0.2);"
+            data-lexical-text="true">
+            Luke Skywalker
+          </span>
+        </p>
+      `,
+    );
+
+    await page.keyboard.type(' is testing');
+    await selectAll(page);
+    await toggleBold(page);
+    await selectFromColorPicker(page);
+    await selectFromAdditionalStylesDropdown(page, '.clear');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span
+            class="mention"
+            style="background-color: rgba(24, 119, 232, 0.2);"
+            data-lexical-text="true">
+            Luke Skywalker
+          </span>
+          <span data-lexical-text="true">is testing</span>
+        </p>
+      `,
+    );
+  });
+});

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -598,6 +598,15 @@ export async function selectFromAdditionalStylesDropdown(page, selector) {
   await click(page, '.dropdown ' + selector);
 }
 
+export async function selectFromBackgroundColorPicker(page) {
+  await click(page, '.toolbar-item[aria-label="Formatting background color"]');
+  await click(page, '.color-picker-basic-color button:first-child'); //Defaulted to red
+}
+
+export async function selectFromColorPicker(page) {
+  await click(page, '.toolbar-item[aria-label="Formatting text color"]');
+  await click(page, '.color-picker-basic-color button:first-child'); //Defaulted to red
+}
 export async function selectFromFormatDropdown(page, selector) {
   await click(
     page,

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
@@ -22,6 +22,7 @@ import {
   REMOVE_LIST_COMMAND,
 } from '@lexical/list';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$isDecoratorBlockNode} from '@lexical/react/LexicalDecoratorBlockNode';
 import {INSERT_HORIZONTAL_RULE_COMMAND} from '@lexical/react/LexicalHorizontalRuleNode';
 import {
   $createHeadingNode,
@@ -37,7 +38,11 @@ import {
   $wrapLeafNodesInElements,
 } from '@lexical/selection';
 import {INSERT_TABLE_COMMAND} from '@lexical/table';
-import {$getNearestNodeOfType, mergeRegister} from '@lexical/utils';
+import {
+  $getNearestBlockElementAncestorOrThrow,
+  $getNearestNodeOfType,
+  mergeRegister,
+} from '@lexical/utils';
 import {
   $createParagraphNode,
   $getNodeByKey,
@@ -941,6 +946,10 @@ export default function ToolbarPlugin(): JSX.Element {
           if ($isTextNode(node)) {
             node.setFormat(0);
             node.setStyle('');
+            $getNearestBlockElementAncestorOrThrow(node).setFormat('');
+          }
+          if ($isDecoratorBlockNode(node)) {
+            node.setFormat('');
           }
         });
 <<<<<<< HEAD
@@ -955,7 +964,6 @@ export default function ToolbarPlugin(): JSX.Element {
 =======
 >>>>>>> use setStyle to remove node styling
       }
-      activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left');
     });
   }, [activeEditor]);
 

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
@@ -952,17 +952,6 @@ export default function ToolbarPlugin(): JSX.Element {
             node.setFormat('');
           }
         });
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-        $patchStyleText(selection, {
-          'background-color': '#fff',
-          color: '#000',
-          'font-family': 'Arial',
-        });
->>>>>>> fixes
-=======
->>>>>>> use setStyle to remove node styling
       }
     });
   }, [activeEditor]);

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
@@ -1012,13 +1012,6 @@ export default function ToolbarPlugin(): JSX.Element {
   return (
     <div className="toolbar">
       <button
-        onClick={clearFormatting}
-        title="Clear text formatting"
-        className="toolbar-item spaced"
-        aria-label="Clear all text formatting">
-        <i className="format clear" />
-      </button>
-      <button
         disabled={!canUndo}
         onClick={() => {
           activeEditor.dispatchCommand(UNDO_COMMAND, undefined);

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
@@ -1004,6 +1004,13 @@ export default function ToolbarPlugin(): JSX.Element {
   return (
     <div className="toolbar">
       <button
+        onClick={clearFormatting}
+        title="Clear Formatting"
+        className="toolbar-item spaced"
+        aria-label="Clear">
+        <i className="format clear" />
+      </button>
+      <button
         disabled={!canUndo}
         onClick={() => {
           activeEditor.dispatchCommand(UNDO_COMMAND, undefined);

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
@@ -944,6 +944,7 @@ export default function ToolbarPlugin(): JSX.Element {
           }
         });
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
         $patchStyleText(selection, {
           'background-color': '#fff',
@@ -951,6 +952,8 @@ export default function ToolbarPlugin(): JSX.Element {
           'font-family': 'Arial',
         });
 >>>>>>> fixes
+=======
+>>>>>>> use setStyle to remove node styling
       }
       activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left');
     });

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin.tsx
@@ -943,6 +943,14 @@ export default function ToolbarPlugin(): JSX.Element {
             node.setStyle('');
           }
         });
+<<<<<<< HEAD
+=======
+        $patchStyleText(selection, {
+          'background-color': '#fff',
+          color: '#000',
+          'font-family': 'Arial',
+        });
+>>>>>>> fixes
       }
       activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left');
     });
@@ -1005,9 +1013,9 @@ export default function ToolbarPlugin(): JSX.Element {
     <div className="toolbar">
       <button
         onClick={clearFormatting}
-        title="Clear Formatting"
+        title="Clear text formatting"
         className="toolbar-item spaced"
-        aria-label="Clear">
+        aria-label="Clear all text formatting">
         <i className="format clear" />
       </button>
       <button


### PR DESCRIPTION
PR #2295 introduced the Clear All Formatting option but still, it doesn't correctly clear the text-alignment of the nodes by removing the styles. Instead, it adds an additional inline styling of "text-align: left" to all nodes. To correct this I have used the `$getNearestBlockElementAncestorOrThrow` to find the blockElement ancestor which aligns the node and formatted it to "" align (i.e. removal). While working on this, I've also realized that previously we didn't cover the alignment for Youtube videos and other nodes of the `DecoratorBlockNode` type and have fixed it as well.

cc @thegreatercurve 

Sorry for the inconvenience!