### PR TITLE
Remove unused function args from LexicalUtils

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -625,7 +625,7 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
         $setCompositionKey(null);
       }
     } else {
-      $updateSelectedTextFromDOM(editor, false);
+      $updateSelectedTextFromDOM(false);
 
       // onInput always fires after onCompositionEnd for FF.
       if (isFirefoxEndingComposition) {
@@ -721,7 +721,7 @@ function onCompositionEndImpl(editor: LexicalEditor, data?: string): void {
     }
   }
 
-  $updateSelectedTextFromDOM(editor, true, data);
+  $updateSelectedTextFromDOM(true, data);
 }
 
 function onCompositionEnd(
@@ -752,17 +752,17 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
 
   const {keyCode, shiftKey, ctrlKey, metaKey, altKey} = event;
 
-  if (isMoveForward(keyCode, ctrlKey, shiftKey, altKey, metaKey)) {
+  if (isMoveForward(keyCode, ctrlKey, altKey, metaKey)) {
     dispatchCommand(editor, KEY_ARROW_RIGHT_COMMAND, event);
   } else if (isMoveToEnd(keyCode, ctrlKey, shiftKey, altKey, metaKey)) {
     dispatchCommand(editor, MOVE_TO_END, event);
-  } else if (isMoveBackward(keyCode, ctrlKey, shiftKey, altKey, metaKey)) {
+  } else if (isMoveBackward(keyCode, ctrlKey, altKey, metaKey)) {
     dispatchCommand(editor, KEY_ARROW_LEFT_COMMAND, event);
   } else if (isMoveToStart(keyCode, ctrlKey, shiftKey, altKey, metaKey)) {
     dispatchCommand(editor, MOVE_TO_START, event);
-  } else if (isMoveUp(keyCode, ctrlKey, shiftKey, altKey, metaKey)) {
+  } else if (isMoveUp(keyCode, ctrlKey, metaKey)) {
     dispatchCommand(editor, KEY_ARROW_UP_COMMAND, event);
-  } else if (isMoveDown(keyCode, ctrlKey, shiftKey, altKey, metaKey)) {
+  } else if (isMoveDown(keyCode, ctrlKey, metaKey)) {
     dispatchCommand(editor, KEY_ARROW_DOWN_COMMAND, event);
   } else if (isLineBreak(keyCode, shiftKey)) {
     isInsertLineBreak = true;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -496,7 +496,6 @@ export function createUID(): string {
 }
 
 export function $updateSelectedTextFromDOM(
-  editor: LexicalEditor,
   isCompositionEnd: boolean,
   data?: string,
 ): void {
@@ -882,7 +881,6 @@ function isArrowDown(keyCode: number): boolean {
 export function isMoveBackward(
   keyCode: number,
   ctrlKey: boolean,
-  shiftKey: boolean,
   altKey: boolean,
   metaKey: boolean,
 ): boolean {
@@ -902,7 +900,6 @@ export function isMoveToStart(
 export function isMoveForward(
   keyCode: number,
   ctrlKey: boolean,
-  shiftKey: boolean,
   altKey: boolean,
   metaKey: boolean,
 ): boolean {
@@ -922,8 +919,6 @@ export function isMoveToEnd(
 export function isMoveUp(
   keyCode: number,
   ctrlKey: boolean,
-  shiftKey: boolean,
-  altKey: boolean,
   metaKey: boolean,
 ): boolean {
   return isArrowUp(keyCode) && !ctrlKey && !metaKey;
@@ -932,8 +927,6 @@ export function isMoveUp(
 export function isMoveDown(
   keyCode: number,
   ctrlKey: boolean,
-  shiftKey: boolean,
-  altKey: boolean,
   metaKey: boolean,
 ): boolean {
   return isArrowDown(keyCode) && !ctrlKey && !metaKey;


### PR DESCRIPTION
These aren't exported externally so it's not a breaking change.