### PR TITLE
Fix editor content clipping bug

### DIFF
--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -188,8 +188,8 @@ export default function Editor(): JSX.Element {
         <div className="toc">
           {showTableOfContents && <TableOfContentsPlugin />}
         </div>
+        <ActionsPlugin isRichText={isRichText} />
       </div>
-      <ActionsPlugin isRichText={isRichText} showTreeView={showTreeView} />
       {showTreeView && <TreeViewPlugin />}
     </>
   );

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1071,12 +1071,11 @@ i.prettier-error {
 }
 
 .actions {
-  position: relative;
+  position: absolute;
   text-align: right;
   padding: 10px;
-  border-bottom-left-radius: 10px;
-  border-bottom-right-radius: 10px;
-  background: #fff;
+  bottom: 0;
+  right: 0;
 }
 
 .actions.tree-view {

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -38,10 +38,8 @@ import {
 
 export default function ActionsPlugin({
   isRichText,
-  showTreeView,
 }: {
   isRichText: boolean;
-  showTreeView: boolean;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
   const [isReadOnly, setIsReadOnly] = useState(() => editor.isReadOnly());
@@ -110,7 +108,7 @@ export default function ActionsPlugin({
   }, [editor]);
 
   return (
-    <div className={`actions ${showTreeView ? 'tree-view' : ''}`}>
+    <div className="actions">
       {SUPPORT_SPEECH_RECOGNITION && (
         <button
           onClick={() => {


### PR DESCRIPTION
The editor box doesn't properly clip at the boundaries of the white box (regression from https://github.com/facebook/lexical/pull/2724). This PR puts back the correct dimensions so the actions bar floats over the editor content

![Screenshot 2022-08-25 at 14 56 28](https://user-images.githubusercontent.com/1519870/186684239-e98b3139-dd16-4258-9344-97b4262350f1.png)
.