### PR TITLE
fix(lexical): deselecting a image/poll node by clicking

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -66,6 +66,7 @@ import {
 import {KEY_MODIFIER_COMMAND} from './LexicalCommands';
 import {
   COMPOSITION_START_CHAR,
+  DOM_ELEMENT_TYPE,
   DOM_TEXT_TYPE,
   DOUBLE_LINE_BREAK,
 } from './LexicalConstants';
@@ -310,7 +311,10 @@ function onClick(event: MouseEvent, editor: LexicalEditor): void {
       const domAnchor = domSelection.anchorNode;
       // If the user is attempting to click selection back onto text, then
       // we should attempt create a range selection.
-      if (domAnchor !== null && domAnchor.nodeType === DOM_TEXT_TYPE) {
+      // When we click on an empty paragraph node or the end of a paragraph that ends
+      // with an image/poll, the nodeType will be ELEMENT_NODE
+      const allowedNodeType = [DOM_ELEMENT_TYPE, DOM_TEXT_TYPE];
+      if (domAnchor !== null && allowedNodeType.includes(domAnchor.nodeType)) {
         const newSelection = internalCreateRangeSelection(
           lastSelection,
           domSelection,


### PR DESCRIPTION
### Description
After we have selected an image/poll. When we click on an empty paragraph node or the end of a paragraph that ends with an image/poll, the `domAnchor.nodeType` will be ELEMENT_NODE


https://user-images.githubusercontent.com/22126563/176342847-82d30cc5-7094-4f9d-abd7-cbf428a15b02.mov



closes #2457 