### PR TITLE
Fix nested mark creation when wrapping forward selection

### DIFF
--- a/packages/lexical-mark/src/index.ts
+++ b/packages/lexical-mark/src/index.ts
@@ -77,13 +77,16 @@ export function $wrapSelectionInMarkNode(
           ? splitNodes[1]
           : splitNodes[0];
     } else if ($isMarkNode(node)) {
-      // Case 2: the node is a mark node and we can ignore it, moving on to its
-      // children. Note that when we make a mark inside another mark, it may
-      // utlimately be unnested by a call to
+      // Case 2: the node is a mark node and we can ignore it as a target,
+      // moving on to its children. Note that when we make a mark inside
+      // another mark, it may utlimately be unnested by a call to
       // `registerNestedElementResolver<MarkNode>` somewhere else in the
       // codebase.
+
       continue;
     } else if ($isElementNode(node) && node.isInline()) {
+      // Case 3: inline element nodes can be added in their entirety to the new
+      // mark
       targetNode = node;
     }
 

--- a/packages/lexical-mark/src/index.ts
+++ b/packages/lexical-mark/src/index.ts
@@ -41,15 +41,19 @@ export function $wrapSelectionInMarkNode(
   const startOffset = isBackward ? focusOffset : anchorOffset;
   const endOffset = isBackward ? anchorOffset : focusOffset;
   let currentNodeParent;
-  let currentMarkNode;
+  let lastCreatedMarkNode;
 
   // We only want wrap adjacent text nodes, line break nodes
   // and inline element nodes. For decorator nodes and block
-  // element nodes, we stop out their boundary and start again
-  // after, if there are more nodes.
+  // element nodes, we step out of their boundary and start
+  // again after, if there are more nodes.
   for (let i = 0; i < nodesLength; i++) {
     const node = nodes[i];
-    if ($isElementNode(currentMarkNode) && currentMarkNode.isParentOf(node)) {
+    if (
+      $isElementNode(lastCreatedMarkNode) &&
+      lastCreatedMarkNode.isParentOf(node)
+    ) {
+      // If the current node is a child of the last created mark node, there is nothing to do here
       continue;
     }
     const isFirstNode = i === 0;
@@ -57,6 +61,7 @@ export function $wrapSelectionInMarkNode(
     let targetNode: LexicalNode | null = null;
 
     if ($isTextNode(node)) {
+      // Case 1: The node is a text node and we can split it
       const textContentSize = node.getTextContentSize();
       const startTextOffset = isFirstNode ? startOffset : 0;
       const endTextOffset = isLastNode ? endOffset : textContentSize;
@@ -71,26 +76,47 @@ export function $wrapSelectionInMarkNode(
           endTextOffset === textContentSize)
           ? splitNodes[1]
           : splitNodes[0];
+    } else if ($isMarkNode(node)) {
+      // Case 2: the node is a mark node and we can ignore it, moving on to its
+      // children. Note that when we make a mark inside another mark, it may
+      // utlimately be unnested by a call to
+      // `registerNestedElementResolver<MarkNode>` somewhere else in the
+      // codebase.
+      continue;
     } else if ($isElementNode(node) && node.isInline()) {
       targetNode = node;
     }
+
     if (targetNode !== null) {
+      // Now that we have a target node for wrapping with a mark, we can run
+      // through special cases.
       if (targetNode && targetNode.is(currentNodeParent)) {
+        // The current node is a child of the target node to be wrapped, there
+        // is nothing to do here.
         continue;
       }
       const parentNode = targetNode.getParent();
       if (parentNode == null || !parentNode.is(currentNodeParent)) {
-        currentMarkNode = undefined;
+        // If the parent node is not the current node's parent node, we can
+        // clear the last created mark node.
+        lastCreatedMarkNode = undefined;
       }
+
       currentNodeParent = parentNode;
-      if (currentMarkNode === undefined) {
-        currentMarkNode = $createMarkNode([id]);
-        targetNode.insertBefore(currentMarkNode);
+
+      if (lastCreatedMarkNode === undefined) {
+        // If we don't have a created mark node, we can make one
+        lastCreatedMarkNode = $createMarkNode([id]);
+        targetNode.insertBefore(lastCreatedMarkNode);
       }
-      currentMarkNode.append(targetNode);
+
+      // Add the target node to be wrapped in the latest created mark node
+      lastCreatedMarkNode.append(targetNode);
     } else {
+      // If we don't have a target node to wrap we can clear our state and
+      // continue on with the next node
       currentNodeParent = undefined;
-      currentMarkNode = undefined;
+      lastCreatedMarkNode = undefined;
     }
   }
 }


### PR DESCRIPTION
As noted in #3026, creating a nested mark while wrapping a forward selection is currently broken because the logic sets all inline elements as the target node to be wrapped, whereas if the inline element is a mark node we should continue in to the existing mark node to split its children, rather than wrap the entire mark node. This only affects forward selections because the forward selection contains the mark node, whereas a backward selection which ends inside another mark node does not include that mark node.

I also added some comments and renamed one variable for additional clarity in following the logic. The comments may be able to be improved, they reflect my understanding of this code just coming to it from the outside.

Fixes #3026
