### PR TITLE
Selection.extract fix

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1596,7 +1596,7 @@ export class RangeSelection implements BaseSelection {
     if (selectedNodesLength === 0) {
       return [];
     } else if (selectedNodesLength === 1) {
-      if ($isTextNode(firstNode)) {
+      if ($isTextNode(firstNode) && !this.isCollapsed()) {
         const startOffset =
           anchorOffset > focusOffset ? focusOffset : anchorOffset;
         const endOffset =


### PR DESCRIPTION
I think there's some additional weirdness in Selection.extract around partial selection and text splitting (looking at the code, it seems not all the cases are covered), but I think this is more correct than before. Basically, if only a single node is selected and the selection is collapsed, we don't need to worry about splitting or anything - just return that node.