### PR TITLE
Convert pasted Google Docs Title text into a Heading

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -18,6 +18,7 @@ import {
 import {
   assertHTML,
   assertSelection,
+  clearEditor,
   click,
   copyToClipboard,
   focus,
@@ -2206,6 +2207,53 @@ test.describe('CopyAndPaste', () => {
             </span>
           </sup>
         </p>
+      `,
+    );
+  });
+
+  test('HTML Copy + paste a Title from Google Docs', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    const clipboard = {
+      'text/html': `<meta charset='utf-8'><meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-whatever"><span style="font-size:26pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">My document</span></b>`,
+    };
+
+    await pasteFromClipboard(page, clipboard);
+
+    await assertHTML(
+      page,
+      html`
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">My document</span>
+        </h1>
+      `,
+    );
+
+    await clearEditor(page);
+    await focusEditor(page);
+
+    // These can sometimes be put onto the clipboard wrapped in a paragraph element
+    clipboard[
+      'text/html'
+    ] = `<meta charset='utf-8'><meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-wjatever"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:3pt;"><span style="font-size:26pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">My document</span></p></b>`;
+
+    await pasteFromClipboard(page, clipboard);
+
+    await assertHTML(
+      page,
+      html`
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">My document</span>
+        </h1>
       `,
     );
   });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -253,38 +253,36 @@ export class HeadingNode extends ElementNode {
         conversion: convertHeadingElement,
         priority: 0,
       }),
-      p: (node: Node) => ({
-        conversion: (domNode: Node) => {
-          // domNode is a <p> since we matched it by nodeName
-          const p = domNode as HTMLParagraphElement;
-          const firstChild = p.firstChild;
-          if (firstChild && firstChild.nodeName.toLowerCase() === 'span') {
-            const span = firstChild as HTMLSpanElement;
-            if (span.style.fontSize === '26pt') {
-              return {
-                node: $createHeadingNode('h1'),
-              };
-            }
+      p: (node: Node) => {
+        // domNode is a <p> since we matched it by nodeName
+        const paragraph = node as HTMLParagraphElement;
+        const firstChild = paragraph.firstChild;
+        if (
+          firstChild !== null &&
+          firstChild.nodeName.toLowerCase() === 'span'
+        ) {
+          const span = firstChild as HTMLParagraphElement;
+          if (span.style.fontSize === '26pt') {
+            return {
+              conversion: () => ({node: null}),
+              priority: 3,
+            };
           }
-          return {node: null};
-        },
-        priority: 2,
-      }),
+        }
+        return null;
+      },
       span: () => ({
         conversion: (domNode: Node) => {
           // domNode is a <span> since we matched it by nodeName
-          let node = null;
           const span = domNode as HTMLSpanElement;
-          const parent = domNode.parentNode;
           if (span.style.fontSize === '26pt') {
-            node =
-              parent && parent.nodeName.toLowerCase() === 'p'
-                ? null
-                : $createHeadingNode('h1');
+            return {
+              node: $createHeadingNode('h1'),
+            };
           }
-          return {node};
+          return {node: null};
         },
-        priority: 4,
+        priority: 3,
       }),
     };
   }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -257,33 +257,27 @@ export class HeadingNode extends ElementNode {
         // domNode is a <p> since we matched it by nodeName
         const paragraph = node as HTMLParagraphElement;
         const firstChild = paragraph.firstChild;
-        if (
-          firstChild !== null &&
-          firstChild.nodeName.toLowerCase() === 'span'
-        ) {
-          const span = firstChild as HTMLParagraphElement;
-          if (span.style.fontSize === '26pt') {
-            return {
-              conversion: () => ({node: null}),
-              priority: 3,
-            };
-          }
+        if (firstChild !== null && isGoogleDocsTitle(firstChild)) {
+          return {
+            conversion: () => ({node: null}),
+            priority: 3,
+          };
         }
         return null;
       },
-      span: () => ({
-        conversion: (domNode: Node) => {
-          // domNode is a <span> since we matched it by nodeName
-          const span = domNode as HTMLSpanElement;
-          if (span.style.fontSize === '26pt') {
-            return {
-              node: $createHeadingNode('h1'),
-            };
-          }
-          return {node: null};
-        },
-        priority: 3,
-      }),
+      span: (node: Node) => {
+        if (isGoogleDocsTitle(node)) {
+          return {
+            conversion: (domNode: Node) => {
+              return {
+                node: $createHeadingNode('h1'),
+              };
+            },
+            priority: 3,
+          };
+        }
+        return null;
+      },
     };
   }
 
@@ -325,6 +319,13 @@ export class HeadingNode extends ElementNode {
   extractWithChild(): boolean {
     return true;
   }
+}
+
+function isGoogleDocsTitle(domNode: Node): boolean {
+  if (domNode.nodeName.toLowerCase() === 'span') {
+    return (domNode as HTMLSpanElement).style.fontSize === '26pt';
+  }
+  return false;
 }
 
 function convertHeadingElement(domNode: Node): DOMConversionOutput {

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -253,6 +253,39 @@ export class HeadingNode extends ElementNode {
         conversion: convertHeadingElement,
         priority: 0,
       }),
+      p: (node: Node) => ({
+        conversion: (domNode: Node) => {
+          // domNode is a <p> since we matched it by nodeName
+          const p = domNode as HTMLParagraphElement;
+          const firstChild = p.firstChild;
+          if (firstChild && firstChild.nodeName.toLowerCase() === 'span') {
+            const span = firstChild as HTMLSpanElement;
+            if (span.style.fontSize === '26pt') {
+              return {
+                node: $createHeadingNode('h1'),
+              };
+            }
+          }
+          return {node: null};
+        },
+        priority: 2,
+      }),
+      span: () => ({
+        conversion: (domNode: Node) => {
+          // domNode is a <span> since we matched it by nodeName
+          let node = null;
+          const span = domNode as HTMLSpanElement;
+          const parent = domNode.parentNode;
+          if (span.style.fontSize === '26pt') {
+            node =
+              parent && parent.nodeName.toLowerCase() === 'p'
+                ? null
+                : $createHeadingNode('h1');
+          }
+          return {node};
+        },
+        priority: 4,
+      }),
     };
   }
 

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -187,7 +187,6 @@ function onSelectionChange(
     focusNode: focusDOM,
     focusOffset,
   } = domSelection;
-
   if (isSelectionChangeFromDOMUpdate) {
     isSelectionChangeFromDOMUpdate = false;
 


### PR DESCRIPTION
This adds some pretty fragile logic to preserve the formatting of a Google Docs "Title" when pasted into a Lexical editor using the core HeadingNode from @lexical/rich-text.

I do not understand why Google doesn't put something vaguely resembling semantic HTML on the clipboard when users copy from Docs, but I don't think it's going to change and we need to find a more robust way to deal with the idiosyncrasies.  

I noticed CKEditor has a whole separate plugin just for handling pasted HTML from Docs. Perhaps the most robust solution would be to not use HTML at all and instead build a conversion between the Google Docs JSON format (that is also on the clipboard) and Lexical.

For now, we have this.