### PR TITLE
[0.5] Remove initialEditorState from  Plain/RichTextPlugin

### DIFF
--- a/packages/lexical-plain-text/flow/LexicalPlainText.js.flow
+++ b/packages/lexical-plain-text/flow/LexicalPlainText.js.flow
@@ -7,13 +7,5 @@
  * @flow strict
  */
 import type {EditorState, LexicalEditor} from 'lexical';
-export type InitialEditorStateType =
-  | null
-  | string
-  | EditorState
-  | ((editor: LexicalEditor) => void);
 
-declare export function registerPlainText(
-  editor: LexicalEditor,
-  initialEditorState?: InitialEditorStateType,
-): () => void;
+declare export function registerPlainText(editor: LexicalEditor): () => void;

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -7,7 +7,7 @@
  *
  */
 
-import type {CommandPayloadType, EditorState, LexicalEditor} from 'lexical';
+import type {CommandPayloadType, LexicalEditor} from 'lexical';
 
 import {
   $getHtmlContent,
@@ -19,8 +19,6 @@ import {
 } from '@lexical/selection';
 import {mergeRegister} from '@lexical/utils';
 import {
-  $createParagraphNode,
-  $getRoot,
   $getSelection,
   $isRangeSelection,
   COMMAND_PRIORITY_EDITOR,
@@ -43,26 +41,6 @@ import {
   REMOVE_TEXT_COMMAND,
 } from 'lexical';
 import {CAN_USE_BEFORE_INPUT, IS_IOS, IS_SAFARI} from 'shared/environment';
-
-export type InitialEditorStateType =
-  | null
-  | string
-  | EditorState
-  | ((editor: LexicalEditor) => void);
-
-// Convoluted logic to make this work with Flow. Order matters.
-const options = {
-  tag: 'history-merge',
-};
-
-const setEditorOptions: {
-  tag?: string;
-} = options;
-const updateOptions: {
-  onUpdate?: () => void;
-  skipTransforms?: true;
-  tag?: string;
-} = options;
 
 function onCopyForPlainText(
   event: CommandPayloadType<typeof COPY_COMMAND>,
@@ -123,58 +101,7 @@ function onCutForPlainText(
   });
 }
 
-function initializeEditor(
-  editor: LexicalEditor,
-  initialEditorState?: InitialEditorStateType,
-): void {
-  if (initialEditorState === null) {
-    return;
-  } else if (initialEditorState === undefined) {
-    editor.update(() => {
-      const root = $getRoot();
-      if (root.isEmpty()) {
-        const paragraph = $createParagraphNode();
-        root.append(paragraph);
-        const activeElement = document.activeElement;
-
-        if (
-          $getSelection() !== null ||
-          (activeElement !== null && activeElement === editor.getRootElement())
-        ) {
-          paragraph.select();
-        }
-      }
-    }, updateOptions);
-  } else if (initialEditorState !== null) {
-    switch (typeof initialEditorState) {
-      case 'string': {
-        const parsedEditorState = editor.parseEditorState(initialEditorState);
-        editor.setEditorState(parsedEditorState, setEditorOptions);
-        break;
-      }
-
-      case 'object': {
-        editor.setEditorState(initialEditorState, setEditorOptions);
-        break;
-      }
-
-      case 'function': {
-        editor.update(() => {
-          const root = $getRoot();
-          if (root.isEmpty()) {
-            initialEditorState(editor);
-          }
-        }, updateOptions);
-        break;
-      }
-    }
-  }
-}
-
-export function registerPlainText(
-  editor: LexicalEditor,
-  initialEditorState?: InitialEditorStateType,
-): () => void {
+export function registerPlainText(editor: LexicalEditor): () => void {
   const removeListener = mergeRegister(
     editor.registerCommand<boolean>(
       DELETE_CHARACTER_COMMAND,
@@ -462,6 +389,5 @@ export function registerPlainText(
       COMMAND_PRIORITY_EDITOR,
     ),
   );
-  initializeEditor(editor, initialEditorState);
   return removeListener;
 }

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -148,8 +148,6 @@ export default function Editor(): JSX.Element {
                 </div>
               }
               placeholder={placeholder}
-              // TODO Collab support until 0.4
-              initialEditorState={isCollab ? null : undefined}
             />
             <MarkdownShortcutPlugin />
             <CodeHighlightPlugin />
@@ -199,8 +197,6 @@ export default function Editor(): JSX.Element {
             <PlainTextPlugin
               contentEditable={<ContentEditable />}
               placeholder={placeholder}
-              // TODO Collab support until 0.4
-              initialEditorState={isCollab ? null : undefined}
             />
             <HistoryPlugin externalHistoryState={historyState} />
           </>

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -352,8 +352,6 @@ export default function ImageComponent({
                     Enter a caption...
                   </Placeholder>
                 }
-                // TODO Remove after it's inherited from the parent (LexicalComposer)
-                initialEditorState={isCollabActive ? null : undefined}
               />
               {showNestedEditorTreeView === true ? <TreeViewPlugin /> : null}
             </LexicalNestedComposer>

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -255,8 +255,6 @@ export default function StickyComponent({
                 What's up?
               </Placeholder>
             }
-            // TODO Remove after it's inherited from the parent (LexicalComposer)
-            initialEditorState={null}
           />
         </LexicalNestedComposer>
       </div>

--- a/packages/lexical-react/flow/DEPRECATED_useLexicalPlainText.js.flow
+++ b/packages/lexical-react/flow/DEPRECATED_useLexicalPlainText.js.flow
@@ -14,5 +14,4 @@ import type {EditorState, LexicalEditor} from 'lexical';
 declare export function useLexicalPlainText(
   editor: LexicalEditor,
   externalHistoryState?: HistoryState,
-  initialEditorState?: null | string | EditorState | (() => void),
 ): void;

--- a/packages/lexical-react/flow/DEPRECATED_useLexicalRichText.js.flow
+++ b/packages/lexical-react/flow/DEPRECATED_useLexicalRichText.js.flow
@@ -14,5 +14,4 @@ import type {EditorState, LexicalEditor} from 'lexical';
 declare export function useLexicalRichText(
   editor: LexicalEditor,
   externalHistoryState?: HistoryState,
-  initialEditorState?: null | string | EditorState | (() => void),
 ): void;

--- a/packages/lexical-react/flow/LexicalComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalComposer.js.flow
@@ -7,9 +7,18 @@
  * @flow strict
  */
 
-import type {EditorThemeClasses, LexicalEditor, LexicalNode} from 'lexical';
-import type {InitialEditorStateType as InitialEditorStatePlainTextType} from '@lexical/plain-text';
-import type {InitialEditorStateType as InitialEditorStateRichTextType} from '@lexical/rich-text';
+import type {
+  EditorThemeClasses,
+  LexicalEditor,
+  LexicalNode,
+  EditorState,
+} from 'lexical';
+
+export type InitialEditorStateType =
+  | null
+  | string
+  | EditorState
+  | ((editor: LexicalEditor) => void);
 
 type Props = {
   initialConfig: $ReadOnly<{
@@ -18,9 +27,7 @@ type Props = {
     namespace: string,
     nodes?: $ReadOnlyArray<Class<LexicalNode>>,
     theme?: EditorThemeClasses,
-    editorState?:
-      | InitialEditorStateRichTextType
-      | InitialEditorStatePlainTextType,
+    editorState?: InitialEditorStateType,
     onError: (error: Error, editor: LexicalEditor) => void,
   }>,
   children: React$Node,

--- a/packages/lexical-react/src/DEPRECATED_useLexicalPlainText.ts
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalPlainText.ts
@@ -7,7 +7,7 @@
  */
 
 import type {HistoryState} from './DEPRECATED_useLexicalHistory';
-import type {EditorState, LexicalEditor} from 'lexical';
+import type {LexicalEditor} from 'lexical';
 
 import {useLexicalHistory} from './DEPRECATED_useLexicalHistory';
 import {usePlainTextSetup} from './shared/usePlainTextSetup';
@@ -15,8 +15,7 @@ import {usePlainTextSetup} from './shared/usePlainTextSetup';
 export function useLexicalPlainText(
   editor: LexicalEditor,
   externalHistoryState?: HistoryState,
-  initialEditorState?: null | string | EditorState | (() => void),
 ): void {
-  usePlainTextSetup(editor, initialEditorState);
+  usePlainTextSetup(editor);
   useLexicalHistory(editor, externalHistoryState);
 }

--- a/packages/lexical-react/src/DEPRECATED_useLexicalRichText.ts
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalRichText.ts
@@ -7,7 +7,7 @@
  */
 
 import type {HistoryState} from './DEPRECATED_useLexicalHistory';
-import type {EditorState, LexicalEditor} from 'lexical';
+import type {LexicalEditor} from 'lexical';
 
 import {useLexicalHistory} from './DEPRECATED_useLexicalHistory';
 import {useRichTextSetup} from './shared/useRichTextSetup';
@@ -15,8 +15,7 @@ import {useRichTextSetup} from './shared/useRichTextSetup';
 export function useLexicalRichText(
   editor: LexicalEditor,
   externalHistoryState?: HistoryState,
-  initialEditorState?: null | string | EditorState | (() => void),
 ): void {
-  useRichTextSetup(editor, initialEditorState);
+  useRichTextSetup(editor);
   useLexicalHistory(editor, externalHistoryState);
 }

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -7,17 +7,19 @@
  */
 
 import type {LexicalComposerContextType} from '@lexical/react/LexicalComposerContext';
-import type {Klass} from 'lexical';
 
 import {
   createLexicalComposerContext,
   LexicalComposerContext,
 } from '@lexical/react/LexicalComposerContext';
 import {
+  $createParagraphNode,
   $getRoot,
+  $getSelection,
   createEditor,
   EditorState,
   EditorThemeClasses,
+  Klass,
   LexicalEditor,
   LexicalNode,
 } from 'lexical';
@@ -109,21 +111,20 @@ function initializeEditor(
   if (initialEditorState === null) {
     return;
   } else if (initialEditorState === undefined) {
-    // TODO Uncomment in 0.4
-    // editor.update(() => {
-    //   const root = $getRoot();
-    //   if (root.isEmpty()) {
-    //     const paragraph = $createParagraphNode();
-    //     root.append(paragraph);
-    //     const activeElement = document.activeElement;
-    //     if (
-    //       $getSelection() !== null ||
-    //       (activeElement !== null && activeElement === editor.getRootElement())
-    //     ) {
-    //       paragraph.select();
-    //     }
-    //   }
-    // }, HISTORY_MERGE_OPTIONS);
+    editor.update(() => {
+      const root = $getRoot();
+      if (root.isEmpty()) {
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
+        const activeElement = document.activeElement;
+        if (
+          $getSelection() !== null ||
+          (activeElement !== null && activeElement === editor.getRootElement())
+        ) {
+          paragraph.select();
+        }
+      }
+    }, HISTORY_MERGE_OPTIONS);
   } else if (initialEditorState !== null) {
     switch (typeof initialEditorState) {
       case 'string': {

--- a/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
@@ -6,40 +6,24 @@
  *
  */
 
-import {InitialEditorStateType} from '@lexical/plain-text';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
-import warnOnlyOnce from 'shared/warnOnlyOnce';
 
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 import {useDecorators} from './shared/useDecorators';
 import {usePlainTextSetup} from './shared/usePlainTextSetup';
 
-const deprecatedInitialEditorStateWarning = warnOnlyOnce(
-  '`initialEditorState` on `PlainTextPlugin` is deprecated and will be removed soon. Use the `initialConfig.editorState` prop on the `LexicalComposer` instead.',
-);
-
 export function PlainTextPlugin({
   contentEditable,
   placeholder,
-  initialEditorState,
 }: {
   contentEditable: JSX.Element;
-  // TODO Remove in 0.4
-  initialEditorState?: InitialEditorStateType;
   placeholder: JSX.Element | string;
 }): JSX.Element {
-  if (
-    __DEV__ &&
-    deprecatedInitialEditorStateWarning &&
-    initialEditorState !== undefined
-  ) {
-    deprecatedInitialEditorStateWarning();
-  }
   const [editor] = useLexicalComposerContext();
   const showPlaceholder = useCanShowPlaceholder(editor);
   const decorators = useDecorators(editor);
-  usePlainTextSetup(editor, initialEditorState);
+  usePlainTextSetup(editor);
 
   return (
     <>

--- a/packages/lexical-react/src/LexicalRichTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalRichTextPlugin.tsx
@@ -7,39 +7,23 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {InitialEditorStateType} from '@lexical/rich-text';
 import * as React from 'react';
-import warnOnlyOnce from 'shared/warnOnlyOnce';
 
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 import {useDecorators} from './shared/useDecorators';
 import {useRichTextSetup} from './shared/useRichTextSetup';
 
-const deprecatedInitialEditorStateWarning = warnOnlyOnce(
-  '`initialEditorState` on `RichTextPlugin` is deprecated and will be removed soon. Use the `initialConfig.editorState` prop on the `LexicalComposer` instead.',
-);
-
 export function RichTextPlugin({
   contentEditable,
   placeholder,
-  initialEditorState,
 }: Readonly<{
   contentEditable: JSX.Element;
-  // TODO Remove in 0.4
-  initialEditorState?: InitialEditorStateType;
   placeholder: JSX.Element | string;
 }>): JSX.Element {
-  if (
-    __DEV__ &&
-    deprecatedInitialEditorStateWarning &&
-    initialEditorState !== undefined
-  ) {
-    deprecatedInitialEditorStateWarning();
-  }
   const [editor] = useLexicalComposerContext();
   const showPlaceholder = useCanShowPlaceholder(editor);
   const decorators = useDecorators(editor);
-  useRichTextSetup(editor, initialEditorState);
+  useRichTextSetup(editor);
 
   return (
     <>

--- a/packages/lexical-react/src/__tests__/unit/utils.tsx
+++ b/packages/lexical-react/src/__tests__/unit/utils.tsx
@@ -39,7 +39,7 @@ function Editor({doc, provider, setEditor}) {
       />
       <RichTextPlugin
         contentEditable={<ContentEditable />}
-        placeholder={null}
+        placeholder={<></>}
       />
     </>
   );
@@ -160,6 +160,7 @@ class Client {
       reactRoot.render(
         <LexicalComposer
           initialConfig={{
+            editorState: null,
             namespace: '',
             onError: () => {
               throw Error();

--- a/packages/lexical-react/src/shared/usePlainTextSetup.ts
+++ b/packages/lexical-react/src/shared/usePlainTextSetup.ts
@@ -9,17 +9,14 @@
 import type {LexicalEditor} from 'lexical';
 
 import {registerDragonSupport} from '@lexical/dragon';
-import {InitialEditorStateType, registerPlainText} from '@lexical/plain-text';
+import {registerPlainText} from '@lexical/plain-text';
 import {mergeRegister} from '@lexical/utils';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
-export function usePlainTextSetup(
-  editor: LexicalEditor,
-  initialEditorState?: InitialEditorStateType,
-): void {
+export function usePlainTextSetup(editor: LexicalEditor): void {
   useLayoutEffect(() => {
     return mergeRegister(
-      registerPlainText(editor, initialEditorState),
+      registerPlainText(editor),
       registerDragonSupport(editor),
     );
 

--- a/packages/lexical-react/src/shared/useRichTextSetup.ts
+++ b/packages/lexical-react/src/shared/useRichTextSetup.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import type {InitialEditorStateType} from '@lexical/rich-text';
 import type {LexicalEditor} from 'lexical';
 
 import {registerDragonSupport} from '@lexical/dragon';
@@ -14,13 +13,10 @@ import {registerRichText} from '@lexical/rich-text';
 import {mergeRegister} from '@lexical/utils';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
-export function useRichTextSetup(
-  editor: LexicalEditor,
-  initialEditorState?: InitialEditorStateType,
-): void {
+export function useRichTextSetup(editor: LexicalEditor): void {
   useLayoutEffect(() => {
     return mergeRegister(
-      registerRichText(editor, initialEditorState),
+      registerRichText(editor),
       registerDragonSupport(editor),
     );
 

--- a/packages/lexical-rich-text/flow/LexicalRichText.js.flow
+++ b/packages/lexical-rich-text/flow/LexicalRichText.js.flow
@@ -16,11 +16,6 @@ import type {
   LexicalEditor,
 } from 'lexical';
 import {ElementNode} from 'lexical';
-export type InitialEditorStateType =
-  | null
-  | string
-  | EditorState
-  | ((editor: LexicalEditor) => void);
 
 declare export class QuoteNode extends ElementNode {
   static getType(): string;
@@ -54,7 +49,4 @@ declare export function $createHeadingNode(
 declare export function $isHeadingNode(
   node: ?LexicalNode,
 ): boolean %checks(node instanceof HeadingNode);
-declare export function registerRichText(
-  editor: LexicalEditor,
-  initialEditorState?: InitialEditorStateType,
-): () => void;
+declare export function registerRichText(editor: LexicalEditor): () => void;

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -506,6 +506,7 @@ export class TextNode extends LexicalNode {
 
   // TODO 0.5 This should just be a `string`.
   setDetail(detail: TextDetailType | number): this {
+    //
     const self = this.getWritable();
     self.__detail =
       typeof detail === 'string' ? DETAIL_TYPE_TO_DETAIL[detail] : detail;

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -506,7 +506,6 @@ export class TextNode extends LexicalNode {
 
   // TODO 0.5 This should just be a `string`.
   setDetail(detail: TextDetailType | number): this {
-    //
     const self = this.getWritable();
     self.__detail =
       typeof detail === 'string' ? DETAIL_TYPE_TO_DETAIL[detail] : detail;


### PR DESCRIPTION
Remove warning, make the change permanent