### PR TITLE
fix: commenting issue after ts migration

### DIFF
--- a/packages/lexical-playground/src/commenting/index.ts
+++ b/packages/lexical-playground/src/commenting/index.ts
@@ -362,9 +362,11 @@ export class CommentStore {
                           map.get('timeStamp'),
                         );
                   this._withLocalTransaction(() => {
-                    if (parentThread !== undefined && parentThread !== false) {
-                      this.addComment(commentOrThread, parentThread, offset);
-                    }
+                    this.addComment(
+                      commentOrThread,
+                      parentThread as Thread,
+                      offset,
+                    );
                   });
                 });
               } else if (typeof retain === 'number') {
@@ -376,9 +378,7 @@ export class CommentStore {
                       ? this._comments[offset]
                       : parentThread.comments[offset];
                   this._withLocalTransaction(() => {
-                    if (parentThread !== undefined && parentThread !== false) {
-                      this.deleteComment(commentOrThread, parentThread);
-                    }
+                    this.deleteComment(commentOrThread, parentThread as Thread);
                   });
                   offset++;
                 }


### PR DESCRIPTION
Commenting is not working in collab mode after the #2496 TS migration. This PR fixes it.
### Before

[Can be reproduced on [playground](https://playground.lexical.dev/split?isCollab=true) as well]

https://user-images.githubusercontent.com/64399555/176446636-819079c8-fc89-4fcd-847f-aaead5311516.mp4

### After

https://user-images.githubusercontent.com/64399555/176446981-2e682ec9-aae8-47c3-bbc9-efcf0e366323.mp4

