### PR TITLE
Adjust selection.insertNodes to handle inline elements (links)

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1404,14 +1404,21 @@ export class RangeSelection implements BaseSelection {
           lastChild.selectNext();
         }
       }
+      const $isBlockElementNode = (node) =>
+        $isElementNode(node) && !node.isInline();
       if (siblings.length !== 0) {
+        const originalTarget = target;
         for (let i = siblings.length - 1; i >= 0; i--) {
           const sibling = siblings[i];
           const prevParent = sibling.getParentOrThrow();
-          if ($isElementNode(target) && !$isElementNode(sibling)) {
-            target.append(sibling);
+          if ($isElementNode(target) && !$isBlockElementNode(sibling)) {
+            if (originalTarget === target) {
+              target.append(sibling);
+            } else {
+              target.insertBefore(sibling);
+            }
             target = sibling;
-          } else if (!$isElementNode(target) && !$isElementNode(sibling)) {
+          } else if (!$isElementNode(target) && !$isBlockElementNode(sibling)) {
             target.insertBefore(sibling);
             target = sibling;
           } else {


### PR DESCRIPTION
Not a real fix, code is a mess and need better understanding on why we re-insert siblings into current target. 

Details: #2450