### PR TITLE
Add position property to menus & disable floating link toolbar for autolink nodes

### DIFF
--- a/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
@@ -179,7 +179,6 @@ function AutoEmbedMenuItem({
       id={'typeahead-item-' + index}
       onMouseEnter={onMouseEnter}
       onClick={onClick}>
-      {option.icon}
       <span className="text">{option.title}</span>
     </li>
   );

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -7,9 +7,9 @@
  */
 import './index.css';
 
-import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
+import {$isAutoLinkNode, $isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {mergeRegister} from '@lexical/utils';
+import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
   $getSelection,
   $isRangeSelection,
@@ -217,8 +217,11 @@ function useFloatingLinkEditorToolbar(
     const selection = $getSelection();
     if ($isRangeSelection(selection)) {
       const node = getSelectedNode(selection);
-      const parent = node.getParent();
-      if ($isLinkNode(parent) || $isLinkNode(node)) {
+      const linkParent = $findMatchingParent(node, $isLinkNode);
+      const autoLinkParent = $findMatchingParent(node, $isAutoLinkNode);
+
+      // We don't want this menu to open for auto links.
+      if (linkParent != null && autoLinkParent == null) {
         setIsLink(true);
       } else {
         setIsLink(false);

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -58,18 +58,15 @@ export type EmbedMenuComponent = React.ComponentType<EmbedMenuProps>;
 
 export class AutoEmbedOption extends TypeaheadOption {
   title: string;
-  icon?: JSX.Element;
   onSelect: (targetNode: LexicalNode | null) => void;
   constructor(
     title: string,
     options: {
-      icon?: JSX.Element;
       onSelect: (targetNode: LexicalNode | null) => void;
     },
   ) {
     super(title);
     this.title = title;
-    this.icon = options.icon;
     this.onSelect = options.onSelect.bind(this);
   }
 }

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -44,6 +44,7 @@ export type QueryMatch = {
 
 export type Resolution = {
   match: QueryMatch;
+  position: 'start' | 'end';
   getRect: () => ClientRect;
 };
 
@@ -505,6 +506,7 @@ export type TypeaheadMenuPluginArgs<TOption extends TypeaheadOption> = {
   options: Array<TOption>;
   menuRenderFn: MenuRenderFn<TOption>;
   triggerFn: TriggerFn;
+  position?: 'start' | 'end';
 };
 
 export type TriggerFn = (
@@ -518,6 +520,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends TypeaheadOption>({
   onSelectOption,
   menuRenderFn,
   triggerFn,
+  position = 'start',
 }: TypeaheadMenuPluginArgs<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<Resolution | null>(null);
@@ -558,6 +561,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends TypeaheadOption>({
               setResolution({
                 getRect: () => range.getBoundingClientRect(),
                 match,
+                position,
               }),
             );
             return;
@@ -573,7 +577,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends TypeaheadOption>({
       activeRange = null;
       removeUpdateListener();
     };
-  }, [editor, triggerFn, onQueryChange, resolution]);
+  }, [editor, triggerFn, onQueryChange, resolution, position]);
 
   const closeTypeahead = useCallback(() => {
     setResolution(null);
@@ -602,12 +606,14 @@ type NodeMenuPluginArgs<TOption extends TypeaheadOption> = {
   options: Array<TOption>;
   nodeKey: NodeKey | null;
   onClose: () => void;
+  position?: 'start' | 'end';
   menuRenderFn: MenuRenderFn<TOption>;
 };
 
 export function LexicalNodeMenuPlugin<TOption extends TypeaheadOption>({
   options,
   nodeKey,
+  position = 'end',
   onClose,
   onSelectOption,
   menuRenderFn,
@@ -633,6 +639,7 @@ export function LexicalNodeMenuPlugin<TOption extends TypeaheadOption>({
                 matchingString: text,
                 replaceableString: text,
               },
+              position,
             }),
           );
         }
@@ -640,7 +647,7 @@ export function LexicalNodeMenuPlugin<TOption extends TypeaheadOption>({
     } else if (nodeKey == null && resolution != null) {
       setResolution(null);
     }
-  }, [editor, nodeKey, resolution]);
+  }, [editor, nodeKey, position, resolution]);
 
   return resolution === null || editor === null ? null : (
     <LexicalPopoverMenu

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -467,9 +467,13 @@ function useAnchorElementRef(
       containerDiv.setAttribute('id', 'typeahead-menu');
       containerDiv.setAttribute('role', 'listbox');
       if (rootElement !== null && resolution !== null) {
-        const {left, top, height} = resolution.getRect();
+        const {left, top, width, height} = resolution.getRect();
         containerDiv.style.top = `${top + height + 5 + window.pageYOffset}px`;
-        containerDiv.style.left = `${left + window.pageXOffset}px`;
+        containerDiv.style.left = `${
+          left +
+          (resolution.position === 'start' ? 0 : width) +
+          window.pageXOffset
+        }px`;
         containerDiv.style.display = 'block';
         containerDiv.style.position = 'absolute';
         if (!containerDiv.isConnected) {


### PR DESCRIPTION
Before (notice the embed/dismiss menu is on the left + the floating menu opens even though it's an autolink)
<img width="808" alt="image" src="https://user-images.githubusercontent.com/13852400/191139959-22b36df2-a719-481a-b9ba-72590a0efb3e.png">

After (correct positioning)
<img width="883" alt="image" src="https://user-images.githubusercontent.com/13852400/191139874-34057eee-aaca-443a-9451-05e7d8d433d0.png">
