### PR TITLE
Capture pendingDecorators after garbage collecting detached decorators

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -508,7 +508,6 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
   const dirtyElements = editor._dirtyElements;
   const normalizedNodes = editor._normalizedNodes;
   const tags = editor._updateTags;
-  const pendingDecorators = editor._pendingDecorators;
   const deferred = editor._deferred;
 
   if (needsUpdate) {
@@ -563,6 +562,10 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
     );
   }
 
+  /**
+   * Capture pendingDecorators after garbage collecting detached decorators
+   */
+  const pendingDecorators = editor._pendingDecorators;
   if (pendingDecorators !== null) {
     editor._decorators = pendingDecorators;
     editor._pendingDecorators = null;


### PR DESCRIPTION
Fixes #2993 

Have made changes as suggested by @trueadm. Cursory testing within our app suggests this change fixes the useEffect cleanup bug I noted in #2993, although I cannot speak to any other side effects it might have.
