### PR TITLE
Add `eslint-plugin-header` to lint for correct MIT licence header

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,11 +55,12 @@ module.exports = {
       parserOptions: {
         sourceType: 'module',
       },
-      plugins: ['react', '@typescript-eslint'],
+      plugins: ['react', '@typescript-eslint', 'header'],
       rules: {
         '@typescript-eslint/ban-ts-comment': OFF,
         '@typescript-eslint/no-this-alias': OFF,
         '@typescript-eslint/no-unused-vars': [ERROR, {args: 'none'}],
+        'header/header': [2, 'scripts/www/headerTemplate.js'],
       },
     },
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-babel": "^5.3.1",
         "eslint-plugin-flowtype": "^8.0.3",
+        "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jest": "^24.4.0",
         "eslint-plugin-jsx-a11y": "^6.4.1",
@@ -11907,6 +11908,15 @@
         "@babel/plugin-syntax-flow": "^7.14.5",
         "@babel/plugin-transform-react-jsx": "^7.14.9",
         "eslint": "^8.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-header": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
+      "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=7.7.0"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -38587,6 +38597,12 @@
         "lodash": "^4.17.21",
         "string-natural-compare": "^3.0.1"
       }
+    },
+    "eslint-plugin-header": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
+      "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
+      "dev": true
     },
     "eslint-plugin-import": {
       "version": "2.26.0",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-flowtype": "^8.0.3",
+    "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^24.4.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",

--- a/packages/lexical-devtools/src/App.tsx
+++ b/packages/lexical-devtools/src/App.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/lexical-devtools/src/index.tsx
+++ b/packages/lexical-devtools/src/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/lexical-devtools/tsconfig.json
+++ b/packages/lexical-devtools/tsconfig.json
@@ -2,6 +2,6 @@
   "compilerOptions": {
     "strict": true
   },
-  "extends": "../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "include": ["src"]
 }

--- a/packages/lexical-dragon/LexicalDragon.ts
+++ b/packages/lexical-dragon/LexicalDragon.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+module.exports = require('./dist/LexicalDragon.js');

--- a/packages/lexical-file/LexicalFile.ts
+++ b/packages/lexical-file/LexicalFile.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 module.exports = require('./dist/LexicalFile.js');

--- a/packages/lexical-hashtag/LexicalHashtag.ts
+++ b/packages/lexical-hashtag/LexicalHashtag.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 module.exports = require('./dist/LexicalHashtag.js');

