### PR TITLE
Fix component/plugin import names in get started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 const theme = {
   // Theme styling goes here
-  ...
+  // ...
 }
 
 // When the editor changes, you can get notified via the
@@ -111,11 +111,11 @@ function Editor() {
 
   return (
     <LexicalComposer initialConfig={initialConfig}>
-      <LexicalPlainTextPlugin
-        contentEditable={<LexicalContentEditable />}
+      <PlainTextPlugin
+        contentEditable={<ContentEditable />}
         placeholder={<div>Enter some text...</div>}
       />
-      <LexicalOnChangePlugin onChange={onChange} />
+      <OnChangePlugin onChange={onChange} />
       <HistoryPlugin />
       <MyCustomAutoFocusPlugin />
     </LexicalComposer>


### PR DESCRIPTION
Fixes incorrect plugin names used in JSX to match imported names and comments out the theme ellipsis so the code is copyable into a test js runtime like Codesandbox.