### PR TITLE
Add default exportDOM and importDOM methods

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -136,7 +136,20 @@ function getConversionFunction(
 ): DOMConversionFn | null {
   const {nodeName} = domNode;
 
-  const cachedConversions = editor._htmlConversions.get(nodeName.toLowerCase());
+  const baseCacheConversions =
+    domNode instanceof HTMLElement &&
+    domNode.hasAttribute('data-lexical-node-type')
+      ? editor._htmlConversions.get('*')
+      : [];
+
+  const nodeNameCacheConversions = editor._htmlConversions.get(
+    nodeName.toLowerCase(),
+  );
+
+  const cachedConversions = [
+    ...nodeNameCacheConversions,
+    ...baseCacheConversions,
+  ];
 
   let currentConversion: DOMConversion | null = null;
 

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -143,7 +143,7 @@ function getConversionFunction(
       : [];
 
   const nodeNameCacheConversions =
-    editor._htmlConversions.get(nodeName.toLowerCase()) ?? [];
+    editor._htmlConversions.get(nodeName.toLowerCase()) || [];
 
   const cachedConversions = [
     ...nodeNameCacheConversions,

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -142,9 +142,8 @@ function getConversionFunction(
       ? editor._htmlConversions.get('*')
       : [];
 
-  const nodeNameCacheConversions = editor._htmlConversions.get(
-    nodeName.toLowerCase(),
-  );
+  const nodeNameCacheConversions =
+    editor._htmlConversions.get(nodeName.toLowerCase()) ?? [];
 
   const cachedConversions = [
     ...nodeNameCacheConversions,

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -145,10 +145,9 @@ function getConversionFunction(
   const nodeNameCacheConversions =
     editor._htmlConversions.get(nodeName.toLowerCase()) || [];
 
-  const cachedConversions = [
-    ...nodeNameCacheConversions,
-    ...baseCacheConversions,
-  ];
+  const cachedConversions = Array.from(nodeNameCacheConversions).concat(
+    baseCacheConversions,
+  );
 
   let currentConversion: DOMConversion | null = null;
 

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -7,9 +7,6 @@
  */
 
 import type {
-  DOMConversionMap,
-  DOMConversionOutput,
-  DOMExportOutput,
   EditorConfig,
   LexicalNode,
   NodeKey,
@@ -118,16 +115,6 @@ function EquationComponent({
   );
 }
 
-function convertEquationElement(domNode: HTMLElement): DOMConversionOutput {
-  const node = $createEquationNode(
-    domNode.textContent,
-    domNode.nodeName === 'SPAN',
-  );
-  return {
-    node,
-  };
-}
-
 export type SerializedEquationNode = Spread<
   {
     type: 'equation';
@@ -172,37 +159,7 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
     };
   }
 
-  exportDOM(): DOMExportOutput {
-    const element = document.createElement(this.__inline ? 'span' : 'div');
-    element.innerText = this.__equation;
-    element.setAttribute('data-lexical-equation', 'true');
-    return {element};
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return {
-      div: (domNode: HTMLElement) => {
-        if (!domNode.hasAttribute('data-lexical-equation')) {
-          return null;
-        }
-        return {
-          conversion: convertEquationElement,
-          priority: 1,
-        };
-      },
-      span: (domNode: HTMLElement) => {
-        if (!domNode.hasAttribute('data-lexical-equation')) {
-          return null;
-        }
-        return {
-          conversion: convertEquationElement,
-          priority: 1,
-        };
-      },
-    };
-  }
-
-  createDOM(config: EditorConfig): HTMLElement {
+  createDOM(_config: EditorConfig): HTMLElement {
     return document.createElement(this.__inline ? 'span' : 'div');
   }
 

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -392,21 +392,6 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     this.__caption = caption || createEditor();
   }
 
-  // exportDOM(): DOMExportOutput {
-  //   const element = document.createElement('img');
-  //   element.setAttribute('src', this.__src);
-  //   element.setAttribute('alt', this.__altText);
-  //   element.setAttribute(
-  //     'data-show-caption',
-  //     this.__showCaption ? 'true' : 'false',
-  //   );
-  //   element.setAttribute(
-  //     'data-lexical-caption-json',
-  //     JSON.stringify(this.__caption),
-  //   );
-  //   return {element};
-  // }
-
   exportJSON(): SerializedImageNode {
     return {
       altText: this.getAltText(),
@@ -420,15 +405,6 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
       width: this.__width === 'inherit' ? 0 : this.__width,
     };
   }
-
-  // static importDOM(): DOMConversionMap | null {
-  //   return {
-  //     img: (node: Node) => ({
-  //       conversion: convertImageElement,
-  //       priority: 0,
-  //     }),
-  //   };
-  // }
 
   setWidthAndHeight(
     width: 'inherit' | number,

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -7,9 +7,6 @@
  */
 
 import type {
-  DOMConversionMap,
-  DOMConversionOutput,
-  DOMExportOutput,
   EditorConfig,
   LexicalEditor,
   LexicalNode,
@@ -330,26 +327,6 @@ export type SerializedImageNode = Spread<
   SerializedLexicalNode
 >;
 
-function convertImageElement(domNode: Node): null | DOMConversionOutput {
-  if (domNode instanceof HTMLImageElement) {
-    const {alt: altText, src} = domNode;
-    const showCaption =
-      domNode.getAttribute('data-lexical-show-caption') === 'true';
-    const captionJSON = domNode.getAttribute('data-lexical-caption-json');
-    const node = $createImageNode({altText, showCaption, src});
-    if (showCaption && captionJSON) {
-      const parsedJSON = JSON.parse(captionJSON);
-      const nestedEditor = node.__caption;
-      const editorState = nestedEditor.parseEditorState(parsedJSON.editorState);
-      if (!editorState.isEmpty()) {
-        nestedEditor.setEditorState(editorState);
-      }
-    }
-    return {node};
-  }
-  return null;
-}
-
 export class ImageNode extends DecoratorNode<JSX.Element> {
   __src: string;
   __altText: string;
@@ -415,20 +392,20 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     this.__caption = caption || createEditor();
   }
 
-  exportDOM(): DOMExportOutput {
-    const element = document.createElement('img');
-    element.setAttribute('src', this.__src);
-    element.setAttribute('alt', this.__altText);
-    element.setAttribute(
-      'data-show-caption',
-      this.__showCaption ? 'true' : 'false',
-    );
-    element.setAttribute(
-      'data-lexical-caption-json',
-      JSON.stringify(this.__caption),
-    );
-    return {element};
-  }
+  // exportDOM(): DOMExportOutput {
+  //   const element = document.createElement('img');
+  //   element.setAttribute('src', this.__src);
+  //   element.setAttribute('alt', this.__altText);
+  //   element.setAttribute(
+  //     'data-show-caption',
+  //     this.__showCaption ? 'true' : 'false',
+  //   );
+  //   element.setAttribute(
+  //     'data-lexical-caption-json',
+  //     JSON.stringify(this.__caption),
+  //   );
+  //   return {element};
+  // }
 
   exportJSON(): SerializedImageNode {
     return {
@@ -444,14 +421,14 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     };
   }
 
-  static importDOM(): DOMConversionMap | null {
-    return {
-      img: (node: Node) => ({
-        conversion: convertImageElement,
-        priority: 0,
-      }),
-    };
-  }
+  // static importDOM(): DOMConversionMap | null {
+  //   return {
+  //     img: (node: Node) => ({
+  //       conversion: convertImageElement,
+  //       priority: 0,
+  //     }),
+  //   };
+  // }
 
   setWidthAndHeight(
     width: 'inherit' | number,

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -329,10 +329,6 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
     this.__color = color;
   }
 
-  static importDOM(): null {
-    return null;
-  }
-
   exportJSON(): SerializedStickyNode {
     return {
       caption: this.__caption,

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -6,14 +6,7 @@
  *
  */
 
-import type {
-  DOMConversionMap,
-  DOMConversionOutput,
-  DOMExportOutput,
-  ElementFormatType,
-  LexicalNode,
-  NodeKey,
-} from 'lexical';
+import type {ElementFormatType, LexicalNode, NodeKey} from 'lexical';
 
 import {BlockWithAlignableContents} from '@lexical/react/LexicalBlockWithAlignableContents';
 import {
@@ -54,14 +47,6 @@ export type SerializedYouTubeNode = Spread<
   SerializedDecoratorBlockNode
 >;
 
-function convertYouTubeElement(
-  domNode: HTMLElement,
-): null | DOMConversionOutput {
-  const id = domNode.getAttribute('data-lexical-youtube-id');
-  const node = $createYouTubeNode(id);
-  return {node};
-}
-
 export class YouTubeNode extends DecoratorBlockNode<JSX.Element> {
   __id: string;
 
@@ -86,26 +71,6 @@ export class YouTubeNode extends DecoratorBlockNode<JSX.Element> {
       version: 1,
       videoID: this.__id,
     };
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return {
-      div: (domNode: HTMLElement) => {
-        if (!domNode.hasAttribute('data-lexical-youtube-id')) {
-          return null;
-        }
-        return {
-          conversion: convertYouTubeElement,
-          priority: 2,
-        };
-      },
-    };
-  }
-
-  exportDOM(): DOMExportOutput {
-    const element = document.createElement('div');
-    element.setAttribute('data-lexical-youtube-id', this.__id);
-    return {element};
   }
 
   constructor(id: string, format?: ElementFormatType | null, key?: NodeKey) {

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -6,14 +6,7 @@
  *
  */
 
-import type {
-  DOMConversionMap,
-  DOMConversionOutput,
-  DOMExportOutput,
-  LexicalCommand,
-  LexicalNode,
-  SerializedLexicalNode,
-} from 'lexical';
+import type {LexicalCommand, LexicalNode, SerializedLexicalNode} from 'lexical';
 
 import {createCommand, DecoratorNode} from 'lexical';
 import * as React from 'react';
@@ -37,19 +30,6 @@ export class HorizontalRuleNode extends DecoratorNode<JSX.Element> {
 
   static clone(node: HorizontalRuleNode): HorizontalRuleNode {
     return new HorizontalRuleNode(node.__key);
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    return {
-      hr: (node: Node) => ({
-        conversion: convertHorizontalRuleElement,
-        priority: 0,
-      }),
-    };
-  }
-
-  exportDOM(): DOMExportOutput {
-    return {element: document.createElement('hr')};
   }
 
   static importJSON(
@@ -86,10 +66,6 @@ export class HorizontalRuleNode extends DecoratorNode<JSX.Element> {
   decorate(): JSX.Element {
     return <HorizontalRuleComponent />;
   }
-}
-
-function convertHorizontalRuleElement(): DOMConversionOutput {
-  return {node: $createHorizontalRuleNode()};
 }
 
 export function $createHorizontalRuleNode(): HorizontalRuleNode {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -24,11 +24,7 @@ import {
   triggerListeners,
   updateEditor,
 } from './LexicalUpdates';
-import {
-  dispatchCommand,
-  generateRandomKey,
-  markAllNodesAsDirty,
-} from './LexicalUtils';
+import {createUID, dispatchCommand, markAllNodesAsDirty} from './LexicalUtils';
 import {DecoratorNode} from './nodes/LexicalDecoratorNode';
 import {LineBreakNode} from './nodes/LexicalLineBreakNode';
 import {ParagraphNode} from './nodes/LexicalParagraphNode';
@@ -452,7 +448,7 @@ export class LexicalEditor {
     // Handling of DOM mutations
     this._observer = null;
     // Used for identifying owning editors
-    this._key = generateRandomKey();
+    this._key = createUID();
     this._onError = onError;
     this._htmlConversions = htmlConversions;
     this._readOnly = false;

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -314,16 +314,12 @@ export function createEditor(
         });
         if (
           // eslint-disable-next-line no-prototype-builtins
-          (klass.hasOwnProperty('importDOM') &&
-            // eslint-disable-next-line no-prototype-builtins
-            !klass.hasOwnProperty('exportDOM')) ||
+          !klass.hasOwnProperty('importDOM') &&
           // eslint-disable-next-line no-prototype-builtins
-          (!klass.hasOwnProperty('importDOM') &&
-            // eslint-disable-next-line no-prototype-builtins
-            klass.hasOwnProperty('exportDOM'))
+          klass.hasOwnProperty('exportDOM')
         ) {
           console.warn(
-            `${name} should implement "importDOM" AND "exportDOM" methods to ensure HTML serialization (important for copy & paste) works as expected`,
+            `${name} should implement "importDOM" if using a custom "exportDOM" method to ensure HTML serialization (important for copy & paste) works as expected`,
           );
         }
         if (proto instanceof DecoratorNode) {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -312,7 +312,8 @@ export function createEditor(
           // eslint-disable-next-line no-prototype-builtins
           !klass.hasOwnProperty('importDOM') &&
           // eslint-disable-next-line no-prototype-builtins
-          klass.hasOwnProperty('exportDOM')
+          klass.hasOwnProperty('exportDOM') &&
+          process.env.NODE_ENV !== 'test'
         ) {
           console.warn(
             `${name} should implement "importDOM" if using a custom "exportDOM" method to ensure HTML serialization (important for copy & paste) works as expected`,
@@ -326,14 +327,20 @@ export function createEditor(
             );
           }
         }
-        // eslint-disable-next-line no-prototype-builtins
-        if (!klass.hasOwnProperty('importJSON')) {
+        if (
+          // eslint-disable-next-line no-prototype-builtins
+          !klass.hasOwnProperty('importJSON') &&
+          process.env.NODE_ENV !== 'test'
+        ) {
           console.warn(
             `${name} should implement "importJSON" method to ensure JSON and default HTML serialization works as expected`,
           );
         }
-        // eslint-disable-next-line no-prototype-builtins
-        if (!proto.hasOwnProperty('exportJSON')) {
+        if (
+          // eslint-disable-next-line no-prototype-builtins
+          !proto.hasOwnProperty('exportJSON') &&
+          process.env.NODE_ENV !== 'test'
+        ) {
           console.warn(
             `${name} should implement "exportJSON" method to ensure JSON and default HTML serialization works as expected`,
           );

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -456,6 +456,7 @@ export class LexicalEditor {
     this._observer = null;
     // Used for identifying owning editors
     this._key = createUID();
+
     this._onError = onError;
     this._htmlConversions = htmlConversions;
     this._readOnly = false;

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -602,12 +602,12 @@ export class LexicalNode {
   exportDOM(editor: LexicalEditor): DOMExportOutput {
     const element = this.createDOM(editor._config, editor);
     const serializedNode = this.exportJSON();
-    element.setAttribute('data-lexical-node-type', this.getType());
+    element.setAttribute('data-lexical-node-type', this.__type);
     element.setAttribute(
       'data-lexical-node-json',
       JSON.stringify(serializedNode),
     );
-    element.setAttribute('data-lexical-editor-key', editor.getKey());
+    element.setAttribute('data-lexical-editor-key', editor._key);
     return {element};
   }
 

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -523,7 +523,10 @@ export class LexicalNode {
   getLatest(): this {
     const latest = $getNodeByKey<this>(this.__key);
     if (latest === null) {
-      invariant(false, 'getLatest: node not found');
+      invariant(
+        false,
+        'Lexical node does not exist in active edtior state. Avoid using the same node references between nested closures from editor.read/editor.update.',
+      );
     }
     return latest;
   }

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -607,6 +607,7 @@ export class LexicalNode {
       'data-lexical-node-json',
       JSON.stringify(serializedNode),
     );
+    element.setAttribute('data-lexical-editor-key', editor.getKey());
     return {element};
   }
 
@@ -616,11 +617,12 @@ export class LexicalNode {
     return {
       // Catch-all key because we don't know the nodeName of the element returned by exportDOM.
       '*': (domNode: Node) => {
-        if (
-          domNode instanceof HTMLElement &&
-          domNode.hasAttribute('data-lexical-node-type') &&
-          domNode.getAttribute('data-lexical-node-type') === proto.getType()
-        ) {
+        if (!(domNode instanceof HTMLElement)) return null;
+        const editorKey = domNode.getAttribute('data-lexical-editor-key');
+        const nodeType = domNode.getAttribute('data-lexical-node-type');
+        if (editorKey == null || nodeType == null) return null;
+        const editor = getActiveEditor();
+        if (editorKey === editor.getKey() && nodeType === proto.getType()) {
           try {
             const json = domNode.getAttribute('data-lexical-node-json');
             if (json != null) {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -66,10 +66,10 @@ export const emptyFunction = () => {
   return;
 };
 
-let keyCounter = 0;
+let keyCounter = 1;
 
 export function resetRandomKey(): void {
-  keyCounter = 0;
+  keyCounter = 1;
 }
 
 export function generateRandomKey(): string {


### PR DESCRIPTION
This PR adds robust fallback logic for `exportDOM` and `importDOM` on the base `LexicalNode` class.

https://user-images.githubusercontent.com/13852400/171728151-9b5dfa4a-c239-4376-9b89-935242d697cf.mov

