### PR TITLE
Fix bad warnOnlyOnce minification

### DIFF
--- a/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
@@ -29,7 +29,7 @@ export function PlainTextPlugin({
   initialEditorState?: InitialEditorStateType;
   placeholder: JSX.Element | string;
 }): JSX.Element {
-  if (initialEditorState !== undefined) {
+  if (__DEV__ && initialEditorState !== undefined) {
     deprecatedInitialEditorStateWarning();
   }
   const [editor] = useLexicalComposerContext();

--- a/packages/lexical-react/src/LexicalRichTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalRichTextPlugin.tsx
@@ -29,7 +29,7 @@ export function RichTextPlugin({
   initialEditorState?: InitialEditorStateType;
   placeholder: JSX.Element | string;
 }>): JSX.Element {
-  if (initialEditorState !== undefined) {
+  if (__DEV__ && initialEditorState !== undefined) {
     deprecatedInitialEditorStateWarning();
   }
   const [editor] = useLexicalComposerContext();


### PR DESCRIPTION
Minified to 

```
exports.RichTextPlugin=function({contentEditable:a,placeholder:c,initialEditorState:f}){void 0!==f&&(void 0)();let [b]=e.useLexicalComposerContext(),g=t(b),d=u(b);w(b,f);return h.createElement(h.Fragment,null,a,g&&c,d)}
```

`(void 0)()` -> that's really bad