### PR TITLE
Fix unit test warning

### DIFF
--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -29,6 +29,14 @@ class TestNode extends LexicalNode {
   createDOM() {
     return document.createElement('div');
   }
+
+  importJSON() {
+    return new TestNode();
+  }
+
+  exportJSON() {
+    return {type: 'test', version: 1};
+  }
 }
 
 // This is a hack to bypass the node type validation on LexicalNode. We never want to create


### PR DESCRIPTION
This clutters up the output on failures:

```
console.warn
      TestNode should implement "exportJSON" method to ensure JSON and default HTML serialization works as expected
      362 |             !proto.hasOwnProperty('exportJSON')
      363 |           ) {
    > 364 |             console.warn(
          |                     ^
      365 |               `${name} should implement "exportJSON" method to ensure JSON and default HTML serialization works as expected`,
      366 |             );
      367 |           }
      at createEditor (packages/lexical/src/LexicalEditor.ts:364:21)
      at createTestEditor (packages/lexical/src/__tests__/utils/index.tsx:394:30)
      at packages/lexical/src/__tests__/utils/index.tsx:63:25
      at mountMemo (node_modules/react-dom/cjs/react-dom.development.js:17225:19)
      at Object.useMemo (node_modules/react-dom/cjs/react-dom.development.js:17670:16)
      at Object.useMemo (node_modules/react/cjs/react.development.js:1650:21)
      at useLexicalEditor (packages/lexical/src/__tests__/utils/index.tsx:62:35)
      at Editor (packages/lexical/src/__tests__/utils/index.tsx:75:24)
```