### PR TITLE
fix mispositioning of treeview caret

### DIFF
--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -445,7 +445,7 @@ function printSelectedCharsLine({
     ...indent.slice(0, indent.length - 1),
     selectionLastIndent,
   ];
-  const unselectedChars = Array(start).fill(' ');
+  const unselectedChars = Array(start + 1).fill(' ');
   const selectedChars = Array(end - start).fill(SYMBOLS.selectedChar);
   const paddingLength = typeDisplay.length + 3; // 2 for the spaces around + 1 for the double quote.
 


### PR DESCRIPTION
As the tree view uses " " to display strings, the caret (^) is mispositioned by one character each time text is selected.

Before:
![Screenshot from 2022-06-01 17-49-02](https://user-images.githubusercontent.com/64399555/171403438-bc6360fa-aee2-40df-9a24-281cf2bd457f.png)

After:
![Screenshot from 2022-06-01 17-48-55](https://user-images.githubusercontent.com/64399555/171403450-af21504e-adba-490a-9439-9aebacf646aa.png)

