### PR TITLE
Change linebreak node handling in insertNodes

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -125,16 +125,15 @@ test.describe('Selection', () => {
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
           dir="ltr">
           <span data-lexical-text="true">Line1</span>
-          <br />
-          <code
-            class="PlaygroundEditorTheme__code PlaygroundEditorTheme__ltr"
-            spellcheck="false"
-            dir="ltr"
-            data-highlight-language="javascript"
-            data-gutter="1">
-            <span data-lexical-text="true">Line2</span>
-          </code>
         </p>
+        <code
+          class="PlaygroundEditorTheme__code PlaygroundEditorTheme__ltr"
+          spellcheck="false"
+          dir="ltr"
+          data-highlight-language="javascript"
+          data-gutter="1">
+          <span data-lexical-text="true">Line2</span>
+        </code>
       `,
     );
   });

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1355,13 +1355,18 @@ export class RangeSelection implements BaseSelection {
       } else if (
         !$isElementNode(node) ||
         ($isElementNode(node) && node.isInline()) ||
-        ($isDecoratorNode(target) && target.isTopLevel()) ||
-        $isLineBreakNode(target)
+        ($isDecoratorNode(target) && target.isTopLevel())
       ) {
         lastNode = node;
         target = target.insertAfter(node);
       } else {
-        target = node.getParentOrThrow();
+        const nextTarget: ElementNode = target.getParentOrThrow();
+        // if we're inserting an Element after a LineBreak, we want to move the target to the parent
+        // and remove the LineBreak so we don't have empty space.
+        if ($isLineBreakNode(target)) {
+          target.remove();
+        }
+        target = nextTarget;
         // Re-try again with the target being the parent
         i--;
         continue;


### PR DESCRIPTION
Previously, trying to insert a code block in the middle of a list (i.e., not the last item in a multi-item list) would cause the page to crash because of an infinite loop (in LexicalNode.isAttached) that ultimately happened because, in insertNodes, we were appending a node to it's own child.

This changes how we handle inserting ElementNodes when the calculated insertion target ends up being a LineBreakNode. This happens when there's a LineBreak with nothing else after it OR all the content up to the LineBreak border is selected.

Now, we move the target to the LineBreakNode parent and get rid of the LineBreak.

This prevents the editor from crashing, but it doesn't perfectly handle the case where a LineBreakNode is in the middle of the parent Element (i.e., there's content before and after). What we should probably do there is split the parent node and insert the new Element in the middle. In fact, we already do this in other cases, I just need to figure out how to properly align this code path with that one in the algorithm.