### PR TITLE
Support selection in readonly mode

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -209,6 +209,7 @@ function onSelectionChange(
   updateEditor(editor, () => {
     // Non-active editor don't need any extra logic for selection, it only needs update
     // to reconcile selection (set it to null) to ensure that only one editor has non-null selection.
+
     if (!isActive) {
       $setSelection(null);
       return;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -138,7 +138,7 @@ export function getNearestEditorFromDOMNode(
   while (currentNode != null) {
     // @ts-expect-error: internal field
     const editor: LexicalEditor = currentNode.__lexicalEditor;
-    if (editor != null && !editor.isReadOnly()) {
+    if (editor != null) {
       return editor;
     }
     currentNode = currentNode.parentNode;


### PR DESCRIPTION
I saw this:

https://github.com/facebook/lexical/pull/1339

which looks like the only code path where this function is used. I can't seen any regression around Decorator selection, but maybe there is something I am missing - not sure what the original issue was here.

