### PR TITLE
Fix emoji insertion issue

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -673,8 +673,8 @@ export function $shouldPreventDefaultAndInsertText(
     anchorKey !== focus.key ||
     // If we're working with a non-text node.
     !$isTextNode(anchorNode) ||
-    // If we are replacing a range with a single character, and not composing.
-    (textLength < 2 &&
+    // If we are replacing a range with a single character or grapheme, and not composing.
+    ((textLength < 2 || doesContainGrapheme(text)) &&
       anchor.offset !== focus.offset &&
       !anchorNode.isComposing()) ||
     // Any non standard text node.


### PR DESCRIPTION
We should allow controlled text insertion for instances when a word can be transformed into an emoji (i.e. "angry" becomes "😡"), such as using the native MacBook control strip or a dynamic emoji keyboard.

Fixes #2850