### PR TITLE
[0.5] Treat undefined selection the same as null in $generateNodesFromHtml

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -68,7 +68,7 @@ export function $generateHtmlFromNodes(
 
   for (let i = 0; i < topLevelChildren.length; i++) {
     const topLevelNode = topLevelChildren[i];
-    $appendNodesToHTML(editor, selection, topLevelNode, container);
+    $appendNodesToHTML(editor, topLevelNode, container, selection);
   }
 
   return container.innerHTML;
@@ -76,9 +76,9 @@ export function $generateHtmlFromNodes(
 
 function $appendNodesToHTML(
   editor: LexicalEditor,
-  selection: RangeSelection | NodeSelection | GridSelection | null | undefined,
   currentNode: LexicalNode,
   parentElement: HTMLElement | DocumentFragment,
+  selection: RangeSelection | NodeSelection | GridSelection | null = null,
 ): boolean {
   let shouldInclude = selection != null ? currentNode.isSelected() : true;
   const shouldExclude =
@@ -106,16 +106,15 @@ function $appendNodesToHTML(
     const childNode = children[i];
     const shouldIncludeChild = $appendNodesToHTML(
       editor,
-      selection,
       childNode,
       fragment,
+      selection,
     );
 
     if (
       !shouldInclude &&
       $isElementNode(currentNode) &&
       shouldIncludeChild &&
-      selection !== undefined &&
       currentNode.extractWithChild(childNode, selection, 'html')
     ) {
       shouldInclude = true;

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -68,9 +68,7 @@ export function $generateHtmlFromNodes(
 
   for (let i = 0; i < topLevelChildren.length; i++) {
     const topLevelNode = topLevelChildren[i];
-    if (selection !== undefined) {
-      $appendNodesToHTML(editor, selection, topLevelNode, container);
-    }
+    $appendNodesToHTML(editor, selection, topLevelNode, container);
   }
 
   return container.innerHTML;
@@ -78,7 +76,7 @@ export function $generateHtmlFromNodes(
 
 function $appendNodesToHTML(
   editor: LexicalEditor,
-  selection: RangeSelection | NodeSelection | GridSelection | null,
+  selection: RangeSelection | NodeSelection | GridSelection | null | undefined,
   currentNode: LexicalNode,
   parentElement: HTMLElement | DocumentFragment,
 ): boolean {

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -115,6 +115,7 @@ function $appendNodesToHTML(
       !shouldInclude &&
       $isElementNode(currentNode) &&
       shouldIncludeChild &&
+      selection !== undefined &&
       currentNode.extractWithChild(childNode, selection, 'html')
     ) {
       shouldInclude = true;

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -493,12 +493,7 @@ export class ElementNode extends LexicalNode {
   }
   extractWithChild(
     child: LexicalNode,
-    selection:
-      | RangeSelection
-      | NodeSelection
-      | GridSelection
-      | null
-      | undefined,
+    selection: RangeSelection | NodeSelection | GridSelection | null,
     destination: 'clone' | 'html',
   ): boolean {
     return false;

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -493,7 +493,12 @@ export class ElementNode extends LexicalNode {
   }
   extractWithChild(
     child: LexicalNode,
-    selection: RangeSelection | NodeSelection | GridSelection | null,
+    selection:
+      | RangeSelection
+      | NodeSelection
+      | GridSelection
+      | null
+      | undefined,
     destination: 'clone' | 'html',
   ): boolean {
     return false;


### PR DESCRIPTION
This is a breaking change, so we'll need to go to 0.5.

Previously, we treated undefined differently than null here for backwards compat. undefined would end up just returning an empty string, which is super confusing. Now, leaving off the selection argument completely will return the entire contents of the editor converted to HTML.