### PR TITLE
fix: set cursor grab when image can be dragged

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -937,7 +937,6 @@ i.prettier-error {
 .editor-shell .editor-image img.focused {
   outline: 2px solid rgb(60, 132, 244);
   user-select: none;
-  cursor: move;
   cursor: grab;
 }
 

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -937,6 +937,12 @@ i.prettier-error {
 .editor-shell .editor-image img.focused {
   outline: 2px solid rgb(60, 132, 244);
   user-select: none;
+  cursor: move;
+  cursor: grab;
+}
+
+.editor-shell .editor-image img.focused:active {
+  cursor: grabbing;
 }
 
 .editor-shell .editor-image .image-caption-container .tree-view-output {

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -937,6 +937,7 @@ i.prettier-error {
 .editor-shell .editor-image img.focused {
   outline: 2px solid rgb(60, 132, 244);
   user-select: none;
+  cursor: move;
   cursor: grab;
 }
 


### PR DESCRIPTION
## Description
set cursor grab when image can be dragged. 

#### Additionally
I've tried a lot but still can't resolve the problem of not being able to set the cursor when dragging