### PR TITLE
Fix copy + paste in plain text

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -837,12 +837,17 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
   } else if (isRedo(keyCode, shiftKey, metaKey, ctrlKey)) {
     event.preventDefault();
     dispatchCommand(editor, REDO_COMMAND, undefined);
-  } else if (isCopy(keyCode, shiftKey, metaKey, ctrlKey)) {
-    event.preventDefault();
-    dispatchCommand(editor, COPY_COMMAND, event);
-  } else if (isCut(keyCode, shiftKey, metaKey, ctrlKey)) {
-    event.preventDefault();
-    dispatchCommand(editor, CUT_COMMAND, event);
+  } else {
+    const prevSelection = editor._editorState._selection;
+    if ($isNodeSelection(prevSelection)) {
+      if (isCopy(keyCode, shiftKey, metaKey, ctrlKey)) {
+        event.preventDefault();
+        dispatchCommand(editor, COPY_COMMAND, event);
+      } else if (isCut(keyCode, shiftKey, metaKey, ctrlKey)) {
+        event.preventDefault();
+        dispatchCommand(editor, CUT_COMMAND, event);
+      }
+    }
   }
 
   if (isModifier(ctrlKey, shiftKey, altKey, metaKey)) {


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/2341#issuecomment-1146764943. This logic introduced in a recent PR, should only occur during node selection.