--- a/packages/lexical-hashtag/src/LexicalHashtagNode.ts
+++ b/packages/lexical-hashtag/src/LexicalHashtagNode.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
-
  */
 
 import type {

--- a/packages/lexical-headless/LexicalHeadless.ts
+++ b/packages/lexical-headless/LexicalHeadless.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 module.exports = require('./dist/LexicalHeadless.js');

--- a/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.ts
+++ b/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.ts
@@ -6,6 +6,8 @@
 // to ensure that headless editor works within node environment
 // https://jestjs.io/docs/configuration#testenvironment-string
 
+/* eslint-disable header/header */
+
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *

--- a/packages/lexical-html/LexicalHtml.ts
+++ b/packages/lexical-html/LexicalHtml.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 module.exports = require('./dist/LexicalHtml.js');

--- a/packages/lexical-link/LexicalLink.ts
+++ b/packages/lexical-link/LexicalLink.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 module.exports = require('./dist/LexicalLink.js');

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
-
  */
 
 import type {

--- a/packages/lexical-list/LexicalList.ts
+++ b/packages/lexical-list/LexicalList.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 module.exports = require('./dist/LexicalList.js');

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 import type {Spread} from 'lexical';

--- a/packages/lexical-list/src/utils.ts
+++ b/packages/lexical-list/src/utils.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 import type {LexicalNode} from 'lexical';

--- a/packages/lexical-mark/LexicalMark.ts
+++ b/packages/lexical-mark/LexicalMark.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 module.exports = require('./dist/LexicalMark.js');

--- a/packages/lexical-markdown/LexicalMarkdown.ts
+++ b/packages/lexical-markdown/LexicalMarkdown.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 module.exports = require('./dist/LexicalMarkdown.js');

--- a/packages/lexical-markdown/src/autoFormatUtils.ts
+++ b/packages/lexical-markdown/src/autoFormatUtils.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 import type {

--- a/packages/lexical-markdown/src/convertFromPlainTextUtils.ts
+++ b/packages/lexical-markdown/src/convertFromPlainTextUtils.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 import type {ScanningContext} from './utils';

--- a/packages/lexical-markdown/src/convertToMarkdown.ts
+++ b/packages/lexical-markdown/src/convertToMarkdown.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 import type {ElementNode, LexicalNode, TextFormatType, TextNode} from 'lexical';

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 import type {

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 import type {ListNode, ListType} from '@lexical/list';

--- a/packages/lexical-markdown/src/v2/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/v2/MarkdownExport.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 import type {

--- a/packages/lexical-markdown/src/v2/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/v2/MarkdownImport.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 import type {CodeNode} from '@lexical/code';

--- a/packages/lexical-markdown/src/v2/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/v2/MarkdownShortcuts.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 import type {

--- a/packages/lexical-markdown/src/v2/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/v2/MarkdownTransformers.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
-
  */
 
 import type {ListNode, ListType} from '@lexical/list';

--- a/packages/lexical-markdown/src/v2/utils.ts
+++ b/packages/lexical-markdown/src/v2/utils.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 import type {

--- a/packages/lexical-offset/LexicalOffset.ts
+++ b/packages/lexical-offset/LexicalOffset.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 module.exports = require('./dist/LexicalOffset.js');

--- a/packages/lexical-offset/src/index.ts
+++ b/packages/lexical-offset/src/index.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 import type {

--- a/packages/lexical-overflow/LexicalOverflow.ts
+++ b/packages/lexical-overflow/LexicalOverflow.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 module.exports = require('./dist/LexicalOverflow.js');

--- a/packages/lexical-overflow/src/index.ts
+++ b/packages/lexical-overflow/src/index.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
-
  */
 
 import type {

--- a/packages/lexical-plain-text/LexicalPlainText.ts
+++ b/packages/lexical-plain-text/LexicalPlainText.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 module.exports = require('./dist/LexicalPlainText.js');

--- a/packages/lexical-playground/src/commenting/index.ts
+++ b/packages/lexical-playground/src/commenting/index.ts
@@ -317,6 +317,7 @@ export class CommentStore {
                       | undefined);
 
               if (Array.isArray(insert)) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 insert.forEach((map: YMap<any>) => {
                   const id = map.get('id');
                   const type = map.get('type');

--- a/packages/lexical-playground/src/plugins/MarkdownShortcutPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/MarkdownShortcutPlugin.tsx
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
  *
  */
 

--- a/packages/lexical-playground/src/setupEnv.ts
+++ b/packages/lexical-playground/src/setupEnv.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
-
  */
 
 import {DEFAULT_SETTINGS} from './appSettings';

--- a/packages/lexical-playground/src/ui/ColorPicker.tsx
+++ b/packages/lexical-playground/src/ui/ColorPicker.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/lexical-react/src/LexicalLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalLinkPlugin.ts
@@ -3,6 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
  */
 
 import {LinkNode, TOGGLE_LINK_COMMAND, toggleLink} from '@lexical/link';

--- a/packages/lexical-rich-text/LexicalRichText.ts
+++ b/packages/lexical-rich-text/LexicalRichText.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 
 module.exports = require('./dist/LexicalRichText.js');

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-constant-condition */
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -7,6 +6,7 @@
  *
  */
 
+/* eslint-disable no-constant-condition */
 import type {EditorConfig, LexicalEditor} from './LexicalEditor';
 import type {RangeSelection} from './LexicalSelection';
 import type {Klass} from 'shared/types';

--- a/scripts/www/headerTemplate.js
+++ b/scripts/www/headerTemplate.js
@@ -5,5 +5,3 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
-module.exports = require('./dist/LexicalHistory.js');


### PR DESCRIPTION
Add `eslint-plugin-header` to ensure correct Meta licence header is being applied to all files.

Closes #1499