### PR TITLE
Prevent dispatching redundant can undo/redo commands

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,4 +1,5 @@
 module.exports = {
-  '*.(js|mjs|jsx|css|html|d.ts|js.flow)': 'prettier --write',
+  '*.(js|mjs|jsx|css|html|d.ts|js.flow|ts|tsx)': 'prettier --write',
   '*.(js|mjs|jsx)': ['flow focus-check', 'eslint --fix'],
+  '*.(ts|tsx)': ['eslint --fix'],
 };


### PR DESCRIPTION
- Trigger CAN_UNDO/CAN_REDO only when its value changes (vs on each change causing toolbar rerendering)
- Trigger CAN_UNDO/CAN_REDO commands when clearing history

Misc:
- Add ts/tsx to precommit hooks