### PR TITLE
Add optional cursors container prop for a better positioning in scrollable layouts

### DIFF
--- a/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow
@@ -33,6 +33,7 @@ export type ProviderFactory = (
 
 declare export function CollaborationPlugin(arg0: {
   id: string,
+  cursorsContainerRef?: {current: HTMLElement | null},
   providerFactory: ProviderFactory,
   shouldBootstrap: boolean,
   username?: string,

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.ts
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.ts
@@ -14,6 +14,7 @@ import {useEffect, useMemo} from 'react';
 import {WebsocketProvider} from 'y-websocket';
 
 import {
+  CursorsContainerRef,
   useYjsCollaboration,
   useYjsFocusTracking,
   useYjsHistory,
@@ -24,6 +25,7 @@ export function CollaborationPlugin({
   providerFactory,
   shouldBootstrap,
   username,
+  cursorsContainerRef,
 }: {
   id: string;
   providerFactory: (
@@ -33,6 +35,7 @@ export function CollaborationPlugin({
   ) => WebsocketProvider;
   shouldBootstrap: boolean;
   username?: string;
+  cursorsContainerRef?: CursorsContainerRef;
 }): JSX.Element {
   const collabContext = useCollaborationContext(username);
 
@@ -65,6 +68,7 @@ export function CollaborationPlugin({
     name,
     color,
     shouldBootstrap,
+    cursorsContainerRef,
   );
 
   collabContext.clientID = binding.clientID;

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -37,6 +37,8 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {WebsocketProvider} from 'y-websocket';
 
+export type CursorsContainerRef = React.MutableRefObject<HTMLElement | null>;
+
 export function useYjsCollaboration(
   editor: LexicalEditor,
   id: string,
@@ -45,6 +47,7 @@ export function useYjsCollaboration(
   name: string,
   color: string,
   shouldBootstrap: boolean,
+  cursorsContainerRef?: CursorsContainerRef,
 ): [JSX.Element, Binding] {
   const isReloadingDoc = useRef(false);
   const [doc, setDoc] = useState(docMap.get(id));
@@ -178,8 +181,11 @@ export function useYjsCollaboration(
       binding.cursorsContainer = element;
     };
 
-    return createPortal(<div ref={ref} />, document.body);
-  }, [binding]);
+    return createPortal(
+      <div ref={ref} />,
+      (cursorsContainerRef && cursorsContainerRef.current) || document.body,
+    );
+  }, [binding, cursorsContainerRef]);
 
   useEffect(() => {
     return editor.registerCommand(

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -183,6 +183,12 @@ function updateCursor(
     return;
   }
 
+  const cursorsContainerOffsetParent = cursorsContainer.offsetParent;
+  if (cursorsContainerOffsetParent === null) {
+    return;
+  }
+
+  const containerRect = cursorsContainerOffsetParent.getBoundingClientRect();
   const prevSelection = cursor.selection;
 
   if (nextSelection === null) {
@@ -237,7 +243,9 @@ function updateCursor(
       cursorsContainer.appendChild(selection);
     }
 
-    const style = `position:absolute;top:${selectionRect.top}px;left:${selectionRect.left}px;height:${selectionRect.height}px;width:${selectionRect.width}px;background-color:rgba(${color}, 0.3);pointer-events:none;z-index:5;`;
+    const top = selectionRect.top - containerRect.top;
+    const left = selectionRect.left - containerRect.left;
+    const style = `position:absolute;top:${top}px;left:${left}px;height:${selectionRect.height}px;width:${selectionRect.width}px;background-color:rgba(${color}, 0.3);pointer-events:none;z-index:5;`;
     selection.style.cssText = style;
 
     if (i === selectionRectsLength - 1) {


### PR DESCRIPTION
By default cursors container is appended into body, which works fine for regular layout, but in case it has any nested scrolling or more complicated positioning cursors are not rendered correctly, especially after scrolling. This PR adds `cursorsContainerRef` to `<CollaborationPlugin>` which defines where cursors will be appended.


https://user-images.githubusercontent.com/132642/190506567-913b0270-956a-408a-9642-b070b09a5be1.mov


https://user-images.githubusercontent.com/132642/190506563-127afa67-96da-48be-a367-ba4131dbcdb0.mov

