### PR TITLE
Fix Safari selection bug

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -16,7 +16,6 @@
 .PlaygroundEditorTheme__paragraph {
   margin: 0;
   margin-bottom: 8px;
-  position: relative;
 }
 .PlaygroundEditorTheme__paragraph:last-child {
   margin-bottom: 0;


### PR DESCRIPTION
When a `position` property is declared on a DOM element, Safari will show the range selection highlighting between 2 elements when the anchor node is at the end of an element and the focus node at the start of the next sibling.

Removing the styling should fix this issue without causing any regressions.

Before
<img width="1262" alt="image" src="https://user-images.githubusercontent.com/7748470/188329281-aadd7bae-e010-4126-b121-01f32b421b2d.png">

After
<img width="1262" alt="image" src="https://user-images.githubusercontent.com/7748470/188329247-42391026-6e6d-4984-8265-7782daaa73ff.png">

Closes #2797 