### PR TITLE
Strengthen onClick conditional

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -277,13 +277,15 @@ function onClick(event: MouseEvent, editor: LexicalEditor): void {
 
     if ($isRangeSelection(selection)) {
       const anchor = selection.anchor;
+      const anchorNode = anchor.getNode();
 
       if (
         anchor.type === 'element' &&
         anchor.offset === 0 &&
         selection.isCollapsed() &&
+        !$isRootNode(anchorNode) &&
         $getRoot().getChildrenSize() === 1 &&
-        anchor.getNode().getTopLevelElementOrThrow().isEmpty()
+        anchorNode.getTopLevelElementOrThrow().isEmpty()
       ) {
         const lastSelection = $getPreviousSelection();
 


### PR DESCRIPTION
We should be ensuring that the anchor node is not the root before calling `getTopLevelElementOrThrow` on it, which will result in an invariant.