### PR TITLE
Adjust Typeahead Styles

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -612,7 +612,7 @@ export function LexicalNodeMenuPlugin<TOption extends TypeaheadOption>({
   const [editor] = useLexicalComposerContext();
 
   const [resolution, setResolution] = useState<Resolution | null>(null);
-  const anchorElementRef = useAnchorElementRef(resolution, options);
+  const anchorElementRef = useAnchorElementRef(resolution);
 
   useEffect(() => {
     if (nodeKey && resolution == null) {

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -452,9 +452,8 @@ export function useBasicTypeaheadTriggerMatch(
   );
 }
 
-function useAnchorElementRef<TOption extends TypeaheadOption>(
+function useAnchorElementRef(
   resolution: Resolution | null,
-  options: Array<TOption>,
 ): MutableRefObject<HTMLElement> {
   const [editor] = useLexicalComposerContext();
   const anchorElementRef = useRef<HTMLElement>(document.createElement('div'));
@@ -467,9 +466,9 @@ function useAnchorElementRef<TOption extends TypeaheadOption>(
       containerDiv.setAttribute('id', 'typeahead-menu');
       containerDiv.setAttribute('role', 'listbox');
       if (rootElement !== null && resolution !== null) {
-        const {left, top, height, width} = resolution.getRect();
-        containerDiv.style.top = `${top + height + window.pageYOffset}px`;
-        containerDiv.style.left = `${left + width + window.pageXOffset}px`;
+        const {left, top, height} = resolution.getRect();
+        containerDiv.style.top = `${top + height + 10 + window.pageYOffset}px`;
+        containerDiv.style.left = `${left + window.pageXOffset}px`;
         containerDiv.style.display = 'block';
         containerDiv.style.position = 'absolute';
         if (!containerDiv.isConnected) {
@@ -490,7 +489,7 @@ function useAnchorElementRef<TOption extends TypeaheadOption>(
         }
       };
     }
-  }, [editor, resolution, options]);
+  }, [editor, resolution]);
 
   return anchorElementRef;
 }
@@ -519,7 +518,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends TypeaheadOption>({
 }: TypeaheadMenuPluginArgs<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<Resolution | null>(null);
-  const anchorElementRef = useAnchorElementRef(resolution, options);
+  const anchorElementRef = useAnchorElementRef(resolution);
 
   useEffect(() => {
     let activeRange: Range | null = document.createRange();

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -467,7 +467,7 @@ function useAnchorElementRef(
       containerDiv.setAttribute('role', 'listbox');
       if (rootElement !== null && resolution !== null) {
         const {left, top, height} = resolution.getRect();
-        containerDiv.style.top = `${top + height + 10 + window.pageYOffset}px`;
+        containerDiv.style.top = `${top + height + 5 + window.pageYOffset}px`;
         containerDiv.style.left = `${left + window.pageXOffset}px`;
         containerDiv.style.display = 'block';
         containerDiv.style.position = 'absolute';


### PR DESCRIPTION
Right now the Typeahead Menu moves as you type and positions itself with the cursor instead of the trigger, this PR locks the left value at the trigger.

Before:
<img width="391" alt="image" src="https://user-images.githubusercontent.com/13852400/185240321-b0411a87-f035-4168-848c-890cefb6c8cc.png">

After:
<img width="343" alt="image" src="https://user-images.githubusercontent.com/13852400/185240380-d5f980dc-a1c1-4d7b-a443-efa9d2ac8f39.png">
