### PR TITLE
chore(auto-link-plugin): fix invariant message for node registration check

### DIFF
--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -228,7 +228,7 @@ function useAutoLink(
     if (!editor.hasNodes([AutoLinkNode])) {
       invariant(
         false,
-        'LexicalAutoLinkPlugin: AutoLinkNode, TableCellNode or TableRowNode not registered on editor',
+        'LexicalAutoLinkPlugin: AutoLinkNode not registered on editor',
       );
     }
 

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -73,5 +73,8 @@
   "71": "updateDOM: base method not extended",
   "72": "exportJSON: base method not extended",
   "73": "Create node: Attempted to create node %s that was not previously registered on the editor. You can use register your custom nodes.",
-  "74": "Create node: Type %s in node %s does not match registered node %s with the same type"
+  "74": "Create node: Type %s in node %s does not match registered node %s with the same type",
+  "75": "Reconciliation: could not find DOM element for node key %s",
+  "76": "append: attempting to append self",
+  "77": "LexicalAutoLinkPlugin: AutoLinkNode not registered on editor"
 }


### PR DESCRIPTION
Fix the message when checking for the node registration in the autolink plugin.