### PR TITLE
Fix Poll node arrow position

### DIFF
--- a/packages/lexical-playground/src/nodes/PollNode.css
+++ b/packages/lexical-playground/src/nodes/PollNode.css
@@ -100,7 +100,7 @@
   display: block;
   top: 4px;
   width: 5px;
-  start: 8px;
+  left: 8px;
   height: 9px;
   margin: 0;
   transform: rotate(45deg);


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/77036902/177465579-a3f1d790-7864-46af-a908-86efff659b0c.png)

Fixed after using `left` instead of `start`:

![image](https://user-images.githubusercontent.com/77036902/177465626-62ff299b-5830-4fea-a493-0c1fae81cfbd.png)
