### PR TITLE
[RFC] Allow users to configure HTML exports on core nodes

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -15,7 +15,7 @@ import type {
   SerializedTextNode,
 } from 'lexical';
 
-import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
+import {$generateHtmlFromNodes, $generateNodesFromDOM, DOMExportMap} from '@lexical/html';
 import {$createListNode, $isListItemNode} from '@lexical/list';
 import {
   $addNodeStyle,
@@ -44,7 +44,7 @@ import {
 } from 'lexical';
 import invariant from 'shared/invariant';
 
-export function $getHtmlContent(editor: LexicalEditor): string | null {
+export function $getHtmlContent(editor: LexicalEditor, exportFns?: DOMExportMap): string | null {
   const selection = $getSelection();
 
   if (selection == null) {
@@ -59,7 +59,14 @@ export function $getHtmlContent(editor: LexicalEditor): string | null {
     return null;
   }
 
-  return $generateHtmlFromNodes(editor, selection);
+  let config;
+  if (exportFns !== undefined) {
+    config = {
+      exportOverrides: exportFns
+    }
+  }
+
+  return $generateHtmlFromNodes(editor, selection, config);
 }
 
 export function $getLexicalContent(editor: LexicalEditor): string | null {

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -393,7 +393,14 @@ function onCopyForRichText(event: ClipboardEvent, editor: LexicalEditor): void {
   const selection = $getSelection();
   if (selection !== null) {
     const clipboardData = event.clipboardData;
-    const htmlString = $getHtmlContent(editor);
+    // Users shouldn't have to rewrite this command in order to override a node's HTML export.
+    // Using the global (editor) config allows them to control the behavior here but also maintain
+    let htmlExportFns;
+    const editorExportConfig = editor._exports;
+    if (editorExportConfig !== null && editorExportConfig.html !== undefined) {
+      htmlExportFns = editorExportConfig.html.exportFns;
+    }
+    const htmlString = $getHtmlContent(editor, htmlExportFns);
     const lexicalString = $getLexicalContent(editor);
 
     if (clipboardData != null) {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -7,7 +7,7 @@
  */
 
 import type {EditorState, SerializedEditorState} from './LexicalEditorState';
-import type {DOMConversion, LexicalNode, NodeKey} from './LexicalNode';
+import type {DOMConversion, DOMExportFn, LexicalNode, NodeKey} from './LexicalNode';
 
 import getDOMSelection from 'shared/getDOMSelection';
 import invariant from 'shared/invariant';
@@ -114,6 +114,12 @@ export type EditorConfig = {
   namespace: string;
   theme: EditorThemeClasses;
 };
+
+type ExportConfig = {
+  html?: {
+    exportFns: {[key: string]: DOMExportFn}
+  }
+}
 
 export type RegisteredNodes = Map<string, RegisteredNode>;
 
@@ -287,6 +293,7 @@ export function createEditor(editorConfig?: {
   parentEditor?: LexicalEditor;
   readOnly?: boolean;
   theme?: EditorThemeClasses;
+  exports?: ExportConfig;
 }): LexicalEditor {
   const config = editorConfig || {};
   const activeEditor = internalGetActiveEditor();
@@ -383,6 +390,7 @@ export function createEditor(editorConfig?: {
     onError ? onError : console.error,
     initializeConversionCache(registeredNodes),
     isReadOnly,
+    exports || null
   );
 
   if (initialEditorState !== undefined) {
@@ -419,6 +427,7 @@ export class LexicalEditor {
   _key: string;
   _onError: ErrorHandler;
   _htmlConversions: DOMConversionCache;
+  _exports: ExportConfig | null;
   _readOnly: boolean;
 
   constructor(
@@ -429,6 +438,7 @@ export class LexicalEditor {
     onError: ErrorHandler,
     htmlConversions: DOMConversionCache,
     readOnly: boolean,
+    exports: ExportConfig | null
   ) {
     this._parentEditor = parentEditor;
     // The root element associated with this editor
@@ -476,6 +486,7 @@ export class LexicalEditor {
 
     this._onError = onError;
     this._htmlConversions = htmlConversions;
+    this._exports = exports;
     this._readOnly = false;
     this._headless = false;
   }

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -148,6 +148,8 @@ export type DOMConversionOutput = {
   node: LexicalNode | null;
 };
 
+export type DOMExportFn = (editor: LexicalEditor) => DOMExportOutput
+
 export type DOMExportOutput = {
   after?: (
     generatedElement: HTMLElement | null | undefined,

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -26,6 +26,7 @@ export type {
   DOMConversionFn,
   DOMConversionMap,
   DOMConversionOutput,
+  DOMExportFn,
   DOMExportOutput,
   LexicalNode,
   NodeKey,


### PR DESCRIPTION
Addresses: https://github.com/facebook/lexical/issues/2559

Still thinking through the API here - the idea so far is to allow configurability directly at the @lexical/html level, but also allow overriding defaults for the entire editor via the Editor configuration.

This also needs tests.