### PR TITLE
Fix (Known) Table Bugs

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -2043,6 +2043,9 @@ test.describe('Tables', () => {
     await insertSampleImage(page);
     await page.keyboard.type(' <- it works!');
 
+    // Wait for Decorator to mount.
+    await page.waitForTimeout(3000);
+
     await assertHTML(
       page,
       html`

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -560,6 +560,7 @@ export async function dragMouse(
   toBoundingBox,
   positionStart = 'middle',
   positionEnd = 'middle',
+  mouseUp = true,
 ) {
   let fromX = fromBoundingBox.x;
   let fromY = fromBoundingBox.y;
@@ -584,7 +585,10 @@ export async function dragMouse(
   }
 
   await page.mouse.move(toX, toY);
-  await page.mouse.up();
+
+  if (mouseUp) {
+    await page.mouse.up();
+  }
 }
 
 export async function dragImage(
@@ -705,7 +709,7 @@ export async function selectCellsFromTableCords(page, firstCords, secondCords) {
   );
 
   // Focus on inside the iFrame or the boundingBox() below returns null.
-  await firstRowFirstColumnCell.click();
+  await firstRowFirstColumnCell.click({clickCount: 2});
 
   await dragMouse(
     page,

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -582,6 +582,7 @@ export async function dragMouse(
     toX += toBoundingBox.width;
     toY += toBoundingBox.height;
   }
+
   await page.mouse.move(toX, toY);
   await page.mouse.up();
 }
@@ -692,24 +693,24 @@ export async function selectCellsFromTableCords(page, firstCords, secondCords) {
     leftFrame = await page.frame('left');
   }
 
-  const firstRowFirstColumnCellBoundingBox = await leftFrame.locator(
+  const firstRowFirstColumnCell = await leftFrame.locator(
     `table:first-of-type > tr:nth-child(${firstCords.y + 1}) > th:nth-child(${
       firstCords.x + 1
     })`,
   );
-  const secondRowSecondCellBoundingBox = await leftFrame.locator(
+  const secondRowSecondCell = await leftFrame.locator(
     `table:first-of-type > tr:nth-child(${secondCords.y + 1}) > td:nth-child(${
       secondCords.x + 1
     })`,
   );
 
   // Focus on inside the iFrame or the boundingBox() below returns null.
-  await firstRowFirstColumnCellBoundingBox.click();
+  await firstRowFirstColumnCell.click();
 
   await dragMouse(
     page,
-    await firstRowFirstColumnCellBoundingBox.boundingBox(),
-    await secondRowSecondCellBoundingBox.boundingBox(),
+    await firstRowFirstColumnCell.boundingBox(),
+    await secondRowSecondCell.boundingBox(),
   );
 }
 

--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -22,6 +22,7 @@ import {
 } from '@lexical/react/LexicalTypeaheadMenuPlugin';
 import {$createHeadingNode, $createQuoteNode} from '@lexical/rich-text';
 import {$wrapNodes} from '@lexical/selection';
+import {INSERT_TABLE_COMMAND} from '@lexical/table';
 import {
   $createParagraphNode,
   $getSelection,
@@ -38,7 +39,6 @@ import catTypingGif from '../../images/cat-typing.gif';
 import {EmbedConfigs} from '../AutoEmbedPlugin';
 import {INSERT_EXCALIDRAW_COMMAND} from '../ExcalidrawPlugin';
 import {INSERT_IMAGE_COMMAND} from '../ImagesPlugin';
-import {INSERT_TABLE_COMMAND} from '../TablePlugin';
 import {
   InsertEquationDialog,
   InsertImageDialog,

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -25,9 +25,9 @@ import {
   TableCellNode,
 } from '@lexical/table';
 import {
+  $getRoot,
   $getSelection,
   $isRangeSelection,
-  $setSelection,
   DEPRECATED_$isGridSelection,
 } from 'lexical';
 import * as React from 'react';
@@ -140,7 +140,8 @@ function TableActionMenu({
         updateTableCellNode(tableCellNode.getLatest());
       }
 
-      $setSelection(null);
+      const rootNode = $getRoot();
+      rootNode.selectStart();
     });
   }, [editor, tableCellNode]);
 

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -22,7 +22,6 @@ import {
   $getRoot,
   $getSelection,
   $isElementNode,
-  $isRangeSelection,
   $setSelection,
   DEPRECATED_$createGridSelection,
   DEPRECATED_$isGridSelection,
@@ -200,10 +199,10 @@ export class TableSelection {
       this.focusCell = null;
       this.hasHijackedSelectionStyles = false;
 
-      $updateDOMForSelection(grid, null);
       $setSelection(null);
 
       this.editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      $updateDOMForSelection(grid, null);
 
       this.enableHighlightStyle();
     });
@@ -319,9 +318,9 @@ export class TableSelection {
 
           $setSelection(this.gridSelection);
 
-          $updateDOMForSelection(this.grid, this.gridSelection);
-
           this.editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+
+          $updateDOMForSelection(this.grid, this.gridSelection);
         }
       }
     });
@@ -393,10 +392,7 @@ export class TableSelection {
 
       const selection = $getSelection();
 
-      if (
-        !DEPRECATED_$isGridSelection(selection) &&
-        !$isRangeSelection(selection)
-      ) {
+      if (!DEPRECATED_$isGridSelection(selection)) {
         invariant(false, 'Expected valid selection');
       }
 
@@ -425,11 +421,11 @@ export class TableSelection {
         }
       });
 
-      $updateDOMForSelection(this.grid, null);
-
       $setSelection(null);
 
       this.editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+
+      $updateDOMForSelection(this.grid, null);
     });
   }
 }

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -334,14 +334,19 @@ export class TableSelection {
       // causes the editor loses focus which breaks the Table selection tests.
       // There must be something happening in onDocumentSelectionChange that
       // prevents this but it might be out of the scope of this PR.
+      // const domSelection = getDOMSelection();
+      // if (domSelection && domSelection.anchorNode && domSelection.focusNode) {
+      //   domSelection.setBaseAndExtent(
+      //     domSelection.anchorNode,
+      //     domSelection.anchorOffset,
+      //     domSelection.focusNode,
+      //     domSelection.focusOffset,
+      //   );
+      // }
+
       const domSelection = getDOMSelection();
-      if (domSelection && domSelection.anchorNode && domSelection.focusNode) {
-        domSelection.setBaseAndExtent(
-          domSelection.anchorNode,
-          domSelection.anchorOffset,
-          domSelection.focusNode,
-          domSelection.focusOffset,
-        );
+      if (domSelection) {
+        domSelection.setBaseAndExtent(cell.elem, 0, cell.elem, 0);
       }
 
       const anchorTableCellNode = $getNearestNodeFromDOMNode(cell.elem);

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -239,15 +239,6 @@ export class TableSelection {
       this.gridSelection = selection;
       this.isHighlightingCells = true;
       this.disableHighlightStyle();
-      const anchorElement = this.editor.getElementByKey(selection.anchor.key);
-      const focusElement = this.editor.getElementByKey(selection.focus.key);
-
-      if (anchorElement && focusElement) {
-        const domSelection = getDOMSelection();
-        if (domSelection) {
-          domSelection.setBaseAndExtent(anchorElement, 0, focusElement, 0);
-        }
-      }
       $updateDOMForSelection(this.grid, this.gridSelection);
     }
 
@@ -279,7 +270,12 @@ export class TableSelection {
       if (this.anchorCell !== null) {
         // Collapse the selection
         if (domSelection) {
-          domSelection.setBaseAndExtent(this.anchorCell.elem, 0, cell.elem, 0);
+          domSelection.setBaseAndExtent(
+            this.anchorCell.elem,
+            0,
+            this.anchorCell.elem,
+            0,
+          );
         }
       }
 
@@ -330,24 +326,6 @@ export class TableSelection {
       this.anchorCell = cell;
       this.startX = cell.x;
       this.startY = cell.y;
-      // This weird bit of code is required otherwise playwright mouse.up()
-      // causes the editor loses focus which breaks the Table selection tests.
-      // There must be something happening in onDocumentSelectionChange that
-      // prevents this but it might be out of the scope of this PR.
-      // const domSelection = getDOMSelection();
-      // if (domSelection && domSelection.anchorNode && domSelection.focusNode) {
-      //   domSelection.setBaseAndExtent(
-      //     domSelection.anchorNode,
-      //     domSelection.anchorOffset,
-      //     domSelection.focusNode,
-      //     domSelection.focusOffset,
-      //   );
-      // }
-
-      const domSelection = getDOMSelection();
-      if (domSelection) {
-        domSelection.setBaseAndExtent(cell.elem, 0, cell.elem, 0);
-      }
 
       const anchorTableCellNode = $getNearestNodeFromDOMNode(cell.elem);
 

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -235,7 +235,7 @@ export class TableSelection {
   }
 
   updateTableGridSelection(selection: GridSelection | null) {
-    if (selection != null) {
+    if (selection != null && selection.gridKey === this.tableNodeKey) {
       this.gridSelection = selection;
       this.isHighlightingCells = true;
       this.disableHighlightStyle();
@@ -249,7 +249,9 @@ export class TableSelection {
         }
       }
       $updateDOMForSelection(this.grid, this.gridSelection);
-    } else {
+    }
+
+    if (selection == null) {
       this.clearHighlight();
     }
   }

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -199,10 +199,10 @@ export class TableSelection {
       this.focusCell = null;
       this.hasHijackedSelectionStyles = false;
 
+      $updateDOMForSelection(grid, null);
       $setSelection(null);
 
       this.editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
-      $updateDOMForSelection(grid, null);
 
       this.enableHighlightStyle();
     });
@@ -393,7 +393,7 @@ export class TableSelection {
       const selection = $getSelection();
 
       if (!DEPRECATED_$isGridSelection(selection)) {
-        invariant(false, 'Expected valid selection');
+        invariant(false, 'Expected grid selection');
       }
 
       const selectedNodes = selection.getNodes().filter($isTableCellNode);
@@ -421,11 +421,11 @@ export class TableSelection {
         }
       });
 
+      $updateDOMForSelection(this.grid, null);
+
       $setSelection(null);
 
       this.editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
-
-      $updateDOMForSelection(this.grid, null);
     });
   }
 }

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -265,9 +265,8 @@ export class TableSelection {
       const cellY = cell.y;
       this.focusCell = cell;
 
-      const domSelection = getDOMSelection();
-
       if (this.anchorCell !== null) {
+        const domSelection = getDOMSelection();
         // Collapse the selection
         if (domSelection) {
           domSelection.setBaseAndExtent(
@@ -323,6 +322,14 @@ export class TableSelection {
 
   setAnchorCellForSelection(cell: Cell) {
     this.editor.update(() => {
+      if (this.anchorCell === cell && this.isHighlightingCells) {
+        const domSelection = getDOMSelection();
+        // Collapse the selection
+        if (domSelection) {
+          domSelection.setBaseAndExtent(cell.elem, 0, cell.elem, 0);
+        }
+      }
+
       this.anchorCell = cell;
       this.startX = cell.x;
       this.startY = cell.y;

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -304,10 +304,7 @@ export class TableSelection {
         ) {
           const focusNodeKey = focusTableCellNode.getKey();
 
-          this.gridSelection =
-            this.gridSelection != null
-              ? this.gridSelection.clone()
-              : DEPRECATED_$createGridSelection();
+          this.gridSelection = DEPRECATED_$createGridSelection();
 
           this.focusCellNodeKey = focusNodeKey;
           this.gridSelection.set(

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -925,11 +925,18 @@ export function applyTableHandlers(
             DEPRECATED_$isGridSelection(prevSelection)) &&
           tableSelection.gridSelection !== selection
         ) {
-          tableSelection.updateTableGridSelection(
-            DEPRECATED_$isGridSelection(selection) && tableNode.isSelected()
-              ? selection
-              : null,
-          );
+          if (
+            DEPRECATED_$isGridSelection(selection) &&
+            selection.gridKey === tableSelection.tableNodeKey
+          ) {
+            tableSelection.updateTableGridSelection(selection);
+          } else if (
+            !DEPRECATED_$isGridSelection(selection) &&
+            DEPRECATED_$isGridSelection(prevSelection) &&
+            prevSelection.gridKey === tableSelection.tableNodeKey
+          ) {
+            tableSelection.updateTableGridSelection(null);
+          }
           return false;
         }
 

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -92,8 +92,6 @@ export function applyTableHandlers(
         return;
       }
 
-      isMouseDown = true;
-
       const cell = getCellFromTarget(event.target as Node);
 
       if (cell !== null) {


### PR DESCRIPTION
Long term the solution is to improve on the React-only approach MVP here (#2929) but this gets the existing solution in much better shape.

This PR fixes the following known table bugs (seen list at bottom).

Most notably, now you can change the block type within a `TableCell` without it breaking.

https://user-images.githubusercontent.com/13852400/189770404-f6fe9a07-289b-4c4e-9530-e067341cb9e8.mov

- [X] If there is no content before the table, when pressing Cmd+A and then the delete key, the table is not deleted completely. One single cell remains and the options menu popover button is misplaced.
- [X] When pressing Cmd+Shift+Delete inside a cell, the table breaks and the cell is deleted.
- [X] After deleting the table, no content can be inserted into Composer without creating a new selection.
- [X] Table cells currently break when content is switched from one type of styling to another (closes #2793).
- [X] Content from cell cannot be easily selected/ can’t move cursor inside text from cell.
- [X] Cannot place cursor outside table (closes #2752)
- [X] Closes #1597
- [X] Closes #2010 
- [X] Closes #2793 