### PR TITLE
Remove unit test coverage reports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,13 +13,6 @@ const common = {
 };
 
 module.exports = {
-  collectCoverage: true,
-  collectCoverageFrom: [
-    '<rootDir>/packages/lexical/src/core/**/*.ts',
-    '<rootDir>/packages/lexical/src/extensions/**/*.ts',
-    '<rootDir>/packages/lexical-react/src/**/*.ts',
-  ],
-  coverageReporters: ['json', 'text'],
   projects: [
     {
       ...common,


### PR DESCRIPTION
The coverage reports are causing the unit tests to fail in #2687, with the below error. The code in the PR is absolutely fine though.
```
Failed to collect coverage from /Users/johnflockton/Development/lexical/packages/lexical-react/src/LexicalLinkPlugin.ts
ERROR: Jest worker encountered 3 child process exceptions, exceeding retry limit
STACK: Error: Jest worker encountered 3 child process exceptions, exceeding retry limit
    at ChildProcessWorker.initialize (/Users/johnflockton/Development/lexical/node_modules/jest-worker/build/workers/ChildProcessWorker.js:170:21)
    at ChildProcessWorker._onExit (/Users/johnflockton/Development/lexical/node_modules/jest-worker/build/workers/ChildProcessWorker.js:254:12)
    at ChildProcess.emit (node:events:527:28)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:291:12)
```
There is an [open issue](https://github.com/facebook/jest/issues/13007) on Jest, but given that we don't actually use the coverage reports, it might be easier to just remove them overall.