### PR TITLE
Migrate to TS strict mode 3/n 

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -335,7 +335,7 @@ interface BaseSerializedNode {
   version: number;
 }
 
-function exportNodeToJSON(node: LexicalNode): BaseSerializedNode {
+function exportNodeToJSON<T extends LexicalNode>(node: T): BaseSerializedNode {
   const serializedNode = node.exportJSON();
   const nodeClass = node.constructor;
 

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -185,7 +185,7 @@ function setListThemeClassNames(
   const listTheme = editorThemeClasses.list;
 
   if (listTheme !== undefined) {
-    const listLevelsClassNames = listTheme[node.__tag + 'Depth'] || [];
+    const listLevelsClassNames = listTheme[`${node.__tag}Depth`] || [];
     const listDepth = $getListDepth(node) - 1;
     const normalizedListDepth = listDepth % listLevelsClassNames.length;
     const listLevelClassName = listLevelsClassNames[normalizedListDepth];
@@ -244,7 +244,7 @@ function convertListNode(domNode: Node): DOMConversionOutput {
   return {node};
 }
 
-const TAG_TO_LIST_TYPE: Readonly<Record<ListNodeTagType, ListType>> = {
+const TAG_TO_LIST_TYPE: Record<string, ListType> = {
   ol: 'number',
   ul: 'bullet',
 };

--- a/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts
@@ -313,12 +313,12 @@ describe('LexicalListNode tests', () => {
           __key: '1',
           __start: 1,
           __tag: 'ol',
-        } as ListNode);
+        } as unknown as ListNode);
         const ulNode = ListNode.clone({
           __key: '1',
           __start: 1,
           __tag: 'ul',
-        } as ListNode);
+        } as unknown as ListNode);
         expect(olNode.__listType).toBe('number');
         expect(ulNode.__listType).toBe('bullet');
       });

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -22,8 +22,8 @@ import {
 } from 'lexical';
 import {useMemo} from 'react';
 import * as React from 'react';
+import {Klass} from 'shared/types';
 import useLayoutEffect from 'shared/useLayoutEffect';
-import {Class} from 'utility-types';
 
 const HISTORY_MERGE_OPTIONS = {tag: 'history-merge'};
 
