### PR TITLE
fix: path to icons

### DIFF
--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.css
@@ -41,7 +41,7 @@ i.add-comment {
   height: 20px;
   width: 20px;
   vertical-align: -10px;
-  background-image: url(../images/icons/chat-left-text.svg);
+  background-image: url(../../images/icons/chat-left-text.svg);
 }
 
 .CommentPlugin_CommentInputBox {
@@ -154,7 +154,7 @@ i.comments {
   height: 20px;
   width: 20px;
   vertical-align: -10px;
-  background-image: url(../images/icons/comments.svg);
+  background-image: url(../../images/icons/comments.svg);
   opacity: 0.5;
   transition: opacity 0.2s linear;
 }
@@ -240,7 +240,7 @@ i.send {
   height: 20px;
   width: 20px;
   vertical-align: -10px;
-  background-image: url(../images/icons/send.svg);
+  background-image: url(../../images/icons/send.svg);
   opacity: 0.5;
   transition: opacity 0.2s linear;
 }
@@ -426,6 +426,6 @@ i.send {
   height: 15px;
   width: 15px;
   vertical-align: -10px;
-  background-image: url(../images/icons/trash3.svg);
+  background-image: url(../../images/icons/trash3.svg);
   transition: opacity 0.2s linear;
 }


### PR DESCRIPTION
The icons related to comments are missing https://playground.lexical.dev/; this PR aims to fix that
![Screenshot from 2022-07-22 17-48-57](https://user-images.githubusercontent.com/64399555/180437870-ac17f039-184d-4f44-8168-d695ef3eb69d.png)
.