### PR TITLE
fix(lexical): calculate range selection formatting

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
@@ -6,11 +6,18 @@
  *
  */
 
-import {selectAll} from '../keyboardShortcuts/index.mjs';
+import {
+  selectAll,
+  selectCharacters,
+  toggleBold,
+  toggleItalic,
+  toggleUnderline,
+} from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
   click,
   evaluate,
+  expect,
   focus,
   focusEditor,
   html,
@@ -274,5 +281,28 @@ test.describe('Toolbar', () => {
         </p>
       `,
     );
+  });
+
+  test('When we select three textNodes with different formatting at the same time, the selection formatting should show no formatting at all', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await focusEditor(page);
+
+    await toggleBold(page);
+    await page.keyboard.type('A ');
+    await toggleBold(page);
+    await toggleItalic(page);
+    await page.keyboard.type('B ');
+    await toggleItalic(page);
+    await toggleUnderline(page);
+    await page.keyboard.type('C');
+    await selectCharacters(page, 'left', 5);
+
+    const actives = await page.$$('div.toolbar button.toolbar-item.active');
+    await page.pause();
+    expect(actives.length).toEqual(0);
   });
 });

--- a/packages/lexical/src/LexicalConstants.ts
+++ b/packages/lexical/src/LexicalConstants.ts
@@ -39,6 +39,15 @@ export const IS_CODE = 1 << 4;
 export const IS_SUBSCRIPT = 1 << 5;
 export const IS_SUPERSCRIPT = 1 << 6;
 
+export const IS_ALL_FORMATTING =
+  IS_BOLD |
+  IS_ITALIC |
+  IS_STRIKETHROUGH |
+  IS_UNDERLINE |
+  IS_CODE |
+  IS_SUBSCRIPT |
+  IS_SUPERSCRIPT;
+
 // Text node details
 export const IS_DIRECTIONLESS = 1;
 export const IS_UNMERGEABLE = 1 << 1;

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -69,6 +69,7 @@ import {
   DOM_ELEMENT_TYPE,
   DOM_TEXT_TYPE,
   DOUBLE_LINE_BREAK,
+  IS_ALL_FORMATTING,
 } from './LexicalConstants';
 import {internalCreateRangeSelection, RangeSelection} from './LexicalSelection';
 import {updateEditor} from './LexicalUpdates';
@@ -255,17 +256,14 @@ function onSelectionChange(
           }
         }
       } else {
-        const focus = selection.focus;
-        const focusNode = focus.getNode();
-        let combinedFormat = 0;
+        let combinedFormat = IS_ALL_FORMATTING;
 
-        if (anchor.type === 'text') {
-          combinedFormat |= anchorNode.getFormat();
-        }
-
-        if (focus.type === 'text' && !anchorNode.is(focusNode)) {
-          combinedFormat |= focusNode.getFormat();
-        }
+        const nodes = selection.getNodes();
+        nodes.forEach((node) => {
+          if ($isTextNode(node)) {
+            combinedFormat &= node.getFormat();
+          }
+        });
 
         selection.format = combinedFormat;
       }

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -259,11 +259,16 @@ function onSelectionChange(
         let combinedFormat = IS_ALL_FORMATTING;
 
         const nodes = selection.getNodes();
-        nodes.forEach((node) => {
+        const nodesLength = nodes.length;
+        for (let i = 0; i < nodesLength; i++) {
+          const node = nodes[i];
           if ($isTextNode(node)) {
             combinedFormat &= node.getFormat();
+            if (combinedFormat === 0) {
+              break;
+            }
           }
-        });
+        }
 
         selection.format = combinedFormat;
       }


### PR DESCRIPTION
## Description
Fix range selection formatting.

It looks like this bug is related to the format of our rangeSelection calculation. Here our calculation is not quite the same as the google doc. As an example:

- In google doc. When we have three letters 1(italic) 2(bold) 3(underline), and we select them, the selection will show that the format is nothing at this time. Only when all textNodes have a format at the same time will the selection show that it has a format.
<img width="369" alt="image" src="https://user-images.githubusercontent.com/22126563/178921895-7cf3eec2-2e34-44ff-99b9-bf798983dd51.png">

- And in lexical, our logic is that as long as the anchorNode or focusNode has a certain style, we will show that selection.format has that style.
<img width="515" alt="image" src="https://user-images.githubusercontent.com/22126563/178923541-a4a8092d-e6e1-4c9d-9285-6b7eb5d182b7.png">

- When we can calculate the selection range correctly, the problem mentioned in the issue does not exist anymore.

----
closes #2626 

https://user-images.githubusercontent.com/22126563/178920657-20ba0a72-c574-4635-ab35-472c8fca2d1b.mov
