### PR TITLE
chore: Move useCollaborationContext to dedicated file

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -76,6 +76,7 @@ module.name_mapper='^@lexical/react/LexicalTableOfContents__EXPERIMENTAL' -> '<P
 module.name_mapper='^@lexical/react/LexicalAutoFormatterPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalAutoFormatterPlugin.js.flow'
 module.name_mapper='^@lexical/react/LexicalCharacterLimitPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalCharacterLimitPlugin.js.flow'
 module.name_mapper='^@lexical/react/LexicalClearEditorPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalClearEditorPlugin.js.flow'
+module.name_mapper='^@lexical/react/LexicalCollaborationContext' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalCollaborationContext.js.flow'
 module.name_mapper='^@lexical/react/LexicalCollaborationPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow'
 module.name_mapper='^@lexical/react/LexicalTablePlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalTablePlugin.js.flow'
 module.name_mapper='^@lexical/react/LexicalLinkPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalLinkPlugin.js.flow'

--- a/jest.config.js
+++ b/jest.config.js
@@ -56,6 +56,8 @@ module.exports = {
           '<rootDir>/packages/lexical-react/src/LexicalAutoScrollPlugin.ts',
         '^@lexical/react/LexicalCheckListPlugin$':
           '<rootDir>/packages/lexical-react/src/LexicalCheckListPlugin.ts',
+        '^@lexical/react/LexicalCollaborationContext$':
+          '<rootDir>/packages/lexical-react/src/LexicalCollaborationContext.ts',
         '^@lexical/react/LexicalCollaborationPlugin$':
           '<rootDir>/packages/lexical-react/src/LexicalCollaborationPlugin.ts',
         '^@lexical/react/LexicalComposerContext$':

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -24,10 +24,8 @@ import type {
 
 import './ImageNode.css';
 
-import {
-  CollaborationPlugin,
-  useCollaborationContext,
-} from '@lexical/react/LexicalCollaborationPlugin';
+import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
+import {CollaborationPlugin} from '@lexical/react/LexicalCollaborationPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {HashtagPlugin} from '@lexical/react/LexicalHashtagPlugin';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';

--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -8,7 +8,7 @@
 
 import './PollNode.css';
 
-import {useCollaborationContext} from '@lexical/react/LexicalCollaborationPlugin';
+import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {mergeRegister} from '@lexical/utils';

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -17,10 +17,8 @@ import type {
 
 import './StickyNode.css';
 
-import {
-  CollaborationPlugin,
-  useCollaborationContext,
-} from '@lexical/react/LexicalCollaborationPlugin';
+import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
+import {CollaborationPlugin} from '@lexical/react/LexicalCollaborationPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {LexicalNestedComposer} from '@lexical/react/LexicalNestedComposer';

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -14,7 +14,7 @@ import {
   $convertFromMarkdownString,
   $convertToMarkdownString,
 } from '@lexical/markdown';
-import {useCollaborationContext} from '@lexical/react/LexicalCollaborationPlugin';
+import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
 import {CONNECTED_COMMAND, TOGGLE_CONNECT_COMMAND} from '@lexical/yjs';

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -26,7 +26,7 @@ import {
 } from '@lexical/mark';
 import {AutoFocusPlugin} from '@lexical/react/LexicalAutoFocusPlugin';
 import {ClearEditorPlugin} from '@lexical/react/LexicalClearEditorPlugin';
-import {useCollaborationContext} from '@lexical/react/LexicalCollaborationPlugin';
+import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {LexicalComposer} from '@lexical/react/LexicalComposer';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';

--- a/packages/lexical-playground/vite.config.js
+++ b/packages/lexical-playground/vite.config.js
@@ -127,6 +127,7 @@ const moduleResolution = [
   'LexicalPlainTextPlugin',
   'LexicalRichTextPlugin',
   'LexicalClearEditorPlugin',
+  'LexicalCollaborationContext',
   'LexicalCollaborationPlugin',
   'LexicalHistoryPlugin',
   'LexicalTypeaheadMenuPlugin',
@@ -155,7 +156,7 @@ const moduleResolution = [
       replacement: resolvedPath,
     });
   }
-}); 
+});
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/packages/lexical-playground/vite.prod.config.js
+++ b/packages/lexical-playground/vite.prod.config.js
@@ -127,6 +127,7 @@ const moduleResolution = [
   'LexicalPlainTextPlugin',
   'LexicalRichTextPlugin',
   'LexicalClearEditorPlugin',
+  'LexicalCollaborationContext',
   'LexicalCollaborationPlugin',
   'LexicalHistoryPlugin',
   'LexicalTypeaheadMenuPlugin',

--- a/packages/lexical-react/flow/LexicalCollaborationContext.js.flow
+++ b/packages/lexical-react/flow/LexicalCollaborationContext.js.flow
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {Doc} from 'yjs';
+
+type CollaborationContextType = {
+  clientID: number,
+  color: string,
+  name: string,
+  yjsDocMap: Map<string, Doc>,
+};
+
+declare export var CollaborationContext: React$Context<CollaborationContextType>;
+declare export function useCollaborationContext(): CollaborationContextType;

--- a/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow
@@ -41,13 +41,6 @@ export interface Provider {
   off(type: 'reload', cb: (doc: Doc) => void): void;
 }
 
-type CollaborationContextType = {
-  clientID: number,
-  color: string,
-  name: string,
-  yjsDocMap: Map<string, Doc>,
-};
-
 export type ProviderFactory = (
   id: string,
   yjsDocMap: Map<string, Doc>,
@@ -59,5 +52,3 @@ declare export function CollaborationPlugin(arg0: {
   shouldBootstrap: boolean,
   username?: string,
 }): React$Node;
-declare export var CollaborationContext: React$Context<CollaborationContextType>;
-declare export function useCollaborationContext(): CollaborationContextType;

--- a/packages/lexical-react/src/LexicalCollaborationContext.ts
+++ b/packages/lexical-react/src/LexicalCollaborationContext.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {Doc} from 'yjs';
+
+import {createContext, useContext} from 'react';
+
+type CollaborationContextType = {
+  clientID: number;
+  color: string;
+  name: string;
+  yjsDocMap: Map<string, Doc>;
+};
+
+const entries = [
+  ['Cat', '255,165,0'],
+  ['Dog', '0,200,55'],
+  ['Rabbit', '160,0,200'],
+  ['Frog', '0,172,200'],
+  ['Fox', '197,200,0'],
+  ['Hedgehog', '31,200,0'],
+  ['Pigeon', '200,0,0'],
+  ['Squirrel', '200,0,148'],
+  ['Bear', '255,235,0'],
+  ['Tiger', '86,255,0'],
+  ['Leopard', '0,255,208'],
+  ['Zebra', '0,243,255'],
+  ['Wolf', '0,102,255'],
+  ['Owl', '147,0,255'],
+  ['Gull', '255,0,153'],
+  ['Squid', '0,220,255'],
+];
+
+const randomEntry = entries[Math.floor(Math.random() * entries.length)];
+export const CollaborationContext: React.Context<CollaborationContextType> =
+  createContext({
+    clientID: 0,
+    color: randomEntry[1],
+    name: randomEntry[0],
+    yjsDocMap: new Map(),
+  });
+
+export function useCollaborationContext(
+  username?: string,
+): CollaborationContextType {
+  const collabContext = useContext(CollaborationContext);
+
+  if (username != null) {
+    collabContext.name = username;
+  }
+
+  return collabContext;
+}

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.ts
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.ts
@@ -8,8 +8,9 @@
 
 import type {Doc} from 'yjs';
 
+import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {createContext, useContext, useMemo} from 'react';
+import {useMemo} from 'react';
 import {WebsocketProvider} from 'y-websocket';
 
 import {
@@ -17,34 +18,6 @@ import {
   useYjsFocusTracking,
   useYjsHistory,
 } from './shared/useYjsCollaboration';
-
-type CollaborationContextType = {
-  clientID: number;
-  color: string;
-  name: string;
-  yjsDocMap: Map<string, Doc>;
-};
-
-const entries = [
-  ['Cat', '255,165,0'],
-  ['Dog', '0,200,55'],
-  ['Rabbit', '160,0,200'],
-  ['Frog', '0,172,200'],
-  ['Fox', '197,200,0'],
-  ['Hedgehog', '31,200,0'],
-  ['Pigeon', '200,0,0'],
-  ['Squirrel', '200,0,148'],
-  ['Bear', '255,235,0'],
-  ['Tiger', '86,255,0'],
-  ['Leopard', '0,255,208'],
-  ['Zebra', '0,243,255'],
-  ['Wolf', '0,102,255'],
-  ['Owl', '147,0,255'],
-  ['Gull', '255,0,153'],
-  ['Squid', '0,220,255'],
-];
-
-const randomEntry = entries[Math.floor(Math.random() * entries.length)];
 
 export function CollaborationPlugin({
   id,
@@ -88,24 +61,4 @@ export function CollaborationPlugin({
   useYjsFocusTracking(editor, provider, name, color);
 
   return cursors;
-}
-
-export const CollaborationContext: React.Context<CollaborationContextType> =
-  createContext({
-    clientID: 0,
-    color: randomEntry[1],
-    name: randomEntry[0],
-    yjsDocMap: new Map(),
-  });
-
-export function useCollaborationContext(
-  username?: string,
-): CollaborationContextType {
-  const collabContext = useContext(CollaborationContext);
-
-  if (username != null) {
-    collabContext.name = username;
-  }
-
-  return collabContext;
 }

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -9,7 +9,7 @@
 import type {LexicalComposerContextType} from '@lexical/react/LexicalComposerContext';
 import type {EditorThemeClasses, LexicalEditor} from 'lexical';
 
-import {useCollaborationContext} from '@lexical/react/LexicalCollaborationPlugin';
+import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {
   createLexicalComposerContext,
   LexicalComposerContext,

--- a/packages/lexical-react/src/__tests__/unit/utils.tsx
+++ b/packages/lexical-react/src/__tests__/unit/utils.tsx
@@ -13,10 +13,8 @@ import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as Y from 'yjs';
 
-import {
-  CollaborationPlugin,
-  useCollaborationContext,
-} from '../../LexicalCollaborationPlugin';
+import {useCollaborationContext} from '../../LexicalCollaborationContext';
+import {CollaborationPlugin} from '../../LexicalCollaborationPlugin';
 import {LexicalComposer} from '../../LexicalComposer';
 import {ContentEditable} from '../../LexicalContentEditable';
 import {RichTextPlugin} from '../../LexicalRichTextPlugin';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -135,6 +135,9 @@
       "@lexical/react/LexicalClearEditorPlugin": [
         "./packages/lexical-react/src/LexicalClearEditorPlugin.ts"
       ],
+      "@lexical/react/LexicalCollaborationContext": [
+        "./packages/lexical-react/src/LexicalCollaborationContext.ts"
+      ],
       "@lexical/react/LexicalCollaborationPlugin": [
         "./packages/lexical-react/src/LexicalCollaborationPlugin.ts"
       ],


### PR DESCRIPTION
This PR moves `useCollaborationContext` out of the `LexicalCollaborationPlugin` and into its own file.

`LexicalCollaborationPlugin` imports functions from `@lexical/yjs`, which has a `yjs` peer dependency, and also from `y-websocket`.
At the same time, `useCollaborationContext` is used in `LexicalNestedComposer`.

The combination of those 2 was causing the application to crash if you tried to use `LexicalNestedComposer` without adding `yjs` and `y-websocket` as a dependency on your project.

`yjs` should not be mandatory to use nested composers.

By splitting the 2, it should hopefully solves this issue, as the new context file only imports types from `yjs` and has no runtime dependencies to either `yjs` nor `y-websocket`.