### PR TITLE
fix: transfer format and indent info on wrap

### DIFF
--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -100,6 +100,10 @@ export function insertList(editor: LexicalEditor, listType: ListType): void {
         if ($isRootNode(anchorNodeParent)) {
           anchorNode.replace(list);
           const listItem = $createListItemNode();
+          if ($isElementNode(anchorNode)) {
+            listItem.setFormat(anchorNode.getFormatType());
+            listItem.setIndent(anchorNode.getIndent());
+          }
           list.append(listItem);
         } else if ($isListItemNode(anchorNode)) {
           const parent = anchorNode.getParentOrThrow();
@@ -168,6 +172,8 @@ function createListOrMerge(node: ElementNode, listType: ListType): ListNode {
   const previousSibling = node.getPreviousSibling();
   const nextSibling = node.getNextSibling();
   const listItem = $createListItemNode();
+  listItem.setFormat(node.getFormatType());
+  listItem.setIndent(node.getIndent());
   append(listItem, node.getChildren());
 
   if (

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -607,6 +607,8 @@ export function $wrapLeafNodesInElements(
         : anchor.getNode();
     const children = target.getChildren();
     let element = createElement();
+    element.setFormat(target.getFormatType());
+    element.setIndent(target.getIndent());
     children.forEach((child) => element.append(child));
 
     if (wrappingElement) {
@@ -681,6 +683,8 @@ export function $wrapLeafNodesInElements(
 
       if (elementMapping.get(parentKey) === undefined) {
         const targetElement = createElement();
+        targetElement.setFormat(parent.getFormatType());
+        targetElement.setIndent(parent.getIndent());
         elements.push(targetElement);
         elementMapping.set(parentKey, targetElement);
         // Move node and its siblings to the new
@@ -692,7 +696,10 @@ export function $wrapLeafNodesInElements(
         $removeParentEmptyElements(parent);
       }
     } else if (emptyElements.has(node.getKey())) {
-      elements.push(createElement());
+      const targetElement = createElement();
+      targetElement.setFormat(node.getFormatType());
+      targetElement.setIndent(node.getIndent());
+      elements.push(targetElement);
       node.remove();
     }
   }


### PR DESCRIPTION
Makes the helper function `$wrapLeafNodesInElements` transfer indent and formatting information to the newly created Element

https://user-images.githubusercontent.com/64399555/184502356-d016e5da-e159-4d81-b909-d8b912dcab49.mp4
