### PR TITLE
Fix selection#deleteLine

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -20,6 +20,9 @@ import {
   initialize,
   insertImageCaption,
   insertSampleImage,
+  IS_MAC,
+  keyDownCtrlOrMeta,
+  keyUpCtrlOrMeta,
   selectFromFormatDropdown,
   sleep,
   test,
@@ -132,6 +135,67 @@ test.describe('Selection', () => {
             <span data-lexical-text="true">Line2</span>
           </code>
         </p>
+      `,
+    );
+  });
+
+  test('can delete text by line with CMD+delete', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText || !IS_MAC);
+    await focusEditor(page);
+    await page.keyboard.type('One');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Two');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Three');
+
+    const deleteLine = async () => {
+      await keyDownCtrlOrMeta(page);
+      await page.keyboard.press('Backspace');
+      await keyUpCtrlOrMeta(page);
+    };
+
+    const lines = [
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">One</span>
+        </p>
+      `,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Two</span>
+        </p>
+      `,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Three</span>
+        </p>
+      `,
+    ];
+
+    await deleteLine();
+    await assertHTML(page, lines.slice(0, 3).join(''));
+    await deleteLine();
+    await assertHTML(page, lines.slice(0, 2).join(''));
+    await deleteLine();
+    await assertHTML(page, lines.slice(0, 1).join(''));
+    await deleteLine();
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
       `,
     );
   });

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1786,7 +1786,17 @@ export class RangeSelection implements BaseSelection {
 
   deleteLine(isBackward: boolean): void {
     if (this.isCollapsed()) {
-      this.modify('extend', isBackward, 'lineboundary');
+      if (this.anchor.type === 'text') {
+        this.modify('extend', isBackward, 'lineboundary');
+      }
+
+      // If selection is extended to cover text edge then extend it one character more
+      // to delete its parent element. Otherwise text content will be deleted but empty
+      // parent node will remain
+      const endPoint = isBackward ? this.focus : this.anchor;
+      if (endPoint.offset === 0) {
+        this.modify('extend', isBackward, 'character');
+      }
     }
     this.removeText();
   }


### PR DESCRIPTION
Fix #2810

`deleteLine()` relies on `domSelection.modify('extend', 'backward', 'lineboundary')` which works great when selection is on text, but needed couple adjustments if original or extended selection ends on element


https://user-images.githubusercontent.com/132642/184060903-2cc91a19-bc21-4071-8854-7a273053fb75.mov
