### PR TITLE
Fix scrolling issues due to browser rounding bugs

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1128,9 +1128,11 @@ export function scrollIntoViewIfNeeded(
     } else {
       const rootRect = rootElement.getBoundingClientRect();
 
-      if (rect.bottom > rootRect.bottom) {
+      // Rects can returning decimal numbers that differ due to rounding
+      // differences. So let's normalize the values.
+      if (Math.floor(rect.bottom) > Math.floor(rootRect.bottom)) {
         element.scrollIntoView(false);
-      } else if (rect.top < rootRect.top) {
+      } else if (Math.floor(rect.top) < Math.floor(rootRect.top)) {
         element.scrollIntoView();
       }
     }


### PR DESCRIPTION
After digging into https://bugzilla.mozilla.org/show_bug.cgi?id=1768330, I was able to reproduce the issue using Firefox on Windows. I couldn't get it working with Firefox on macOS. When you zoom in, and do `getBoundingClientRect`, you get back decimal numbers, and strangely, doing it of two elements that are the same size, can return slightly different values. One being `123.21` pxiels and the other being `123.22` pixels, which then causes the logic to incorrectly scroll.