### PR TITLE
Specify the return type of getNearestNodeOfType.

### DIFF
--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -119,7 +119,7 @@ export function $getNearestNodeOfType<T extends ElementNode>(
     parent = parent.getParent();
   }
 
-  return parent;
+  return null;
 }
 
 export function $getNearestBlockElementAncestorOrThrow(

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -108,12 +108,12 @@ function $getDepth(node: LexicalNode): number {
 export function $getNearestNodeOfType<T extends ElementNode>(
   node: LexicalNode,
   klass: Klass<T>,
-) {
+): T | null {
   let parent: ElementNode | LexicalNode | null = node;
 
   while (parent != null) {
     if (parent instanceof klass) {
-      return parent;
+      return parent as T;
     }
 
     parent = parent.getParent();


### PR DESCRIPTION
Specify the return type of `$getNearestNodeOfType`.

an example:

```ts
const parentList = $getNearestNodeOfType(anchorNode, ListNode);
const listType = parentList?.getListType();
```

Currently `listType` is of type `any`, but after this PR it will be of type `ListType | undefined`.