### PR TITLE
Prevent nested editor event duplication

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -748,9 +748,12 @@ function onCompositionEnd(
 }
 
 function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
+  if (hasStoppedLexicalPropagation(event)) {
+    return;
+  }
   lastKeyDownTimeStamp = event.timeStamp;
   lastKeyCode = event.keyCode;
-
+  
   if (editor.isComposing()) {
     return;
   }
@@ -919,6 +922,20 @@ function onDocumentSelectionChange(event: Event): void {
   } else if (activeNestedEditor) {
     activeNestedEditorsMap.delete(rootEditorKey);
   }
+}
+
+function stopLexicalPropagation(event: Event): void {
+  // We attach a special property to ensure the same event doesn't re-fire
+  // for parent editors.
+  // @ts-ignore
+  event._lexicalHandled = true;
+}
+
+function hasStoppedLexicalPropagation(event: Event): boolean {
+  // @ts-ignore
+  const stopped = event._lexicalHandled === true;
+  stopLexicalPropagation(event);
+  return stopped;
 }
 
 export type EventHandler = (event: Event, editor: LexicalEditor) => void;

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -753,7 +753,6 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
   }
   lastKeyDownTimeStamp = event.timeStamp;
   lastKeyCode = event.keyCode;
-  
   if (editor.isComposing()) {
     return;
   }

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -751,6 +751,7 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
   if (hasStoppedLexicalPropagation(event)) {
     return;
   }
+  stopLexicalPropagation(event);
   lastKeyDownTimeStamp = event.timeStamp;
   lastKeyCode = event.keyCode;
   if (editor.isComposing()) {
@@ -933,7 +934,6 @@ function stopLexicalPropagation(event: Event): void {
 function hasStoppedLexicalPropagation(event: Event): boolean {
   // @ts-ignore
   const stopped = event._lexicalHandled === true;
-  stopLexicalPropagation(event);
   return stopped;
 }
 


### PR DESCRIPTION
When we have nested Lexical editors, we run into issues where events are duplicated on the parent editor due to how event propagation works. Rather than block the native event propagation – which can cause bugs around UIs that use other event systems (React's for example) we locally stop propagation for Lexical aware things.