### PR TITLE
add the corresponding import to react doc

### DIFF
--- a/packages/lexical-website-new/docs/react/plugins.md
+++ b/packages/lexical-website-new/docs/react/plugins.md
@@ -6,6 +6,14 @@ sidebar_position: 1
 
 React-based plugins are using Lexical editor instance from `<LexicalComposer>` context:
 
+```js
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
+import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
+import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
+import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
+```
+
 ```jsx
 <LexicalComposer initialConfig={initialConfig}>
   <PlainTextPlugin


### PR DESCRIPTION
In [«Getting Started with React»](https://lexical.dev/docs/getting-started/react) there are the imports shown. But since they are not quite obvious (for a beginner) it's probably good to add them here, at least in the first example so people can then figure out the other imports easily themselves (same logic for all other components)