### PR TITLE
Fix onInput events inside decorator nodes

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -589,7 +589,12 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
 }
 
 function onInput(event: InputEvent, editor: LexicalEditor): void {
-  if (!event.target.closest('[data-lexical-decorator=true]')) {
+  const target = event.target;
+  if (
+    target &&
+    target instanceof HTMLElement &&
+    !target.closest('[data-lexical-decorator=true]')
+  ) {
     // We don't want the onInput to bubble, in the case of nested editors.
     event.stopPropagation();
   }

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -589,8 +589,11 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
 }
 
 function onInput(event: InputEvent, editor: LexicalEditor): void {
-  // We don't want the onInput to bubble, in the case of nested editors.
-  event.stopPropagation();
+  if (!event.target.closest('[data-lexical-decorator=true]')) {
+    // We don't want the onInput to bubble, in the case of nested editors.
+    event.stopPropagation();
+  }
+
   updateEditor(editor, () => {
     const selection = $getSelection();
     const data = event.data;


### PR DESCRIPTION
## Problem
Input elements inside decorator nodes do not receive `input` events because lexical stops propagation in the parent editor.

## Solution
Check if the target element of the input event is from a decorator node, if so - do not stop propagation of the event.

Related conversation in discord: https://discord.com/channels/953974421008293909/1006976156748222464/1007339073683337327