### PR TITLE
fix(lexical-playground): fix toolbar-item button style bug in safari

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1197,6 +1197,7 @@ button.action-button:disabled {
   cursor: pointer;
   vertical-align: middle;
   flex-shrink: 0;
+  align-items: center;
 }
 
 .toolbar button.toolbar-item:disabled {
@@ -1212,7 +1213,6 @@ button.action-button:disabled {
   display: inline-block;
   height: 18px;
   width: 18px;
-  margin-top: 2px;
   vertical-align: -0.25em;
   display: flex;
   opacity: 0.6;


### PR DESCRIPTION
## Description
fix toolbar-item button style bug in safari.

closes #2622 .

before:
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/22126563/178094870-0979b40f-3f8d-42e5-9f54-b60232c41b17.png">

after:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/22126563/178094889-3a6dc102-629a-4466-a3eb-52535f28a102.png">
