### PR TITLE
feat: Link node with target and rel

### DIFF
--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -18,9 +18,11 @@ import {addClassNamesToElement} from '@lexical/utils';
 import {$isElementNode, ElementNode} from 'lexical';
 declare export class LinkNode extends ElementNode {
   __url: string;
+  __target?: string;
+  __rel?: string;
   static getType(): string;
   static clone(node: LinkNode): LinkNode;
-  constructor(url: string, key?: NodeKey): void;
+  constructor(url: string, target?: string, rel?: string, key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
   updateDOM(
     prevNode: LinkNode,
@@ -30,13 +32,21 @@ declare export class LinkNode extends ElementNode {
   static importDOM(): DOMConversionMap | null;
   getURL(): string;
   setURL(url: string): void;
+  getTarget(): string | typeof undefined;
+  setTarget(url: string): void;
+  getRel(): string | typeof undefined;
+  setRel(url: string): void;
   insertNewAfter(selection: RangeSelection): null | ElementNode;
   canInsertTextBefore(): false;
   canInsertTextAfter(): false;
   canBeEmpty(): false;
   isInline(): true;
 }
-declare export function $createLinkNode(url: string): LinkNode;
+declare export function $createLinkNode(
+  url: string,
+  target?: string,
+  rel?: string,
+): LinkNode;
 declare export function $isLinkNode(
   node: ?LexicalNode,
 ): boolean %checks(node instanceof LinkNode);
@@ -51,5 +61,17 @@ declare export function $isAutoLinkNode(
   node: ?LexicalNode,
 ): boolean %checks(node instanceof AutoLinkNode);
 
-declare export var TOGGLE_LINK_COMMAND: LexicalCommand<string | null>;
-declare export function toggleLink(url: null | string): void;
+declare export var TOGGLE_LINK_COMMAND: LexicalCommand<
+  | string
+  | {
+      url: string,
+      target?: string,
+      rel?: string,
+    }
+  | null,
+>;
+declare export function toggleLink(
+  url: null | string,
+  target?: string,
+  rel?: string,
+): void;

--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -33,9 +33,9 @@ declare export class LinkNode extends ElementNode {
   getURL(): string;
   setURL(url: string): void;
   getTarget(): string | typeof undefined;
-  setTarget(url: string): void;
+  setTarget(target: string): void;
   getRel(): string | typeof undefined;
-  setRel(url: string): void;
+  setRel(rel: string): void;
   insertNewAfter(selection: RangeSelection): null | ElementNode;
   canInsertTextBefore(): false;
   canInsertTextAfter(): false;

--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -19,10 +19,15 @@ import {$isElementNode, ElementNode} from 'lexical';
 declare export class LinkNode extends ElementNode {
   __url: string;
   __target?: string;
-  __rel?: string;
+  __relationship?: string;
   static getType(): string;
   static clone(node: LinkNode): LinkNode;
-  constructor(url: string, target?: string, rel?: string, key?: NodeKey): void;
+  constructor(
+    url: string,
+    target?: string,
+    relationship?: string,
+    key?: NodeKey,
+  ): void;
   createDOM(config: EditorConfig): HTMLElement;
   updateDOM(
     prevNode: LinkNode,
@@ -34,8 +39,8 @@ declare export class LinkNode extends ElementNode {
   setURL(url: string): void;
   getTarget(): string | typeof undefined;
   setTarget(target: string): void;
-  getRel(): string | typeof undefined;
-  setRel(rel: string): void;
+  getRelationship(): string | typeof undefined;
+  setRelationship(relationship: string): void;
   insertNewAfter(selection: RangeSelection): null | ElementNode;
   canInsertTextBefore(): false;
   canInsertTextAfter(): false;
@@ -45,7 +50,7 @@ declare export class LinkNode extends ElementNode {
 declare export function $createLinkNode(
   url: string,
   target?: string,
-  rel?: string,
+  relationship?: string,
 ): LinkNode;
 declare export function $isLinkNode(
   node: ?LexicalNode,
@@ -66,12 +71,12 @@ declare export var TOGGLE_LINK_COMMAND: LexicalCommand<
   | {
       url: string,
       target?: string,
-      rel?: string,
+      relationship?: string,
     }
   | null,
 >;
 declare export function toggleLink(
   url: null | string,
   target?: string,
-  rel?: string,
+  relationship?: string,
 ): void;

--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -235,6 +235,36 @@ describe('LexicalLinkNode tests', () => {
       });
     });
 
+    test('LinkNode.updateDOM() with undefined target and undefined rel', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const linkNode = new LinkNode(
+          'https://example.com/foo',
+          '_blank',
+          'noopener noreferrer',
+        );
+
+        const domElement = linkNode.createDOM(editorConfig);
+
+        expect(linkNode.createDOM(editorConfig).outerHTML).toBe(
+          '<a href="https://example.com/foo" target="_blank" rel="noopener noreferrer" class="my-link-class"></a>',
+        );
+
+        const newLinkNode = new LinkNode('https://example.com/bar');
+        const result = newLinkNode.updateDOM(
+          linkNode,
+          domElement,
+          editorConfig,
+        );
+
+        expect(result).toBe(false);
+        expect(domElement.outerHTML).toBe(
+          '<a href="https://example.com/bar" class="my-link-class"></a>',
+        );
+      });
+    });
+
     test('LinkNode.canInsertTextBefore()', async () => {
       const {editor} = testEnv;
 

--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -136,7 +136,7 @@ describe('LexicalLinkNode tests', () => {
     test('LinkNode.createDOM()', async () => {
       const {editor} = testEnv;
 
-      editor.update(() => {
+      await editor.update(() => {
         const linkNode = new LinkNode('https://example.com/foo');
 
         expect(linkNode.createDOM(editorConfig).outerHTML).toBe(
@@ -154,7 +154,7 @@ describe('LexicalLinkNode tests', () => {
     test('LinkNode.createDOM() with target and rel', async () => {
       const {editor} = testEnv;
 
-      editor.update(() => {
+      await editor.update(() => {
         const linkNode = new LinkNode(
           'https://example.com/foo',
           '_blank',

--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -77,6 +77,62 @@ describe('LexicalLinkNode tests', () => {
       });
     });
 
+    test('LinkNode.getTarget()', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const linkNode = new LinkNode('https://example.com/foo', '_blank');
+
+        expect(linkNode.getTarget()).toBe('_blank');
+      });
+    });
+
+    test('LinkNode.setTarget()', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const linkNode = new LinkNode('https://example.com/foo', '_blank');
+
+        expect(linkNode.getTarget()).toBe('_blank');
+
+        linkNode.setTarget('_self');
+
+        expect(linkNode.getTarget()).toBe('_self');
+      });
+    });
+
+    test('LinkNode.getRel()', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const linkNode = new LinkNode(
+          'https://example.com/foo',
+          '_blank',
+          'noopener noreferrer',
+        );
+
+        expect(linkNode.getRel()).toBe('noopener noreferrer');
+      });
+    });
+
+    test('LinkNode.setRel()', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const linkNode = new LinkNode(
+          'https://example.com/foo',
+          '_blank',
+          'noopener',
+        );
+
+        expect(linkNode.getRel()).toBe('noopener');
+
+        linkNode.setRel('noopener noreferrer');
+
+        expect(linkNode.getRel()).toBe('noopener noreferrer');
+      });
+    });
+
     test('LinkNode.createDOM()', async () => {
       const {editor} = testEnv;
 
@@ -92,6 +148,30 @@ describe('LexicalLinkNode tests', () => {
             theme: {},
           }).outerHTML,
         ).toBe('<a href="https://example.com/foo"></a>');
+      });
+    });
+
+    test('LinkNode.createDOM() with target and rel', async () => {
+      const {editor} = testEnv;
+
+      editor.update(() => {
+        const linkNode = new LinkNode(
+          'https://example.com/foo',
+          '_blank',
+          'noopener noreferrer',
+        );
+
+        expect(linkNode.createDOM(editorConfig).outerHTML).toBe(
+          '<a href="https://example.com/foo" target="_blank" rel="noopener noreferrer" class="my-link-class"></a>',
+        );
+        expect(
+          linkNode.createDOM({
+            namespace: '',
+            theme: {},
+          }).outerHTML,
+        ).toBe(
+          '<a href="https://example.com/foo" target="_blank" rel="noopener noreferrer"></a>',
+        );
       });
     });
 
@@ -117,6 +197,40 @@ describe('LexicalLinkNode tests', () => {
         expect(result).toBe(false);
         expect(domElement.outerHTML).toBe(
           '<a href="https://example.com/bar" class="my-link-class"></a>',
+        );
+      });
+    });
+
+    test('LinkNode.updateDOM() with target and rel', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const linkNode = new LinkNode(
+          'https://example.com/foo',
+          '_blank',
+          'noopener noreferrer',
+        );
+
+        const domElement = linkNode.createDOM(editorConfig);
+
+        expect(linkNode.createDOM(editorConfig).outerHTML).toBe(
+          '<a href="https://example.com/foo" target="_blank" rel="noopener noreferrer" class="my-link-class"></a>',
+        );
+
+        const newLinkNode = new LinkNode(
+          'https://example.com/bar',
+          '_self',
+          'noopener',
+        );
+        const result = newLinkNode.updateDOM(
+          linkNode,
+          domElement,
+          editorConfig,
+        );
+
+        expect(result).toBe(false);
+        expect(domElement.outerHTML).toBe(
+          '<a href="https://example.com/bar" target="_self" rel="noopener" class="my-link-class"></a>',
         );
       });
     });
@@ -152,6 +266,31 @@ describe('LexicalLinkNode tests', () => {
         expect(linkNode.__type).toEqual(createdLinkNode.__type);
         expect(linkNode.__parent).toEqual(createdLinkNode.__parent);
         expect(linkNode.__url).toEqual(createdLinkNode.__url);
+        expect(linkNode.__key).not.toEqual(createdLinkNode.__key);
+      });
+    });
+
+    test('$createLinkNode() with target and rel', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const linkNode = new LinkNode(
+          'https://example.com/foo',
+          '_blank',
+          'noopener noreferrer',
+        );
+
+        const createdLinkNode = $createLinkNode(
+          'https://example.com/foo',
+          '_blank',
+          'noopener noreferrer',
+        );
+
+        expect(linkNode.__type).toEqual(createdLinkNode.__type);
+        expect(linkNode.__parent).toEqual(createdLinkNode.__parent);
+        expect(linkNode.__url).toEqual(createdLinkNode.__url);
+        expect(linkNode.__target).toEqual(createdLinkNode.__target);
+        expect(linkNode.__rel).toEqual(createdLinkNode.__rel);
         expect(linkNode.__key).not.toEqual(createdLinkNode.__key);
       });
     });

