### PR TITLE
fix: Verify if there are text nodes before continue

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1052,6 +1052,9 @@ export class RangeSelection implements BaseSelection {
     const selectedTextNodesLength = selectedTextNodes.length;
 
     if (selectedTextNodesLength === 0) {
+      this.toggleFormat(formatType);
+      // When changing format, we should stop composition
+      $setCompositionKey(null);
       return;
     }
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1051,7 +1051,9 @@ export class RangeSelection implements BaseSelection {
     }
     const selectedTextNodesLength = selectedTextNodes.length;
 
-    if (!selectedTextNodesLength) return;
+    if (selectedTextNodesLength === 0) {
+      return;
+    }
 
     let firstIndex = 0;
     const lastIndex = selectedTextNodesLength - 1;

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1050,6 +1050,9 @@ export class RangeSelection implements BaseSelection {
       }
     }
     const selectedTextNodesLength = selectedTextNodes.length;
+
+    if (!selectedTextNodesLength) return;
+
     let firstIndex = 0;
     const lastIndex = selectedTextNodesLength - 1;
     let firstNode = selectedTextNodes[0];


### PR DESCRIPTION
There are cases (like, when the only item in selection is a decorator block) that you will not have text nodes in selection.

This used to fail with `Cannot read properties of undefined (reading 'getFormatFlags')
` previously, now it currently returns abruptly without failing.

Previously:

https://user-images.githubusercontent.com/3399236/178030889-eed3780a-6550-4b55-80f0-7af98dfe09fd.mov

Now:

https://user-images.githubusercontent.com/3399236/178030969-ca3994ec-8def-4a94-889b-fe49ee967745.mov

(basically it will not fail)
