### PR TITLE
Fixing comments list scrolling issue

### DIFF
--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.css
@@ -280,6 +280,7 @@ i.send {
   position: absolute;
   top: 45px;
   overflow-y: auto;
+  height: calc(100% - 45px);
 }
 
 .CommentPlugin_CommentsPanel_List_Comment {


### PR DESCRIPTION
**Description**

The list of comments do not scroll when overflowed, since the removal of footer section. This pr sets the height of the comment list section, and enables scrolling when overflowed.