### PR TITLE
Fix www exports

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -237,7 +237,7 @@ async function build(name, inputFile, outputPath, outputFile, isProd) {
           // Assets pipeline might use "export" word in the beginning of the line
           // as a dependency, avoiding it with empty comment in front
           const patchedSource = isWWW
-            ? source.replace(/^(export)/gm, '/**/$1')
+            ? source.replace(/^(export(?!s))/gm, '/**/$1')
             : source;
           return `${getComment()}\n${patchedSource}`;
         },


### PR DESCRIPTION
Noticed that `/**/` ([#2970](https://github.com/facebook/lexical/pull/2970)) is added in front of `exports.<api exports>`:

```
/**/exports.exportFile = exportFile;
```

Updated reg expo will only prefix `export` word