### PR TITLE
Fix Android backspace bug

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -399,6 +399,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
         // Used for handling backspace in Android.
         if (
           isPossiblyAndroidKeyPress(event.timeStamp) &&
+          editor.isComposing() &&
           selection.anchor.key === selection.focus.key
         ) {
           $setCompositionKey(null);


### PR DESCRIPTION
Sometimes in Android, you're not always in composition, so we should validate this before making assumptions. Fixes #2937.