### PR TITLE
feat(lexical-react): add initialEditorState for LexicalCollaborationPlugin

### DIFF
--- a/packages/lexical-react/src/LexicalCollaborationPlugin.ts
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.ts
@@ -13,6 +13,7 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect, useMemo} from 'react';
 import {WebsocketProvider} from 'y-websocket';
 
+import {InitialEditorStateType} from './LexicalComposer';
 import {
   CursorsContainerRef,
   useYjsCollaboration,
@@ -26,6 +27,7 @@ export function CollaborationPlugin({
   shouldBootstrap,
   username,
   cursorsContainerRef,
+  initialEditorState,
 }: {
   id: string;
   providerFactory: (
@@ -36,6 +38,7 @@ export function CollaborationPlugin({
   shouldBootstrap: boolean;
   username?: string;
   cursorsContainerRef?: CursorsContainerRef;
+  initialEditorState?: InitialEditorStateType;
 }): JSX.Element {
   const collabContext = useCollaborationContext(username);
 
@@ -69,6 +72,7 @@ export function CollaborationPlugin({
     color,
     shouldBootstrap,
     cursorsContainerRef,
+    initialEditorState,
   );
 
   collabContext.clientID = binding.clientID;


### PR DESCRIPTION
This PR is a follow-up of [this discord thread](https://discord.com/channels/953974421008293909/1013899629894565979/1013900284247953498).

I tested this feature, by connecting the WebsocketProvider to my custom Websocket server which removes the YDoc from persistence when there were no connections (last user disconnected)

Here is the `initialEditorState` that I passed to `CollaborationPlugin`

```js
              <CollaborationPlugin
                id="main"
                providerFactory={createWebsocketProvider}
                shouldBootstrap={!skipCollaborationInit}
                initialEditorState={`{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"1","type":"text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"22","type":"text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"333","type":"text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}`}
              />

```

![lexical-init-state-collab](https://user-images.githubusercontent.com/16056918/190136182-b3cf3064-6882-4be7-b9b6-00abd34336a5.gif)