--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -101,7 +101,7 @@ describe('LexicalLinkNode tests', () => {
       });
     });
 
-    test('LinkNode.getRel()', async () => {
+    test('LinkNode.getRelationship()', async () => {
       const {editor} = testEnv;
 
       await editor.update(() => {
@@ -111,11 +111,11 @@ describe('LexicalLinkNode tests', () => {
           'noopener noreferrer',
         );
 
-        expect(linkNode.getRel()).toBe('noopener noreferrer');
+        expect(linkNode.getRelationship()).toBe('noopener noreferrer');
       });
     });
 
-    test('LinkNode.setRel()', async () => {
+    test('LinkNode.setRelationship()', async () => {
       const {editor} = testEnv;
 
       await editor.update(() => {
@@ -125,11 +125,11 @@ describe('LexicalLinkNode tests', () => {
           'noopener',
         );
 
-        expect(linkNode.getRel()).toBe('noopener');
+        expect(linkNode.getRelationship()).toBe('noopener');
 
-        linkNode.setRel('noopener noreferrer');
+        linkNode.setRelationship('noopener noreferrer');
 
-        expect(linkNode.getRel()).toBe('noopener noreferrer');
+        expect(linkNode.getRelationship()).toBe('noopener noreferrer');
       });
     });
 
@@ -290,7 +290,7 @@ describe('LexicalLinkNode tests', () => {
         expect(linkNode.__parent).toEqual(createdLinkNode.__parent);
         expect(linkNode.__url).toEqual(createdLinkNode.__url);
         expect(linkNode.__target).toEqual(createdLinkNode.__target);
-        expect(linkNode.__rel).toEqual(createdLinkNode.__rel);
+        expect(linkNode.__relationship).toEqual(createdLinkNode.__relationship);
         expect(linkNode.__key).not.toEqual(createdLinkNode.__key);
       });
     });

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -158,7 +158,7 @@ export class LinkNode extends ElementNode {
   insertNewAfter(selection: RangeSelection): null | ElementNode {
     const element = this.getParentOrThrow().insertNewAfter(selection);
     if ($isElementNode(element)) {
-      const linkNode = $createLinkNode(this.__url);
+      const linkNode = $createLinkNode(this.__url, this.__target, this.__rel);
       element.append(linkNode);
       return linkNode;
     }
@@ -338,7 +338,7 @@ export function toggleLink(
         const firstNode = nodes[0];
 
         // if the first node is a LinkNode or if its
-        // parent is a LinkNode, we update the URL.
+        // parent is a LinkNode, we update the URL, target and rel.
         if ($isLinkNode(firstNode)) {
           firstNode.setURL(url);
           firstNode.setTarget(target);

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -95,11 +95,21 @@ export class LinkNode extends ElementNode {
     if (url !== prevNode.__url) {
       anchor.href = url;
     }
-    if (target && target !== prevNode.__target) {
-      anchor.target = target;
+
+    if (target !== prevNode.__target) {
+      if (target) {
+        anchor.target = target;
+      } else {
+        anchor.removeAttribute('target');
+      }
     }
-    if (relationship && relationship !== prevNode.__relationship) {
-      anchor.rel = relationship;
+
+    if (relationship !== prevNode.__relationship) {
+      if (relationship) {
+        anchor.rel = relationship;
+      } else {
+        anchor.removeAttribute('rel');
+      }
     }
     return false;
   }

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -243,14 +243,15 @@ export class AutoLinkNode extends LinkNode {
   }
 
   static clone(node: AutoLinkNode): AutoLinkNode {
-    return new AutoLinkNode(node.__url, node.__key);
+    return new AutoLinkNode(node.__url, node.__target, node.__rel, node.__key);
   }
 
   static importJSON(serializedNode: SerializedAutoLinkNode): AutoLinkNode {
-    const node = $createAutoLinkNode(serializedNode.url);
-    node.setFormat(serializedNode.format);
-    node.setIndent(serializedNode.indent);
-    node.setDirection(serializedNode.direction);
+    const {url, target, rel, format, indent, direction} = serializedNode;
+    const node = $createAutoLinkNode(url, target, rel);
+    node.setFormat(format);
+    node.setIndent(indent);
+    node.setDirection(direction);
     return node;
   }
 
@@ -270,7 +271,11 @@ export class AutoLinkNode extends LinkNode {
   insertNewAfter(selection: RangeSelection): null | ElementNode {
     const element = this.getParentOrThrow().insertNewAfter(selection);
     if ($isElementNode(element)) {
-      const linkNode = $createAutoLinkNode(this.__url);
+      const linkNode = $createAutoLinkNode(
+        this.__url,
+        this.__target,
+        this.__rel,
+      );
       element.append(linkNode);
       return linkNode;
     }
@@ -278,8 +283,12 @@ export class AutoLinkNode extends LinkNode {
   }
 }
 
-export function $createAutoLinkNode(url: string): AutoLinkNode {
-  return new AutoLinkNode(url);
+export function $createAutoLinkNode(
+  url: string,
+  target?: string,
+  rel?: string,
+): AutoLinkNode {
+  return new AutoLinkNode(url, target, rel);
 }
 
 export function $isAutoLinkNode(

--- a/packages/lexical-react/src/LexicalLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalLinkPlugin.ts
@@ -27,8 +27,8 @@ export function LinkPlugin(): null {
         if (typeof payload === 'string' || payload === null) {
           toggleLink(payload);
         } else {
-          const {url, target, rel} = payload;
-          toggleLink(url, target, rel);
+          const {url, target, relationship} = payload;
+          toggleLink(url, target, relationship);
         }
         return true;
       },

--- a/packages/lexical-react/src/LexicalLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalLinkPlugin.ts
@@ -21,10 +21,15 @@ export function LinkPlugin(): null {
   }, [editor]);
 
   useEffect(() => {
-    return editor.registerCommand<string | null>(
+    return editor.registerCommand(
       TOGGLE_LINK_COMMAND,
-      (url) => {
-        toggleLink(url);
+      (payload) => {
+        if (typeof payload === 'string' || payload === null) {
+          toggleLink(payload);
+        } else {
+          const {url, target, rel} = payload;
+          toggleLink(url, target, rel);
+        }
         return true;
       },
       COMMAND_PRIORITY_EDITOR,


### PR DESCRIPTION
Issue: https://github.com/facebook/lexical/issues/2671

Support `target` and `rel` for LinkNode

Ideas for the future:
- Add an option in the [playground](https://playground.lexical.dev/) if link should be opened in the new tab