### PR TITLE
Normalize list children

### DIFF
--- a/packages/lexical-list/src/utils.ts
+++ b/packages/lexical-list/src/utils.ts
@@ -10,7 +10,13 @@ import type {LexicalNode} from 'lexical';
 
 import invariant from 'shared/invariant';
 
-import {$isListItemNode, $isListNode, ListItemNode, ListNode} from './';
+import {
+  $createListItemNode,
+  $isListItemNode,
+  $isListNode,
+  ListItemNode,
+  ListNode,
+} from './';
 
 export function $getListDepth(listNode: ListNode): number {
   let depth = 1;
@@ -163,4 +169,9 @@ export function $removeHighestEmptyListParent(
   }
 
   emptyListPtr.remove();
+}
+
+export function wrapInListItem(node: LexicalNode): ListItemNode {
+  const listItemWrapper = $createListItemNode();
+  return listItemWrapper.append(node);
 }

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -1406,6 +1406,212 @@ test.describe('CopyAndPaste', () => {
     );
   });
 
+  test('HTML Copy + paste (Nested List - directly nested ul)', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    const clipboard = {
+      'text/html': '<ul><ul><li>Hello</li></ul><li>world!</li></ul>',
+    };
+
+    await pasteFromClipboard(page, clipboard);
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
+            <ul class="PlaygroundEditorTheme__ul">
+              <li
+                value="1"
+                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">Hello</span>
+              </li>
+            </ul>
+          </li>
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">world!</span>
+          </li>
+        </ul>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 6,
+      anchorPath: [0, 1, 0, 0],
+      focusOffset: 6,
+      focusPath: [0, 1, 0, 0],
+    });
+
+    await selectFromAlignDropdown(page, '.indent');
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
+            <ul class="PlaygroundEditorTheme__ul">
+              <li
+                value="1"
+                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">Hello</span>
+              </li>
+              <li
+                value="2"
+                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">world!</span>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      `,
+    );
+
+    await page.keyboard.press('ArrowUp');
+
+    await selectFromAlignDropdown(page, '.outdent');
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Hello</span>
+          </li>
+          <li
+            value="2"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
+            <ul class="PlaygroundEditorTheme__ul">
+              <li
+                value="1"
+                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">world!</span>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      `,
+    );
+  });
+
+  test('HTML Copy + paste (Nested List - li with non-list content plus ul child)', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    const clipboard = {
+      'text/html': '<ul><li>Hello<ul><li>world!</li></ul></li></ul>',
+    };
+
+    await pasteFromClipboard(page, clipboard);
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Hello</span>
+          </li>
+          <li
+            value="2"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
+            <ul class="PlaygroundEditorTheme__ul">
+              <li
+                value="1"
+                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">world!</span>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 6,
+      anchorPath: [0, 1, 0, 0, 0, 0],
+      focusOffset: 6,
+      focusPath: [0, 1, 0, 0, 0, 0],
+    });
+
+    await selectFromAlignDropdown(page, '.outdent');
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Hello</span>
+          </li>
+          <li
+            value="2"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">world!</span>
+          </li>
+        </ul>
+      `,
+    );
+
+    await page.keyboard.press('ArrowUp');
+
+    await selectFromAlignDropdown(page, '.indent');
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
+            <ul class="PlaygroundEditorTheme__ul">
+              <li
+                value="1"
+                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">Hello</span>
+              </li>
+            </ul>
+          </li>
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">world!</span>
+          </li>
+        </ul>
+      `,
+    );
+  });
+
   test('HTML Copy + paste (Table - Google Docs)', async ({
     page,
     isPlainText,
@@ -1785,11 +1991,11 @@ test.describe('CopyAndPaste', () => {
     await pasteFromClipboard(page, {
       'text/html': `
         <p>Hello
-        
+
         </p>
-        
+
         <p>World</p>
-        
+
       `,
     });
 


### PR DESCRIPTION
Fixes #2503

This probably needs a more comprehensive fix - we need to think about how we want to deal with unexpected HTML structures. Maybe we want to first parse the DOM and then sanitize it, or maybe we need a second sanitization pass on the returned subtree.

This also needs tests.