### PR TITLE
chore(lexical-playground): remove redundant code

### DIFF
--- a/packages/lexical-playground/src/plugins/ImagesPlugin.ts
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin.ts
@@ -149,9 +149,6 @@ function onDrop(event: DragEvent, editor: LexicalEditor): boolean {
   if (canDropImage(event)) {
     const range = getDragSelection(event);
     node.remove();
-    const domSelection = getSelection();
-    domSelection.removeAllRanges();
-    domSelection.addRange(range);
     const rangeSelection = $createRangeSelection();
     rangeSelection.applyDOMRange(range);
     $setSelection(rangeSelection);


### PR DESCRIPTION
### Description
I'm sorry. I made a mistake in this [PR](https://github.com/facebook/lexical/pull/2027). This is a redundant piece of code. I don't think we need it at all, because there is `rangeSelection.applyDOMRange(range);` to set the selection later.

We can remove it, and it won't make any difference.