### PR TITLE
fix: maxlength bug in code node

### DIFF
--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -18,6 +18,7 @@ import type {
   TextNode,
 } from 'lexical';
 
+import {$isCodeHighlightNode} from '@lexical/code';
 import {
   $createTextNode,
   $getDecoratorNode,
@@ -981,7 +982,10 @@ export function trimTextContentFromAnchor(
         .getEditorState()
         .read(() => {
           const prevNode = $getNodeByKey(key);
-          if ($isTextNode(prevNode) && prevNode.isSimpleText()) {
+          if (
+            ($isTextNode(prevNode) && prevNode.isSimpleText()) ||
+            $isCodeHighlightNode(prevNode)
+          ) {
             return prevNode.getTextContent();
           }
           return null;


### PR DESCRIPTION
Follow up to #2428

The MaxLength emoji bug still persists in codeNode because while trimming content, it retrieves the text content of the previous node which is done only when this check passes: [packages/lexical-selection/src/index.ts#L984](https://github.com/facebook/lexical/blob/main/packages/lexical-selection/src/index.ts#L984)

In codeNode, the code highlight node replaces the text node but fails to match __type==="text" above, causing the issue.