### PR TITLE
fix(doc): RichTextPlugin placeholder

### DIFF
--- a/packages/lexical-website-new/docs/react/plugins.md
+++ b/packages/lexical-website-new/docs/react/plugins.md
@@ -36,7 +36,7 @@ React wrapper for `@lexical/rich-text` that adds major features for rich text ed
 ```jsx
 <RichTextPlugin
   contentEditable={<ContentEditable />}
-  placeholder={null}
+  placeholder={<div>Enter some text...</div>}
 />
 ```
 


### PR DESCRIPTION
Thank you for amazing work.

The `RichTextPlugin` currently accepts a placeholder as `JSX.Element | string`. 
But, docs are still documented as `null`. This PR fixes it.

https://github.com/facebook/lexical/blob/48bfe0809b4ea74ef09dbece193e8d1cc1f638d1/packages/lexical-react/src/LexicalRichTextPlugin.tsx#L30