### PR TITLE
Remove `white-space: pre-wrap;` for tree view

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -86,7 +86,6 @@ pre {
   padding: 10px;
   font-size: 12px;
   overflow: auto;
-  white-space: pre-wrap;
   max-height: 180px;
 }
 
@@ -96,13 +95,11 @@ pre {
   color: #fff;
   padding: 0;
   font-size: 12px;
-  white-space: pre-wrap;
   margin: 1px auto 10px auto;
   max-height: 250px;
   position: relative;
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
-  overflow: hidden;
 }
 
 pre::-webkit-scrollbar {


### PR DESCRIPTION
Selection indicators do not wrap with wrapping text in the TreeView. It seems easiest to just remove the wrapping and show the indicators below the text with the correct scroll bars showing.

![image](https://user-images.githubusercontent.com/7748470/176204049-7efbf548-2f46-4107-a5b8-b8149dd8a0e1.png)

Closes #2311