### PR TITLE
Added dragend to list of rootElementEvents

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -135,6 +135,7 @@ const rootElementEvents: RootElementEvents = [
   ['copy', PASS_THROUGH_COMMAND],
   ['dragstart', PASS_THROUGH_COMMAND],
   ['dragover', PASS_THROUGH_COMMAND],
+  ['dragend', PASS_THROUGH_COMMAND],
   ['paste', PASS_THROUGH_COMMAND],
   ['focus', PASS_THROUGH_COMMAND],
   ['blur', PASS_THROUGH_COMMAND],


### PR DESCRIPTION
Looks like 90% of the work to add dragend was done here: https://github.com/facebook/lexical/pull/1986

Only missing to add 'dragend' to the list of events.