### PR TITLE
fix(lexical): caret at wrong place when paste

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -2398,6 +2398,77 @@ describe('LexicalSelectionHelpers tests', () => {
           '<p dir="ltr"><span data-lexical-text="true">Existing text...foo</span></p>',
         );
       });
+
+      test('a paragraph with a child text and a child italic text and a child text', async () => {
+        const editor = createTestEditor();
+
+        const element = document.createElement('div');
+
+        editor.setRootElement(element);
+
+        await editor.update(() => {
+          const root = $getRoot();
+
+          const paragraph = $createParagraphNode();
+          const text = $createTextNode('AE');
+
+          paragraph.append(text);
+          root.append(paragraph);
+
+          setAnchorPoint({
+            key: text.getKey(),
+            offset: 1,
+            type: 'text',
+          });
+
+          setFocusPoint({
+            key: text.getKey(),
+            offset: 1,
+            type: 'text',
+          });
+
+          const insertedParagraph = $createParagraphNode();
+          const insertedTextB = $createTextNode('B');
+          const insertedTextC = $createTextNode('C');
+          const insertedTextD = $createTextNode('D');
+
+          insertedTextC.toggleFormat('italic');
+
+          insertedParagraph.append(insertedTextB, insertedTextC, insertedTextD);
+
+          const selection = $getSelection();
+
+          if (!$isRangeSelection(selection)) {
+            return;
+          }
+
+          selection.insertNodes([insertedParagraph]);
+
+          expect(selection.anchor).toEqual(
+            expect.objectContaining({
+              key: paragraph
+                .getChildAtIndex(paragraph.getChildrenSize() - 2)
+                .getKey(),
+              offset: 1,
+              type: 'text',
+            }),
+          );
+
+          expect(selection.focus).toEqual(
+            expect.objectContaining({
+              key: paragraph
+                .getChildAtIndex(paragraph.getChildrenSize() - 2)
+                .getKey(),
+              offset: 1,
+              type: 'text',
+            }),
+          );
+        });
+
+        expect(element.innerHTML).toBe(
+          '<p dir="ltr"><span data-lexical-text="true">AB</span><em data-lexical-text="true">C</em><span data-lexical-text="true">DE</span></p>',
+        );
+      });
     });
   });
 });

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1231,7 +1231,7 @@ export class RangeSelection implements BaseSelection {
 
     const firstNode = nodes[0];
     let didReplaceOrMerge = false;
-    let lastNodeInserted = null;
+    let lastNode = null;
 
     // Time to insert the nodes!
     for (let i = 0; i < nodes.length; i++) {
@@ -1296,16 +1296,15 @@ export class RangeSelection implements BaseSelection {
             const childrenLength = children.length;
             if ($isElementNode(target)) {
               for (let s = 0; s < childrenLength; s++) {
-                lastNodeInserted = children[s];
-                target.append(lastNodeInserted);
+                target.append(children[s]);
               }
             } else {
               for (let s = childrenLength - 1; s >= 0; s--) {
-                lastNodeInserted = children[s];
-                target.insertAfter(lastNodeInserted);
+                target.insertAfter(children[s]);
               }
               target = target.getParentOrThrow();
             }
+            lastNode = children[childrenLength - 1];
             element.remove();
             didReplaceOrMerge = true;
             if (element.is(node)) {
@@ -1331,7 +1330,7 @@ export class RangeSelection implements BaseSelection {
       }
       didReplaceOrMerge = false;
       if ($isElementNode(target) && !target.isInline()) {
-        lastNodeInserted = node;
+        lastNode = node;
         if ($isDecoratorNode(node) && node.isTopLevel()) {
           target = target.insertAfter(node);
         } else if (!$isElementNode(node)) {
@@ -1363,7 +1362,7 @@ export class RangeSelection implements BaseSelection {
         ($isElementNode(node) && node.isInline()) ||
         ($isDecoratorNode(target) && target.isTopLevel())
       ) {
-        lastNodeInserted = node;
+        lastNode = node;
         target = target.insertAfter(node);
       } else {
         target = node.getParentOrThrow();
@@ -1391,8 +1390,8 @@ export class RangeSelection implements BaseSelection {
     if ($isElementNode(target)) {
       // If the last node to be inserted was a text node,
       // then we should attempt to move selection to that.
-      const lastChild = $isTextNode(lastNodeInserted)
-        ? lastNodeInserted
+      const lastChild = $isTextNode(lastNode)
+        ? lastNode
         : target.getLastDescendant();
       if (!selectStart) {
         // Handle moving selection to end for elements


### PR DESCRIPTION
### Description
Fix bug: Copy/Pasting formatted text from/to the editor places the caret at wrong place.

The reason for this bug appears to be that at some point the last element inserted is not equal to the last element

https://user-images.githubusercontent.com/22126563/174320921-b8ca7305-2fe9-41cc-abd6-b3270249e478.mov

closes #2459 