### PR TITLE
fix: add styles on copy

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -17,6 +17,7 @@ import type {
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
 import {$createListNode, $isListItemNode} from '@lexical/list';
 import {
+  $addNodeStyle,
   $cloneWithProperties,
   $sliceSelectedTextNodeContent,
 } from '@lexical/selection';
@@ -448,7 +449,11 @@ export function $generateNodesFromSerializedNodes(
   const nodes = [];
   for (let i = 0; i < serializedNodes.length; i++) {
     const serializedNode = serializedNodes[i];
-    nodes.push($parseSerializedNode(serializedNode));
+    const node = $parseSerializedNode(serializedNode);
+    if ($isTextNode(node)) {
+      $addNodeStyle(node);
+    }
+    nodes.push(node);
   }
   return nodes;
 }

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -303,6 +303,18 @@ export function getStyleObjectFromCSS(
   return cssToStyles.get(css) || null;
 }
 
+function getStyleObjectFromRawCSS(css: string): Record<string, string> {
+  const styleObject = {};
+  const styles = css.split(';').slice(0, -1);
+
+  for (const style of styles) {
+    const patch = style.split(': ');
+    styleObject[patch[0]] = patch[1];
+  }
+
+  return styleObject;
+}
+
 function getCSSFromStyleObject(styles: Record<string, string>): string {
   let css = '';
 
@@ -313,6 +325,12 @@ function getCSSFromStyleObject(styles: Record<string, string>): string {
   }
 
   return css;
+}
+
+export function $addNodeStyle(node: TextNode): void {
+  const CSSText = node.getStyle();
+  const styles = getStyleObjectFromRawCSS(CSSText);
+  cssToStyles.set(CSSText, styles);
 }
 
 function $patchNodeStyle(node: TextNode, patch: Record<string, string>): void {


### PR DESCRIPTION
Currently we face an issue while pasting from Lexical <-> Lexical, the styles and formatting get copied as they should be (Thanks to #2370) But the problem is that the toolbar doesn't recognize the styles that are being pasted. You can see the issue in the video below:

# Before

https://user-images.githubusercontent.com/64399555/173834698-d79eef4f-771d-4585-abdc-bf9904f0a7cc.mp4

This is apparently because all the styles are stored in a Map which only gets set on applying a style, this PR adds the functionality to add styles to the Map even on paste.

# After

https://user-images.githubusercontent.com/64399555/173834724-424b655b-50e7-4e5a-b35d-b5520c62b55d.mp4
