### PR TITLE
Inject DevTools Script in Browser Extension

### DIFF
--- a/packages/lexical-devtools/public/inject.js
+++ b/packages/lexical-devtools/public/inject.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';
+
+let editorDOMNode, editorKey;
+
+// the existing editorState.toJSON() does not contain lexicalKeys
+// therefore, we have a custom serializeEditorState helper
+const serializeEditorState = (editorState) => {
+  const nodeMap = Object.fromEntries(editorState._nodeMap); // convert from Map structure to JSON-friendly object
+  return {nodeMap};
+};
+
+const postEditorState = (editorState) => {
+  const serializedEditorState = serializeEditorState(editorState);
+  const data = {editorState: serializedEditorState};
+  document.dispatchEvent(new CustomEvent('editorStateUpdate', {detail: data}));
+};
+
+document.addEventListener('loadEditorState', function (e) {
+  // query document for Lexical editor instance.
+  // TODO: add support multiple Lexical editors within the same page
+  editorDOMNode = document.querySelectorAll('div[data-lexical-editor]')[0];
+  const editor = editorDOMNode.__lexicalEditor;
+  editorKey = editorDOMNode.__lexicalEditor._key; // dynamically generated upon each pageload, we need this to find DOM nodes for highlighting
+
+  const initialEditorState = editor.getEditorState();
+  postEditorState(initialEditorState);
+
+  editor.registerUpdateListener(({editorState}) => {
+    postEditorState(editorState);
+  });
+});
+
+// append highlight overlay <div> to document
+const highlightOverlay = document.createElement('div');
+highlightOverlay.style.position = 'absolute';
+highlightOverlay.style.background = 'rgba(119, 182, 255, 0.5)';
+highlightOverlay.style.border = '1px dashed #77b6ff';
+document.body.appendChild(highlightOverlay);
+
+// functions to highlight/dehighlight DOM nodes onHover of DevTools nodes
+document.addEventListener('highlight', function (e) {
+  highlight(e.detail.lexicalKey);
+});
+
+document.addEventListener('dehighlight', function (e) {
+  dehighlight();
+});
+
+// depth first search to find DOM node with lexicalKey
+const findDOMNode = (node, targetKey) => {
+  // each DOM node has its Lexical key stored at a particular key eg. DOMNode[__lexicalKey_pzely]
+  const key = '__lexicalKey_' + editorKey;
+
+  if (targetKey === 'root') {
+    return editorDOMNode;
+  }
+
+  if (node[key] && node[key] === targetKey) {
+    return node;
+  }
+
+  for (let i = 0; i < node.childNodes.length; i++) {
+    const child = findDOMNode(node.childNodes[i], targetKey);
+    if (child) return child;
+  }
+
+  return null;
+};
+
+const highlight = (targetKey) => {
+  const node = findDOMNode(editorDOMNode, targetKey);
+  const {width, height, top, left} = node.getBoundingClientRect();
+  highlightOverlay.style.width = width + 'px';
+  highlightOverlay.style.height = height + 'px';
+  highlightOverlay.style.top = top + window.scrollY + 'px';
+  highlightOverlay.style.left = left + window.scrollX + 'px';
+  highlightOverlay.style.display = 'block';
+};
+
+const dehighlight = () => {
+  highlightOverlay.style.display = 'none';
+};

--- a/packages/lexical-devtools/public/manifest.json
+++ b/packages/lexical-devtools/public/manifest.json
@@ -22,5 +22,5 @@
     }
   ],
   "permissions": ["activeTab"],
-  "web_accessible_resources": ["inject.js"]
+  "web_accessible_resources": ["src/inject/index.js"]
 }

--- a/packages/lexical-devtools/public/manifest.json
+++ b/packages/lexical-devtools/public/manifest.json
@@ -21,5 +21,6 @@
       "js": ["src/content/index.js"]
     }
   ],
-  "permissions": ["activeTab"]
+  "permissions": ["activeTab"],
+  "web_accessible_resources": ["inject.js"]
 }

