### PR TITLE
Bug: typo in Documentation. It should be ReactNode instead of React (…

### DIFF
--- a/examples/decorators.md
+++ b/examples/decorators.md
@@ -4,7 +4,7 @@ Decorator node is a way to embed non-text components into the editor. It can be 
 
 Here's an example of how you can create a decorator node for embedding a video:
 
-```js
+```ts
 export class VideoNode extends DecoratorNode {
   __url: string;
 
@@ -36,7 +36,7 @@ export class VideoNode extends DecoratorNode {
     writable.__url = url;
   }
 
-  decorate(editor: LexicalEditor): React$Node {
+  decorate(editor: LexicalEditor): ReactNode {
     return <VideoPlayer url={this.__url} />;
   }
 }
@@ -58,13 +58,13 @@ As any other custom Lexical node, decorator nodes need to be registered _before_
 </LexicalComposer>
 ```
 
-```js
+```ts
 // Create a custom command with a typed payload.
 type CommandPayload = string;
 export const INSERT_VIDEO_COMMAND: LexicalCommand<CommandPayload> =
   createCommand();
 
-function VideoPlugin(): React$Node {
+function VideoPlugin(): ReactNode {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
@@ -98,10 +98,10 @@ function VideoPlugin(): React$Node {
 
 Then assuming we have a some UE insert a video into the editor:
 
-```js
+```ts
 import {INSERT_VIDEO_COMMAND} from 'VideoPlugin';
 
-function ToolbarVideoButton(): React$Node {
+function ToolbarVideoButton(): ReactNode {
   const [editor] = useLexicalComposerContext();
   const insertVideo = url => {
       // Executing command defined in a plugin

--- a/packages/lexical-website-new/docs/concepts/nodes.md
+++ b/packages/lexical-website-new/docs/concepts/nodes.md
@@ -240,8 +240,8 @@ export function $isColoredNode(node: ?LexicalNode): boolean {
 
 ### Extending `DecoratorNode`
 
-```js
-export class VideoNode extends DecoratorNode<React$Node> {
+```ts
+export class VideoNode extends DecoratorNode<ReactNode> {
   __id: string;
 
   static getType(): string {
@@ -265,7 +265,7 @@ export class VideoNode extends DecoratorNode<React$Node> {
     return false;
   }
 
-  decorate(): React$Node {
+  decorate(): ReactNode {
     return <VideoPlayer videoID={this.__id} />;
   }
 }


### PR DESCRIPTION
…https://github.com/facebook/lexical/issues/2731)