### PR TITLE
[Automated Releases] Add logging and dry run to release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,6 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm run prepare-release
-      - run: node ./scripts/npm/release.js --non-interactive --dry-run --channel $GITHUB_REF_NAME
+      - run: node ./scripts/npm/release.js --non-interactive --dry-run=${{ secrets.RELEASE_DRY_RUN }} --channel $GITHUB_REF_NAME
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,6 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm run prepare-release
-        #- run: node ./scripts/npm/release.js --non-interactive --channel $GITHUB_REF_NAME
+      - run: node ./scripts/npm/release.js --non-interactive --dry-run --channel $GITHUB_REF_NAME
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -92,8 +92,9 @@
     "prepare-www": "node scripts/www/rewriteImports.js",
     "changelog": "func() { git --no-pager log --oneline ${1}...HEAD --pretty=format:\"- %s %an\"; }; func",
     "increment-version": "node ./scripts/npm/increment-version",
+    "update-changelog": "node ./scripts/npm/update-changelog",
     "update-version": "node ./scripts/updateVersion",
-    "postversion": "git checkout -b $npm_package_version && npm install && npm run update-version && git add -A && git commit -m v${npm_package_version} && git tag -a v${npm_package_version} -m v${npm_package_version}",
+    "postversion": "git checkout -b $npm_package_version && npm install && npm run update-version && npm run update-changelog && git add -A && git commit -m v${npm_package_version} && git tag -a v${npm_package_version} -m v${npm_package_version}",
     "release": "npm run prepare-release && node ./scripts/npm/release.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prepare-release": "npm run build-release && node ./scripts/npm/prepare-release.js",
     "prepare": "husky install",
     "prepare-www": "node scripts/www/rewriteImports.js",
-    "changelog": "func() { git log --oneline ${1}...HEAD --pretty=format:\"- %s %an\"; }; func",
+    "changelog": "func() { git --no-pager log --oneline ${1}...HEAD --pretty=format:\"- %s %an\"; }; func",
     "increment-version": "node ./scripts/npm/increment-version",
     "update-version": "node ./scripts/updateVersion",
     "postversion": "git checkout -b $npm_package_version && npm install && npm run update-version && git add -A && git commit -m v${npm_package_version} && git tag -a v${npm_package_version} -m v${npm_package_version}",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "changelog": "func() { git log --oneline ${1}...HEAD --pretty=format:\"- %s %an\"; }; func",
     "increment-version": "node ./scripts/npm/increment-version",
     "update-version": "node ./scripts/updateVersion",
