### PR TITLE
Improve markdown newline export/import

### DIFF
--- a/packages/lexical-markdown/src/v2/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/v2/MarkdownExport.ts
@@ -46,7 +46,7 @@ export function createMarkdownExport(
       }
     }
 
-    return output.join('\n');
+    return output.join('\n\n');
   };
 }
 

--- a/packages/lexical-playground/__tests__/e2e/Markdown-v2.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown-v2.spec.mjs
@@ -765,9 +765,14 @@ const TYPED_MARKDOWN_HTML = html`
 const IMPORTED_MARKDOWN = `# Markdown Import
 ### Formatting
 This is *italic*, _italic_, **bold**, __bold__, ~~strikethrough~~ text
-This is *__~~bold italic strikethrough~~__* text, ___~~this one too~~___
+
+This is *__~~bold italic strikethrough~~__* text,
+___~~this one too~~___
+
 It ~~___works [with links](https://lexical.io)___~~ too
+
 Links [with underscores](https://lexical.io/tag_here_and__here__and___here___too)
+
 *Nested **stars tags** are handled too*
 ### Headings
 # h1 Heading
@@ -780,13 +785,19 @@ Links [with underscores](https://lexical.io/tag_here_and__here__and___here___too
 ---
 ### Blockquotes
 > Blockquotes text goes here
+> And second
+line after
+
+> Standalone again
+
 ### Unordered lists
 - Create a list with \`+\`, \`-\`, or \`*\`
     - Lists can be indented with 2 spaces
         - Very easy
 ### Ordered lists
 1. Oredered lists started with numbers as \`1.\`
-    1. And can be nested as well
+    1. And can be nested
+    and multiline as well
 
 31. Have any starting number
 ### Inline code
@@ -842,6 +853,7 @@ const IMPORTED_MARKDOWN_HTML = html`
       bold italic strikethrough
     </strong>
     <span data-lexical-text="true">text,</span>
+    <br />
     <strong
       class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
       data-lexical-text="true">
@@ -932,6 +944,15 @@ const IMPORTED_MARKDOWN_HTML = html`
     class="PlaygroundEditorTheme__quote PlaygroundEditorTheme__ltr"
     dir="ltr">
     <span data-lexical-text="true">Blockquotes text goes here</span>
+    <br />
+    <span data-lexical-text="true">And second</span>
+    <br />
+    <span data-lexical-text="true">line after</span>
+  </blockquote>
+  <blockquote
+    class="PlaygroundEditorTheme__quote PlaygroundEditorTheme__ltr"
+    dir="ltr">
+    <span data-lexical-text="true">Standalone again</span>
   </blockquote>
   <h3 class="PlaygroundEditorTheme__h3 PlaygroundEditorTheme__ltr" dir="ltr">
     <span data-lexical-text="true">Unordered lists</span>
@@ -1004,12 +1025,13 @@ const IMPORTED_MARKDOWN_HTML = html`
           value="1"
           class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
           dir="ltr">
-          <span data-lexical-text="true">And can be nested as well</span>
+          <span data-lexical-text="true">And can be nested</span>
+          <br />
+          <span data-lexical-text="true">and multiline as well</span>
         </li>
       </ol>
     </li>
   </ol>
-  <p class="PlaygroundEditorTheme__paragraph"><br /></p>
   <ol start="31" class="PlaygroundEditorTheme__ol1">
     <li
       value="31"


### PR DESCRIPTION
Adjustments around how markdown import/export deal with new lines:
- Export will use `\n\n` as block separator
- Import ignores empty paragraphs (but keeps empty quotes, lists, headings)
- Paragraph content is appended to the previous sibling if it is not empty separated by [hard line breaks](https://spec.commonmark.org/0.30/#hard-line-breaks)
- Multi-line blockquote content is appended 

These changes should make our markdown a bit closer to commonmark spec. It still has some differences, e.g. we do not support nested quotes (in general we do not nest quotes in editor) or soft line breaks

input:
```markdown
Paragraph text
continuation

Another paragraph
- List item
continuation
> Quote line 1
> line 2
continuation
```
output:

```html
<p>
  Paragraph text<br>
  continuation
</p>
<p>
  Another paragraph
</p>
<ul>
  <li>
    List item<br>
    continuation
  </li>
</ul>
<bloquoute>
  Quote line 1<br>
  line 2<br>
  continuation
</bloquoute>
```