### PR TITLE
Editor instance `toJSON` should call `toJSON` method on editor state

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -9,6 +9,7 @@
 import type {EditorState, SerializedEditorState} from './LexicalEditorState';
 import type {DOMConversion, LexicalNode, NodeKey} from './LexicalNode';
 
+import {SerializedEditor} from 'lexical';
 import getDOMSelection from 'shared/getDOMSelection';
 import invariant from 'shared/invariant';
 import {Class} from 'utility-types';
@@ -793,11 +794,9 @@ export class LexicalEditor {
     triggerListeners('readonly', this, true, readOnly);
   }
 
-  toJSON(): {
-    editorState: EditorState;
-  } {
+  toJSON(): SerializedEditor {
     return {
-      editorState: this._editorState,
+      editorState: this._editorState.toJSON(),
     };
   }
 }


### PR DESCRIPTION
Came across this when working on the TS types auto-generation. 

The types for `LexicalEditor.toJSON` are `toJSON(): SerializedEditor`, but we're not actually turning the editor state into JSON. 

This causes a type issue on the ImageNode in the playground here, for the nested editor on the caption: https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/nodes/ImageNode.tsx#L396 

Am I right in thinking that the `.toJSON` method on the editor should also call `.toJSON` on the editor state? 