### PR TITLE
initializeEditorState on LexicalComposer

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -100,6 +100,7 @@ module.name_mapper='^@lexical/yjs$' -> '<PROJECT_ROOT>/packages/lexical-yjs/flow
 module.name_mapper='^shared/getDOMSelection' -> '<PROJECT_ROOT>/packages/shared/src/getDOMSelection.js'
 module.name_mapper='^shared/simpleDiffWithCursor' -> '<PROJECT_ROOT>/packages/shared/src/simpleDiffWithCursor.js'
 module.name_mapper='^shared/invariant' -> '<PROJECT_ROOT>/packages/shared/src/invariant.js'
+module.name_mapper='^shared/warnOnlyOnce' -> '<PROJECT_ROOT>/packages/shared/src/warnOnlyOnce.js'
 module.name_mapper='^shared/environment' -> '<PROJECT_ROOT>/packages/shared/src/environment.js'
 module.name_mapper='^shared/useLayoutEffect' -> '<PROJECT_ROOT>/packages/shared/src/useLayoutEffect.js'
 module.name_mapper='^shared/canUseDOM' -> '<PROJECT_ROOT>/packages/shared/src/canUseDOM.js'

--- a/jest.config.js
+++ b/jest.config.js
@@ -91,6 +91,8 @@ module.exports = {
           '<rootDir>/packages/shared/src/simpleDiffWithCursor.ts',
         '^shared/useLayoutEffect$':
           '<rootDir>/packages/shared/src/useLayoutEffect.ts',
+        '^shared/warnOnlyOnce$':
+          '<rootDir>/packages/shared/src/warnOnlyOnce.ts',
         formatProdErrorMessage:
           '<rootDir>/scripts/error-codes/formatProdErrorMessage.js',
       },

