### PR TITLE
fix(lexical): "selection.format" is not set correctly

### DIFF
--- a/packages/lexical-markdown/src/v2/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/v2/MarkdownShortcuts.ts
@@ -242,6 +242,7 @@ function runTextFormatTransformers(
       openNodeText.slice(0, openTagStartIndex) +
         openNodeText.slice(openTagStartIndex + tagLength),
     );
+    const selection = $getSelection();
     const nextSelection = $createRangeSelection();
     $setSelection(nextSelection);
     // Adjust offset based on deleted chars
@@ -269,6 +270,10 @@ function runTextFormatTransformers(
       if (nextSelection.hasFormat(format)) {
         nextSelection.toggleFormat(format);
       }
+    }
+
+    if ($isRangeSelection(selection)) {
+      nextSelection.format = selection.format;
     }
 
     return true;

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -20,6 +20,8 @@ import {
   assertHTML,
   assertSelection,
   click,
+  evaluate,
+  expect,
   focusEditor,
   html,
   initialize,
@@ -913,5 +915,43 @@ test.describe('TextFormatting', () => {
         </p>
       `,
     );
+  });
+
+  test(`The active state of the button in the toolbar should to be displayed correctly`, async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    await page.keyboard.type('A');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('B');
+    await selectCharacters(page, 'left', 3);
+    await toggleBold(page);
+    await toggleItalic(page);
+
+    const isButtonActiveStatusDisplayedCorrectly = await evaluate(page, () => {
+      const isFloatingToolbarBoldButtonActive = !!document.querySelector(
+        '.floating-text-format-popup .popup-item.active i.format.bold',
+      );
+      const isFloatingToolbarItalicButtonActive = !!document.querySelector(
+        '.floating-text-format-popup .popup-item.active i.format.italic',
+      );
+      const isToolbarBoldButtonActive = !!document.querySelector(
+        '.toolbar .toolbar-item.active i.format.bold',
+      );
+      const isToolbarItalicButtonActive = !!document.querySelector(
+        '.toolbar .toolbar-item.active i.format.italic',
+      );
+
+      return (
+        isFloatingToolbarBoldButtonActive &&
+        isFloatingToolbarItalicButtonActive &&
+        isToolbarBoldButtonActive &&
+        isToolbarItalicButtonActive
+      );
+    });
+
+    expect(isButtonActiveStatusDisplayedCorrectly).toBe(true);
   });
 });

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1145,6 +1145,8 @@ export class RangeSelection implements BaseSelection {
         }
       }
 
+      this.format = firstNextFormat | lastNextFormat;
+
       // deal with all the nodes in between
       for (let i = 1; i < lastIndex; i++) {
         const selectedNode = selectedNodes[i];


### PR DESCRIPTION
### Description
It seems that the problem is mainly related to the `selectionchange` event not being fired correctly. The update of the button style on the toolbar depends on the selectionchange event. However, when focusNode, focusOffset, anchorNode, and anchorOffset are exactly the same and selection has a format applied, the event is not fired correctly.

https://user-images.githubusercontent.com/22126563/175352875-77839c7a-06c6-450d-8dd3-d6eac56c9fb7.mov

closes #2498 