### PR TITLE
Exported DEFAULT_TRANSFORMERS array in react LexicalMarkdownShortcutPlugin

### DIFF
--- a/packages/lexical-react/flow/LexicalMarkdownShortcutPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalMarkdownShortcutPlugin.js.flow
@@ -9,6 +9,8 @@
 
 import type {Transformer} from '@lexical/markdown';
 
+declare export var DEFAULT_TRANSFORMERS: Array<Transformer>;
+
 declare export function MarkdownShortcutPlugin({
   transformers?: Array<Transformer>,
 }): React$Node;

--- a/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.tsx
+++ b/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.tsx
@@ -36,7 +36,7 @@ const HR: ElementTransformer = {
   },
   type: 'element',
 };
-const DEFAULT_TRANSFORMERS = [HR, ...TRANSFORMERS];
+export const DEFAULT_TRANSFORMERS = [HR, ...TRANSFORMERS];
 
 export function MarkdownShortcutPlugin({
   transformers = DEFAULT_TRANSFORMERS,


### PR DESCRIPTION
The `LexicalMarkdownShortcutPlugin` package extends the defaults from `@lexical/markdown` with a HR transform but didn't expose that default list making it harder for anyone wanting to use the defaults plus their own extensions.
