### PR TITLE
Allow code highlighting to run without active selection

### DIFF
--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -310,7 +310,10 @@ function updateAndRetainSelection(
   updateFn: () => boolean,
 ): void {
   const selection = $getSelection();
-  if (!$isRangeSelection(selection) || !selection.anchor) {
+  // If it's not range selection (or null selection) there's no need to change it,
+  // but we can still run highlighting logic
+  if (!$isRangeSelection(selection)) {
+    updateFn();
     return;
   }
 


### PR DESCRIPTION
Setting content from outside of editor (e.g. via setEditorContent) does not trigger highlighting as it checked for selection to retain it. In such cases if there's no selection or if it's not a range we don't need to change it and just run highlighting update