### PR TITLE
[0.4] Remove $addUpdateTags

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -784,7 +784,6 @@ declare export function $isGridCellNode(
  * LexicalUtils
  */
 declare export function $hasUpdateTag(tag: string): boolean;
-declare export function $addUpdateTag(tag: string): void;
 declare export function $getNearestNodeFromDOMNode(
   startingDOM: Node,
 ): LexicalNode | null;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1142,9 +1142,3 @@ export function $hasUpdateTag(tag: string): boolean {
   const editor = getActiveEditor();
   return editor._updateTags.has(tag);
 }
-
-export function $addUpdateTag(tag: string): void {
-  errorOnReadOnly();
-  const editor = getActiveEditor();
-  editor._updateTags.add(tag);
-}


### PR DESCRIPTION
This PR is the first of many

# Accidential tag inheritance

Updates can be tagged but they can also potentially be batched. **Batching can be lead the unexpected behavior** / race conditions.

For example, I bootstrap the editor and run a second update to add an emoji. The first is a `history-merge` update while the second the default update. Should the second be batched with the first? Probably not since this will introduce different behavior for undo-redo.

![tag-problem](https://user-images.githubusercontent.com/193447/173871335-39d92111-ef08-493e-b1ed-b04224e371d4.png)

## Fix

We can flush sync incompatible updates immediately. If the second update has different tags than the first we can immediately reconcile the first and generate the final EditorState from it.

## Concerns

1. $addUpdateTags: This method can be called literally anywhere in the update cycle, even in transforms. Transforms are unpredictable and we can't find out until they're executed, whereas we have full control of the tags passed in updates.
2. Not so much of a concern but nested updates have to be taken into consideration. They'd follow the same rules, first run the parent, if the nested update has incompatible/different tags flush sync the parent and then follow up with the nested.

## Follow-up

1. Why are updates limited to a single tag? They can potentially carry many. This can become particularly useful if you're passing tags to fulfill the requirements of some built-in plugin while you still want to introduce your personal ones.
3. This introduces the opportunity to batch the reconciliation while still delivering users the corresponding EditorStates. It's a nice BE work but also requires further conversation on whether we want to this because we break the promise that updateListener matches the reconciled/rendered EditorState._