### PR TITLE
Remove `utility-types`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,6 @@
         "tmp": "^0.2.1",
         "ts-jest": "^28.0.2",
         "typescript": "^4.6.4",
-        "utility-types": "^3.10.0",
         "uuid": "^8.3.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "tmp": "^0.2.1",
     "ts-jest": "^28.0.2",
     "typescript": "^4.6.4",
-    "utility-types": "^3.10.0",
     "uuid": "^8.3.2"
   },
   "overrides": {

--- a/packages/lexical-headless/src/index.ts
+++ b/packages/lexical-headless/src/index.ts
@@ -12,15 +12,15 @@ import type {
   LexicalEditor,
   LexicalNode,
 } from 'lexical';
+import type {Klass} from 'shared/types';
 
 import {createEditor} from 'lexical';
-import {Class} from 'utility-types';
 
 export function createHeadlessEditor(editorConfig?: {
   disableEvents?: boolean;
   editorState?: EditorState;
   namespace: string;
-  nodes?: ReadonlyArray<Class<LexicalNode>>;
+  nodes?: ReadonlyArray<Klass<LexicalNode>>;
   onError: (error: Error) => void;
   parentEditor?: LexicalEditor;
   readOnly?: boolean;

--- a/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
+++ b/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
@@ -7,6 +7,7 @@
  */
 
 import type {LexicalNode} from 'lexical';
+import type {Klass} from 'shared/types';
 
 import {CodeHighlightNode, CodeNode} from '@lexical/code';
 import {HashtagNode} from '@lexical/hashtag';
@@ -17,7 +18,6 @@ import {OverflowNode} from '@lexical/overflow';
 import {HorizontalRuleNode} from '@lexical/react/LexicalHorizontalRuleNode';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
-import {Class} from 'utility-types';
 
 import {AutocompleteNode} from './AutocompleteNode';
 import {EmojiNode} from './EmojiNode';
@@ -32,7 +32,7 @@ import {TweetNode} from './TweetNode';
 import {TypeaheadNode} from './TypeaheadNode';
 import {YouTubeNode} from './YouTubeNode';
 
-const PlaygroundNodes: Array<Class<LexicalNode>> = [
+const PlaygroundNodes: Array<Klass<LexicalNode>> = [
   HeadingNode,
   ListNode,
   ListItemNode,

--- a/packages/lexical-react/src/DEPRECATED_useLexical.ts
+++ b/packages/lexical-react/src/DEPRECATED_useLexical.ts
@@ -12,10 +12,10 @@ import type {
   LexicalEditor,
   LexicalNode,
 } from 'lexical';
+import type {Klass} from 'shared/types';
 
 import {createEditor} from 'lexical';
 import {useMemo} from 'react';
-import {Class} from 'utility-types';
 
 import {useLexicalEditor} from './DEPRECATED_useLexicalEditor';
 
@@ -23,7 +23,7 @@ export function useLexical(editorConfig: {
   disableEvents?: boolean;
   editorState?: EditorState;
   namespace: string;
-  nodes?: ReadonlyArray<Class<LexicalNode>>;
+  nodes?: ReadonlyArray<Klass<LexicalNode>>;
   onError: (error: Error) => void;
   parentEditor?: LexicalEditor;
   readOnly?: boolean;

--- a/packages/lexical-react/src/useLexicalTextEntity.ts
+++ b/packages/lexical-react/src/useLexicalTextEntity.ts
@@ -8,16 +8,16 @@
 
 import type {EntityMatch} from '@lexical/text';
 import type {TextNode} from 'lexical';
+import type {Klass} from 'shared/types';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {registerLexicalTextEntity} from '@lexical/text';
 import {mergeRegister} from '@lexical/utils';
 import {useEffect} from 'react';
-import {Class} from 'utility-types';
 
 export function useLexicalTextEntity<N extends TextNode>(
   getMatch: (text: string) => null | EntityMatch,
-  targetNode: Class<N>,
+  targetNode: Klass<N>,
   createNode: (textNode: TextNode) => N,
 ): void {
   const [editor] = useLexicalComposerContext();

--- a/packages/lexical-text/src/index.ts
+++ b/packages/lexical-text/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type {ElementNode, LexicalEditor, LexicalNode, RootNode} from 'lexical';
+import type {Klass} from 'shared/types';
 
 import {
   $createTextNode,
@@ -16,7 +17,6 @@ import {
   TextNode,
 } from 'lexical';
 import invariant from 'shared/invariant';
-import {Class} from 'utility-types';
 
 export type TextNodeWithOffset = {
   node: TextNode;
@@ -255,7 +255,7 @@ export type EntityMatch = {end: number; start: number};
 export function registerLexicalTextEntity<N extends TextNode>(
   editor: LexicalEditor,
   getMatch: (text: string) => null | EntityMatch,
-  targetNode: Class<N>,
+  targetNode: Klass<N>,
   createNode: (textNode: TextNode) => N,
 ): Array<() => void> {
   const isTargetNode = (node: LexicalNode | null | undefined): node is N => {

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -13,6 +13,7 @@ import type {
   LexicalNode,
   NodeKey,
 } from 'lexical';
+import type {Klass} from 'shared/types';
 
 import {
   $getRoot,
@@ -22,7 +23,6 @@ import {
   createEditor,
 } from 'lexical';
 import invariant from 'shared/invariant';
-import {Class} from 'utility-types';
 
 export type DFSNode = Readonly<{
   depth: number;
@@ -105,7 +105,7 @@ function $getDepth(node: LexicalNode): number {
 
 export function $getNearestNodeOfType<T extends ElementNode>(
   node: LexicalNode,
-  klass: Class<T>,
+  klass: Klass<T>,
 ): T | LexicalNode {
   let parent: T | LexicalNode = node;
 
@@ -173,7 +173,7 @@ export function mergeRegister(...func: Array<Func>): () => void {
 
 export function registerNestedElementResolver<N extends ElementNode>(
   editor: LexicalEditor,
-  targetNode: {new (...args: unknown[]): N},
+  targetNode: Klass<N>,
   cloneNode: (from: N) => N,
   handleOverlap: (from: N, to: N) => void,
 ): () => void {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -8,10 +8,10 @@
 
 import type {EditorState, SerializedEditorState} from './LexicalEditorState';
 import type {DOMConversion, LexicalNode, NodeKey} from './LexicalNode';
+import type {Klass} from 'shared/types';
 
 import getDOMSelection from 'shared/getDOMSelection';
 import invariant from 'shared/invariant';
-import {Class} from 'utility-types';
 
 import {$getRoot, $getSelection, TextNode} from '.';
 import {FULL_RECONCILE, NO_DIRTY_NODES} from './LexicalConstants';
@@ -120,7 +120,7 @@ export type EditorConfig = {
 export type RegisteredNodes = Map<string, RegisteredNode>;
 
 export type RegisteredNode = {
-  klass: Class<LexicalNode>;
+  klass: Klass<LexicalNode>;
   transforms: Set<Transform<LexicalNode>>;
 };
 
@@ -128,9 +128,9 @@ export type Transform<T> = (node: T) => void;
 
 export type ErrorHandler = (error: Error) => void;
 
-export type MutationListeners = Map<MutationListener, Class<LexicalNode>>;
+export type MutationListeners = Map<MutationListener, Klass<LexicalNode>>;
 
-export type MutatedNodes = Map<Class<LexicalNode>, Map<NodeKey, NodeMutation>>;
+export type MutatedNodes = Map<Klass<LexicalNode>, Map<NodeKey, NodeMutation>>;
 
 export type NodeMutation = 'created' | 'updated' | 'destroyed';
 
@@ -286,7 +286,7 @@ export function createEditor(editorConfig?: {
   disableEvents?: boolean;
   editorState?: EditorState;
   namespace?: string;
-  nodes?: ReadonlyArray<Class<LexicalNode>>;
+  nodes?: ReadonlyArray<Klass<LexicalNode>>;
   onError?: ErrorHandler;
   parentEditor?: LexicalEditor;
   readOnly?: boolean;
@@ -578,7 +578,7 @@ export class LexicalEditor {
   }
 
   registerMutationListener(
-    klass: Class<LexicalNode>,
+    klass: Klass<LexicalNode>,
     listener: MutationListener,
   ): () => void {
     // @ts-expect-error TODO Replace Class utility type with InstanceType
@@ -600,7 +600,7 @@ export class LexicalEditor {
   }
 
   registerNodeTransform<T extends LexicalNode>(
-    klass: Class<T>,
+    klass: Klass<T>,
     listener: Transform<T>,
   ): () => void {
     // @ts-expect-error TODO Replace Class utility type with InstanceType
@@ -624,9 +624,7 @@ export class LexicalEditor {
     };
   }
 
-  hasNodes<T extends {new (...args: unknown[]): LexicalNode}>(
-    nodes: Array<T>,
-  ): boolean {
+  hasNodes<T extends Klass<LexicalNode>>(nodes: Array<T>): boolean {
     for (let i = 0; i < nodes.length; i++) {
       const klass = nodes[i];
       // @ts-expect-error

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -9,9 +9,9 @@
 
 import type {EditorConfig, LexicalEditor} from './LexicalEditor';
 import type {RangeSelection} from './LexicalSelection';
+import type {Klass} from 'shared/types';
 
 import invariant from 'shared/invariant';
-import {Class} from 'utility-types';
 
 import {$isElementNode, $isRootNode, $isTextNode, ElementNode} from '.';
 import {
@@ -778,7 +778,7 @@ export class LexicalNode {
 
 function errorOnTypeKlassMismatch(
   type: string,
-  klass: Class<LexicalNode>,
+  klass: Klass<LexicalNode>,
 ): void {
   const registeredNode = getActiveEditor()._nodes.get(type);
   // Common error - split in its own invariant

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -25,11 +25,11 @@ import type {
 } from './LexicalSelection';
 import type {RootNode} from './nodes/LexicalRootNode';
 import type {TextFormatType, TextNode} from './nodes/LexicalTextNode';
+import type {Klass} from 'shared/types';
 
 import {IS_APPLE, IS_IOS, IS_SAFARI} from 'shared/environment';
 import getDOMSelection from 'shared/getDOMSelection';
 import invariant from 'shared/invariant';
-import {Class} from 'utility-types';
 
 import {
   $createTextNode,
@@ -992,9 +992,7 @@ export function setMutatedNode(
   }
 }
 
-export function $nodesOfType<T extends LexicalNode>(
-  klass: Class<LexicalNode>,
-): Array<T> {
+export function $nodesOfType<T extends LexicalNode>(klass: Klass<T>): Array<T> {
   const editorState = getActiveEditorState();
   const readOnly = editorState._readOnly;
   // @ts-expect-error TODO Replace Class utility type with InstanceType

--- a/packages/shared/types.d.ts
+++ b/packages/shared/types.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {LexicalNode} from 'lexical';
+
+export type Klass<T extends LexicalNode> = new (...args: unknown[]) => T;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -177,7 +177,8 @@
       ],
       "shared/invariant": ["./packages/shared/src/invariant.ts"],
       "shared/environment": ["./packages/shared/src/environment.ts"],
-      "shared/useLayoutEffect": ["./packages/shared/src/useLayoutEffect.ts"]
+      "shared/useLayoutEffect": ["./packages/shared/src/useLayoutEffect.ts"],
+      "shared/types": ["./packages/shared/src/types.d.ts"]
     }
   },
   "include": ["./libdefs", "./packages"],


### PR DESCRIPTION
We can remove `utility-types` and just create our own shared utility types.