### PR TITLE
Delete doc from ydocMap on unmount. Fixes init on re-mount

### DIFF
--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -157,6 +157,7 @@ export function useYjsCollaboration(
       provider.off('reload', onProviderDocReload);
       awareness.off('update', onAwarenessUpdate);
       root.getSharedType().unobserveDeep(onYjsTreeChanges);
+      docMap.delete(id);
       removeListener();
     };
   }, [


### PR DESCRIPTION
Re-mounting collab editor does not trigger yjs tree update and keeps editor blank. Deleting root ydoc from ydocMap on collab unmount will make sure that re-mount will follow same doc sync process as original mount:

https://github.com/facebook/lexical/blob/11ad8f14bbd6ee523337a074e717cb55b3be5c18/packages/lexical-playground/src/collaboration.ts#L26-L31

Issue:

https://user-images.githubusercontent.com/132642/178752416-09283f40-ce3e-4d1a-b9fb-202c4e9bb931.mov


