### PR TITLE
fixed getStyleObjectFromRawCSS to handle css values with a colon

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -2150,7 +2150,7 @@ describe('LexicalSelection tests', () => {
         const root = $getRoot();
         const paragraph = $createParagraphNode();
         const textNode = $createTextNode('Hello, World!');
-        textNode.setStyle('   color    :   red   ;top     : 50px');
+        textNode.setStyle('   font-family  : Arial  ;  color    :   red   ;top     : 50px');
         $addNodeStyle(textNode);
         paragraph.append(textNode);
         root.append(paragraph);
@@ -2170,12 +2170,20 @@ describe('LexicalSelection tests', () => {
           type: 'text',
         });
 
+        const cssFontFamilyValue = $getSelectionStyleValueForProperty(
+          selection,
+          'font-family',
+          '',
+        );
+        expect(cssFontFamilyValue).toBe('Arial');
+        
         const cssColorValue = $getSelectionStyleValueForProperty(
           selection,
           'color',
           '',
         );
         expect(cssColorValue).toBe('red');
+
         const cssTopValue = $getSelectionStyleValueForProperty(
           selection,
           'top',
@@ -2196,7 +2204,7 @@ describe('LexicalSelection tests', () => {
         const root = $getRoot();
         const paragraph = $createParagraphNode();
         const textNode = $createTextNode('Hello, World!');
-        textNode.setStyle('font-family: prefix:Arial; color: white');
+        textNode.setStyle('font-family: double:prefix:Arial; color: color:white; font-size: 30px');
         $addNodeStyle(textNode);
         paragraph.append(textNode);
         root.append(paragraph);
@@ -2216,18 +2224,26 @@ describe('LexicalSelection tests', () => {
           type: 'text',
         });
 
-        const cssColorValue = $getSelectionStyleValueForProperty(
+        const cssFontFamilyValue = $getSelectionStyleValueForProperty(
           selection,
           'font-family',
           '',
         );
-        expect(cssColorValue).toBe('prefix:Arial');
-        const cssTopValue = $getSelectionStyleValueForProperty(
+        expect(cssFontFamilyValue).toBe('double:prefix:Arial');
+
+        const cssColorValue = $getSelectionStyleValueForProperty(
           selection,
           'color',
           '',
         );
-        expect(cssTopValue).toBe('white');
+        expect(cssColorValue).toBe('color:white');
+
+        const cssFontSizeValue = $getSelectionStyleValueForProperty(
+          selection,
+          'font-size',
+          '',
+        );
+        expect(cssFontSizeValue).toBe('30px');
       });
     });
   });

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -2150,7 +2150,9 @@ describe('LexicalSelection tests', () => {
         const root = $getRoot();
         const paragraph = $createParagraphNode();
         const textNode = $createTextNode('Hello, World!');
-        textNode.setStyle('   font-family  : Arial  ;  color    :   red   ;top     : 50px');
+        textNode.setStyle(
+          '   font-family  : Arial  ;  color    :   red   ;top     : 50px',
+        );
         $addNodeStyle(textNode);
         paragraph.append(textNode);
         root.append(paragraph);
@@ -2176,7 +2178,7 @@ describe('LexicalSelection tests', () => {
           '',
         );
         expect(cssFontFamilyValue).toBe('Arial');
-        
+
         const cssColorValue = $getSelectionStyleValueForProperty(
           selection,
           'color',
@@ -2204,7 +2206,9 @@ describe('LexicalSelection tests', () => {
         const root = $getRoot();
         const paragraph = $createParagraphNode();
         const textNode = $createTextNode('Hello, World!');
-        textNode.setStyle('font-family: double:prefix:Arial; color: color:white; font-size: 30px');
+        textNode.setStyle(
+          'font-family: double:prefix:Arial; color: color:white; font-size: 30px',
+        );
         $addNodeStyle(textNode);
         paragraph.append(textNode);
         root.append(paragraph);

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -2185,4 +2185,50 @@ describe('LexicalSelection tests', () => {
       });
     });
   });
+
+  describe('Testing that getStyleObjectFromRawCSS handles values with colons', () => {
+    test('', async () => {
+      const testEditor = createTestEditor();
+      const element = document.createElement('div');
+      testEditor.setRootElement(element);
+
+      await testEditor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        const textNode = $createTextNode('Hello, World!');
+        textNode.setStyle('font-family: prefix:Arial; color: white');
+        $addNodeStyle(textNode);
+        paragraph.append(textNode);
+        root.append(paragraph);
+
+        const selection = $createRangeSelection();
+        $setSelection(selection);
+        selection.insertParagraph();
+        setAnchorPoint({
+          key: textNode.getKey(),
+          offset: 0,
+          type: 'text',
+        });
+
+        setFocusPoint({
+          key: textNode.getKey(),
+          offset: 10,
+          type: 'text',
+        });
+
+        const cssColorValue = $getSelectionStyleValueForProperty(
+          selection,
+          'font-family',
+          '',
+        );
+        expect(cssColorValue).toBe('prefix:Arial');
+        const cssTopValue = $getSelectionStyleValueForProperty(
+          selection,
+          'color',
+          '',
+        );
+        expect(cssTopValue).toBe('white');
+      });
+    });
+  });
 });

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -310,8 +310,8 @@ function getStyleObjectFromRawCSS(css: string): Record<string, string> {
 
   for (const style of styles) {
     if (style !== '') {
-      const [key, ...value] = style.split(':');
-      styleObject[key.trim()] = value.join(':').trim();
+      const [key, value] = style.split(/:([^]+)/); // split on first colon
+      styleObject[key.trim()] = value.trim();
     }
   }
 

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -310,8 +310,8 @@ function getStyleObjectFromRawCSS(css: string): Record<string, string> {
 
   for (const style of styles) {
     if (style !== '') {
-      const patch = style.split(':');
-      styleObject[patch[0].trim()] = patch[1].trim();
+      const [key, ...value] = style.split(':');
+      styleObject[key.trim()] = value.join(':').trim();
     }
   }
 


### PR DESCRIPTION
Currently if a css property has a colon in its value the rest of the value following the colon gets cut off.
Ran into this when using a font family with a prefix e.g. `font-family: prefix:Arial`