### PR TITLE
Improve heuristics around node selection and keyboard navigation

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
@@ -70,14 +70,6 @@ test.describe('HorizontalRule', () => {
     });
 
     await page.keyboard.press('ArrowRight');
-
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [0],
-      focusOffset: 0,
-      focusPath: [0],
-    });
-
     await page.keyboard.press('ArrowRight');
 
     await assertSelection(page, {
@@ -88,6 +80,7 @@ test.describe('HorizontalRule', () => {
     });
 
     await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowLeft');
 
     await assertSelection(page, {
       anchorOffset: 0,
@@ -96,12 +89,9 @@ test.describe('HorizontalRule', () => {
       focusPath: [0],
     });
 
-    await page.keyboard.press('ArrowLeft');
-
     await page.keyboard.type('Some text');
 
     await page.keyboard.press('ArrowRight');
-
     await page.keyboard.press('ArrowRight');
 
     await assertSelection(page, {

--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
@@ -73,6 +73,15 @@ test.describe('HorizontalRule', () => {
 
     await assertSelection(page, {
       anchorOffset: 0,
+      anchorPath: [0],
+      focusOffset: 0,
+      focusPath: [0],
+    });
+
+    await page.keyboard.press('ArrowRight');
+
+    await assertSelection(page, {
+      anchorOffset: 0,
       anchorPath: [2],
       focusOffset: 0,
       focusPath: [2],
@@ -87,7 +96,11 @@ test.describe('HorizontalRule', () => {
       focusPath: [0],
     });
 
+    await page.keyboard.press('ArrowLeft');
+
     await page.keyboard.type('Some text');
+
+    await page.keyboard.press('ArrowRight');
 
     await page.keyboard.press('ArrowRight');
 
@@ -123,6 +136,8 @@ test.describe('HorizontalRule', () => {
     );
 
     await moveToLineBeginning(page);
+
+    await page.keyboard.press('ArrowLeft');
 
     await page.keyboard.press('ArrowLeft');
 

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -67,6 +67,7 @@ test.describe('Images', () => {
 
     await focusEditor(page);
     await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowLeft');
     await assertSelection(page, {
       anchorOffset: 0,
       anchorPath: [0],
@@ -75,6 +76,7 @@ test.describe('Images', () => {
     });
 
     await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight');
     await assertSelection(page, {
       anchorOffset: 1,
       anchorPath: [0],
@@ -82,6 +84,7 @@ test.describe('Images', () => {
       focusPath: [0],
     });
 
+    await page.keyboard.press('ArrowRight');
     await page.keyboard.press('ArrowRight');
     await page.keyboard.press('Backspace');
 

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -120,7 +120,7 @@ test.describe('Images', () => {
                   alt="Yellow flower in tilt shift lens"
                   draggable="false"
                   style="height: inherit; max-width: 500px; width: inherit;"
-                  class="focused" />
+                  class="focused draggable" />
               </div>
               <div>
                 <button class="image-caption-button">Add Caption</button>
@@ -216,7 +216,7 @@ test.describe('Images', () => {
     await insertSampleImage(page);
 
     await focusEditor(page);
-    await moveLeft(page, 2);
+    await moveLeft(page, 4);
 
     await assertHTML(
       page,
@@ -304,7 +304,7 @@ test.describe('Images', () => {
     await insertSampleImage(page);
 
     await focusEditor(page);
-    await moveLeft(page, 2);
+    await moveLeft(page, 4);
 
     await assertHTML(
       page,

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -187,7 +187,7 @@ test.describe('Images', () => {
 
     await page.keyboard.press('ArrowLeft');
     await page.keyboard.press('ArrowLeft');
-    
+
     await page.keyboard.press('Delete');
 
     await assertHTML(

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -186,6 +186,8 @@ test.describe('Images', () => {
     });
 
     await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowLeft');
+    
     await page.keyboard.press('Delete');
 
     await assertHTML(

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -947,6 +947,7 @@ test.describe('TextFormatting', () => {
 
   test('Regression #2523: can toggle format when selecting a TextNode edge followed by a non TextNode; ', async ({
     page,
+    isCollab,
     isPlainText,
   }) => {
     test.skip(isPlainText);
@@ -959,30 +960,32 @@ test.describe('TextFormatting', () => {
     await moveLeft(page, 1);
     await selectCharacters(page, 'left', 2);
 
-    await assertHTML(
-      page,
-      html`
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">A</span>
-          <span
-            class="editor-image"
-            contenteditable="false"
-            data-lexical-decorator="true">
-            <div draggable="false">
-              <img
-                alt="Yellow flower in tilt shift lens"
-                class="focused"
-                draggable="false"
-                src="${SAMPLE_IMAGE_URL}"
-                style="height: inherit; max-width: 500px; width: inherit" />
-            </div>
-          </span>
-          <span data-lexical-text="true">BC</span>
-        </p>
-      `,
-    );
+    if (!isCollab) {
+      await assertHTML(
+        page,
+        html`
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">A</span>
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="false">
+                <img
+                  alt="Yellow flower in tilt shift lens"
+                  class="focused"
+                  draggable="false"
+                  src="${SAMPLE_IMAGE_URL}"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+            </span>
+            <span data-lexical-text="true">BC</span>
+          </p>
+        `,
+      );
+    }
     await toggleBold(page);
     await assertHTML(
       page,

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -973,6 +973,7 @@ test.describe('TextFormatting', () => {
             <div draggable="false">
               <img
                 alt="Yellow flower in tilt shift lens"
+                class="focused"
                 draggable="false"
                 src="${SAMPLE_IMAGE_URL}"
                 style="height: inherit; max-width: 500px; width: inherit" />

--- a/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
@@ -224,7 +224,7 @@ test.describe('Toolbar', () => {
             <div draggable="true">
               <img
                 alt="Yellow flower in tilt shift lens"
-                class="focused"
+                class="focused draggable"
                 draggable="false"
                 src="${SAMPLE_IMAGE_URL}"
                 style="height: inherit; max-width: 500px; width: inherit" />
@@ -260,7 +260,7 @@ test.describe('Toolbar', () => {
             <div draggable="true">
               <img
                 alt="Yellow flower in tilt shift lens"
-                class="focused"
+                class="focused draggable"
                 draggable="false"
                 src="${SAMPLE_IMAGE_URL}"
                 style="height: inherit; max-width: 500px; width: inherit" />

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1536,3 +1536,23 @@ button.item.dropdown-item-active {
 button.item.dropdown-item-active i {
   opacity: 1;
 }
+
+hr {
+  padding: 2px 2px;
+  border: none;
+  margin: 1em 0;
+  cursor: pointer;
+}
+
+hr:after {
+  content: "";
+  display: block;
+  height: 2px;
+  background-color: #ccc;
+  line-height: 2px;
+}
+
+hr.selected {
+  outline: 2px solid rgb(60, 132, 244);
+  user-select: none; 
+}

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1545,7 +1545,7 @@ hr {
 }
 
 hr:after {
-  content: "";
+  content: '';
   display: block;
   height: 2px;
   background-color: #ccc;
@@ -1554,5 +1554,5 @@ hr:after {
 
 hr.selected {
   outline: 2px solid rgb(60, 132, 244);
-  user-select: none; 
+  user-select: none;
 }

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -910,16 +910,19 @@ i.prettier-error {
 
 .editor-shell .editor-image img {
   max-width: 100%;
+  cursor: default;
 }
 
 .editor-shell .editor-image img.focused {
   outline: 2px solid rgb(60, 132, 244);
   user-select: none;
-  cursor: move;
+}
+
+.editor-shell .editor-image img.focused.draggable {
   cursor: grab;
 }
 
-.editor-shell .editor-image img.focused:active {
+.editor-shell .editor-image img.focused.draggable:active {
   cursor: grabbing;
 }
 

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -18,6 +18,8 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
+  $getSelection,
+  $isNodeSelection,
   COMMAND_PRIORITY_HIGH,
   DecoratorNode,
   KEY_ESCAPE_COMMAND,
@@ -96,8 +98,22 @@ function EquationComponent({
           COMMAND_PRIORITY_HIGH,
         ),
       );
+    } else {
+      return editor.registerUpdateListener(({editorState}) => {
+        const isSelected = editorState.read(() => {
+          const selection = $getSelection();
+          return (
+            $isNodeSelection(selection) &&
+            selection.has(nodeKey) &&
+            selection.getNodes().length === 1
+          );
+        });
+        if (isSelected) {
+          setShowEquationEditor(true);
+        }
+      });
     }
-  }, [editor, onHide, showEquationEditor]);
+  }, [editor, nodeKey, onHide, showEquationEditor]);
 
   return (
     <>

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -52,6 +52,7 @@ function ExcalidrawComponent({
   );
   const imageContainerRef = useRef<HTMLImageElement | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const captionButtonRef = useRef<HTMLButtonElement | null>(null);
   const [isSelected, setSelected, clearSelection] =
     useLexicalNodeSelection(nodeKey);
   const [isResizing, setIsResizing] = useState<boolean>(false);
@@ -184,6 +185,7 @@ function ExcalidrawComponent({
           />
           {(isSelected || isResizing) && (
             <ImageResizer
+              buttonRef={captionButtonRef}
               showCaption={true}
               setShowCaption={() => null}
               imageRef={imageContainerRef}

--- a/packages/lexical-playground/src/ui/ImageResizer.tsx
+++ b/packages/lexical-playground/src/ui/ImageResizer.tsx
@@ -25,6 +25,7 @@ const Direction = {
 export default function ImageResizer({
   onResizeStart,
   onResizeEnd,
+  buttonRef,
   imageRef,
   maxWidth,
   editor,
@@ -32,6 +33,7 @@ export default function ImageResizer({
   setShowCaption,
 }: {
   editor: LexicalEditor;
+  buttonRef: {current: null | HTMLButtonElement};
   imageRef: {current: null | HTMLElement};
   maxWidth?: number;
   onResizeEnd: (width: 'inherit' | number, height: 'inherit' | number) => void;
@@ -39,7 +41,6 @@ export default function ImageResizer({
   setShowCaption: (show: boolean) => void;
   showCaption: boolean;
 }): JSX.Element {
-  const buttonRef = useRef(null);
   const controlWrapperRef = useRef<HTMLDivElement>(null);
   const userSelect = useRef({
     priority: '',

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -92,7 +92,7 @@ function HorizontalRuleComponent({nodeKey}: {nodeKey: NodeKey}) {
     );
   }, [clearSelection, editor, isSelected, onDelete, setSelected]);
 
-  return <hr ref={hrRef} className={isSelected ? 'selected' : ''} />;
+  return <hr ref={hrRef} className={isSelected ? 'selected' : undefined} />;
 }
 
 export class HorizontalRuleNode extends DecoratorNode<JSX.Element> {

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -6,10 +6,29 @@
  *
  */
 
-import type {LexicalCommand, LexicalNode, SerializedLexicalNode} from 'lexical';
+import type {
+  LexicalCommand,
+  LexicalNode,
+  NodeKey,
+  SerializedLexicalNode,
+} from 'lexical';
 
-import {createCommand, DecoratorNode} from 'lexical';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
+import {mergeRegister} from '@lexical/utils';
+import {
+  $getNodeByKey,
+  $getSelection,
+  $isNodeSelection,
+  CLICK_COMMAND,
+  COMMAND_PRIORITY_LOW,
+  createCommand,
+  DecoratorNode,
+  KEY_BACKSPACE_COMMAND,
+  KEY_DELETE_COMMAND,
+} from 'lexical';
 import * as React from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 
 export type SerializedHorizontalRuleNode = SerializedLexicalNode & {
   type: 'horizontalrule';
@@ -19,8 +38,61 @@ export type SerializedHorizontalRuleNode = SerializedLexicalNode & {
 export const INSERT_HORIZONTAL_RULE_COMMAND: LexicalCommand<void> =
   createCommand();
 
-function HorizontalRuleComponent() {
-  return <hr />;
+function HorizontalRuleComponent({nodeKey}: {nodeKey: NodeKey}) {
+  const [editor] = useLexicalComposerContext();
+  const hrRef = useRef(null);
+  const [isSelected, setSelected, clearSelection] =
+    useLexicalNodeSelection(nodeKey);
+
+  const onDelete = useCallback(
+    (payload: KeyboardEvent) => {
+      if (isSelected && $isNodeSelection($getSelection())) {
+        const event: KeyboardEvent = payload;
+        event.preventDefault();
+        const node = $getNodeByKey(nodeKey);
+        if ($isHorizontalRuleNode(node)) {
+          node.remove();
+        }
+        setSelected(false);
+      }
+      return false;
+    },
+    [isSelected, nodeKey, setSelected],
+  );
+
+  useEffect(() => {
+    return mergeRegister(
+      editor.registerCommand(
+        CLICK_COMMAND,
+        (event: MouseEvent) => {
+          const hrElem = hrRef.current;
+
+          if (event.target === hrElem) {
+            if (!event.shiftKey) {
+              clearSelection();
+            }
+            setSelected(!isSelected);
+            return true;
+          }
+
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        KEY_DELETE_COMMAND,
+        onDelete,
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        KEY_BACKSPACE_COMMAND,
+        onDelete,
+        COMMAND_PRIORITY_LOW,
+      ),
+    );
+  }, [clearSelection, editor, isSelected, onDelete, setSelected]);
+
+  return <hr ref={hrRef} className={isSelected ? 'selected' : ''} />;
 }
 
 export class HorizontalRuleNode extends DecoratorNode<JSX.Element> {
@@ -64,7 +136,7 @@ export class HorizontalRuleNode extends DecoratorNode<JSX.Element> {
   }
 
   decorate(): JSX.Element {
-    return <HorizontalRuleComponent />;
+    return <HorizontalRuleComponent nodeKey={this.__key} />;
   }
 }
 

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -63,8 +63,10 @@ import {
   INDENT_CONTENT_COMMAND,
   INSERT_LINE_BREAK_COMMAND,
   INSERT_PARAGRAPH_COMMAND,
+  KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
+  KEY_ARROW_UP_COMMAND,
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
   KEY_ENTER_COMMAND,
@@ -706,14 +708,58 @@ export function registerRichText(
       COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerCommand<KeyboardEvent>(
+      KEY_ARROW_UP_COMMAND,
+      (event) => {
+        const selection = $getSelection();
+        if ($isNodeSelection(selection)) {
+          // If selection is on a node, let's try and move selection
+          // back to being a range selection.
+          const nodes = selection.getNodes();
+          if (nodes.length > 0) {
+            nodes[0].selectPrevious();
+            return true;
+          }
+        }
+        return false;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    ),
+    editor.registerCommand<KeyboardEvent>(
+      KEY_ARROW_DOWN_COMMAND,
+      (event) => {
+        const selection = $getSelection();
+        if ($isNodeSelection(selection)) {
+          // If selection is on a node, let's try and move selection
+          // back to being a range selection.
+          const nodes = selection.getNodes();
+          if (nodes.length > 0) {
+            nodes[0].selectNext(0, 0);
+            return true;
+          }
+        }
+        return false;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    ),
+    editor.registerCommand<KeyboardEvent>(
       KEY_ARROW_LEFT_COMMAND,
       (event) => {
         const selection = $getSelection();
+        if ($isNodeSelection(selection)) {
+          // If selection is on a node, let's try and move selection
+          // back to being a range selection.
+          const nodes = selection.getNodes();
+          if (nodes.length > 0) {
+            event.preventDefault();
+            nodes[0].selectPrevious();
+            return true;
+          }
+        }
         if (!$isRangeSelection(selection)) {
           return false;
         }
-        const isHoldingShift = event.shiftKey;
         if ($shouldOverrideDefaultCharacterSelection(selection, true)) {
+          const isHoldingShift = event.shiftKey;
           event.preventDefault();
           $moveCharacter(selection, isHoldingShift, true);
           return true;
@@ -726,6 +772,16 @@ export function registerRichText(
       KEY_ARROW_RIGHT_COMMAND,
       (event) => {
         const selection = $getSelection();
+        if ($isNodeSelection(selection)) {
+          // If selection is on a node, let's try and move selection
+          // back to being a range selection.
+          const nodes = selection.getNodes();
+          if (nodes.length > 0) {
+            event.preventDefault();
+            nodes[0].selectNext(0, 0);
+            return true;
+          }
+        }
         if (!$isRangeSelection(selection)) {
           return false;
         }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -46,6 +46,7 @@ import {
   $isGridSelection,
   $isNodeSelection,
   $isRangeSelection,
+  $isRootNode,
   $isTextNode,
   CLICK_COMMAND,
   COMMAND_PRIORITY_EDITOR,
@@ -807,9 +808,11 @@ export function registerRichText(
         }
         event.preventDefault();
         const {anchor} = selection;
-        if (selection.isCollapsed() && anchor.offset === 0) {
+        const anchorNode = anchor.getNode();
+
+        if (selection.isCollapsed() && anchor.offset === 0 && !$isRootNode(anchorNode)) {
           const element = $getNearestBlockElementAncestorOrThrow(
-            anchor.getNode(),
+            anchorNode,
           );
           if (element.getIndent() > 0) {
             return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -810,10 +810,12 @@ export function registerRichText(
         const {anchor} = selection;
         const anchorNode = anchor.getNode();
 
-        if (selection.isCollapsed() && anchor.offset === 0 && !$isRootNode(anchorNode)) {
-          const element = $getNearestBlockElementAncestorOrThrow(
-            anchorNode,
-          );
+        if (
+          selection.isCollapsed() &&
+          anchor.offset === 0 &&
+          !$isRootNode(anchorNode)
+        ) {
+          const element = $getNearestBlockElementAncestorOrThrow(anchorNode);
           if (element.getIndent() > 0) {
             return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
           }

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -798,15 +798,18 @@ export class LexicalEditor {
         },
         {
           onUpdate: () => {
+            rootElement.removeAttribute('autocapitalize');
             if (callbackFn) {
               callbackFn();
             }
           },
         },
       );
-      setTimeout(() => {
+      // In the case where onUpdate doesn't fire (due to the focus update not
+      // occuring).
+      if (this._pendingEditorState === null) {
         rootElement.removeAttribute('autocapitalize');
-      }, 10)
+      }
     }
   }
 

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -798,14 +798,15 @@ export class LexicalEditor {
         },
         {
           onUpdate: () => {
-            rootElement.removeAttribute('autocapitalize');
-
             if (callbackFn) {
               callbackFn();
             }
           },
         },
       );
+      setTimeout(() => {
+        rootElement.removeAttribute('autocapitalize');
+      }, 10)
     }
   }
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1653,7 +1653,7 @@ export class RangeSelection implements BaseSelection {
     // Handle the selection movement around decorators.
     const possibleNode = $getDecoratorNode(focus, isBackward);
     if ($isDecoratorNode(possibleNode) && !possibleNode.isIsolated()) {
-      // Enable it possible to move selection from range selection to
+      // Make it possible to move selection from range selection to
       // node selection on the node.
       if (collapse) {
         const nodeSelection = $createNodeSelection();

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -29,6 +29,7 @@ import {
   $isLineBreakNode,
   $isRootNode,
   $isTextNode,
+  $setSelection,
   DecoratorNode,
   GridCellNode,
   GridNode,
@@ -1652,6 +1653,14 @@ export class RangeSelection implements BaseSelection {
     // Handle the selection movement around decorators.
     const possibleNode = $getDecoratorNode(focus, isBackward);
     if ($isDecoratorNode(possibleNode) && !possibleNode.isIsolated()) {
+      // Enable it possible to move selection from range selection to
+      // node selection on the node.
+      if (collapse) {
+        const nodeSelection = $createNodeSelection();
+        nodeSelection.add(possibleNode.__key);
+        $setSelection(nodeSelection);
+        return;
+      }
       const sibling = isBackward
         ? possibleNode.getPreviousSibling()
         : possibleNode.getNextSibling();


### PR DESCRIPTION
Keyboard navigation today around node selection is a bit wonky and broken. Specifically, you can't actually select a node using the keyboard arrow keys properly, nor can you escape node selection and move back to range selection using the keyboard arrow keys.

This PR fixes that problem and also tackles a few accessibility issues along the way with image nodes and horizontal rule nodes too.