### PR TITLE
Capture the expected payload type in commands

### DIFF
--- a/packages/lexical-code/src/index.ts
+++ b/packages/lexical-code/src/index.ts
@@ -1160,24 +1160,22 @@ export function registerCodeHighlighting(editor: LexicalEditor): () => void {
     ),
     editor.registerCommand(
       KEY_ARROW_UP_COMMAND,
-      (payload: KeyboardEvent): boolean =>
-        handleShiftLines(KEY_ARROW_UP_COMMAND, payload),
+      (payload): boolean => handleShiftLines(KEY_ARROW_UP_COMMAND, payload),
       COMMAND_PRIORITY_LOW,
     ),
     editor.registerCommand(
       KEY_ARROW_DOWN_COMMAND,
-      (payload: KeyboardEvent): boolean =>
-        handleShiftLines(KEY_ARROW_DOWN_COMMAND, payload),
+      (payload): boolean => handleShiftLines(KEY_ARROW_DOWN_COMMAND, payload),
       COMMAND_PRIORITY_LOW,
     ),
     editor.registerCommand(
       MOVE_TO_END,
-      (payload: KeyboardEvent): boolean => handleMoveTo(MOVE_TO_END, payload),
+      (payload): boolean => handleMoveTo(MOVE_TO_END, payload),
       COMMAND_PRIORITY_LOW,
     ),
     editor.registerCommand(
       MOVE_TO_START,
-      (payload: KeyboardEvent): boolean => handleMoveTo(MOVE_TO_START, payload),
+      (payload): boolean => handleMoveTo(MOVE_TO_START, payload),
       COMMAND_PRIORITY_LOW,
     ),
   );

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -70,7 +70,7 @@ function onCopyForPlainText(
   event.preventDefault();
   editor.update(() => {
     const clipboardData =
-      event instanceof ClipboardEvent ? event.clipboardData : null;
+      event instanceof KeyboardEvent ? null : event.clipboardData;
     const selection = $getSelection();
 
     if (selection !== null) {
@@ -95,7 +95,7 @@ function onPasteForPlainText(
   editor.update(() => {
     const selection = $getSelection();
     const clipboardData =
-      event instanceof ClipboardEvent ? event.clipboardData : null;
+      event instanceof InputEvent ? null : event.clipboardData;
 
     if (clipboardData != null && $isRangeSelection(selection)) {
       $insertDataTransferForPlainText(clipboardData, selection);

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import type {EditorState, LexicalEditor} from 'lexical';
+import type {CommandPayloadType, EditorState, LexicalEditor} from 'lexical';
 
 import {
   $getHtmlContent,
@@ -64,12 +64,13 @@ const updateOptions: {
 } = options;
 
 function onCopyForPlainText(
-  event: ClipboardEvent,
+  event: CommandPayloadType<typeof COPY_COMMAND>,
   editor: LexicalEditor,
 ): void {
   event.preventDefault();
   editor.update(() => {
-    const clipboardData = event.clipboardData;
+    const clipboardData =
+      event instanceof ClipboardEvent ? event.clipboardData : null;
     const selection = $getSelection();
 
     if (selection !== null) {
@@ -87,13 +88,14 @@ function onCopyForPlainText(
 }
 
 function onPasteForPlainText(
-  event: ClipboardEvent,
+  event: CommandPayloadType<typeof PASTE_COMMAND>,
   editor: LexicalEditor,
 ): void {
   event.preventDefault();
   editor.update(() => {
     const selection = $getSelection();
-    const clipboardData = event.clipboardData;
+    const clipboardData =
+      event instanceof ClipboardEvent ? event.clipboardData : null;
 
     if (clipboardData != null && $isRangeSelection(selection)) {
       $insertDataTransferForPlainText(clipboardData, selection);
@@ -101,7 +103,10 @@ function onPasteForPlainText(
   });
 }
 
-function onCutForPlainText(event: ClipboardEvent, editor: LexicalEditor): void {
+function onCutForPlainText(
+  event: CommandPayloadType<typeof CUT_COMMAND>,
+  editor: LexicalEditor,
+): void {
   onCopyForPlainText(event, editor);
   editor.update(() => {
     const selection = $getSelection();
@@ -378,7 +383,7 @@ export function registerPlainText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<ClipboardEvent>(
+    editor.registerCommand(
       COPY_COMMAND,
       (event) => {
         const selection = $getSelection();
@@ -392,7 +397,7 @@ export function registerPlainText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<ClipboardEvent>(
+    editor.registerCommand(
       CUT_COMMAND,
       (event) => {
         const selection = $getSelection();
@@ -406,7 +411,7 @@ export function registerPlainText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<ClipboardEvent>(
+    editor.registerCommand(
       PASTE_COMMAND,
       (event) => {
         const selection = $getSelection();

--- a/packages/lexical-playground/src/plugins/ActionsPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin.tsx
@@ -113,10 +113,7 @@ export default function ActionsPlugin({
       {SUPPORT_SPEECH_RECOGNITION && (
         <button
           onClick={() => {
-            editor.dispatchCommand<boolean>(
-              SPEECH_TO_TEXT_COMMAND,
-              !isSpeechToText,
-            );
+            editor.dispatchCommand(SPEECH_TO_TEXT_COMMAND, !isSpeechToText);
             setIsSpeechToText(!isSpeechToText);
           }}
           className={
@@ -210,7 +207,7 @@ function ShowClearDialog({
       <div className="Modal__content">
         <Button
           onClick={() => {
-            editor.dispatchCommand<void>(CLEAR_EDITOR_COMMAND, undefined);
+            editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined);
             editor.focus();
             onClose();
           }}>

--- a/packages/lexical-playground/src/plugins/CommentPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin.tsx
@@ -932,7 +932,7 @@ export default function CommentPlugin({
   }, [editor, markNodeMap]);
 
   const onAddComment = () => {
-    editor.dispatchCommand(INSERT_INLINE_COMMAND, null);
+    editor.dispatchCommand(INSERT_INLINE_COMMAND, undefined);
   };
 
   return (

--- a/packages/lexical-playground/src/plugins/TextFormatFloatingToolbarPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TextFormatFloatingToolbarPlugin.tsx
@@ -89,7 +89,7 @@ function TextFormatFloatingToolbar({
   }, [editor, isLink]);
 
   const insertComment = () => {
-    editor.dispatchCommand(INSERT_INLINE_COMMAND, null);
+    editor.dispatchCommand(INSERT_INLINE_COMMAND, undefined);
   };
 
   const updateTextFormatFloatingToolbar = useCallback(() => {

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type {
+  CommandPayloadType,
   DOMConversionMap,
   DOMConversionOutput,
   EditorConfig,
@@ -372,13 +373,14 @@ function initializeEditor(
 }
 
 function onPasteForRichText(
-  event: ClipboardEvent,
+  event: CommandPayloadType<typeof PASTE_COMMAND>,
   editor: LexicalEditor,
 ): void {
   event.preventDefault();
   editor.update(() => {
     const selection = $getSelection();
-    const clipboardData = event.clipboardData;
+    const clipboardData =
+      event instanceof ClipboardEvent ? event.clipboardData : null;
     if (
       clipboardData != null &&
       ($isRangeSelection(selection) || $isGridSelection(selection))
@@ -388,11 +390,15 @@ function onPasteForRichText(
   });
 }
 
-function onCopyForRichText(event: ClipboardEvent, editor: LexicalEditor): void {
+function onCopyForRichText(
+  event: CommandPayloadType<typeof COPY_COMMAND>,
+  editor: LexicalEditor,
+): void {
   event.preventDefault();
   const selection = $getSelection();
   if (selection !== null) {
-    const clipboardData = event.clipboardData;
+    const clipboardData =
+      event instanceof ClipboardEvent ? event.clipboardData : null;
     const htmlString = $getHtmlContent(editor);
     const lexicalString = $getLexicalContent(editor);
 
@@ -423,7 +429,10 @@ function onCopyForRichText(event: ClipboardEvent, editor: LexicalEditor): void {
   }
 }
 
-function onCutForRichText(event: ClipboardEvent, editor: LexicalEditor): void {
+function onCutForRichText(
+  event: CommandPayloadType<typeof CUT_COMMAND>,
+  editor: LexicalEditor,
+): void {
   onCopyForRichText(event, editor);
   const selection = $getSelection();
   if ($isRangeSelection(selection)) {
@@ -806,7 +815,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<ClipboardEvent>(
+    editor.registerCommand(
       COPY_COMMAND,
       (event) => {
         onCopyForRichText(event, editor);
@@ -814,7 +823,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<ClipboardEvent>(
+    editor.registerCommand(
       CUT_COMMAND,
       (event) => {
         onCutForRichText(event, editor);
@@ -822,7 +831,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<ClipboardEvent>(
+    editor.registerCommand(
       PASTE_COMMAND,
       (event) => {
         const selection = $getSelection();

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -380,7 +380,7 @@ function onPasteForRichText(
   editor.update(() => {
     const selection = $getSelection();
     const clipboardData =
-      event instanceof ClipboardEvent ? event.clipboardData : null;
+      event instanceof InputEvent ? null : event.clipboardData;
     if (
       clipboardData != null &&
       ($isRangeSelection(selection) || $isGridSelection(selection))
@@ -398,7 +398,7 @@ function onCopyForRichText(
   const selection = $getSelection();
   if (selection !== null) {
     const clipboardData =
-      event instanceof ClipboardEvent ? event.clipboardData : null;
+      event instanceof KeyboardEvent ? null : event.clipboardData;
     const htmlString = $getHtmlContent(editor);
     const lexicalString = $getLexicalContent(editor);
 

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -518,7 +518,7 @@ export function registerRichText(
       },
       COMMAND_PRIORITY_EDITOR,
     ),
-    editor.registerCommand<InputEvent | string>(
+    editor.registerCommand(
       CONTROLLED_TEXT_INSERTION_COMMAND,
       (eventOrText) => {
         const selection = $getSelection();

--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -19,8 +19,9 @@ export const DELETE_CHARACTER_COMMAND: LexicalCommand<boolean> =
 export const INSERT_LINE_BREAK_COMMAND: LexicalCommand<boolean> =
   createCommand();
 export const INSERT_PARAGRAPH_COMMAND: LexicalCommand<void> = createCommand();
-export const CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<string> =
-  createCommand();
+export const CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<
+  InputEvent | string
+> = createCommand();
 export const PASTE_COMMAND: LexicalCommand<ClipboardEvent> = createCommand();
 export const REMOVE_TEXT_COMMAND: LexicalCommand<void> = createCommand();
 export const DELETE_WORD_COMMAND: LexicalCommand<boolean> = createCommand();

--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -8,10 +8,6 @@
 
 import type {ElementFormatType, LexicalCommand, TextFormatType} from 'lexical';
 
-export type CommandPayloadType<C> = C extends LexicalCommand<infer R>
-  ? R
-  : never;
-
 export function createCommand<T>(): LexicalCommand<T> {
   return {};
 }

--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -8,6 +8,10 @@
 
 import type {ElementFormatType, LexicalCommand, TextFormatType} from 'lexical';
 
+export type CommandPayloadType<C> = C extends LexicalCommand<infer R>
+  ? R
+  : never;
+
 export function createCommand<T>(): LexicalCommand<T> {
   return {};
 }
@@ -22,7 +26,8 @@ export const INSERT_PARAGRAPH_COMMAND: LexicalCommand<void> = createCommand();
 export const CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<
   InputEvent | string
 > = createCommand();
-export const PASTE_COMMAND: LexicalCommand<ClipboardEvent> = createCommand();
+export const PASTE_COMMAND: LexicalCommand<ClipboardEvent | InputEvent> =
+  createCommand();
 export const REMOVE_TEXT_COMMAND: LexicalCommand<void> = createCommand();
 export const DELETE_WORD_COMMAND: LexicalCommand<boolean> = createCommand();
 export const DELETE_LINE_COMMAND: LexicalCommand<boolean> = createCommand();
@@ -58,8 +63,10 @@ export const FORMAT_ELEMENT_COMMAND: LexicalCommand<ElementFormatType> =
 export const DRAGSTART_COMMAND: LexicalCommand<DragEvent> = createCommand();
 export const DRAGOVER_COMMAND: LexicalCommand<DragEvent> = createCommand();
 export const DRAGEND_COMMAND: LexicalCommand<DragEvent> = createCommand();
-export const COPY_COMMAND: LexicalCommand<ClipboardEvent> = createCommand();
-export const CUT_COMMAND: LexicalCommand<ClipboardEvent> = createCommand();
+export const COPY_COMMAND: LexicalCommand<ClipboardEvent | KeyboardEvent> =
+  createCommand();
+export const CUT_COMMAND: LexicalCommand<ClipboardEvent | KeyboardEvent> =
+  createCommand();
 export const CLEAR_EDITOR_COMMAND: LexicalCommand<void> = createCommand();
 export const CLEAR_HISTORY_COMMAND: LexicalCommand<void> = createCommand();
 export const CAN_REDO_COMMAND: LexicalCommand<boolean> = createCommand();

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -170,11 +170,30 @@ export const COMMAND_PRIORITY_NORMAL = 2;
 export const COMMAND_PRIORITY_HIGH = 3;
 export const COMMAND_PRIORITY_CRITICAL = 4;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-interface
-export interface LexicalCommand<TPayload> {}
-export type CommandPayloadType<C> = C extends LexicalCommand<infer R>
-  ? R
-  : never;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type LexicalCommand<TPayload> = Record<string, never>;
+/**
+ * Type helper for extracting the payload type from a command.
+ *
+ * @example
+ * ```ts
+ * const MY_COMMAND = createCommand<SomeType>();
+ *
+ * // ...
+ *
+ * editor.registerCommand(MY_COMMAND, payload => {
+ *   // Type of `payload` is inferred here. But lets say we want to extract a function to delegate to
+ *   handleMyCommand(editor, payload);
+ *   return true;
+ * });
+ *
+ * function handleMyCommand(editor: LexicalEditor, payload: CommandPayloadType<typeof MY_COMMAND>) {
+ *   // `payload` is of type `SomeType`, extracted from the command.
+ * }
+ * ```
+ */
+export type CommandPayloadType<TCommand extends LexicalCommand<unknown>> =
+  TCommand extends LexicalCommand<infer TPayload> ? TPayload : never;
 
 type Commands = Map<
   LexicalCommand<unknown>,

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -171,7 +171,13 @@ export const COMMAND_PRIORITY_HIGH = 3;
 export const COMMAND_PRIORITY_CRITICAL = 4;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type LexicalCommand<T = never> = Readonly<Record<string, unknown>>;
+export type LexicalCommand<T = never> = Readonly<{
+  /**
+   * Capture the type of the payload this command expects. This ensures that `dispatchCommand` and `registerCommand` can
+   * correctly enforce and infer the payload later on
+   */
+  _payloadType?: T;
+}>;
 type Commands = Map<
   LexicalCommand<unknown>,
   Array<Set<CommandListener<unknown>>>

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -170,14 +170,12 @@ export const COMMAND_PRIORITY_NORMAL = 2;
 export const COMMAND_PRIORITY_HIGH = 3;
 export const COMMAND_PRIORITY_CRITICAL = 4;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type LexicalCommand<T = never> = Readonly<{
-  /**
-   * Capture the type of the payload this command expects. This ensures that `dispatchCommand` and `registerCommand` can
-   * correctly enforce and infer the payload later on
-   */
-  _payloadType?: T;
-}>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-interface
+export interface LexicalCommand<TPayload> {}
+export type CommandPayloadType<C> = C extends LexicalCommand<infer R>
+  ? R
+  : never;
+
 type Commands = Map<
   LexicalCommand<unknown>,
   Array<Set<CommandListener<unknown>>>
@@ -640,7 +638,10 @@ export class LexicalEditor {
     return true;
   }
 
-  dispatchCommand<P>(type: LexicalCommand<P>, payload: P): boolean {
+  dispatchCommand<
+    TCommand extends LexicalCommand<unknown>,
+    TPayload extends CommandPayloadType<TCommand>,
+  >(type: TCommand, payload: TPayload): boolean {
     return dispatchCommand(this, type, payload);
   }
 

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -487,7 +487,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
     if (inputType === 'insertText') {
       if (data === '\n') {
         event.preventDefault();
-        dispatchCommand(editor, INSERT_LINE_BREAK_COMMAND, undefined);
+        dispatchCommand(editor, INSERT_LINE_BREAK_COMMAND, false);
       } else if (data === DOUBLE_LINE_BREAK) {
         event.preventDefault();
         dispatchCommand(editor, INSERT_PARAGRAPH_COMMAND, undefined);
@@ -530,7 +530,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
       case 'insertLineBreak': {
         // Used for Android
         $setCompositionKey(null);
-        dispatchCommand(editor, INSERT_LINE_BREAK_COMMAND, undefined);
+        dispatchCommand(editor, INSERT_LINE_BREAK_COMMAND, false);
         break;
       }
 
@@ -542,7 +542,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
         // So instead, we need to infer it from the keyboard event.
         if (isInsertLineBreak) {
           isInsertLineBreak = false;
-          dispatchCommand(editor, INSERT_LINE_BREAK_COMMAND, undefined);
+          dispatchCommand(editor, INSERT_LINE_BREAK_COMMAND, false);
         } else {
           dispatchCommand(editor, INSERT_PARAGRAPH_COMMAND, undefined);
         }
@@ -972,31 +972,67 @@ export function addRootElementEvents(
             if (!editor.isReadOnly()) {
               switch (eventName) {
                 case 'cut':
-                  return dispatchCommand(editor, CUT_COMMAND, event);
+                  return dispatchCommand(
+                    editor,
+                    CUT_COMMAND,
+                    event as ClipboardEvent,
+                  );
 
                 case 'copy':
-                  return dispatchCommand(editor, COPY_COMMAND, event);
+                  return dispatchCommand(
+                    editor,
+                    COPY_COMMAND,
+                    event as ClipboardEvent,
+                  );
 
                 case 'paste':
-                  return dispatchCommand(editor, PASTE_COMMAND, event);
+                  return dispatchCommand(
+                    editor,
+                    PASTE_COMMAND,
+                    event as ClipboardEvent,
+                  );
 
                 case 'dragstart':
-                  return dispatchCommand(editor, DRAGSTART_COMMAND, event);
+                  return dispatchCommand(
+                    editor,
+                    DRAGSTART_COMMAND,
+                    event as DragEvent,
+                  );
 
                 case 'dragover':
-                  return dispatchCommand(editor, DRAGOVER_COMMAND, event);
+                  return dispatchCommand(
+                    editor,
+                    DRAGOVER_COMMAND,
+                    event as DragEvent,
+                  );
 
                 case 'dragend':
-                  return dispatchCommand(editor, DRAGEND_COMMAND, event);
+                  return dispatchCommand(
+                    editor,
+                    DRAGEND_COMMAND,
+                    event as DragEvent,
+                  );
 
                 case 'focus':
-                  return dispatchCommand(editor, FOCUS_COMMAND, event);
+                  return dispatchCommand(
+                    editor,
+                    FOCUS_COMMAND,
+                    event as FocusEvent,
+                  );
 
                 case 'blur':
-                  return dispatchCommand(editor, BLUR_COMMAND, event);
+                  return dispatchCommand(
+                    editor,
+                    BLUR_COMMAND,
+                    event as FocusEvent,
+                  );
 
                 case 'drop':
-                  return dispatchCommand(editor, DROP_COMMAND, event);
+                  return dispatchCommand(
+                    editor,
+                    DROP_COMMAND,
+                    event as DragEvent,
+                  );
               }
             }
           };

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -7,6 +7,7 @@
  */
 
 import type {
+  CommandPayloadType,
   EditorThemeClasses,
   IntentionallyMarkedAsDirtyElement,
   Klass,
@@ -1098,11 +1099,10 @@ export function isFirefoxClipboardEvents(): boolean {
   );
 }
 
-export function dispatchCommand<P>(
-  editor: LexicalEditor,
-  type: LexicalCommand<P>,
-  payload: P,
-): boolean {
+export function dispatchCommand<
+  TCommand extends LexicalCommand<unknown>,
+  TPayload extends CommandPayloadType<TCommand>,
+>(editor: LexicalEditor, type: TCommand, payload: TPayload): boolean {
   return triggerCommandListeners(editor, type, payload);
 }
 

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -6,6 +6,7 @@
  *
  */
 
+export type {CommandPayloadType} from './LexicalCommands';
 export type {
   CommandListenerPriority,
   EditorConfig,

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -6,9 +6,9 @@
  *
  */
 
-export type {CommandPayloadType} from './LexicalCommands';
 export type {
   CommandListenerPriority,
+  CommandPayloadType,
   EditorConfig,
   EditorThemeClasses,
   IntentionallyMarkedAsDirtyElement,


### PR DESCRIPTION
Implements inference and enforcement of the payload type for `LexicalCommand`, as discussed in point 2. in #2536.