### PR TITLE
[0.5] Add DEPRECATED prefix to Grid APIs

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -24,22 +24,22 @@ import {
 } from '@lexical/selection';
 import {$findMatchingParent} from '@lexical/utils';
 import {
-  $createGridSelection,
   $createParagraphNode,
   $getRoot,
   $getSelection,
   $isDecoratorNode,
   $isElementNode,
-  $isGridCellNode,
-  $isGridNode,
-  $isGridRowNode,
-  $isGridSelection,
   $isLineBreakNode,
   $isRangeSelection,
   $isTextNode,
   $parseSerializedNode,
   $setSelection,
-  GridNode,
+  DEPRECATED_$createGridSelection,
+  DEPRECATED_$isGridCellNode,
+  DEPRECATED_$isGridNode,
+  DEPRECATED_$isGridRowNode,
+  DEPRECATED_$isGridSelection,
+  DEPRECATED_GridNode,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import invariant from 'shared/invariant';
@@ -148,15 +148,19 @@ export function $insertGeneratedNodes(
   selection: RangeSelection | GridSelection,
 ) {
   const isSelectionInsideOfGrid =
-    $isGridSelection(selection) ||
+    DEPRECATED_$isGridSelection(selection) ||
     ($findMatchingParent(selection.anchor.getNode(), (n) =>
-      $isGridCellNode(n),
+      DEPRECATED_$isGridCellNode(n),
     ) !== null &&
       $findMatchingParent(selection.focus.getNode(), (n) =>
-        $isGridCellNode(n),
+        DEPRECATED_$isGridCellNode(n),
       ) !== null);
 
-  if (isSelectionInsideOfGrid && nodes.length === 1 && $isGridNode(nodes[0])) {
+  if (
+    isSelectionInsideOfGrid &&
+    nodes.length === 1 &&
+    DEPRECATED_$isGridNode(nodes[0])
+  ) {
     $mergeGridNodesStrategy(nodes, selection, false, editor);
     return;
   }
@@ -216,11 +220,11 @@ function $basicInsertStrategy(
 
   if ($isRangeSelection(selection)) {
     selection.insertNodes(topLevelBlocks);
-  } else if ($isGridSelection(selection)) {
+  } else if (DEPRECATED_$isGridSelection(selection)) {
     // If there's an active grid selection and a non grid is pasted, add to the anchor.
     const anchorCell = selection.anchor.getNode();
 
-    if (!$isGridCellNode(anchorCell)) {
+    if (!DEPRECATED_$isGridCellNode(anchorCell)) {
       invariant(false, 'Expected Grid Cell in Grid Selection');
     }
 
@@ -234,28 +238,30 @@ function $mergeGridNodesStrategy(
   isFromLexical: boolean,
   editor: LexicalEditor,
 ) {
-  if (nodes.length !== 1 || !$isGridNode(nodes[0])) {
+  if (nodes.length !== 1 || !DEPRECATED_$isGridNode(nodes[0])) {
     invariant(false, '$mergeGridNodesStrategy: Expected Grid insertion.');
   }
 
   const newGrid = nodes[0];
   const newGridRows = newGrid.getChildren();
   const newColumnCount = newGrid
-    .getFirstChildOrThrow<GridNode>()
+    .getFirstChildOrThrow<DEPRECATED_GridNode>()
     .getChildrenSize();
   const newRowCount = newGrid.getChildrenSize();
   const gridCellNode = $findMatchingParent(selection.anchor.getNode(), (n) =>
-    $isGridCellNode(n),
+    DEPRECATED_$isGridCellNode(n),
   );
   const gridRowNode =
-    gridCellNode && $findMatchingParent(gridCellNode, (n) => $isGridRowNode(n));
+    gridCellNode &&
+    $findMatchingParent(gridCellNode, (n) => DEPRECATED_$isGridRowNode(n));
   const gridNode =
-    gridRowNode && $findMatchingParent(gridRowNode, (n) => $isGridNode(n));
+    gridRowNode &&
+    $findMatchingParent(gridRowNode, (n) => DEPRECATED_$isGridNode(n));
 
   if (
-    !$isGridCellNode(gridCellNode) ||
-    !$isGridRowNode(gridRowNode) ||
-    !$isGridNode(gridNode)
+    !DEPRECATED_$isGridCellNode(gridCellNode) ||
+    !DEPRECATED_$isGridRowNode(gridRowNode) ||
+    !DEPRECATED_$isGridNode(gridNode)
   ) {
     invariant(
       false,
@@ -285,13 +291,13 @@ function $mergeGridNodesStrategy(
   for (let r = fromY; r <= toY; r++) {
     const currentGridRowNode = gridRowNodes[r];
 
-    if (!$isGridRowNode(currentGridRowNode)) {
+    if (!DEPRECATED_$isGridRowNode(currentGridRowNode)) {
       invariant(false, 'getNodes: expected to find GridRowNode');
     }
 
     const newGridRowNode = newGridRows[newRowIdx];
 
-    if (!$isGridRowNode(newGridRowNode)) {
+    if (!DEPRECATED_$isGridRowNode(newGridRowNode)) {
       invariant(false, 'getNodes: expected to find GridRowNode');
     }
 
@@ -302,13 +308,13 @@ function $mergeGridNodesStrategy(
     for (let c = fromX; c <= toX; c++) {
       const currentGridCellNode = gridCellNodes[c];
 
-      if (!$isGridCellNode(currentGridCellNode)) {
+      if (!DEPRECATED_$isGridCellNode(currentGridCellNode)) {
         invariant(false, 'getNodes: expected to find GridCellNode');
       }
 
       const newGridCellNode = newGridCellNodes[newColumnIdx];
 
-      if (!$isGridCellNode(newGridCellNode)) {
+      if (!DEPRECATED_$isGridCellNode(newGridCellNode)) {
         invariant(false, 'getNodes: expected to find GridCellNode');
       }
 
@@ -336,7 +342,7 @@ function $mergeGridNodesStrategy(
   }
 
   if (newAnchorCellKey && newFocusCellKey) {
-    const newGridSelection = $createGridSelection();
+    const newGridSelection = DEPRECATED_$createGridSelection();
     newGridSelection.set(gridNode.getKey(), newAnchorCellKey, newFocusCellKey);
     $setSelection(newGridSelection);
     editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -26,9 +26,9 @@ import {
 } from '@lexical/table';
 import {
   $getSelection,
-  $isGridSelection,
   $isRangeSelection,
   $setSelection,
+  DEPRECATED_$isGridSelection,
 } from 'lexical';
 import * as React from 'react';
 import {ReactPortal, useCallback, useEffect, useRef, useState} from 'react';
@@ -72,7 +72,7 @@ function TableActionMenu({
     editor.getEditorState().read(() => {
       const selection = $getSelection();
 
-      if ($isGridSelection(selection)) {
+      if (DEPRECATED_$isGridSelection(selection)) {
         const selectionShape = selection.getShape();
 
         updateSelectionCounts({
@@ -153,7 +153,7 @@ function TableActionMenu({
 
         let tableRowIndex;
 
-        if ($isGridSelection(selection)) {
+        if (DEPRECATED_$isGridSelection(selection)) {
           const selectionShape = selection.getShape();
           tableRowIndex = shouldInsertAfter
             ? selectionShape.toY
@@ -189,7 +189,7 @@ function TableActionMenu({
 
         let tableColumnIndex;
 
-        if ($isGridSelection(selection)) {
+        if (DEPRECATED_$isGridSelection(selection)) {
           const selectionShape = selection.getShape();
           tableColumnIndex = shouldInsertAfter
             ? selectionShape.toX

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -22,8 +22,8 @@ import {
 import {
   $getNearestNodeFromDOMNode,
   $getSelection,
-  $isGridSelection,
   COMMAND_PRIORITY_HIGH,
+  DEPRECATED_$isGridSelection,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import * as React from 'react';
@@ -67,7 +67,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
       SELECTION_CHANGE_COMMAND,
       (payload) => {
         const selection = $getSelection();
-        const isGridSelection = $isGridSelection(selection);
+        const isGridSelection = DEPRECATED_$isGridSelection(selection);
 
         if (isSelectingGrid !== isGridSelection) {
           updateIsSelectingGrid(isGridSelection);

--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -22,9 +22,9 @@ import {
   $getRoot,
   $getSelection,
   $isElementNode,
-  $isGridSelection,
   $isRangeSelection,
   $isTextNode,
+  DEPRECATED_$isGridSelection,
 } from 'lexical';
 import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
@@ -280,7 +280,7 @@ function generateContent(editorState: EditorState): string {
       ? ': null'
       : $isRangeSelection(selection)
       ? printRangeSelection(selection)
-      : $isGridSelection(selection)
+      : DEPRECATED_$isGridSelection(selection)
       ? printGridSelection(selection)
       : printObjectSelection(selection);
   });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -43,7 +43,6 @@ import {
   $getRoot,
   $getSelection,
   $isDecoratorNode,
-  $isGridSelection,
   $isNodeSelection,
   $isRangeSelection,
   $isRootNode,
@@ -56,6 +55,7 @@ import {
   DELETE_CHARACTER_COMMAND,
   DELETE_LINE_COMMAND,
   DELETE_WORD_COMMAND,
+  DEPRECATED_$isGridSelection,
   DRAGSTART_COMMAND,
   DROP_COMMAND,
   ElementNode,
@@ -425,7 +425,7 @@ function onPasteForRichText(
           : event.clipboardData;
       if (
         clipboardData != null &&
-        ($isRangeSelection(selection) || $isGridSelection(selection))
+        ($isRangeSelection(selection) || DEPRECATED_$isGridSelection(selection))
       ) {
         $insertDataTransferForRichText(clipboardData, selection, editor);
       }
@@ -581,11 +581,14 @@ export function registerRichText(
         if (typeof eventOrText === 'string') {
           if ($isRangeSelection(selection)) {
             selection.insertText(eventOrText);
-          } else if ($isGridSelection(selection)) {
+          } else if (DEPRECATED_$isGridSelection(selection)) {
             // TODO: Insert into the first cell & clear selection.
           }
         } else {
-          if (!$isRangeSelection(selection) && !$isGridSelection(selection)) {
+          if (
+            !$isRangeSelection(selection) &&
+            !DEPRECATED_$isGridSelection(selection)
+          ) {
             return false;
           }
 
@@ -945,7 +948,10 @@ export function registerRichText(
       PASTE_COMMAND,
       (event) => {
         const selection = $getSelection();
-        if ($isRangeSelection(selection) || $isGridSelection(selection)) {
+        if (
+          $isRangeSelection(selection) ||
+          DEPRECATED_$isGridSelection(selection)
+        ) {
           onPasteForRichText(event, editor);
           return true;
         }

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -26,12 +26,12 @@ import {
   $getPreviousSelection,
   $isDecoratorNode,
   $isElementNode,
-  $isGridSelection,
   $isLeafNode,
   $isRangeSelection,
   $isRootNode,
   $isTextNode,
   $setSelection,
+  DEPRECATED_$isGridSelection,
 } from 'lexical';
 import invariant from 'shared/invariant';
 
@@ -281,7 +281,7 @@ function $cloneContentsImpl(
       nodeMap: Array.from(nodeMap.entries()),
       range,
     };
-  } else if ($isGridSelection(selection)) {
+  } else if (DEPRECATED_$isGridSelection(selection)) {
     const nodeMap = selection.getNodes().map<[NodeKey, LexicalNode]>((node) => {
       const nodeKey = node.getKey();
 
@@ -1045,7 +1045,7 @@ export function $sliceSelectedTextNodeContent(
     textNode.isSelected() &&
     !textNode.isSegmented() &&
     !textNode.isToken() &&
-    ($isRangeSelection(selection) || $isGridSelection(selection))
+    ($isRangeSelection(selection) || DEPRECATED_$isGridSelection(selection))
   ) {
     const anchorNode = selection.anchor.getNode();
     const focusNode = selection.focus.getNode();

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -23,7 +23,7 @@ import {
   $createParagraphNode,
   $isElementNode,
   $isLineBreakNode,
-  GridCellNode,
+  DEPRECATED_GridCellNode,
 } from 'lexical';
 
 export const TableCellHeaderStates = {
@@ -46,7 +46,7 @@ export type SerializedTableCellNode = Spread<
 >;
 
 /** @noInheritDoc */
-export class TableCellNode extends GridCellNode {
+export class TableCellNode extends DEPRECATED_GridCellNode {
   /** @internal */
   __headerState: TableCellHeaderState;
   /** @internal */

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -21,7 +21,7 @@ import type {
 } from 'lexical';
 
 import {addClassNamesToElement} from '@lexical/utils';
-import {$getNearestNodeFromDOMNode, GridNode} from 'lexical';
+import {$getNearestNodeFromDOMNode, DEPRECATED_GridNode} from 'lexical';
 
 import {$isTableCellNode} from './LexicalTableCellNode';
 import {$isTableRowNode, TableRowNode} from './LexicalTableRowNode';
@@ -36,7 +36,7 @@ export type SerializedTableNode = Spread<
 >;
 
 /** @noInheritDoc */
-export class TableNode extends GridNode {
+export class TableNode extends DEPRECATED_GridNode {
   /** @internal */
   __grid?: Grid;
 

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -10,10 +10,10 @@ import type {Spread} from 'lexical';
 
 import {addClassNamesToElement} from '@lexical/utils';
 import {
+  DEPRECATED_GridRowNode,
   DOMConversionMap,
   DOMConversionOutput,
   EditorConfig,
-  GridRowNode,
   LexicalNode,
   NodeKey,
   SerializedElementNode,
@@ -29,7 +29,7 @@ export type SerializedTableRowNode = Spread<
 >;
 
 /** @noInheritDoc */
-export class TableRowNode extends GridRowNode {
+export class TableRowNode extends DEPRECATED_GridRowNode {
   /** @internal */
   __height?: number;
 

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -14,7 +14,6 @@ import type {
 } from 'lexical';
 
 import {
-  $createGridSelection,
   $createParagraphNode,
   $createRangeSelection,
   $createTextNode,
@@ -22,8 +21,9 @@ import {
   $getNodeByKey,
   $getSelection,
   $isElementNode,
-  $isGridSelection,
   $setSelection,
+  DEPRECATED_$createGridSelection,
+  DEPRECATED_$isGridSelection,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import {CAN_USE_DOM} from 'shared/canUseDOM';
@@ -303,7 +303,7 @@ export class TableSelection {
         ) {
           const focusNodeKey = focusTableCellNode.getKey();
 
-          this.gridSelection = $createGridSelection();
+          this.gridSelection = DEPRECATED_$createGridSelection();
 
           this.focusCellNodeKey = focusNodeKey;
           this.gridSelection.set(
@@ -335,7 +335,7 @@ export class TableSelection {
 
       if ($isTableCellNode(anchorTableCellNode)) {
         const anchorNodeKey = anchorTableCellNode.getKey();
-        this.gridSelection = $createGridSelection();
+        this.gridSelection = DEPRECATED_$createGridSelection();
         this.anchorCellNodeKey = anchorNodeKey;
       }
     });
@@ -345,7 +345,7 @@ export class TableSelection {
     this.editor.update(() => {
       const selection = $getSelection();
 
-      if (!$isGridSelection(selection)) {
+      if (!DEPRECATED_$isGridSelection(selection)) {
         invariant(false, 'Expected grid selection');
       }
 
@@ -378,7 +378,7 @@ export class TableSelection {
 
       const selection = $getSelection();
 
-      if (!$isGridSelection(selection)) {
+      if (!DEPRECATED_$isGridSelection(selection)) {
         invariant(false, 'Expected grid selection');
       }
 

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -25,13 +25,13 @@ import {
   $getPreviousSelection,
   $getSelection,
   $isElementNode,
-  $isGridSelection,
   $isParagraphNode,
   $isRangeSelection,
   $setSelection,
   COMMAND_PRIORITY_CRITICAL,
   CONTROLLED_TEXT_INSERTION_COMMAND,
   DELETE_CHARACTER_COMMAND,
+  DEPRECATED_$isGridSelection,
   FOCUS_COMMAND,
   FORMAT_TEXT_COMMAND,
   KEY_ARROW_DOWN_COMMAND,
@@ -158,7 +158,7 @@ export function applyTableHandlers(
       const selection = $getSelection();
 
       if (
-        $isGridSelection(selection) &&
+        DEPRECATED_$isGridSelection(selection) &&
         selection.gridKey === tableSelection.tableNodeKey &&
         rootElement.contains(event.target as Node)
       ) {
@@ -257,7 +257,7 @@ export function applyTableHandlers(
               );
             }
           }
-        } else if ($isGridSelection(selection) && event.shiftKey) {
+        } else if (DEPRECATED_$isGridSelection(selection) && event.shiftKey) {
           const tableCellNode = selection.focus.getNode();
 
           if (!$isTableCellNode(tableCellNode)) {
@@ -362,7 +362,7 @@ export function applyTableHandlers(
               );
             }
           }
-        } else if ($isGridSelection(selection) && event.shiftKey) {
+        } else if (DEPRECATED_$isGridSelection(selection) && event.shiftKey) {
           const tableCellNode = selection.focus.getNode();
 
           if (!$isTableCellNode(tableCellNode)) {
@@ -462,7 +462,7 @@ export function applyTableHandlers(
               );
             }
           }
-        } else if ($isGridSelection(selection) && event.shiftKey) {
+        } else if (DEPRECATED_$isGridSelection(selection) && event.shiftKey) {
           const tableCellNode = selection.focus.getNode();
 
           if (!$isTableCellNode(tableCellNode)) {
@@ -566,7 +566,7 @@ export function applyTableHandlers(
               );
             }
           }
-        } else if ($isGridSelection(selection) && event.shiftKey) {
+        } else if (DEPRECATED_$isGridSelection(selection) && event.shiftKey) {
           const tableCellNode = selection.focus.getNode();
 
           if (!$isTableCellNode(tableCellNode)) {
@@ -607,7 +607,7 @@ export function applyTableHandlers(
           return false;
         }
 
-        if ($isGridSelection(selection)) {
+        if (DEPRECATED_$isGridSelection(selection)) {
           tableSelection.clearText();
 
           return true;
@@ -655,7 +655,7 @@ export function applyTableHandlers(
           return false;
         }
 
-        if ($isGridSelection(selection)) {
+        if (DEPRECATED_$isGridSelection(selection)) {
           event.preventDefault();
           event.stopPropagation();
           tableSelection.clearText();
@@ -688,7 +688,7 @@ export function applyTableHandlers(
           return false;
         }
 
-        if ($isGridSelection(selection)) {
+        if (DEPRECATED_$isGridSelection(selection)) {
           tableSelection.formatCells(payload);
 
           return true;
@@ -719,7 +719,7 @@ export function applyTableHandlers(
           return false;
         }
 
-        if ($isGridSelection(selection)) {
+        if (DEPRECATED_$isGridSelection(selection)) {
           tableSelection.clearHighlight();
 
           return false;
@@ -804,11 +804,12 @@ export function applyTableHandlers(
 
         if (
           selection !== prevSelection &&
-          ($isGridSelection(selection) || $isGridSelection(prevSelection)) &&
+          (DEPRECATED_$isGridSelection(selection) ||
+            DEPRECATED_$isGridSelection(prevSelection)) &&
           tableSelection.gridSelection !== selection
         ) {
           tableSelection.updateTableGridSelection(
-            $isGridSelection(selection) && tableNode.isSelected()
+            DEPRECATED_$isGridSelection(selection) && tableNode.isSelected()
               ? selection
               : null,
           );
@@ -1182,7 +1183,7 @@ function $isSelectionInTable(
   selection: null | GridSelection | RangeSelection | NodeSelection,
   tableNode: TableNode,
 ): boolean {
-  if ($isRangeSelection(selection) || $isGridSelection(selection)) {
+  if ($isRangeSelection(selection) || DEPRECATED_$isGridSelection(selection)) {
     const isAnchorInside = tableNode.isParentOf(selection.anchor.getNode());
     const isFocusInside = tableNode.isParentOf(selection.focus.getNode());
 

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -12,12 +12,12 @@ import {
   $getRoot,
   $getSelection,
   $isElementNode,
-  $isGridSelection,
   $isNodeSelection,
   $isRangeSelection,
   $isTextNode,
   $setSelection,
   createEditor,
+  DEPRECATED_$isGridSelection,
   EditorState,
   ElementNode,
   Klass,
@@ -415,7 +415,10 @@ export function $insertBlockNode<T extends LexicalNode>(node: T): T {
   if ($isRangeSelection(selection)) {
     const focusNode = selection.focus.getNode();
     focusNode.getTopLevelElementOrThrow().insertAfter(node);
-  } else if ($isNodeSelection(selection) || $isGridSelection(selection)) {
+  } else if (
+    $isNodeSelection(selection) ||
+    DEPRECATED_$isGridSelection(selection)
+  ) {
     const nodes = selection.getNodes();
     nodes[nodes.length - 1].getTopLevelElementOrThrow().insertAfter(node);
   } else {

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -418,7 +418,7 @@ declare export class GridSelection implements BaseSelection {
   getTextContent(): string;
 }
 
-declare export function $isGridSelection(
+declare export function DEPRECATED_$isGridSelection(
   x: ?mixed,
 ): boolean %checks(x instanceof GridSelection);
 
@@ -533,7 +533,7 @@ declare class _Point {
 
 declare export function $createRangeSelection(): RangeSelection;
 declare export function $createNodeSelection(): NodeSelection;
-declare export function $createGridSelection(): GridSelection;
+declare export function DEPRECATED_$createGridSelection(): GridSelection;
 declare export function $isRangeSelection(
   x: ?mixed,
 ): boolean %checks(x instanceof RangeSelection);
@@ -769,27 +769,27 @@ declare export function $isParagraphNode(
   node: ?LexicalNode,
 ): boolean %checks(node instanceof ParagraphNode);
 
-declare export class GridNode extends ElementNode {}
+declare export class deprecated_GridNode extends ElementNode {}
 
-declare export function $isGridNode(
+declare export function DEPRECATED_$isGridNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof GridNode);
+): boolean %checks(node instanceof deprecated_GridNode);
 
-declare export class GridRowNode extends ElementNode {}
+declare export class deprecated_GridRowNode extends ElementNode {}
 
-declare export function $isGridRowNode(
+declare export function DEPRECATED_$isGridRowNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof GridRowNode);
+): boolean %checks(node instanceof deprecated_GridRowNode);
 
-declare export class GridCellNode extends ElementNode {
+declare export class deprecated_GridCellNode extends ElementNode {
   __colSpan: number;
 
   constructor(colSpan: number, key?: NodeKey): void;
 }
 
-declare export function $isGridCellNode(
+declare export function DEPRECATED_$isGridCellNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof GridCellNode);
+): boolean %checks(node instanceof deprecated_GridCellNode);
 
 /**
  * LexicalUtils

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -22,17 +22,17 @@ import {
   $createTextNode,
   $isDecoratorNode,
   $isElementNode,
-  $isGridCellNode,
-  $isGridNode,
-  $isGridRowNode,
   $isLeafNode,
   $isLineBreakNode,
   $isRootNode,
   $isTextNode,
   $setSelection,
   DecoratorNode,
-  GridCellNode,
-  GridNode,
+  DEPRECATED_$isGridCellNode,
+  DEPRECATED_$isGridNode,
+  DEPRECATED_$isGridRowNode,
+  DEPRECATED_GridCellNode,
+  DEPRECATED_GridNode,
   TextNode,
 } from '.';
 import {DOM_ELEMENT_TYPE, TEXT_TYPE_TO_FORMAT} from './LexicalConstants';
@@ -369,7 +369,7 @@ export class GridSelection implements BaseSelection {
   is(
     selection: null | RangeSelection | NodeSelection | GridSelection,
   ): boolean {
-    if (!$isGridSelection(selection)) {
+    if (!DEPRECATED_$isGridSelection(selection)) {
       return false;
     }
     return this.gridKey === selection.gridKey && this.anchor.is(this.focus);
@@ -448,8 +448,8 @@ export class GridSelection implements BaseSelection {
     const nodesSet = new Set<LexicalNode>();
     const {fromX, fromY, toX, toY} = this.getShape();
 
-    const gridNode = $getNodeByKey<GridNode>(this.gridKey);
-    if (!$isGridNode(gridNode)) {
+    const gridNode = $getNodeByKey<DEPRECATED_GridNode>(this.gridKey);
+    if (!DEPRECATED_$isGridNode(gridNode)) {
       invariant(false, 'getNodes: expected to find GridNode');
     }
     nodesSet.add(gridNode);
@@ -459,13 +459,13 @@ export class GridSelection implements BaseSelection {
       const gridRowNode = gridRowNodes[r];
       nodesSet.add(gridRowNode);
 
-      if (!$isGridRowNode(gridRowNode)) {
+      if (!DEPRECATED_$isGridRowNode(gridRowNode)) {
         invariant(false, 'getNodes: expected to find GridRowNode');
       }
-      const gridCellNodes = gridRowNode.getChildren<GridCellNode>();
+      const gridCellNodes = gridRowNode.getChildren<DEPRECATED_GridCellNode>();
       for (let c = fromX; c <= toX; c++) {
         const gridCellNode = gridCellNodes[c];
-        if (!$isGridCellNode(gridCellNode)) {
+        if (!DEPRECATED_$isGridCellNode(gridCellNode)) {
           invariant(false, 'getNodes: expected to find GridCellNode');
         }
         nodesSet.add(gridCellNode);
@@ -498,7 +498,7 @@ export class GridSelection implements BaseSelection {
   }
 }
 
-export function $isGridSelection(x: unknown): x is GridSelection {
+export function DEPRECATED_$isGridSelection(x: unknown): x is GridSelection {
   return x instanceof GridSelection;
 }
 
@@ -2256,7 +2256,7 @@ export function $createNodeSelection(): NodeSelection {
   return new NodeSelection(new Set());
 }
 
-export function $createGridSelection(): GridSelection {
+export function DEPRECATED_$createGridSelection(): GridSelection {
   const anchor = $createPoint('root', 0, 'element');
   const focus = $createPoint('root', 0, 'element');
   return new GridSelection('root', anchor, focus);
@@ -2269,7 +2269,10 @@ export function internalCreateSelection(
   const lastSelection = currentEditorState._selection;
   const domSelection = getDOMSelection();
 
-  if ($isNodeSelection(lastSelection) || $isGridSelection(lastSelection)) {
+  if (
+    $isNodeSelection(lastSelection) ||
+    DEPRECATED_$isGridSelection(lastSelection)
+  ) {
     return lastSelection.clone();
   }
 

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -17,7 +17,6 @@ import {
   TableRowNode,
 } from '@lexical/table';
 import {
-  $createGridSelection,
   $createLineBreakNode,
   $createNodeSelection,
   $createParagraphNode,
@@ -31,6 +30,7 @@ import {
   COMMAND_PRIORITY_EDITOR,
   COMMAND_PRIORITY_LOW,
   createCommand,
+  DEPRECATED_$createGridSelection,
   ElementNode,
   LexicalEditor,
   NodeKey,
@@ -1217,7 +1217,7 @@ describe('LexicalEditor tests', () => {
         await update(() => {
           const paragraph = $createParagraphNode();
           originalText = $createTextNode('Hello world');
-          const selection = $createGridSelection();
+          const selection = DEPRECATED_$createGridSelection();
           selection.set(
             originalText.getKey(),
             originalText.getKey(),

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -112,14 +112,14 @@ export {
 } from './LexicalEditor';
 export type {EventHandler} from './LexicalEvents';
 export {
-  $createGridSelection,
   $createNodeSelection,
   $createRangeSelection,
   $getPreviousSelection,
   $getSelection,
-  $isGridSelection,
   $isNodeSelection,
   $isRangeSelection,
+  DEPRECATED_$createGridSelection,
+  DEPRECATED_$isGridSelection,
 } from './LexicalSelection';
 export {$parseSerializedNode} from './LexicalUpdates';
 export {
@@ -136,9 +136,18 @@ export {
 export {VERSION} from './LexicalVersion';
 export {$isDecoratorNode, DecoratorNode} from './nodes/LexicalDecoratorNode';
 export {$isElementNode, ElementNode} from './nodes/LexicalElementNode';
-export {$isGridCellNode, GridCellNode} from './nodes/LexicalGridCellNode';
-export {$isGridNode, GridNode} from './nodes/LexicalGridNode';
-export {$isGridRowNode, GridRowNode} from './nodes/LexicalGridRowNode';
+export {
+  DEPRECATED_$isGridCellNode,
+  DEPRECATED_GridCellNode,
+} from './nodes/LexicalGridCellNode';
+export {
+  DEPRECATED_$isGridNode,
+  DEPRECATED_GridNode,
+} from './nodes/LexicalGridNode';
+export {
+  DEPRECATED_$isGridRowNode,
+  DEPRECATED_GridRowNode,
+} from './nodes/LexicalGridRowNode';
 export type {SerializedLineBreakNode} from './nodes/LexicalLineBreakNode';
 export {
   $createLineBreakNode,

--- a/packages/lexical/src/nodes/LexicalGridCellNode.ts
+++ b/packages/lexical/src/nodes/LexicalGridCellNode.ts
@@ -23,7 +23,7 @@ export type SerializedGridCellNode = Spread<
 >;
 
 /** @noInheritDoc */
-export class GridCellNode extends ElementNode {
+export class DEPRECATED_GridCellNode extends ElementNode {
   /** @internal */
   __colSpan: number;
 
@@ -40,8 +40,8 @@ export class GridCellNode extends ElementNode {
   }
 }
 
-export function $isGridCellNode(
-  node: GridCellNode | LexicalNode | null | undefined,
-): node is GridCellNode {
-  return node instanceof GridCellNode;
+export function DEPRECATED_$isGridCellNode(
+  node: DEPRECATED_GridCellNode | LexicalNode | null | undefined,
+): node is DEPRECATED_GridCellNode {
+  return node instanceof DEPRECATED_GridCellNode;
 }

--- a/packages/lexical/src/nodes/LexicalGridNode.ts
+++ b/packages/lexical/src/nodes/LexicalGridNode.ts
@@ -10,10 +10,10 @@ import type {LexicalNode} from '../LexicalNode';
 
 import {ElementNode} from './LexicalElementNode';
 
-export class GridNode extends ElementNode {}
+export class DEPRECATED_GridNode extends ElementNode {}
 
-export function $isGridNode(
+export function DEPRECATED_$isGridNode(
   node: LexicalNode | null | undefined,
-): node is GridNode {
-  return node instanceof GridNode;
+): node is DEPRECATED_GridNode {
+  return node instanceof DEPRECATED_GridNode;
 }

--- a/packages/lexical/src/nodes/LexicalGridRowNode.ts
+++ b/packages/lexical/src/nodes/LexicalGridRowNode.ts
@@ -10,10 +10,10 @@ import type {LexicalNode} from '../LexicalNode';
 
 import {ElementNode} from './LexicalElementNode';
 
-export class GridRowNode extends ElementNode {}
+export class DEPRECATED_GridRowNode extends ElementNode {}
 
-export function $isGridRowNode(
+export function DEPRECATED_$isGridRowNode(
   node: LexicalNode | null | undefined,
-): node is GridRowNode {
-  return node instanceof GridRowNode;
+): node is DEPRECATED_GridRowNode {
+  return node instanceof DEPRECATED_GridRowNode;
 }


### PR DESCRIPTION
Long-term, we want to eventually remove these APIs from Lexical's core. This work can likely be done by migrating the logic into the table package directly, or by using an alternative approach to handling tables. Lots of the logic for handling grids in core is just purely around tables and it seems unnecessary that every Lexical user should take the 3-4kb cost for having this logic if they don't ever use it.

Short-term though, this is a lot of work to do and we have higher priorities to fulfil first as a team. So in the interests of advocating for users to not invest more time into this APIs, this PR adds the `DEPRECATED_` prefix to all the Grid APIs.