### PR TITLE
fix overflow issue in input field

### DIFF
--- a/packages/lexical-playground/src/ui/Input.css
+++ b/packages/lexical-playground/src/ui/Input.css
@@ -28,4 +28,5 @@
   padding-right: 10px;
   font-size: 16px;
   border-radius: 5px;
+  min-width: 0;
 }


### PR DESCRIPTION
Reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1067136
This would cause issues when there's less space like this:
# Before
![Screenshot from 2022-06-09 23-43-33](https://user-images.githubusercontent.com/64399555/172916305-3ed16888-2e9d-40d5-9bee-442678451877.png)
# After
![Screenshot from 2022-06-09 23-47-57](https://user-images.githubusercontent.com/64399555/172916882-afed03d2-2a99-471c-9ff0-d89062d5bf0e.png)

