### PR TITLE
Fix bad TypeaheadMenuPlugin prod build

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -252,7 +252,7 @@ function LexicalPopoverMenu<TOption extends TypeaheadOption>({
   }, [resolution.match.matchingString]);
 
   const selectOptionAndCleanUp = useCallback(
-    async (selectedEntry: TOption) => {
+    (selectedEntry: TOption) => {
       editor.update(() => {
         const textNodeContainingQuery = splitNodeContainingQuery(
           editor,


### PR DESCRIPTION
![Screen Shot 2022-09-13 at 8 42 25 am](https://user-images.githubusercontent.com/193447/189903878-df2ca33d-0ee6-4ecd-9729-dd6d18809410.png)

Shouldn't be here in the prod build nor asynchronous behavior is required