### PR TITLE
Remove unnecessary editor state generic from Flow types

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -164,8 +164,8 @@ declare export class LexicalEditor {
   getElementByKey(key: NodeKey): null | HTMLElement;
   getEditorState(): EditorState;
   setEditorState(editorState: EditorState, options?: EditorSetOptions): void;
-  parseEditorState<SerializedNode>(
-    maybeStringifiedEditorState: string | SerializedEditorState<SerializedNode>,
+  parseEditorState(
+    maybeStringifiedEditorState: string | SerializedEditorState,
     updateFn?: () => void,
   ): EditorState;
   update(updateFn: () => void, options?: EditorUpdateOptions): boolean;
@@ -173,7 +173,7 @@ declare export class LexicalEditor {
   blur(): void;
   isReadOnly(): boolean;
   setReadOnly(readOnly: boolean): void;
-  toJSON(): SerializedEditor<>;
+  toJSON(): SerializedEditor;
 }
 type EditorUpdateOptions = {
   onUpdate?: () => void,
@@ -275,7 +275,7 @@ export interface EditorState {
   ): void;
   isEmpty(): boolean;
   read<V>(callbackFn: () => V): V;
-  toJSON<SerializedNode>(): SerializedEditorState<SerializedNode>;
+  toJSON(): SerializedEditorState;
   clone(
     selection?: RangeSelection | NodeSelection | GridSelection | null,
   ): EditorState;


### PR DESCRIPTION
We can remove this due to #2390.