### PR TITLE
fix: check if options are empty

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -336,7 +336,7 @@ function ShortcutTypeahead<TOption extends TypeaheadOption>({
         KEY_ARROW_DOWN_COMMAND,
         (payload) => {
           const event = payload;
-          if (options !== null && selectedIndex !== null) {
+          if (options !== null && options.length && selectedIndex !== null) {
             const newSelectedIndex =
               selectedIndex !== options.length - 1 ? selectedIndex + 1 : 0;
             updateSelectedIndex(newSelectedIndex);
@@ -355,7 +355,7 @@ function ShortcutTypeahead<TOption extends TypeaheadOption>({
         KEY_ARROW_UP_COMMAND,
         (payload) => {
           const event = payload;
-          if (options !== null && selectedIndex !== null) {
+          if (options !== null && options.length && selectedIndex !== null) {
             const newSelectedIndex =
               selectedIndex !== 0 ? selectedIndex - 1 : options.length - 1;
             updateSelectedIndex(newSelectedIndex);


### PR DESCRIPTION
Typeahead plugin gives error on some instances:
i) No option found, []
ii) On switching from linebreak in quote node to heading node

https://user-images.githubusercontent.com/64399555/180824717-377b0d41-4828-4838-a2b5-72971542c6ef.mp4