-    "postversion": "git checkout -b $npm_package_version && npm install && npm run update-version && git add -A && git commit -m v${npm_package_version}",
+    "postversion": "git checkout -b $npm_package_version && npm install && npm run update-version && git add -A && git commit -m v${npm_package_version} && git tag -a v${npm_package_version} -m v${npm_package_version}",
     "release": "npm run prepare-release && node ./scripts/npm/release.js"
   },
   "devDependencies": {

--- a/scripts/npm/increment-version.js
+++ b/scripts/npm/increment-version.js
@@ -24,22 +24,6 @@ async function incrementVersion(increment) {
   const workspaces = '';
   const command = `npm --no-git-tag-version version ${increment} --include-workspace-root true ${preId} ${workspaces}`;
   await exec(command);
-  if (increment !== 'prelease') {
-    const date = (await exec(`git show --format=%as | head -1`)).stdout.trim();
-    const header = `## v${process.env.npm_package_version} (${date})`;
-    const previousReleaseHash = (
-      await exec(`git log -n 1 origin/latest --pretty=format:"%H"`)
-    ).stdout.trim();
-    const tmpFilePath = './changelog-tmp';
-    await exec(`echo "${header}\n\n" >> ${tmpFilePath}`);
-    await exec(
-      `git --no-pager log --oneline ${previousReleaseHash}...HEAD --pretty=format:\"- %s %an\" >> ${tmpFilePath}`,
-    );
-    await exec(
-      `cat ./CHANGELOG.md >> ${tmpFilePath} && mv ${tmpFilePath} ./CHANGELOG.md`,
-    );
-    await exec(`git commit --amend --no-edit`);
-  }
 }
 
 incrementVersion(increment);

--- a/scripts/npm/increment-version.js
+++ b/scripts/npm/increment-version.js
@@ -24,6 +24,22 @@ async function incrementVersion(increment) {
   const workspaces = '';
   const command = `npm --no-git-tag-version version ${increment} --include-workspace-root true ${preId} ${workspaces}`;
   await exec(command);
+  if (increment !== 'prelease') {
+    const date = (await exec(`git show --format=%as | head -1`)).stdout.trim();
+    const header = `## v${process.env.npm_package_version} (${date})`;
+    const previousReleaseHash = (
+      await exec(`git log -n 1 origin/latest --pretty=format:"%H"`)
+    ).stdout.trim();
+    const tmpFilePath = './changelog-tmp';
+    await exec(`echo "${header}\n\n" >> ${tmpFilePath}`);
+    await exec(
+      `git --no-pager log --oneline ${previousReleaseHash}...HEAD --pretty=format:\"- %s %an\" >> ${tmpFilePath}`,
+    );
+    await exec(
+      `cat ./CHANGELOG.md >> ${tmpFilePath} && mv ${tmpFilePath} ./CHANGELOG.md`,
+    );
+    await exec(`git commit --amend --no-edit`);
+  }
 }
 
 incrementVersion(increment);

--- a/scripts/npm/release.js
+++ b/scripts/npm/release.js
@@ -39,7 +39,7 @@ async function publish() {
   for (let i = 0; i < pkgs.length; i++) {
     const pkg = pkgs[i];
     console.info(`Publishing ${pkg}...`);
-    if (!dryRun) {
+    if (dryRun === undefined || dryRun === 0) {
       await exec(
         `cd ./packages/${pkg}/npm && npm publish --access public --tag ${channel}`,
       );

--- a/scripts/npm/release.js
+++ b/scripts/npm/release.js
@@ -16,6 +16,7 @@ const {LEXICAL_PKG, DEFAULT_PKGS} = require('./packages');
 const argv = require('minimist')(process.argv.slice(2));
 
 const nonInteractive = argv['non-interactive'];
+const dryRun = argv['dry-run'];
 const channel = argv.channel;
 const validChannels = new Set('next', 'latest');
 if (!validChannels.has(channel)) {
@@ -37,9 +38,15 @@ async function publish() {
 
   for (let i = 0; i < pkgs.length; i++) {
     const pkg = pkgs[i];
-    await exec(
-      `cd ./packages/${pkg}/npm && npm publish --access public --tag ${channel}`,
-    );
+    console.info(`Publishing ${pkg}...`);
+    if (!dryRun) {
+      await exec(
+        `cd ./packages/${pkg}/npm && npm publish --access public --tag ${channel}`,
+      );
+      console.info(`Done!`);
+    } else {
+      console.info(`Dry run - skipping publish step.`);
+    }
   }
 }
 

--- a/scripts/npm/release.js
+++ b/scripts/npm/release.js
@@ -18,7 +18,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const nonInteractive = argv['non-interactive'];
 const dryRun = argv['dry-run'];
 const channel = argv.channel;
-const validChannels = new Set('next', 'latest');
+const validChannels = new Set(['next', 'latest']);
 if (!validChannels.has(channel)) {
   console.error(`Invalid release channel: ${channel}`);
   process.exit(1);

--- a/scripts/npm/update-changelog.js
+++ b/scripts/npm/update-changelog.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+const isPrerelease = process.env.npm_package_version.indexOf('-') !== -1;
+
+if (!isPrerelease) {
+  const date = (await exec(`git show --format=%as | head -1`)).stdout.trim();
+  const header = `## v${process.env.npm_package_version} (${date})`;
+  const previousReleaseHash = (
+    await exec(`git log -n 1 origin/latest --pretty=format:"%H"`)
+  ).stdout.trim();
+  const tmpFilePath = './changelog-tmp';
+  await exec(`echo "${header}\n\n" >> ${tmpFilePath}`);
+  await exec(
+    `git --no-pager log --oneline ${previousReleaseHash}...HEAD --pretty=format:\"- %s %an\" >> ${tmpFilePath}`,
+  );
+  await exec(
+    `cat ./CHANGELOG.md >> ${tmpFilePath} && mv ${tmpFilePath} ./CHANGELOG.md`,
+  );
+  await exec(`git commit --amend --no-edit`);
+}

--- a/scripts/npm/update-changelog.js
+++ b/scripts/npm/update-changelog.js
@@ -22,7 +22,7 @@ async function updateChangelog() {
   ).stdout.trim();
   const changelogContent = (
     await exec(
-      `git --no-pager log --oneline ${previousReleaseHash}...HEAD --pretty=format:\"- %s %an\"`,
+      `git --no-pager log --oneline ${previousReleaseHash}...HEAD~1 --pretty=format:\"- %s %an\"`,
     )
   ).stdout.trim();
   const tmpFilePath = './changelog-tmp';

--- a/scripts/npm/update-changelog.js
+++ b/scripts/npm/update-changelog.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+const {exec} = require('child-process-promise');
+
 const isPrerelease = process.env.npm_package_version.indexOf('-') !== -1;
 
 if (!isPrerelease) {

--- a/scripts/npm/update-changelog.js
+++ b/scripts/npm/update-changelog.js
@@ -20,11 +20,14 @@ async function updateChangelog() {
   const previousReleaseHash = (
     await exec(`git log -n 1 origin/latest --pretty=format:"%H"`)
   ).stdout.trim();
+  const changelogContent = (
+    await exec(
+      `git --no-pager log --oneline ${previousReleaseHash}...HEAD --pretty=format:\"- %s %an\"`,
+    )
+  ).stdout.trim();
   const tmpFilePath = './changelog-tmp';
-  await exec(`echo "${header}\n\n" >> ${tmpFilePath}`);
-  await exec(
-    `git --no-pager log --oneline ${previousReleaseHash}...HEAD --pretty=format:\"- %s %an\" >> ${tmpFilePath}`,
-  );
+  await exec(`echo "${header}\n" >> ${tmpFilePath}`);
+  await exec(`echo "${changelogContent}\n >> ${tmpFilePath}`);
   await exec(
     `cat ./CHANGELOG.md >> ${tmpFilePath} && mv ${tmpFilePath} ./CHANGELOG.md`,
   );

--- a/scripts/npm/update-changelog.js
+++ b/scripts/npm/update-changelog.js
@@ -27,7 +27,7 @@ async function updateChangelog() {
   ).stdout.trim();
   const tmpFilePath = './changelog-tmp';
   await exec(`echo "${header}\n" >> ${tmpFilePath}`);
-  await exec(`echo "${changelogContent}\n >> ${tmpFilePath}`);
+  await exec(`echo "${changelogContent}\n" >> ${tmpFilePath}`);
   await exec(
     `cat ./CHANGELOG.md >> ${tmpFilePath} && mv ${tmpFilePath} ./CHANGELOG.md`,
   );

--- a/scripts/npm/update-changelog.js
+++ b/scripts/npm/update-changelog.js
@@ -14,7 +14,7 @@ const {exec} = require('child-process-promise');
 
 const isPrerelease = process.env.npm_package_version.indexOf('-') !== -1;
 
-if (!isPrerelease) {
+async function updateChangelog() {
   const date = (await exec(`git show --format=%as | head -1`)).stdout.trim();
   const header = `## v${process.env.npm_package_version} (${date})`;
   const previousReleaseHash = (
@@ -29,4 +29,8 @@ if (!isPrerelease) {
     `cat ./CHANGELOG.md >> ${tmpFilePath} && mv ${tmpFilePath} ./CHANGELOG.md`,
   );
   await exec(`git commit --amend --no-edit`);
+}
+
+if (!isPrerelease) {
+  updateChangelog();
 }


### PR DESCRIPTION
This adds some logging and optional dry-run argument to the release script.

The workflow to create a release branch now works. The next step is to run this workflow, which kicks off whenever we push to latest or next. In that case, it runs the release build and releases on the appropriate channel. dry-run mode is controlled by a github secret and these branches are protected (like main) such that they can only be touched via PR.

After this is approved, I'll try releasing to the "next" branch, first as a dry run, then live, to see if it all works (including npm auth). "latest" is our stable branch and we won't touch that until we're sure next has been working well for a while.