### PR TITLE
Export createEmptyEditorState

### DIFF
--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -22,7 +22,7 @@ export type {
   SerializedEditor,
   Spread,
 } from './LexicalEditor';
-export type {EditorState, SerializedEditorState} from './LexicalEditorState';
+export type {EditorState, SerializedEditorState, createEmptyEditorState} from './LexicalEditorState';
 export type {
   DOMChildConversion,
   DOMConversion,


### PR DESCRIPTION
Useful for resetting the editor to a blank slate.