### PR TITLE
Fix selection format for empty paragraphs

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
@@ -302,7 +302,19 @@ test.describe('Toolbar', () => {
     await selectCharacters(page, 'left', 5);
 
     const actives = await page.$$('div.toolbar button.toolbar-item.active');
-    await page.pause();
+    expect(actives.length).toEqual(0);
+  });
+
+  test('Selecting empty paragraphs has empty selection format', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await focusEditor(page);
+    await page.keyboard.press('Enter');
+    await selectAll(page);
+    const actives = await page.$$('div.toolbar button.toolbar-item.active');
     expect(actives.length).toEqual(0);
   });
 });

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -256,12 +256,14 @@ function onSelectionChange(
         }
       } else {
         let combinedFormat = IS_ALL_FORMATTING;
+        let hasTextNodes = false;
 
         const nodes = selection.getNodes();
         const nodesLength = nodes.length;
         for (let i = 0; i < nodesLength; i++) {
           const node = nodes[i];
           if ($isTextNode(node)) {
+            hasTextNodes = true;
             combinedFormat &= node.getFormat();
             if (combinedFormat === 0) {
               break;
@@ -269,7 +271,7 @@ function onSelectionChange(
           }
         }
 
-        selection.format = combinedFormat;
+        selection.format = hasTextNodes ? combinedFormat : 0;
       }
     }
 


### PR DESCRIPTION
Selecting empty paragraphs calculated wrong selection format:

<img width="1049" alt="Screen Shot 2022-08-04 at 10 39 29 AM" src="https://user-images.githubusercontent.com/132642/182875256-52c7ac6b-aa4b-4053-9118-69e9b08abf12.png">
