### PR TITLE
Fix deprecation warning for `initialEditorState`

### DIFF
--- a/packages/lexical-markdown/README.md
+++ b/packages/lexical-markdown/README.md
@@ -22,9 +22,9 @@ editor.update(() => {
 
 It can also be used for initializing editor's state from markdown string. Here's an example with react `<RichTextPlugin>`
 ```jsx
-<LexicalComposer initialEditorState={() => {
-    $convertFromMarkdownString(markdown, TRANSFORMERS);
-  }}>
+<LexicalComposer initialConfig={{
+  editorState: () => $convertFromMarkdownString(markdown, TRANSFORMERS)
+}}>
   <RichTextPlugin />
 </LexicalComposer>
 ```

--- a/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
@@ -16,7 +16,7 @@ import {useDecorators} from './shared/useDecorators';
 import {usePlainTextSetup} from './shared/usePlainTextSetup';
 
 const deprecatedInitialEditorStateWarning = warnOnlyOnce(
-  'initialEditorState on PlainTextPlugin is deprecated and will be removed soon. Use LexicalComposer initialEditorState instead.',
+  '`initialEditorState` on `PlainTextPlugin` is deprecated and will be removed soon. Use the `initialConfig.editorState` prop on the `LexicalComposer` instead.',
 );
 
 export function PlainTextPlugin({

--- a/packages/lexical-react/src/LexicalRichTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalRichTextPlugin.tsx
@@ -16,7 +16,7 @@ import {useDecorators} from './shared/useDecorators';
 import {useRichTextSetup} from './shared/useRichTextSetup';
 
 const deprecatedInitialEditorStateWarning = warnOnlyOnce(
-  'initialEditorState on RichTextPlugin is deprecated and will be removed soon. Use LexicalComposer initialEditorState instead.',
+  '`initialEditorState` on `RichTextPlugin` is deprecated and will be removed soon. Use the `initialConfig.editorState` prop on the `LexicalComposer` instead.',
 );
 
 export function RichTextPlugin({

--- a/packages/lexical-website-new/docs/concepts/editor-state.md
+++ b/packages/lexical-website-new/docs/concepts/editor-state.md
@@ -47,7 +47,9 @@ For React it could be something following:
 const initialEditorState = await loadContent();
 const editorStateRef = useRef();
 
-<LexicalComposer initialEditorState={initialEditorState}>
+<LexicalComposer initialConfig={{
+  editorState: initialEditorState
+}}>
   <LexicalRichTextPlugin />
   <LexicalOnChangePlugin onChange={editorState => editorStateRef.current = editorState} />
   <Button label="Save" onPress={() => {
@@ -58,7 +60,7 @@ const editorStateRef = useRef();
 </LexicalComposer>
 ```
 
-Note that Lexical uses `initialEditorState` only once (when it's being initialized) and passing different value later
+Note that Lexical uses `initialConfig.editorState` only once (when it's being initialized) and passing different value later
 won't be reflected in editor. See "Update state" below for proper ways of updating editor state.
 
 ## Updating state


### PR DESCRIPTION
The warning message for `initialEditorState` isn't accurate, and some of the docs are now outdated. This PR fixes the issue. 

Closes #2461