### PR TITLE
Selection#formatText to retain selection and handle all text nodes

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -183,9 +183,9 @@ test.describe('TextFormatting', () => {
       `,
     );
     await assertSelection(page, {
-      anchorOffset: 0,
+      anchorOffset: 5,
       anchorPath: [0, 1, 0],
-      focusOffset: 5,
+      focusOffset: 0,
       focusPath: [0, 1, 0],
     });
 
@@ -201,9 +201,9 @@ test.describe('TextFormatting', () => {
       `,
     );
     await assertSelection(page, {
-      anchorOffset: 6,
+      anchorOffset: 11,
       anchorPath: [0, 0, 0],
-      focusOffset: 11,
+      focusOffset: 6,
       focusPath: [0, 0, 0],
     });
   });
@@ -289,9 +289,9 @@ test.describe('TextFormatting', () => {
       `,
     );
     await assertSelection(page, {
-      anchorOffset: 0,
+      anchorOffset: 5,
       anchorPath: [0, 1, 0],
-      focusOffset: 5,
+      focusOffset: 0,
       focusPath: [0, 1, 0],
     });
 
@@ -307,9 +307,9 @@ test.describe('TextFormatting', () => {
       `,
     );
     await assertSelection(page, {
-      anchorOffset: 6,
+      anchorOffset: 11,
       anchorPath: [0, 0, 0],
-      focusOffset: 11,
+      focusOffset: 6,
       focusPath: [0, 0, 0],
     });
   });
@@ -349,9 +349,9 @@ test.describe('TextFormatting', () => {
       `,
     );
     await assertSelection(page, {
-      anchorOffset: 0,
+      anchorOffset: 5,
       anchorPath: [0, 1, 0],
-      focusOffset: 5,
+      focusOffset: 0,
       focusPath: [0, 1, 0],
     });
 
@@ -367,9 +367,9 @@ test.describe('TextFormatting', () => {
       `,
     );
     await assertSelection(page, {
-      anchorOffset: 6,
+      anchorOffset: 11,
       anchorPath: [0, 0, 0],
-      focusOffset: 11,
+      focusOffset: 6,
       focusPath: [0, 0, 0],
     });
 
@@ -394,9 +394,9 @@ test.describe('TextFormatting', () => {
       `,
     );
     await assertSelection(page, {
-      anchorOffset: 0,
+      anchorOffset: 5,
       anchorPath: [0, 1, 0],
-      focusOffset: 5,
+      focusOffset: 0,
       focusPath: [0, 1, 0],
     });
 
@@ -419,9 +419,9 @@ test.describe('TextFormatting', () => {
       `,
     );
     await assertSelection(page, {
-      anchorOffset: 0,
+      anchorOffset: 5,
       anchorPath: [0, 1, 0],
-      focusOffset: 5,
+      focusOffset: 0,
       focusPath: [0, 1, 0],
     });
   });
