### PR TITLE
Changed type of includeHeaders parameter

### DIFF
--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -239,5 +239,5 @@ declare export class TableSelection {
 declare export var INSERT_TABLE_COMMAND: LexicalCommand<{
   rows: string,
   columns: string,
-  includeHeaders?: string,
+  includeHeaders?: boolean,
 }>;


### PR DESCRIPTION
Changed type for includeHeaders parameter from string to boolean to match the type of the parameter from the $createTableNodeWithDimensions function.