### PR TITLE
Customize default focus position

### DIFF
--- a/packages/lexical-react/flow/LexicalAutoFocusPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalAutoFocusPlugin.js.flow
@@ -7,4 +7,8 @@
  * @flow strict
  */
 
-declare export function AutoFocusPlugin(): null;
+type Props = $ReadOnly<{
+  defaultSelection?: 'rootStart' | 'rootEnd',
+}>;
+
+declare export function AutoFocusPlugin(props: Props): null;

--- a/packages/lexical-react/src/LexicalAutoFocusPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoFocusPlugin.ts
@@ -9,27 +9,34 @@
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
 
-export function AutoFocusPlugin(): null {
+type Props = {
+  defaultSelection?: 'rootStart' | 'rootEnd';
+};
+
+export function AutoFocusPlugin({defaultSelection}: Props): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    editor.focus(() => {
-      // If we try and move selection to the same point with setBaseAndExtent, it won't
-      // trigger a re-focus on the element. So in the case this occurs, we'll need to correct it.
-      // Normally this is fine, Selection API !== Focus API, but fore the intents of the naming
-      // of this plugin, which should preserve focus too.
-      const activeElement = document.activeElement;
-      const rootElement = editor.getRootElement() as HTMLDivElement;
-      if (
-        !rootElement.contains(activeElement) ||
-        rootElement !== null ||
-        activeElement === null
-      ) {
-        // Note: preventScroll won't work in Webkit.
-        rootElement.focus({preventScroll: true});
-      }
-    });
-  }, [editor]);
+    editor.focus(
+      () => {
+        // If we try and move selection to the same point with setBaseAndExtent, it won't
+        // trigger a re-focus on the element. So in the case this occurs, we'll need to correct it.
+        // Normally this is fine, Selection API !== Focus API, but fore the intents of the naming
+        // of this plugin, which should preserve focus too.
+        const activeElement = document.activeElement;
+        const rootElement = editor.getRootElement() as HTMLDivElement;
+        if (
+          !rootElement.contains(activeElement) ||
+          rootElement !== null ||
+          activeElement === null
+        ) {
+          // Note: preventScroll won't work in Webkit.
+          rootElement.focus({preventScroll: true});
+        }
+      },
+      {defaultSelection},
+    );
+  }, [defaultSelection, editor]);
 
   return null;
 }

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -169,7 +169,7 @@ declare export class LexicalEditor {
     updateFn?: () => void,
   ): EditorState;
   update(updateFn: () => void, options?: EditorUpdateOptions): boolean;
-  focus(callbackFn?: () => void): void;
+  focus(callbackFn?: () => void, options?: EditorFocusOptions): void;
   blur(): void;
   isReadOnly(): boolean;
   setReadOnly(readOnly: boolean): void;
@@ -179,6 +179,9 @@ type EditorUpdateOptions = {
   onUpdate?: () => void,
   tag?: string,
   skipTransforms?: true,
+};
+type EditorFocusOptions = {
+  defaultSelection?: 'rootStart' | 'rootEnd',
 };
 type EditorSetOptions = {
   tag?: string,

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -61,6 +61,10 @@ export type EditorSetOptions = {
   tag?: string;
 };
 
+export type EditorFocusOptions = {
+  defaultSelection?: 'rootStart' | 'rootEnd';
+};
+
 export type EditorThemeClasses = {
   characterLimit?: EditorThemeClassName;
   code?: EditorThemeClassName;
@@ -740,7 +744,7 @@ export class LexicalEditor {
     updateEditor(this, updateFn, options);
   }
 
-  focus(callbackFn?: () => void): void {
+  focus(callbackFn?: () => void, options: EditorFocusOptions = {}): void {
     const rootElement = this._rootElement;
 
     if (rootElement !== null) {
@@ -756,7 +760,11 @@ export class LexicalEditor {
             // Marking the selection dirty will force the selection back to it
             selection.dirty = true;
           } else if (root.getChildrenSize() !== 0) {
-            root.selectEnd();
+            if (options.defaultSelection === 'rootStart') {
+              root.selectStart();
+            } else {
+              root.selectEnd();
+            }
           }
         },
         {


### PR DESCRIPTION
For long documents, `selectStart` is often more appropriate, whereas for shorter inputs `selectEnd` is preferable. Let's give the users the option to customize where the initial selection should be