### PR TITLE
Remove `utility-types` from all packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24616,10 +24616,7 @@
     },
     "packages/lexical": {
       "version": "0.3.5",
-      "license": "MIT",
-      "devDependencies": {
-        "utility-types": "^3.10.0"
-      }
+      "license": "MIT"
     },
     "packages/lexical-clipboard": {
       "name": "@lexical/clipboard",
@@ -24714,9 +24711,6 @@
       "name": "@lexical/headless",
       "version": "0.3.5",
       "license": "MIT",
-      "devDependencies": {
-        "utility-types": "^3.10.0"
-      },
       "peerDependencies": {
         "lexical": "0.3.5"
       }
@@ -24844,7 +24838,6 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^1.0.7",
-        "utility-types": "^3.10.0",
         "vite": "^2.8.0",
         "vite-plugin-replace": "0.1.1"
       }
@@ -24871,9 +24864,6 @@
         "@lexical/text": "0.3.5",
         "@lexical/utils": "0.3.5",
         "@lexical/yjs": "0.3.5"
-      },
-      "devDependencies": {
-        "utility-types": "^3.10.0"
       },
       "peerDependencies": {
         "lexical": "0.3.5",
@@ -24915,9 +24905,6 @@
       "name": "@lexical/text",
       "version": "0.3.5",
       "license": "MIT",
-      "devDependencies": {
-        "utility-types": "^3.10.0"
-      },
       "peerDependencies": {
         "lexical": "0.3.5"
       }
@@ -24929,9 +24916,6 @@
       "dependencies": {
         "@lexical/list": "0.3.5",
         "@lexical/table": "0.3.5"
-      },
-      "devDependencies": {
-        "utility-types": "^3.10.0"
       },
       "peerDependencies": {
         "lexical": "0.3.5"
@@ -28549,10 +28533,7 @@
       }
     },
     "@lexical/headless": {
-      "version": "file:packages/lexical-headless",
-      "requires": {
-        "utility-types": "^3.10.0"
-      }
+      "version": "file:packages/lexical-headless"
     },
     "@lexical/history": {
       "version": "file:packages/lexical-history",
@@ -28620,8 +28601,7 @@
         "@lexical/table": "0.3.5",
         "@lexical/text": "0.3.5",
         "@lexical/utils": "0.3.5",
-        "@lexical/yjs": "0.3.5",
-        "utility-types": "^3.10.0"
+        "@lexical/yjs": "0.3.5"
       }
     },
     "@lexical/rich-text": {
@@ -28637,17 +28617,13 @@
       }
     },
     "@lexical/text": {
-      "version": "file:packages/lexical-text",
-      "requires": {
-        "utility-types": "^3.10.0"
-      }
+      "version": "file:packages/lexical-text"
     },
     "@lexical/utils": {
       "version": "file:packages/lexical-utils",
       "requires": {
         "@lexical/list": "0.3.5",
-        "@lexical/table": "0.3.5",
-        "utility-types": "^3.10.0"
+        "@lexical/table": "0.3.5"
       }
     },
     "@lexical/yjs": {
@@ -36734,10 +36710,7 @@
       }
     },
     "lexical": {
-      "version": "file:packages/lexical",
-      "requires": {
-        "utility-types": "^3.10.0"
-      }
+      "version": "file:packages/lexical"
     },
     "lexical-dev-tools": {
       "version": "file:packages/lexical-devtools",
@@ -36796,7 +36769,6 @@
         "link-preview-generator": "1.0.7",
         "react": "^18.0.0-alpha-64931821a-20210808",
         "react-dom": "^18.0.0-alpha-64931821a-20210808",
-        "utility-types": "^3.10.0",
         "vite": "^2.8.0",
         "vite-plugin-replace": "0.1.1",
         "y-websocket": ">=1.3.x",

--- a/packages/lexical-headless/package.json
+++ b/packages/lexical-headless/package.json
@@ -17,8 +17,5 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-headless"
-  },
-  "devDependencies": {
-    "utility-types": "^3.10.0"
   }
 }

--- a/packages/lexical-playground/package.json
+++ b/packages/lexical-playground/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^1.0.7",
-    "utility-types": "^3.10.0",
     "vite": "^2.8.0",
     "vite-plugin-replace": "0.1.1"
   }

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -37,8 +37,5 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-react"
-  },
-  "devDependencies": {
-    "utility-types": "^3.10.0"
   }
 }

--- a/packages/lexical-text/package.json
+++ b/packages/lexical-text/package.json
@@ -18,8 +18,5 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-text"
-  },
-  "devDependencies": {
-    "utility-types": "^3.10.0"
   }
 }

--- a/packages/lexical-utils/package.json
+++ b/packages/lexical-utils/package.json
@@ -21,8 +21,5 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-utils"
-  },
-  "devDependencies": {
-    "utility-types": "^3.10.0"
   }
 }

--- a/packages/lexical/package.json
+++ b/packages/lexical/package.json
@@ -15,8 +15,5 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical"
-  },
-  "devDependencies": {
-    "utility-types": "^3.10.0"
   }
 }


### PR DESCRIPTION
We don't use `utility-types` any more but it's still incorrectly listed as an import in some packages. This PR Removes the imports.