### PR TITLE
Apply history differently

### DIFF
--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -313,6 +313,9 @@ function createMergeActionGetter(
 }
 
 function redo(editor: LexicalEditor, historyState: HistoryState): void {
+  // historyState is a record of the history that should be restored, while the
+  // incoming editor instance is the object to which it should be applied
+
   const redoStack = historyState.redoStack;
   const undoStack = historyState.undoStack;
 
@@ -333,7 +336,7 @@ function redo(editor: LexicalEditor, historyState: HistoryState): void {
     historyState.current = historyStateEntry || null;
 
     if (historyStateEntry) {
-      historyStateEntry.editor.setEditorState(historyStateEntry.editorState, {
+      editor.setEditorState(historyStateEntry.editorState, {
         tag: 'historic',
       });
     }
@@ -341,11 +344,13 @@ function redo(editor: LexicalEditor, historyState: HistoryState): void {
 }
 
 function undo(editor: LexicalEditor, historyState: HistoryState): void {
+  // historyState is a record of the history that should be restored, while the
+  // incoming editor instance is the object to which it should be applied
+
   const redoStack = historyState.redoStack;
   const undoStack = historyState.undoStack;
-  const undoStackLength = undoStack.length;
 
-  if (undoStackLength !== 0) {
+  if (undoStack.length !== 0) {
     const current = historyState.current;
     const historyStateEntry = undoStack.pop();
 
@@ -361,7 +366,7 @@ function undo(editor: LexicalEditor, historyState: HistoryState): void {
     historyState.current = historyStateEntry || null;
 
     if (historyStateEntry) {
-      historyStateEntry.editor.setEditorState(
+      editor.setEditorState(
         historyStateEntry.editorState.clone(historyStateEntry.undoSelection),
         {
           tag: 'historic',


### PR DESCRIPTION
**Issue**

- It does not currently seem to be possible to restore a `historyStack` when trying to load a saved `editorState.` 
- The reason is that the [undo](https://github.com/facebook/lexical/blob/main/packages/lexical-history/src/index.ts#L365) and [redo](https://github.com/facebook/lexical/blob/main/packages/lexical-history/src/index.ts#L336) functions in the history package try to apply each `editorState` in the `historyStack` to the instance that produced it. This "historical" instance was saved to the `historyStack`, along with the `editorState` we care about, via the [`registerHistory`](https://github.com/facebook/lexical/blob/main/packages/lexical-history/src/index.ts#L380) function. 
- [More info from Discord](https://discord.com/channels/953974421008293909/953974421486436393/1016796173027250176).


**Reason**

- I ran into this problem while attempting to pass Lexical editors around my UI (outside LexicalContext). 
- I achieve this by: 

  a.  Saving the `editorState` and `historyStack` of the current editor, 
  b. Unmounting the current Lexical editor, 
  c. Mounting a new Lexical editor, and 
  d. Passing the saved `editorState` and `historyStack` into it as initial config. 

- While the `editorState` worked as expected, I was not able to undo/redo through the preexisting `historyStack` entries. 

**Analysis**

- The problem here is that the new Lexical editor does not match the editor instances that are found in each of the `historyStack`'s preexisting entries. 
  - You can see the mismatch by comparing the new instance's `.__key` to the `.__key` property on the instances found in the preexisting `historyStack.`
  - This seems to mean that Lexical is running the `undo` and `redo` functions on a now non-existent editor.

**Conclusion**

- The preexisting `historyStack` will work with the new editor instance by modifying the `undo` and `redo` functions to apply the preexisting `editorState` to the current editor instance. It's passed into each function as an argument. 
  - In fact, this "active" editor instance is currently used to dispatch the "canUndo" and "canRedo" commands.

- This pull request makes this change. The test suite seems to pass. The e2e tests seem to pass to the same degree as they currently do on the main branch.
  - I also: 
    a. Added an explanatory comment to each function, and 
    b. Changed a `.length` test for more consistency between the two functions
  - I signed the contributor agreement yesterday.

- I'm currently addressing this via patch-package, but would love to see the change migrate upstream. 

- Please let me know if I've misunderstood something or how I can further help. 

Thanks so much for the time. -j