### PR TITLE
Fix overriding keyboard controls on internal decorator

### DIFF
--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -215,18 +215,28 @@ function ImageComponent({
     [caption, isSelected, showCaption],
   );
 
-  const onEscape = useCallback(() => {
-    if (activeEditorRef.current === caption) {
-      $setSelection(null);
-      editor.update(() => {
-        const nodeSelection = $createNodeSelection();
-        nodeSelection.add(nodeKey);
-        $setSelection(nodeSelection);
-      });
-      return true;
-    }
-    return false;
-  }, [caption, editor, nodeKey]);
+  const onEscape = useCallback(
+    (event: KeyboardEvent) => {
+      if (
+        activeEditorRef.current === caption ||
+        buttonRef.current === event.target
+      ) {
+        $setSelection(null);
+        editor.update(() => {
+          const nodeSelection = $createNodeSelection();
+          nodeSelection.add(nodeKey);
+          const parentRootElement = editor.getRootElement();
+          if (parentRootElement !== null) {
+            parentRootElement.focus();
+          }
+          $setSelection(nodeSelection);
+        });
+        return true;
+      }
+      return false;
+    },
+    [caption, editor, nodeKey],
+  );
 
   useEffect(() => {
     return mergeRegister(

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -712,7 +712,10 @@ export function registerRichText(
       KEY_ARROW_UP_COMMAND,
       (event) => {
         const selection = $getSelection();
-        if ($isNodeSelection(selection)) {
+        if (
+          $isNodeSelection(selection) &&
+          !isTargetWithinDecorator(event.target as HTMLElement)
+        ) {
           // If selection is on a node, let's try and move selection
           // back to being a range selection.
           const nodes = selection.getNodes();
@@ -729,7 +732,10 @@ export function registerRichText(
       KEY_ARROW_DOWN_COMMAND,
       (event) => {
         const selection = $getSelection();
-        if ($isNodeSelection(selection)) {
+        if (
+          $isNodeSelection(selection) &&
+          !isTargetWithinDecorator(event.target as HTMLElement)
+        ) {
           // If selection is on a node, let's try and move selection
           // back to being a range selection.
           const nodes = selection.getNodes();
@@ -746,7 +752,10 @@ export function registerRichText(
       KEY_ARROW_LEFT_COMMAND,
       (event) => {
         const selection = $getSelection();
-        if ($isNodeSelection(selection)) {
+        if (
+          $isNodeSelection(selection) &&
+          !isTargetWithinDecorator(event.target as HTMLElement)
+        ) {
           // If selection is on a node, let's try and move selection
           // back to being a range selection.
           const nodes = selection.getNodes();
@@ -773,7 +782,10 @@ export function registerRichText(
       KEY_ARROW_RIGHT_COMMAND,
       (event) => {
         const selection = $getSelection();
-        if ($isNodeSelection(selection)) {
+        if (
+          $isNodeSelection(selection) &&
+          !isTargetWithinDecorator(event.target as HTMLElement)
+        ) {
           // If selection is on a node, let's try and move selection
           // back to being a range selection.
           const nodes = selection.getNodes();


### PR DESCRIPTION
https://github.com/facebook/lexical/pull/2884 Introduced a bug where keyboard controls on inputs and other controls within a decorator were incorrectly triggering navigation on the decorator itself. We should always ensure that we're not within the decorator when doing such things.