--- a/packages/lexical-devtools/src/content/index.ts
+++ b/packages/lexical-devtools/src/content/index.ts
@@ -7,17 +7,16 @@
  */
 import {IS_FIREFOX} from 'shared/environment';
 
-// const CAN_USE_DOM =
-//   typeof window !== 'undefined' &&
-//   typeof window.document !== 'undefined' &&
-//   typeof window.document.createElement !== 'undefined';
-// const IS_FIREFOX =
-//   CAN_USE_DOM && /^(?!.*Seamonkey)(?=.*Firefox).*/i.test(navigator.userAgent);
+declare global {
+  interface DocumentEventMap {
+    editorStateUpdate: CustomEvent;
+  }
+}
 
 // for security reasons, content scripts cannot read Lexical's changes to the DOM
 // in order to access the editorState, we inject this script directly into the page
 const script = document.createElement('script');
-script.src = chrome.runtime.getURL('inject.js');
+script.src = chrome.runtime.getURL('./index/inject.js');
 document.documentElement.appendChild(script);
 if (script.parentNode) script.parentNode.removeChild(script);
 

--- a/packages/lexical-devtools/src/content/index.ts
+++ b/packages/lexical-devtools/src/content/index.ts
@@ -18,7 +18,7 @@ declare global {
 // for security reasons, content scripts cannot read Lexical's changes to the DOM
 // in order to access the editorState, we inject this script directly into the page
 const script = document.createElement('script');
-script.src = chrome.runtime.getURL('./index/inject.js');
+script.src = chrome.runtime.getURL('src/inject/index.js');
 document.documentElement.appendChild(script);
 if (script.parentNode) script.parentNode.removeChild(script);
 

--- a/packages/lexical-devtools/src/content/index.ts
+++ b/packages/lexical-devtools/src/content/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import type {CloneInto} from '../../types';
+
 import {IS_FIREFOX} from 'shared/environment';
 
 declare global {
@@ -60,7 +62,7 @@ port.onMessage.addListener((message) => {
     const data = {lexicalKey: message.lexicalKey};
     const detail = IS_FIREFOX
       ? // eslint-disable-next-line no-undef
-        cloneInto(data, document.defaultView) // see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts#cloneinto
+        (cloneInto(data, document.defaultView) as CloneInto) // see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts#cloneinto
       : data;
     document.dispatchEvent(
       new CustomEvent('highlight', {

--- a/packages/lexical-devtools/src/devtools/index.ts
+++ b/packages/lexical-devtools/src/devtools/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+const port = chrome.runtime.connect();
+
 // Create the panel which appears within the browser's DevTools, loading the Lexical DevTools App within index.html.
 chrome.devtools.panels.create(
   'Lexical',
@@ -16,118 +18,12 @@ chrome.devtools.panels.create(
   },
 );
 
-chrome.runtime.onConnect.addListener((port) => {
-  port.onMessage.addListener((message) => {
-    if (message.name === 'highlight') {
-      chrome.devtools.inspectedWindow.eval(`
-        highlight('${message.lexicalKey}');
-      `);
-    }
-
-    if (message.name === 'dehighlight') {
-      chrome.devtools.inspectedWindow.eval(`
-        dehighlight();
-      `);
-    }
-  });
-});
-
 function handleShown() {
-  // Security concerns related to chrome.devtools.inspectedWindow.eval():
-  //   https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts
-  //   https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/eval
-
-  // query document for Lexical editor instance.
-  // TODO: add support multiple Lexical editors within the same page
-  // lexicalKey is attached to each DOM node like so: DOMNode[__lexicalKey_{editorKey}]
-  chrome.devtools.inspectedWindow.eval(`
-    const editorDOMNode = document.querySelectorAll(
-      'div[data-lexical-editor]',
-    )[0];
-    const editor = editorDOMNode.__lexicalEditor;
-    const editorKey = editorDOMNode.__lexicalEditor._key;
-    const lexicalKey = '__lexicalKey_' + editorKey;
-  `);
-
-  // depth first search to find DOM node with lexicalKey
-  chrome.devtools.inspectedWindow.eval(`
-    const findDOMNode = (node, targetKey) => {
-      if (targetKey === 'root') {
-        return editorDOMNode;
-      }
-
-      if (node[lexicalKey] && node[lexicalKey] === targetKey) {
-        return node;
-      }
-    
-      for (let i = 0; i < node.childNodes.length; i++) {
-        const child = findDOMNode(node.childNodes[i], targetKey);
-        if (child) return child;
-      }
-    
-      return null;
-    };
-  `);
-
-  // functions to highlight/dehighlight DOM nodes onHover of DevTools nodes
-  chrome.devtools.inspectedWindow.eval(`
-    const highlight = (lexicalKey) => {
-      const node = findDOMNode(editorDOMNode, lexicalKey);
-      const {width, height, top, left} = node.getBoundingClientRect();
-      highlightOverlay.style.width = width + 'px';
-      highlightOverlay.style.height = height + 'px';
-      highlightOverlay.style.top = top + window.scrollY + 'px';
-      highlightOverlay.style.left = left + window.scrollX + 'px';
-      highlightOverlay.style.display = 'block';
-    };
-
-    const dehighlight = () => {
-      highlightOverlay.style.display = 'none';
-    };
-  `);
-
-  // append highlight overlay <div> to document
-  chrome.devtools.inspectedWindow.eval(`
-    const highlightOverlay = document.createElement('div');
-    highlightOverlay.style.position = 'absolute';
-    highlightOverlay.style.background = 'rgba(119, 182, 255, 0.5)';
-    highlightOverlay.style.border = '1px dashed #77b6ff';
-    document.body.appendChild(highlightOverlay);
-  `);
-
-  // send initial editorState to devtools app through window.postMessage.
-  // the existing editorState.toJSON() does not contain lexicalKey
-  // therefore, we have a custom serializeEditorState helper
-  chrome.devtools.inspectedWindow.eval(`
-    const initialEditorState = editor.getEditorState();
-
-    const serializeEditorState = (editorState) => {
-      const nodeMap = Object.fromEntries(editorState._nodeMap);
-      return {nodeMap};
-    };
-
-    window.postMessage(
-      {
-        editorState: serializeEditorState(initialEditorState),
-        name: 'editor-update',
-        type: 'FROM_PAGE',
-      },
-      '*',
-    );
-  `);
-
-  // Attach a registerUpdateListener within the window to subscribe to changes in editorState.
-  // After the initial registration, all editorState updates are done via browser.runtime.onConnect & window.postMessage
-  chrome.devtools.inspectedWindow.eval(`
-    editor.registerUpdateListener(({editorState}) => {
-      window.postMessage(
-        {
-          editorState: serializeEditorState(editorState),
-          name: 'editor-update',
-          type: 'FROM_PAGE',
-        },
-        '*',
-      );
-    });
-  `);
+  // init message goes → background script → content script
+  // content script handles initial load of editorState
+  port.postMessage({
+    name: 'init',
+    tabId: chrome.devtools.inspectedWindow.tabId,
+    type: 'FROM_DEVTOOLS',
+  });
 }

--- a/packages/lexical-devtools/src/inject/index.ts
+++ b/packages/lexical-devtools/src/inject/index.ts
@@ -8,12 +8,6 @@
 import {EditorState} from 'lexical';
 import {LexicalHTMLElement, LexicalKey} from 'packages/lexical-devtools/types';
 
-declare global {
-  interface DocumentEventMap {
-    highlight: CustomEvent;
-  }
-}
-
 let editorDOMNode: LexicalHTMLElement | null, editorKey: string | null;
 
 // the existing editorState.toJSON() does not contain lexicalKeys

--- a/packages/lexical-devtools/src/inject/index.ts
+++ b/packages/lexical-devtools/src/inject/index.ts
@@ -5,18 +5,25 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-'use strict';
+import {EditorState} from 'lexical';
+import {LexicalHTMLElement, LexicalKey} from 'packages/lexical-devtools/types';
 
-let editorDOMNode, editorKey;
+declare global {
+  interface DocumentEventMap {
+    highlight: CustomEvent;
+  }
+}
+
+let editorDOMNode: LexicalHTMLElement | null, editorKey: string | null;
 
 // the existing editorState.toJSON() does not contain lexicalKeys
 // therefore, we have a custom serializeEditorState helper
-const serializeEditorState = (editorState) => {
+const serializeEditorState = (editorState: EditorState) => {
   const nodeMap = Object.fromEntries(editorState._nodeMap); // convert from Map structure to JSON-friendly object
   return {nodeMap};
 };
 
-const postEditorState = (editorState) => {
+const postEditorState = (editorState: EditorState) => {
   const serializedEditorState = serializeEditorState(editorState);
   const data = {editorState: serializedEditorState};
   document.dispatchEvent(new CustomEvent('editorStateUpdate', {detail: data}));
@@ -25,7 +32,9 @@ const postEditorState = (editorState) => {
 document.addEventListener('loadEditorState', function (e) {
   // query document for Lexical editor instance.
   // TODO: add support multiple Lexical editors within the same page
-  editorDOMNode = document.querySelectorAll('div[data-lexical-editor]')[0];
+  editorDOMNode = document.querySelectorAll(
+    'div[data-lexical-editor]',
+  )[0] as LexicalHTMLElement;
   const editor = editorDOMNode.__lexicalEditor;
   editorKey = editorDOMNode.__lexicalEditor._key; // dynamically generated upon each pageload, we need this to find DOM nodes for highlighting
 
@@ -45,18 +54,21 @@ highlightOverlay.style.border = '1px dashed #77b6ff';
 document.body.appendChild(highlightOverlay);
 
 // functions to highlight/dehighlight DOM nodes onHover of DevTools nodes
-document.addEventListener('highlight', function (e) {
-  highlight(e.detail.lexicalKey);
+document.addEventListener('highlight', (evt: CustomEvent) => {
+  highlight(evt.detail.lexicalKey);
 });
 
-document.addEventListener('dehighlight', function (e) {
+document.addEventListener('dehighlight', function () {
   dehighlight();
 });
 
 // depth first search to find DOM node with lexicalKey
-const findDOMNode = (node, targetKey) => {
+const findDOMNode = (
+  node: LexicalHTMLElement,
+  targetKey: string,
+): LexicalHTMLElement | null => {
   // each DOM node has its Lexical key stored at a particular key eg. DOMNode[__lexicalKey_pzely]
-  const key = '__lexicalKey_' + editorKey;
+  const key = ('__lexicalKey_' + editorKey) as LexicalKey;
 
   if (targetKey === 'root') {
     return editorDOMNode;
@@ -67,21 +79,26 @@ const findDOMNode = (node, targetKey) => {
   }
 
   for (let i = 0; i < node.childNodes.length; i++) {
-    const child = findDOMNode(node.childNodes[i], targetKey);
-    if (child) return child;
+    const child = node.childNodes[i] as LexicalHTMLElement;
+    const childResults = findDOMNode(child, targetKey);
+    if (childResults) return child;
   }
 
   return null;
 };
 
-const highlight = (targetKey) => {
-  const node = findDOMNode(editorDOMNode, targetKey);
-  const {width, height, top, left} = node.getBoundingClientRect();
-  highlightOverlay.style.width = width + 'px';
-  highlightOverlay.style.height = height + 'px';
-  highlightOverlay.style.top = top + window.scrollY + 'px';
-  highlightOverlay.style.left = left + window.scrollX + 'px';
-  highlightOverlay.style.display = 'block';
+const highlight = (targetKey: string) => {
+  if (editorDOMNode) {
+    const node = findDOMNode(editorDOMNode, targetKey);
+    if (node) {
+      const {width, height, top, left} = node.getBoundingClientRect();
+      highlightOverlay.style.width = width + 'px';
+      highlightOverlay.style.height = height + 'px';
+      highlightOverlay.style.top = top + window.scrollY + 'px';
+      highlightOverlay.style.left = left + window.scrollX + 'px';
+      highlightOverlay.style.display = 'block';
+    }
+  }
 };
 
 const dehighlight = () => {

--- a/packages/lexical-devtools/src/inject/index.ts
+++ b/packages/lexical-devtools/src/inject/index.ts
@@ -81,7 +81,7 @@ const findDOMNode = (
   for (let i = 0; i < node.childNodes.length; i++) {
     const child = node.childNodes[i] as LexicalHTMLElement;
     const childResults = findDOMNode(child, targetKey);
-    if (childResults) return child;
+    if (childResults) return childResults;
   }
 
   return null;

--- a/packages/lexical-devtools/types.ts
+++ b/packages/lexical-devtools/types.ts
@@ -31,7 +31,7 @@ export interface LexicalHTMLElement extends HTMLElement {
   __lexicalEditor: LexicalEditor;
 }
 
-export type cloneInto = (
-  arg: {data: {lexicalKey: string}},
-  arg2: WindowProxy,
+export type CloneInto = (
+  arg: {lexicalKey: string},
+  arg2: Window,
 ) => {data: {lexicalKey: string}};

--- a/packages/lexical-devtools/types.ts
+++ b/packages/lexical-devtools/types.ts
@@ -30,3 +30,8 @@ export interface LexicalHTMLElement extends HTMLElement {
   [key: LexicalKey]: string;
   __lexicalEditor: LexicalEditor;
 }
+
+export type cloneInto = (
+  arg: {data: {lexicalKey: string}},
+  arg2: WindowProxy,
+) => {data: {lexicalKey: string}};

--- a/packages/lexical-devtools/types.ts
+++ b/packages/lexical-devtools/types.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import {LexicalEditor} from 'lexical';
+
 export interface DevToolsTree {
   [key: string]: DevToolsNode;
 }
@@ -20,4 +22,11 @@ export interface DevToolsNode {
   highlightDOMNode: (lexicalKey: string) => void;
   lexicalKey: string;
   monospaceWidth: string;
+}
+
+export type LexicalKey = `__lexicalKey_${string}`;
+
+export interface LexicalHTMLElement extends HTMLElement {
+  [key: LexicalKey]: string;
+  __lexicalEditor: LexicalEditor;
 }

--- a/packages/lexical-devtools/vite.config.js
+++ b/packages/lexical-devtools/vite.config.js
@@ -1,12 +1,23 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path';
+import path from 'path';
 
 const root = resolve(__dirname, 'src');
+
+const moduleResolution = [
+  {
+    find: 'shared',
+    replacement: path.resolve('../shared/src'),
+  }
+];
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: moduleResolution,
+  },
   build: {
     outDir: 'build',
     rollupOptions: {

--- a/packages/lexical-devtools/vite.config.js
+++ b/packages/lexical-devtools/vite.config.js
@@ -25,6 +25,7 @@ export default defineConfig({
         background: resolve(root, 'background', 'index.ts'),
         content: resolve(root, 'content', 'index.ts'),
         devtools: resolve(root, 'devtools', 'index.html'),
+        inject: resolve(root, 'inject', 'index.ts'),
         panel: resolve(root, 'panel', 'index.html'),
         popup: resolve(root, 'popup', 'index.html')
       },


### PR DESCRIPTION
This moves all of the code that was previously running as an inline string in `devtools.inspectedWindow.eval()` like so:
<img width="636" alt="Screen Shot 2022-08-05 at 6 34 11 PM" src="https://user-images.githubusercontent.com/4361605/183264248-295f5bef-e1a1-4b61-8072-17cdfd0def10.png">

And moves it to a new `inject.ts` file:
<img width="651" alt="Screen Shot 2022-08-05 at 6 34 51 PM" src="https://user-images.githubusercontent.com/4361605/183264259-7c7988cc-12fb-407a-b0be-c2853644ec0d.png">

---
Developer Tools Web Extension Planning Issue: #2127

