### PR TITLE
Automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,6 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm run prepare-release
-      #- run: node ./scripts/npm/release.js --non-interactive --channel $GITHUB_REF_NAME
+        #- run: node ./scripts/npm/release.js --non-interactive --channel $GITHUB_REF_NAME
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,8 @@
-name: Publish Package to npmjs
-on: workflow_dispatch
-  inputs:
-    increment:
-        description: 'Version Increment'
-        required: true
-        default: 'prerelease'
-        type: choice
-        options:
-        - prerelease
-        - patch
-        - minor
+name: Publish to NPM
+on:
+  push:
+    branches:
+      - next
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -20,12 +13,7 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm run increment-version -- --i $INCREMENT
-        env:
-          INCREMENT: ${{ inputs.increment }}
-      - run: npm run update-version -- --deps-only
       - run: npm run prepare-release
-      - run: node ./scripts/npm/release.js --non-interactive --increment $INCREMENT
+      - run: node ./scripts/npm/release.js --non-interactive --channel $GITHUB_REF_NAME
         env:
-          INCREMENT: ${{ inputs.increment }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Publish Package to npmjs
+on: workflow_dispatch
+  inputs:
+    increment:
+        description: 'Version Increment'
+        required: true
+        default: 'prerelease'
+        type: choice
+        options:
+        - prerelease
+        - patch
+        - minor
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm run increment-version -- --i $INCREMENT
+        env:
+          INCREMENT: ${{ inputs.increment }}
+      - run: npm run update-version -- --deps-only
+      - run: npm run release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,6 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm run prepare-release
-      - run: node ./scripts/npm/release.js --non-interactive --channel $GITHUB_REF_NAME
+      #- run: node ./scripts/npm/release.js --non-interactive --channel $GITHUB_REF_NAME
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
         env:
           INCREMENT: ${{ inputs.increment }}
       - run: npm run update-version -- --deps-only
-      - run: npm run release
+      - run: npm run prepare-release
+      - run: node ./scripts/npm/release.js --non-interactive --increment $INCREMENT
         env:
+          INCREMENT: ${{ inputs.increment }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - next
+      - latest
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -8,9 +8,9 @@ on:
         default: 'prerelease'
         type: choice
         options:
-        - prerelease
-        - patch
-        - minor
+          - prerelease
+          - patch
+          - minor
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -7,9 +7,9 @@ on: workflow_dispatch
         default: 'prerelease'
         type: choice
         options:
-        - prerelease
-        - patch
-        - minor
+          - prerelease
+          - patch
+          - minor
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,26 @@
+name: Create New Release Branch
+on: workflow_dispatch
+  inputs:
+    increment:
+        description: 'Version Increment'
+        required: true
+        default: 'prerelease'
+        type: choice
+        options:
+        - prerelease
+        - patch
+        - minor
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm run increment-version -- --i $INCREMENT
+        env:
+          INCREMENT: ${{ inputs.increment }}
+      - run: git push --follow-tags

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -2,14 +2,14 @@ name: Create New Release Branch
 on: workflow_dispatch
   inputs:
     increment:
-        description: 'Version Increment'
-        required: true
-        default: 'prerelease'
-        type: choice
-        options:
-          - prerelease
-          - patch
-          - minor
+      description: 'Version Increment'
+      required: true
+      default: 'prerelease'
+      type: choice
+      options:
+      - prerelease
+      - patch
+      - minor
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,15 +1,16 @@
 name: Create New Release Branch
-on: workflow_dispatch
-  inputs:
-    increment:
-      description: 'Version Increment'
-      required: true
-      default: 'prerelease'
-      type: choice
-      options:
-      - prerelease
-      - patch
-      - minor
+on:
+  workflow_dispatch:
+    inputs:
+      increment:
+        description: 'Version Increment'
+        required: true
+        default: 'prerelease'
+        type: choice
+        options:
+        - prerelease
+        - patch
+        - minor
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "changelog": "func() { git log --oneline ${1}...HEAD --pretty=format:\"- %s %an\"; }; func",
     "increment-version": "node ./scripts/npm/increment-version",
     "update-version": "node ./scripts/updateVersion",
-    "postversion": "git checkout -b $npm_package_version && npm install && npm run update-version && git add -A && git commit --amend --no-edit",
+    "postversion": "git checkout -b $npm_package_version && git branch -u origin $npm_package_version && npm install && npm run update-version && git add -A && git commit --amend --no-edit",
     "release": "npm run prepare-release && node ./scripts/npm/release.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,9 @@
     "prepare": "husky install",
     "prepare-www": "node scripts/www/rewriteImports.js",
     "changelog": "func() { git log --oneline ${1}...HEAD --pretty=format:\"- %s %an\"; }; func",
+    "increment-version": "node ./scripts/npm/increment-version",
     "update-version": "node ./scripts/updateVersion",
+    "version": "npm install && git add -A",
     "release": "npm run prepare-release && node ./scripts/npm/release.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "changelog": "func() { git log --oneline ${1}...HEAD --pretty=format:\"- %s %an\"; }; func",
     "increment-version": "node ./scripts/npm/increment-version",
     "update-version": "node ./scripts/updateVersion",
-    "postversion": "npm install && npm run update-version && git add -A && git commit --amend --no-edit",
+    "postversion": "git checkout -b $npm_package_version && npm install && npm run update-version && git add -A && git commit --amend --no-edit",
     "release": "npm run prepare-release && node ./scripts/npm/release.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "changelog": "func() { git log --oneline ${1}...HEAD --pretty=format:\"- %s %an\"; }; func",
     "increment-version": "node ./scripts/npm/increment-version",
     "update-version": "node ./scripts/updateVersion",
-    "version": "npm install && git add -A",
+    "postversion": "npm install && npm run update-version && git add -A && git commit --amend --no-edit",
     "release": "npm run prepare-release && node ./scripts/npm/release.js"
   },
   "devDependencies": {

--- a/scripts/npm/increment-version.js
+++ b/scripts/npm/increment-version.js
@@ -24,7 +24,8 @@ const packages = [LEXICAL_PKG, ...DEFAULT_PKGS, SHARED_PKG];
 
 async function incrementVersion(increment) {
   const preId = increment === 'prerelease' ? '--preid next' : '';
-  const workspaces = packages.map((pkg) => `-w packages/${pkg}`).join(' ');
+  //const workspaces = packages.map((pkg) => `-w packages/${pkg}`).join(' ');
+  const workspaces = '';
   const command = `npm version ${increment} --include-workspace-root true ${preId} ${workspaces}`;
   await exec(command);
 }

--- a/scripts/npm/increment-version.js
+++ b/scripts/npm/increment-version.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+const {exec} = require('child-process-promise');
+const {LEXICAL_PKG, DEFAULT_PKGS, SHARED_PKG} = require('./packages');
+const argv = require('minimist')(process.argv.slice(2));
+const increment = argv.i;
+const validIncrements = new Set(['minor', 'patch', 'prerelease']);
+if (!validIncrements.has(increment)) {
+  console.error(`Invalid value for increment: ${increment}`);
+  process.exit(1);
+}
+
+const packages = [LEXICAL_PKG, ...DEFAULT_PKGS, SHARED_PKG];
+
+async function incrementVersion(increment) {
+  const preId = increment === 'prerelease' ? '--preid next' : '';
+  const workspaces = packages.map((pkg) => `-w packages/${pkg}`).join(' ');
+  const command = `npm version ${increment} --include-workspace-root true ${preId} ${workspaces}`;
+  await exec(command);
+}
+
+incrementVersion(increment);

--- a/scripts/npm/increment-version.js
+++ b/scripts/npm/increment-version.js
@@ -11,7 +11,6 @@
 'use strict';
 
 const {exec} = require('child-process-promise');
-const {LEXICAL_PKG, DEFAULT_PKGS, SHARED_PKG} = require('./packages');
 const argv = require('minimist')(process.argv.slice(2));
 const increment = argv.i;
 const validIncrements = new Set(['minor', 'patch', 'prerelease']);
@@ -20,11 +19,8 @@ if (!validIncrements.has(increment)) {
   process.exit(1);
 }
 
-const packages = [LEXICAL_PKG, ...DEFAULT_PKGS, SHARED_PKG];
-
 async function incrementVersion(increment) {
   const preId = increment === 'prerelease' ? '--preid next' : '';
-  //const workspaces = packages.map((pkg) => `-w packages/${pkg}`).join(' ');
   const workspaces = '';
   const command = `npm version ${increment} --include-workspace-root true ${preId} ${workspaces}`;
   await exec(command);

--- a/scripts/npm/release.js
+++ b/scripts/npm/release.js
@@ -13,21 +13,32 @@
 const readline = require('readline');
 const {exec} = require('child-process-promise');
 const {LEXICAL_PKG, DEFAULT_PKGS} = require('./packages');
+const argv = require('minimist')(process.argv.slice(2));
+
+const nonInteractive = argv.nonInteractive;
+const distTag = argv.distTag || 'latest';
+const validDistTags = new Set('next', 'latest');
+if (!validDistTags.has(distTag)) {
+  console.error(`Invalid dist tag ${distTag}`);
+  process.exit(1);
+}
 
 async function publish() {
   const pkgs = [LEXICAL_PKG, ...DEFAULT_PKGS];
+  if (!nonInteractive) {
+    console.info(
+      `You're about to publish:
+    ${pkgs.join('\n')}
 
-  console.info(
-    `You're about to publish:
-${pkgs.join('\n')}
-
-Type "publish" to confirm.`,
-  );
-  await waitForInput();
-
+    Type "publish" to confirm.`,
+    );
+    await waitForInput();
+  }
   for (let i = 0; i < pkgs.length; i++) {
     const pkg = pkgs[i];
-    await exec(`cd ./packages/${pkg}/npm && npm publish --access public`);
+    await exec(
+      `cd ./packages/${pkg}/npm && npm publish --access public --tag ${distTag}`,
+    );
   }
 }
 

--- a/scripts/npm/release.js
+++ b/scripts/npm/release.js
@@ -16,10 +16,10 @@ const {LEXICAL_PKG, DEFAULT_PKGS} = require('./packages');
 const argv = require('minimist')(process.argv.slice(2));
 
 const nonInteractive = argv['non-interactive'];
-const increment = argv.increment;
-const validIncrements = new Set('minor', 'patch', 'prerelease');
-if (!validIncrements.has(increment)) {
-  console.error(`Invalid increment: ${increment}`);
+const channel = argv.channel;
+const validChannels = new Set('next', 'latest');
+if (!validChannels.has(channel)) {
+  console.error(`Invalid release channel: ${channel}`);
   process.exit(1);
 }
 
@@ -34,11 +34,11 @@ async function publish() {
     );
     await waitForInput();
   }
-  const distTag = increment === 'prerelease' ? 'next' : 'latest';
+
   for (let i = 0; i < pkgs.length; i++) {
     const pkg = pkgs[i];
     await exec(
-      `cd ./packages/${pkg}/npm && npm publish --access public --tag ${distTag}`,
+      `cd ./packages/${pkg}/npm && npm publish --access public --tag ${channel}`,
     );
   }
 }

--- a/scripts/npm/release.js
+++ b/scripts/npm/release.js
@@ -15,11 +15,11 @@ const {exec} = require('child-process-promise');
 const {LEXICAL_PKG, DEFAULT_PKGS} = require('./packages');
 const argv = require('minimist')(process.argv.slice(2));
 
-const nonInteractive = argv.nonInteractive;
-const distTag = argv.distTag || 'latest';
-const validDistTags = new Set('next', 'latest');
-if (!validDistTags.has(distTag)) {
-  console.error(`Invalid dist tag ${distTag}`);
+const nonInteractive = argv['non-interactive'];
+const increment = argv.increment;
+const validIncrements = new Set('minor', 'patch', 'prerelease');
+if (!validIncrements.has(increment)) {
+  console.error(`Invalid increment: ${increment}`);
   process.exit(1);
 }
 
@@ -34,6 +34,7 @@ async function publish() {
     );
     await waitForInput();
   }
+  const distTag = increment === 'prerelease' ? 'next' : 'latest';
   for (let i = 0; i < pkgs.length; i++) {
     const pkg = pkgs[i];
     await exec(

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -9,7 +9,6 @@
 'use strict';
 
 const fs = require('fs-extra');
-const argv = require('minimist')(process.argv.slice(2));
 
 const packages = {
   '@lexical/clipboard': 'lexical-clipboard',
@@ -39,8 +38,6 @@ const packages = {
   shared: 'shared',
 };
 
-const depsOnly = argv['deps-only'];
-
 function updateVersion() {
   // get version from monorepo package.json version
   const basePackageJSON = fs.readJsonSync(`./package.json`);
@@ -48,9 +45,7 @@ function updateVersion() {
   // update individual packages
   Object.values(packages).forEach((pkg) => {
     const packageJSON = fs.readJsonSync(`./packages/${pkg}/package.json`);
-    if (!depsOnly) {
-      packageJSON.version = version;
-    }
+    packageJSON.version = version;
     updateDependencies(packageJSON, version);
     fs.writeJsonSync(`./packages/${pkg}/package.json`, packageJSON, {
       spaces: 2,


### PR DESCRIPTION
This will initially let us manually kick off end-to-end automated releases. Later, we can adjust the config easily to add support for nightly prerelease runs, or even release on every commit (to a different channel) if we want.

What this actually does now:

Creates a new manually-initiated workflow that creates a new branch, bumps the version across all packages, commits the changes, and pushes the branch to the remote. From there, someone needs to create a PR for it.

Creates a second automated workflow that runs when a commit is pushed to the "next" or "latest" branch. This won't actually release right now because I commented that step out, but once enabled, this would publish all packages to the npm release channel associated with the destination branch ('next' for prerelease and 'latest' as the default for stable releases).

Todo:

- [x] Fix version script to add all package.json before committing - can probably change this to just run npm version on the workspace root, then run the updateVersion script like before to get the rest. Then, we can just do the git commit and git tag with shell commands.
- [ ] Rewrite changelog to auto-generate for fully automated builds.
- [ ] Possibly update version in LexicalVersion.ts in postversion step.
- [ ] The manual workflow should create a PR automatically.