### PR TITLE
Tighten check on top level decorator nodes 

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -294,7 +294,7 @@ export class LexicalNode {
       const parent: ElementNode | this | null = node.getParent();
       if (
         $isRootNode(parent) &&
-        ($isElementNode(node) || $isDecoratorNode(node))
+        ($isElementNode(node) || ($isDecoratorNode(node) && node.isTopLevel()))
       ) {
         return node;
       }


### PR DESCRIPTION
I realised we should also check for `isTopLevel` in #2741.