### PR TITLE
Remove default json and node-type from DOM output.

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -136,18 +136,7 @@ function getConversionFunction(
 ): DOMConversionFn | null {
   const {nodeName} = domNode;
 
-  const baseCacheConversions =
-    domNode instanceof HTMLElement &&
-    domNode.hasAttribute('data-lexical-node-type')
-      ? editor._htmlConversions.get('*')
-      : [];
-
-  const nodeNameCacheConversions =
-    editor._htmlConversions.get(nodeName.toLowerCase()) || [];
-
-  const cachedConversions = Array.from(nodeNameCacheConversions).concat(
-    baseCacheConversions,
-  );
+  const cachedConversions = editor._htmlConversions.get(nodeName.toLowerCase());
 
   let currentConversion: DOMConversion | null = null;
 

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -250,7 +250,7 @@ function initializeConversionCache(nodes: RegisteredNodes): DOMConversionCache {
           node.klass.importDOM.bind(node.klass)
         : null;
 
-    if (importDOM != null && handledConversions.has(importDOM)) {
+    if (importDOM == null || handledConversions.has(importDOM)) {
       return;
     }
 

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -243,11 +243,14 @@ function initializeConversionCache(nodes: RegisteredNodes): DOMConversionCache {
   const conversionCache = new Map();
   const handledConversions = new Set();
   nodes.forEach((node) => {
-    // @ts-expect-error TODO Replace Class utility type with InstanceType
-    const importDOM = node.klass.importDOM.bind(node.klass);
+    const importDOM =
+      // @ts-expect-error TODO Replace Class utility type with InstanceType
+      node.klass.importDOM != null
+        ? // @ts-expect-error TODO Replace Class utility type with InstanceType
+          node.klass.importDOM.bind(node.klass)
+        : null;
 
-    // debugger;
-    if (handledConversions.has(importDOM)) {
+    if (importDOM != null && handledConversions.has(importDOM)) {
       return;
     }
 

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -605,47 +605,7 @@ export class LexicalNode {
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
     const element = this.createDOM(editor._config, editor);
-    const serializedNode = this.exportJSON();
-    element.setAttribute('data-lexical-node-type', this.__type);
-    element.setAttribute(
-      'data-lexical-node-json',
-      JSON.stringify(serializedNode),
-    );
-    element.setAttribute('data-lexical-editor-key', editor._key);
     return {element};
-  }
-
-  static importDOM(): DOMConversionMap | null {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const proto: any = this.prototype.constructor;
-    return {
-      // Catch-all key because we don't know the nodeName of the element returned by exportDOM.
-      '*': (domNode: Node) => {
-        if (!(domNode instanceof HTMLElement)) return null;
-        const editorKey = domNode.getAttribute('data-lexical-editor-key');
-        const nodeType = domNode.getAttribute('data-lexical-node-type');
-        if (editorKey == null || nodeType == null) return null;
-        const editor = getActiveEditor();
-        if (editorKey === editor.getKey() && nodeType === proto.getType()) {
-          try {
-            const json = domNode.getAttribute('data-lexical-node-json');
-            if (json != null) {
-              const serializedNode: SerializedLexicalNode = JSON.parse(json);
-              const node = proto.importJSON(serializedNode);
-              return {
-                conversion: () => ({node}),
-                // Max priority because of the 'data-lexical-node-type' attribute
-                // matching the one on node klass guarantees a match.
-                priority: 4,
-              };
-              // eslint-disable-next-line no-empty
-            }
-            // eslint-disable-next-line no-empty
-          } catch {}
-        }
-        return null;
-      },
-    };
   }
 
   exportJSON(): SerializedLexicalNode {


### PR DESCRIPTION
Because nodes are now serialized and added to the clipboard (#2370) there's no need for these default import/export DOM methods.