### PR TITLE
Do not import LexicalTypeaheadMenuPlugin from src folder

### DIFF
--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -12,7 +12,7 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   LexicalNodeMenuPlugin,
   TypeaheadOption,
-} from '@lexical/react/src/LexicalTypeaheadMenuPlugin';
+} from '@lexical/react/LexicalTypeaheadMenuPlugin';
 import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,


### PR DESCRIPTION
The `AutoEmbedPlugin` import from the source folder  `@lexical/react/src/LexicalTypeaheadMenuPlugin` which generates type definitions giving issue in downstream users.