### PR TITLE
Customizable DecoratorBlockNode via theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "clean": "node scripts/clean.js",
     "extract-codes": "node scripts/build.js --codes",
     "flow": "node ./scripts/check-flow-types.js",
-    "tsc-watch": "tsc -w",
     "collab": "cross-env HOST=localhost PORT=1234 npx y-websocket-server",
     "test-unit": "jest --selectProjects unit --testPathPattern",
     "test-unit-watch": "npm run test-unit -- --watch --coverage=''",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "clean": "node scripts/clean.js",
     "extract-codes": "node scripts/build.js --codes",
     "flow": "node ./scripts/check-flow-types.js",
+    "tsc-watch": "tsc -w",
     "collab": "cross-env HOST=localhost PORT=1234 npx y-websocket-server",
     "test-unit": "jest --selectProjects unit --testPathPattern",
     "test-unit-watch": "npm run test-unit -- --watch --coverage=''",

--- a/packages/lexical-playground/__tests__/e2e/BlockWithAlignableContents.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/BlockWithAlignableContents.spec.mjs
@@ -48,7 +48,7 @@ test.describe('BlockWithAlignableContents', () => {
           <span data-lexical-text="true">Hello world</span>
         </p>
         <div contenteditable="false" data-lexical-decorator="true">
-          <div class="embed-block">
+          <div class="PlaygroundEditorTheme__embedBlock">
             <iframe
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowfullscreen=""
@@ -81,7 +81,7 @@ test.describe('BlockWithAlignableContents', () => {
           <span data-lexical-text="true">Hello world</span>
         </p>
         <div contenteditable="false" data-lexical-decorator="true">
-          <div class="embed-block">
+          <div class="PlaygroundEditorTheme__embedBlock">
             <iframe
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowfullscreen=""
@@ -107,7 +107,9 @@ test.describe('BlockWithAlignableContents', () => {
           <span data-lexical-text="true">Hello world</span>
         </p>
         <div contenteditable="false" data-lexical-decorator="true">
-          <div class="embed-block focused" style="text-align: center">
+          <div
+            class="PlaygroundEditorTheme__embedBlock PlaygroundEditorTheme__embedBlockFocus"
+            style="text-align: center">
             <iframe
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowfullscreen=""

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1540,11 +1540,6 @@ button.action-button:disabled {
   user-select: none;
 }
 
-.embed-block.focused {
-  outline: 2px solid rgb(60, 132, 244);
-  user-select: none;
-}
-
 .github-corner:hover .octo-arm {
   animation: octocat-wave 560ms ease-in-out;
 }

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -296,7 +296,7 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
     self.__data = data;
   }
 
-  decorate(editor: LexicalEditor): JSX.Element {
+  decorate(config: EditorConfig, editor: LexicalEditor): JSX.Element {
     return <ExcalidrawComponent nodeKey={this.getKey()} data={this.__data} />;
   }
 }

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -296,7 +296,7 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
     self.__data = data;
   }
 
-  decorate(config: EditorConfig, editor: LexicalEditor): JSX.Element {
+  decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {
     return <ExcalidrawComponent nodeKey={this.getKey()} data={this.__data} />;
   }
 }

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -362,7 +362,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
     writable.__color = writable.__color === 'pink' ? 'yellow' : 'pink';
   }
 
-  decorate(editor: LexicalEditor): JSX.Element {
+  decorate(config: EditorConfig, editor: LexicalEditor): JSX.Element {
     return createPortal(
       <StickyComponent
         color={this.__color}

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -362,7 +362,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
     writable.__color = writable.__color === 'pink' ? 'yellow' : 'pink';
   }
 
-  decorate(config: EditorConfig, editor: LexicalEditor): JSX.Element {
+  decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {
     return createPortal(
       <StickyComponent
         color={this.__color}

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -12,6 +12,7 @@ import type {
   DOMExportOutput,
   EditorConfig,
   ElementFormatType,
+  LexicalEditor,
   LexicalNode,
   NodeKey,
   Spread,
@@ -179,7 +180,7 @@ export class TweetNode extends DecoratorBlockNode {
     return this.__id;
   }
 
-  decorate(config: EditorConfig): JSX.Element {
+  decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {
     const embedBlockTheme = config.theme.embedBlock || {};
     const className = {
       base: embedBlockTheme.base || '',

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -10,6 +10,7 @@ import type {
   DOMConversionMap,
   DOMConversionOutput,
   DOMExportOutput,
+  EditorConfig,
   ElementFormatType,
   LexicalNode,
   NodeKey,
@@ -30,6 +31,10 @@ const getHasScriptCached = () =>
   document.querySelector(`script[src="${WIDGET_SCRIPT_URL}"]`);
 
 type TweetComponentProps = Readonly<{
+  className: Readonly<{
+    base: string;
+    focus: string;
+  }>;
   format: ElementFormatType | null;
   loadingComponent?: JSX.Element | string;
   nodeKey: NodeKey;
@@ -45,6 +50,7 @@ function convertTweetElement(domNode: HTMLElement): null | DOMConversionOutput {
 }
 
 function TweetComponent({
+  className,
   format,
   loadingComponent,
   nodeKey,
@@ -96,7 +102,10 @@ function TweetComponent({
   }, [createTweet, onError, tweetID]);
 
   return (
-    <BlockWithAlignableContents format={format} nodeKey={nodeKey}>
+    <BlockWithAlignableContents
+      className={className}
+      format={format}
+      nodeKey={nodeKey}>
       {isLoading ? loadingComponent : null}
       <div
         style={{display: 'inline-block', width: '550px'}}
@@ -170,9 +179,15 @@ export class TweetNode extends DecoratorBlockNode {
     return this.__id;
   }
 
-  decorate(): JSX.Element {
+  decorate(config: EditorConfig): JSX.Element {
+    const embedBlockTheme = config.theme.embedBlock || {};
+    const className = {
+      base: embedBlockTheme.base || '',
+      focus: embedBlockTheme.focus || '',
+    };
     return (
       <TweetComponent
+        className={className}
         format={this.__format}
         loadingComponent="Loading..."
         nodeKey={this.getKey()}

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -6,7 +6,13 @@
  *
  */
 
-import type {ElementFormatType, LexicalNode, NodeKey, Spread} from 'lexical';
+import type {
+  EditorConfig,
+  ElementFormatType,
+  LexicalNode,
+  NodeKey,
+  Spread,
+} from 'lexical';
 
 import {BlockWithAlignableContents} from '@lexical/react/LexicalBlockWithAlignableContents';
 import {
@@ -16,14 +22,26 @@ import {
 import * as React from 'react';
 
 type YouTubeComponentProps = Readonly<{
+  className: Readonly<{
+    base: string;
+    focus: string;
+  }>;
   format: ElementFormatType | null;
   nodeKey: NodeKey;
   videoID: string;
 }>;
 
-function YouTubeComponent({format, nodeKey, videoID}: YouTubeComponentProps) {
+function YouTubeComponent({
+  className,
+  format,
+  nodeKey,
+  videoID,
+}: YouTubeComponentProps) {
   return (
-    <BlockWithAlignableContents format={format} nodeKey={nodeKey}>
+    <BlockWithAlignableContents
+      className={className}
+      format={format}
+      nodeKey={nodeKey}>
       <iframe
         width="560"
         height="315"
@@ -81,9 +99,15 @@ export class YouTubeNode extends DecoratorBlockNode {
     return false;
   }
 
-  decorate(): JSX.Element {
+  decorate(config: EditorConfig): JSX.Element {
+    const embedBlockTheme = config.theme.embedBlock || {};
+    const className = {
+      base: embedBlockTheme.base || '',
+      focus: embedBlockTheme.focus || '',
+    };
     return (
       <YouTubeComponent
+        className={className}
         format={this.__format}
         nodeKey={this.getKey()}
         videoID={this.__id}

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -9,6 +9,7 @@
 import type {
   EditorConfig,
   ElementFormatType,
+  LexicalEditor,
   LexicalNode,
   NodeKey,
   Spread,
@@ -99,7 +100,7 @@ export class YouTubeNode extends DecoratorBlockNode {
     return false;
   }
 
-  decorate(config: EditorConfig): JSX.Element {
+  decorate(_editor: LexicalEditor, config: EditorConfig): JSX.Element {
     const embedBlockTheme = config.theme.embedBlock || {};
     const className = {
       base: embedBlockTheme.base || '',

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -272,24 +272,26 @@
 .PlaygroundEditorTheme__tokenFunction {
   color: #dd4a68;
 }
-
 .PlaygroundEditorTheme__mark {
   background: rgba(255, 212, 0, 0.14);
   border-bottom: 2px solid rgba(255, 212, 0, 0.3);
   padding-bottom: 2px;
 }
-
 .PlaygroundEditorTheme__markOverlap {
   background: rgba(255, 212, 0, 0.3);
   border-bottom: 2px solid rgba(255, 212, 0, 0.7);
 }
-
 .PlaygroundEditorTheme__mark.selected {
   background: rgba(255, 212, 0, 0.5);
   border-bottom: 2px solid rgba(255, 212, 0, 1);
 }
-
 .PlaygroundEditorTheme__markOverlap.selected {
   background: rgba(255, 212, 0, 0.7);
   border-bottom: 2px solid rgba(255, 212, 0, 0.7);
+}
+.PlaygroundEditorTheme__embedBlock {
+  user-select: none;
+}
+.PlaygroundEditorTheme__embedBlockFocus {
+  outline: 2px solid rgb(60, 132, 244);
 }

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.ts
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.ts
@@ -45,6 +45,10 @@ const theme: EditorThemeClasses = {
     url: 'PlaygroundEditorTheme__tokenOperator',
     variable: 'PlaygroundEditorTheme__tokenVariable',
   },
+  embedBlock: {
+    base: 'PlaygroundEditorTheme__embedBlock',
+    focus: 'PlaygroundEditorTheme__embedBlockFocus',
+  },
   hashtag: 'PlaygroundEditorTheme__hashtag',
   heading: {
     h1: 'PlaygroundEditorTheme__h1',

--- a/packages/lexical-react/flow/LexicalBlockWithAlignableContents.js.flow
+++ b/packages/lexical-react/flow/LexicalBlockWithAlignableContents.js.flow
@@ -19,6 +19,10 @@ type Props = $ReadOnly<{
   children: React$Node,
   format: ?ElementFormatType,
   nodeKey: NodeKey,
+  className: $ReadOnly<{
+    base: string,
+    focus: string,
+  }>,
 }>;
 
 declare export function BlockWithAlignableContents(Props): React$Node;

--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -34,12 +34,17 @@ type Props = Readonly<{
   children: JSX.Element | string | (JSX.Element | string)[];
   format: ElementFormatType | null | undefined;
   nodeKey: NodeKey;
+  className: Readonly<{
+    base: string;
+    focus: string;
+  }>;
 }>;
 
 export function BlockWithAlignableContents({
   children,
   format,
   nodeKey,
+  className,
 }: Props): JSX.Element {
   const [editor] = useLexicalComposerContext();
 
@@ -135,7 +140,9 @@ export function BlockWithAlignableContents({
 
   return (
     <div
-      className={`embed-block${isSelected ? ' focused' : ''}`}
+      className={[className.base, isSelected ? className.focus : null]
+        .filter(Boolean)
+        .join(' ')}
       ref={ref}
       style={{
         textAlign: format ? format : null,

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -233,6 +233,10 @@ export type EditorThemeClasses = {
     h5?: EditorThemeClassName,
     h6?: EditorThemeClassName,
   },
+  embedBlock?: {
+    base?: EditorThemeClassName,
+    focus?: EditorThemeClassName,
+  },
   // Handle other generic values
   [string]: EditorThemeClassName | {[string]: EditorThemeClassName},
 };
@@ -729,7 +733,7 @@ declare export function $isElementNode(
 
 declare export class DecoratorNode<X> extends LexicalNode {
   constructor(key?: NodeKey): void;
-  decorate(editor: LexicalEditor): X;
+  decorate(config: EditorConfig, editor: LexicalEditor): X;
   isIsolated(): boolean;
   isTopLevel(): boolean;
 }

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -733,7 +733,7 @@ declare export function $isElementNode(
 
 declare export class DecoratorNode<X> extends LexicalNode {
   constructor(key?: NodeKey): void;
-  decorate(config: EditorConfig, editor: LexicalEditor): X;
+  decorate(editor: LexicalEditor, config: EditorConfig): X;
   isIsolated(): boolean;
   isTopLevel(): boolean;
 }

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -96,6 +96,10 @@ export type EditorThemeClasses = {
   tableCellHeader?: EditorThemeClassName;
   tableRow?: EditorThemeClassName;
   text?: TextNodeThemeClasses;
+  embedBlock?: {
+    base?: EditorThemeClassName;
+    focus?: EditorThemeClassName;
+  };
   // Handle other generic values
   [key: string]:
     | EditorThemeClassName

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -188,7 +188,7 @@ function createNode(
     const text = node.getTextContent();
 
     if ($isDecoratorNode(node)) {
-      const decorator = node.decorate(activeEditor);
+      const decorator = node.decorate(activeEditorConfig, activeEditor);
 
       if (decorator !== null) {
         reconcileDecorator(key, decorator);
@@ -578,7 +578,7 @@ function reconcileNode(
     const text = nextNode.getTextContent();
 
     if ($isDecoratorNode(nextNode)) {
-      const decorator = nextNode.decorate(activeEditor);
+      const decorator = nextNode.decorate(activeEditorConfig, activeEditor);
 
       if (decorator !== null) {
         reconcileDecorator(key, decorator);

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -188,7 +188,7 @@ function createNode(
     const text = node.getTextContent();
 
     if ($isDecoratorNode(node)) {
-      const decorator = node.decorate(activeEditorConfig, activeEditor);
+      const decorator = node.decorate(activeEditor, activeEditorConfig);
 
       if (decorator !== null) {
         reconcileDecorator(key, decorator);
@@ -578,7 +578,7 @@ function reconcileNode(
     const text = nextNode.getTextContent();
 
     if ($isDecoratorNode(nextNode)) {
-      const decorator = nextNode.decorate(activeEditorConfig, activeEditor);
+      const decorator = nextNode.decorate(activeEditor, activeEditorConfig);
 
       if (decorator !== null) {
         reconcileDecorator(key, decorator);

--- a/packages/lexical/src/nodes/LexicalDecoratorNode.ts
+++ b/packages/lexical/src/nodes/LexicalDecoratorNode.ts
@@ -9,6 +9,7 @@
 import type {LexicalEditor} from '../LexicalEditor';
 import type {NodeKey} from '../LexicalNode';
 
+import {EditorConfig} from 'lexical';
 import invariant from 'shared/invariant';
 
 import {LexicalNode} from '../LexicalNode';
@@ -18,7 +19,7 @@ export class DecoratorNode<T> extends LexicalNode {
     super(key);
   }
 
-  decorate(editor: LexicalEditor): T {
+  decorate(config: EditorConfig, editor: LexicalEditor): T {
     invariant(false, 'decorate: base method not extended');
   }
 

--- a/packages/lexical/src/nodes/LexicalDecoratorNode.ts
+++ b/packages/lexical/src/nodes/LexicalDecoratorNode.ts
@@ -19,7 +19,7 @@ export class DecoratorNode<T> extends LexicalNode {
     super(key);
   }
 
-  decorate(config: EditorConfig, editor: LexicalEditor): T {
+  decorate(editor: LexicalEditor, config: EditorConfig): T {
     invariant(false, 'decorate: base method not extended');
   }
 


### PR DESCRIPTION
Decorator now has an additional config parameter like createDOM. Do we strictly need DOM like in createDOM? The answer is we don't, we can't potentially build a good abstraction on top that extract the styles. However, it's reality, it's annoying, usually these nodes are tied with the component itself, so for the user having to create an additional abstract to pass their own styles in a different way it's not convenient.

This way we can pass `theme.embedBlock` and the component will automatically be rendered correctly without any further modifications.