### PR TITLE
Improve `Spread` type

### DIFF
--- a/packages/lexical-code/src/index.ts
+++ b/packages/lexical-code/src/index.ts
@@ -181,6 +181,7 @@ export class CodeHighlightNode extends TextNode {
       ...super.exportJSON(),
       highlightType: this.getHighlightType(),
       type: 'code-highlight',
+      version: 1,
     };
   }
 
@@ -333,6 +334,7 @@ export class CodeNode extends ElementNode {
       ...super.exportJSON(),
       language: this.getLanguage(),
       type: 'code',
+      version: 1,
     };
   }
 

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -80,7 +80,9 @@ export class LinkNode extends ElementNode {
     };
   }
 
-  static importJSON(serializedNode: SerializedLinkNode): LinkNode {
+  static importJSON(
+    serializedNode: SerializedLinkNode | SerializedAutoLinkNode,
+  ): LinkNode {
     const node = $createLinkNode(serializedNode.url);
     node.setFormat(serializedNode.format);
     node.setIndent(serializedNode.indent);
@@ -88,11 +90,12 @@ export class LinkNode extends ElementNode {
     return node;
   }
 
-  exportJSON(): SerializedLinkNode {
+  exportJSON(): SerializedLinkNode | SerializedAutoLinkNode {
     return {
       ...super.exportJSON(),
       type: 'link',
       url: this.getURL(),
+      version: 1,
     };
   }
 
@@ -169,9 +172,7 @@ export class AutoLinkNode extends LinkNode {
     return new AutoLinkNode(node.__url, node.__key);
   }
 
-  static importJSON(
-    serializedNode: SerializedLinkNode | SerializedAutoLinkNode,
-  ): AutoLinkNode {
+  static importJSON(serializedNode: SerializedAutoLinkNode): AutoLinkNode {
     const node = $createAutoLinkNode(serializedNode.url);
     node.setFormat(serializedNode.format);
     node.setIndent(serializedNode.indent);
@@ -188,6 +189,7 @@ export class AutoLinkNode extends LinkNode {
     return {
       ...super.exportJSON(),
       type: 'autolink',
+      version: 1,
     };
   }
 

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -125,6 +125,7 @@ export class ListItemNode extends ElementNode {
       checked: this.getChecked(),
       type: 'listitem',
       value: this.getValue(),
+      version: 1,
     };
   }
 

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -136,6 +136,7 @@ export class ListNode extends ElementNode {
       start: this.getStart(),
       tag: this.getTag(),
       type: 'list',
+      version: 1,
     };
   }
 

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -60,6 +60,7 @@ export class MarkNode extends ElementNode {
       ...super.exportJSON(),
       ids: this.getIDs(),
       type: 'mark',
+      version: 1,
     };
   }
 

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -154,7 +154,7 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
     return {
       equation: this.getEquation(),
       inline: this.__inline,
-      type: 'emoji',
+      type: 'equation',
       version: 1,
     };
   }

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -31,7 +31,7 @@ import {LineBreakNode} from './nodes/LexicalLineBreakNode';
 import {ParagraphNode} from './nodes/LexicalParagraphNode';
 import {RootNode} from './nodes/LexicalRootNode';
 
-export type Spread<T1, T2> = {[K in Exclude<keyof T1, keyof T2>]: T1[K]} & T2;
+export type Spread<T1, T2> = Omit<T2, keyof T1> & T1;
 
 export type EditorThemeClassName = string;
 

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -117,7 +117,11 @@ export class TestElementNode extends ElementNode {
   }
 
   exportJSON(): SerializedTestElementNode {
-    return super.exportJSON();
+    return {
+      ...super.exportJSON(),
+      type: 'test_block',
+      version: 1,
+    };
   }
 
   createDOM() {
@@ -161,7 +165,11 @@ export class TestInlineElementNode extends ElementNode {
   }
 
   exportJSON(): SerializedTestInlineElementNode {
-    return super.exportJSON();
+    return {
+      ...super.exportJSON(),
+      type: 'test_inline_block',
+      version: 1,
+    };
   }
 
   createDOM() {
@@ -210,7 +218,11 @@ export class TestSegmentedNode extends TextNode {
   }
 
   exportJSON(): SerializedTestSegmentedNode {
-    return super.exportJSON();
+    return {
+      ...super.exportJSON(),
+      type: 'test_segmented',
+      version: 1,
+    };
   }
 }
 
@@ -220,7 +232,7 @@ export function $createTestSegmentedNode(text): TestSegmentedNode {
 
 export type SerializedTestExcludeFromCopyElementNode = Spread<
   {
-    type: 'test_inline_block';
+    type: 'test_exclude_from_copy_block';
     version: 1;
   },
   SerializedElementNode
@@ -246,7 +258,11 @@ export class TestExcludeFromCopyElementNode extends ElementNode {
   }
 
   exportJSON(): SerializedTestExcludeFromCopyElementNode {
-    return super.exportJSON();
+    return {
+      ...super.exportJSON(),
+      type: 'test_exclude_from_copy_block',
+      version: 1,
+    };
   }
 
   createDOM() {
@@ -290,7 +306,11 @@ export class TestDecoratorNode extends DecoratorNode<JSX.Element> {
   }
 
   exportJSON(): SerializedTestDecoratorNode {
-    return super.exportJSON();
+    return {
+      ...super.exportJSON(),
+      type: 'test_decorator',
+      version: 1,
+    };
   }
 
   getTextContent() {

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -102,7 +102,7 @@ describe('LexicalElementNode tests', () => {
           direction: null,
           format: '',
           indent: 0,
-          type: 'element',
+          type: 'test_block',
           version: 1,
         });
       });


### PR DESCRIPTION
The `Spread` type could be a lot simpler, and is failing to pick up a few type issues, so this PR simplifies the logic and fixes any type errors.

```ts
// new:
export type Spread<T1, T2> = Omit<T2, keyof T1> & T1;

// old: 
export type Spread<T1, T2> = {[K in Exclude<keyof T1, keyof T2>]: T1[K]} & T2;
```
