### PR TITLE
fix: composing text input interruption when editor is at composing state

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -629,6 +629,9 @@ function $shouldInsertTextAfterOrBeforeTextNode(
   if (node.isSegmented()) {
     return true;
   }
+  if (node.isComposing()) {
+    return false;
+  }
   if (!selection.isCollapsed()) {
     return false;
   }


### PR DESCRIPTION
When I type some Chinese for appending text to HashtagNode (Editor is in composing state), lexical should prevent default action and stop inserting text for TextNode.

https://user-images.githubusercontent.com/1413056/181918441-07c6bcf2-785f-469e-b11e-07e2a11c2699.mov


