### PR TITLE
Port ASCII State Tree to Browser Extension

### DIFF
--- a/packages/lexical-devtools/src/background/index.ts
+++ b/packages/lexical-devtools/src/background/index.ts
@@ -16,11 +16,12 @@ const tabsToPorts: Record<
 // The Lexical DevTools React UI sends a message to initialize the port.
 chrome.runtime.onConnect.addListener((port: chrome.runtime.Port) => {
   port.onMessage.addListener((message) => {
-    if (!port.sender || !port.sender.tab) {
+    if ((!port.sender || !port.sender.tab) && !message.tabId) {
+      // in the DevTools React App, port.sender is undefined, so we make an exception for messages that have tabId defined.
       return;
     }
 
-    const tabId = port.sender.tab.id;
+    const tabId = port?.sender?.tab?.id || message.tabId;
 
     if (!tabId) {
       return;

--- a/packages/lexical-devtools/src/background/index.ts
+++ b/packages/lexical-devtools/src/background/index.ts
@@ -16,14 +16,15 @@ const tabsToPorts: Record<
 // The Lexical DevTools React UI sends a message to initialize the port.
 chrome.runtime.onConnect.addListener((port: chrome.runtime.Port) => {
   port.onMessage.addListener((message) => {
-    if ((!port.sender || !port.sender.tab) && !message.tabId) {
-      // in the DevTools React App, port.sender is undefined, so we make an exception for messages that have tabId defined.
-      return;
-    }
+    let tabId;
 
-    const tabId = port?.sender?.tab?.id || message.tabId;
-
-    if (!tabId) {
+    if (port.sender && port.sender.tab) {
+      tabId = port.sender.tab.id;
+    } else if (message.tabId) {
+      // in the DevTools React App, port.sender is undefined within FROM_APP messages
+      // instead tabId is sent within message payload
+      tabId = message.tabId;
+    } else {
       return;
     }
 

--- a/packages/lexical-devtools/src/content/index.ts
+++ b/packages/lexical-devtools/src/content/index.ts
@@ -21,7 +21,11 @@ window.addEventListener('message', function (event) {
     return;
   }
 
-  if (event.data.type && event.data.type === 'FROM_PAGE') {
+  if (
+    event.data.type &&
+    event.data.type === 'FROM_PAGE' &&
+    event.data.name === 'editor-update'
+  ) {
     const nodeMap = IS_FIREFOX
       ? event.data.editorState._nodeMap
       : Object.fromEntries(event.data.editorState._nodeMap); // workaround, for some reason Object.fromEntries fails without console.error in Firefox

--- a/packages/lexical-devtools/src/content/index.ts
+++ b/packages/lexical-devtools/src/content/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+const IS_FIREFOX = navigator.userAgent.indexOf('Firefox') >= 0;
+
 const port = chrome.runtime.connect();
 
 port.postMessage({
@@ -20,8 +22,11 @@ window.addEventListener('message', function (event) {
   }
 
   if (event.data.type && event.data.type === 'FROM_PAGE') {
+    const nodeMap = IS_FIREFOX
+      ? event.data.editorState._nodeMap
+      : Object.fromEntries(event.data.editorState._nodeMap); // workaround, for some reason Object.fromEntries fails without console.error in Firefox
     port.postMessage({
-      editorState: event.data.editorState._nodeMap, // placeholder, sending _nodeMap for now because Chrome & Edge auto-serialize postMessages. sending the whole editorState throws a JSON serialization error due to its 'circular' JSON structure
+      editorState: {nodeMap},
       name: 'editor-update',
       type: 'FROM_CONTENT',
     });

--- a/packages/lexical-devtools/src/content/index.ts
+++ b/packages/lexical-devtools/src/content/index.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-const IS_FIREFOX = navigator.userAgent.indexOf('Firefox') >= 0;
-
 const port = chrome.runtime.connect();
 
 port.postMessage({
@@ -26,11 +24,8 @@ window.addEventListener('message', function (event) {
     event.data.type === 'FROM_PAGE' &&
     event.data.name === 'editor-update'
   ) {
-    const nodeMap = IS_FIREFOX
-      ? event.data.editorState._nodeMap
-      : Object.fromEntries(event.data.editorState._nodeMap); // workaround, for some reason Object.fromEntries fails without console.error in Firefox
     port.postMessage({
-      editorState: {nodeMap},
+      editorState: event.data.editorState,
       name: 'editor-update',
       type: 'FROM_CONTENT',
     });

--- a/packages/lexical-devtools/src/devtools/index.ts
+++ b/packages/lexical-devtools/src/devtools/index.ts
@@ -10,27 +10,45 @@ chrome.devtools.panels.create(
   'Lexical',
   '/../../favicon-32x32.png',
   '/src/panel/index.html',
+  function (panel) {
+    panel.onShown.addListener(handleShown);
+    // to do: add handleHidden() listener
+  },
 );
 
-// Use devtools.inspectedWindow.eval() to get editorState updates. For more info on security concerns:
-//   https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts
-//   https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/eval
-chrome.devtools.inspectedWindow
-  // Attach a registerUpdateListener within the window to subscribe to changes in editorState.
-  // After the initial registration, all editorState updates are done via browser.runtime.onConnect & window.postMessage
-  .eval(
-    `
+function handleShown() {
+  // Use devtools.inspectedWindow.eval() to get editorState updates. For more info on security concerns:
+  //   https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts
+  //   https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/eval
+  chrome.devtools.inspectedWindow
+    // Attach a registerUpdateListener within the window to subscribe to changes in editorState.
+    // After the initial registration, all editorState updates are done via browser.runtime.onConnect & window.postMessage
+    .eval(
+      `
     const editor = document.querySelectorAll('div[data-lexical-editor]')[0]
       .__lexicalEditor;
+
+    const initialEditorState = editor.getEditorState();
+
+    window.postMessage(
+      {
+        editorState: initialEditorState,
+        name: 'editor-update',
+        type: 'FROM_PAGE',
+      },
+      '*',
+    );
 
     editor.registerUpdateListener(({editorState}) => {
       window.postMessage(
         {
           editorState,
+          name: 'editor-update',
           type: 'FROM_PAGE',
         },
         '*',
       );
     });
   `,
-  ); // to do: add error handling eg. .then(handleError)
+    ); // to do: add error handling eg. .then(handleError)
+}

--- a/packages/lexical-devtools/src/panel/components/App/index.css
+++ b/packages/lexical-devtools/src/panel/components/App/index.css
@@ -9,12 +9,12 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: 24px;
+  font-size: 2em;
   color: white;
 }
 
 .loading-view {
   background: #222;
   color: #fff;
-  font-size: 36px;
+  font-size: 3em;
 }

--- a/packages/lexical-devtools/src/panel/components/App/index.css
+++ b/packages/lexical-devtools/src/panel/components/App/index.css
@@ -2,26 +2,19 @@
   text-align: center;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
 .App-header {
   background-color: #282c34;
-  min-height: 100vh;
+  font-family: monospace;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
+  font-size: 24px;
   color: white;
 }
 
-.App-link {
-  color: #61dafb;
-}
-
-button {
-  font-size: calc(10px + 2vmin);
+.loading-view {
+  background: #222;
+  color: #fff;
+  font-size: 36px;
 }

--- a/packages/lexical-devtools/src/panel/components/App/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/App/index.tsx
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import type {EditorState} from 'lexical';
 
 import './index.css';
 
@@ -12,11 +13,12 @@ import {EditorState} from 'lexical';
 import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
 
-import logo from '../../../images/lexical-white.png';
+import TreeView from '../TreeView';
 
 function App(): JSX.Element {
   const [count, setCount] = useState<number>(0);
-  const [, setEditorState] = useState<EditorState | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [editorState, setEditorState] = useState<EditorState | null>(null);
   const port = useRef<chrome.runtime.Port | null>(null);
 
   useEffect(() => {
@@ -35,6 +37,7 @@ function App(): JSX.Element {
       port.current.onMessage.addListener(
         (message: {editorState: EditorState}) => {
           setCount(count + 1);
+          setIsLoading(false);
           setEditorState(message.editorState);
         },
       );
@@ -44,12 +47,17 @@ function App(): JSX.Element {
   return (
     <div className="App">
       <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
         <p>Lexical Developer Tools</p>
-        <p>
-          <code>editorState</code> updates: {count}
-        </p>
       </header>
+      {isLoading ? (
+        <>
+          <div className="loading-view">
+            <p>Loading...</p>
+          </div>
+        </>
+      ) : (
+        <TreeView viewClassName="tree-view-output" editorState={editorState} />
+      )}
     </div>
   );
 }

--- a/packages/lexical-devtools/src/panel/components/App/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/App/index.tsx
@@ -37,11 +37,7 @@ function App(): JSX.Element {
         (message: {editorState: {nodeMap: NodeMap}}) => {
           setCount(count + 1);
           setIsLoading(false);
-          // workaround for Firefox, message.editorState.nodeMap is either a vanilla object or a Map structure
-          const newNodeMap =
-            message.editorState.nodeMap instanceof Map
-              ? Object.fromEntries(message.editorState.nodeMap) // we need object dot notation to work TreeView, so we convert Map to Object
-              : message.editorState.nodeMap;
+          const newNodeMap = message.editorState.nodeMap;
           setNodeMap(newNodeMap);
         },
       );

--- a/packages/lexical-devtools/src/panel/components/App/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/App/index.tsx
@@ -35,7 +35,7 @@ function App(): JSX.Element {
   useEffect(() => {
     if (port.current !== null) {
       port.current.onMessage.addListener(
-        (message: {editorState: EditorState}) => {
+        (message: {editorState: {nodeMap: NodeMap}}) => {
           setCount(count + 1);
           setIsLoading(false);
           // workaround for Firefox, message.editorState.nodeMap is either a vanilla object or a Map structure

--- a/packages/lexical-devtools/src/panel/components/App/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/App/index.tsx
@@ -9,7 +9,6 @@ import type {NodeMap} from 'lexical';
 
 import './index.css';
 
-import {EditorState} from 'lexical';
 import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
 

--- a/packages/lexical-devtools/src/panel/components/App/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/App/index.tsx
@@ -16,9 +16,7 @@ import TreeView from '../TreeView';
 function App(): JSX.Element {
   const [count, setCount] = useState<number>(0);
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [nodeMap, setNodeMap] = useState<DevToolsTree | Record<string, never>>(
-    {},
-  );
+  const [nodeMap, setNodeMap] = useState<DevToolsTree>({});
   const port = useRef<chrome.runtime.Port | null>(null);
 
   useEffect(() => {

--- a/packages/lexical-devtools/src/panel/components/App/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/App/index.tsx
@@ -5,10 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import type {NodeMap} from 'lexical';
-
 import './index.css';
 
+import {DevToolsTree} from 'packages/lexical-devtools/types';
 import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
 
@@ -17,13 +16,16 @@ import TreeView from '../TreeView';
 function App(): JSX.Element {
   const [count, setCount] = useState<number>(0);
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [nodeMap, setNodeMap] = useState<NodeMap | Record<string, never>>({});
+  const [nodeMap, setNodeMap] = useState<DevToolsTree | Record<string, never>>(
+    {},
+  );
   const port = useRef<chrome.runtime.Port | null>(null);
 
   useEffect(() => {
     // create and initialize the messaging port to receive editorState updates
     port.current = window.chrome.runtime.connect();
 
+    // post init message to background JS so tabId will be registered
     port.current.postMessage({
       name: 'init',
       tabId: window.chrome.devtools.inspectedWindow.tabId,
@@ -33,8 +35,9 @@ function App(): JSX.Element {
 
   useEffect(() => {
     if (port.current !== null) {
+      // message listener for editorState updates from inspectedWindow
       port.current.onMessage.addListener(
-        (message: {editorState: {nodeMap: NodeMap}}) => {
+        (message: {editorState: {nodeMap: DevToolsTree}}) => {
           setCount(count + 1);
           setIsLoading(false);
           const newNodeMap = message.editorState.nodeMap;

--- a/packages/lexical-devtools/src/panel/components/App/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/App/index.tsx
@@ -54,11 +54,9 @@ function App(): JSX.Element {
         <p>Lexical Developer Tools</p>
       </header>
       {isLoading ? (
-        <>
-          <div className="loading-view">
-            <p>Loading...</p>
-          </div>
-        </>
+        <div className="loading-view">
+          <p>Loading...</p>
+        </div>
       ) : (
         <TreeView viewClassName="tree-view-output" nodeMap={nodeMap} />
       )}

--- a/packages/lexical-devtools/src/panel/components/Node/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/Node/index.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import * as React from 'react';
+
+function Node({
+  lexicalKey,
+  text,
+  type,
+  children,
+}: {
+  children: Array<object>;
+  lexicalKey: string;
+  text: string;
+  type: string;
+}): JSX.Element {
+  return (
+    <li key={lexicalKey}>
+      ({lexicalKey}) {type} {text ? '"' + text + '"' : ''}
+      {children.length > 0 ? (
+        <ul>
+          {children.map((child) => (
+            <Node {...child} />
+          ))}
+        </ul>
+      ) : (
+        ''
+      )}
+    </li>
+  );
+}
+
+export default Node;

--- a/packages/lexical-devtools/src/panel/components/TreeNode/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/TreeNode/index.tsx
@@ -5,26 +5,27 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import {DevToolsNode} from 'packages/lexical-devtools/types';
 import * as React from 'react';
 
-function Node({
+function TreeNode({
   lexicalKey,
-  text,
-  type,
+  __text,
+  __type,
   children,
 }: {
-  children: Array<object>;
+  children: Array<DevToolsNode>;
   lexicalKey: string;
-  text: string;
-  type: string;
+  __text?: string;
+  __type: string;
 }): JSX.Element {
   return (
     <li key={lexicalKey}>
-      ({lexicalKey}) {type} {text ? '"' + text + '"' : ''}
+      ({lexicalKey}) {__type} {__text ? '"' + __text + '"' : ''}
       {children.length > 0 ? (
         <ul>
           {children.map((child) => (
-            <Node {...child} />
+            <TreeNode {...child} />
           ))}
         </ul>
       ) : (
@@ -34,4 +35,4 @@ function Node({
   );
 }
 
-export default Node;
+export default TreeNode;

--- a/packages/lexical-devtools/src/panel/components/TreeView/index.css
+++ b/packages/lexical-devtools/src/panel/components/TreeView/index.css
@@ -1,0 +1,17 @@
+.tree-view-output {
+  line-height: 1.1;
+  background: #222;
+  color: #fff;
+  margin: 0;
+  padding: 10px;
+  font-size: 12px;
+  overflow: auto;
+  text-align: left;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+}
+
+.tree-view-output ul li {
+  font-family: monospace;
+  padding-left: 5px;
+}

--- a/packages/lexical-devtools/src/panel/components/TreeView/index.css
+++ b/packages/lexical-devtools/src/panel/components/TreeView/index.css
@@ -3,8 +3,8 @@
   background: #222;
   color: #fff;
   margin: 0;
-  padding: 10px;
-  font-size: 12px;
+  padding: 1em;
+  font-size: 1em;
   overflow: auto;
   text-align: left;
   -moz-osx-font-smoothing: grayscale;
@@ -13,5 +13,5 @@
 
 .tree-view-output ul li {
   font-family: monospace;
-  padding-left: 5px;
+  padding-left: 0.5em;
 }

--- a/packages/lexical-devtools/src/panel/components/TreeView/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/TreeView/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import type {EditorState} from 'lexical';
+import type {NodeMap} from 'lexical';
 
 import './index.css';
 
@@ -15,10 +15,10 @@ import Node from '../Node';
 
 function TreeView({
   viewClassName,
-  editorState,
+  nodeMap,
 }: {
   viewClassName: string;
-  editorState: EditorState;
+  nodeMap: NodeMap;
 }): JSX.Element {
   const depthFirstSearch = (node) => {
     const {
@@ -33,7 +33,7 @@ function TreeView({
 
     if (Object.prototype.hasOwnProperty.call(node, '__children')) {
       node.__children.forEach((childKey) => {
-        const child = editorState.get(childKey);
+        const child = nodeMap[childKey];
         children.push(depthFirstSearch(child));
       });
     }
@@ -42,14 +42,14 @@ function TreeView({
     return branch;
   };
 
-  const generateTree = (nodeMap) => {
-    const root = depthFirstSearch(nodeMap.get('root'));
+  const generateTree = (map) => {
+    const root = depthFirstSearch(map.root);
     return <Node {...root} />;
   };
 
   return (
     <div className={viewClassName}>
-      <ul>{generateTree(editorState)}</ul>
+      <ul>{generateTree(nodeMap)}</ul>
     </div>
   );
 }

--- a/packages/lexical-devtools/src/panel/components/TreeView/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/TreeView/index.tsx
@@ -5,46 +5,36 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import type {NodeKey, NodeMap} from 'lexical';
-
 import './index.css';
 
+import {DevToolsNode, DevToolsTree} from 'packages/lexical-devtools/types';
 import * as React from 'react';
 
-import Node from '../Node';
+import TreeNode from '../TreeNode';
 
 function TreeView({
   viewClassName,
   nodeMap,
 }: {
   viewClassName: string;
-  nodeMap: NodeMap;
+  nodeMap: DevToolsTree;
 }): JSX.Element {
-  const depthFirstSearch = (node) => {
-    const {
-      __cachedText: cachedText,
-      __key: lexicalKey,
-      __text: text,
-      __type: type,
-    } = node;
-    const branch = {cachedText, lexicalKey, text, type};
-
-    const children: Array<NodeKey> = [];
+  const depthFirstSearch = (node: DevToolsNode): DevToolsNode => {
+    const children: Array<DevToolsNode> = [];
 
     if (Object.prototype.hasOwnProperty.call(node, '__children')) {
-      node.__children.forEach((childKey) => {
+      node.__children.forEach((childKey: string) => {
         const child = nodeMap[childKey];
         children.push(depthFirstSearch(child));
       });
     }
 
-    branch.children = children;
-    return branch;
+    return {...node, __type: node.__type, children, lexicalKey: node.__key};
   };
 
-  const generateTree = (map) => {
+  const generateTree = (map: DevToolsTree): JSX.Element => {
     const root = depthFirstSearch(map.root);
-    return <Node {...root} />;
+    return <TreeNode {...root} />;
   };
 
   return (

--- a/packages/lexical-devtools/src/panel/components/TreeView/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/TreeView/index.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import type {EditorState} from 'lexical';
+
+import './index.css';
+
+import * as React from 'react';
+
+import Node from '../Node';
+
+function TreeView({
+  viewClassName,
+  editorState,
+}: {
+  viewClassName: string;
+  editorState: EditorState;
+}): JSX.Element {
+  const depthFirstSearch = (node) => {
+    const {
+      __cachedText: cachedText,
+      __key: lexicalKey,
+      __text: text,
+      __type: type,
+    } = node;
+    const branch = {cachedText, lexicalKey, text, type};
+
+    const children = [];
+
+    if (Object.prototype.hasOwnProperty.call(node, '__children')) {
+      node.__children.forEach((childKey) => {
+        const child = editorState.get(childKey);
+        children.push(depthFirstSearch(child));
+      });
+    }
+
+    branch.children = children;
+    return branch;
+  };
+
+  const generateTree = (nodeMap) => {
+    const root = depthFirstSearch(nodeMap.get('root'));
+    return <Node {...root} />;
+  };
+
+  return (
+    <div className={viewClassName}>
+      <ul>{generateTree(editorState)}</ul>
+    </div>
+  );
+}
+
+export default TreeView;

--- a/packages/lexical-devtools/src/panel/components/TreeView/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/TreeView/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import type {NodeMap} from 'lexical';
+import type {NodeKey, NodeMap} from 'lexical';
 
 import './index.css';
 
@@ -29,7 +29,7 @@ function TreeView({
     } = node;
     const branch = {cachedText, lexicalKey, text, type};
 
-    const children = [];
+    const children: Array<NodeKey> = [];
 
     if (Object.prototype.hasOwnProperty.call(node, '__children')) {
       node.__children.forEach((childKey) => {

--- a/packages/lexical-devtools/src/panel/components/main/index.css
+++ b/packages/lexical-devtools/src/panel/components/main/index.css
@@ -1,13 +1,7 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: monospace;
+  background: #222;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
 }

--- a/packages/lexical-devtools/types.ts
+++ b/packages/lexical-devtools/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+export interface DevToolsTree {
+  [key: string]: DevToolsNode;
+}
+
+export interface DevToolsNode {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [x: string]: any;
+  children: Array<DevToolsNode>;
+  __text?: string;
+  __type: string;
+  lexicalKey: string;
+}


### PR DESCRIPTION
## Features
- Fetches JSON `editorState._nodeMap` on initial app loading, and on subsequent updates.
- Renders tree `<Node>`s recursively.

https://user-images.githubusercontent.com/4361605/178168320-1aca6b43-cb8b-4325-9483-f4bce942a4cb.mov

---
Developer Tools Web Extension Planning Issue: #2127