### PR TITLE
getStyleObjectFromCSS to compute when cache miss

### DIFF
--- a/packages/lexical-selection/flow/LexicalSelection.js.flow
+++ b/packages/lexical-selection/flow/LexicalSelection.js.flow
@@ -25,7 +25,7 @@ declare export function $cloneContents<T: LexicalNode>(
 declare export function $cloneWithProperties<T: LexicalNode>(node: T): T;
 declare export function getStyleObjectFromCSS(css: string): {
   [string]: string,
-} | null;
+};
 declare export function $patchStyleText(
   selection: RangeSelection | GridSelection,
   patch: {

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -298,10 +298,13 @@ function $cloneContentsImpl(
   invariant(false, 'TODO');
 }
 
-export function getStyleObjectFromCSS(
-  css: string,
-): Record<string, string> | null {
-  return cssToStyles.get(css) || null;
+export function getStyleObjectFromCSS(css: string): Record<string, string> {
+  let value = cssToStyles.get(css);
+  if (value === undefined) {
+    value = getStyleObjectFromRawCSS(css);
+    cssToStyles.set(css, value);
+  }
+  return value;
 }
 
 function getStyleObjectFromRawCSS(css: string): Record<string, string> {


### PR DESCRIPTION
We currently offer `$getSelectionStyleValueForProperty` and `$getStyleObjectFromCSS` as a way to directly access the value of the style properties they set on a TextNode.

Problem is it only works when these styles are applied via @lexical/selection, lexical style changes are never taken into account.

There's 3 ways to fix this:
1. Have this function be more generic and less Node centric. The style records are always computed regardless of the source. (They weren't cleaned up anyway)
2. Have some sort of listener that listens to TextNode modifications are updates the Map accordingly (difficult to use)
3. Add to cache whenever you setValue: requires moving all style CSS to core (worth it?)

This PR implements 1 which is the one with the least friction and more user-friendly.

https://github.com/facebook/lexical/issues/3010