@@ -601,9 +601,9 @@ test.describe('TextFormatting', () => {
       `,
     );
     await assertSelection(page, {
-      anchorOffset: 0,
+      anchorOffset: 5,
       anchorPath: [0, 1, 0],
-      focusOffset: 5,
+      focusOffset: 0,
       focusPath: [0, 1, 0],
     });
 
@@ -736,21 +736,12 @@ test.describe('TextFormatting', () => {
       `,
     );
 
-    if (browserName === 'webkit') {
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [0, 1, 0],
-        focusOffset: 5,
-        focusPath: [0, 1, 0],
-      });
-    } else {
-      await assertSelection(page, {
-        anchorOffset: 6,
-        anchorPath: [0, 0, 0],
-        focusOffset: 5,
-        focusPath: [0, 1, 0],
-      });
-    }
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0, 1, 0],
+      focusOffset: 5,
+      focusPath: [0, 1, 0],
+    });
 
     await toggleItalic(page);
     await assertHTML(

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -471,6 +471,62 @@ describe('LexicalSelection tests', () => {
         '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">' +
         '<p class="editor-paragraph"><br></p>' +
         '<p class="editor-paragraph" dir="ltr">' +
+        '<strong class="editor-text-bold" data-lexical-text="true">Hello</strong>' +
+        '</p>' +
+        '<p class="editor-paragraph" dir="ltr">' +
+        '<strong class="editor-text-bold" data-lexical-text="true">world</strong>' +
+        '</p>' +
+        '<p class="editor-paragraph"><br></p>' +
+        '</div>',
+      expectedSelection: {
+        anchorOffset: 0,
+        anchorPath: [0],
+        focusOffset: 0,
+        focusPath: [3],
+      },
+      inputs: [
+        insertParagraph(),
+        insertText('Hello'),
+        insertParagraph(),
+        insertText('world'),
+        insertParagraph(),
+        moveNativeSelection([0], 0, [3], 0),
+        formatBold(),
+      ],
+      name: 'Format multiline text selection that starts and ends on element and retain selection',
+    },
+    {
+      expectedHTML:
+        '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">' +
+        '<p class="editor-paragraph" dir="ltr">' +
+        '<span data-lexical-text="true">He</span>' +
+        '<strong class="editor-text-bold" data-lexical-text="true">llo</strong>' +
+        '</p>' +
+        '<p class="editor-paragraph" dir="ltr">' +
+        '<strong class="editor-text-bold" data-lexical-text="true">wo</strong>' +
+        '<span data-lexical-text="true">rld</span>' +
+        '</p>' +
+        '</div>',
+      expectedSelection: {
+        anchorOffset: 0,
+        anchorPath: [0, 1, 0],
+        focusOffset: 2,
+        focusPath: [1, 0, 0],
+      },
+      inputs: [
+        insertText('Hello'),
+        insertParagraph(),
+        insertText('world'),
+        moveNativeSelection([0, 0, 0], 2, [1, 0, 0], 2),
+        formatBold(),
+      ],
+      name: 'Format multiline text selection that starts and ends within text',
+    },
+    {
+      expectedHTML:
+        '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">' +
+        '<p class="editor-paragraph"><br></p>' +
+        '<p class="editor-paragraph" dir="ltr">' +
         '<span data-lexical-text="true">Hello </span>' +
         '<strong class="editor-text-bold" data-lexical-text="true">world</strong>' +
         '</p>' +

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -50,6 +50,7 @@ import {
   formatStrikeThrough,
   formatUnderline,
   getNodeFromPath,
+  insertParagraph,
   insertSegmentedNode,
   insertText,
   insertTokenNode,
@@ -440,6 +441,80 @@ describe('LexicalSelection tests', () => {
         convertToSegmentedNode(),
       ],
       name: 'Convert text to a segmented node',
+    },
+    {
+      expectedHTML:
+        '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">' +
+        '<p class="editor-paragraph"><br></p>' +
+        '<p class="editor-paragraph" dir="ltr">' +
+        '<strong class="editor-text-bold" data-lexical-text="true">Hello world</strong>' +
+        '</p>' +
+        '<p class="editor-paragraph"><br></p>' +
+        '</div>',
+      expectedSelection: {
+        anchorOffset: 0,
+        anchorPath: [0],
+        focusOffset: 0,
+        focusPath: [2],
+      },
+      inputs: [
+        insertParagraph(),
+        insertText('Hello world'),
+        insertParagraph(),
+        moveNativeSelection([0], 0, [2], 0),
+        formatBold(),
+      ],
+      name: 'Format selection that starts and ends on element and retain selection',
+    },
+    {
+      expectedHTML:
+        '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">' +
+        '<p class="editor-paragraph"><br></p>' +
+        '<p class="editor-paragraph" dir="ltr">' +
+        '<span data-lexical-text="true">Hello </span>' +
+        '<strong class="editor-text-bold" data-lexical-text="true">world</strong>' +
+        '</p>' +
+        '<p class="editor-paragraph"><br></p>' +
+        '</div>',
+      expectedSelection: {
+        anchorOffset: 0,
+        anchorPath: [1, 1, 0],
+        focusOffset: 0,
+        focusPath: [2],
+      },
+      inputs: [
+        insertParagraph(),
+        insertText('Hello world'),
+        insertParagraph(),
+        moveNativeSelection([1, 0, 0], 6, [2], 0),
+        formatBold(),
+      ],
+      name: 'Format selection that starts on text and ends on element and retain selection',
+    },
+    {
+      expectedHTML:
+        '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">' +
+        '<p class="editor-paragraph"><br></p>' +
+        '<p class="editor-paragraph" dir="ltr">' +
+        '<strong class="editor-text-bold" data-lexical-text="true">Hello</strong>' +
+        '<span data-lexical-text="true"> world</span>' +
+        '</p>' +
+        '<p class="editor-paragraph"><br></p>' +
+        '</div>',
+      expectedSelection: {
+        anchorOffset: 0,
+        anchorPath: [0],
+        focusOffset: 5,
+        focusPath: [1, 0, 0],
+      },
+      inputs: [
+        insertParagraph(),
+        insertText('Hello world'),
+        insertParagraph(),
+        moveNativeSelection([0], 0, [1, 0, 0], 5),
+        formatBold(),
+      ],
+      name: 'Format selection that starts on element and ends on text and retain selection',
     },
     // Tests need fixing:
     // ...GRAPHEME_SCENARIOS.flatMap(({description, grapheme}) => [

--- a/packages/lexical-selection/src/__tests__/utils/index.ts
+++ b/packages/lexical-selection/src/__tests__/utils/index.ts
@@ -259,7 +259,7 @@ export function convertToSegmentedNode() {
   };
 }
 
-export function insertParagraph(text) {
+export function insertParagraph() {
   return {
     type: 'insert_paragraph',
   };


### PR DESCRIPTION
A few bugs in formatText affected selection retention and nodes formatting in case selection starts with non-text node:

1. Selection changes after formatting

https://user-images.githubusercontent.com/132642/183076029-8d848c8b-4427-4c9e-bb1e-aa9c78ae1ca5.mov

https://user-images.githubusercontent.com/132642/183076594-afb91e3d-6e51-44f6-994c-b35420246be8.mov



2. Selection formats only first text node


https://user-images.githubusercontent.com/132642/183076292-32adb1b1-6104-408c-8a3f-ce0f409c90e1.mov

3. Backward selection (focus is before anchor) converted to a regular one (anchor goes first). Select word backward, make it bold, press Shift + left arrow. Expected selection to keep expanding backward

https://user-images.githubusercontent.com/132642/183086040-c8f09519-25ef-4f45-933e-39d15822f002.mov




Overall logic:
- Get selected text nodes (skip first one if selection starts on its end)
- Get start/end text offsets including cases with non-text anchor/focus
- Split first/last nodes if selection starts or ends inside text node and format it
- Format all text nodes in between
- Move selection only in case when it was on text node that was split, otherwise keep it as is (including cases when it's on element node)

Adjusted e2e that expected backward selection to be converted to a regular one

