### PR TITLE
Fix $generateHtmlFromNodes behavior if selection is null

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -67,7 +67,7 @@ export function $generateHtmlFromNodes(
 
   for (let i = 0; i < topLevelChildren.length; i++) {
     const topLevelNode = topLevelChildren[i];
-    if (selection) {
+    if (selection !== undefined) {
       $appendNodesToHTML(editor, selection, topLevelNode, container);
     }
   }
@@ -77,7 +77,7 @@ export function $generateHtmlFromNodes(
 
 function $appendNodesToHTML(
   editor: LexicalEditor,
-  selection: RangeSelection | NodeSelection | GridSelection,
+  selection: RangeSelection | NodeSelection | GridSelection | null,
   currentNode: LexicalNode,
   parentElement: HTMLElement | DocumentFragment,
 ): boolean {


### PR DESCRIPTION
Nothing is generated if selection is null. This PR fixes $generateHtmlFromNodes to output whole editor contents if selection is null.

https://lexical.dev/docs/concepts/serialization

> When generating HTML from an editor you can pass in a selection object to narrow it down to a certain section or pass in null to convert the whole editor.

I think it might be more natural to generate it even when the selection is undefined.