### PR TITLE
fix(lexical-playground): LexicalTypeaheadMenuPlugin import

### DIFF
--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -18,7 +18,7 @@ import {
   LexicalTypeaheadMenuPlugin,
   TypeaheadOption,
   useBasicTypeaheadTriggerMatch,
-} from '@lexical/react/src/LexicalTypeaheadMenuPlugin';
+} from '@lexical/react/LexicalTypeaheadMenuPlugin';
 import {$createHeadingNode, $createQuoteNode} from '@lexical/rich-text';
 import {$wrapLeafNodesInElements} from '@lexical/selection';
 import {INSERT_TABLE_COMMAND} from '@lexical/table';


### PR DESCRIPTION
Use the correct import path that available in NPM package