### PR TITLE
fix(lexical-playground): Floating toolbar displayed on composition

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Composition.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Composition.spec.mjs
@@ -6,11 +6,17 @@
  *
  */
 
-import {moveLeft, moveToLineBeginning} from '../keyboardShortcuts/index.mjs';
+import {
+  moveLeft,
+  moveToLineBeginning,
+  selectCharacters,
+} from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
   assertSelection,
   enableCompositionKeyEvents,
+  evaluate,
+  expect,
   focusEditor,
   html,
   initialize,
@@ -665,6 +671,40 @@ test.describe('Composition', () => {
         focusOffset: 0,
         focusPath: [0, 0, 0],
       });
+    });
+
+    test('Floating toolbar should not be displayed when using IME', async ({
+      page,
+      browserName,
+      isPlainText,
+    }) => {
+      test.skip(isPlainText);
+      // We don't yet support FF.
+      test.skip(browserName === 'firefox');
+
+      await focusEditor(page);
+      await enableCompositionKeyEvents(page);
+
+      await page.keyboard.imeSetComposition('ｓ', 0, 1);
+      await page.keyboard.imeSetComposition('す', 0, 1);
+      await page.keyboard.imeSetComposition('すｓ', 0, 2);
+      await page.keyboard.imeSetComposition('すｓｈ', 0, 3);
+      await page.keyboard.imeSetComposition('すｓｈ', 0, 4);
+
+      const isFloatingToolbarDisplayedWhenUseIME = await evaluate(page, () => {
+        return !!document.querySelector('.floating-text-format-popup');
+      });
+
+      expect(isFloatingToolbarDisplayedWhenUseIME).toEqual(false);
+
+      await page.keyboard.insertText('すｓｈ');
+      await selectCharacters(page, 'left', 3);
+
+      const isFloatingToolbarDisplayed = await evaluate(page, () => {
+        return !!document.querySelector('.floating-text-format-popup');
+      });
+
+      expect(isFloatingToolbarDisplayed).toEqual(true);
     });
   });
 });

--- a/packages/lexical-playground/src/plugins/TextFormatFloatingToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TextFormatFloatingToolbarPlugin.tsx
@@ -270,9 +270,8 @@ function useTextFormatFloatingToolbar(
 
   const updatePopup = useCallback(() => {
     editor.getEditorState().read(() => {
-      const isComposition = editor._compositionKey !== null;
       // Should not to pop up the floating toolbar when using IME input
-      if (isComposition) {
+      if (editor.isComposing()) {
         return;
       }
       const selection = $getSelection();

--- a/packages/lexical-playground/src/plugins/TextFormatFloatingToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TextFormatFloatingToolbarPlugin.tsx
@@ -270,6 +270,11 @@ function useTextFormatFloatingToolbar(
 
   const updatePopup = useCallback(() => {
     editor.getEditorState().read(() => {
+      const isComposition = editor._compositionKey !== null;
+      // Should not to pop up the floating toolbar when using IME input
+      if (isComposition) {
+        return;
+      }
       const selection = $getSelection();
       const nativeSelection = window.getSelection();
       const rootElement = editor.getRootElement();


### PR DESCRIPTION
### Description
Float toolbar should not be displayed during composition.

https://user-images.githubusercontent.com/22126563/175507437-674a9c3a-2eba-4498-8b0c-2dbd876e717f.mov

closes #2344 