### PR TITLE
Remove comment box from comments sidebar footer

### DIFF
--- a/packages/lexical-playground/src/plugins/CommentPlugin.css
+++ b/packages/lexical-playground/src/plugins/CommentPlugin.css
@@ -204,14 +204,6 @@ i.comments {
   overflow: hidden;
 }
 
-.CommentPlugin_CommentsPanel_Footer {
-  border-top: 1px solid #eee;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-}
-
 .CommentPlugin_CommentsPanel_Editor {
   position: relative;
   border: 1px solid #ccc;

--- a/packages/lexical-playground/src/plugins/CommentPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin.tsx
@@ -406,23 +406,6 @@ function CommentsComposer({
   );
 }
 
-function CommentsPanelFooter({
-  footerRef,
-  submitAddComment,
-}: {
-  footerRef: {current: null | HTMLDivElement};
-  submitAddComment: (
-    commentOrThread: Comment | Thread,
-    isInlineComment: boolean,
-  ) => void;
-}) {
-  return (
-    <div className="CommentPlugin_CommentsPanel_Footer" ref={footerRef}>
-      <CommentsComposer submitAddComment={submitAddComment} />
-    </div>
-  );
-}
-
 function ShowDeleteCommentOrThreadDialog({
   commentOrThread,
   deleteCommentOrThread,
@@ -682,30 +665,8 @@ function CommentsPanel({
     thread?: Thread,
   ) => void;
 }): JSX.Element {
-  const footerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const isEmpty = comments.length === 0;
-
-  useLayoutEffect(() => {
-    const footerElem = footerRef.current;
-    if (footerElem !== null) {
-      const updateSize = () => {
-        const listElem = listRef.current;
-        if (listElem !== null) {
-          const rect = footerElem.getBoundingClientRect();
-          listElem.style.height = window.innerHeight - rect.height - 133 + 'px';
-        }
-      };
-      const resizeObserver = new ResizeObserver(updateSize);
-      resizeObserver.observe(footerElem);
-      window.addEventListener('resize', updateSize);
-
-      return () => {
-        window.removeEventListener('resize', updateSize);
-        resizeObserver.disconnect();
-      };
-    }
-  }, [isEmpty]);
 
   return (
     <div className="CommentPlugin_CommentsPanel">
@@ -722,10 +683,6 @@ function CommentsPanel({
           markNodeMap={markNodeMap}
         />
       )}
-      <CommentsPanelFooter
-        submitAddComment={submitAddComment}
-        footerRef={footerRef}
-      />
     </div>
   );
 }


### PR DESCRIPTION
The comment box in the footer of the collab comments sidebar is mainly there for decorative purposes, but as it doesn't allow replies, it's causing some UX confusion (i.e. #2615)

Rather than refactor it to be a thread, as it doesn't really showcase any functionality of Lexical that can't be shown with the inline comments, I thought it would be simpler to just remove the box.

Closes #2615

|Before|After|
|--|--|
|<img width="274" alt="image" src="https://user-images.githubusercontent.com/7748470/178762709-37a565aa-8c4e-4de9-9a52-74f81ca85587.png">|<img width="274" alt="image" src="https://user-images.githubusercontent.com/7748470/178762526-2801d6e7-4bd4-4acc-8ffe-61c2d6cd3c85.png">|