### PR TITLE
Revisit formatText node selection

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -12,7 +12,6 @@ import {
   assertSelection,
   click,
   dragImage,
-  E2E_PORT,
   focusEditor,
   html,
   initialize,
@@ -20,14 +19,10 @@ import {
   insertUploadImage,
   insertUrlImage,
   IS_WINDOWS,
+  SAMPLE_IMAGE_URL,
   test,
   waitForSelector,
 } from '../utils/index.mjs';
-
-const IMAGE_URL =
-  E2E_PORT === 3000
-    ? '/src/images/yellow-flower.jpg'
-    : '/assets/yellow-flower.bf6d0400.jpg';
 
 test.describe('Images', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
@@ -53,7 +48,7 @@ test.describe('Images', () => {
             data-lexical-decorator="true">
             <div draggable="false">
               <img
-                src="${IMAGE_URL}"
+                src="${SAMPLE_IMAGE_URL}"
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
                 style="height: inherit; max-width: 500px; width: inherit;" />
@@ -118,7 +113,7 @@ test.describe('Images', () => {
               data-lexical-decorator="true">
               <div draggable="true">
                 <img
-                  src="${IMAGE_URL}"
+                  src="${SAMPLE_IMAGE_URL}"
                   alt="Yellow flower in tilt shift lens"
                   draggable="false"
                   style="height: inherit; max-width: 500px; width: inherit;"
@@ -168,7 +163,7 @@ test.describe('Images', () => {
             data-lexical-decorator="true">
             <div draggable="false">
               <img
-                src="${IMAGE_URL}"
+                src="${SAMPLE_IMAGE_URL}"
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
                 style="height: inherit; max-width: 500px; width: inherit;" />
@@ -228,7 +223,7 @@ test.describe('Images', () => {
             data-lexical-decorator="true">
             <div draggable="false">
               <img
-                src="${IMAGE_URL}"
+                src="${SAMPLE_IMAGE_URL}"
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
                 style="height: inherit; max-width: 500px; width: inherit;" />
@@ -240,7 +235,7 @@ test.describe('Images', () => {
             data-lexical-decorator="true">
             <div draggable="false">
               <img
-                src="${IMAGE_URL}"
+                src="${SAMPLE_IMAGE_URL}"
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
                 style="height: inherit; max-width: 500px; width: inherit;" />
@@ -268,7 +263,7 @@ test.describe('Images', () => {
             data-lexical-decorator="true">
             <div draggable="false">
               <img
-                src="${IMAGE_URL}"
+                src="${SAMPLE_IMAGE_URL}"
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
                 style="height: inherit; max-width: 500px; width: inherit;" />
@@ -319,7 +314,7 @@ test.describe('Images', () => {
             data-lexical-decorator="true">
             <div draggable="false">
               <img
-                src="${IMAGE_URL}"
+                src="${SAMPLE_IMAGE_URL}"
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
                 style="height: inherit; max-width: 500px; width: inherit;" />
@@ -331,7 +326,7 @@ test.describe('Images', () => {
             data-lexical-decorator="true">
             <div draggable="false">
               <img
-                src="${IMAGE_URL}"
+                src="${SAMPLE_IMAGE_URL}"
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
                 style="height: inherit; max-width: 500px; width: inherit;" />
@@ -361,7 +356,7 @@ test.describe('Images', () => {
             data-lexical-decorator="true">
             <div draggable="false">
               <img
-                src="${IMAGE_URL}"
+                src="${SAMPLE_IMAGE_URL}"
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
                 style="height: inherit; max-width: 500px; width: inherit;" />
@@ -477,7 +472,7 @@ test.describe('Images', () => {
                 <img
                   alt="Yellow flower in tilt shift lens"
                   draggable="false"
-                  src="${IMAGE_URL}"
+                  src="${SAMPLE_IMAGE_URL}"
                   style="height: inherit; max-width: 500px; width: inherit" />
               </div>
             </span>
@@ -513,7 +508,7 @@ test.describe('Images', () => {
                 <img
                   alt="Yellow flower in tilt shift lens"
                   draggable="false"
-                  src="${IMAGE_URL}"
+                  src="${SAMPLE_IMAGE_URL}"
                   style="height: inherit; max-width: 500px; width: inherit" />
               </div>
             </span>
@@ -561,7 +556,7 @@ test.describe('Images', () => {
               <img
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
-                src="${IMAGE_URL}"
+                src="${SAMPLE_IMAGE_URL}"
                 style="height: inherit; max-width: 500px; width: inherit" />
             </div>
           </span>

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -25,6 +25,7 @@ import {
   focusEditor,
   html,
   initialize,
+  insertSampleImage,
   repeat,
   selectOption,
   test,
@@ -866,7 +867,7 @@ test.describe('TextFormatting', () => {
     });
   });
 
-  test(`Regression test #2439: can format backwards when at first text node boundary`, async ({
+  test(`Regression #2439: can format backwards when at first text node boundary`, async ({
     page,
     isPlainText,
   }) => {
@@ -953,5 +954,97 @@ test.describe('TextFormatting', () => {
     });
 
     expect(isButtonActiveStatusDisplayedCorrectly).toBe(true);
+  });
+
+  test('Regression #2523: can toggle format when selecting a TextNode edge followed by a non TextNode; ', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+
+    await page.keyboard.type('A');
+    await insertSampleImage(page);
+    await page.keyboard.type('BC');
+
+    await moveLeft(page, 1);
+    await selectCharacters(page, 'left', 2);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">A</span>
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="false">
+              <img
+                alt="Yellow flower in tilt shift lens"
+                draggable="false"
+                src="/src/images/yellow-flower.jpg"
+                style="height: inherit; max-width: 500px; width: inherit" />
+            </div>
+          </span>
+          <span data-lexical-text="true">BC</span>
+        </p>
+      `,
+    );
+    await toggleBold(page);
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">A</span>
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="false">
+              <img
+                alt="Yellow flower in tilt shift lens"
+                draggable="false"
+                src="/src/images/yellow-flower.jpg"
+                style="height: inherit; max-width: 500px; width: inherit" />
+            </div>
+          </span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            B
+          </strong>
+          <span data-lexical-text="true">C</span>
+        </p>
+      `,
+    );
+    await toggleBold(page);
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">A</span>
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="false">
+              <img
+                alt="Yellow flower in tilt shift lens"
+                draggable="false"
+                src="/src/images/yellow-flower.jpg"
+                style="height: inherit; max-width: 500px; width: inherit" />
+            </div>
+          </span>
+          <span data-lexical-text="true">BC</span>
+        </p>
+      `,
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -27,6 +27,7 @@ import {
   initialize,
   insertSampleImage,
   repeat,
+  SAMPLE_IMAGE_URL,
   selectOption,
   test,
   waitForSelector,
@@ -985,7 +986,7 @@ test.describe('TextFormatting', () => {
               <img
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
-                src="/src/images/yellow-flower.jpg"
+                src="${SAMPLE_IMAGE_URL}"
                 style="height: inherit; max-width: 500px; width: inherit" />
             </div>
           </span>
@@ -1009,7 +1010,7 @@ test.describe('TextFormatting', () => {
               <img
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
-                src="/src/images/yellow-flower.jpg"
+                src="${SAMPLE_IMAGE_URL}"
                 style="height: inherit; max-width: 500px; width: inherit" />
             </div>
           </span>
@@ -1038,7 +1039,7 @@ test.describe('TextFormatting', () => {
               <img
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
-                src="/src/images/yellow-flower.jpg"
+                src="${SAMPLE_IMAGE_URL}"
                 style="height: inherit; max-width: 500px; width: inherit" />
             </div>
           </span>

--- a/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
@@ -10,22 +10,17 @@ import {selectAll} from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
   click,
-  E2E_PORT,
   evaluate,
   focus,
   focusEditor,
   html,
   initialize,
   insertSampleImage,
+  SAMPLE_IMAGE_URL,
   selectFromAlignDropdown,
   selectFromInsertDropdown,
   test,
 } from '../utils/index.mjs';
-
-const IMAGE_URL =
-  E2E_PORT === 3000
-    ? '/src/images/yellow-flower.jpg'
-    : '/assets/yellow-flower.bf6d0400.jpg';
 
 test.describe('Toolbar', () => {
   test.beforeEach(({isCollab, page}) =>
@@ -51,7 +46,7 @@ test.describe('Toolbar', () => {
               <img
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
-                src="${IMAGE_URL}" />
+                src="${SAMPLE_IMAGE_URL}" />
             </div>
             <div>
               <div
@@ -224,7 +219,7 @@ test.describe('Toolbar', () => {
                 alt="Yellow flower in tilt shift lens"
                 class="focused"
                 draggable="false"
-                src="${IMAGE_URL}"
+                src="${SAMPLE_IMAGE_URL}"
                 style="height: inherit; max-width: 500px; width: inherit" />
             </div>
             <button class="image-caption-button">Add Caption</button>
@@ -258,7 +253,7 @@ test.describe('Toolbar', () => {
                 alt="Yellow flower in tilt shift lens"
                 class="focused"
                 draggable="false"
-                src="${IMAGE_URL}"
+                src="${SAMPLE_IMAGE_URL}"
                 style="height: inherit; max-width: 500px; width: inherit" />
             </div>
             <button class="image-caption-button">Add Caption</button>

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -23,6 +23,10 @@ export const IS_COLLAB =
 const IS_RICH_TEXT = process.env.E2E_EDITOR_MODE !== 'plain-text';
 const IS_PLAIN_TEXT = process.env.E2E_EDITOR_MODE === 'plain-text';
 export const LEGACY_EVENTS = process.env.E2E_EVENTS_MODE === 'legacy-events';
+export const SAMPLE_IMAGE_URL =
+  E2E_PORT === 3000
+    ? '/src/images/yellow-flower.jpg'
+    : '/assets/yellow-flower.bf6d0400.jpg';
 
 export async function initialize({
   page,

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1043,9 +1043,8 @@ export class RangeSelection implements BaseSelection {
   formatText(formatType: TextFormatType): void {
     // TODO I wonder if this methods use selection.extract() instead?
     const selectedNodes = this.getNodes();
-    const selectedTextNodes = [];
-    for (let i = 0; i < selectedNodes.length; i += 1) {
-      const selectedNode = selectedNodes[i];
+    const selectedTextNodes: Array<TextNode> = [];
+    for (const selectedNode of selectedNodes) {
       if ($isTextNode(selectedNode)) {
         selectedTextNodes.push(selectedNode);
       }
@@ -1073,28 +1072,12 @@ export class RangeSelection implements BaseSelection {
     const endOffset = isBefore ? focusOffset : anchorOffset;
     let startOffset = isBefore ? anchorOffset : focusOffset;
 
-    // // This is the case where the user only selected the very end of the
-    // // first node so we don't want to include it in the formatting change.
-    // if (startOffset === firstNode.getTextContentSize()) {
-    //   let nextSibling = firstNode.getNextSibling();
-
-    //   if ($isElementNode(nextSibling) && nextSibling.isInline()) {
-    //     nextSibling = nextSibling.getFirstChild();
-    //   }
-
-    //   if ($isTextNode(nextSibling)) {
-    //     // we basically make the second node the firstNode, changing offsets accordingly
-    //     startOffset = 0;
-    //     firstNode = nextSibling;
-    //     firstNodeTextLength = nextSibling.getTextContent().length;
-    //     firstNextFormat = nextSibling.getFormatFlags(formatType, null);
-    //   }
-    // }
+    // This is the case where the user only selected the very end of the
+    // first node so we don't want to include it in the formatting change.
     if (
       startOffset === firstNode.getTextContentSize() &&
       selectedTextNodes.length > 1
     ) {
-      // debugger;
       const nextNode = selectedTextNodes[1];
       startOffset = 0;
       firstIndex = 1;
@@ -1102,7 +1085,6 @@ export class RangeSelection implements BaseSelection {
       firstNodeTextLength = nextNode.getTextContentSize();
       firstNextFormat = nextNode.getFormatFlags(formatType, null);
     }
-    // check if there's something to format
 
     // This is the case where we only selected a single node
     if (firstNode.is(lastNode)) {
@@ -1135,15 +1117,11 @@ export class RangeSelection implements BaseSelection {
       // multiple nodes selected.
     } else {
       if ($isTextNode(firstNode) && startOffset !== firstNodeTextLength) {
-        // console.info(startOffset, firstNode);
         if (startOffset !== 0) {
-          // debugger;
           // the entire first node isn't selected, so split it
           [, firstNode as TextNode] = firstNode.splitText(startOffset);
-
           startOffset = 0;
         }
-        // console.info('2', firstNode);
         firstNode.setFormat(firstNextFormat);
       }
       let lastNextFormat = firstNextFormat;
@@ -1165,7 +1143,7 @@ export class RangeSelection implements BaseSelection {
 
       this.format = firstNextFormat | lastNextFormat;
 
-      // deal with all the nodes in between HERE
+      // deal with all the nodes in between
       for (let i = firstIndex + 1; i < lastIndex; i++) {
         const selectedNode = selectedTextNodes[i];
         const selectedNodeKey = selectedNode.__key;

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1116,6 +1116,8 @@ export class RangeSelection implements BaseSelection {
       }
       // multiple nodes selected.
     } else {
+      // Note: startOffset !== firstNodeTextLength should only occur within rare programatic
+      // update functions; transforms normalization ensure there's no empty text nodes.
       if ($isTextNode(firstNode) && startOffset !== firstNodeTextLength) {
         if (startOffset !== 0) {
           // the entire first node isn't selected, so split it

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1043,10 +1043,18 @@ export class RangeSelection implements BaseSelection {
   formatText(formatType: TextFormatType): void {
     // TODO I wonder if this methods use selection.extract() instead?
     const selectedNodes = this.getNodes();
-    const selectedNodesLength = selectedNodes.length;
-    const lastIndex = selectedNodesLength - 1;
-    let firstNode = selectedNodes[0];
-    let lastNode = selectedNodes[lastIndex];
+    const selectedTextNodes = [];
+    for (let i = 0; i < selectedNodes.length; i += 1) {
+      const selectedNode = selectedNodes[i];
+      if ($isTextNode(selectedNode)) {
+        selectedTextNodes.push(selectedNode);
+      }
+    }
+    const selectedTextNodesLength = selectedTextNodes.length;
+    let firstIndex = 0;
+    const lastIndex = selectedTextNodesLength - 1;
+    let firstNode = selectedTextNodes[0];
+    let lastNode = selectedTextNodes[lastIndex];
 
     if (this.isCollapsed()) {
       this.toggleFormat(formatType);
@@ -1058,37 +1066,43 @@ export class RangeSelection implements BaseSelection {
     const focus = this.focus;
     const anchorOffset = anchor.offset;
     const focusOffset = focus.offset;
-    let firstNextFormat = 0;
+    let firstNextFormat = firstNode.getFormatFlags(formatType, null);
     let firstNodeTextLength = firstNode.getTextContent().length;
 
-    for (let i = 0; i < selectedNodes.length; i++) {
-      const selectedNode = selectedNodes[i];
-      if ($isTextNode(selectedNode)) {
-        firstNextFormat = selectedNode.getFormatFlags(formatType, null);
-        break;
-      }
-    }
     const isBefore = anchor.isBefore(focus);
     const endOffset = isBefore ? focusOffset : anchorOffset;
     let startOffset = isBefore ? anchorOffset : focusOffset;
 
-    // This is the case where the user only selected the very end of the
-    // first node so we don't want to include it in the formatting change.
-    if (startOffset === firstNode.getTextContentSize()) {
-      let nextSibling = firstNode.getNextSibling();
+    // // This is the case where the user only selected the very end of the
+    // // first node so we don't want to include it in the formatting change.
+    // if (startOffset === firstNode.getTextContentSize()) {
+    //   let nextSibling = firstNode.getNextSibling();
 
-      if ($isElementNode(nextSibling) && nextSibling.isInline()) {
-        nextSibling = nextSibling.getFirstChild();
-      }
+    //   if ($isElementNode(nextSibling) && nextSibling.isInline()) {
+    //     nextSibling = nextSibling.getFirstChild();
+    //   }
 
-      if ($isTextNode(nextSibling)) {
-        // we basically make the second node the firstNode, changing offsets accordingly
-        startOffset = 0;
-        firstNode = nextSibling;
-        firstNodeTextLength = nextSibling.getTextContent().length;
-        firstNextFormat = nextSibling.getFormatFlags(formatType, null);
-      }
+    //   if ($isTextNode(nextSibling)) {
+    //     // we basically make the second node the firstNode, changing offsets accordingly
+    //     startOffset = 0;
+    //     firstNode = nextSibling;
+    //     firstNodeTextLength = nextSibling.getTextContent().length;
+    //     firstNextFormat = nextSibling.getFormatFlags(formatType, null);
+    //   }
+    // }
+    if (
+      startOffset === firstNode.getTextContentSize() &&
+      selectedTextNodes.length > 1
+    ) {
+      // debugger;
+      const nextNode = selectedTextNodes[1];
+      startOffset = 0;
+      firstIndex = 1;
+      firstNode = nextNode;
+      firstNodeTextLength = nextNode.getTextContentSize();
+      firstNextFormat = nextNode.getFormatFlags(formatType, null);
     }
+    // check if there's something to format
 
     // This is the case where we only selected a single node
     if (firstNode.is(lastNode)) {
@@ -1120,12 +1134,17 @@ export class RangeSelection implements BaseSelection {
       }
       // multiple nodes selected.
     } else {
-      if ($isTextNode(firstNode)) {
+      if ($isTextNode(firstNode) && startOffset !== firstNodeTextLength) {
+        // console.info(startOffset, firstNode);
         if (startOffset !== 0) {
+          // debugger;
+          let x;
           // the entire first node isn't selected, so split it
-          [, firstNode as TextNode] = firstNode.splitText(startOffset);
+          [x, firstNode as TextNode] = firstNode.splitText(startOffset);
+
           startOffset = 0;
         }
+        // console.info('2', firstNode);
         firstNode.setFormat(firstNextFormat);
       }
       let lastNextFormat = firstNextFormat;
@@ -1147,9 +1166,9 @@ export class RangeSelection implements BaseSelection {
 
       this.format = firstNextFormat | lastNextFormat;
 
-      // deal with all the nodes in between
-      for (let i = 1; i < lastIndex; i++) {
-        const selectedNode = selectedNodes[i];
+      // deal with all the nodes in between HERE
+      for (let i = firstIndex + 1; i < lastIndex; i++) {
+        const selectedNode = selectedTextNodes[i];
         const selectedNodeKey = selectedNode.__key;
         if (
           $isTextNode(selectedNode) &&

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1138,9 +1138,8 @@ export class RangeSelection implements BaseSelection {
         // console.info(startOffset, firstNode);
         if (startOffset !== 0) {
           // debugger;
-          let x;
           // the entire first node isn't selected, so split it
-          [x, firstNode as TextNode] = firstNode.splitText(startOffset);
+          [, firstNode as TextNode] = firstNode.splitText(startOffset);
 
           startOffset = 0;
         }


### PR DESCRIPTION
The current logic is based on hardcoded conditions that rely on either the first node being a TextNode or the second. This breaks when the immediate sibling is not a TextNode. Given that `formatText` has to look exclusively at text nodes we can improve the logic by looking exclusively at the sorted text nodes.

https://user-images.githubusercontent.com/193447/175930858-4941a0d7-ae79-4a68-b61f-bee2b74b8d11.mov

Closes https://github.com/facebook/lexical/issues/2523