### PR TITLE
Improve text mutations around selection format changes

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -439,7 +439,9 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
             });
           }, ANDROID_COMPOSITION_LATENCY);
           if ($isRangeSelection(selection)) {
-            selection.anchor.getNode().markDirty();
+            const anchorNode = selection.anchor.getNode();
+            anchorNode.markDirty();
+            selection.format = anchorNode.getFormat();
           }
         } else {
           event.preventDefault();

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import type {LexicalNode, TextNode} from '.';
+import type {TextNode} from '.';
 import type {LexicalEditor} from './LexicalEditor';
 import type {
   GridSelection,

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -21,9 +21,9 @@ import {
   $getSelection,
   $isDecoratorNode,
   $isElementNode,
+  $isRangeSelection,
   $isTextNode,
   $setSelection,
-  $isRangeSelection,
 } from '.';
 import {DOM_TEXT_TYPE} from './LexicalConstants';
 import {updateEditor} from './LexicalUpdates';

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -764,6 +764,7 @@ export class RangeSelection implements BaseSelection {
         $isTokenOrInertOrSegmented(nextSibling)
       ) {
         nextSibling = $createTextNode();
+        nextSibling.setFormat(format);
         if (!firstNodeParent.canInsertTextAfter()) {
           firstNodeParent.insertAfter(nextSibling);
         } else {
@@ -790,6 +791,7 @@ export class RangeSelection implements BaseSelection {
         $isTokenOrInertOrSegmented(prevSibling)
       ) {
         prevSibling = $createTextNode();
+        prevSibling.setFormat(format);
         if (!firstNodeParent.canInsertTextBefore()) {
           firstNodeParent.insertBefore(prevSibling);
         } else {
@@ -804,6 +806,7 @@ export class RangeSelection implements BaseSelection {
       }
     } else if (firstNode.isSegmented() && startOffset !== firstNodeTextLength) {
       const textNode = $createTextNode(firstNode.getTextContent());
+      textNode.setFormat(format);
       firstNode.replace(textNode);
       firstNode = textNode;
     } else if (!this.isCollapsed() && text !== '') {

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -862,10 +862,14 @@ export class RangeSelection implements BaseSelection {
       firstNode = firstNode.spliceText(startOffset, delCount, text, true);
       if (firstNode.getTextContent() === '') {
         firstNode.remove();
-      } else if (firstNode.isComposing() && this.anchor.type === 'text') {
-        // When composing, we need to adjust the anchor offset so that
-        // we correctly replace that right range.
-        this.anchor.offset -= text.length;
+      } else if (this.anchor.type === 'text') {
+        if (firstNode.isComposing()) {
+          // When composing, we need to adjust the anchor offset so that
+          // we correctly replace that right range.
+          this.anchor.offset -= text.length;
+        } else {
+          this.format = firstNodeFormat;
+        }
       }
     } else {
       const markedNodeKeysForKeep = new Set([


### PR DESCRIPTION
When we try and handle DOM text mutations, sometimes the mutation might not be one we want to use. One case is where a mutation happens on a node where the previous selection format did not match. Fixes https://github.com/facebook/lexical/issues/2403.