### PR TITLE
fix(playground): fix rendering Exclidraw

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
@@ -85,12 +85,7 @@ export default function ExcalidrawImage({
 
   useEffect(() => {
     const setContent = async () => {
-      if (appState === null) {
-        return;
-      }
-
       const svg: SVGElement = await exportToSvg({
-        appState,
         elements,
         files: null,
       });


### PR DESCRIPTION
This PR is nearly the same as #2174.

The Exclidraw feature isn't available in the current version, and this PR fixes it.

The reason is that in https://github.com/facebook/lexical/pull/2496/files#diff-f45027bac56b3f85c3bec26a2889fb714d521d060db7b1d9554ff6d1fc3421efR88 , the change in #2174 is reverted and the bug appears again.