### PR TITLE
Fix `lexical-offset` type errors

### DIFF
--- a/packages/lexical-offset/src/index.ts
+++ b/packages/lexical-offset/src/index.ts
@@ -387,23 +387,20 @@ function $searchForNodeWithOffset(
   return null;
 }
 
-function $createInternalOffsetNode<
-  TChild extends OffsetNode,
-  TParent extends OffsetElementNode = OffsetElementNode,
->(
-  child: null | TChild,
+function $createInternalOffsetNode(
+  child: null | OffsetNode,
   type: 'element' | 'text' | 'inline',
   start: number,
   end: number,
   key: NodeKey,
-  parent: null | TParent,
+  parent: null | OffsetElementNode,
 ): {
-  child: null | TChild;
+  child: null | OffsetNode;
   type: 'element' | 'text' | 'inline';
   start: number;
   end: number;
   key: NodeKey;
-  parent: null | TParent;
+  parent: null | OffsetElementNode;
   next: null;
   prev: null;
 } {
@@ -459,8 +456,8 @@ function $createOffsetNode(
       state.offset += blockOffsetSize;
     }
 
-    const offsetNode = $createInternalOffsetNode<OffsetElementNode>(
-      child as OffsetElementNode,
+    const offsetNode = $createInternalOffsetNode(
+      child,
       'element',
       start,
       start,
@@ -484,15 +481,18 @@ function $createOffsetNode(
   const length = isText ? node.__text.length : 1;
   const end = (state.offset += length);
 
-  const offsetNode = $createInternalOffsetNode<
-    OffsetTextNode | OffsetInlineNode
-  >(null, isText ? 'text' : 'inline', start, end, key, parent) as
-    | OffsetTextNode
-    | OffsetInlineNode;
+  const offsetNode = $createInternalOffsetNode(
+    null,
+    isText ? 'text' : 'inline',
+    start,
+    end,
+    key,
+    parent,
+  );
 
-  offsetMap.set(key, offsetNode);
+  offsetMap.set(key, offsetNode as OffsetNode);
 
-  return offsetNode;
+  return offsetNode as OffsetNode;
 }
 
 function $createOffsetChild(


### PR DESCRIPTION
Not sure why this wasn't picked up in the CI, but we're getting type errors in `lexical-offset` which block the internal sync. In this PR, I'm just simplifying the types.