### PR TITLE
Pasting multi-line plain text into rich-text mode produces separate paragraphs

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -1887,4 +1887,31 @@ test.describe('CopyAndPaste', () => {
       `,
     );
   });
+
+  test('Copy + paste multi-line plain text into rich text produces separate paragraphs', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    await page.keyboard.type('# Hello ');
+    await pasteFromClipboard(page, {
+      'text/plain': 'world\nAnd text below',
+    });
+    await assertHTML(
+      page,
+      html`
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello world</span>
+        </h1>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">And text below</span>
+        </p>
+      `,
+    );
+  });
 });


### PR DESCRIPTION
Reported by TextExpander users (app for text snippets) and matches other editors behavior

Before:

<img width="1102" alt="Screen Shot 2022-06-24 at 7 28 37 AM" src="https://user-images.githubusercontent.com/132642/175525698-8fa529de-eea5-4b60-8ac2-0ed9ff2e307d.png">

After:

https://user-images.githubusercontent.com/132642/175525525-a83d4702-5abc-4048-8317-1ec3a9c56bdb.mov
