### PR TITLE
Enable copy+paste on NodeSelection

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -1631,11 +1631,7 @@ test.describe('CopyAndPaste', () => {
     );
   });
 
-  test('Merge Grids on Copy + paste', async ({
-    page,
-    isPlainText,
-    isCollab,
-  }) => {
+  test('Merge Grids on Copy + paste', async ({page, isPlainText, isCollab}) => {
     test.skip(isPlainText);
     test.fixme(
       isCollab,

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -1652,10 +1652,12 @@ test.describe('CopyAndPaste', () => {
     await assertHTML(
       page,
       html`
-        <table class="PlaygroundEditorTheme__table">
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table disable-selection">
           <tr>
             <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
@@ -1663,62 +1665,45 @@ test.describe('CopyAndPaste', () => {
               </p>
             </th>
             <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
                 <span data-lexical-text="true">b</span>
               </p>
             </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
           </tr>
           <tr>
             <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
                 <span data-lexical-text="true">c</span>
               </p>
             </th>
-            <td class="PlaygroundEditorTheme__tableCell">
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              style="background-color: rgb(172, 206, 247); caret-color: transparent;">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
                 <span data-lexical-text="true">d</span>
               </p>
-            </td>
-          </tr>
-        </table>
-        <table class="PlaygroundEditorTheme__table">
-          <tr>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </th>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </th>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </th>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </th>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </th>
-          </tr>
-          <tr>
-            <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </th>
-            <td class="PlaygroundEditorTheme__tableCell">
-              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -1631,7 +1631,11 @@ test.describe('CopyAndPaste', () => {
     );
   });
 
-  test('Merge Grids on Copy + paste', async ({page, isPlainText, isCollab}) => {
+  test('Merge Grids on Copy + paste', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
     test.skip(isPlainText);
     test.fixme(
       isCollab,
@@ -1652,12 +1656,10 @@ test.describe('CopyAndPaste', () => {
     await assertHTML(
       page,
       html`
-        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-        <table class="PlaygroundEditorTheme__table disable-selection">
+        <table class="PlaygroundEditorTheme__table">
           <tr>
             <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-              style="background-color: rgb(172, 206, 247); caret-color: transparent;">
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
@@ -1665,13 +1667,41 @@ test.describe('CopyAndPaste', () => {
               </p>
             </th>
             <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-              style="background-color: rgb(172, 206, 247); caret-color: transparent;">
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
                 <span data-lexical-text="true">b</span>
               </p>
+            </th>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">c</span>
+              </p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">d</span>
+              </p>
+            </td>
+          </tr>
+        </table>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -1688,22 +1718,11 @@ test.describe('CopyAndPaste', () => {
           </tr>
           <tr>
             <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-              style="background-color: rgb(172, 206, 247); caret-color: transparent;">
-              <p
-                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                dir="ltr">
-                <span data-lexical-text="true">c</span>
-              </p>
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
-            <td
-              class="PlaygroundEditorTheme__tableCell"
-              style="background-color: rgb(172, 206, 247); caret-color: transparent;">
-              <p
-                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                dir="ltr">
-                <span data-lexical-text="true">d</span>
-              </p>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -805,6 +805,7 @@ select.font-family {
   cursor: default;
   display: inline-block;
   position: relative;
+  user-select: none;
 }
 
 .editor-shell .editor-image img {

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -156,17 +156,15 @@ function ImageComponent({
       if (isSelected && $isNodeSelection($getSelection())) {
         const event: KeyboardEvent = payload;
         event.preventDefault();
-        editor.update(() => {
-          const node = $getNodeByKey(nodeKey);
-          if ($isImageNode(node)) {
-            node.remove();
-          }
-          setSelected(false);
-        });
+        const node = $getNodeByKey(nodeKey);
+        if ($isImageNode(node)) {
+          node.remove();
+        }
+        setSelected(false);
       }
       return false;
     },
-    [editor, isSelected, nodeKey, setSelected],
+    [isSelected, nodeKey, setSelected],
   );
 
   useEffect(() => {

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -384,7 +384,7 @@ function onCopyForRichText(event: ClipboardEvent, editor: LexicalEditor): void {
       }
       const plainString = selection.getTextContent();
       clipboardData.setData('text/plain', plainString);
-    } else {
+    } else if ($isNodeSelection(selection)) {
       const clipboard = navigator.clipboard;
       if (clipboard != null) {
         // Most browsers only support a single item in the clipboard at one time.

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -384,7 +384,7 @@ function onCopyForRichText(event: ClipboardEvent, editor: LexicalEditor): void {
       }
       const plainString = selection.getTextContent();
       clipboardData.setData('text/plain', plainString);
-    } else if ($isNodeSelection(selection)) {
+    } else {
       const clipboard = navigator.clipboard;
       if (clipboard != null) {
         // Most browsers only support a single item in the clipboard at one time.

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -145,6 +145,7 @@ if (CAN_USE_BEFORE_INPUT) {
 }
 
 let lastKeyDownTimeStamp = 0;
+let lastClickTimeStamp = 0;
 let rootElementsRegistered = 0;
 let isSelectionChangeFromDOMUpdate = false;
 let isInsertLineBreak = false;
@@ -155,6 +156,10 @@ let collapsedSelectionFormat: [number, number, NodeKey, number] = [
   'root',
   0,
 ];
+
+export function hasSelectonDisengaged(): boolean {
+  return performance.now() > lastClickTimeStamp + 100;
+}
 
 function shouldSkipSelectionChange(
   domNode: null | Node,
@@ -274,6 +279,7 @@ function onSelectionChange(
 // also help other browsers when selection might "appear" lost, when it
 // really isn't.
 function onClick(event: MouseEvent, editor: LexicalEditor): void {
+  lastClickTimeStamp = event.timeStamp;
   updateEditor(editor, () => {
     const selection = $getSelection();
 

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -145,7 +145,6 @@ if (CAN_USE_BEFORE_INPUT) {
 }
 
 let lastKeyDownTimeStamp = 0;
-let lastClickTimeStamp = 0;
 let rootElementsRegistered = 0;
 let isSelectionChangeFromDOMUpdate = false;
 let isInsertLineBreak = false;
@@ -157,9 +156,6 @@ let collapsedSelectionFormat: [number, number, NodeKey, number] = [
   0,
 ];
 
-export function hasSelectonDisengaged(): boolean {
-  return performance.now() > lastClickTimeStamp + 100;
-}
 
 function shouldSkipSelectionChange(
   domNode: null | Node,
@@ -279,7 +275,6 @@ function onSelectionChange(
 // also help other browsers when selection might "appear" lost, when it
 // really isn't.
 function onClick(event: MouseEvent, editor: LexicalEditor): void {
-  lastClickTimeStamp = event.timeStamp;
   updateEditor(editor, () => {
     const selection = $getSelection();
 

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -156,7 +156,6 @@ let collapsedSelectionFormat: [number, number, NodeKey, number] = [
   0,
 ];
 
-
 function shouldSkipSelectionChange(
   domNode: null | Node,
   offset: number,

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -85,6 +85,8 @@ import {
   getNearestEditorFromDOMNode,
   isBackspace,
   isBold,
+  isCopy,
+  isCut,
   isDelete,
   isDeleteBackward,
   isDeleteForward,
@@ -822,6 +824,12 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
   } else if (isRedo(keyCode, shiftKey, metaKey, ctrlKey)) {
     event.preventDefault();
     dispatchCommand(editor, REDO_COMMAND, undefined);
+  } else if (isCopy(keyCode, shiftKey, metaKey, ctrlKey)) {
+    event.preventDefault();
+    dispatchCommand(editor, COPY_COMMAND, event);
+  } else if (isCut(keyCode, shiftKey, metaKey, ctrlKey)) {
+    event.preventDefault();
+    dispatchCommand(editor, CUT_COMMAND, event);
   }
 
   if (isModifier(ctrlKey, shiftKey, altKey, metaKey)) {

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2218,17 +2218,14 @@ export function internalCreateSelection(
   const lastSelection = currentEditorState._selection;
   const domSelection = getDOMSelection();
 
-  if (
-    ($isNodeSelection(lastSelection) && domSelection.rangeCount === 0) ||
-    $isGridSelection(lastSelection)
-  ) {
+  if ($isNodeSelection(lastSelection) || $isGridSelection(lastSelection)) {
     return lastSelection.clone();
   }
 
   return internalCreateRangeSelection(lastSelection, domSelection, editor);
 }
 
-function internalCreateRangeSelection(
+export function internalCreateRangeSelection(
   lastSelection: null | RangeSelection | NodeSelection | GridSelection,
   domSelection: Selection | null,
   editor: LexicalEditor,

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2218,7 +2218,10 @@ export function internalCreateSelection(
   const lastSelection = currentEditorState._selection;
   const domSelection = getDOMSelection();
 
-  if ($isNodeSelection(lastSelection) || $isGridSelection(lastSelection)) {
+  if (
+    domSelection.rangeCount === 0 &&
+    ($isNodeSelection(lastSelection) || $isGridSelection(lastSelection))
+  ) {
     return lastSelection.clone();
   }
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2215,25 +2215,14 @@ export function internalCreateSelection(
   editor: LexicalEditor,
 ): null | RangeSelection | NodeSelection | GridSelection {
   const currentEditorState = editor.getEditorState();
-  const lastEditorState = currentEditorState;
-  const lastSelection = lastEditorState._selection;
+  const lastSelection = currentEditorState._selection;
   const domSelection = getDOMSelection();
 
-  if ($isNodeSelection(lastSelection) || $isGridSelection(lastSelection)) {
-    const selectedNodes = lastEditorState.read(() => lastSelection.getNodes());
-    const anchorNode = domSelection.anchorNode;
-    for (let i = 0; i < selectedNodes.length; i++) {
-      const selectedNode = selectedNodes[i];
-      const selectedNodeKey = selectedNode.__key;
-      const selectedElement = editor.getElementByKey(selectedNodeKey);
-      if (
-        selectedElement === null ||
-        anchorNode === null ||
-        selectedElement.contains(anchorNode)
-      ) {
-        return lastSelection.clone();
-      }
-    }
+  if (
+    ($isNodeSelection(lastSelection) && domSelection.rangeCount === 0) ||
+    $isGridSelection(lastSelection)
+  ) {
+    return lastSelection.clone();
   }
 
   return internalCreateRangeSelection(lastSelection, domSelection, editor);

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -36,6 +36,7 @@ import {
 } from '.';
 import {DOM_ELEMENT_TYPE, TEXT_TYPE_TO_FORMAT} from './LexicalConstants';
 import {
+  hasSelectonDisengaged,
   markCollapsedSelectionFormat,
   markSelectionChangeFromDOMUpdate,
 } from './LexicalEvents';
@@ -2219,8 +2220,8 @@ export function internalCreateSelection(
   const domSelection = getDOMSelection();
 
   if (
-    domSelection.rangeCount === 0 &&
-    ($isNodeSelection(lastSelection) || $isGridSelection(lastSelection))
+    ($isNodeSelection(lastSelection) || $isGridSelection(lastSelection)) &&
+    (domSelection.rangeCount === 0 || hasSelectonDisengaged())
   ) {
     return lastSelection.clone();
   }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -808,6 +808,34 @@ export function isRedo(
   return (keyCode === 89 && ctrlKey) || (keyCode === 90 && ctrlKey && shiftKey);
 }
 
+export function isCopy(
+  keyCode: number,
+  shiftKey: boolean,
+  metaKey: boolean,
+  ctrlKey: boolean,
+): boolean {
+  if (shiftKey) {
+    return false;
+  }
+  if (keyCode === 67) {
+    return IS_APPLE ? metaKey : ctrlKey;
+  }
+}
+
+export function isCut(
+  keyCode: number,
+  shiftKey: boolean,
+  metaKey: boolean,
+  ctrlKey: boolean,
+): boolean {
+  if (shiftKey) {
+    return false;
+  }
+  if (keyCode === 88) {
+    return IS_APPLE ? metaKey : ctrlKey;
+  }
+}
+
 function isArrowLeft(keyCode: number): boolean {
   return keyCode === 37;
 }


### PR DESCRIPTION
Right now, how copy+cut with `NodeSelection` is broken. This PR attempts to actually make it work.