### PR TITLE
fix: dropdown icon css

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -765,6 +765,8 @@ i.prettier-error {
   margin-right: 12px;
   line-height: 16px;
   background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .dropdown .divider {


### PR DESCRIPTION
(Notice Figma Icon)

### Before
<img width="200px" src="https://user-images.githubusercontent.com/64399555/183387069-8c426046-a7f4-4e69-ac24-144328c6cba9.png"/>

### After
<img width="200px" src="https://user-images.githubusercontent.com/64399555/183387100-741cc160-2052-44d1-a9cc-d3b25eb8caaf.png"/>

