### PR TITLE
Clean up redundant newlines during pasting

### DIFF
--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -290,12 +290,13 @@ export function $isCodeNode(
 }
 
 function convertPreElement(domNode: Node): DOMConversionOutput {
-  return {node: $createCodeNode()};
+  return {node: $createCodeNode(), preformatted: true};
 }
 
 function convertDivElement(domNode: Node): DOMConversionOutput {
   // domNode is a <div> since we matched it by nodeName
   const div = domNode as HTMLDivElement;
+  const isCode = isCodeElement(div);
   return {
     after: (childLexicalNodes) => {
       const domParent = domNode.parentNode;
@@ -304,12 +305,13 @@ function convertDivElement(domNode: Node): DOMConversionOutput {
       }
       return childLexicalNodes;
     },
-    node: isCodeElement(div) ? $createCodeNode() : null,
+    node: isCode ? $createCodeNode() : null,
+    preformatted: isCode,
   };
 }
 
 function convertTableElement(): DOMConversionOutput {
-  return {node: $createCodeNode()};
+  return {node: $createCodeNode(), preformatted: true};
 }
 
 function convertCodeNoop(): DOMConversionOutput {

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -172,6 +172,7 @@ function $createNodesFromDOM(
   editor: LexicalEditor,
   forChildMap: Map<string, DOMChildConversion> = new Map(),
   parentLexicalNode?: LexicalNode | null | undefined,
+  preformatted = false,
 ): Array<LexicalNode> {
   let lexicalNodes: Array<LexicalNode> = [];
 
@@ -182,7 +183,7 @@ function $createNodesFromDOM(
   let currentLexicalNode = null;
   const transformFunction = getConversionFunction(node, editor);
   const transformOutput = transformFunction
-    ? transformFunction(node as HTMLElement)
+    ? transformFunction(node as HTMLElement, undefined, preformatted)
     : null;
   let postTransform = null;
 
@@ -224,6 +225,8 @@ function $createNodesFromDOM(
         editor,
         new Map(forChildMap),
         currentLexicalNode,
+        preformatted ||
+          (transformOutput && transformOutput.preformatted) === true,
       ),
     );
   }

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -108,6 +108,7 @@ export type DOMConversion = {
 export type DOMConversionFn = (
   element: Node,
   parent?: Node,
+  preformatted?: boolean,
 ) => DOMConversionOutput;
 
 export type DOMConversionOutput = {
@@ -147,12 +148,13 @@ static importDOM(): DOMConversionMap | null {
 
 If the imported ```<table>``` doesn't align with the expected GitHub code HTML, then we return null and allow the node to be handled by lower priority conversions.
 
-Much like `exportDOM`, `importDOM` exposes APIs to allow for post-processing of converted Nodes. The conversion function returns a `DOMConversionOutput` which can specify a function to run for each converted child (forChild) or on all the child nodes after the conversion is complete (after). The key difference here is that ```forChild``` runs for every deeply nested child node of the current node, whereas ```after``` will run only once after the transformation of the node and all its children is complete.
+Much like `exportDOM`, `importDOM` exposes APIs to allow for post-processing of converted Nodes. The conversion function returns a `DOMConversionOutput` which can specify a function to run for each converted child (forChild) or on all the child nodes after the conversion is complete (after). The key difference here is that ```forChild``` runs for every deeply nested child node of the current node, whereas ```after``` will run only once after the transformation of the node and all its children is complete. Finally, `preformatted` flag indicates that nested text content is preformatted (similar to `<pre>` tag) and all newlines and spaces should be preserved as is.
 
 ```js
 export type DOMConversionFn = (
   element: Node,
   parent?: Node,
+  preformatted?: boolean,
 ) => DOMConversionOutput;
 
 export type DOMConversionOutput = {

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -136,6 +136,7 @@ export type DOMConversion<T extends HTMLElement = HTMLElement> = {
 export type DOMConversionFn<T extends HTMLElement = HTMLElement> = (
   element: T,
   parent?: Node,
+  preformatted?: boolean,
 ) => DOMConversionOutput | null;
 
 export type DOMChildConversion = (
@@ -153,6 +154,7 @@ export type DOMConversionOutput = {
   after?: (childLexicalNodes: Array<LexicalNode>) => Array<LexicalNode>;
   forChild?: DOMChildConversion;
   node: LexicalNode | null;
+  preformatted?: boolean;
 };
 
 export type DOMExportOutput = {

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -882,14 +882,17 @@ function convertBringAttentionToElement(domNode: Node): DOMConversionOutput {
     node: null,
   };
 }
-function convertTextDOMNode(domNode: Node): DOMConversionOutput {
-  const {parentElement} = domNode;
-  const textContent = domNode.textContent || '';
-  const textContentTrim = textContent.trim();
-  const isPre =
-    parentElement != null && parentElement.tagName.toLowerCase() === 'pre';
-  if (!isPre && textContentTrim.length === 0 && textContent.includes('\n')) {
-    return {node: null};
+function convertTextDOMNode(
+  domNode: Node,
+  _parent?: Node,
+  preformatted?: boolean,
+): DOMConversionOutput {
+  let textContent = domNode.textContent || '';
+  if (!preformatted) {
+    textContent = textContent.replace(/\r?\n/gm, ' ');
+    if (textContent.trim().length === 0) {
+      return {node: null};
+    }
   }
   return {node: $createTextNode(textContent)};
 }


### PR DESCRIPTION
When parsing html we should ignore newlines except if it's within `<pre>` or code-like tags where it needs to be preserved. Although we can check for explicit`<pre>` tag, we can't easily check for code-like cases (e.g. github gists use tables for it) so this PR introduces "preformatted" flag for DOMTransformerFn, which will indicate that nested content should preserve newlines, otherwise it'll be removed.

Before:

https://user-images.githubusercontent.com/132642/189204784-3fa241d7-f07f-4543-b997-9bf6d0b312a6.mov

After:

https://user-images.githubusercontent.com/132642/189204778-6db2ba17-7727-466b-ba77-6253ffeef2aa.mov


