### PR TITLE
Attempt transform of NodeSelection to RangeSelection on mouseDown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ npm
 .env.test.local
 .env.production.local
 .ts-temp
+.docusaurus
 e2e-screenshots
 test-results
 

--- a/packages/lexical-playground/__tests__/e2e/CodeActionMenu.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CodeActionMenu.spec.mjs
@@ -14,7 +14,7 @@ import {
   expect,
   focusEditor,
   initialize,
-  mouseMoveTo,
+  mouseMoveToSelector,
   pasteFromClipboard,
   test,
   waitForSelector,
@@ -81,7 +81,7 @@ test.describe('CodeActionMenu', () => {
       `,
     );
 
-    await mouseMoveTo(page, 'code.PlaygroundEditorTheme__code');
+    await mouseMoveToSelector(page, 'code.PlaygroundEditorTheme__code');
 
     if (browserName === 'chromium') {
       await context.grantPermissions(['clipboard-write']);
@@ -213,7 +213,7 @@ test.describe('CodeActionMenu', () => {
       `,
     );
 
-    await mouseMoveTo(page, 'code.PlaygroundEditorTheme__code');
+    await mouseMoveToSelector(page, 'code.PlaygroundEditorTheme__code');
     await click(page, 'button[aria-label=prettier]');
 
     await assertHTML(
@@ -281,7 +281,7 @@ test.describe('CodeActionMenu', () => {
       `,
     );
 
-    await mouseMoveTo(page, 'code.PlaygroundEditorTheme__code');
+    await mouseMoveToSelector(page, 'code.PlaygroundEditorTheme__code');
     await click(page, 'button[aria-label=prettier]');
 
     expect(await page.$('i.format.prettier-error')).toBeTruthy();

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -6,12 +6,16 @@
  *
  */
 
+import {expect} from '@playwright/test';
+
 import {moveLeft} from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
   assertSelection,
   click,
   dragImage,
+  dragMouse,
+  evaluate,
   focusEditor,
   html,
   initialize,
@@ -20,6 +24,7 @@ import {
   insertUrlImage,
   IS_WINDOWS,
   SAMPLE_IMAGE_URL,
+  selectorBoundingBox,
   test,
   waitForSelector,
 } from '../utils/index.mjs';
@@ -455,7 +460,7 @@ test.describe('Images', () => {
     // but when running the playwright test, we can't get the correct values from `event.rangeParent` and `event.rangeOffset`,
     // so for now we can only test the case of dragging the image to the end of the text
     if (browserName === 'firefox') {
-      await dragImage(page, 'span[data-lexical-text="true"]', 'end');
+      await dragImage(page, 'span[data-lexical-text="true"]', 'middle', 'end');
 
       await waitForSelector(page, '.editor-image img');
 
@@ -541,6 +546,7 @@ test.describe('Images', () => {
     await page.keyboard.press('Enter');
 
     await insertSampleImage(page);
+    await page.pause();
 
     await dragImage(page, 'span[data-lexical-text="true"]');
 
@@ -571,5 +577,32 @@ test.describe('Images', () => {
         </p>
       `,
     );
+  });
+
+  test('Select image, then select text - EditorState._selection updates with mousedown #2901', async ({
+    page,
+    isPlainText,
+    browserName,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await page.keyboard.type('HelloWorld');
+    await page.keyboard.press('Enter');
+    await insertSampleImage(page);
+    await click(page, '.editor-image img');
+
+    const textBoundingBox = await selectorBoundingBox(
+      page,
+      'span[data-lexical-text="true"]',
+    );
+    await dragMouse(page, textBoundingBox, textBoundingBox, 'start', 'middle');
+
+    const selectionTypeOf = await evaluate(page, (editor) => {
+      return window.lexicalEditor._editorState._selection.constructor.name;
+    });
+    expect(selectionTypeOf).toBe('RangeSelection');
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -600,9 +600,10 @@ test.describe('Images', () => {
     );
     await dragMouse(page, textBoundingBox, textBoundingBox, 'start', 'middle');
 
-    const selectionTypeOf = await evaluate(page, (editor) => {
-      return window.lexicalEditor._editorState._selection.constructor.name;
+    const lexicalSelection = await evaluate(page, (editor) => {
+      return window.lexicalEditor._editorState._selection;
     });
-    expect(selectionTypeOf).toBe('RangeSelection');
+    expect(lexicalSelection.anchor).toBeTruthy();
+    expect(lexicalSelection.focus).toBeTruthy();
   });
 });

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -76,6 +76,7 @@ import {updateEditor} from './LexicalUpdates';
 import {
   $flushMutations,
   $getNodeByKey,
+  $isSelectionCapturedInDecorator,
   $isTokenOrInert,
   $setSelection,
   $shouldPreventDefaultAndInsertText,
@@ -316,8 +317,18 @@ function onClick(event: MouseEvent, editor: LexicalEditor): void {
   });
 }
 
-function onMouseDown(_event: MouseEvent, _editor: LexicalEditor) {
-  isSelectionChangeFromMouseDown = true;
+function onMouseDown(event: MouseEvent, editor: LexicalEditor) {
+  // TODO implement text drag & drop
+  const target = event.target;
+  if (target instanceof Node) {
+    updateEditor(editor, () => {
+      // Drag & drop should not recompute selection until mouse up; otherwise the initially
+      // selected content is lost.
+      if (!$isSelectionCapturedInDecorator(target)) {
+        isSelectionChangeFromMouseDown = true;
+      }
+    });
+  }
 }
 
 function $applyTargetRange(selection: RangeSelection, event: InputEvent): void {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -101,7 +101,12 @@ export const scheduleMicroTask: (fn: () => void) => void =
         Promise.resolve().then(fn);
       };
 
-function isSelectionCapturedInDecoratorInput(anchorDOM: Node): boolean {
+export function $isSelectionCapturedInDecorator(node: Node): boolean {
+  return $isDecoratorNode($getNearestNodeFromDOMNode(node));
+}
+
+// TODO change to $ function
+export function isSelectionCapturedInDecoratorInput(anchorDOM: Node): boolean {
   const activeElement = document.activeElement;
   const nodeName = activeElement !== null ? activeElement.nodeName : null;
   return (


### PR DESCRIPTION
Different approach (old https://github.com/facebook/lexical/pull/2872) by levering mouse down.

Techical considerations:
- The mousedown event alone is insufficient for to track the new selection. The DOM anchor/focus nodes will still be marked as null.
- Mousedown + mouseup combination is unreliable. FF has a different order: Chrome/Safari: mousedown -> selectionchange -> mouseup; FF (sometimes): mousedown -> mouseup -> selectionchange
- Since mousedown + selectionChange seems reliable across browsers I'm relying on this order in this PR.

https://user-images.githubusercontent.com/193447/186977135-0c511363-d2ce-4d23-a7a7-0fc6654a6ea3.mov

Closes https://github.com/facebook/lexical/issues/2856