### PR TITLE
doc: fix wrong components names

### DIFF
--- a/packages/lexical-website-new/docs/getting-started/react.md
+++ b/packages/lexical-website-new/docs/getting-started/react.md
@@ -70,11 +70,11 @@ function Editor() {
 
   return (
     <LexicalComposer initialConfig={initialConfig}>
-      <LexicalPlainTextPlugin
-        contentEditable={<LexicalContentEditable />}
+      <PlainTextPlugin
+        contentEditable={ContentEditable />}
         placeholder={<div>Enter some text...</div>}
       />
-      <LexicalOnChangePlugin onChange={onChange} />
+      <OnChangePlugin onChange={onChange} />
       <HistoryPlugin />
       <MyCustomAutoFocusPlugin />
     </LexicalComposer>


### PR DESCRIPTION
Introduced by 0.3.0 global renaming.

I haven't checked if it's generalized to all the documentation 🤔 