### PR TITLE
Revise Vite compression

### DIFF
--- a/packages/lexical-playground/vite.prod.config.js
+++ b/packages/lexical-playground/vite.prod.config.js
@@ -13,6 +13,7 @@ import path from 'path';
 import fs from 'fs';
 import {replaceCodePlugin} from 'vite-plugin-replace';
 import babel from '@rollup/plugin-babel';
+import terser from 'terser';
 
 const moduleResolution = [
   {
@@ -183,5 +184,14 @@ export default defineConfig({
       },
     },
     commonjsOptions: {include: []},
+    minify: 'terser',
+    terserOptions: {
+      compress: {
+        arguments: true,
+        booleans_as_integers: true,
+        module: true,
+        toplevel: true,
+      }
+    },
   },
 });

--- a/packages/lexical-playground/vite.prod.config.js
+++ b/packages/lexical-playground/vite.prod.config.js
@@ -13,7 +13,6 @@ import path from 'path';
 import fs from 'fs';
 import {replaceCodePlugin} from 'vite-plugin-replace';
 import babel from '@rollup/plugin-babel';
-import terser from 'terser';
 
 const moduleResolution = [
   {


### PR DESCRIPTION
Seems like these props shave 93.8KB (-4.2%) on our Playground main.js prod build