### PR TITLE
Avoid preventing default for copy events when there is no selection

### DIFF
--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -68,22 +68,20 @@ function onCopyForPlainText(
   event: CommandPayloadType<typeof COPY_COMMAND>,
   editor: LexicalEditor,
 ): void {
-  event.preventDefault();
   editor.update(() => {
     const clipboardData =
       event instanceof KeyboardEvent ? null : event.clipboardData;
     const selection = $getSelection();
 
-    if (selection !== null) {
-      if (clipboardData != null) {
-        const htmlString = $getHtmlContent(editor);
+    if (selection !== null && clipboardData != null) {
+      event.preventDefault();
+      const htmlString = $getHtmlContent(editor);
 
-        if (htmlString !== null) {
-          clipboardData.setData('text/html', htmlString);
-        }
-
-        clipboardData.setData('text/plain', selection.getTextContent());
+      if (htmlString !== null) {
+        clipboardData.setData('text/html', htmlString);
       }
+
+      clipboardData.setData('text/plain', selection.getTextContent());
     }
   });
 }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -438,9 +438,9 @@ function onCopyForRichText(
   event: CommandPayloadType<typeof COPY_COMMAND>,
   editor: LexicalEditor,
 ): void {
-  event.preventDefault();
   const selection = $getSelection();
   if (selection !== null) {
+    event.preventDefault();
     const clipboardData =
       event instanceof KeyboardEvent ? null : event.clipboardData;
     const htmlString = $getHtmlContent(editor);


### PR DESCRIPTION
We should let the default browser logic work if we don't have any selection, as we might be inside a decorator or other part of the editor that is showing some content unrelated to Lexical's selection model.