### PR TITLE
OnChangePlugin ignoreInitialChange -> ignoreHistoryMergeTagChange

### DIFF
--- a/packages/lexical-react/flow/LexicalOnChangePlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalOnChangePlugin.js.flow
@@ -10,6 +10,7 @@
 import type {EditorState, LexicalEditor} from 'lexical';
 
 declare export function OnChangePlugin({
+  ignoreHistoryMergeTagChange?: boolean,
   ignoreInitialChange?: boolean,
   ignoreSelectionChange?: boolean,
   onChange: (editorState: EditorState, editor: LexicalEditor) => void,

--- a/packages/lexical-react/src/LexicalOnChangePlugin.ts
+++ b/packages/lexical-react/src/LexicalOnChangePlugin.ts
@@ -12,10 +12,13 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
 export function OnChangePlugin({
+  ignoreHistoryMergeTagChange = true,
   ignoreInitialChange = true,
   ignoreSelectionChange = false,
   onChange,
 }: {
+  ignoreHistoryMergeTagChange?: boolean;
+  // TODO 0.4 remove
   ignoreInitialChange?: boolean;
   ignoreSelectionChange?: boolean;
   onChange: (editorState: EditorState, editor: LexicalEditor) => void;
@@ -25,11 +28,12 @@ export function OnChangePlugin({
   useLayoutEffect(() => {
     if (onChange) {
       return editor.registerUpdateListener(
-        ({editorState, dirtyElements, dirtyLeaves, prevEditorState}) => {
+        ({editorState, dirtyElements, dirtyLeaves, prevEditorState, tags}) => {
           if (
-            ignoreSelectionChange &&
-            dirtyElements.size === 0 &&
-            dirtyLeaves.size === 0
+            (ignoreSelectionChange &&
+              dirtyElements.size === 0 &&
+              dirtyLeaves.size === 0) ||
+            (ignoreHistoryMergeTagChange && tags.has('history-merge'))
           ) {
             return;
           }
@@ -42,7 +46,13 @@ export function OnChangePlugin({
         },
       );
     }
-  }, [editor, ignoreInitialChange, ignoreSelectionChange, onChange]);
+  }, [
+    editor,
+    ignoreHistoryMergeTagChange,
+    ignoreInitialChange,
+    ignoreSelectionChange,
+    onChange,
+  ]);
 
   return null;
 }


### PR DESCRIPTION
The `ignoreInitialChange` property is a trap. While, it's logically well implemented it doesn't account for plugins that may load later in time and cause nodes to be dirty even when this results to 0 DOM changes.

This race condition is accentuated when we use `editorState` inside LexicalComposer instead as it loads even before other `useLayoutEffects`

Hence, I'm proposing killing this property and replacing it for `ignoreHistoryMergeTag` that practically speaking does the same job we intended this one to do.