### PR TITLE
npm run changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,9 @@
     "prepare-release": "npm run build-release && node ./scripts/npm/prepare-release.js",
     "prepare": "husky install",
     "prepare-www": "node scripts/www/rewriteImports.js",
-    "release": "npm run prepare-release && node ./scripts/npm/release.js",
-    "update-version": "node ./scripts/updateVersion"
+    "changelog": "func() { git log --oneline ${1}...HEAD --pretty=format:\"- %s %an\"; }; func",
+    "update-version": "node ./scripts/updateVersion",
+    "release": "npm run prepare-release && node ./scripts/npm/release.js"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",


### PR DESCRIPTION
```
- fix(lexical): Text with underline format is stripped out on paste (#2555) 子瞻 Luci
- Trigger readonly listener only when value has changed (#2550) Maksim Horbachevsky
- fix(lexical): deselecting a decorator node by clicking (#2554) 子瞻 Luci
- Remove wordwrap for tree view (#2551) John Flockton
- add docs for headless package (#2539) Acy Watson
```