### PR TITLE
include bullet points as a part of list item

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -161,35 +161,41 @@
   padding: 0;
   margin: 0;
   margin-left: 16px;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol2 {
   padding: 0;
   margin: 0;
   margin-left: 16px;
   list-style-type: upper-alpha;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol3 {
   padding: 0;
   margin: 0;
   margin-left: 16px;
   list-style-type: lower-alpha;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol4 {
   padding: 0;
   margin: 0;
   margin-left: 16px;
   list-style-type: upper-roman;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol5 {
   padding: 0;
   margin: 0;
   margin-left: 16px;
   list-style-type: lower-roman;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ul {
   padding: 0;
   margin: 0;
   margin-left: 16px;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__listItem {
   margin: 8px 32px;


### PR DESCRIPTION
Small fix so that markers get aligned with the text as well. (Followed by Google Docs and Word too)

![Screenshot from 2022-06-03 15-50-06](https://user-images.githubusercontent.com/64399555/171836552-95cd89d9-2ed9-4a6d-b55d-a33e182bd8c9.png)
![Screenshot from 2022-06-03 15-50-28](https://user-images.githubusercontent.com/64399555/171836558-10f2199e-4ab1-4007-b0e4-8a42504cdc0e.png)

