### PR TITLE
Node Proxies

### DIFF
--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -10,7 +10,12 @@ import {$createLinkNode} from '@lexical/link';
 import {$createListItemNode, $createListNode} from '@lexical/list';
 import {LexicalComposer} from '@lexical/react/LexicalComposer';
 import {$createHeadingNode, $createQuoteNode} from '@lexical/rich-text';
-import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  TextNode,
+} from 'lexical';
 import * as React from 'react';
 
 import {isDevPlayground} from './appSettings';
@@ -19,6 +24,7 @@ import {SharedAutocompleteContext} from './context/SharedAutocompleteContext';
 import {SharedHistoryContext} from './context/SharedHistoryContext';
 import Editor from './Editor';
 import logo from './images/logo.svg';
+import {$createACTextNode} from './nodes/ACTextNode';
 import PlaygroundNodes from './nodes/PlaygroundNodes';
 import PasteLogPlugin from './plugins/PasteLogPlugin';
 import TestRecorderPlugin from './plugins/TestRecorderPlugin';
@@ -126,10 +132,25 @@ function App(): JSX.Element {
     onError: (error: Error) => {
       throw error;
     },
+    proxies: new Map([
+      // TODO make this an array instead of Map (better typing)
+      [
+        TextNode,
+        (textNode: TextNode) => {
+          const node = $createACTextNode(textNode.__text);
+          node.setFormat(textNode.format);
+          node.setDetail(textNode.detail);
+          node.setMode(textNode.mode);
+          node.setStyle(textNode.style);
+          return node;
+        },
+      ],
+    ]),
     theme: PlaygroundEditorTheme,
   };
 
   return (
+    // @ts-ignore for now
     <LexicalComposer initialConfig={initialConfig}>
       <SharedHistoryContext>
         <SharedAutocompleteContext>

--- a/packages/lexical-playground/src/nodes/ACTextNode.tsx
+++ b/packages/lexical-playground/src/nodes/ACTextNode.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+// AC = Alternating Case
+
+import type {Spread} from 'lexical';
+
+import {LexicalNode, SerializedTextNode, TextNode} from 'lexical';
+
+export type SerializedACTextNode = Spread<
+  {
+    type: 'ac-text';
+    version: 1;
+  },
+  SerializedTextNode
+>;
+
+export class ACTextNode extends TextNode {
+  static getType(): string {
+    return 'ac-text';
+  }
+
+  static clone(node: ACTextNode): ACTextNode {
+    return new ACTextNode(node.__text, node.__key);
+  }
+
+  static importJSON(serializedNode: SerializedACTextNode): ACTextNode {
+    const node = $createACTextNode(serializedNode.text);
+    node.setTextContent(serializedNode.text);
+    node.setFormat(serializedNode.format);
+    node.setDetail(serializedNode.detail);
+    node.setMode(serializedNode.mode);
+    node.setStyle(serializedNode.style);
+    return node;
+  }
+
+  setTextContent(text: string): this {
+    const a = 'a'.charCodeAt(0);
+    const A = 'A'.charCodeAt(0);
+    const z = 'z'.charCodeAt(0);
+    const Z = 'Z'.charCodeAt(0);
+    const aADiff = a - A;
+    const textLength = text.length;
+    let acText = '';
+    let isOdd = true;
+    for (let i = 0; i < textLength; i++) {
+      const code = text.charCodeAt(i);
+      if (!isOdd && code >= a && code <= z) {
+        acText += String.fromCharCode(code - aADiff);
+      } else if (isOdd && code >= A && code <= Z) {
+        acText += String.fromCharCode(code + aADiff);
+      } else {
+        acText += text.charAt(i);
+      }
+      isOdd = !isOdd;
+    }
+    // @ts-ignore[2322] do better
+    return TextNode.prototype.setTextContent.call(this, acText);
+  }
+
+  exportJSON(): SerializedACTextNode {
+    return {
+      ...super.exportJSON(),
+      type: 'ac-text',
+      version: 1,
+    };
+  }
+}
+
+export function $createACTextNode(acTextName: string): ACTextNode {
+  return new ACTextNode(acTextName);
+}
+
+export function $isACTextNode(
+  node: LexicalNode | null | undefined,
+): node is ACTextNode {
+  return node instanceof ACTextNode;
+}

--- a/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
+++ b/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
@@ -18,6 +18,7 @@ import {HorizontalRuleNode} from '@lexical/react/LexicalHorizontalRuleNode';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
 
+import {ACTextNode} from './ACTextNode';
 import {AutocompleteNode} from './AutocompleteNode';
 import {EmojiNode} from './EmojiNode';
 import {EquationNode} from './EquationNode';
@@ -33,6 +34,7 @@ import {TypeaheadNode} from './TypeaheadNode';
 import {YouTubeNode} from './YouTubeNode';
 
 const PlaygroundNodes: Array<Klass<LexicalNode>> = [
+  ACTextNode,
   HeadingNode,
   ListNode,
   ListItemNode,

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -7,7 +7,7 @@
  */
 
 import type {LexicalComposerContextType} from '@lexical/react/LexicalComposerContext';
-import type {Klass} from 'lexical';
+import type {Klass, Proxies} from 'lexical';
 
 import {
   createLexicalComposerContext,
@@ -39,6 +39,7 @@ type Props = {
     editor__DEPRECATED?: LexicalEditor | null;
     namespace: string;
     nodes?: ReadonlyArray<Klass<LexicalNode>>;
+    proxies?: Proxies;
     onError: (error: Error, editor: LexicalEditor) => void;
     readOnly?: boolean;
     theme?: EditorThemeClasses;
@@ -55,6 +56,7 @@ export function LexicalComposer({initialConfig, children}: Props): JSX.Element {
         editor__DEPRECATED: initialEditor,
         nodes,
         onError,
+        proxies,
         editorState: initialEditorState,
       } = initialConfig;
 
@@ -70,6 +72,7 @@ export function LexicalComposer({initialConfig, children}: Props): JSX.Element {
           namespace,
           nodes,
           onError: (error) => onError(error, newEditor),
+          proxies,
           readOnly: true,
           theme,
         });

--- a/packages/lexical/src/LexicalProxy.ts
+++ b/packages/lexical/src/LexicalProxy.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {LexicalNode} from 'lexical';
+
+import invariant from 'shared/invariant';
+
+import {getActiveEditor} from './LexicalUpdates';
+
+export function $withNodeProxy<T extends LexicalNode>(createNode: () => T): T {
+  const editor = getActiveEditor();
+  const originalNode = createNode();
+  const type = originalNode.__type;
+
+  const registeredNode = editor._nodes.get(type);
+  invariant(
+    registeredNode !== undefined,
+    'Node type %s is not registered',
+    type,
+  );
+  const proxyFn = registeredNode.proxy;
+  if (proxyFn === null) {
+    return originalNode;
+  }
+
+  return proxyFn(originalNode);
+}

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -62,6 +62,7 @@ import {
   scrollIntoViewIfNeeded,
   toggleTextFormatType,
 } from './LexicalUtils';
+import {$withNodeProxy} from './LexicalProxy';
 
 export type TextPointType = {
   _selection: RangeSelection | GridSelection;
@@ -211,7 +212,7 @@ function $transferStartingElementPointToTextPoint(
 ) {
   const element = start.getNode();
   const placementNode = element.getChildAtIndex(start.offset);
-  const textNode = $createTextNode();
+  const textNode = $withNodeProxy(() => $createTextNode());
   const target = $isRootNode(element)
     ? $createParagraphNode().append(textNode)
     : textNode;
@@ -846,7 +847,7 @@ export class RangeSelection implements BaseSelection {
         if (firstNode.getTextContent() === '') {
           firstNode.setFormat(format);
         } else {
-          const textNode = $createTextNode(text);
+          const textNode = $withNodeProxy(() => $createTextNode(text));
           textNode.setFormat(format);
           textNode.select();
           if (startOffset === 0) {

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -91,6 +91,10 @@ export function getActiveEditorState(): EditorState {
   return activeEditorState;
 }
 
+export function internalGetActiveEditor(): null | LexicalEditor {
+  return activeEditor;
+}
+
 export function getActiveEditor(): LexicalEditor {
   if (activeEditor === null) {
     invariant(
@@ -912,8 +916,4 @@ export function updateEditor(
   } else {
     beginUpdate(editor, updateFn, options);
   }
-}
-
-export function internalGetActiveEditor(): null | LexicalEditor {
-  return activeEditor;
 }

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -18,11 +18,13 @@ export type {
   LexicalEditor,
   MutationListener,
   NodeMutation,
+  Proxies,
   ReadOnlyListener,
   SerializedEditor,
   Spread,
 } from './LexicalEditor';
 export type {EditorState, SerializedEditorState} from './LexicalEditorState';
+export type {EventHandler} from './LexicalEvents';
 export type {
   DOMChildConversion,
   DOMConversion,
@@ -110,7 +112,7 @@ export {
   COMMAND_PRIORITY_NORMAL,
   createEditor,
 } from './LexicalEditor';
-export type {EventHandler} from './LexicalEvents';
+export {$withNodeProxy} from './LexicalProxy';
 export {
   $createGridSelection,
   $createNodeSelection,


### PR DESCRIPTION
👷‍♂️ This PR is a WIP

https://user-images.githubusercontent.com/193447/187757372-05e030a7-4ef1-4dcf-8189-103c1661781f.mov

## Problem

You want to customize a previously defined node like TextNode or even within a plugin you don't control. Your options:
1. Submit these customization to the original source (Lexical repo for TextNode)
2. Patch it via transform and/or node mutation listeners

Neither of them are ideal. 1. may be rejected for very custom feature, 2. runs either after the update (in case of transform) or after the reconciliation cycle (in case of mutation listeners).

Ideally you want a mechanism that immediately and synchronously  creates a YourCustomNode when OriginalNode is created. Such process should happen behind the scenes, work everywhere within the code and be transparent to the implementation.

## Proposal

Proxies. A function, defined at editor creation time, capable of morphing nodes.

```
<MLCComposer initialConfig={
  nodes: [TextNode, ACTextNode],
  proxies: [
    [TextNode, (textNode: TextNode) => {
        const node = $createACTextNode(textNode.__text);
        node.setFormat(textNode.format);
        node.setDetail(textNode.detail);
        node.setMode(textNode.mode);
        node.setStyle(textNode.style);
        return node;
      }]
  ]}>
```

Every time a Textnode is created it will immediately be replaced by an ACTextNode.

Unfortunately, we can't make it automatic out of the box, `$createTextNode` will always create a TextNode and so will `new TextNode. However, for those pro users who require Proxies we can use a wrapper function that will facilitate this instead.

```
$withNodeProxy(() => $createTextNode());
```

## Food for thought

Obviously, the `$withNodeProxy` is verbose and very user friendly. While it's true that it is specifically designed to be used by library created and advanced users we can possible do better.

```
$createNode(ParagraphNode);
```

Where `$createNode` will performs all this proxying behind the scenes.

This is major breaking change as it would imply getting rid of constructor properties and deprecating the use of `new`. However, it would also fix collab specific issues when we populate nodes by reflection and enforce a standardized way of node creation.

---

Thanks @trueadm for the factory and $ function proposals in #1262 and offline

Closes https://github.com/facebook/lexical/issues/1262

