### PR TITLE
Add default value for undefined case in markdown transformers

### DIFF
--- a/packages/lexical-markdown/src/v2/utils.ts
+++ b/packages/lexical-markdown/src/v2/utils.ts
@@ -41,8 +41,8 @@ export function transformersByType(transformers: Array<Transformer>): Readonly<{
 
   return {
     element: byType.element as Array<ElementTransformer>,
-    textFormat: byType['text-format'] as Array<TextFormatTransformer>,
-    textMatch: byType['text-match'] as Array<TextMatchTransformer>,
+    textFormat: (byType['text-format'] ?? []) as Array<TextFormatTransformer>,
+    textMatch: (byType['text-match'] ?? []) as Array<TextMatchTransformer>,
   };
 }
 


### PR DESCRIPTION
Easy review

Context:
I was playing with the rich text playground and noticed that if you only used the `ELEMENT_TRANFORMERS` from `@lexical/markdown`, you will get a runtime error as it tries to iterate over the textFormat and textMatch fields, which are undefined in this case.

They're undefined because none of the element transformers have these fields in them.

I consider this a bug, because there shouldn't be any reason someone not to be able to use
> for quote
1. for list
etc..
without using the rest of the markdown exports

Solution: 
Add a default empty array value to `text-format` and `text-match` 