### PR TITLE
docs: Fix URL of rich-text and plain-text

### DIFF
--- a/packages/lexical-plain-text/README.md
+++ b/packages/lexical-plain-text/README.md
@@ -2,4 +2,4 @@
 
 This package provides a starting point for Lexical users by registering listeners for a set of basic commands that cover simple text-editing behavior such as entering text, deleting characters, copy + paste, or changing the selection with arrow keys.
 
-You can use this package as a starting point, and then add additional command listeners to customize the functionality of your editor. If you want to add rich-text features, such as headings, blockquotes, or formatted text, you may want to consider using [@lexical/rich-text](https://lexical.dev/docs/api/lexical-rich-text) instead.
+You can use this package as a starting point, and then add additional command listeners to customize the functionality of your editor. If you want to add rich-text features, such as headings, blockquotes, or formatted text, you may want to consider using [@lexical/rich-text](https://lexical.dev/docs/packages/lexical-rich-text) instead.

--- a/packages/lexical-rich-text/README.md
+++ b/packages/lexical-rich-text/README.md
@@ -2,4 +2,4 @@
 
 This package provides a starting point for Lexical users by registering listeners for a set of basic commands that cover simple text-editing behavior such as entering text, deleting characters, copy + paste, or changing the selection with arrow keys. It also provides default behavior for rich text features, such as headings, formatted, text and blockquotes.
 
-You can use this package as a starting point, and then add additional command listeners to customize the functionality of your editor. If you don't want or need rich text functionality, you may want to consider using [@lexical/plain-text](https://lexical.dev/docs/api/lexical-plain-text) instead.
+You can use this package as a starting point, and then add additional command listeners to customize the functionality of your editor. If you don't want or need rich text functionality, you may want to consider using [@lexical/plain-text](https://lexical.dev/docs/packages/lexical-plain-text) instead.

--- a/packages/lexical-website/docs/getting-started/quick-start.md
+++ b/packages/lexical-website/docs/getting-started/quick-start.md
@@ -105,7 +105,7 @@ editor.update(() => {
   root.append(paragraphNode);
 });
 ```
-**It's important to note that the core library (the 'lexical' package) does not listen for any commands or perform any updates to the editor state in response to user events out-of-the-box.** In order to see text and other content appear in the editor, you need to register [command listeners](https://lexical.dev/docs/concepts/commands#editorregistercommand) and update the editor in the callback. Lexical provides a couple of helper packages to make it easy wire up a lot of the basic commands you might want for [plain text](https://lexical.dev/docs/api/lexical-plain-text) or [rich text](https://lexical.dev/docs/api/lexical-rich-text) experiences.
+**It's important to note that the core library (the 'lexical' package) does not listen for any commands or perform any updates to the editor state in response to user events out-of-the-box.** In order to see text and other content appear in the editor, you need to register [command listeners](https://lexical.dev/docs/concepts/commands#editorregistercommand) and update the editor in the callback. Lexical provides a couple of helper packages to make it easy wire up a lot of the basic commands you might want for [plain text](https://lexical.dev/docs/packages/lexical-plain-text) or [rich text](https://lexical.dev/docs/packages/lexical-rich-text) experiences.
 
 If you want to know when the editor updates so you can react to the changes, you can add an update
 listener to the editor, as shown below:


### PR DESCRIPTION
The link to rich-text and plain-text is "Page Not Found" in an [official document](https://lexical.dev/docs/getting-started/quick-start).

I changed the URL to the package page.
Let me know if this is not the intended link.