### PR TITLE
Fix IME bug in `lexical-history`

### DIFF
--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -95,7 +95,7 @@ function getChangeType(
 ): ChangeType {
   if (
     prevEditorState === null ||
-    (dirtyLeavesSet.size === 0 && dirtyElementsSet.size === 0)
+    (dirtyLeavesSet.size === 0 && dirtyElementsSet.size === 0 && !isComposing)
   ) {
     return OTHER;
   }

--- a/packages/lexical-playground/__tests__/e2e/History.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/History.spec.mjs
@@ -557,13 +557,19 @@ test.describe('History', () => {
     await redo(page);
     await assertHTML(page, step1HTML);
   });
+});
 
+test.use({launchOptions: {slowMo: 50}});
+test.describe('History - IME', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
   test('Can undo composed Hirigana via IME after composition ends (#2479)', async ({
     page,
     browserName,
+    isCollab,
+    isPlainText,
   }) => {
     // We don't yet support FF.
-    test.skip(browserName === 'firefox');
+    test.skip(isCollab || isPlainText || browserName === 'firefox');
 
     await focusEditor(page);
     await enableCompositionKeyEvents(page);
@@ -602,13 +608,15 @@ test.describe('History', () => {
 
     await undo(page);
 
+    const WHITESPACE_TOKEN = ' ';
+
     await assertHTML(
       page,
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
           dir="ltr">
-          <span data-lexical-text="true">すし</span>
+          <span data-lexical-text="true">すし${WHITESPACE_TOKEN}</span>
         </p>
       `,
     );

--- a/packages/lexical-playground/__tests__/e2e/History.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/History.spec.mjs
@@ -10,6 +10,7 @@ import {moveLeft, redo, toggleBold, undo} from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
   assertSelection,
+  enableCompositionKeyEvents,
   focusEditor,
   html,
   initialize,
@@ -555,5 +556,124 @@ test.describe('History', () => {
     await assertHTML(page, step2HTML);
     await redo(page);
     await assertHTML(page, step1HTML);
+  });
+
+  test('Can undo composed Hirigana via IME after composition ends (#2479)', async ({
+    page,
+    browserName,
+  }) => {
+    // We don't yet support FF.
+    test.skip(browserName === 'firefox');
+
+    await focusEditor(page);
+    await enableCompositionKeyEvents(page);
+
+    await page.keyboard.imeSetComposition('ｓ', 1, 1);
+    await page.keyboard.imeSetComposition('す', 1, 1);
+    await page.keyboard.imeSetComposition('すｓ', 2, 2);
+    await page.keyboard.imeSetComposition('すｓｈ', 3, 3);
+    await page.keyboard.imeSetComposition('すし', 2, 2);
+    await page.keyboard.insertText('すし');
+    await page.keyboard.type(' ');
+    await page.keyboard.imeSetComposition('m', 1, 1);
+    await page.keyboard.imeSetComposition('も', 1, 1);
+    await page.keyboard.imeSetComposition('もj', 2, 2);
+    await page.keyboard.imeSetComposition('もじ', 2, 2);
+    await page.keyboard.imeSetComposition('もじあ', 3, 3);
+    await page.keyboard.insertText('もじあ');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">すし もじあ</span>
+        </p>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 6,
+      anchorPath: [0, 0, 0],
+      focusOffset: 6,
+      focusPath: [0, 0, 0],
+    });
+
+    await undo(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">すし</span>
+        </p>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 3,
+      anchorPath: [0, 0, 0],
+      focusOffset: 3,
+      focusPath: [0, 0, 0],
+    });
+
+    await undo(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">すし</span>
+        </p>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 2,
+      anchorPath: [0, 0, 0],
+      focusOffset: 2,
+      focusPath: [0, 0, 0],
+    });
+
+    await undo(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0],
+      focusOffset: 0,
+      focusPath: [0],
+    });
+
+    await redo(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">すし</span>
+        </p>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 2,
+      anchorPath: [0, 0, 0],
+      focusOffset: 2,
+      focusPath: [0, 0, 0],
+    });
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/History.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/History.spec.mjs
@@ -559,7 +559,6 @@ test.describe('History', () => {
   });
 });
 
-test.use({launchOptions: {slowMo: 50}});
 test.describe('History - IME', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
   test('Can undo composed Hirigana via IME after composition ends (#2479)', async ({
@@ -567,6 +566,7 @@ test.describe('History - IME', () => {
     browserName,
     isCollab,
     isPlainText,
+    legacyEvents,
   }) => {
     // We don't yet support FF.
     test.skip(isCollab || isPlainText || browserName === 'firefox');
@@ -647,28 +647,59 @@ test.describe('History - IME', () => {
       `,
     );
 
-    await assertSelection(page, {
-      anchorOffset: 2,
-      anchorPath: [0, 0, 0],
-      focusOffset: 2,
-      focusPath: [0, 0, 0],
-    });
+    if (browserName === 'webkit' && !legacyEvents) {
+      await assertSelection(page, {
+        anchorOffset: 3,
+        anchorPath: [0, 0, 0],
+        focusOffset: 3,
+        focusPath: [0, 0, 0],
+      });
+    } else {
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [0, 0, 0],
+        focusOffset: 2,
+        focusPath: [0, 0, 0],
+      });
+    }
 
     await undo(page);
 
-    await assertHTML(
-      page,
-      html`
-        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-      `,
-    );
+    if (browserName === 'webkit' && !legacyEvents) {
+      await assertHTML(
+        page,
+        html`
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">すし</span>
+          </p>
+        `,
+      );
+    } else {
+      await assertHTML(
+        page,
+        html`
+          <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        `,
+      );
+    }
 
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [0],
-      focusOffset: 0,
-      focusPath: [0],
-    });
+    if (browserName === 'webkit' && !legacyEvents) {
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [0, 0, 0],
+        focusOffset: 2,
+        focusPath: [0, 0, 0],
+      });
+    } else {
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0],
+        focusOffset: 0,
+        focusPath: [0],
+      });
+    }
 
     await redo(page);
 
