### PR TITLE
Fix button--outline hover color dark mode

### DIFF
--- a/packages/lexical-website-new/src/css/custom.css
+++ b/packages/lexical-website-new/src/css/custom.css
@@ -40,3 +40,7 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
 .footer__links {
   margin-bottom: 3rem;
 }
+
+.button--outline:hover {
+  color: white;
+}

--- a/packages/lexical-website-new/src/css/custom.css
+++ b/packages/lexical-website-new/src/css/custom.css
@@ -41,6 +41,6 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   margin-bottom: 3rem;
 }
 
-.button--outline:hover {
+html[data-theme='dark'] .button--outline:hover {
   color: white;
 }


### PR DESCRIPTION
"Visit Playground" text color becomes invisible when using dark mode

https://user-images.githubusercontent.com/78015359/174300865-2e290ec4-88bb-4568-8879-72d99c6b5056.mp4

