### PR TITLE
fix(lexical-list): remove list breaks if selection in empty

### DIFF
--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -238,6 +238,14 @@ export function removeList(editor: LexicalEditor): void {
             insertionPoint.insertAfter(paragraph);
             insertionPoint = paragraph;
 
+            if (listItemNode.__key === selection.anchor.key) {
+              selection.anchor.set(paragraph.getKey(), 0, 'element');
+            }
+
+            if (listItemNode.__key === selection.focus.key) {
+              selection.focus.set(paragraph.getKey(), 0, 'element');
+            }
+
             listItemNode.remove();
           }
         });

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -238,6 +238,12 @@ export function removeList(editor: LexicalEditor): void {
             insertionPoint.insertAfter(paragraph);
             insertionPoint = paragraph;
 
+            // When the anchor and focus fall on the textNode
+            // we don't have to change the selection because the textNode will be appended to
+            // the newly generated paragraph.
+            // When selection is in empty nested list item, selection is actually on the listItemNode.
+            // When the corresponding listItemNode is deleted and replaced by the newly generated paragraph
+            // we should manually set the selection's focus and anchor to the newly generated paragraph.
             if (listItemNode.__key === selection.anchor.key) {
               selection.anchor.set(paragraph.getKey(), 0, 'element');
             }

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -21,6 +21,7 @@ import {
 } from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
+  assertSelection,
   clearEditor,
   click,
   copyToClipboard,
@@ -1461,5 +1462,78 @@ test.describe('Nested List', () => {
         </ul>
       `,
     );
+  });
+
+  test('remove list breaks when selection in empty nested list item', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello World');
+    await page.keyboard.press('Enter');
+    await toggleBulletList(page);
+    await page.keyboard.press('Tab');
+    await toggleBulletList(page);
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello World</span>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+    await page.pause();
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [1],
+      focusOffset: 0,
+      focusPath: [1],
+    });
+  });
+
+  test('remove list breaks when selection in empty nested list item 2', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello World');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('a');
+    await toggleBulletList(page);
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('b');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Tab');
+    await toggleBulletList(page);
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello World</span>
+        </p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">a</span>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">b</span>
+        </p>
+      `,
+    );
+    await page.pause();
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [2],
+      focusOffset: 0,
+      focusPath: [2],
+    });
   });
 });


### PR DESCRIPTION
## Description
When the anchor and focus of our selection fall on the textNode, we don't have to change the selection because the textNode will be appended to the newly generated paragraph.

When selection is in empty nested list item, selection is actually on the listItemNode. When the corresponding listItemNode is deleted and replaced by the newly generated paragraph, we should manually set the selection's focus and anchor to the newly generated paragraph.

closes #2640

https://user-images.githubusercontent.com/22126563/180176157-f72e29ce-4cfc-4a70-8dc4-43719f7be7e1.mov
