### PR TITLE
Remove readOnly from ContentEditable props type

### DIFF
--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -27,7 +27,6 @@ export type Props = Readonly<{
   autoCorrect?: boolean;
   className?: string;
   id?: string;
-  readOnly?: boolean;
   role?: string;
   spellCheck?: boolean;
   style?: CSSProperties;


### PR DESCRIPTION
The readOnly prop is on the ContentEditable Props type but isn't actually passed into the component. It caught me out as I was passing readOnly to ContentEditable where it has no effect instead of to the LexicalComposer component.