### PR TITLE
fix: `timeoutId` type

### DIFF
--- a/packages/lexical-playground/src/hooks/useReport.ts
+++ b/packages/lexical-playground/src/hooks/useReport.ts
@@ -31,11 +31,13 @@ const getElement = (): HTMLElement => {
   return element;
 };
 
-export default function useReport(): (arg0: string) => number {
-  const timer = useRef<number | null>(null);
+export default function useReport(): (
+  arg0: string,
+) => ReturnType<typeof setTimeout> {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cleanup = useCallback(() => {
     if (timer !== null) {
-      clearTimeout(timer.current as number);
+      clearTimeout(timer.current as ReturnType<typeof setTimeout>);
     }
 
     if (document.body) {
@@ -52,9 +54,9 @@ export default function useReport(): (arg0: string) => number {
       // eslint-disable-next-line no-console
       console.log(content);
       const element = getElement();
-      clearTimeout(timer.current as number);
+      clearTimeout(timer.current as ReturnType<typeof setTimeout>);
       element.innerHTML = content;
-      timer.current = window.setTimeout(cleanup, 1000);
+      timer.current = setTimeout(cleanup, 1000);
       return timer.current;
     },
     [cleanup],

--- a/packages/lexical-playground/src/hooks/useReport.ts
+++ b/packages/lexical-playground/src/hooks/useReport.ts
@@ -31,11 +31,11 @@ const getElement = (): HTMLElement => {
   return element;
 };
 
-export default function useReport(): (arg0: string) => NodeJS.Timeout {
-  const timer = useRef<NodeJS.Timeout | null>(null);
+export default function useReport(): (arg0: string) => number {
+  const timer = useRef<number | null>(null);
   const cleanup = useCallback(() => {
     if (timer !== null) {
-      clearTimeout(timer.current as NodeJS.Timeout);
+      clearTimeout(timer.current as number);
     }
 
     if (document.body) {
@@ -52,9 +52,9 @@ export default function useReport(): (arg0: string) => NodeJS.Timeout {
       // eslint-disable-next-line no-console
       console.log(content);
       const element = getElement();
-      clearTimeout(timer.current as NodeJS.Timeout);
+      clearTimeout(timer.current as number);
       element.innerHTML = content;
-      timer.current = setTimeout(cleanup, 1000);
+      timer.current = window.setTimeout(cleanup, 1000);
       return timer.current;
     },
     [cleanup],

--- a/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
@@ -33,8 +33,8 @@ export default function TypingPerfPlugin(): JSX.Element | null {
   const report = useReport();
   useEffect(() => {
     let start = 0;
-    let timerId: number | null;
-    let keyPressTimerId: number | null;
+    let timerId: ReturnType<typeof setTimeout> | null;
+    let keyPressTimerId: ReturnType<typeof setTimeout> | null;
     let log: Array<DOMHighResTimeStamp> = [];
     let invalidatingEvent = false;
 
@@ -59,9 +59,9 @@ export default function TypingPerfPlugin(): JSX.Element | null {
 
       // We use a setTimeout(0) instead of requestAnimationFrame, due to
       // inconsistencies between the sequencing of rAF in different browsers.
-      keyPressTimerId = window.setTimeout(measureEventEnd, 0);
+      keyPressTimerId = setTimeout(measureEventEnd, 0);
       // Schedule a timer to report the results.
-      timerId = window.setTimeout(() => {
+      timerId = setTimeout(() => {
         const total = log.reduce((a, b) => a + b, 0);
         const reportedText =
           'Typing Perf: ' + Math.round((total / log.length) * 100) / 100 + 'ms';

--- a/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
@@ -33,7 +33,7 @@ export default function TypingPerfPlugin(): JSX.Element | null {
   const report = useReport();
   useEffect(() => {
     let start = 0;
-    let timerId: NodeJS.Timeout | null;
+    let timerId: number | null;
     let keyPressTimerId: number | null;
     let log: Array<DOMHighResTimeStamp> = [];
     let invalidatingEvent = false;
@@ -61,7 +61,7 @@ export default function TypingPerfPlugin(): JSX.Element | null {
       // inconsistencies between the sequencing of rAF in different browsers.
       keyPressTimerId = window.setTimeout(measureEventEnd, 0);
       // Schedule a timer to report the results.
-      timerId = setTimeout(() => {
+      timerId = window.setTimeout(() => {
         const total = log.reduce((a, b) => a + b, 0);
         const reportedText =
           'Typing Perf: ' + Math.round((total / log.length) * 100) / 100 + 'ms';

--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -92,7 +92,7 @@ export function TreeView({
 
   useEffect(() => {
     if (isPlaying) {
-      let timeoutId: number;
+      let timeoutId: ReturnType<typeof setTimeout>;
 
       const play = () => {
         const currentIndex = playingIndexRef.current;
@@ -105,7 +105,7 @@ export function TreeView({
         const currentTime = timeStampedEditorStates[currentIndex][0];
         const nextTime = timeStampedEditorStates[currentIndex + 1][0];
         const timeDiff = nextTime - currentTime;
-        timeoutId = window.setTimeout(() => {
+        timeoutId = setTimeout(() => {
           playingIndexRef.current++;
           const index = playingIndexRef.current;
           const input = inputRef.current;
@@ -122,7 +122,7 @@ export function TreeView({
       play();
 
       return () => {
-        window.clearTimeout(timeoutId);
+        clearTimeout(timeoutId);
       };
     }
   }, [timeStampedEditorStates, isPlaying, editor, totalEditorStates]);

--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -92,7 +92,7 @@ export function TreeView({
 
   useEffect(() => {
     if (isPlaying) {
-      let timeoutId: NodeJS.Timeout;
+      let timeoutId: number;
 
       const play = () => {
         const currentIndex = playingIndexRef.current;
@@ -105,7 +105,7 @@ export function TreeView({
         const currentTime = timeStampedEditorStates[currentIndex][0];
         const nextTime = timeStampedEditorStates[currentIndex + 1][0];
         const timeDiff = nextTime - currentTime;
-        timeoutId = setTimeout(() => {
+        timeoutId = window.setTimeout(() => {
           playingIndexRef.current++;
           const index = playingIndexRef.current;
           const input = inputRef.current;


### PR DESCRIPTION
- Fixed `timeoutId` type (`setTimeout` returns a number  in browser  and `Timeout` object in node)
- Removed `window.` prefix, since it might break during **SSR**

