### PR TITLE
Add empty comment in front of 'export' in a bundled file

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -234,8 +234,12 @@ async function build(name, inputFile, outputPath, outputFile, isProd) {
       isProd && compiler(closureOptions),
       {
         renderChunk(source) {
-          return `${getComment()}
-${source}`;
+          // Assets pipeline might use "export" word in the beginning of the line
+          // as a dependency, avoiding it with empty comment in front
+          const patchedSource = isWWW
+            ? source.replace(/^(export)/gm, '/**/$1')
+            : source;
+          return `${getComment()}\n${patchedSource}`;
         },
       },
     ],


### PR DESCRIPTION
Fix for internal build

<img width="368" alt="Screen Shot 2022-09-08 at 3 27 11 PM" src="https://user-images.githubusercontent.com/132642/189209466-ee31fd7f-995a-45b3-9613-393b3f528ae5.png">
