### PR TITLE
Fix inserting nodes next to top level decorators

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1404,7 +1404,11 @@ export class RangeSelection implements BaseSelection {
         for (let i = siblings.length - 1; i >= 0; i--) {
           const sibling = siblings[i];
           const prevParent = sibling.getParentOrThrow();
-          if ($isElementNode(target) && !$isBlockElementNode(sibling)) {
+          if (
+            $isElementNode(target) &&
+            !$isBlockElementNode(sibling) &&
+            !($isDecoratorNode(sibling) && sibling.isTopLevel())
+          ) {
             if (originalTarget === target) {
               target.append(sibling);
             } else {

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -328,6 +328,14 @@ export class TestDecoratorNode extends DecoratorNode<JSX.Element> {
     return document.createElement('span');
   }
 
+  updateDOM() {
+    return false;
+  }
+
+  isTopLevel() {
+    return false;
+  }
+
   decorate() {
     return <Decorator text={'Hello world'} />;
   }


### PR DESCRIPTION
Fixes #2753

When running #insertNodes top level decorators should be treated as element nodes (vs text nodes, inline elements or inline decorators)

https://user-images.githubusercontent.com/132642/183555305-c7e13e25-cbe3-4e33-b939-0b7a40c37f67.mov


