### PR TITLE
Fix bug where transforms are inherited by nested editors

### DIFF
--- a/packages/lexical-react/flow/LexicalNestedComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalNestedComposer.js.flow
@@ -13,5 +13,5 @@ declare export function LexicalNestedComposer({
   children: React$Node,
   initialEditor: LexicalEditor,
   initialTheme?: EditorThemeClasses,
-  initialNodes?: $ReadOnlyArray<Class<LexicalNode>>;
+  initialNodes?: $ReadOnlyArray<Class<LexicalNode>>,
 }): React$Node;

--- a/packages/lexical-react/flow/LexicalNestedComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalNestedComposer.js.flow
@@ -13,4 +13,5 @@ declare export function LexicalNestedComposer({
   children: React$Node,
   initialEditor: LexicalEditor,
   initialTheme?: EditorThemeClasses,
+  initialNodes?: $ReadOnlyArray<Class<LexicalNode>>;
 }): React$Node;

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -50,7 +50,10 @@ export function LexicalNestedComposer({
       }
 
       initialEditor._parentEditor = parentEditor;
-      initialEditor._nodes = parentEditor._nodes;
+      const parentNodes = (initialEditor._nodes = new Map(parentEditor._nodes));
+      for (const [, entry] of parentNodes) {
+        entry.transforms.clear();
+      }
       initialEditor._config.namespace = parentEditor._config.namespace;
 
       return [initialEditor, context];

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -7,7 +7,12 @@
  */
 
 import type {LexicalComposerContextType} from '@lexical/react/LexicalComposerContext';
-import type {EditorThemeClasses, Klass, LexicalEditor, LexicalNode} from 'lexical';
+import type {
+  EditorThemeClasses,
+  Klass,
+  LexicalEditor,
+  LexicalNode,
+} from 'lexical';
 
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {
@@ -54,7 +59,9 @@ export function LexicalNestedComposer({
       initialEditor._parentEditor = parentEditor;
 
       if (!initialNodes) {
-        const parentNodes = (initialEditor._nodes = new Map(parentEditor._nodes));
+        const parentNodes = (initialEditor._nodes = new Map(
+          parentEditor._nodes,
+        ));
         for (const [type, entry] of parentNodes) {
           initialEditor._nodes.set(type, {
             klass: entry.klass,

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -55,8 +55,11 @@ export function LexicalNestedComposer({
 
       if (!initialNodes) {
         const parentNodes = (initialEditor._nodes = new Map(parentEditor._nodes));
-        for (const [, entry] of parentNodes) {
-          entry.transforms.clear();
+        for (const [type, entry] of parentNodes) {
+          initialEditor._nodes.set(type, {
+            klass: entry.klass,
+            transforms: new Set(),
+          });
         }
       } else {
         for (const klass of initialNodes) {

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -277,7 +277,10 @@ function unstable_internalCreateNodeFromParse(
         const nestedEditor = createEditor({
           namespace: parsedEditorState.namespace,
         });
-        nestedEditor._nodes = editor._nodes;
+        const parentNodes = (nestedEditor._nodes = new Map(editor._nodes));
+        for (const [, entry] of parentNodes) {
+          entry.transforms.clear();
+        }
         nestedEditor._parentEditor = editor._parentEditor;
         nestedEditor._pendingEditorState =
           unstable_convertLegacyJSONEditorState(

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -277,10 +277,7 @@ function unstable_internalCreateNodeFromParse(
         const nestedEditor = createEditor({
           namespace: parsedEditorState.namespace,
         });
-        const parentNodes = (nestedEditor._nodes = new Map(editor._nodes));
-        for (const [, entry] of parentNodes) {
-          entry.transforms.clear();
-        }
+        nestedEditor._nodes = editor._nodes;
         nestedEditor._parentEditor = editor._parentEditor;
         nestedEditor._pendingEditorState =
           unstable_convertLegacyJSONEditorState(


### PR DESCRIPTION
This fixes a nasty bug whereby nested editors incorrectly inherited the transforms of the parent editor. Also provides a way of defining nodes separately from the parent editor.