### PR TITLE
Fix WWW import rewrite for React

### DIFF
--- a/packages/lexical-react/flow/LexicalTableOfContents__EXPERIMENTAL.js.flow
+++ b/packages/lexical-react/flow/LexicalTableOfContents__EXPERIMENTAL.js.flow
@@ -10,7 +10,7 @@
 import type {HeadingTagType} from '@lexical/rich-text';
 import type {NodeKey} from 'lexical';
 
-declare export function LexicalTableOfContentsPlugin({
+declare export default function LexicalTableOfContentsPlugin({
   children: (
     tableOfContents: Array<[NodeKey, string, HeadingTagType]>,
   ) => React$Node,

--- a/scripts/www/rewriteImports.js
+++ b/scripts/www/rewriteImports.js
@@ -74,7 +74,7 @@ glob('packages/**/flow/*.flow', options, function (error1, files) {
           /from '@lexical\/react\/DEPRECATED_useLexicalHistory'/g,
           "from 'DEPRECATED_useLexicalHistory'",
         )
-        .replace(/from '@lexical\/react\/'/g, "from 'Lexical")
+        .replace(/from '@lexical\/react\/Lexical/g, "from 'Lexical")
         .replace(/from '@lexical\/utils\/'/g, "from 'LexicalUtils")
         .replace(/from '@lexical\/clipboard\'/g, "from 'LexicalClipboard'")
         .replace(/from '@lexical\/code\'/g, "from 'LexicalCode'")


### PR DESCRIPTION
The current REGEX assumes it will end with a quote but React package imports always have a submodule