### PR TITLE
Conditionally utilize `startTransition` if it's present

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -213,11 +213,11 @@ function isSelectionOnEntityBoundary(
   });
 }
 
-function startTransition (callback: () => void) {
+function startTransition(callback: () => void) {
   if (React.startTransition) {
-    React.startTransition(callback)
+    React.startTransition(callback);
   } else {
-    callback()
+    callback();
   }
 }
 

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -25,7 +25,6 @@ import {
 import {
   MutableRefObject,
   ReactPortal,
-  startTransition,
   useCallback,
   useEffect,
   useMemo,
@@ -212,6 +211,14 @@ function isSelectionOnEntityBoundary(
     }
     return false;
   });
+}
+
+function startTransition (callback) {
+  if (React.startTransition) {
+    React.startTransition(callback)
+  } else {
+    callback()
+  }
 }
 
 function ShortcutTypeahead<TOption extends TypeaheadOption>({

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -213,7 +213,7 @@ function isSelectionOnEntityBoundary(
   });
 }
 
-function startTransition (callback) {
+function startTransition (callback: () => void) {
   if (React.startTransition) {
     React.startTransition(callback)
   } else {


### PR DESCRIPTION
This allows the `LexicalTypeaheadMenuPlugin` to be utilized in React 17