### PR TITLE
Remove redundant newlines on pasting html

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -1774,4 +1774,39 @@ test.describe('CopyAndPaste', () => {
       `,
     );
   });
+
+  test('HTML Copy + paste multi line html with extra newlines', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await pasteFromClipboard(page, {
+      'text/html': `
+        <p>Hello
+        
+        </p>
+        
+        <p>World</p>
+        
+      `,
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello</span>
+        </p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">World</span>
+        </p>
+      `,
+    );
+  });
 });

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -864,7 +864,14 @@ function convertBringAttentionToElement(domNode: Node): DOMConversionOutput {
   };
 }
 function convertTextDOMNode(domNode: Node): DOMConversionOutput {
-  return {node: $createTextNode(domNode.textContent)};
+  const {parentElement, textContent} = domNode;
+  const textContentTrim = textContent.trim();
+  const isPre =
+    parentElement != null && parentElement.tagName.toLowerCase() === 'pre';
+  if (!isPre && textContentTrim.length === 0 && textContent.includes('\n')) {
+    return {node: null};
+  }
+  return {node: $createTextNode(textContent)};
 }
 const nodeNameToTextFormat: Record<string, TextFormatType> = {
   em: 'italic',


### PR DESCRIPTION
Before

https://user-images.githubusercontent.com/132642/173874728-2782a7d1-f1c0-4531-a966-1ea3e78011b9.mov

After

https://user-images.githubusercontent.com/132642/173874726-13f067fb-1f46-494c-b0a4-44342e8b710b.mov


