### PR TITLE
Add watch mode for auto-gen doc comments in dev

### DIFF
--- a/packages/lexical-website-new/docusaurus.config.js
+++ b/packages/lexical-website-new/docusaurus.config.js
@@ -59,6 +59,7 @@ const config = {
           position: 5,
         },
         tsconfig: '../../tsconfig.json',
+        watch: process.env.TYPEDOC_WATCH === 'true',
       },
     ],
   ],

--- a/packages/lexical-website-new/package.json
+++ b/packages/lexical-website-new/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": " TYPEDOC_WATCH=true docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
This makes it so that adding a JSDOC comment to a function in one of the packages automatically does an incremental rebuild of the website in dev mode (npm run start:website)