### PR TITLE
Prototype Pollution in minimist

### DIFF
--- a/packages/lexical-website-new/package-lock.json
+++ b/packages/lexical-website-new/package-lock.json
@@ -6913,7 +6913,7 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "dependencies": {
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"


### PR DESCRIPTION
Minimist <=1.2.5 is vulnerable to Prototype Pollution via file index.js, function setKey() (lines 69-95).

**CVE-2021-44906**
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`
`9.8/ 10`