### PR TITLE
Preserve clipboard color/background-color for TextNode

### DIFF
--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -836,6 +836,10 @@ function convertSpanElement(domNode: Node): DOMConversionOutput {
   const hasUnderlineTextDecoration = span.style.textDecoration === 'underline';
   // Google Docs uses span tags + vertical-align to specify subscript and superscript
   const verticalAlign = span.style.verticalAlign;
+  const color = span.style.color;
+  const backgroundColor = span.style.backgroundColor;
+
+  const rawStyles: string[] = [];
 
   return {
     forChild: (lexicalNode) => {
@@ -859,6 +863,16 @@ function convertSpanElement(domNode: Node): DOMConversionOutput {
       }
       if (verticalAlign === 'super') {
         lexicalNode.toggleFormat('superscript');
+      }
+
+      if (color !== undefined) {
+        rawStyles.push(`color: ${color}`);
+      }
+      if (backgroundColor !== undefined) {
+        rawStyles.push(`background-color: ${backgroundColor}`);
+      }
+      if (rawStyles.length > 0) {
+        lexicalNode.setStyle(rawStyles.join(';'));
       }
 
       return lexicalNode;


### PR DESCRIPTION


https://user-images.githubusercontent.com/193447/190220228-b55485a4-e1cc-4626-8449-cd69e8bbccb2.mov
(Recorded forcing HTML paste)

Not the most complete fix but I'd rather us allow list these properties one by one than having a wildcard and randomly importing all the props from other sources

Closes https://github.com/facebook/lexical/issues/3010