### PR TITLE
Lexical Features

### DIFF
--- a/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
+++ b/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
@@ -6,8 +6,6 @@
  *
  */
 
-import type {Klass, LexicalNode} from 'lexical';
-
 import {CodeHighlightNode, CodeNode} from '@lexical/code';
 import {HashtagNode} from '@lexical/hashtag';
 import {AutoLinkNode, LinkNode} from '@lexical/link';
@@ -17,6 +15,13 @@ import {OverflowNode} from '@lexical/overflow';
 import {HorizontalRuleNode} from '@lexical/react/LexicalHorizontalRuleNode';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
+import {
+  Klass,
+  LexicalNode,
+  NodeRegistration,
+  nodeRegistration,
+  TextNode,
+} from 'lexical';
 
 import {AutocompleteNode} from './AutocompleteNode';
 import {EmojiNode} from './EmojiNode';
@@ -31,7 +36,14 @@ import {TweetNode} from './TweetNode';
 import {TypeaheadNode} from './TypeaheadNode';
 import {YouTubeNode} from './YouTubeNode';
 
-const PlaygroundNodes: Array<Klass<LexicalNode>> = [
+const PlaygroundNodes: Array<Klass<LexicalNode> | NodeRegistration> = [
+  nodeRegistration(TextNode, {
+    features: [],
+  }),
+  // nodeRegistration(TextNode, {
+  //   features: ['strikethrough'],
+  // }),
+  // TextNode,
   HeadingNode,
   ListNode,
   ListItemNode,

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1176,3 +1176,15 @@ export function $addUpdateTag(tag: string): void {
   const editor = getActiveEditor();
   editor._updateTags.add(tag);
 }
+
+export function hasFeature<T extends LexicalNode>(
+  klass: Klass<T>,
+  feature: string,
+): boolean {
+  // Maybe?
+  // const klass = this.constructor();
+  errorOnReadOnly();
+  const editor = getActiveEditor();
+  const features = editor._nodes.get(klass.getType()).features;
+  return features === null || features.includes(feature);
+}

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -16,6 +16,7 @@ export type {
   LexicalCommand,
   LexicalEditor,
   NodeMutation,
+  NodeRegistration,
   ReadOnlyListener,
   SerializedEditor,
   Spread,
@@ -107,6 +108,7 @@ export {
   COMMAND_PRIORITY_LOW,
   COMMAND_PRIORITY_NORMAL,
   createEditor,
+  nodeRegistration,
 } from './LexicalEditor';
 export type {EventHandler} from './LexicalEvents';
 export {

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -55,6 +55,7 @@ import {
   $getCompositionKey,
   $setCompositionKey,
   getCachedClassNameArray,
+  hasFeature,
   internalMarkSiblingsAsDirty,
   toggleTextFormatType,
 } from '../LexicalUtils';
@@ -513,6 +514,13 @@ export class TextNode extends LexicalNode {
     const self = this.getWritable();
     self.__format =
       typeof format === 'string' ? TEXT_TYPE_TO_FORMAT[format] : format;
+    if (
+      (self.__format & TEXT_TYPE_TO_FORMAT.strikethrough) !== 0 &&
+      !hasFeature(this.constructor, 'strikethrough')
+    ) {
+      console.warn(`LexicalTextNode feature disabled: strikethrough`);
+      self.__format ^= IS_STRIKETHROUGH;
+    }
     return self;
   }
 


### PR DESCRIPTION
# Lexical Features

With the introduction of rich text late 2021, we have gone a long way to have full support for the common and not so common rich text features to mimic the most complex and complete text editors like GDocs and MS Word.

However, while a full composer editor would benefit from most/all of these, smaller composers prefers a reduced set of functionality. For example, no tables or strikethrough text.

The features that are provided via self-contained plugins are easy to toggle but the ones that come bundled into core nodes or into other multi-purpose plugins are more complicated to toggle. For example, strikethrough or other TextNode formatting. These are only possible to control via transforms.

Transforms are not very convenient. Not only they are verbose to type but also they can potentially break with the introduction of new Lexical versions. For example, if the next version of Lexical were to introduce a new type of format. 

> Note that the formatting can come from UI (toolbar), keyboard shortcuts or copy-paste.

## Features proposal

This new features flag would allow developers to control the node behavior and would be up to the owner to maintain and support toggling new features.

```
nodes: [
  nodeRegistration(TextNode, {
    features: ['strikethrough'],
  }),
  HeadingNode,
]
```

The optional features array and node registration allows the developer to safely control and rollout new features.

Then the developer can control this feature on the node via the 'lexical' exposed `hasFeature`

```
  setFormat(format: TextFormatType | number): this {
    errorOnReadOnly();
    const self = this.getWritable();
    self.__format =
      typeof format === 'string' ? TEXT_TYPE_TO_FORMAT[format] : format;
    if (
      (self.__format & TEXT_TYPE_TO_FORMAT.strikethrough) !== 0 &&
      !hasFeature(this.constructor, 'strikethrough')
    ) {
      console.warn(`LexicalTextNode feature disabled: strikethrough`);
      self.__format ^= IS_STRIKETHROUGH;
    }
    return self;
  }
```