### PR TITLE
Add ability to set format and details on TextNode by `string`

### DIFF
--- a/packages/lexical/src/LexicalConstants.ts
+++ b/packages/lexical/src/LexicalConstants.ts
@@ -7,7 +7,11 @@
  */
 
 import type {ElementFormatType} from './nodes/LexicalElementNode';
-import type {TextFormatType, TextModeType} from './nodes/LexicalTextNode';
+import type {
+  TextDetailType,
+  TextFormatType,
+  TextModeType,
+} from './nodes/LexicalTextNode';
 
 import {IS_FIREFOX, IS_IOS, IS_SAFARI} from 'shared/environment';
 
@@ -78,6 +82,11 @@ export const TEXT_TYPE_TO_FORMAT: Record<TextFormatType | string, number> = {
   subscript: IS_SUBSCRIPT,
   superscript: IS_SUPERSCRIPT,
   underline: IS_UNDERLINE,
+};
+
+export const DETAIL_TYPE_TO_DETAIL: Record<TextDetailType | string, number> = {
+  directionless: IS_DIRECTIONLESS,
+  unmergeable: IS_UNMERGEABLE,
 };
 
 export const ELEMENT_TYPE_TO_FORMAT: Record<

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -25,6 +25,7 @@ import invariant from 'shared/invariant';
 
 import {
   COMPOSITION_SUFFIX,
+  DETAIL_TYPE_TO_DETAIL,
   IS_BOLD,
   IS_CODE,
   IS_DIRECTIONLESS,
@@ -77,6 +78,8 @@ export type TextFormatType =
   | 'code'
   | 'subscript'
   | 'superscript';
+
+export type TextDetailType = 'directionless' | 'unmergable';
 
 export type TextModeType = 'normal' | 'token' | 'segmented' | 'inert';
 
@@ -500,17 +503,21 @@ export class TextNode extends LexicalNode {
     return;
   }
 
-  setFormat(format: number): this {
+  // TODO 0.4 This should just be a `string`.
+  setFormat(format: TextFormatType | number): this {
     errorOnReadOnly();
     const self = this.getWritable();
-    self.__format = format;
+    self.__format =
+      typeof format === 'string' ? TEXT_TYPE_TO_FORMAT[format] : format;
     return self;
   }
 
-  setDetail(detail: number): this {
+  // TODO 0.4 This should just be a `string`.
+  setDetail(detail: TextDetailType | number): this {
     errorOnReadOnly();
     const self = this.getWritable();
-    self.__detail = detail;
+    self.__detail =
+      typeof detail === 'string' ? DETAIL_TYPE_TO_DETAIL[detail] : detail;
     return self;
   }
 


### PR DESCRIPTION
Small improvement to the API of `TextNode`, to make the logic consistent with `toggleFormat`

Closes #2491 