### PR TITLE
Allow selection in readonly mode

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -143,12 +143,11 @@ export function getNearestEditorFromDOMNode(
   while (currentNode != null) {
     // @ts-expect-error: internal field
     const editor: LexicalEditor = currentNode.__lexicalEditor;
-    if (editor != null && !editor.isReadOnly()) {
+    if (editor != null) {
       return editor;
     }
     currentNode = currentNode.parentNode;
   }
-
   return null;
 }
 


### PR DESCRIPTION
I've come full circle on this, and now I think the best idea here is to allow programmatic updates of the editor state regardless of the value of editor._readOnly. In attempting to implement something in the core that would stop programmatic updates by default and allow overriding that for specific updates via an update option, the intent was to make it easy for people to convert their editors into static content without having to worry about adding separate conditionals in all the places where programmatic updates can be triggered.

Practically, there are a lot of challenges with implementing this in the core. Command listeners are implicitly wrapped in a single editor.update, which causes a lot of problems with trying to apply behavior-changing modifiers (like options or tags) to individual "updates". We can't decouple command listeners from updates because batching can make updates async, which makes it hard to get the return value out of the update closure. It also seems like tags are broken with batching in general, as batched changes will all have the same tag applied to them.

From a conceptual standpoint, it probably makes just as much sense to make this a concern of the UI and/or the Lexical consumer as it does to try to bake a semantic guarantee around updates into the core.

This PR just takes out the check that prevents us from tracking Selection in readOnly mode, which will allow things like Commenting to work in that case.