### PR TITLE
Only normalize text nodes into list item nodes if they are not empty

### DIFF
--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -6,14 +6,13 @@
  *
  */
 
-import {$isTextNode, Spread} from 'lexical';
-
 import {
   addClassNamesToElement,
   removeClassNamesFromElement,
 } from '@lexical/utils';
 import {
   $createTextNode,
+  $isTextNode,
   DOMConversionMap,
   DOMConversionOutput,
   EditorConfig,
@@ -23,6 +22,7 @@ import {
   LexicalNode,
   NodeKey,
   SerializedElementNode,
+  Spread,
 } from 'lexical';
 
 import {$createListItemNode, $isListItemNode, ListItemNode} from '.';

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -247,7 +247,7 @@ function normalizeChildren(nodes: Array<LexicalNode>): Array<ListItemNode> {
           normalizedListItems.push(wrapInListItem(child));
         }
       });
-    } else if (!$isTextNode(node) || node.getTextContent().trim()) {
+    } else if (!$isTextNode(node) || node.getTextContent().trim() !== '') {
       normalizedListItems.push(wrapInListItem(node));
     }
   }

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -240,7 +240,6 @@ function normalizeChildren(nodes: Array<LexicalNode>): Array<ListItemNode> {
   const normalizedListItems: Array<ListItemNode> = [];
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
-    console.log(node);
     if ($isListItemNode(node)) {
       normalizedListItems.push(node);
       node.getChildren().forEach((child) => {

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import type {Spread} from 'lexical';
+import {$isTextNode, Spread} from 'lexical';
 
 import {
   addClassNamesToElement,
@@ -240,6 +240,7 @@ function normalizeChildren(nodes: Array<LexicalNode>): Array<ListItemNode> {
   const normalizedListItems: Array<ListItemNode> = [];
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
+    console.log(node);
     if ($isListItemNode(node)) {
       normalizedListItems.push(node);
       node.getChildren().forEach((child) => {
@@ -247,7 +248,7 @@ function normalizeChildren(nodes: Array<LexicalNode>): Array<ListItemNode> {
           normalizedListItems.push(wrapInListItem(child));
         }
       });
-    } else {
+    } else if (!$isTextNode(node) || node.getTextContent().trim()) {
       normalizedListItems.push(wrapInListItem(node));
     }
   }

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -1613,6 +1613,106 @@ test.describe('CopyAndPaste', () => {
     );
   });
 
+  test('HTML Copy + paste (List with whitespace between list items)', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    const clipboard = {
+      'text/html': '<ul> <li>Hello <li>world!</li> </ul>',
+    };
+
+    await pasteFromClipboard(page, clipboard);
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Hello</span>
+          </li>
+          <li
+            value="2"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
+            <ul class="PlaygroundEditorTheme__ul">
+              <li
+                value="1"
+                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">world!</span>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 6,
+      anchorPath: [0, 1, 0, 0, 0, 0],
+      focusOffset: 6,
+      focusPath: [0, 1, 0, 0, 0, 0],
+    });
+
+    await selectFromAlignDropdown(page, '.outdent');
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Hello</span>
+          </li>
+          <li
+            value="2"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">world!</span>
+          </li>
+        </ul>
+      `,
+    );
+
+    await page.keyboard.press('ArrowUp');
+
+    await selectFromAlignDropdown(page, '.indent');
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
+            <ul class="PlaygroundEditorTheme__ul">
+              <li
+                value="1"
+                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">Hello</span>
+              </li>
+            </ul>
+          </li>
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">world!</span>
+          </li>
+        </ul>
+      `,
+    );
+  });
+
   test('HTML Copy + paste (Table - Google Docs)', async ({
     page,
     isPlainText,

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -1629,28 +1629,7 @@ test.describe('CopyAndPaste', () => {
 
     await assertHTML(
       page,
-      html`
-        <ul class="PlaygroundEditorTheme__ul">
-          <li
-            value="1"
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr">
-            <span data-lexical-text="true">Hello</span>
-          </li>
-          <li
-            value="2"
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
-            <ul class="PlaygroundEditorTheme__ul">
-              <li
-                value="1"
-                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-                dir="ltr">
-                <span data-lexical-text="true">world!</span>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      `,
+      `<ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">Hello</span></li> <li value="2" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"><ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">world!</span></li></ul></li></ul>`,
     );
 
     await assertSelection(page, {
@@ -1688,28 +1667,7 @@ test.describe('CopyAndPaste', () => {
 
     await assertHTML(
       page,
-      html`
-        <ul class="PlaygroundEditorTheme__ul">
-          <li
-            value="1"
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem">
-            <ul class="PlaygroundEditorTheme__ul">
-              <li
-                value="1"
-                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-                dir="ltr">
-                <span data-lexical-text="true">Hello</span>
-              </li>
-            </ul>
-          </li>
-          <li
-            value="1"
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr">
-            <span data-lexical-text="true">world!</span>
-          </li>
-        </ul>
-      `,
+      html`<ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"><ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">Hello</span></li></ul></li> <li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">world!</span></li></ul>`,
     );
   });
 


### PR DESCRIPTION
Fixes #2807. The issue with wrapping empty text nodes in list item nodes as a default normalization is that this assumes the incoming HTML is minified.
