### PR TITLE
docs: loadContent clarification

### DIFF
--- a/packages/lexical-website/docs/concepts/editor-state.md
+++ b/packages/lexical-website/docs/concepts/editor-state.md
@@ -28,7 +28,14 @@ to deserialize stringified editor states.
 Here's an example of how you can initialize editor with some state and then persist it:
 
 ```js
-// Create editor with initial state (e.g. loaded from backend)
+// Get editor initial state (e.g. loaded from backend)
+const loadContent = async () => {
+  // 'empty' editor
+  const value = '{"root":{"children":[{"children":[],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}';
+
+  return value;
+}
+
 const initialEditorState = await loadContent();
 const editor = createEditor(...);
 registerRichText(editor, initialEditorState);


### PR DESCRIPTION
The documentation on saving/loading editor state is unclear what kind of data is expected from the `initialEditorState` which leads to confusion as in #1937. Mocked-up the `loadContent` function to return an `'empty'` initial editor state to make it clear.