### PR TITLE
Set Playground Sticky initialNodes

### DIFF
--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -236,6 +236,7 @@ export default function StickyComponent({
         </button>
         <LexicalNestedComposer
           initialEditor={caption}
+          initialNodes={[]}
           initialTheme={StickyEditorTheme}>
           {isCollabActive ? (
             <CollaborationPlugin

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -77,7 +77,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
     super(key);
     this.__x = x;
     this.__y = y;
-    this.__caption = caption || createEditor();
+    this.__caption = caption || createEditor({});
     this.__color = color;
   }
 


### PR DESCRIPTION
**Work in progress**

Updating any Playground plugins that use nested editors to use the new `initialNodes` prop to restrict which nodes can be inserted into the nested editors.