--- a/packages/lexical-markdown/README.md
+++ b/packages/lexical-markdown/README.md
@@ -22,10 +22,10 @@ editor.update(() => {
 
 It can also be used for initializing editor's state from markdown string. Here's an example with react `<RichTextPlugin>`
 ```jsx
-<LexicalComposer>
-  <RichTextPlugin initialEditorState={() => {
+<LexicalComposer initialEditorState={() => {
     $convertFromMarkdownString(markdown, TRANSFORMERS);
-  }} />
+  }}>
+  <RichTextPlugin />
 </LexicalComposer>
 ```
 

--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -6,7 +6,11 @@
  *
  */
 
+import {$createLinkNode} from '@lexical/link';
+import {$createListItemNode, $createListNode} from '@lexical/list';
 import {LexicalComposer} from '@lexical/react/LexicalComposer';
+import {$createHeadingNode, $createQuoteNode} from '@lexical/rich-text';
+import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
 import * as React from 'react';
 
 import {isDevPlayground} from './appSettings';
@@ -25,11 +29,97 @@ console.warn(
   'If you are profiling the playground app, please ensure you turn off the debug view. You can disable it by pressing on the settings control in the bottom-left of your screen and toggling the debug view setting.',
 );
 
+function prepopulatedRichText() {
+  const root = $getRoot();
+  if (root.getFirstChild() === null) {
+    const heading = $createHeadingNode('h1');
+    heading.append($createTextNode('Welcome to the playground'));
+    root.append(heading);
+    const quote = $createQuoteNode();
+    quote.append(
+      $createTextNode(
+        `In case you were wondering what the black box at the bottom is – it's the debug view, showing the current state of editor. ` +
+          `You can disable it by pressing on the settings control in the bottom-left of your screen and toggling the debug view setting.`,
+      ),
+    );
+    root.append(quote);
+    const paragraph = $createParagraphNode();
+    paragraph.append(
+      $createTextNode('The playground is a demo environment built with '),
+      $createTextNode('@lexical/react').toggleFormat('code'),
+      $createTextNode('.'),
+      $createTextNode(' Try typing in '),
+      $createTextNode('some text').toggleFormat('bold'),
+      $createTextNode(' with '),
+      $createTextNode('different').toggleFormat('italic'),
+      $createTextNode(' formats.'),
+    );
+    root.append(paragraph);
+    const paragraph2 = $createParagraphNode();
+    paragraph2.append(
+      $createTextNode(
+        'Make sure to check out the various plugins in the toolbar. You can also use #hashtags or @-mentions too!',
+      ),
+    );
+    root.append(paragraph2);
+    const paragraph3 = $createParagraphNode();
+    paragraph3.append(
+      $createTextNode(`If you'd like to find out more about Lexical, you can:`),
+    );
+    root.append(paragraph3);
+    const list = $createListNode('bullet');
+    list.append(
+      $createListItemNode().append(
+        $createTextNode(`Visit the `),
+        $createLinkNode('https://lexical.dev/').append(
+          $createTextNode('Lexical website'),
+        ),
+        $createTextNode(` for documentation and more information.`),
+      ),
+      $createListItemNode().append(
+        $createTextNode(`Check out the code on our `),
+        $createLinkNode('https://github.com/facebook/lexical').append(
+          $createTextNode('GitHub repository'),
+        ),
+        $createTextNode(`.`),
+      ),
+      $createListItemNode().append(
+        $createTextNode(`Playground code can be found `),
+        $createLinkNode(
+          'https://github.com/facebook/lexical/tree/main/packages/lexical-playground',
+        ).append($createTextNode('here')),
+        $createTextNode(`.`),
+      ),
+      $createListItemNode().append(
+        $createTextNode(`Join our `),
+        $createLinkNode('https://discord.com/invite/KmG4wQnnD9').append(
+          $createTextNode('Discord Server'),
+        ),
+        $createTextNode(` and chat with the team.`),
+      ),
+    );
+    root.append(list);
+    const paragraph4 = $createParagraphNode();
+    paragraph4.append(
+      $createTextNode(
+        `Lastly, we're constantly adding cool new features to this playground. So make sure you check back here when you next get a chance :).`,
+      ),
+    );
+    root.append(paragraph4);
+  }
+}
+
 function App(): JSX.Element {
-  const {settings} = useSettings();
-  const {measureTypingPerf} = settings;
+  const {
+    settings: {isCollab, emptyEditor, measureTypingPerf},
+  } = useSettings();
 
   const initialConfig = {
+    editorState: isCollab
+      ? null
+      : emptyEditor
+      ? undefined
+      : prepopulatedRichText,
     namespace: 'Playground',
     nodes: [...PlaygroundNodes],
     onError: (error) => {

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -6,8 +6,6 @@
  *
  */
 
-import {$createLinkNode} from '@lexical/link';
-import {$createListItemNode, $createListNode} from '@lexical/list';
 import {AutoFocusPlugin} from '@lexical/react/LexicalAutoFocusPlugin';
 import {AutoScrollPlugin} from '@lexical/react/LexicalAutoScrollPlugin';
 import {CharacterLimitPlugin} from '@lexical/react/LexicalCharacterLimitPlugin';
@@ -21,8 +19,6 @@ import {ListPlugin} from '@lexical/react/LexicalListPlugin';
 import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
 import {TablePlugin} from '@lexical/react/LexicalTablePlugin';
-import {$createHeadingNode, $createQuoteNode} from '@lexical/rich-text';
-import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
 import * as React from 'react';
 import {useRef} from 'react';
 
@@ -62,86 +58,6 @@ const skipCollaborationInit =
   // @ts-ignore
   window.parent != null && window.parent.frames.right === window;
 
-function prepopulatedRichText() {
-  const root = $getRoot();
-  if (root.getFirstChild() === null) {
-    const heading = $createHeadingNode('h1');
-    heading.append($createTextNode('Welcome to the playground'));
-    root.append(heading);
-    const quote = $createQuoteNode();
-    quote.append(
-      $createTextNode(
-        `In case you were wondering what the black box at the bottom is – it's the debug view, showing the current state of editor. ` +
-          `You can disable it by pressing on the settings control in the bottom-left of your screen and toggling the debug view setting.`,
-      ),
-    );
-    root.append(quote);
-    const paragraph = $createParagraphNode();
-    paragraph.append(
-      $createTextNode('The playground is a demo environment built with '),
-      $createTextNode('@lexical/react').toggleFormat('code'),
-      $createTextNode('.'),
-      $createTextNode(' Try typing in '),
-      $createTextNode('some text').toggleFormat('bold'),
-      $createTextNode(' with '),
-      $createTextNode('different').toggleFormat('italic'),
-      $createTextNode(' formats.'),
-    );
-    root.append(paragraph);
-    const paragraph2 = $createParagraphNode();
-    paragraph2.append(
-      $createTextNode(
-        'Make sure to check out the various plugins in the toolbar. You can also use #hashtags or @-mentions too!',
-      ),
-    );
-    root.append(paragraph2);
-    const paragraph3 = $createParagraphNode();
-    paragraph3.append(
-      $createTextNode(`If you'd like to find out more about Lexical, you can:`),
-    );
-    root.append(paragraph3);
-    const list = $createListNode('bullet');
-    list.append(
-      $createListItemNode().append(
-        $createTextNode(`Visit the `),
-        $createLinkNode('https://lexical.dev/').append(
-          $createTextNode('Lexical website'),
-        ),
-        $createTextNode(` for documentation and more information.`),
-      ),
-      $createListItemNode().append(
-        $createTextNode(`Check out the code on our `),
-        $createLinkNode('https://github.com/facebook/lexical').append(
-          $createTextNode('GitHub repository'),
-        ),
-        $createTextNode(`.`),
-      ),
-      $createListItemNode().append(
-        $createTextNode(`Playground code can be found `),
-        $createLinkNode(
-          'https://github.com/facebook/lexical/tree/main/packages/lexical-playground',
-        ).append($createTextNode('here')),
-        $createTextNode(`.`),
-      ),
-      $createListItemNode().append(
-        $createTextNode(`Join our `),
-        $createLinkNode('https://discord.com/invite/KmG4wQnnD9').append(
-          $createTextNode('Discord Server'),
-        ),
-        $createTextNode(` and chat with the team.`),
-      ),
-    );
-    root.append(list);
-    const paragraph4 = $createParagraphNode();
-    paragraph4.append(
-      $createTextNode(
-        `Lastly, we're constantly adding cool new features to this playground. So make sure you check back here when you next get a chance :).`,
-      ),
-    );
-    root.append(paragraph4);
-  }
-}
-
 export default function Editor(): JSX.Element {
   const {historyState} = useSharedHistoryContext();
   const {
@@ -153,7 +69,6 @@ export default function Editor(): JSX.Element {
       isCharLimitUtf8,
       isRichText,
       showTreeView,
-      emptyEditor,
     },
   } = useSettings();
   const text = isCollab
@@ -199,9 +114,6 @@ export default function Editor(): JSX.Element {
             <RichTextPlugin
               contentEditable={<ContentEditable />}
               placeholder={placeholder}
-              initialEditorState={
-                isCollab ? null : emptyEditor ? undefined : prepopulatedRichText
-              }
             />
             <MarkdownShortcutPlugin />
             <CodeHighlightPlugin />

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -114,6 +114,8 @@ export default function Editor(): JSX.Element {
             <RichTextPlugin
               contentEditable={<ContentEditable />}
               placeholder={placeholder}
+              // TODO Collab support until 0.4
+              initialEditorState={null}
             />
             <MarkdownShortcutPlugin />
             <CodeHighlightPlugin />
@@ -140,6 +142,8 @@ export default function Editor(): JSX.Element {
             <PlainTextPlugin
               contentEditable={<ContentEditable />}
               placeholder={placeholder}
+              // TODO Collab support until 0.4
+              initialEditorState={null}
             />
             <HistoryPlugin externalHistoryState={historyState} />
           </>

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -115,7 +115,7 @@ export default function Editor(): JSX.Element {
               contentEditable={<ContentEditable />}
               placeholder={placeholder}
               // TODO Collab support until 0.4
-              initialEditorState={null}
+              initialEditorState={isCollab ? null : undefined}
             />
             <MarkdownShortcutPlugin />
             <CodeHighlightPlugin />
@@ -143,7 +143,7 @@ export default function Editor(): JSX.Element {
               contentEditable={<ContentEditable />}
               placeholder={placeholder}
               // TODO Collab support until 0.4
-              initialEditorState={null}
+              initialEditorState={isCollab ? null : undefined}
             />
             <HistoryPlugin externalHistoryState={historyState} />
           </>

--- a/packages/lexical-playground/src/appSettings.ts
+++ b/packages/lexical-playground/src/appSettings.ts
@@ -28,7 +28,8 @@ export const isDevPlayground: boolean =
 
 export const DEFAULT_SETTINGS: Settings = {
   disableBeforeInput: false,
-  emptyEditor: isDevPlayground,
+  // emptyEditor: isDevPlayground,
+  emptyEditor: false,
   isAutocomplete: false,
   isCharLimit: false,
   isCharLimitUtf8: false,

--- a/packages/lexical-playground/src/appSettings.ts
+++ b/packages/lexical-playground/src/appSettings.ts
@@ -28,8 +28,7 @@ export const isDevPlayground: boolean =
 
 export const DEFAULT_SETTINGS: Settings = {
   disableBeforeInput: false,
-  // emptyEditor: isDevPlayground,
-  emptyEditor: false,
+  emptyEditor: isDevPlayground,
   isAutocomplete: false,
   isCharLimit: false,
   isCharLimitUtf8: false,

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -288,6 +288,8 @@ function ImageComponent({
                     Enter a caption...
                   </Placeholder>
                 }
+                // TODO Remove after it's inherited from the parent (LexicalComposer)
+                initialEditorState={null}
               />
               {showNestedEditorTreeView === true ? <TreeViewPlugin /> : null}
             </LexicalNestedComposer>

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -288,7 +288,6 @@ function ImageComponent({
                     Enter a caption...
                   </Placeholder>
                 }
-                initialEditorState={null}
               />
               {showNestedEditorTreeView === true ? <TreeViewPlugin /> : null}
             </LexicalNestedComposer>

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -265,6 +265,8 @@ function StickyComponent({
                 What's up?
               </Placeholder>
             }
+            // TODO Remove after it's inherited from the parent (LexicalComposer)
+            initialEditorState={null}
           />
         </LexicalNestedComposer>
       </div>

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -265,7 +265,6 @@ function StickyComponent({
                 What's up?
               </Placeholder>
             }
-            initialEditorState={null}
           />
         </LexicalNestedComposer>
       </div>

--- a/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
@@ -9,10 +9,15 @@
 import {InitialEditorStateType} from '@lexical/plain-text';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
+import warnOnlyOnce from 'shared/warnOnlyOnce';
 
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 import {useDecorators} from './shared/useDecorators';
 import {usePlainTextSetup} from './shared/usePlainTextSetup';
+
+const deprecatedInitialEditorStateWarning = warnOnlyOnce(
+  'initialEditorState on PlainTextPlugin is deprecated and will be removed soon. Use LexicalComposer initialEditorState instead.',
+);
 
 export function PlainTextPlugin({
   contentEditable,
@@ -20,14 +25,17 @@ export function PlainTextPlugin({
   initialEditorState,
 }: {
   contentEditable: JSX.Element;
+  // TODO Remove in 0.4
   initialEditorState?: InitialEditorStateType;
   placeholder: JSX.Element | string;
 }): JSX.Element {
+  if (initialEditorState !== undefined) {
+    deprecatedInitialEditorStateWarning();
+  }
   const [editor] = useLexicalComposerContext();
-
   const showPlaceholder = useCanShowPlaceholder(editor);
-  usePlainTextSetup(editor, initialEditorState);
   const decorators = useDecorators(editor);
+  usePlainTextSetup(editor, initialEditorState);
 
   return (
     <>

--- a/packages/lexical-react/src/LexicalRichTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalRichTextPlugin.tsx
@@ -9,10 +9,15 @@
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {InitialEditorStateType} from '@lexical/rich-text';
 import * as React from 'react';
+import warnOnlyOnce from 'shared/warnOnlyOnce';
 
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 import {useDecorators} from './shared/useDecorators';
 import {useRichTextSetup} from './shared/useRichTextSetup';
+
+const deprecatedInitialEditorStateWarning = warnOnlyOnce(
+  'initialEditorState on RichTextPlugin is deprecated and will be removed soon. Use LexicalComposer initialEditorState instead.',
+);
 
 export function RichTextPlugin({
   contentEditable,
@@ -20,16 +25,17 @@ export function RichTextPlugin({
   initialEditorState,
 }: Readonly<{
   contentEditable: JSX.Element;
+  // TODO Remove in 0.4
   initialEditorState?: InitialEditorStateType;
   placeholder: JSX.Element | string;
 }>): JSX.Element {
+  if (initialEditorState !== undefined) {
+    deprecatedInitialEditorStateWarning();
+  }
   const [editor] = useLexicalComposerContext();
-
   const showPlaceholder = useCanShowPlaceholder(editor);
-
-  useRichTextSetup(editor, initialEditorState);
-
   const decorators = useDecorators(editor);
+  useRichTextSetup(editor, initialEditorState);
 
   return (
     <>

--- a/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
@@ -67,6 +67,7 @@ describe('LexicalNodeHelpers tests', () => {
         return (
           <LexicalComposer
             initialConfig={{
+              editorState: $initialEditorState,
               namespace: '',
               nodes:
                 plugin === 'PlainTextPlugin'
@@ -95,13 +96,11 @@ describe('LexicalNodeHelpers tests', () => {
             {plugin === 'PlainTextPlugin' ? (
               <PlainTextPlugin
                 contentEditable={<ContentEditable />}
-                initialEditorState={$initialEditorState}
                 placeholder=""
               />
             ) : (
               <RichTextPlugin
                 contentEditable={<ContentEditable />}
-                initialEditorState={$initialEditorState}
                 placeholder=""
               />
             )}
@@ -134,6 +133,7 @@ describe('LexicalNodeHelpers tests', () => {
         return (
           <LexicalComposer
             initialConfig={{
+              editorState: initialEditorStateJson,
               namespace: '',
               nodes:
                 plugin === 'PlainTextPlugin'
@@ -162,13 +162,11 @@ describe('LexicalNodeHelpers tests', () => {
             {plugin === 'PlainTextPlugin' ? (
               <PlainTextPlugin
                 contentEditable={<ContentEditable />}
-                initialEditorState={initialEditorStateJson}
                 placeholder=""
               />
             ) : (
               <RichTextPlugin
                 contentEditable={<ContentEditable />}
-                initialEditorState={initialEditorStateJson}
                 placeholder=""
               />
             )}

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -74,6 +74,7 @@ import {
 } from 'lexical';
 import {CAN_USE_BEFORE_INPUT, IS_IOS, IS_SAFARI} from 'shared/environment';
 
+// TODO Remove in 0.4
 export type InitialEditorStateType =
   | null
   | string

--- a/packages/lexical-website-new/docs/concepts/editor-state.md
+++ b/packages/lexical-website-new/docs/concepts/editor-state.md
@@ -47,8 +47,8 @@ For React it could be something following:
 const initialEditorState = await loadContent();
 const editorStateRef = useRef();
 
-<LexicalComposer ...>
-  <LexicalRichTextPlugin initialEditorState={initialEditorState} />
+<LexicalComposer initialEditorState={initialEditorState}>
+  <LexicalRichTextPlugin />
   <LexicalOnChangePlugin onChange={editorState => editorStateRef.current = editorState} />
   <Button label="Save" onPress={() => {
     if (editorStateRef.current) {

--- a/packages/shared/src/warnOnlyOnce.ts
+++ b/packages/shared/src/warnOnlyOnce.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export default function warnOnlyOnce(message: string) {
+  if (!__DEV__) {
+    return;
+  }
+  let run = false;
+  return () => {
+    if (!run) {
+      console.warn(message);
+    }
+    run = true;
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -177,6 +177,7 @@
         "packages/shared/src/simpleDiffWithCursor.ts"
       ],
       "shared/invariant": ["./packages/shared/src/invariant.ts"],
+      "shared/warnOnlyOnce": ["./packages/shared/src/warnOnlyOnce.ts"],
       "shared/environment": ["./packages/shared/src/environment.ts"],
       "shared/useLayoutEffect": ["./packages/shared/src/useLayoutEffect.ts"],
       "shared/types": ["./packages/shared/src/types.d.ts"]


### PR DESCRIPTION
Seemingly a gimmick but it's actually important for 2 reasons:
1. Support users to switch between plain text and rich text without conditionals
2. Fix nested editor initialEditorState population, which is very complicated is things are loosely coupled by plugins. Instead, with a LexicalComposer + NestedLexicalComposer we can handle this easily out of the box