### PR TITLE
Fix Lexical package main entry points

### DIFF
--- a/packages/lexical-clipboard/LexicalClipboard.js
+++ b/packages/lexical-clipboard/LexicalClipboard.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalHashtag.js');
+'use strict';
+
+module.exports = require('./dist/LexicalClipboard.js');

--- a/packages/lexical-code/LexicalCode.js
+++ b/packages/lexical-code/LexicalCode.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalMark.js');
+'use strict';
+
+module.exports = require('./dist/LexicalCode.js');

--- a/packages/lexical-dragon/LexicalDragon.js
+++ b/packages/lexical-dragon/LexicalDragon.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalCode.js');
+'use strict';
+
+module.exports = require('./dist/LexicalDragon.js');

--- a/packages/lexical-file/LexicalFile.js
+++ b/packages/lexical-file/LexicalFile.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalOffset.js');
+'use strict';
+
+module.exports = require('./dist/LexicalFile.js');

--- a/packages/lexical-hashtag/LexicalHashtag.js
+++ b/packages/lexical-hashtag/LexicalHashtag.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalClipboard.js');
+'use strict';
+
+module.exports = require('./dist/LexicalHashtag.js');

--- a/packages/lexical-headless/LexicalHeadless.js
+++ b/packages/lexical-headless/LexicalHeadless.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalUtils.js');
+'use strict';
+
+module.exports = require('./dist/LexicalHeadless.js');

--- a/packages/lexical-history/LexicalHistory.js
+++ b/packages/lexical-history/LexicalHistory.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalDragon.js');
+'use strict';
+
+module.exports = require('./dist/LexicalHistory.js');

--- a/packages/lexical-html/LexicalHtml.js
+++ b/packages/lexical-html/LexicalHtml.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalFile.js');
+'use strict';
+
+module.exports = require('./dist/LexicalHtml.js');

--- a/packages/lexical-link/LexicalLink.js
+++ b/packages/lexical-link/LexicalLink.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalYjs.js');
+'use strict';
+
+module.exports = require('./dist/LexicalLink.js');

--- a/packages/lexical-list/LexicalList.js
+++ b/packages/lexical-list/LexicalList.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalText.js');
+'use strict';
+
+module.exports = require('./dist/LexicalList.js');

--- a/packages/lexical-mark/LexicalMark.js
+++ b/packages/lexical-mark/LexicalMark.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalMarkdown.js');
+'use strict';
+
+module.exports = require('./dist/LexicalMark.js');

--- a/packages/lexical-markdown/LexicalMarkdown.js
+++ b/packages/lexical-markdown/LexicalMarkdown.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalHtml.js');
+'use strict';
+
+module.exports = require('./dist/LexicalMarkdown.js');

--- a/packages/lexical-offset/LexicalOffset.js
+++ b/packages/lexical-offset/LexicalOffset.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalSelection.js');
+'use strict';
+
+module.exports = require('./dist/LexicalOffset.js');

--- a/packages/lexical-overflow/LexicalOverflow.js
+++ b/packages/lexical-overflow/LexicalOverflow.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalHeadless.js');
+'use strict';
+
+module.exports = require('./dist/LexicalOverflow.js');

--- a/packages/lexical-plain-text/LexicalPlainText.js
+++ b/packages/lexical-plain-text/LexicalPlainText.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalHistory.js');
+'use strict';
+
+module.exports = require('./dist/LexicalPlainText.js');

--- a/packages/lexical-rich-text/LexicalRichText.js
+++ b/packages/lexical-rich-text/LexicalRichText.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalOverflow.js');
+'use strict';
+
+module.exports = require('./dist/LexicalRichText.js');

--- a/packages/lexical-selection/LexicalSelection.js
+++ b/packages/lexical-selection/LexicalSelection.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalPlainText.js');
+'use strict';
+
+module.exports = require('./dist/LexicalSelection.js');

--- a/packages/lexical-table/LexicalTable.js
+++ b/packages/lexical-table/LexicalTable.js
@@ -6,4 +6,6 @@
  *
  */
 
+'use strict';
+
 module.exports = require('./dist/LexicalTable.js');

--- a/packages/lexical-text/LexicalText.js
+++ b/packages/lexical-text/LexicalText.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalList.js');
+'use strict';
+
+module.exports = require('./dist/LexicalText.js');

--- a/packages/lexical-utils/LexicalUtils.js
+++ b/packages/lexical-utils/LexicalUtils.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/Lexical.js');
+'use strict';
+
+module.exports = require('./dist/LexicalUtils.js');

--- a/packages/lexical-yjs/LexicalYjs.js
+++ b/packages/lexical-yjs/LexicalYjs.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalLink.js');
+'use strict';
+
+module.exports = require('./dist/LexicalYjs.js');

--- a/packages/lexical/Lexical.js
+++ b/packages/lexical/Lexical.js
@@ -6,4 +6,6 @@
  *
  */
 
-module.exports = require('./dist/LexicalRichText.js');
+'use strict';
+
+module.exports = require('./dist/Lexical.js');


### PR DESCRIPTION
These seem to have been renamed to `ts` modules by accident. This breaks local package referencing outside of Vite.