### PR TITLE
Listen for ESC in Escalidraw modal 

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -166,10 +166,6 @@ function ExcalidrawComponent({
         initialElements={elements}
         isShown={isModalOpen}
         onDelete={deleteNode}
-        onHide={() => {
-          editor.setReadOnly(false);
-          setModalOpen(false);
-        }}
         onSave={(newData) => {
           editor.setReadOnly(false);
           setData(newData);

--- a/packages/lexical-playground/src/plugins/ExcalidrawPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/ExcalidrawPlugin/index.ts
@@ -22,7 +22,8 @@ import {
 } from '../../nodes/ExcalidrawNode';
 
 export const INSERT_EXCALIDRAW_COMMAND: LexicalCommand<void> = createCommand();
-export default function ExcalidrawPlugin(): JSX.Element | null {
+
+export default function ExcalidrawPlugin(): null {
   const [editor] = useLexicalComposerContext();
   useEffect(() => {
     if (!editor.hasNodes([ExcalidrawNode])) {


### PR DESCRIPTION
Closes #1812 

- Add listeners for ESC key in Ecalidraw modal.
- Remove `onHide` method in favour of just `onDelete`, which was causing bugs (i.e. leaving empty Excalidraw nodes in the editor).