### PR TITLE
Handle `insertTranspose` for `beforeinput` event

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Keyboard.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Keyboard.spec.mjs
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  assertHTML,
+  E2E_BROWSER,
+  focusEditor,
+  html,
+  initialize,
+  IS_MAC,
+  test,
+} from '../utils/index.mjs';
+
+const supportsTranspose = IS_MAC && E2E_BROWSER !== 'firefox';
+
+test.describe('Keyboard shortcuts', () => {
+  test.beforeEach(
+    ({isCollab, page}) => supportsTranspose && initialize({isCollab, page}),
+  );
+
+  test('handles "insertTranspose" event from Control+T on MAC', async ({
+    page,
+    context,
+    isPlainText,
+    browserName,
+  }) => {
+    test.skip(!supportsTranspose);
+
+    await focusEditor(page);
+    await page.keyboard.type('abc');
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.down('Control');
+    await page.keyboard.press('T');
+    await page.keyboard.press('T');
+    await page.keyboard.up('Control');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">bca</span>
+        </p>
+      `,
+    );
+  });
+});

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -436,7 +436,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
     const anchorNode = anchor.getNode();
     const focusNode = focus.getNode();
 
-    if (inputType === 'insertText') {
+    if (inputType === 'insertText' || inputType === 'insertTranspose') {
       if (data === '\n') {
         event.preventDefault();
         dispatchCommand(editor, INSERT_LINE_BREAK_COMMAND, false);


### PR DESCRIPTION
Pressing `^ + T` works in Safari since it triggers onbeforeinput with `inputType=insertText`, while chrome uses `inputType=insertTranspose`:

fix #2751

https://user-images.githubusercontent.com/132642/182932055-f9a849a7-28f8-40c8-a320-312a2d4afb44.mov

