### PR TITLE
Ensure we only mutate a non-readonly editor state

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -493,6 +493,7 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
   }
 
   if (!pendingEditorState._readOnly) {
+    pendingEditorState._readOnly = true;
     if (__DEV__) {
       handleDEVOnlyPendingUpdateGuarantees(pendingEditorState);
       if ($isRangeSelection(pendingSelection)) {
@@ -501,7 +502,6 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
       }
       Object.freeze(pendingSelection);
     }
-    pendingEditorState._readOnly = true;
   }
 
   const dirtyLeaves = editor._dirtyLeaves;

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -492,15 +492,16 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
     }
   }
 
-  pendingEditorState._readOnly = true;
-
-  if (__DEV__) {
-    handleDEVOnlyPendingUpdateGuarantees(pendingEditorState);
-    if ($isRangeSelection(pendingSelection)) {
-      Object.freeze(pendingSelection.anchor);
-      Object.freeze(pendingSelection.focus);
+  if (!pendingEditorState._readOnly) {
+    if (__DEV__) {
+      handleDEVOnlyPendingUpdateGuarantees(pendingEditorState);
+      if ($isRangeSelection(pendingSelection)) {
+        Object.freeze(pendingSelection.anchor);
+        Object.freeze(pendingSelection.focus);
+      }
+      Object.freeze(pendingSelection);
     }
-    Object.freeze(pendingSelection);
+    pendingEditorState._readOnly = true;
   }
 
   const dirtyLeaves = editor._dirtyLeaves;


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/2907.