### PR TITLE
Update e2e test docs and run-all script

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ editor.registerUpdateListener(({editorState}) => {
 
 3. Start local server and run tests
    - `npm run start`
-   - `npm run test-e2e:chromium` to run only chromium e2e tests
+   - `npm run test-e2e-chromium` to run only chromium e2e tests
      - The server needs to be running for the e2e tests
 
 `npm run start` will start both the dev server and collab server. If you don't need collab, use `npm run dev` to start just the dev server.
@@ -373,12 +373,12 @@ Lexical engineers are checking this regularly.
 ## Running tests
 
 - `npm run test-unit` runs only unit tests.
-- `npm run test-e2e:chromium` runs only chromium e2e tests.
-- `npm run debug-test-e2e:chromium` runs only chromium e2e tests in head mode for debugging.
-- `npm run test-e2e:firefox` runs only firefox e2e tests.
-- `npm run debug-test-e2e:firefox` runs only firefox e2e tests in head mode for debugging.
-- `npm run test-e2e:webkit` runs only webkit e2e tests.
-- `npm run debug-test-e2e:webkit` runs only webkit e2e tests in head mode for debugging.
+- `npm run test-e2e-chromium` runs only chromium e2e tests.
+- `npm run debug-test-e2e-chromium` runs only chromium e2e tests in head mode for debugging.
+- `npm run test-e2e-firefox` runs only firefox e2e tests.
+- `npm run debug-test-e2e-firefox` runs only firefox e2e tests in head mode for debugging.
+- `npm run test-e2e-webkit` runs only webkit e2e tests.
+- `npm run debug-test-e2e-webkit` runs only webkit e2e tests in head mode for debugging.
 
 ### License
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,7 +26,7 @@ To run E2E tests use:
 
 ```
 npm run start &
-npm run test-e2e:chromium # or :firefox, :webkit
+npm run test-e2e-chromium # or -firefox, -webkit
 ```
 
 E2E tests can be found in [this directory](/packages/lexical-playground/__tests__)

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test-e2e-collab-ci-webkit": "cross-env E2E_PORT=4000 start-server-and-test prepare-ci-collab 4000 test-e2e-collab-webkit",
     "test-e2e-prod-ci-chromium": "cross-env E2E_PORT=4000 start-server-and-test prepare-ci-prod 4000 test-e2e-prod-chromium",
     "test-e2e-collab-prod-ci-chromium": "cross-env E2E_PORT=4000 start-server-and-test prepare-ci-collab-prod 4000 test-e2e-collab-prod-chromium",
-    "run-all": "npm-run-all debug-test-e2e:*",
+    "run-all": "npm-run-all debug-test-e2e-*",
     "debug-test-e2e": "cross-env playwright test --debug",
     "debug-test-e2e-chromium": "cross-env E2E_BROWSER=chromium playwright test --debug --project=\"chromium\"",
     "debug-test-e2e-prod-chromium": "cross-env E2E_BROWSER=chromium E2E_PORT=4173 playwright test --debug --project=\"chromium\"",


### PR DESCRIPTION
The npm scripts for e2e testing have changed and this PR update docs and the run-all npm script.

https://github.com/facebook/lexical/pull/2513
