### PR TITLE
Fix playground visual styling

### DIFF
--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -189,7 +189,7 @@ export default function Editor(): JSX.Element {
           {showTableOfContents && <TableOfContentsPlugin />}
         </div>
       </div>
-      <ActionsPlugin isRichText={isRichText} />
+      <ActionsPlugin isRichText={isRichText} showTreeView={showTreeView} />
       {showTreeView && <TreeViewPlugin />}
     </>
   );

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -116,6 +116,7 @@ pre {
   margin: 1px auto 10px auto;
   max-height: 250px;
   position: relative;
+  overflow: hidden;
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
 }
@@ -1073,6 +1074,11 @@ i.prettier-error {
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
   background: #fff;
+}
+
+.actions.tree-view {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .actions i {

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -38,8 +38,10 @@ import {
 
 export default function ActionsPlugin({
   isRichText,
+  showTreeView,
 }: {
   isRichText: boolean;
+  showTreeView: boolean;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
   const [isReadOnly, setIsReadOnly] = useState(() => editor.isReadOnly());
@@ -108,7 +110,7 @@ export default function ActionsPlugin({
   }, [editor]);
 
   return (
-    <div className="actions">
+    <div className={`actions ${showTreeView ? 'tree-view' : ''}`}>
       {SUPPORT_SPEECH_RECOGNITION && (
         <button
           onClick={() => {


### PR DESCRIPTION
Not sure when, but the border radius of the text and debug views is incorrect. This PR fixes them back to how they were before.