### PR TITLE
Add Selection View in DevTools

### DIFF
--- a/packages/lexical-devtools/src/panel/components/App/index.css
+++ b/packages/lexical-devtools/src/panel/components/App/index.css
@@ -1,26 +1,14 @@
 .App {
   display: grid;
-  grid-template-columns: auto 40em;
+  grid-template-columns: auto calc(100vh - 4em);
   grid-template-areas:
-    'header header'
+    'selection time-travel'
     'tree-view inspected-element';
   text-align: center;
 }
 
-.App-header {
-  align-items: center;
-  background-color: #282c34;
-  color: white;
-  display: flex;
-  flex-direction: column;
-  font-family: monospace;
-  font-size: 2em;
-  grid-area: header;
-  justify-content: center;
-}
-
 .loading-view {
   background: var(--main-dark-gray);
-  color: #fff;
+  color: var(--main-white);
   font-size: 3em;
 }

--- a/packages/lexical-devtools/src/panel/components/App/index.css
+++ b/packages/lexical-devtools/src/panel/components/App/index.css
@@ -1,6 +1,7 @@
 .App {
   display: grid;
-  grid-template-columns: auto calc(100vh - 4em);
+  grid-template-columns: calc(100vw - 24em) 24em;
+  grid-template-rows: 3.5em auto;
   grid-template-areas:
     'selection time-travel'
     'tree-view inspected-element';

--- a/packages/lexical-devtools/src/panel/components/App/index.css
+++ b/packages/lexical-devtools/src/panel/components/App/index.css
@@ -1,10 +1,4 @@
 .App {
-  display: grid;
-  grid-template-columns: calc(100vw - 24em) 24em;
-  grid-template-rows: 3.5em auto;
-  grid-template-areas:
-    'selection time-travel'
-    'tree-view inspected-element';
   text-align: center;
 }
 

--- a/packages/lexical-devtools/src/panel/components/App/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/App/index.tsx
@@ -7,25 +7,33 @@
  */
 import './index.css';
 
-import {DevToolsTree, NodeProperties} from 'packages/lexical-devtools/types';
+import {
+  DevToolsSelection,
+  DevToolsTree,
+  NodeProperties,
+} from 'packages/lexical-devtools/types';
 import * as React from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 import InspectedElementView from '../InspectedElementView';
+import SelectionView from '../SelectionView';
+import TimeTravelView from '../TimeTravelView';
 import TreeView from '../TreeView';
 
 function App(): JSX.Element {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [nodeMap, setNodeMap] = useState<DevToolsTree>({});
+  const [selection, setSelection] = useState<DevToolsSelection | null>(null);
   const [selectedNode, setSelectedNode] = useState<NodeProperties | null>(null);
   const port = useRef<chrome.runtime.Port | null>(null);
 
   const updateEditorState = (message: {
-    editorState: {nodeMap: DevToolsTree};
+    editorState: {nodeMap: DevToolsTree; selection: DevToolsSelection};
   }) => {
     setIsLoading(false);
     const newNodeMap = message.editorState.nodeMap;
     setNodeMap(newNodeMap);
+    setSelection(message.editorState.selection);
   };
 
   // highlight & dehighlight the corresponding DOM nodes onHover of DevTools nodes
@@ -81,16 +89,14 @@ function App(): JSX.Element {
   });
 
   return (
-    <div className="App">
-      <header className="App-header">
-        <p>Lexical Developer Tools</p>
-      </header>
+    <>
       {isLoading ? (
         <div className="loading-view">
           <p>Loading...</p>
         </div>
       ) : (
-        <>
+        <div className="App">
+          <SelectionView selection={selection} />
           <TreeView
             deHighlightDOMNode={deHighlightDOMNode}
             handleNodeClick={setSelectedNode}
@@ -99,9 +105,10 @@ function App(): JSX.Element {
             nodeMap={nodeMap}
           />
           <InspectedElementView nodeProps={selectedNode} />
-        </>
+          <TimeTravelView />
+        </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/packages/lexical-devtools/src/panel/components/Chevron/index.css
+++ b/packages/lexical-devtools/src/panel/components/Chevron/index.css
@@ -1,7 +1,7 @@
 .chevron-button {
   background: var(--main-dark-gray);
   border: none;
-  color: #fff;
+  color: var(--main-white);
   cursor: pointer;
   margin: 0;
   padding: 0;

--- a/packages/lexical-devtools/src/panel/components/InspectedElementView/index.css
+++ b/packages/lexical-devtools/src/panel/components/InspectedElementView/index.css
@@ -1,11 +1,19 @@
+.inspected-element-container {
+  padding: 1em 2em;
+  overflow: scroll;
+}
+
 .inspected-element-view {
   align-self: start;
-  border: 1px solid #282c34;
-  color: #fff;
+  background: var(--main-dark-gray);
+  border: 1px solid var(--highlight-dark-gray);
+  color: var(--main-white);
   grid-area: inspected-element;
-  height: 100vh;
-  padding: 1em 2em;
-  position: sticky;
+  height: 100%;
+  left: calc(100vw - 24em);
+  overflow: auto;
+  position: fixed;
   text-align: left;
-  top: 0em;
+  top: 3.5em;
+  width: 24em;
 }

--- a/packages/lexical-devtools/src/panel/components/InspectedElementView/index.css
+++ b/packages/lexical-devtools/src/panel/components/InspectedElementView/index.css
@@ -4,11 +4,9 @@
 }
 
 .inspected-element-view {
-  align-self: start;
   background: var(--main-dark-gray);
   border: 1px solid var(--highlight-dark-gray);
   color: var(--main-white);
-  grid-area: inspected-element;
   height: calc(100vh - var(--top-row-height));
   left: calc(100vw - var(--right-column-width));
   overflow: auto;

--- a/packages/lexical-devtools/src/panel/components/InspectedElementView/index.css
+++ b/packages/lexical-devtools/src/panel/components/InspectedElementView/index.css
@@ -9,11 +9,11 @@
   border: 1px solid var(--highlight-dark-gray);
   color: var(--main-white);
   grid-area: inspected-element;
-  height: 100%;
-  left: calc(100vw - 24em);
+  height: calc(100vh - var(--top-row-height));
+  left: calc(100vw - var(--right-column-width));
   overflow: auto;
   position: fixed;
   text-align: left;
-  top: 3.5em;
-  width: 24em;
+  top: var(--top-row-height);
+  width: var(--right-column-width);
 }

--- a/packages/lexical-devtools/src/panel/components/InspectedElementView/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/InspectedElementView/index.tsx
@@ -19,11 +19,13 @@ function InspectedElementView({
 }): JSX.Element {
   return (
     <div className="inspected-element-view">
-      {nodeProps
-        ? Object.entries(nodeProps).map(([key, value]) => (
-            <InspectedElementRow propName={key} property={value} />
-          ))
-        : ''}
+      <div className="inspected-element-container">
+        {nodeProps
+          ? Object.entries(nodeProps).map(([key, value]) => (
+              <InspectedElementRow propName={key} property={value} />
+            ))
+          : ''}
+      </div>
     </div>
   );
 }

--- a/packages/lexical-devtools/src/panel/components/SelectionView/index.css
+++ b/packages/lexical-devtools/src/panel/components/SelectionView/index.css
@@ -1,11 +1,15 @@
+.selection-container {
+  text-align: left;
+}
+
 .selection-view {
+  align-items: center;
   background: var(--main-dark-gray);
   border: 1px solid var(--highlight-dark-gray);
   color: var(--main-white);
-  grid-area: selection;
+  display: flex;
   height: var(--top-row-height);
   left: 0em;
-  padding: 1em 2em;
   position: fixed;
   text-align: left;
   top: 0em;

--- a/packages/lexical-devtools/src/panel/components/SelectionView/index.css
+++ b/packages/lexical-devtools/src/panel/components/SelectionView/index.css
@@ -3,8 +3,10 @@
   border: 1px solid var(--highlight-dark-gray);
   color: var(--main-white);
   grid-area: selection;
+  left: 0em;
   padding: 1em 2em;
-  position: sticky;
+  position: fixed;
   text-align: left;
   top: 0em;
+  width: 100%;
 }

--- a/packages/lexical-devtools/src/panel/components/SelectionView/index.css
+++ b/packages/lexical-devtools/src/panel/components/SelectionView/index.css
@@ -1,5 +1,10 @@
 .selection-container {
+  padding-left: var(--monospace-character-width);
   text-align: left;
+}
+
+.selection-property-name {
+  color: var(--main-blue);
 }
 
 .selection-view {

--- a/packages/lexical-devtools/src/panel/components/SelectionView/index.css
+++ b/packages/lexical-devtools/src/panel/components/SelectionView/index.css
@@ -1,0 +1,10 @@
+.selection-view {
+  background: var(--main-dark-gray);
+  border: 1px solid var(--highlight-dark-gray);
+  color: var(--main-white);
+  grid-area: selection;
+  padding: 1em 2em;
+  position: sticky;
+  text-align: left;
+  top: 0em;
+}

--- a/packages/lexical-devtools/src/panel/components/SelectionView/index.css
+++ b/packages/lexical-devtools/src/panel/components/SelectionView/index.css
@@ -3,10 +3,11 @@
   border: 1px solid var(--highlight-dark-gray);
   color: var(--main-white);
   grid-area: selection;
+  height: var(--top-row-height);
   left: 0em;
   padding: 1em 2em;
   position: fixed;
   text-align: left;
   top: 0em;
-  width: 100%;
+  width: calc(100vw - var(--right-column-width));
 }

--- a/packages/lexical-devtools/src/panel/components/SelectionView/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/SelectionView/index.tsx
@@ -11,7 +11,11 @@ import {DevToolsSelection} from 'packages/lexical-devtools/types';
 import * as React from 'react';
 
 function SelectionView({selection}: {selection: DevToolsSelection | null}) {
-  return <div className="selection-view">selection view</div>;
+  return (
+    <div className="selection-view">
+      <div className="selection-container">selection view</div>
+    </div>
+  );
 }
 
 export default SelectionView;

--- a/packages/lexical-devtools/src/panel/components/SelectionView/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/SelectionView/index.tsx
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import './index.css';
+
+import {DevToolsSelection} from 'packages/lexical-devtools/types';
+import * as React from 'react';
+
+function SelectionView({selection}: {selection: DevToolsSelection | null}) {
+  return <div className="selection-view">selection view</div>;
+}
+
+export default SelectionView;

--- a/packages/lexical-devtools/src/panel/components/SelectionView/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/SelectionView/index.tsx
@@ -11,9 +11,43 @@ import {DevToolsSelection} from 'packages/lexical-devtools/types';
 import * as React from 'react';
 
 function SelectionView({selection}: {selection: DevToolsSelection | null}) {
+  const anchor =
+    selection && 'anchor' in selection ? (
+      <div>
+        {'anchor { '}
+        <span className="selection-property-name">key:</span>{' '}
+        {selection.anchor.key},{' '}
+        <span className="selection-property-name">offset:</span>{' '}
+        {selection.anchor.offset},{' '}
+        <span className="selection-property-name">type:</span>{' '}
+        {selection.anchor.type}
+        {' }'}
+      </div>
+    ) : (
+      ''
+    );
+  const focus =
+    selection && 'focus' in selection ? (
+      <div>
+        {'focus { '}
+        <span className="selection-property-name">key:</span>{' '}
+        {selection.focus.key},{' '}
+        <span className="selection-property-name">offset:</span>{' '}
+        {selection.focus.offset},{' '}
+        <span className="selection-property-name">type:</span>{' '}
+        {selection.focus.type}
+        {' }'}
+      </div>
+    ) : (
+      ''
+    );
+
   return (
     <div className="selection-view">
-      <div className="selection-container">selection view</div>
+      <div className="selection-container">
+        {anchor}
+        {focus}
+      </div>
     </div>
   );
 }

--- a/packages/lexical-devtools/src/panel/components/TimeTravelView/index.css
+++ b/packages/lexical-devtools/src/panel/components/TimeTravelView/index.css
@@ -3,10 +3,10 @@
   border: 1px solid var(--highlight-dark-gray);
   color: var(--main-white);
   grid-area: time-travel;
-  left: calc(100vw - 24em);
+  left: calc(100vw - var(--right-column-width));
   padding: 1em 2em;
   position: fixed;
   text-align: left;
   top: 0em;
-  width: 100%;
+  width: var(--right-column-width);
 }

--- a/packages/lexical-devtools/src/panel/components/TimeTravelView/index.css
+++ b/packages/lexical-devtools/src/panel/components/TimeTravelView/index.css
@@ -1,10 +1,11 @@
 .time-travel-view {
+  align-items: center;
   background: var(--main-dark-gray);
   border: 1px solid var(--highlight-dark-gray);
+  display: flex;
   color: var(--main-white);
-  grid-area: time-travel;
+  height: var(--top-row-height);
   left: calc(100vw - var(--right-column-width));
-  padding: 1em 2em;
   position: fixed;
   text-align: left;
   top: 0em;

--- a/packages/lexical-devtools/src/panel/components/TimeTravelView/index.css
+++ b/packages/lexical-devtools/src/panel/components/TimeTravelView/index.css
@@ -3,8 +3,10 @@
   border: 1px solid var(--highlight-dark-gray);
   color: var(--main-white);
   grid-area: time-travel;
+  left: calc(100vw - 24em);
   padding: 1em 2em;
-  position: sticky;
+  position: fixed;
   text-align: left;
   top: 0em;
+  width: 100%;
 }

--- a/packages/lexical-devtools/src/panel/components/TimeTravelView/index.css
+++ b/packages/lexical-devtools/src/panel/components/TimeTravelView/index.css
@@ -1,0 +1,10 @@
+.time-travel-view {
+  background: var(--main-dark-gray);
+  border: 1px solid var(--highlight-dark-gray);
+  color: var(--main-white);
+  grid-area: time-travel;
+  padding: 1em 2em;
+  position: sticky;
+  text-align: left;
+  top: 0em;
+}

--- a/packages/lexical-devtools/src/panel/components/TimeTravelView/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/TimeTravelView/index.tsx
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import './index.css';
+
+import * as React from 'react';
+
+function TimeTravelView() {
+  return <div className="time-travel-view">time travel</div>;
+}
+
+export default TimeTravelView;

--- a/packages/lexical-devtools/src/panel/components/TimeTravelView/index.tsx
+++ b/packages/lexical-devtools/src/panel/components/TimeTravelView/index.tsx
@@ -10,7 +10,7 @@ import './index.css';
 import * as React from 'react';
 
 function TimeTravelView() {
-  return <div className="time-travel-view">time travel</div>;
+  return <div className="time-travel-view" />;
 }
 
 export default TimeTravelView;

--- a/packages/lexical-devtools/src/panel/components/TreeView/index.css
+++ b/packages/lexical-devtools/src/panel/components/TreeView/index.css
@@ -1,10 +1,8 @@
 .tree-view-output {
   background: var(--main-dark-gray);
-  /* border: 1px solid var(--highlight-dark-gray); */
   color: var(--main-white);
   font-size: 1.2em;
   font-weight: 400;
-  grid-area: tree-view;
   height: calc(100vh - var(--top-row-height));
   line-height: 1.1;
   margin: 0;

--- a/packages/lexical-devtools/src/panel/components/TreeView/index.css
+++ b/packages/lexical-devtools/src/panel/components/TreeView/index.css
@@ -1,13 +1,17 @@
 .tree-view-output {
   background: var(--main-dark-gray);
-  color: #fff;
+  /* border: 1px solid var(--highlight-dark-gray); */
+  color: var(--main-white);
   font-size: 1.2em;
   font-weight: 400;
   grid-area: tree-view;
+  height: calc(100vh - 3.5em);
   line-height: 1.1;
   margin: 0;
-  padding: 1em 0;
-  overflow: auto;
+  position: fixed;
+  overflow-x: hidden;
+  overflow-y: auto;
   text-align: left;
+  top: 3.5em;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/packages/lexical-devtools/src/panel/components/TreeView/index.css
+++ b/packages/lexical-devtools/src/panel/components/TreeView/index.css
@@ -5,13 +5,13 @@
   font-size: 1.2em;
   font-weight: 400;
   grid-area: tree-view;
-  height: calc(100vh - 3.5em);
+  height: calc(100vh - var(--top-row-height));
   line-height: 1.1;
   margin: 0;
   position: fixed;
   overflow-x: hidden;
   overflow-y: auto;
   text-align: left;
-  top: 3.5em;
+  top: var(--top-row-height);
   -moz-osx-font-smoothing: grayscale;
 }

--- a/packages/lexical-devtools/src/panel/components/main/index.css
+++ b/packages/lexical-devtools/src/panel/components/main/index.css
@@ -4,6 +4,8 @@
   --main-blue: #77b6ff;
   --main-dark-gray: #222;
   --main-white: #fff;
+  --top-row-height: 3.5em;
+  --right-column-width: 24em;
 }
 
 body {

--- a/packages/lexical-devtools/src/panel/components/main/index.css
+++ b/packages/lexical-devtools/src/panel/components/main/index.css
@@ -1,7 +1,9 @@
 :root {
+  --highlight-dark-gray: #282c34;
   --monospace-character-width: 1.2em;
   --main-blue: #77b6ff;
   --main-dark-gray: #222;
+  --main-white: #fff;
 }
 
 body {

--- a/packages/lexical-devtools/types.ts
+++ b/packages/lexical-devtools/types.ts
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {GridSelection, LexicalEditor, RangeSelection} from 'lexical';
+import {
+  GridSelection,
+  LexicalEditor,
+  NodeSelection,
+  RangeSelection,
+} from 'lexical';
 import {
   ElementPointType,
   TextPointType,
@@ -28,6 +33,11 @@ export interface DevToolsNode {
   lexicalKey: string;
   monospaceWidth: string;
 }
+
+export type DevToolsSelection =
+  | GridSelectionJSON
+  | NodeSelection
+  | RangeSelectionJSON;
 
 // the anchor property as PointType includes a _selection property
 // when anchor is present on a selection object, it creates circularity

--- a/packages/lexical-devtools/types.ts
+++ b/packages/lexical-devtools/types.ts
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {LexicalEditor} from 'lexical';
+import {GridSelection, LexicalEditor, RangeSelection} from 'lexical';
+import {
+  ElementPointType,
+  TextPointType,
+} from 'packages/lexical/src/LexicalSelection';
 
 export interface DevToolsTree {
   [key: string]: DevToolsNode;
@@ -25,8 +29,34 @@ export interface DevToolsNode {
   monospaceWidth: string;
 }
 
+// the anchor property as PointType includes a _selection property
+// when anchor is present on a selection object, it creates circularity
+// we have to remove this circularity in order to serialize the selection as JSON
+export type PointTypeJSON =
+  | (Omit<TextPointType, '_selection'> & {
+      [key: string]: unknown;
+    })
+  | (Omit<ElementPointType, '_selection'> & {
+      [key: string]: unknown;
+    });
+
+export interface GridSelectionJSON
+  extends Omit<GridSelection, 'anchor' | 'focus'> {
+  anchor: PointTypeJSON;
+  focus: PointTypeJSON;
+}
+
+export interface RangeSelectionJSON
+  extends Omit<RangeSelection, 'anchor' | 'focus'> {
+  anchor: PointTypeJSON;
+  focus: PointTypeJSON;
+}
+
 export type LexicalKey = `__lexicalKey_${string}`;
 
+// allow lookup of a Lexical HTML element's lexicalKey
+// lexicalKey is stored on the DOM node under key __lexicalKey_{editorKey}
+// where editorKey is a 5 letter string, dynamically generated with each editor instance
 export interface LexicalHTMLElement extends HTMLElement {
   [key: LexicalKey]: string;
   __lexicalEditor: LexicalEditor;


### PR DESCRIPTION
This adds a panel displaying data about selection anchor/focus to the DevTools browser extension:

https://user-images.githubusercontent.com/4361605/188968979-d3c36cdb-dc0a-4a25-8e96-3fef0b6dd778.mov

Not 100% yet, I want to add more commits to this PR to have UI changes for highlighted nodes (as in the existing `LexicalTreeView`)

---
Developer Tools Web Extension Planning Issue: #2127