### PR TITLE
feat: new way to delete comments and threads

### DIFF
--- a/packages/lexical-playground/src/commenting/index.ts
+++ b/packages/lexical-playground/src/commenting/index.ts
@@ -171,8 +171,7 @@ export class CommentStore {
   deleteCommentOrThread(
     commentOrThread: Comment | Thread,
     thread?: Thread,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): any {
+  ): {markedComment: Comment; index: number} | null {
     const nextComments = Array.from(this._comments);
     // The YJS types explicitly use `any` as well.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -213,7 +212,7 @@ export class CommentStore {
 
     if (commentOrThread.type === 'comment') {
       return {
-        index: commentIndex,
+        index: commentIndex as number,
         markedComment: markDeleted(commentOrThread as Comment),
       };
     }

--- a/packages/lexical-playground/src/commenting/index.ts
+++ b/packages/lexical-playground/src/commenting/index.ts
@@ -23,6 +23,7 @@ import {
 export type Comment = {
   author: string;
   content: string;
+  deleted: boolean;
   id: string;
   timeStamp: number;
   type: 'comment';
@@ -49,10 +50,12 @@ export function createComment(
   author: string,
   id?: string,
   timeStamp?: number,
+  deleted?: boolean,
 ): Comment {
   return {
     author,
     content,
+    deleted: deleted === undefined ? false : deleted,
     id: id === undefined ? createUID() : id,
     timeStamp: timeStamp === undefined ? performance.now() : timeStamp,
     type: 'comment',
@@ -78,6 +81,17 @@ function cloneThread(thread: Thread): Thread {
     id: thread.id,
     quote: thread.quote,
     type: 'thread',
+  };
+}
+
+function markDeleted(comment: Comment): Comment {
+  return {
+    author: comment.author,
+    content: '[Deleted Comment]',
+    deleted: true,
+    id: comment.id,
+    timeStamp: comment.timeStamp,
+    type: 'comment',
   };
 }
 
@@ -125,7 +139,8 @@ export class CommentStore {
         if (comment.type === 'thread' && comment.id === thread.id) {
           const newThread = cloneThread(comment);
           nextComments.splice(i, 1, newThread);
-          const insertOffset = offset || newThread.comments.length;
+          const insertOffset =
+            offset !== undefined ? offset : newThread.comments.length;
           if (this.isCollaborative() && sharedCommentsArray !== null) {
             const parentSharedArray = sharedCommentsArray
               .get(i)
@@ -140,11 +155,11 @@ export class CommentStore {
         }
       }
     } else {
-      const insertOffset = offset || nextComments.length;
+      const insertOffset = offset !== undefined ? offset : nextComments.length;
       if (this.isCollaborative() && sharedCommentsArray !== null) {
         this._withRemoteTransaction(() => {
           const sharedMap = this._createCollabSharedMap(commentOrThread);
-          sharedCommentsArray.insert(nextComments.length, [sharedMap]);
+          sharedCommentsArray.insert(insertOffset, [sharedMap]);
         });
       }
       nextComments.splice(insertOffset, 0, commentOrThread);
@@ -153,11 +168,16 @@ export class CommentStore {
     triggerOnChange(this);
   }
 
-  deleteComment(commentOrThread: Comment | Thread, thread?: Thread): void {
+  deleteCommentOrThread(
+    commentOrThread: Comment | Thread,
+    thread?: Thread,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): any {
     const nextComments = Array.from(this._comments);
     // The YJS types explicitly use `any` as well.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sharedCommentsArray: YArray<any> | null = this._getCollabComments();
+    let commentIndex: number | null = null;
 
     if (thread !== undefined) {
       for (let i = 0; i < nextComments.length; i++) {
@@ -166,40 +186,39 @@ export class CommentStore {
           const newThread = cloneThread(nextComment);
           nextComments.splice(i, 1, newThread);
           const threadComments = newThread.comments;
-          if (threadComments.length === 1) {
-            const threadIndex = nextComments.indexOf(newThread);
-            if (this.isCollaborative() && sharedCommentsArray !== null) {
-              this._withRemoteTransaction(() => {
-                sharedCommentsArray.delete(threadIndex);
-              });
-            }
-            nextComments.splice(threadIndex, 1);
-          } else {
-            const index = threadComments.indexOf(commentOrThread as Comment);
-            if (this.isCollaborative() && sharedCommentsArray !== null) {
-              const parentSharedArray = sharedCommentsArray
-                .get(i)
-                .get('comments');
-              this._withRemoteTransaction(() => {
-                parentSharedArray.delete(index);
-              });
-            }
-            threadComments.splice(index, 1);
+          commentIndex = threadComments.indexOf(commentOrThread as Comment);
+          if (this.isCollaborative() && sharedCommentsArray !== null) {
+            const parentSharedArray = sharedCommentsArray
+              .get(i)
+              .get('comments');
+            this._withRemoteTransaction(() => {
+              parentSharedArray.delete(commentIndex);
+            });
           }
+          threadComments.splice(commentIndex, 1);
           break;
         }
       }
     } else {
-      const index = nextComments.indexOf(commentOrThread);
+      commentIndex = nextComments.indexOf(commentOrThread);
       if (this.isCollaborative() && sharedCommentsArray !== null) {
         this._withRemoteTransaction(() => {
-          sharedCommentsArray.delete(index);
+          sharedCommentsArray.delete(commentIndex as number);
         });
       }
-      nextComments.splice(index, 1);
+      nextComments.splice(commentIndex, 1);
     }
     this._comments = nextComments;
     triggerOnChange(this);
+
+    if (commentOrThread.type === 'comment') {
+      return {
+        index: commentIndex,
+        markedComment: markDeleted(commentOrThread as Comment),
+      };
+    }
+
+    return null;
   }
 
   registerOnChange(onChange: () => void): () => void {
@@ -251,6 +270,7 @@ export class CommentStore {
     if (type === 'comment') {
       sharedMap.set('author', commentOrThread.author);
       sharedMap.set('content', commentOrThread.content);
+      sharedMap.set('deleted', commentOrThread.deleted);
       sharedMap.set('timeStamp', commentOrThread.timeStamp);
     } else {
       sharedMap.set('quote', commentOrThread.quote);
@@ -345,13 +365,20 @@ export class CommentStore {
                             .get('comments')
                             .toArray()
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            .map((innerComment: Map<string, string | number>) =>
-                              createComment(
-                                innerComment.get('content') as string,
-                                innerComment.get('author') as string,
-                                innerComment.get('id') as string,
-                                innerComment.get('timeStamp') as number,
-                              ),
+                            .map(
+                              (
+                                innerComment: Map<
+                                  string,
+                                  string | number | boolean
+                                >,
+                              ) =>
+                                createComment(
+                                  innerComment.get('content') as string,
+                                  innerComment.get('author') as string,
+                                  innerComment.get('id') as string,
+                                  innerComment.get('timeStamp') as number,
+                                  innerComment.get('deleted') as boolean,
+                                ),
                             ),
                           id,
                         )
@@ -360,6 +387,7 @@ export class CommentStore {
                           map.get('author'),
                           id,
                           map.get('timeStamp'),
+                          map.get('deleted'),
                         );
                   this._withLocalTransaction(() => {
                     this.addComment(
@@ -378,7 +406,10 @@ export class CommentStore {
                       ? this._comments[offset]
                       : parentThread.comments[offset];
                   this._withLocalTransaction(() => {
-                    this.deleteComment(commentOrThread, parentThread as Thread);
+                    this.deleteCommentOrThread(
+                      commentOrThread,
+                      parentThread as Thread,
+                    );
                   });
                   offset++;
                 }

--- a/packages/lexical-playground/src/plugins/CommentPlugin.css
+++ b/packages/lexical-playground/src/plugins/CommentPlugin.css
@@ -353,11 +353,14 @@ i.send {
   cursor: inherit;
 }
 
-.CommentPlugin_CommentsPanel_List_Thread_Quote {
+.CommentPlugin_CommentsPanel_List_Thread_QuoteBox {
   padding-top: 10px;
-  margin: 0px 10px 0 10px;
   color: #ccc;
   display: block;
+}
+
+.CommentPlugin_CommentsPanel_List_Thread_Quote {
+  margin: 0px 10px 0 10px;
 }
 
 .CommentPlugin_CommentsPanel_List_Thread_Quote span {
@@ -408,7 +411,10 @@ i.send {
   opacity: 0;
 }
 
+.CommentPlugin_CommentsPanel_DeletedComment,
 .CommentPlugin_CommentsPanel_List_Comment:hover
+  .CommentPlugin_CommentsPanel_List_DeleteButton,
+.CommentPlugin_CommentsPanel_List_Thread_QuoteBox:hover
   .CommentPlugin_CommentsPanel_List_DeleteButton {
   opacity: 0.5;
 }

--- a/packages/lexical-playground/src/plugins/CommentPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin.tsx
@@ -778,10 +778,12 @@ export default function CommentPlugin({
   const deleteCommentOrThread = useCallback(
     (comment: Comment | Thread, thread?: Thread) => {
       if (comment.type === 'comment') {
-        const {markedComment, index} = commentStore.deleteCommentOrThread(
+        const deletionInfo = commentStore.deleteCommentOrThread(
           comment,
           thread,
         );
+        if (!deletionInfo) return;
+        const {markedComment, index} = deletionInfo;
         commentStore.addComment(markedComment, thread, index);
       } else {
         commentStore.deleteCommentOrThread(comment);

--- a/packages/lexical-playground/src/plugins/CommentPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin.tsx
@@ -423,16 +423,16 @@ function CommentsPanelFooter({
   );
 }
 
-function ShowDeleteCommentDialog({
-  comment,
-  deleteComment,
+function ShowDeleteCommentOrThreadDialog({
+  commentOrThread,
+  deleteCommentOrThread,
   onClose,
-  thread,
+  thread = undefined,
 }: {
-  comment: Comment;
+  commentOrThread: Comment | Thread;
 
-  deleteComment: (
-    commentOrThread: Comment,
+  deleteCommentOrThread: (
+    comment: Comment | Thread,
     // eslint-disable-next-line no-shadow
     thread?: Thread,
   ) => void;
@@ -441,11 +441,11 @@ function ShowDeleteCommentDialog({
 }): JSX.Element {
   return (
     <>
-      Are you sure you want to delete this comment?
+      Are you sure you want to delete this {commentOrThread.type}?
       <div className="Modal__content">
         <Button
           onClick={() => {
-            deleteComment(comment, thread);
+            deleteCommentOrThread(commentOrThread, thread);
             onClose();
           }}>
           Delete
@@ -469,7 +469,7 @@ function CommentsPanelListComment({
 }: {
   comment: Comment;
   deleteComment: (
-    commentOrThread: Comment,
+    commentOrThread: Comment | Thread,
     // eslint-disable-next-line no-shadow
     thread?: Thread,
   ) => void;
@@ -490,22 +490,31 @@ function CommentsPanelListComment({
           · {seconds > -10 ? 'Just now' : rtf.format(minutes, 'minute')}
         </span>
       </div>
-      <p>{comment.content}</p>
-      <Button
-        onClick={() => {
-          showModal('Delete Comment', (onClose) => (
-            <ShowDeleteCommentDialog
-              comment={comment}
-              deleteComment={deleteComment}
-              thread={thread}
-              onClose={onClose}
-            />
-          ));
-        }}
-        className="CommentPlugin_CommentsPanel_List_DeleteButton">
-        <i className="delete" />
-      </Button>
-      {modal}
+      <p
+        className={
+          comment.deleted ? 'CommentPlugin_CommentsPanel_DeletedComment' : ''
+        }>
+        {comment.content}
+      </p>
+      {!comment.deleted && (
+        <>
+          <Button
+            onClick={() => {
+              showModal('Delete Comment', (onClose) => (
+                <ShowDeleteCommentOrThreadDialog
+                  commentOrThread={comment}
+                  deleteCommentOrThread={deleteComment}
+                  thread={thread}
+                  onClose={onClose}
+                />
+              ));
+            }}
+            className="CommentPlugin_CommentsPanel_List_DeleteButton">
+            <i className="delete" />
+          </Button>
+          {modal}
+        </>
+      )}
     </li>
   );
 }
@@ -513,14 +522,17 @@ function CommentsPanelListComment({
 function CommentsPanelList({
   activeIDs,
   comments,
-  deleteComment,
+  deleteCommentOrThread,
   listRef,
   submitAddComment,
   markNodeMap,
 }: {
   activeIDs: Array<string>;
   comments: Comments;
-  deleteComment: (commentOrThread: Comment, thread?: Thread) => void;
+  deleteCommentOrThread: (
+    commentOrThread: Comment | Thread,
+    thread?: Thread,
+  ) => void;
   listRef: {current: null | HTMLUListElement};
   markNodeMap: Map<string, Set<NodeKey>>;
   submitAddComment: (
@@ -531,6 +543,7 @@ function CommentsPanelList({
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
   const [counter, setCounter] = useState(0);
+  const [modal, showModal] = useModal();
   const rtf = useMemo(
     () =>
       new Intl.RelativeTimeFormat('en', {
@@ -594,15 +607,33 @@ function CommentsPanelList({
               className={`CommentPlugin_CommentsPanel_List_Thread ${
                 markNodeMap.has(id) ? 'interactive' : ''
               } ${activeIDs.indexOf(id) === -1 ? '' : 'active'}`}>
-              <blockquote className="CommentPlugin_CommentsPanel_List_Thread_Quote">
-                `{'> '}`<span>{commentOrThread.quote}</span>
-              </blockquote>
+              <div className="CommentPlugin_CommentsPanel_List_Thread_QuoteBox">
+                <blockquote className="CommentPlugin_CommentsPanel_List_Thread_Quote">
+                  {'> '}
+                  <span>{commentOrThread.quote}</span>
+                </blockquote>
+                {/* INTRODUCE DELETE THREAD HERE*/}
+                <Button
+                  onClick={() => {
+                    showModal('Delete Thread', (onClose) => (
+                      <ShowDeleteCommentOrThreadDialog
+                        commentOrThread={commentOrThread}
+                        deleteCommentOrThread={deleteCommentOrThread}
+                        onClose={onClose}
+                      />
+                    ));
+                  }}
+                  className="CommentPlugin_CommentsPanel_List_DeleteButton">
+                  <i className="delete" />
+                </Button>
+                {modal}
+              </div>
               <ul className="CommentPlugin_CommentsPanel_List_Thread_Comments">
                 {commentOrThread.comments.map((comment) => (
                   <CommentsPanelListComment
                     key={comment.id}
                     comment={comment}
-                    deleteComment={deleteComment}
+                    deleteComment={deleteCommentOrThread}
                     thread={commentOrThread}
                     rtf={rtf}
                   />
@@ -622,7 +653,7 @@ function CommentsPanelList({
           <CommentsPanelListComment
             key={id}
             comment={commentOrThread}
-            deleteComment={deleteComment}
+            deleteComment={deleteCommentOrThread}
             rtf={rtf}
           />
         );
@@ -633,14 +664,17 @@ function CommentsPanelList({
 
 function CommentsPanel({
   activeIDs,
-  deleteComment,
+  deleteCommentOrThread,
   comments,
   submitAddComment,
   markNodeMap,
 }: {
   activeIDs: Array<string>;
   comments: Comments;
-  deleteComment: (commentOrThread: Comment, thread?: Thread) => void;
+  deleteCommentOrThread: (
+    commentOrThread: Comment | Thread,
+    thread?: Thread,
+  ) => void;
   markNodeMap: Map<string, Set<NodeKey>>;
   submitAddComment: (
     commentOrThread: Comment | Thread,
@@ -682,7 +716,7 @@ function CommentsPanel({
         <CommentsPanelList
           activeIDs={activeIDs}
           comments={comments}
-          deleteComment={deleteComment}
+          deleteCommentOrThread={deleteCommentOrThread}
           listRef={listRef}
           submitAddComment={submitAddComment}
           markNodeMap={markNodeMap}
@@ -741,27 +775,35 @@ export default function CommentPlugin({
     setShowCommentInput(false);
   }, [editor]);
 
-  const deleteComment = useCallback(
-    (comment: Comment, thread?: Thread) => {
-      commentStore.deleteComment(comment, thread);
-      // Remove ids from associated marks
-      const id = thread !== undefined ? thread.id : comment.id;
-      const markNodeKeys = markNodeMap.get(id);
-      if (markNodeKeys !== undefined) {
-        // Do async to avoid causing a React infinite loop
-        setTimeout(() => {
-          editor.update(() => {
-            for (const key of markNodeKeys) {
-              const node: null | MarkNode = $getNodeByKey(key);
-              if ($isMarkNode(node)) {
-                node.deleteID(id);
-                if (node.getIDs().length === 0) {
-                  $unwrapMarkNode(node);
+  const deleteCommentOrThread = useCallback(
+    (comment: Comment | Thread, thread?: Thread) => {
+      if (comment.type === 'comment') {
+        const {markedComment, index} = commentStore.deleteCommentOrThread(
+          comment,
+          thread,
+        );
+        commentStore.addComment(markedComment, thread, index);
+      } else {
+        commentStore.deleteCommentOrThread(comment);
+        // Remove ids from associated marks
+        const id = thread !== undefined ? thread.id : comment.id;
+        const markNodeKeys = markNodeMap.get(id);
+        if (markNodeKeys !== undefined) {
+          // Do async to avoid causing a React infinite loop
+          setTimeout(() => {
+            editor.update(() => {
+              for (const key of markNodeKeys) {
+                const node: null | MarkNode = $getNodeByKey(key);
+                if ($isMarkNode(node)) {
+                  node.deleteID(id);
+                  if (node.getIDs().length === 0) {
+                    $unwrapMarkNode(node);
+                  }
                 }
               }
-            }
+            });
           });
-        });
+        }
       }
     },
     [commentStore, editor, markNodeMap],
@@ -973,7 +1015,7 @@ export default function CommentPlugin({
           <CommentsPanel
             comments={comments}
             submitAddComment={submitAddComment}
-            deleteComment={deleteComment}
+            deleteCommentOrThread={deleteCommentOrThread}
             activeIDs={activeIDs}
             markNodeMap={markNodeMap}
           />,


### PR DESCRIPTION
Fixes #2494

This modifies the code to introduce thread deletion too (removal), while comments are marked as deleted on deletion. Demo:

https://user-images.githubusercontent.com/64399555/176635280-a3a39f2a-4830-44b8-b083-75e6fe743613.mp4


