### PR TITLE
Small toolbar style fix

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -48,7 +48,7 @@ header h1 {
 .editor-shell {
   margin: 20px auto;
   border-radius: 2px;
-  max-width: 1000px;
+  max-width: 1100px;
   color: #000;
   position: relative;
   line-height: 20px;
@@ -753,7 +753,7 @@ i.prettier-error {
   height: 1px;
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1100px) {
   .dropdown-button-text {
     display: none !important;
   }


### PR DESCRIPTION
The toolbar sometimes shows it's scrollbar at max width if the first dropdown contains a long enough string #2848

Fixes the below:

<img width="1311" alt="image" src="https://user-images.githubusercontent.com/7748470/185417407-47ec33f4-e567-4b70-8e38-bb8136dd9194.png">
