### PR TITLE
Don't merge history entries from different editors

### DIFF
--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -255,9 +255,11 @@ function createMergeActionGetter(
     );
 
     const mergeAction = (() => {
+      const isSameEditor =
+        currentHistoryEntry === null || currentHistoryEntry.editor === editor;
       const shouldPushHistory = tags.has('history-push');
       const shouldMergeHistory =
-        !shouldPushHistory && tags.has('history-merge');
+        !shouldPushHistory && isSameEditor && tags.has('history-merge');
 
       if (shouldMergeHistory) {
         return HISTORY_MERGE;
@@ -278,9 +280,6 @@ function createMergeActionGetter(
 
         return DISCARD_HISTORY_CANDIDATE;
       }
-
-      const isSameEditor =
-        currentHistoryEntry === null || currentHistoryEntry.editor === editor;
 
       if (
         shouldPushHistory === false &&

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -259,10 +259,13 @@ function createMergeActionGetter(
         currentHistoryEntry === null || currentHistoryEntry.editor === editor;
       const shouldPushHistory = tags.has('history-push');
       const shouldMergeHistory =
-        !shouldPushHistory && isSameEditor && tags.has('history-merge');
+        !shouldPushHistory && tags.has('history-merge');
 
       if (shouldMergeHistory) {
-        return HISTORY_MERGE;
+        if (isSameEditor) {
+          return HISTORY_MERGE;
+        }
+        return DISCARD_HISTORY_CANDIDATE;
       }
 
       if (prevEditorState === null) {

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -259,13 +259,10 @@ function createMergeActionGetter(
         currentHistoryEntry === null || currentHistoryEntry.editor === editor;
       const shouldPushHistory = tags.has('history-push');
       const shouldMergeHistory =
-        !shouldPushHistory && tags.has('history-merge');
+        !shouldPushHistory && isSameEditor && tags.has('history-merge');
 
       if (shouldMergeHistory) {
-        if (isSameEditor) {
-          return HISTORY_MERGE;
-        }
-        return DISCARD_HISTORY_CANDIDATE;
+        return HISTORY_MERGE;
       }
 
       if (prevEditorState === null) {


### PR DESCRIPTION
Merging history entries from different editors can lead to a situation where the initial state update of a nested editor is merged with a change from the parent editor, leading to the EditorState with containing just the parent editor change never going onto the undo stack.

Example is an ImageNode that eagerly renders a nested editor caption with initial state set to undefined. This causes the following series of events:

1) editor.update -> insertImageNode
2) nestedEditor.update -> initializeEditorState
3) LexicalHistory updateListener (1) -> applyChange
4) HISTORY_PUSH -> put state before image node insertion onto undo stack, set historyEntry.current to new state with image inserted.
5) LexicalHistory updateListener (2) -> applyChange
6) HISTORY_MERGE (because of tag) -> don't push anything onto undo stack, set historyEntry.current to nestedEditor state.

This means the EditorState where the ImageNode exists is never put onto the undo stack, so if you delete the ImageNode subsequently, you can't undo and get it back.

To fix this, we only merge two entries if the editors are the same. The downside of pushing instead of mergin is that updates 1 and 2 are treated separately on the history stack, so the user perceives one action - inserting an image, but when they undo, they need to undo twice to actually get back to the state without the image (the first undo restores the same state from the stack - it gets put there because the nested editor change now causes a HISTORY_PUSH instead of a merge.

Instead, we might be able to just discard attempted merges from different editors.