@@ -683,11 +714,20 @@ test.describe('History - IME', () => {
       `,
     );
 
-    await assertSelection(page, {
-      anchorOffset: 2,
-      anchorPath: [0, 0, 0],
-      focusOffset: 2,
-      focusPath: [0, 0, 0],
-    });
+    if (browserName === 'webkit' && !legacyEvents) {
+      await assertSelection(page, {
+        anchorOffset: 3,
+        anchorPath: [0, 0, 0],
+        focusOffset: 3,
+        focusPath: [0, 0, 0],
+      });
+    } else {
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [0, 0, 0],
+        focusOffset: 2,
+        focusPath: [0, 0, 0],
+      });
+    }
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/History.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/History.spec.mjs
@@ -580,7 +580,13 @@ test.describe('History - IME', () => {
     await page.keyboard.imeSetComposition('すｓｈ', 3, 3);
     await page.keyboard.imeSetComposition('すし', 2, 2);
     await page.keyboard.insertText('すし');
+
+    await sleep(1050); // default merge interval is 1000, add 50ms as overhead due to CI latency.
+
     await page.keyboard.type(' ');
+
+    await sleep(1050);
+
     await page.keyboard.imeSetComposition('m', 1, 1);
     await page.keyboard.imeSetComposition('も', 1, 1);
     await page.keyboard.imeSetComposition('もj', 2, 2);


### PR DESCRIPTION
The reason for the below bug is that when the `beforeInput` and `input` events fire simultaneously during composition, to trigger the update listeners,  the `beforeInput` event was being classed as an `OTHER` `changeType` instead of `COMPOSING_CHARACTER`. 

This PR ensure all composition events are classed as `COMPOSING_CHARACTER`. 

This ensures all history events when composing are correctly merged, meaning on undo or redo, the whole composed word is removed/re-inserted.

NOTE: There seems to be disparities between how some editors handle this. Word and Notes will remove the whole composed word on undo, despite if you pause during composition. ProseMirror and Quill will take you back to the last pause point.

Closes #2479 