### PR TITLE
fix: getTopLevelElement for decoratorNode

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -13,7 +13,13 @@ import type {Klass} from 'lexical';
 
 import invariant from 'shared/invariant';
 
-import {$isElementNode, $isRootNode, $isTextNode, ElementNode} from '.';
+import {
+  $isDecoratorNode,
+  $isElementNode,
+  $isRootNode,
+  $isTextNode,
+  ElementNode,
+} from '.';
 import {
   $getSelection,
   $isRangeSelection,
@@ -286,7 +292,10 @@ export class LexicalNode {
     let node: ElementNode | this | null = this;
     while (node !== null) {
       const parent: ElementNode | this | null = node.getParent();
-      if ($isRootNode(parent) && $isElementNode(node)) {
+      if (
+        $isRootNode(parent) &&
+        ($isElementNode(node) || $isDecoratorNode(node))
+      ) {
         return node;
       }
       node = parent;


### PR DESCRIPTION
If a node is inserted while a `decoratorNode` is selected, it gives an error as it fails to receive a `topLevelElement`

Fix: The `topLevelElement` should be itself during a node selection so that the inserted node can be added using `insertAfter`

## Before
https://user-images.githubusercontent.com/64399555/182132955-f6fe368e-a68c-4bad-ad98-d862ae5495e6.mp4
## After
https://user-images.githubusercontent.com/64399555/182132988-7ec067ac-7342-4a07-90a0-11b0055ca318.mp4


