### PR TITLE
Improve flow type for LexicalContentEditable

### DIFF
--- a/packages/lexical-react/flow/LexicalContentEditable.js.flow
+++ b/packages/lexical-react/flow/LexicalContentEditable.js.flow
@@ -24,7 +24,7 @@ export type Props = $ReadOnly<{
   className?: string,
   readOnly?: boolean,
   role?: string,
-  style?: StyleSheetList,
+  style?: $Shape<{[string]: string | number}>,
   spellCheck?: boolean,
   tabIndex?: number,
   testid?: string,


### PR DESCRIPTION
The existing flow type for the `style` prop on `LexicalContentEditable` is `StyleSheetList` which disallows setting actuals styles directly.

As there are no built-in types exported from the react flow types for `style` https://github.com/facebook/flow/issues/6522, I'm adding slightly better types that are still much wider than necessary but at least allow setting styles directly.

Let me know if this makes sense or if you prefer an different approach