### PR TITLE
Fix link breaking when formatting on

### DIFF
--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -133,8 +133,9 @@ function handleLinkCreation(
         );
       }
 
+      let nodeFormat = node.__format;
       const linkNode = $createAutoLinkNode(match.url);
-      linkNode.append($createTextNode(match.text));
+      linkNode.append($createTextNode(match.text).setFormat(nodeFormat));
       middleNode.replace(linkNode);
       onChange(match.url, null);
     }

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -133,7 +133,7 @@ function handleLinkCreation(
         );
       }
 
-      let nodeFormat = node.__format;
+      const nodeFormat = node.__format;
       const linkNode = $createAutoLinkNode(match.url);
       linkNode.append($createTextNode(match.text).setFormat(nodeFormat));
       middleNode.replace(linkNode);


### PR DESCRIPTION
As can be seen at https://codesandbox.io/s/lexical-rich-text-example-5tncvy, if any sort of formatting is active (bold, italic, etc...) while typing a link, the formatting will be disabled on the text of the detected url, and on subsequent keystrokes, the url will break.

![Screen Shot 2022-09-07 at 4 11 04 PM](https://user-images.githubusercontent.com/57294106/188968087-186f645c-399d-4d90-80a8-1ab5ac9bbbc0.png)

By applying the parent node's format to the autolink, this problem is resolved.