### PR TITLE
fix: insert text after delete next to inline node

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -7,6 +7,7 @@
  */
 
 import {
+  deleteBackward,
   moveLeft,
   moveRight,
   moveToLineBeginning,
@@ -1014,6 +1015,71 @@ test.describe('Links', () => {
             <span data-lexical-text="true">An Awesome Website</span>
           </a>
           <span data-lexical-text="true">!</span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Can delete text up to a link and then add text after`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('This is an Awesome Website right?');
+    await moveLeft(page, ' right?'.length);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">
+            This is an Awesome Website right?
+          </span>
+        </p>
+      `,
+    );
+
+    await selectCharacters(page, 'left', 'Awesome Website'.length);
+    await click(page, '.link');
+    await assertHTML(
+      page,
+      `
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">This is an</span>
+          <a
+            href="https://"
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Awesome Website</span>
+          </a>
+          <span data-lexical-text="true"> right?</span>
+        </p>
+      `,
+    );
+
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight');
+    await deleteBackward(page);
+
+    await page.keyboard.type(', ');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">This is an</span>
+          <a
+            href="https://"
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Awesome Website</span>
+          </a>
+          <span data-lexical-text="true">, right?</span>
         </p>
       `,
     );

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -645,10 +645,7 @@ function $shouldInsertTextAfterOrBeforeTextNode(
       ));
   const shouldInsertTextAfter =
     node.getTextContentSize() === offset &&
-    (!node.canInsertTextBefore() ||
-      !parent.canInsertTextBefore() ||
-      isToken ||
-      $siblingDoesNotAcceptText(node.getNextSibling(), 'canInsertTextBefore'));
+    (!node.canInsertTextBefore() || !parent.canInsertTextBefore() || isToken);
   return shouldInsertTextBefore || shouldInsertTextAfter;
 }
 

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -611,13 +611,13 @@ export function $updateTextNodeFromDOMContent(
   }
 }
 
-function $siblingDoesNotAcceptText(
-  sibling: LexicalNode | null,
-  method: 'canInsertTextAfter' | 'canInsertTextBefore',
-): boolean {
+function $previousSiblingDoesNotAcceptText(node: TextNode): boolean {
+  const previousSibling = node.getPreviousSibling();
+
   return (
-    ($isTextNode(sibling) || ($isElementNode(sibling) && sibling.isInline())) &&
-    !sibling[method]()
+    ($isTextNode(previousSibling) ||
+      ($isElementNode(previousSibling) && previousSibling.isInline())) &&
+    !previousSibling.canInsertTextAfter()
   );
 }
 
@@ -639,10 +639,7 @@ function $shouldInsertTextAfterOrBeforeTextNode(
     (!node.canInsertTextBefore() ||
       !parent.canInsertTextBefore() ||
       isToken ||
-      $siblingDoesNotAcceptText(
-        node.getPreviousSibling(),
-        'canInsertTextAfter',
-      ));
+      $previousSiblingDoesNotAcceptText(node));
   const shouldInsertTextAfter =
     node.getTextContentSize() === offset &&
     (!node.canInsertTextBefore() || !parent.canInsertTextBefore() || isToken);


### PR DESCRIPTION
This PR fixes #2520 by considering siblings in `$shouldInsertTextAfterOrBeforeTextNode`.