### PR TITLE
Fix delete backward bug

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -413,7 +413,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
           }
         } else {
           event.preventDefault();
-          dispatchCommand(editor, DELETE_CHARACTER_COMMAND, false);
+          dispatchCommand(editor, DELETE_CHARACTER_COMMAND, true);
         }
         return;
       }


### PR DESCRIPTION
This was an obvious bug on reflection – the boolean flag should have been `true` for delete backward.

Fixes https://github.com/facebook/lexical/issues/2824