### PR TITLE
Fix Autocomplete test on Collab

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
@@ -87,7 +87,7 @@ test.describe('Auto Links', () => {
       {ignoreClasses: true},
     );
     await page.keyboard.press('Backspace');
-    await assertHTML(page, htmlWithLink, {ignoreClasses: true});
+    await assertHTML(page, htmlWithLink, undefined, {ignoreClasses: true});
 
     // Add non-url text before the link
     await moveToLineBeginning(page);
@@ -103,7 +103,7 @@ test.describe('Auto Links', () => {
       {ignoreClasses: true},
     );
     await page.keyboard.press('Backspace');
-    await assertHTML(page, htmlWithLink, {ignoreClasses: true});
+    await assertHTML(page, htmlWithLink, undefined, {ignoreClasses: true});
 
     // Add newline after link
     await moveToLineEnd(page);
@@ -118,7 +118,7 @@ test.describe('Auto Links', () => {
       {ignoreClasses: true},
     );
     await page.keyboard.press('Backspace');
-    await assertHTML(page, htmlWithLink, {ignoreClasses: true});
+    await assertHTML(page, htmlWithLink, undefined, {ignoreClasses: true});
   });
 
   test('Can create link when pasting text with urls', async ({

--- a/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
@@ -72,7 +72,7 @@ test.describe('Auto Links', () => {
 
     await focusEditor(page);
     await page.keyboard.type('http://example.com');
-    await assertHTML(page, htmlWithLink, {ignoreClasses: true});
+    await assertHTML(page, htmlWithLink, undefined, {ignoreClasses: true});
 
     // Add non-url text after the link
     await page.keyboard.type('!');

--- a/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
@@ -52,6 +52,7 @@ test.describe('Auto Links', () => {
           </a>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -82,6 +83,7 @@ test.describe('Auto Links', () => {
           <span data-lexical-text="true">http://example.com!</span>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
     await page.keyboard.press('Backspace');
@@ -97,6 +99,7 @@ test.describe('Auto Links', () => {
           <span data-lexical-text="true">!http://example.com</span>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
     await page.keyboard.press('Backspace');
@@ -111,6 +114,7 @@ test.describe('Auto Links', () => {
         html`
           <p><br /></p>
         `,
+      undefined,
       {ignoreClasses: true},
     );
     await page.keyboard.press('Backspace');
@@ -147,6 +151,7 @@ test.describe('Auto Links', () => {
           </a>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -168,6 +173,7 @@ test.describe('Auto Links', () => {
           </a>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
     await moveLeft(page, 1);
@@ -182,6 +188,7 @@ test.describe('Auto Links', () => {
           </a>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -214,6 +221,7 @@ test.describe('Auto Links', () => {
           </a>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });

--- a/packages/lexical-playground/__tests__/e2e/Autocomplete.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Autocomplete.spec.mjs
@@ -38,10 +38,6 @@ test.describe('Autocomplete', () => {
           <br />
         </p>
       `,
-      {frame: 'left'},
-    );
-    await assertHTML(
-      page,
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
@@ -51,7 +47,6 @@ test.describe('Autocomplete', () => {
           <br />
         </p>
       `,
-      {frame: 'right'},
     );
     await page.keyboard.press('Tab');
     await page.keyboard.type(' order:');

--- a/packages/lexical-playground/__tests__/e2e/Autocomplete.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Autocomplete.spec.mjs
@@ -7,49 +7,63 @@
  */
 
 import {
-  // assertHTML,
-  // focusEditor,
-  // html,
-  // initialize,
-  // sleep,
+  assertHTML,
+  focusEditor,
+  html,
+  initialize,
+  sleep,
   test,
 } from '../utils/index.mjs';
 
 test.describe('Autocomplete', () => {
-  // test.beforeEach(({isCollab, page}) =>
-  //   initialize({isAutocomplete: true, isCollab, page}),
-  // );
-  // test('Can autocomplete a word', async ({page, isPlainText}) => {
-  //   await focusEditor(page);
-  //   await page.keyboard.type('Sort by alpha');
-  //   await sleep(500);
-  //   await assertHTML(
-  //     page,
-  //     html`
-  //       <p
-  //         class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-  //         dir="ltr">
-  //         <span data-lexical-text="true">Sort by alpha</span>
-  //         <span contenteditable="false" data-lexical-decorator="true">
-  //           <span spellcheck="false" style="color: rgb(204, 204, 204)">
-  //             betical (TAB)
-  //           </span>
-  //         </span>
-  //         <br />
-  //       </p>
-  //     `,
-  //   );
-  //   await page.keyboard.press('Tab');
-  //   await page.keyboard.type(' order:');
-  //   await assertHTML(
-  //     page,
-  //     html`
-  //       <p
-  //         class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-  //         dir="ltr">
-  //         <span data-lexical-text="true">Sort by alphabetical order:</span>
-  //       </p>
-  //     `,
-  //   );
-  // });
+  test.beforeEach(({isCollab, page}) =>
+    initialize({isAutocomplete: true, isCollab, page}),
+  );
+  test('Can autocomplete a word', async ({page, isPlainText}) => {
+    await focusEditor(page);
+    await page.keyboard.type('Sort by alpha');
+    await sleep(500);
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Sort by alpha</span>
+          <span contenteditable="false" data-lexical-decorator="true">
+            <span spellcheck="false" style="color: rgb(204, 204, 204)">
+              betical (TAB)
+            </span>
+          </span>
+          <br />
+        </p>
+      `,
+      {frame: 'left'},
+    );
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Sort by alpha</span>
+          <span contenteditable="false" data-lexical-decorator="true"></span>
+          <br />
+        </p>
+      `,
+      {frame: 'right'},
+    );
+    await page.keyboard.press('Tab');
+    await page.keyboard.type(' order:');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Sort by alphabetical order:</span>
+        </p>
+      `,
+    );
+  });
 });

--- a/packages/lexical-playground/__tests__/e2e/BlockWithAlignableContents.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/BlockWithAlignableContents.spec.mjs
@@ -122,6 +122,7 @@ test.describe('BlockWithAlignableContents', () => {
           <br />
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });

--- a/packages/lexical-playground/__tests__/e2e/ElementFormat.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ElementFormat.spec.mjs
@@ -51,6 +51,7 @@ test.describe('Element format', () => {
           <span data-lexical-text="true">world</span>
         </p>
       `,
+      undefined,
       {
         ignoreClasses: false,
         ignoreInlineStyles: false,

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -1152,6 +1152,7 @@ test.describe('Links', () => {
           </a>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -1184,6 +1185,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">world</span>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -1223,6 +1225,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">world</span>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -1251,6 +1254,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">world</span>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -1279,6 +1283,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">world</span>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -356,6 +356,7 @@ test.describe('Nested List', () => {
           </li>
         </ul>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -1135,6 +1136,7 @@ test.describe('Nested List', () => {
           </li>
         </ul>
       `,
+      undefined,
       {ignoreClasses: true},
     );
     await selectFromFormatDropdown(page, '.paragraph');
@@ -1143,6 +1145,7 @@ test.describe('Nested List', () => {
       html`
         <p dir="ltr"><span data-lexical-text="true">a</span></p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -1167,6 +1170,7 @@ test.describe('Nested List', () => {
           </li>
         </ul>
       `,
+      undefined,
       {ignoreClasses: true},
     );
     await selectFromFormatDropdown(page, '.paragraph');
@@ -1180,6 +1184,7 @@ test.describe('Nested List', () => {
         </ul>
         <p dir="ltr"><span data-lexical-text="true">b</span></p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -1210,6 +1215,7 @@ test.describe('Nested List', () => {
           </li>
         </ul>
       `,
+      undefined,
       {ignoreClasses: true},
     );
     await selectFromFormatDropdown(page, '.paragraph');
@@ -1228,6 +1234,7 @@ test.describe('Nested List', () => {
           </li>
         </ul>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });

--- a/packages/lexical-playground/__tests__/e2e/Markdown-v2.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown-v2.spec.mjs
@@ -35,7 +35,7 @@ async function assertMarkdownImportExport(
   await page.keyboard.type('```markdown ');
   await page.keyboard.type(textToImport);
   await click(page, '.action-button .markdown');
-  await assertHTML(page, expectedHTML, {ignoreClasses});
+  await assertHTML(page, expectedHTML, undefined, {ignoreClasses});
 
   // Cycle through import-export to verify it produces the same result
   await click(page, '.action-button .markdown');

--- a/packages/lexical-playground/__tests__/e2e/Markdown-v2.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown-v2.spec.mjs
@@ -340,7 +340,7 @@ test.describe('Markdown', () => {
     }) => {
       await focusEditor(page);
       await page.keyboard.type(testCase.text);
-      await assertHTML(page, testCase.html, {ignoreClasses: true});
+      await assertHTML(page, testCase.html, undefined, {ignoreClasses: true});
 
       if (!isCollab) {
         const escapedText = testCase.text.replace('>', '&gt;');
@@ -348,10 +348,11 @@ test.describe('Markdown', () => {
         await assertHTML(
           page,
           `<p><span data-lexical-text="true">${escapedText}</span></p>`,
+          undefined,
           {ignoreClasses: true},
         );
         await redo(page);
-        await assertHTML(page, testCase.html, {ignoreClasses: true});
+        await assertHTML(page, testCase.html, undefined, {ignoreClasses: true});
       }
     });
   });
@@ -365,7 +366,7 @@ test.describe('Markdown', () => {
       await page.keyboard.type(testCase.text, {
         delay: LEGACY_EVENTS ? 50 : 0,
       });
-      await assertHTML(page, testCase.html, {ignoreClasses: false});
+      await assertHTML(page, testCase.html, undefined, {ignoreClasses: false});
       await assertMarkdownImportExport(page, testCase.text, testCase.html);
     });
   });
@@ -376,7 +377,7 @@ test.describe('Markdown', () => {
       await page.keyboard.type(testCase.text, {
         delay: LEGACY_EVENTS ? 50 : 0,
       });
-      await assertHTML(page, testCase.html, {ignoreClasses: false});
+      await assertHTML(page, testCase.html, undefined, {ignoreClasses: false});
       await assertMarkdownImportExport(page, testCase.text, testCase.html);
     });
   });

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -498,7 +498,7 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
-      {ignoreClasses: true, ignoreSecondFrame: true},
+      {frame: 'left', ignoreClasses: true},
     );
 
     // Check that the highlight styles are applied.
@@ -611,7 +611,7 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
-      {ignoreClasses: true, ignoreSecondFrame: true},
+      {frame: 'left', ignoreClasses: true},
     );
   });
 
@@ -754,7 +754,7 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
-      {ignoreClasses: true, ignoreSecondFrame: true},
+      {frame: 'left', ignoreClasses: true},
     );
   });
 
@@ -881,7 +881,7 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
-      {ignoreClasses: true, ignoreSecondFrame: true},
+      {frame: 'left', ignoreClasses: true},
     );
   });
 
@@ -1069,7 +1069,7 @@ test.describe('Tables', () => {
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
       `,
-      {ignoreClasses: true, ignoreSecondFrame: true},
+      {frame: 'left', ignoreClasses: true},
     );
   });
 

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -149,6 +149,7 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -256,6 +257,7 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -373,6 +375,7 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -498,7 +501,98 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
-      {frame: 'left', ignoreClasses: true},
+      html`
+        <p><br /></p>
+        <table>
+          <tr>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">a</span></p>
+            </th>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">bb</span></p>
+            </th>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+            </th>
+            <th>
+              <p><br /></p>
+            </th>
+            <th>
+              <p><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">d</span></p>
+            </th>
+            <td>
+              <p dir="ltr"><span data-lexical-text="true">e</span></p>
+            </td>
+            <td>
+              <p dir="ltr"><span data-lexical-text="true">f</span></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p><br /></p>
+      `,
+      {ignoreClasses: true},
     );
 
     // Check that the highlight styles are applied.
@@ -611,7 +705,98 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
-      {frame: 'left', ignoreClasses: true},
+      html`
+        <p><br /></p>
+        <table>
+          <tr>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">a</span></p>
+            </th>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">bb</span></p>
+            </th>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+            </th>
+            <th>
+              <p><br /></p>
+            </th>
+            <th>
+              <p><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">d</span></p>
+            </th>
+            <td>
+              <p dir="ltr"><span data-lexical-text="true">e</span></p>
+            </td>
+            <td>
+              <p dir="ltr"><span data-lexical-text="true">f</span></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p><br /></p>
+      `,
+      {ignoreClasses: true},
     );
   });
 
@@ -754,7 +939,98 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
-      {frame: 'left', ignoreClasses: true},
+      html`
+        <p><br /></p>
+        <table>
+          <tr>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">a</span></p>
+            </th>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">bb</span></p>
+            </th>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+            </th>
+            <th>
+              <p><br /></p>
+            </th>
+            <th>
+              <p><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">d</span></p>
+            </th>
+            <td>
+              <p dir="ltr"><span data-lexical-text="true">e</span></p>
+            </td>
+            <td>
+              <p dir="ltr"><span data-lexical-text="true">f</span></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p><br /></p>
+      `,
+      {ignoreClasses: true},
     );
   });
 
@@ -881,7 +1157,98 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
-      {frame: 'left', ignoreClasses: true},
+      html`
+        <p><br /></p>
+        <table>
+          <tr>
+            <th>
+              <p dir="ltr"><strong data-lexical-text="true">a</strong></p>
+            </th>
+            <th>
+              <p dir="ltr"><strong data-lexical-text="true">bb</strong></p>
+            </th>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+            </th>
+            <th>
+              <p><br /></p>
+            </th>
+            <th>
+              <p><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th>
+              <p dir="ltr"><strong data-lexical-text="true">d</strong></p>
+            </th>
+            <td>
+              <p dir="ltr"><strong data-lexical-text="true">e</strong></p>
+            </td>
+            <td>
+              <p dir="ltr"><span data-lexical-text="true">f</span></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p><br /></p>
+      `,
+      {ignoreClasses: true},
     );
   });
 
@@ -1069,7 +1436,8 @@ test.describe('Tables', () => {
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
       `,
-      {frame: 'left', ignoreClasses: true},
+      undefined,
+      {ignoreClasses: true},
     );
   });
 
@@ -1182,6 +1550,7 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -1364,6 +1733,7 @@ test.describe('Tables', () => {
           </table>
           <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         `,
+        undefined,
         {ignoreClasses: true},
       );
     }
@@ -1533,6 +1903,7 @@ test.describe('Tables', () => {
           </table>
           <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         `,
+        undefined,
         {ignoreClasses: true},
       );
     }

--- a/packages/lexical-playground/__tests__/e2e/TextEntry.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextEntry.spec.mjs
@@ -119,6 +119,7 @@ test.describe('TextEntry', () => {
           <strong data-lexical-text="true">world</strong>
         </p>
       `,
+      undefined,
       {ignoreClasses: true},
     );
     await assertSelection(page, {

--- a/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
@@ -70,6 +70,7 @@ test.describe('Toolbar', () => {
           <br />
         </p>
       `,
+      undefined,
       {
         ignoreClasses: true,
         ignoreInlineStyles: true,
@@ -89,6 +90,7 @@ test.describe('Toolbar', () => {
       html`
         <p><br /></p>
       `,
+      undefined,
       {
         ignoreClasses: true,
         ignoreInlineStyles: true,
@@ -194,6 +196,7 @@ test.describe('Toolbar', () => {
         </table>
         <p><br /></p>
       `,
+      undefined,
       {
         ignoreClasses: true,
         ignoreInlineStyles: true,

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -113,11 +113,12 @@ async function assertHTMLOnPageOrFrame(
 export async function assertHTML(
   page,
   expectedHtml,
-  {frame = 'both', ignoreClasses = false, ignoreInlineStyles = false} = {},
+  expectedHtmlFrameRight = expectedHtml,
+  {ignoreClasses = false, ignoreInlineStyles = false} = {},
 ) {
   if (IS_COLLAB) {
     const withRetry = async (fn) => await retryAsync(page, fn, 5);
-    const left = async () =>
+    await Promise.all([
       withRetry(async () => {
         const leftFrame = await page.frame('left');
         return assertHTMLOnPageOrFrame(
@@ -126,24 +127,17 @@ export async function assertHTML(
           ignoreClasses,
           ignoreInlineStyles,
         );
-      });
-    const right = async () =>
+      }),
       withRetry(async () => {
         const rightFrame = await page.frame('right');
         return assertHTMLOnPageOrFrame(
           rightFrame,
-          expectedHtml,
+          expectedHtmlFrameRight,
           ignoreClasses,
           ignoreInlineStyles,
         );
-      });
-    if (frame === 'both') {
-      await Promise.all([left(), right()]);
-    } else if (frame === 'left') {
-      await left();
-    } else if (frame === 'right') {
-      await right();
-    }
+      }),
+    ]);
   } else {
     await assertHTMLOnPageOrFrame(
       page,


### PR DESCRIPTION
Turns out the test failure was that we were checking both frames and expecting the same result.

Also, added the possibility to assert specific frames.