### PR TITLE
Fix exposed private methods

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -238,7 +238,7 @@ function $setPointValues(
   point.type = type;
 }
 
-interface BaseSelection {
+export interface BaseSelection {
   clone(): BaseSelection;
   dirty: boolean;
   extract(): Array<LexicalNode>;

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -6,21 +6,50 @@
  *
  */
 
-export * from './LexicalCommands';
-export * from './LexicalEditor';
-export * from './LexicalEditorState';
-export * from './LexicalEvents';
-export * from './LexicalNode';
-export * from './LexicalSelection';
-export * from './LexicalUpdates';
-export * from './LexicalUtils';
-export * from './LexicalVersion';
-export * from './nodes/LexicalDecoratorNode';
-export * from './nodes/LexicalElementNode';
-export * from './nodes/LexicalGridCellNode';
-export * from './nodes/LexicalGridNode';
-export * from './nodes/LexicalGridRowNode';
-export * from './nodes/LexicalLineBreakNode';
-export * from './nodes/LexicalParagraphNode';
-export * from './nodes/LexicalRootNode';
-export * from './nodes/LexicalTextNode';
+export {
+  COMMAND_PRIORITY_CRITICAL,
+  COMMAND_PRIORITY_EDITOR,
+  COMMAND_PRIORITY_HIGH,
+  COMMAND_PRIORITY_LOW,
+  COMMAND_PRIORITY_NORMAL,
+  createEditor,
+} from './LexicalEditor';
+export {
+  $createGridSelection,
+  $createNodeSelection,
+  $createRangeSelection,
+  $getPreviousSelection,
+  $getSelection,
+  $isGridSelection,
+  $isNodeSelection,
+  $isRangeSelection,
+} from './LexicalSelection';
+export {$parseSerializedNode} from './LexicalUpdates';
+export {
+  $getDecoratorNode,
+  $getNearestNodeFromDOMNode,
+  $getNodeByKey,
+  $getRoot,
+  $isLeafNode,
+  $nodesOfType,
+  $setCompositionKey,
+  $setSelection,
+} from './LexicalUtils';
+export {VERSION} from './LexicalVersion';
+export {$isDecoratorNode, DecoratorNode} from './nodes/LexicalDecoratorNode';
+export {$isElementNode, ElementNode} from './nodes/LexicalElementNode';
+export {$isGridCellNode, GridCellNode} from './nodes/LexicalGridCellNode';
+export {$isGridNode, GridNode} from './nodes/LexicalGridNode';
+export {$isGridRowNode, GridRowNode} from './nodes/LexicalGridRowNode';
+export {
+  $createLineBreakNode,
+  $isLineBreakNode,
+  LineBreakNode,
+} from './nodes/LexicalLineBreakNode';
+export {
+  $createParagraphNode,
+  $isParagraphNode,
+  ParagraphNode,
+} from './nodes/LexicalParagraphNode';
+export {$isRootNode, RootNode} from './nodes/LexicalRootNode';
+export {$createTextNode, $isTextNode, TextNode} from './nodes/LexicalTextNode';

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -6,6 +6,98 @@
  *
  */
 
+export type {
+  CommandListenerPriority,
+  EditorConfig,
+  EditorThemeClasses,
+  IntentionallyMarkedAsDirtyElement,
+  LexicalCommand,
+  LexicalEditor,
+  NodeMutation,
+  ReadOnlyListener,
+  SerializedEditor,
+  Spread,
+} from './LexicalEditor';
+export type {EditorState, SerializedEditorState} from './LexicalEditorState';
+export type {
+  DOMChildConversion,
+  DOMConversion,
+  DOMConversionFn,
+  DOMConversionMap,
+  DOMConversionOutput,
+  DOMExportOutput,
+  LexicalNode,
+  NodeKey,
+  NodeMap,
+  SerializedLexicalNode,
+} from './LexicalNode';
+export type {
+  BaseSelection,
+  ElementPointType as ElementPoint,
+  GridSelection,
+  GridSelectionShape,
+  NodeSelection,
+  Point,
+  RangeSelection,
+  TextPointType as TextPoint,
+} from './LexicalSelection';
+export type {
+  ElementFormatType,
+  SerializedElementNode,
+} from './nodes/LexicalElementNode';
+export type {SerializedGridCellNode} from './nodes/LexicalGridCellNode';
+export type {SerializedRootNode} from './nodes/LexicalRootNode';
+export type {
+  SerializedTextNode,
+  TextFormatType,
+  TextModeType,
+} from './nodes/LexicalTextNode';
+
+// TODO Move this somewhere else and/or recheck if we still need this
+export {
+  BLUR_COMMAND,
+  CAN_REDO_COMMAND,
+  CAN_UNDO_COMMAND,
+  CLEAR_EDITOR_COMMAND,
+  CLEAR_HISTORY_COMMAND,
+  CLICK_COMMAND,
+  CONTROLLED_TEXT_INSERTION_COMMAND,
+  COPY_COMMAND,
+  createCommand,
+  CUT_COMMAND,
+  DELETE_CHARACTER_COMMAND,
+  DELETE_LINE_COMMAND,
+  DELETE_WORD_COMMAND,
+  DRAGEND_COMMAND,
+  DRAGOVER_COMMAND,
+  DRAGSTART_COMMAND,
+  DROP_COMMAND,
+  FOCUS_COMMAND,
+  FORMAT_ELEMENT_COMMAND,
+  FORMAT_TEXT_COMMAND,
+  INDENT_CONTENT_COMMAND,
+  INSERT_LINE_BREAK_COMMAND,
+  INSERT_PARAGRAPH_COMMAND,
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ARROW_LEFT_COMMAND,
+  KEY_ARROW_RIGHT_COMMAND,
+  KEY_ARROW_UP_COMMAND,
+  KEY_BACKSPACE_COMMAND,
+  KEY_DELETE_COMMAND,
+  KEY_ENTER_COMMAND,
+  KEY_ESCAPE_COMMAND,
+  KEY_MODIFIER_COMMAND,
+  KEY_SPACE_COMMAND,
+  KEY_TAB_COMMAND,
+  MOVE_TO_END,
+  MOVE_TO_START,
+  OUTDENT_CONTENT_COMMAND,
+  PASTE_COMMAND,
+  REDO_COMMAND,
+  REMOVE_TEXT_COMMAND,
+  SELECTION_CHANGE_COMMAND,
+  UNDO_COMMAND,
+} from './LexicalCommands';
 export {
   COMMAND_PRIORITY_CRITICAL,
   COMMAND_PRIORITY_EDITOR,
@@ -14,6 +106,7 @@ export {
   COMMAND_PRIORITY_NORMAL,
   createEditor,
 } from './LexicalEditor';
+export type {EventHandler} from './LexicalEvents';
 export {
   $createGridSelection,
   $createNodeSelection,


### PR DESCRIPTION
![Screen Shot 2022-06-15 at 3 20 54 pm](https://user-images.githubusercontent.com/193447/173850910-2306f7d3-687b-4336-a2b5-f07cd641a68e.png)

⚠️ While I tried not to make any breaking changes, there are still minor (but still interesting to bundle in because they're sort of fixes):
- LexicalNode
- LexicalEditor
- EditorState
- RangeSelection
- NodeSelection

All of the above will now only be exported as types, instead of interfaces or classes. These were always meant to be exported this way but originally were exported as classes because of Flow limitations.