### PR TITLE
Strengthen RangeSelection dirty toggle

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -231,7 +231,10 @@ function onSelectionChange(
 
       if (selection.isCollapsed()) {
         // Badly interpreted range selection when collapsed - #1482
-        if (domSelection.type === 'Range') {
+        if (
+          domSelection.type === 'Range' &&
+          domSelection.anchorNode === domSelection.focusNode
+        ) {
           selection.dirty = true;
         }
 


### PR DESCRIPTION
Should resolve part of the issue found in https://github.com/facebook/lexical/issues/2991. This strengthens the logic around making selection dirty.