### PR TITLE
fix: added basic validation for unsafe url and unsafe data url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28813,7 +28813,7 @@
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.23.0-next-alpha-trueadm-fork"
+        "playwright-core": "1.23.1"
       }
     },
     "@polka/url": {

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -258,6 +258,22 @@ function FloatingLinkEditor({editor}: {editor: LexicalEditor}): JSX.Element {
     return true;
   }, [editor]);
 
+  const sanitizeUrl = (url: string): string => {
+    /** A pattern that matches safe  URLs. */
+    const SAFE_URL_PATTERN =
+      /^(?:(?:https?|mailto|ftp|tel|file|sms):|[^&:/?#]*(?:[/?#]|$))/gi;
+
+    /** A pattern that matches safe data URLs. */
+    const DATA_URL_PATTERN =
+      /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+/]+=*$/i;
+
+    url = String(url).trim();
+
+    if (url.match(SAFE_URL_PATTERN) || url.match(DATA_URL_PATTERN)) return url;
+
+    return `https://`;
+  };
+
   useEffect(() => {
     const onResize = () => {
       editor.getEditorState().read(() => {
@@ -310,7 +326,7 @@ function FloatingLinkEditor({editor}: {editor: LexicalEditor}): JSX.Element {
           className="link-input"
           value={linkUrl}
           onChange={(event) => {
-            setLinkUrl(event.target.value);
+            setLinkUrl(sanitizeUrl(event.target.value));
           }}
           onKeyDown={(event) => {
             if (event.key === 'Enter') {


### PR DESCRIPTION
![XSS-video (1)](https://user-images.githubusercontent.com/68782077/184342833-96dddd04-a1bb-4814-9c5b-dc009e7ac856.gif)


Hi, this is my very first open source pull request. Any comment would be a great learning source for me.

### Problem

xss vulnerability 

- when adding an url for a link, where was no validation logic for potential javascript injection for unsafe urls (javascript: or data:).

### Solution

- I have implemented function called sanitizeUrl that validates event.target.value before it's passed to setLinkUrl().

- When user enters unsafe url string starts with javascript: or data: , it returns default https://





