### PR TITLE
Fix Flow Type

### DIFF
--- a/packages/lexical-react/flow/LexicalComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalComposer.js.flow
@@ -14,7 +14,7 @@ import type {InitialEditorStateType as InitialEditorStateRichTextType} from '@le
 type Props = {
   initialConfig: $ReadOnly<{
     editor__DEPRECATED?: LexicalEditor | null,
-    readOnly?: boolean,
+    editable?: boolean,
     namespace: string,
     nodes?: $ReadOnlyArray<Class<LexicalNode>>,
     theme?: EditorThemeClasses,


### PR DESCRIPTION
We missed this one on the readOnly API change.