### PR TITLE
Remove redundant readonly checks.

### DIFF
--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -121,6 +121,7 @@ export function useYjsCollaboration(
     provider.on('status', onStatus);
     provider.on('sync', onSync);
     awareness.on('update', onAwarenessUpdate);
+    // This updates the local editor state when we recieve updates from other clients
     root.getSharedType().observeDeep(onYjsTreeChanges);
     const removeListener = editor.registerUpdateListener(
       ({

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -637,7 +637,6 @@ export class LexicalNode {
   // Setters and mutators
 
   remove(preserveEmptyParent?: boolean): void {
-    errorOnReadOnly();
     removeNode(this, true, preserveEmptyParent);
   }
 
@@ -728,7 +727,6 @@ export class LexicalNode {
   }
 
   insertBefore(nodeToInsert: LexicalNode): LexicalNode {
-    errorOnReadOnly();
     const writableSelf = this.getWritable();
     const writableNodeToInsert = nodeToInsert.getWritable();
     removeFromParent(writableNodeToInsert);

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -645,9 +645,12 @@ export function triggerCommandListeners<P>(
 ): boolean {
   if (editor._updating === false || activeEditor !== editor) {
     let returnVal = false;
-    editor.update(() => {
-      returnVal = triggerCommandListeners(editor, type, payload);
-    });
+    editor.update(
+      () => {
+        returnVal = triggerCommandListeners(editor, type, payload);
+      },
+      {tag: 'ignore-read-only'},
+    );
     return returnVal;
   }
 
@@ -907,6 +910,11 @@ export function updateEditor(
   updateFn: () => void,
   options?: EditorUpdateOptions,
 ): void {
+  const ignoreReadOnly =
+    options &&
+    (options.tag === 'collaboration' || options.tag === 'ignore-read-only');
+  const canUpdate = !editor._readOnly || ignoreReadOnly;
+  invariant(canUpdate, 'Cannot update in readOnly mode.');
   if (editor._updating) {
     editor._updates.push([updateFn, options]);
   } else {

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -645,12 +645,9 @@ export function triggerCommandListeners<P>(
 ): boolean {
   if (editor._updating === false || activeEditor !== editor) {
     let returnVal = false;
-    editor.update(
-      () => {
-        returnVal = triggerCommandListeners(editor, type, payload);
-      },
-      {tag: 'ignore-read-only'},
-    );
+    editor.update(() => {
+      returnVal = triggerCommandListeners(editor, type, payload);
+    });
     return returnVal;
   }
 
@@ -910,11 +907,6 @@ export function updateEditor(
   updateFn: () => void,
   options?: EditorUpdateOptions,
 ): void {
-  const ignoreReadOnly =
-    options &&
-    (options.tag === 'collaboration' || options.tag === 'ignore-read-only');
-  const canUpdate = !editor._readOnly || ignoreReadOnly;
-  invariant(canUpdate, 'Cannot update in readOnly mode.');
   if (editor._updating) {
     editor._updates.push([updateFn, options]);
   } else {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -143,12 +143,11 @@ export function getNearestEditorFromDOMNode(
   while (currentNode != null) {
     // @ts-expect-error: internal field
     const editor: LexicalEditor = currentNode.__lexicalEditor;
-    if (editor != null && !editor.isReadOnly()) {
+    if (editor != null) {
       return editor;
     }
     currentNode = currentNode.parentNode;
   }
-
   return null;
 }
 

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -143,7 +143,7 @@ export function getNearestEditorFromDOMNode(
   while (currentNode != null) {
     // @ts-expect-error: internal field
     const editor: LexicalEditor = currentNode.__lexicalEditor;
-    if (editor != null) {
+    if (editor != null && !editor.isReadOnly()) {
       return editor;
     }
     currentNode = currentNode.parentNode;

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -292,30 +292,25 @@ export class ElementNode extends LexicalNode {
     return this.select();
   }
   clear(): this {
-    errorOnReadOnly();
     const writableSelf = this.getWritable();
     const children = this.getChildren();
     children.forEach((child) => child.remove());
     return writableSelf;
   }
   append(...nodesToAppend: LexicalNode[]): this {
-    errorOnReadOnly();
     return this.splice(this.getChildrenSize(), 0, nodesToAppend);
   }
   setDirection(direction: 'ltr' | 'rtl' | null): this {
-    errorOnReadOnly();
     const self = this.getWritable();
     self.__dir = direction;
     return self;
   }
   setFormat(type: ElementFormatType): this {
-    errorOnReadOnly();
     const self = this.getWritable();
     self.__format = type !== '' ? ELEMENT_TYPE_TO_FORMAT[type] : 0;
     return this;
   }
   setIndent(indentLevel: number): this {
-    errorOnReadOnly();
     const self = this.getWritable();
     self.__indent = indentLevel;
     return this;
@@ -325,7 +320,6 @@ export class ElementNode extends LexicalNode {
     deleteCount: number,
     nodesToInsert: Array<LexicalNode>,
   ): this {
-    errorOnReadOnly();
     const writableSelf = this.getWritable();
     const writableSelfKey = writableSelf.__key;
     const writableSelfChildren = writableSelf.__children;

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -510,7 +510,6 @@ export class TextNode extends LexicalNode {
 
   // TODO 0.4 This should just be a `string`.
   setFormat(format: TextFormatType | number): this {
-    errorOnReadOnly();
     const self = this.getWritable();
     self.__format =
       typeof format === 'string' ? TEXT_TYPE_TO_FORMAT[format] : format;
@@ -519,7 +518,6 @@ export class TextNode extends LexicalNode {
 
   // TODO 0.4 This should just be a `string`.
   setDetail(detail: TextDetailType | number): this {
-    errorOnReadOnly();
     const self = this.getWritable();
     self.__detail =
       typeof detail === 'string' ? DETAIL_TYPE_TO_DETAIL[detail] : detail;
@@ -527,7 +525,6 @@ export class TextNode extends LexicalNode {
   }
 
   setStyle(style: string): this {
-    errorOnReadOnly();
     const self = this.getWritable();
     self.__style = style;
     return self;
@@ -539,21 +536,18 @@ export class TextNode extends LexicalNode {
   }
 
   toggleDirectionless(): this {
-    errorOnReadOnly();
     const self = this.getWritable();
     self.__detail ^= IS_DIRECTIONLESS;
     return self;
   }
 
   toggleUnmergeable(): this {
-    errorOnReadOnly();
     const self = this.getWritable();
     self.__detail ^= IS_UNMERGEABLE;
     return self;
   }
 
   setMode(type: TextModeType): this {
-    errorOnReadOnly();
     const mode = TEXT_MODE_TO_TYPE[type];
     const self = this.getWritable();
     self.__mode = mode;
@@ -561,7 +555,6 @@ export class TextNode extends LexicalNode {
   }
 
   setTextContent(text: string): this {
-    errorOnReadOnly();
     const writableSelf = this.getWritable();
     writableSelf.__text = text;
     return writableSelf;
@@ -614,7 +607,6 @@ export class TextNode extends LexicalNode {
     newText: string,
     moveSelection?: boolean,
   ): TextNode {
-    errorOnReadOnly();
     const writableSelf = this.getWritable();
     const text = writableSelf.__text;
     const handledTextLength = newText.length;


### PR DESCRIPTION
One thing I discovered in exploring readOnly is that a lot of these checks are redundant, since we already check readOnly in the getWritable method.