@@ -38,7 +38,7 @@ type Props = {
   initialConfig: Readonly<{
     editor__DEPRECATED?: LexicalEditor | null;
     namespace: string;
-    nodes?: ReadonlyArray<Class<LexicalNode>>;
+    nodes?: ReadonlyArray<Klass<LexicalNode>>;
     onError: (error: Error, editor: LexicalEditor) => void;
     readOnly?: boolean;
     theme?: EditorThemeClasses;

--- a/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
+++ b/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
@@ -18,17 +18,17 @@ import {DecoratorNode} from 'lexical';
 
 export type SerializedDecoratorBlockNode = Spread<
   {
-    format: ElementFormatType | '';
+    format: ElementFormatType;
   },
   SerializedLexicalNode
 >;
 
 export class DecoratorBlockNode extends DecoratorNode<JSX.Element> {
-  __format: ElementFormatType | null | undefined;
+  __format: ElementFormatType;
 
   constructor(format?: ElementFormatType, key?: NodeKey) {
     super(key);
-    this.__format = format;
+    this.__format = format || '';
   }
 
   exportJSON(): SerializedDecoratorBlockNode {

--- a/packages/lexical-react/src/useLexicalTextEntity.ts
+++ b/packages/lexical-react/src/useLexicalTextEntity.ts
@@ -8,17 +8,17 @@
 
 import type {EntityMatch} from '@lexical/text';
 import type {TextNode} from 'lexical';
-import type {Klass} from 'shared/types';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {registerLexicalTextEntity} from '@lexical/text';
 import {mergeRegister} from '@lexical/utils';
 import {useEffect} from 'react';
+import {Klass} from 'shared/types';
 
-export function useLexicalTextEntity<N extends TextNode>(
+export function useLexicalTextEntity<T extends TextNode>(
   getMatch: (text: string) => null | EntityMatch,
-  targetNode: Klass<N>,
-  createNode: (textNode: TextNode) => N,
+  targetNode: Klass<T>,
+  createNode: (textNode: TextNode) => T,
 ): void {
   const [editor] = useLexicalComposerContext();
 

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -40,7 +40,7 @@ export type SerializedTableCellNode = Spread<
   {
     headerState: TableCellHeaderState;
     type: 'tablecell';
-    width: number | undefined;
+    width?: number;
   },
   SerializedGridCellNode
 >;
@@ -79,7 +79,7 @@ export class TableCellNode extends GridCellNode {
     return $createTableCellNode(
       serializedNode.headerState,
       serializedNode.colSpan,
-      serializedNode.width,
+      serializedNode.width || undefined,
     );
   }
 

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -52,7 +52,7 @@ export class TableRowNode extends GridRowNode {
     return $createTableRowNode(serializedNode.height);
   }
 
-  constructor(height?: number | undefined, key?: NodeKey) {
+  constructor(height?: number, key?: NodeKey) {
     super(key);
     this.__height = height;
   }

--- a/packages/lexical-text/src/index.ts
+++ b/packages/lexical-text/src/index.ts
@@ -252,13 +252,13 @@ export function $canShowPlaceholderCurry(
 
 export type EntityMatch = {end: number; start: number};
 
-export function registerLexicalTextEntity<N extends TextNode>(
+export function registerLexicalTextEntity<T extends TextNode>(
   editor: LexicalEditor,
   getMatch: (text: string) => null | EntityMatch,
-  targetNode: Klass<N>,
-  createNode: (textNode: TextNode) => N,
+  targetNode: Klass<T>,
+  createNode: (textNode: TextNode) => T,
 ): Array<() => void> {
-  const isTargetNode = (node: LexicalNode | null | undefined): node is N => {
+  const isTargetNode = (node: LexicalNode | null | undefined): node is T => {
     return node instanceof targetNode;
   };
 
@@ -382,7 +382,7 @@ export function registerLexicalTextEntity<N extends TextNode>(
     }
   };
 
-  const reverseNodeTransform = (node: N) => {
+  const reverseNodeTransform = (node: T) => {
     const text = node.getTextContent();
     const match = getMatch(text);
 
@@ -422,7 +422,7 @@ export function registerLexicalTextEntity<N extends TextNode>(
     TextNode,
     textNodeTransform,
   );
-  const removeReverseNodeTransform = editor.registerNodeTransform<N>(
+  const removeReverseNodeTransform = editor.registerNodeTransform<T>(
     targetNode,
     reverseNodeTransform,
   );

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -31,7 +31,7 @@ export type DFSNode = Readonly<{
 
 export function addClassNamesToElement(
   element: HTMLElement,
-  ...classNames: Array<string | boolean | null | undefined>
+  ...classNames: Array<typeof undefined | boolean | null | string>
 ): void {
   classNames.forEach((className) => {
     if (typeof className === 'string') {
@@ -42,7 +42,7 @@ export function addClassNamesToElement(
 
 export function removeClassNamesFromElement(
   element: HTMLElement,
-  ...classNames: Array<string | boolean | null | undefined>
+  ...classNames: Array<typeof undefined | boolean | null | string>
 ): void {
   classNames.forEach((className) => {
     if (typeof className === 'string') {
@@ -106,8 +106,8 @@ function $getDepth(node: LexicalNode): number {
 export function $getNearestNodeOfType<T extends ElementNode>(
   node: LexicalNode,
   klass: Klass<T>,
-): T | LexicalNode {
-  let parent: T | LexicalNode = node;
+) {
+  let parent: ElementNode | LexicalNode | null = node;
 
   while (parent != null) {
     if (parent instanceof klass) {
@@ -291,7 +291,6 @@ function unstable_internalCreateNodeFromParse(
   // We set the parsedKey to undefined before calling clone() so that
   // we get a new random key assigned.
   parsedNode.__key = undefined;
-  // @ts-expect-error TODO Replace Class utility type with InstanceType
   const node = NodeKlass.clone(parsedNode);
   parsedNode.__key = parsedKey;
   const key = node.__key;

--- a/packages/lexical-website-new/docs/concepts/serialization.md
+++ b/packages/lexical-website-new/docs/concepts/serialization.md
@@ -97,7 +97,7 @@ The return value of `importDOM` is a map of the lower case (DOM) [Node.nodeName]
 
 ```js
 export type DOMConversionMap = {
-  [NodeName]: (node: Node) => DOMConversion | null,
+  [NodeName]: <T: HTMLElement>(node: T) => DOMConversion | null,
 };
 
 export type DOMConversion = {

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -196,6 +196,7 @@ type TextNodeThemeClasses = {
   superscript?: EditorThemeClassName,
 };
 export type EditorThemeClasses = {
+  characterLimit?: EditorThemeClassName,
   ltr?: EditorThemeClassName,
   rtl?: EditorThemeClassName,
   text?: TextNodeThemeClasses,

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -303,7 +303,7 @@ export type DOMChildConversion = (
   parentLexicalNode: ?LexicalNode | null,
 ) => LexicalNode | null | void;
 export type DOMConversionMap = {
-  [NodeName]: (node: Node) => DOMConversion | null,
+  [NodeName]: <T: HTMLElement>(node: T) => DOMConversion | null,
 };
 type NodeName = string;
 export type DOMConversionOutput = {

--- a/packages/lexical/src/LexicalConstants.ts
+++ b/packages/lexical/src/LexicalConstants.ts
@@ -70,7 +70,7 @@ export const RTL_REGEX = new RegExp('^[^' + LTR + ']*[' + RTL + ']');
 // eslint-disable-next-line no-misleading-character-class
 export const LTR_REGEX = new RegExp('^[^' + RTL + ']*[' + LTR + ']');
 
-export const TEXT_TYPE_TO_FORMAT: Record<TextFormatType, number> = {
+export const TEXT_TYPE_TO_FORMAT: Record<TextFormatType | string, number> = {
   bold: IS_BOLD,
   code: IS_CODE,
   italic: IS_ITALIC,
@@ -80,9 +80,9 @@ export const TEXT_TYPE_TO_FORMAT: Record<TextFormatType, number> = {
   underline: IS_UNDERLINE,
 };
 
-export const ELEMENT_TYPE_TO_FORMAT: Omit<
-  Record<ElementFormatType, number>,
-  ''
+export const ELEMENT_TYPE_TO_FORMAT: Record<
+  Exclude<ElementFormatType, ''>,
+  number
 > = {
   center: IS_ALIGN_CENTER,
   justify: IS_ALIGN_JUSTIFY,

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -58,6 +58,7 @@ export type EditorSetOptions = {
 };
 
 export type EditorThemeClasses = {
+  characterLimit?: EditorThemeClassName;
   code?: EditorThemeClassName;
   codeHighlight?: Record<string, EditorThemeClassName>;
   hashtag?: EditorThemeClassName;
@@ -100,19 +101,8 @@ export type EditorThemeClasses = {
     base?: EditorThemeClassName;
     focus?: EditorThemeClassName;
   };
-  // Handle other generic values
-  [key: string]:
-    | EditorThemeClassName
-    | TextNodeThemeClasses
-    | {
-        [key: string]:
-          | Array<EditorThemeClassName>
-          | EditorThemeClassName
-          | TextNodeThemeClasses
-          | {
-              [key: string]: EditorThemeClassName;
-            };
-      };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
 };
 
 export type EditorConfig = {
@@ -128,7 +118,7 @@ export type RegisteredNode = {
   transforms: Set<Transform<LexicalNode>>;
 };
 
-export type Transform<T> = (node: T) => void;
+export type Transform<T extends LexicalNode> = (node: T) => void;
 
 export type ErrorHandler = (error: Error) => void;
 
@@ -147,7 +137,7 @@ export type UpdateListener = (arg0: {
   tags: Set<string>;
 }) => void;
 
-export type DecoratorListener<T = unknown> = (
+export type DecoratorListener<T = never> = (
   decorator: Record<NodeKey, T>,
 ) => void;
 
@@ -173,7 +163,7 @@ export const COMMAND_PRIORITY_HIGH = 3;
 export const COMMAND_PRIORITY_CRITICAL = 4;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type LexicalCommand<T> = Readonly<Record<string, unknown>>;
+export type LexicalCommand<T = never> = Readonly<Record<string, unknown>>;
 type Commands = Map<
   LexicalCommand<unknown>,
   Array<Set<CommandListener<unknown>>>
@@ -257,10 +247,8 @@ function initializeConversionCache(nodes: RegisteredNodes): DOMConversionCache {
   const handledConversions = new Set();
   nodes.forEach((node) => {
     const importDOM =
-      // @ts-expect-error TODO Replace Class utility type with InstanceType
       node.klass.importDOM != null
-        ? // @ts-expect-error TODO Replace Class utility type with InstanceType
-          node.klass.importDOM.bind(node.klass)
+        ? node.klass.importDOM.bind(node.klass)
         : null;
 
     if (importDOM == null || handledConversions.has(importDOM)) {
@@ -349,7 +337,7 @@ export function createEditor(editorConfig?: {
             // eslint-disable-next-line no-prototype-builtins
             if (!proto.hasOwnProperty('decorate')) {
               console.warn(
-                `${this.constructor.name} must implement "decorate" method`,
+                `${proto.constructor.name} must implement "decorate" method`,
               );
             }
           }
@@ -371,7 +359,6 @@ export function createEditor(editorConfig?: {
           }
         }
       }
-      // @ts-expect-error TODO Replace Class utility type with InstanceType
       const type = klass.getType();
       registeredNodes.set(type, {
         klass,
@@ -389,7 +376,7 @@ export function createEditor(editorConfig?: {
       namespace,
       theme,
     },
-    onError,
+    onError ? onError : console.error,
     initializeConversionCache(registeredNodes),
     isReadOnly,
   );
@@ -567,9 +554,9 @@ export class LexicalEditor {
     }
 
     const listeners = listenersInPriorityOrder[priority];
-    listeners.add(listener);
+    listeners.add(listener as CommandListener<unknown>);
     return () => {
-      listeners.delete(listener);
+      listeners.delete(listener as CommandListener<unknown>);
 
       if (
         listenersInPriorityOrder.every(
@@ -585,7 +572,6 @@ export class LexicalEditor {
     klass: Klass<LexicalNode>,
     listener: MutationListener,
   ): () => void {
-    // @ts-expect-error TODO Replace Class utility type with InstanceType
     const registeredNode = this._nodes.get(klass.getType());
 
     if (registeredNode === undefined) {
@@ -607,7 +593,6 @@ export class LexicalEditor {
     klass: Klass<T>,
     listener: Transform<T>,
   ): () => void {
-    // @ts-expect-error TODO Replace Class utility type with InstanceType
     const type = klass.getType();
 
     const registeredNode = this._nodes.get(type);
@@ -621,17 +606,16 @@ export class LexicalEditor {
     }
 
     const transforms = registeredNode.transforms;
-    transforms.add(listener);
+    transforms.add(listener as Transform<LexicalNode>);
     markAllNodesAsDirty(this, type);
     return () => {
-      transforms.delete(listener);
+      transforms.delete(listener as Transform<LexicalNode>);
     };
   }
 
   hasNodes<T extends Klass<LexicalNode>>(nodes: Array<T>): boolean {
     for (let i = 0; i < nodes.length; i++) {
       const klass = nodes[i];
-      // @ts-expect-error
       const type = klass.getType();
 
       if (!this._nodes.has(type)) {

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -141,7 +141,10 @@ const rootElementEvents: RootElementEvents = [
 ];
 
 if (CAN_USE_BEFORE_INPUT) {
-  rootElementEvents.push(['beforeinput', onBeforeInput]);
+  rootElementEvents.push([
+    'beforeinput',
+    (event, editor) => onBeforeInput(event as InputEvent, editor),
+  ]);
 }
 
 let lastKeyDownTimeStamp = 0;
@@ -163,6 +166,7 @@ function shouldSkipSelectionChange(
 ): boolean {
   return (
     domNode !== null &&
+    domNode.nodeValue !== null &&
     domNode.nodeType === DOM_TEXT_TYPE &&
     offset !== 0 &&
     offset !== domNode.nodeValue.length
@@ -285,6 +289,7 @@ function onClick(event: MouseEvent, editor: LexicalEditor): void {
       const anchorNode = anchor.getNode();
 
       if (
+        domSelection &&
         anchor.type === 'element' &&
         anchor.offset === 0 &&
         selection.isCollapsed() &&
@@ -297,7 +302,11 @@ function onClick(event: MouseEvent, editor: LexicalEditor): void {
         domSelection.removeAllRanges();
         selection.dirty = true;
       }
-    } else if ($isNodeSelection(selection) && domSelection.isCollapsed) {
+    } else if (
+      domSelection &&
+      $isNodeSelection(selection) &&
+      domSelection.isCollapsed
+    ) {
       const domAnchor = domSelection.anchorNode;
       // If the user is attempting to click selection back onto text, then
       // we should attempt create a range selection.
@@ -651,7 +660,7 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
 
       // onInput always fires after onCompositionEnd for FF.
       if (isFirefoxEndingComposition) {
-        onCompositionEndImpl(editor, data);
+        onCompositionEndImpl(editor, data || undefined);
         isFirefoxEndingComposition = false;
       }
     }
@@ -698,10 +707,7 @@ function onCompositionStart(
   });
 }
 
-function onCompositionEndImpl(
-  editor: LexicalEditor,
-  data: string | null | undefined,
-): void {
+function onCompositionEndImpl(editor: LexicalEditor, data?: string): void {
   const compositionKey = editor._compositionKey;
   $setCompositionKey(null);
 
@@ -713,7 +719,11 @@ function onCompositionEndImpl(
       const node = $getNodeByKey(compositionKey);
       const textNode = getDOMTextNode(editor.getElementByKey(compositionKey));
 
-      if (textNode !== null && $isTextNode(node)) {
+      if (
+        textNode !== null &&
+        textNode.nodeValue !== null &&
+        $isTextNode(node)
+      ) {
         $updateTextNodeFromDOMContent(
           node,
           textNode.nodeValue,
@@ -881,6 +891,10 @@ const activeNestedEditorsMap: Map<string, LexicalEditor> = new Map();
 
 function onDocumentSelectionChange(event: Event): void {
   const selection = getDOMSelection();
+  if (!selection) {
+    return;
+  }
+
   const nextActiveEditor = getNearestEditorFromDOMNode(selection.anchorNode);
 
   if (nextActiveEditor === null) {
@@ -991,7 +1005,7 @@ export function removeRootElementEvents(rootElement: HTMLElement): void {
   // @ts-expect-error: internal field
   const editor: LexicalEditor | null | undefined = rootElement.__lexicalEditor;
 
-  if (editor !== null || editor !== undefined) {
+  if (editor !== null && editor !== undefined) {
     cleanActiveNestedEditorsMap(editor);
     // @ts-expect-error: internal field
     rootElement.__lexicalEditor = null;

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -44,7 +44,7 @@ export function getIsProcesssingMutations(): boolean {
   return isProcessingMutations;
 }
 
-function updateTimeStamp(event) {
+function updateTimeStamp(event: Event) {
   lastTextEntryTimeStamp = event.timeStamp;
 }
 
@@ -62,7 +62,8 @@ function isManagedLineBreak(
   return (
     // @ts-expect-error: internal field
     target.__lexicalLineBreak === dom ||
-    dom['__lexicalKey_' + editor._key] !== undefined
+    // @ts-ignore We intentionally add this to the Node.
+    dom[`__lexicalKey_${editor._key}`] !== undefined
   );
 }
 
@@ -90,7 +91,9 @@ function handleTextMutation(
   }
 
   const text = target.nodeValue;
-  $updateTextNodeFromDOMContent(node, text, anchorOffset, focusOffset, false);
+  if (text) {
+    $updateTextNodeFromDOMContent(node, text, anchorOffset, focusOffset, false);
+  }
 }
 
 function shouldUpdateTextNodeFromMutation(

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -138,7 +138,7 @@ export type DOMChildConversion = (
 
 export type DOMConversionMap = Record<
   NodeName,
-  (node: Node) => DOMConversion | null
+  <T extends HTMLElement>(node: T) => DOMConversion | null
 >;
 type NodeName = string;
 

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -161,7 +161,8 @@ export class LexicalNode {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [x: string]: any;
   __type: string;
-  __key: NodeKey;
+  // @ts-ignore We set the key in the constructor.
+  __key: string;
   __parent: null | NodeKey;
 
   // Flow doesn't support abstract classes unfortunately, so we can't _force_
@@ -209,12 +210,13 @@ export class LexicalNode {
   }
 
   isAttached(): boolean {
-    let nodeKey = this.__key;
+    let nodeKey: string | null = this.__key;
     while (nodeKey !== null) {
       if (nodeKey === 'root') {
         return true;
       }
-      const node = $getNodeByKey(nodeKey);
+
+      const node: LexicalNode | null = $getNodeByKey(nodeKey);
 
       if (node === null) {
         break;
@@ -280,9 +282,9 @@ export class LexicalNode {
   }
 
   getTopLevelElement(): ElementNode | this | null {
-    let node: ElementNode | this = this;
+    let node: ElementNode | this | null = this;
     while (node !== null) {
-      const parent = node.getParent();
+      const parent: ElementNode | this | null = node.getParent();
       if ($isRootNode(parent) && $isElementNode(node)) {
         return node;
       }
@@ -303,8 +305,8 @@ export class LexicalNode {
     return parent;
   }
 
-  getParents<T extends ElementNode>(): Array<T> {
-    const parents = [];
+  getParents(): Array<ElementNode> {
+    const parents: Array<ElementNode> = [];
     let node = this.getParent();
     while (node !== null) {
       parents.push(node);
@@ -377,10 +379,9 @@ export class LexicalNode {
   getCommonAncestor<T extends ElementNode = ElementNode>(
     node: LexicalNode,
   ): T | null {
-    const a = this.getParents<T>();
+    const a = this.getParents();
     const b = node.getParents();
     if ($isElementNode(this)) {
-      // @ts-expect-error
       a.unshift(this);
     }
     if ($isElementNode(node)) {
@@ -420,7 +421,7 @@ export class LexicalNode {
     let indexB = 0;
     let node: this | ElementNode | LexicalNode = this;
     while (true) {
-      const parent = node.getParentOrThrow();
+      const parent: ElementNode = node.getParentOrThrow();
       if (parent === commonAncestor) {
         indexA = parent.__children.indexOf(node.__key);
         break;
@@ -429,7 +430,7 @@ export class LexicalNode {
     }
     node = targetNode;
     while (true) {
-      const parent = node.getParentOrThrow();
+      const parent: ElementNode = node.getParentOrThrow();
       if (parent === commonAncestor) {
         indexB = parent.__children.indexOf(node.__key);
         break;
@@ -444,7 +445,7 @@ export class LexicalNode {
     if (key === targetNode.__key) {
       return false;
     }
-    let node = targetNode;
+    let node: ElementNode | LexicalNode | null = targetNode;
     while (node !== null) {
       if (node.__key === key) {
         return true;
@@ -492,7 +493,7 @@ export class LexicalNode {
         break;
       }
       let parentSibling = null;
-      let ancestor = parent;
+      let ancestor: ElementNode | null = parent;
       do {
         if (ancestor === null) {
           invariant(false, 'getNodesBetween: ancestor is null');

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -52,7 +52,7 @@ let activeEditorNodes: RegisteredNodes;
 let treatAllNodesAsDirty = false;
 let activeEditorStateReadOnly = false;
 let activeMutationListeners: MutationListeners;
-let activeTextDirection = null;
+let activeTextDirection: 'ltr' | 'rtl' | null = null;
 let activeDirtyElements: Map<NodeKey, IntentionallyMarkedAsDirtyElement>;
 let activeDirtyLeaves: Set<NodeKey>;
 let activePrevNodeMap: NodeMap;
@@ -350,11 +350,10 @@ function reconcileBlockDirection(element: ElementNode, dom: HTMLElement): void {
       if (previousDirectionTheme !== undefined) {
         if (typeof previousDirectionTheme === 'string') {
           const classNamesArr = previousDirectionTheme.split(' ');
-          // @ts-expect-error: intentional
           previousDirectionTheme = theme[previousDirection] = classNamesArr;
         }
 
-        // @ts-expect-error: intentional
+        // @ts-ignore: intentional
         classList.remove(...previousDirectionTheme);
       }
 
@@ -373,7 +372,9 @@ function reconcileBlockDirection(element: ElementNode, dom: HTMLElement): void {
             nextDirectionTheme = theme[direction] = classNamesArr;
           }
 
-          classList.add(...nextDirectionTheme);
+          if (nextDirectionTheme !== undefined) {
+            classList.add(...nextDirectionTheme);
+          }
         }
 
         // Update direction
@@ -646,8 +647,8 @@ function reconcileNodeChildren(
 ): void {
   const prevEndIndex = prevChildrenLength - 1;
   const nextEndIndex = nextChildrenLength - 1;
-  let prevChildrenSet: Set<NodeKey>;
-  let nextChildrenSet: Set<NodeKey>;
+  let prevChildrenSet: Set<NodeKey> | undefined;
+  let nextChildrenSet: Set<NodeKey> | undefined;
   let siblingDOM: null | Node = getFirstChild(dom);
   let prevIndex = 0;
   let nextIndex = 0;
@@ -750,14 +751,23 @@ export function reconcileRoot(
   // so instead we make it seem that these values are always set.
   // We also want to make sure we clear them down, otherwise we
   // can leak memory.
+  // @ts-ignore
   activeEditor = undefined;
+  // @ts-ignore
   activeEditorNodes = undefined;
+  // @ts-ignore
   activeDirtyElements = undefined;
+  // @ts-ignore
   activeDirtyLeaves = undefined;
+  // @ts-ignore
   activePrevNodeMap = undefined;
+  // @ts-ignore
   activeNextNodeMap = undefined;
+  // @ts-ignore
   activeEditorConfig = undefined;
+  // @ts-ignore
   activePrevKeyToDOMMap = undefined;
+  // @ts-ignore
   mutatedNodes = undefined;
 
   return currentMutatedNodes;
@@ -769,6 +779,7 @@ export function storeDOMWithKey(
   editor: LexicalEditor,
 ): void {
   const keyToDOMMap = editor._keyToDOMMap;
+  // @ts-ignore We intentionally add this to the Node.
   dom['__lexicalKey_' + editor._key] = key;
   keyToDOMMap.set(key, dom);
 }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1416,6 +1416,7 @@ export class RangeSelection implements BaseSelection {
             target = sibling;
           } else {
             if ($isElementNode(sibling) && !sibling.canInsertAfter(target)) {
+              // @ts-ignore The clone method does exist on the constructor.
               const prevParentClone = prevParent.constructor.clone(prevParent);
               if (!$isElementNode(prevParentClone)) {
                 invariant(
@@ -1678,6 +1679,10 @@ export class RangeSelection implements BaseSelection {
     }
 
     const domSelection = getDOMSelection();
+
+    if (!domSelection) {
+      return;
+    }
     // We use the DOM selection.modify API here to "tell" us what the selection
     // will be. We then use it to update the Lexical selection accordingly. This
     // is much more reliable than waiting for a beforeinput and using the ranges
@@ -2529,7 +2534,7 @@ export function updateDOMSelection(
   editor: LexicalEditor,
   domSelection: Selection,
   tags: Set<string>,
-  rootElement: HTMLElement,
+  rootElement: HTMLElement | null,
 ): void {
   const anchorDOMNode = domSelection.anchorNode;
   const focusDOMNode = domSelection.focusNode;
@@ -2613,7 +2618,10 @@ export function updateDOMSelection(
     !(domSelection.type === 'Range' && isCollapsed)
   ) {
     // If the root element does not have focus, ensure it has focus
-    if (activeElement === null || !rootElement.contains(activeElement)) {
+    if (
+      rootElement !== null &&
+      (activeElement === null || !rootElement.contains(activeElement))
+    ) {
       rootElement.focus({
         preventScroll: true,
       });
@@ -2637,7 +2645,11 @@ export function updateDOMSelection(
       nextFocusOffset,
     );
 
-    if (nextSelection.isCollapsed() && rootElement === activeElement) {
+    if (
+      nextSelection.isCollapsed() &&
+      rootElement !== null &&
+      rootElement === activeElement
+    ) {
       scrollIntoViewIfNeeded(editor, anchor, rootElement, tags);
     }
 

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -296,7 +296,6 @@ function $parseSerializedNodeImpl<
 
   const nodeClass = registeredNode.klass;
 
-  // @ts-expect-error TODO Replace Class utility type with InstanceType
   if (serializedNode.type !== nodeClass.getType()) {
     invariant(
       false,
@@ -305,7 +304,6 @@ function $parseSerializedNodeImpl<
     );
   }
 
-  // @ts-expect-error TODO Replace Class utility type with InstanceType
   const node = nodeClass.importJSON(serializedNode);
   const children = serializedNode.children;
 
@@ -464,7 +462,9 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
       );
     } catch (error) {
       // Report errors
-      editor._onError(error);
+      if (error instanceof Error) {
+        editor._onError(error);
+      }
 
       // Reset editor and restore incoming editor state to the DOM
       if (!isAttemptingToRecoverFromReconcilerError) {
@@ -481,7 +481,7 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
 
       return;
     } finally {
-      observer.observe(rootElement, {
+      observer.observe(rootElement as Node, {
         characterData: true,
         childList: true,
         subtree: true,
@@ -623,6 +623,7 @@ export function triggerListeners(
   try {
     const listeners = Array.from<Listener>(editor._listeners[type]);
     for (let i = 0; i < listeners.length; i++) {
+      // @ts-ignore
       listeners[i].apply(null, payload);
     }
   } finally {
@@ -672,8 +673,11 @@ function triggerEnqueuedUpdates(editor: LexicalEditor): void {
   const queuedUpdates = editor._updates;
 
   if (queuedUpdates.length !== 0) {
-    const [updateFn, options] = queuedUpdates.shift();
-    beginUpdate(editor, updateFn, options);
+    const queuedUpdate = queuedUpdates.shift();
+    if (queuedUpdate) {
+      const [updateFn, options] = queuedUpdate;
+      beginUpdate(editor, updateFn, options);
+    }
   }
 }
 
@@ -708,28 +712,32 @@ function processNestedUpdates(
   // to handle each update as we go until the updates array is
   // empty.
   while (queuedUpdates.length !== 0) {
-    const [nextUpdateFn, options] = queuedUpdates.shift();
-    let onUpdate;
-    let tag;
+    const queuedUpdate = queuedUpdates.shift();
+    if (queuedUpdate) {
+      const [nextUpdateFn, options] = queuedUpdate;
 
-    if (options !== undefined) {
-      onUpdate = options.onUpdate;
-      tag = options.tag;
+      let onUpdate;
+      let tag;
 
-      if (options.skipTransforms) {
-        skipTransforms = true;
+      if (options !== undefined) {
+        onUpdate = options.onUpdate;
+        tag = options.tag;
+
+        if (options.skipTransforms) {
+          skipTransforms = true;
+        }
+
+        if (onUpdate) {
+          editor._deferred.push(onUpdate);
+        }
+
+        if (tag) {
+          editor._updateTags.add(tag);
+        }
       }
 
-      if (onUpdate) {
-        editor._deferred.push(onUpdate);
-      }
-
-      if (tag) {
-        editor._updateTags.add(tag);
-      }
+      nextUpdateFn();
     }
-
-    nextUpdateFn();
   }
 
   return skipTransforms;
@@ -753,7 +761,7 @@ function beginUpdate(
       updateTags.add(tag);
     }
 
-    skipTransforms = options.skipTransforms;
+    skipTransforms = options.skipTransforms || false;
   }
 
   if (onUpdate) {
@@ -836,7 +844,9 @@ function beginUpdate(
     }
   } catch (error) {
     // Report errors
-    editor._onError(error);
+    if (error instanceof Error) {
+      editor._onError(error);
+    }
 
     // Restore existing editor state to the DOM
     editor._pendingEditorState = currentEditorState;
@@ -887,7 +897,7 @@ export function updateEditor(
   updateFn: () => void,
   options?: EditorUpdateOptions,
 ): void {
-  if (editor._updating) {
+  if (editor._updating && options) {
     editor._updates.push([updateFn, options]);
   } else {
     beginUpdate(editor, updateFn, options);

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -7,6 +7,7 @@
  */
 
 import type {
+  EditorThemeClasses,
   IntentionallyMarkedAsDirtyElement,
   LexicalCommand,
   MutatedNodes,
@@ -121,7 +122,7 @@ export function isSelectionWithinEditor(
       rootElement.contains(focusDOM) &&
       // Ignore if selection is within nested editor
       anchorDOM !== null &&
-      isSelectionCapturedInDecoratorInput(anchorDOM) &&
+      isSelectionCapturedInDecoratorInput(anchorDOM as Node) &&
       getNearestEditorFromDOMNode(anchorDOM) === editor
     );
   } catch (error) {
@@ -233,7 +234,7 @@ function internalMarkParentElementsAsDirty(
   nodeMap: NodeMap,
   dirtyElements: Map<NodeKey, IntentionallyMarkedAsDirtyElement>,
 ): void {
-  let nextParentKey = parentKey;
+  let nextParentKey: string | null = parentKey;
   while (nextParentKey !== null) {
     if (dirtyElements.has(nextParentKey)) {
       return;
@@ -338,7 +339,8 @@ export function getNodeFromDOMNode(
   editorState?: EditorState,
 ): LexicalNode | null {
   const editor = getActiveEditor();
-  const key = dom['__lexicalKey_' + editor._key];
+  // @ts-ignore We intentionally add this to the Node.
+  const key = dom[`__lexicalKey_${editor._key}`];
   if (key !== undefined) {
     return $getNodeByKey(key, editorState);
   }
@@ -349,7 +351,7 @@ export function $getNearestNodeFromDOMNode(
   startingDOM: Node,
   editorState?: EditorState,
 ): LexicalNode | null {
-  let dom = startingDOM;
+  let dom: Node | null = startingDOM;
   while (dom != null) {
     const node = getNodeFromDOMNode(dom, editorState);
     if (node !== null) {
@@ -369,7 +371,7 @@ export function cloneDecorators(
   return pendingDecorators;
 }
 
-export function getEditorStateTextContent(editorState): string {
+export function getEditorStateTextContent(editorState: EditorState): string {
   return editorState.read(() => $getRoot().getTextContent());
 }
 
@@ -457,9 +459,10 @@ function getNodeKeyFromDOM(
   dom: Node,
   editor: LexicalEditor,
 ): NodeKey | null {
-  let node = dom;
+  let node: Node | null = dom;
   while (node != null) {
-    const key: NodeKey = node['__lexicalKey_' + editor._key];
+    // @ts-ignore We intentionally add this to the Node.
+    const key: NodeKey = node[`__lexicalKey_${editor._key}`];
     if (key !== undefined) {
       return key;
     }
@@ -476,7 +479,7 @@ export function getEditorsToPropagate(
   editor: LexicalEditor,
 ): Array<LexicalEditor> {
   const editorsToPropagate = [];
-  let currentEditor = editor;
+  let currentEditor: LexicalEditor | null = editor;
   while (currentEditor !== null) {
     editorsToPropagate.push(currentEditor);
     currentEditor = currentEditor._parentEditor;
@@ -516,13 +519,15 @@ export function $updateSelectedTextFromDOM(
         focusOffset = offset;
       }
 
-      $updateTextNodeFromDOMContent(
-        node,
-        textContent,
-        anchorOffset,
-        focusOffset,
-        isCompositionEnd,
-      );
+      if (textContent) {
+        $updateTextNodeFromDOMContent(
+          node,
+          textContent,
+          anchorOffset,
+          focusOffset,
+          isCompositionEnd,
+        );
+      }
     }
   }
 }
@@ -824,6 +829,8 @@ export function isCopy(
   if (keyCode === 67) {
     return IS_APPLE ? metaKey : ctrlKey;
   }
+
+  return false;
 }
 
 export function isCut(
@@ -838,6 +845,8 @@ export function isCut(
   if (keyCode === 88) {
     return IS_APPLE ? metaKey : ctrlKey;
   }
+
+  return false;
 }
 
 function isArrowLeft(keyCode: number): boolean {
@@ -952,8 +961,8 @@ export function isDelete(keyCode: number): boolean {
   return keyCode === 46;
 }
 
-export function getCachedClassNameArray<T>(
-  classNamesTheme: T,
+export function getCachedClassNameArray(
+  classNamesTheme: EditorThemeClasses,
   classNameThemeType: string,
 ): Array<string> {
   const classNames = classNamesTheme[classNameThemeType];
@@ -997,10 +1006,11 @@ export function setMutatedNode(
   }
 }
 
-export function $nodesOfType<T extends LexicalNode>(klass: Klass<T>): Array<T> {
+export function $nodesOfType<T extends LexicalNode>(
+  klass: Klass<T>,
+): Array<LexicalNode> {
   const editorState = getActiveEditorState();
   const readOnly = editorState._readOnly;
-  // @ts-expect-error TODO Replace Class utility type with InstanceType
   const klassType = klass.getType();
   const nodes = editorState._nodeMap;
   const nodesOfType = [];

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -78,9 +78,9 @@ export class ElementNode extends LexicalNode {
   getChildren<T extends LexicalNode>(): Array<T> {
     const self = this.getLatest();
     const children = self.__children;
-    const childrenNodes = [];
+    const childrenNodes: Array<T> = [];
     for (let i = 0; i < children.length; i++) {
-      const childNode = $getNodeByKey(children[i]);
+      const childNode = $getNodeByKey<T>(children[i]);
       if (childNode !== null) {
         childrenNodes.push(childNode);
       }
@@ -226,8 +226,11 @@ export class ElementNode extends LexicalNode {
     return self.__dir;
   }
   hasFormat(type: ElementFormatType): boolean {
-    const formatFlag = ELEMENT_TYPE_TO_FORMAT[type];
-    return (this.getFormat() & formatFlag) !== 0;
+    if (type !== '') {
+      const formatFlag = ELEMENT_TYPE_TO_FORMAT[type];
+      return (this.getFormat() & formatFlag) !== 0;
+    }
+    return false;
   }
 
   // Mutators
@@ -303,7 +306,7 @@ export class ElementNode extends LexicalNode {
   setFormat(type: ElementFormatType): this {
     errorOnReadOnly();
     const self = this.getWritable();
-    self.__format = ELEMENT_TYPE_TO_FORMAT[type] || 0;
+    self.__format = type !== '' ? ELEMENT_TYPE_TO_FORMAT[type] : 0;
     return this;
   }
   setIndent(indentLevel: number): this {
@@ -349,7 +352,7 @@ export class ElementNode extends LexicalNode {
     }
 
     // Remove defined range of children
-    let nodesToRemoveKeys;
+    let nodesToRemoveKeys: Array<NodeKey>;
 
     // Using faster push when only appending nodes
     if (start === writableSelfChildren.length) {
@@ -373,7 +376,7 @@ export class ElementNode extends LexicalNode {
         const nodesToRemoveKeySet = new Set(nodesToRemoveKeys);
         const nodesToInsertKeySet = new Set(nodesToInsertKeys);
         const isPointRemoved = (point: PointType): boolean => {
-          let node = point.getNode();
+          let node: ElementNode | TextNode | null = point.getNode();
           while (node) {
             const nodeKey = node.__key;
             if (

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -6,11 +6,7 @@
  *
  */
 
-import type {
-  EditorConfig,
-  EditorThemeClasses,
-  LexicalEditor,
-} from '../LexicalEditor';
+import type {EditorConfig, LexicalEditor} from '../LexicalEditor';
 import type {
   DOMConversionMap,
   DOMConversionOutput,
@@ -45,10 +41,7 @@ export class ParagraphNode extends ElementNode {
 
   createDOM(config: EditorConfig): HTMLElement {
     const dom = document.createElement('p');
-    const classNames = getCachedClassNameArray<EditorThemeClasses>(
-      config.theme,
-      'paragraph',
-    );
+    const classNames = getCachedClassNameArray(config.theme, 'paragraph');
     if (classNames !== undefined) {
       const domClassList = dom.classList;
       domClassList.add(...classNames);

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -116,10 +116,7 @@ function setTextThemeClassNames(
 ): void {
   const domClassList = dom.classList;
   // Firstly we handle the base theme.
-  let classNames = getCachedClassNameArray<TextNodeThemeClasses>(
-    textClassNames,
-    'base',
-  );
+  let classNames = getCachedClassNameArray(textClassNames, 'base');
   if (classNames !== undefined) {
     domClassList.add(...classNames);
   }
@@ -128,7 +125,7 @@ function setTextThemeClassNames(
   // the same CSS property will need to be used: text-decoration.
   // In an ideal world we shouldn't have to do this, but there's no
   // easy workaround for many atomic CSS systems today.
-  classNames = getCachedClassNameArray<TextNodeThemeClasses>(
+  classNames = getCachedClassNameArray(
     textClassNames,
     'underlineStrikethrough',
   );
@@ -152,10 +149,7 @@ function setTextThemeClassNames(
   for (const key in TEXT_TYPE_TO_FORMAT) {
     const format = key;
     const flag = TEXT_TYPE_TO_FORMAT[format];
-    classNames = getCachedClassNameArray<TextNodeThemeClasses>(
-      textClassNames,
-      key,
-    );
+    classNames = getCachedClassNameArray(textClassNames, key);
     if (classNames !== undefined) {
       if (nextFormat & flag) {
         if (
@@ -210,13 +204,13 @@ function setTextContent(
   const isComposing = node.isComposing();
   // Always add a suffix if we're composing a node
   const suffix = isComposing ? COMPOSITION_SUFFIX : '';
-  const text = nextText + suffix;
+  const text: string = nextText + suffix;
 
   if (firstChild == null) {
     dom.textContent = text;
   } else {
     const nodeValue = firstChild.nodeValue;
-    if (nodeValue !== text)
+    if (nodeValue && nodeValue !== text)
       if (isComposing || IS_FIREFOX) {
         // We also use the diff composed text for general text in FF to avoid
         // the spellcheck red line from flickering.
@@ -819,9 +813,9 @@ export class TextNode extends LexicalNode {
   }
 }
 
-function convertSpanElement(domNode: HTMLSpanElement): DOMConversionOutput {
+function convertSpanElement(domNode: Node): DOMConversionOutput {
   // domNode is a <span> since we matched it by nodeName
-  const span = domNode;
+  const span = domNode as HTMLSpanElement;
   // Google Docs uses span tags + font-weight for bold text
   const hasBoldFontWeight = span.style.fontWeight === '700';
   // Google Docs uses span tags + text-decoration for strikethrough text
@@ -864,7 +858,8 @@ function convertBringAttentionToElement(domNode: Node): DOMConversionOutput {
   };
 }
 function convertTextDOMNode(domNode: Node): DOMConversionOutput {
-  const {parentElement, textContent} = domNode;
+  const {parentElement} = domNode;
+  const textContent = domNode.textContent || '';
   const textContentTrim = textContent.trim();
   const isPre =
     parentElement != null && parentElement.tagName.toLowerCase() === 'pre';

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -451,7 +451,7 @@ export class TextNode extends LexicalNode {
         conversion: convertTextFormatElement,
         priority: 0,
       }),
-      span: (node: Node) => ({
+      span: (node: HTMLSpanElement) => ({
         conversion: convertSpanElement,
         priority: 0,
       }),

--- a/packages/shared/types.d.ts
+++ b/packages/shared/types.d.ts
@@ -8,4 +8,8 @@
 
 import {LexicalNode} from 'lexical';
 
-export type Klass<T extends LexicalNode> = new (...args: unknown[]) => T;
+import {SerializedLexicalNode} from 'lexical';
+
+export type Klass<T extends LexicalNode> = {
+  new (...args: any[]): T;
+} & Omit<LexicalNode, 'constructor'>;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "declarationDir": "./.ts-temp",
-    "strict": false
+    "strict": true
   },
   "exclude": [
     "**/__tests__/**",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     "downlevelIteration": true,
     "noEmit": true,
-    "strict": false,
+    "strict": true,
     "baseUrl": ".",
     "typeRoots": ["node_modules/@types", "libdefs/globals"],
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     "downlevelIteration": true,
     "noEmit": true,
-    "strict": true,
+    "strict": false,
     "baseUrl": ".",
     "typeRoots": ["node_modules/@types", "libdefs/globals"],
     "skipLibCheck": true,


### PR DESCRIPTION
Writing these as smaller PRs as some of these types fixes involve changing business logic. This PR reduces the number of TS errors from 129 to 0 and enables strict mode for the build config (i.e. excluding Playground).

To test TS strict mode, run `tsc -p tsconfig.build.json`. 

**This PR needs to be reviewed carefully as it touches core business logic.**

#2469