### PR TITLE
⏸ TextNode setFormat/setDetail to accept a number only

### DIFF
--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -113,7 +113,7 @@ export class MentionNode extends TextNode {
 
 export function $createMentionNode(mentionName: string): MentionNode {
   const mentionNode = new MentionNode(mentionName);
-  mentionNode.setMode('segmented').toggleDirectionless();
+  mentionNode.setMode('segmented').toggleDetail('directionless');
   return mentionNode;
 }
 

--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -365,8 +365,8 @@ const FORMAT_PREDICATES = [
 ];
 
 const DETAIL_PREDICATES = [
-  (node: LexicalNode) => node.isDirectionless() && 'Directionless',
-  (node: LexicalNode) => node.isUnmergeable() && 'Unmergeable',
+  (node: LexicalNode) => node.hasDetail('directionless') && 'Directionless',
+  (node: LexicalNode) => node.hasDetail('unmergeable') && 'Unmergeable',
 ];
 
 const MODE_PREDICATES = [

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -39,7 +39,7 @@ function createParagraphWithNodes(editor, nodes) {
     nodeMap.set(key, textNode);
 
     if (!mergeable) {
-      textNode.toggleUnmergeable();
+      textNode.toggleDetail('unmergeable');
     }
 
     paragraph.append(textNode);

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -550,6 +550,7 @@ export type TextFormatType =
   | 'subscript'
   | 'superscript';
 type TextModeType = 'normal' | 'token' | 'segmented';
+type TextDetailType = 'directionless' | 'unmergeable';
 
 declare export class TextNode extends LexicalNode {
   __text: string;
@@ -582,11 +583,11 @@ declare export class TextNode extends LexicalNode {
   setFormat(format: number): this;
   setStyle(style: string): this;
   toggleFormat(type: TextFormatType): TextNode;
-  toggleDirectionless(): this;
-  toggleUnmergeable(): this;
   setMode(type: TextModeType): this;
   setDetail(detail: number): this;
   getDetail(): number;
+  toggleDetail(detail: TextDetailType): this;
+  hasDetail(type: TextDetailType): boolean;
   getMode(): TextModeType;
   setTextContent(text: string): TextNode;
   select(_anchorOffset?: number, _focusOffset?: number): RangeSelection;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -565,8 +565,6 @@ declare export class TextNode extends LexicalNode {
   isComposing(): boolean;
   isToken(): boolean;
   isSegmented(): boolean;
-  isDirectionless(): boolean;
-  isUnmergeable(): boolean;
   hasFormat(type: TextFormatType): boolean;
   isSimpleText(): boolean;
   getTextContent(): string;

--- a/packages/lexical/src/LexicalNormalization.ts
+++ b/packages/lexical/src/LexicalNormalization.ts
@@ -42,7 +42,11 @@ function $mergeTextNodes(node1: TextNode, node2: TextNode): TextNode {
 export function $normalizeTextNode(textNode: TextNode): void {
   let node = textNode;
 
-  if (node.__text === '' && node.isSimpleText() && !node.isUnmergeable()) {
+  if (
+    node.__text === '' &&
+    node.isSimpleText() &&
+    !node.hasDetail('unmergeable')
+  ) {
     node.remove();
     return;
   }
@@ -54,7 +58,7 @@ export function $normalizeTextNode(textNode: TextNode): void {
     (previousNode = node.getPreviousSibling()) !== null &&
     $isTextNode(previousNode) &&
     previousNode.isSimpleText() &&
-    !previousNode.isUnmergeable()
+    !previousNode.hasDetail('unmergeable')
   ) {
     if (previousNode.__text === '') {
       previousNode.remove();
@@ -73,7 +77,7 @@ export function $normalizeTextNode(textNode: TextNode): void {
     (nextNode = node.getNextSibling()) !== null &&
     $isTextNode(nextNode) &&
     nextNode.isSimpleText() &&
-    !nextNode.isUnmergeable()
+    !nextNode.hasDetail('unmergeable')
   ) {
     if (nextNode.__text === '') {
       nextNode.remove();

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -197,7 +197,7 @@ function createNode(
       // Decorators are always non editable
       dom.contentEditable = 'false';
     } else if ($isTextNode(node)) {
-      if (!node.isDirectionless()) {
+      if (!node.hasDetail('directionless')) {
         subTreeDirectionedTextContent += text;
       }
     }
@@ -502,7 +502,7 @@ function reconcileNode(
     } else {
       const text = prevNode.getTextContent();
 
-      if ($isTextNode(prevNode) && !prevNode.isDirectionless()) {
+      if ($isTextNode(prevNode) && !prevNode.hasDetail('directionless')) {
         subTreeDirectionedTextContent += text;
       }
 
@@ -575,7 +575,7 @@ function reconcileNode(
       if (decorator !== null) {
         reconcileDecorator(key, decorator);
       }
-    } else if ($isTextNode(nextNode) && !nextNode.isDirectionless()) {
+    } else if ($isTextNode(nextNode) && !nextNode.hasDetail('directionless')) {
       // Handle text content, for LTR, LTR cases.
       subTreeDirectionedTextContent += text;
     }

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -156,7 +156,7 @@ function $normalizeAllDirtyTextNodes(
       $isTextNode(node) &&
       node.isAttached() &&
       node.isSimpleText() &&
-      !node.isUnmergeable()
+      !node.hasDetail('unmergeable')
     ) {
       $normalizeTextNode(node);
     }
@@ -203,7 +203,7 @@ function $applyAllTransforms(
           $isTextNode(node) &&
           node.isAttached() &&
           node.isSimpleText() &&
-          !node.isUnmergeable()
+          !node.hasDetail('unmergeable')
         ) {
           $normalizeTextNode(node);
         }

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -543,8 +543,8 @@ describe('LexicalEditor tests', () => {
       const paragraph = $createParagraphNode();
       root.append(paragraph);
       paragraph.append(
-        $createTextNode('Foo').toggleUnmergeable(),
-        $createTextNode('Bar').toggleUnmergeable(),
+        $createTextNode('Foo').toggleDetail('unmergeable'),
+        $createTextNode('Bar').toggleDetail('unmergeable'),
       );
     });
 
@@ -625,7 +625,7 @@ describe('LexicalEditor tests', () => {
         const textNodes = [];
 
         for (let i = 0; i < 6; i++) {
-          const node = $createTextNode(String(i)).toggleUnmergeable();
+          const node = $createTextNode(String(i)).toggleDetail('unmergeable');
           textNodes.push(node);
           textNodeKeys.push(node.getKey());
           textTransformCount[i] = 0;
@@ -693,7 +693,7 @@ describe('LexicalEditor tests', () => {
     it('on append', async () => {
       await editor.update(() => {
         const paragraph1 = $getRoot().getFirstChild<ParagraphNode>();
-        paragraph1.append($createTextNode('6').toggleUnmergeable());
+        paragraph1.append($createTextNode('6').toggleDetail('unmergeable'));
         textTransformCount.push(0);
       });
       expect(textTransformCount).toEqual([1, 1, 2, 1, 1, 1, 1]);
@@ -1374,7 +1374,9 @@ describe('LexicalEditor tests', () => {
 
           for (let i = 0; i < previous.length; i++) {
             const previousText = previous[i];
-            const textNode = new TextNode(previousText).toggleUnmergeable();
+            const textNode = new TextNode(previousText).toggleDetail(
+              'unmergeable',
+            );
             textNode.__parent = writableParagraph.__key;
 
             writableParagraph.__children.push(textNode.__key);
@@ -1414,7 +1416,7 @@ describe('LexicalEditor tests', () => {
 
             if (nextKey === undefined) {
               // New node; append to the end
-              textNode = new TextNode(nextText).toggleUnmergeable();
+              textNode = new TextNode(nextText).toggleDetail('unmergeable');
               textNode.__parent = writableParagraph.__key;
 
               expect($getNodeByKey(nextKey)).toBe(null);

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -302,7 +302,7 @@ describe('LexicalNode tests', () => {
 
         await editor.update(() => {
           barTextNode = new TextNode('bar');
-          barTextNode.toggleUnmergeable();
+          barTextNode.toggleDetail('unmergeable');
           paragraphNode.append(barTextNode);
         });
 
@@ -324,9 +324,9 @@ describe('LexicalNode tests', () => {
 
         await editor.update(() => {
           barTextNode = new TextNode('bar');
-          barTextNode.toggleUnmergeable();
+          barTextNode.toggleDetail('unmergeable');
           bazTextNode = new TextNode('baz');
-          bazTextNode.toggleUnmergeable();
+          bazTextNode.toggleDetail('unmergeable');
           paragraphNode.append(barTextNode, bazTextNode);
         });
 
@@ -351,7 +351,7 @@ describe('LexicalNode tests', () => {
 
         await editor.update(() => {
           barTextNode = new TextNode('bar');
-          barTextNode.toggleUnmergeable();
+          barTextNode.toggleDetail('unmergeable');
           paragraphNode.append(barTextNode);
         });
 
@@ -373,9 +373,9 @@ describe('LexicalNode tests', () => {
 
         await editor.update(() => {
           barTextNode = new TextNode('bar');
-          barTextNode.toggleUnmergeable();
+          barTextNode.toggleDetail('unmergeable');
           bazTextNode = new TextNode('baz');
-          bazTextNode.toggleUnmergeable();
+          bazTextNode.toggleDetail('unmergeable');
           paragraphNode.append(barTextNode, bazTextNode);
         });
 
@@ -406,12 +406,12 @@ describe('LexicalNode tests', () => {
           const rootNode = $getRoot();
           barParagraphNode = new ParagraphNode();
           barTextNode = new TextNode('bar');
-          barTextNode.toggleUnmergeable();
+          barTextNode.toggleDetail('unmergeable');
           bazParagraphNode = new ParagraphNode();
           bazTextNode = new TextNode('baz');
-          bazTextNode.toggleUnmergeable();
+          bazTextNode.toggleDetail('unmergeable');
           quxTextNode = new TextNode('qux');
-          quxTextNode.toggleUnmergeable();
+          quxTextNode.toggleDetail('unmergeable');
           paragraphNode.append(quxTextNode);
           expect(barTextNode.getCommonAncestor(bazTextNode)).toBe(null);
           barParagraphNode.append(barTextNode);
@@ -447,9 +447,9 @@ describe('LexicalNode tests', () => {
 
         await editor.update(() => {
           barTextNode = new TextNode('bar');
-          barTextNode.toggleUnmergeable();
+          barTextNode.toggleDetail('unmergeable');
           bazTextNode = new TextNode('baz');
-          bazTextNode.toggleUnmergeable();
+          bazTextNode.toggleDetail('unmergeable');
           paragraphNode.append(barTextNode, bazTextNode);
         });
 
@@ -493,12 +493,12 @@ describe('LexicalNode tests', () => {
         await editor.update(() => {
           const rootNode = $getRoot();
           barTextNode = new TextNode('bar');
-          barTextNode.toggleUnmergeable();
+          barTextNode.toggleDetail('unmergeable');
           bazTextNode = new TextNode('baz');
-          bazTextNode.toggleUnmergeable();
+          bazTextNode.toggleDetail('unmergeable');
           newParagraphNode = new ParagraphNode();
           quxTextNode = new TextNode('qux');
-          quxTextNode.toggleUnmergeable();
+          quxTextNode.toggleDetail('unmergeable');
           rootNode.append(newParagraphNode);
           paragraphNode.append(barTextNode, bazTextNode);
           newParagraphNode.append(quxTextNode);
@@ -571,15 +571,15 @@ describe('LexicalNode tests', () => {
         expect(() => textNode.isSegmented()).toThrow();
       });
 
-      test('LexicalNode.isDirectionless()', async () => {
+      test('LexicalNode.hasDetail("directionless")', async () => {
         const {editor} = testEnv;
         let directionlessTextNode;
 
         await editor.update(() => {
-          directionlessTextNode = new TextNode(
+          directionlessTextNode = new TextNode('directionless').toggleDetail(
             'directionless',
-          ).toggleDirectionless();
-          directionlessTextNode.toggleUnmergeable();
+          );
+          directionlessTextNode.toggleDetail('unmergeable');
           paragraphNode.append(directionlessTextNode);
         });
 
@@ -588,10 +588,12 @@ describe('LexicalNode tests', () => {
         );
 
         await editor.getEditorState().read(() => {
-          expect(textNode.isDirectionless()).toBe(false);
-          expect(directionlessTextNode.isDirectionless()).toBe(true);
+          expect(textNode.hasDetail('directionless')).toBe(false);
+          expect(directionlessTextNode.hasDetail('directionless')).toBe(true);
         });
-        expect(() => directionlessTextNode.isDirectionless()).toThrow();
+        expect(() =>
+          directionlessTextNode.hasDetail('directionless'),
+        ).toThrow();
       });
 
       test('LexicalNode.getLatest()', async () => {
@@ -798,7 +800,7 @@ describe('LexicalNode tests', () => {
         );
 
         await editor.update(() => {
-          const barTextNode = new TextNode(`bar`).toggleDirectionless();
+          const barTextNode = new TextNode(`bar`).toggleDetail('directionless');
           textNode.replace(barTextNode);
         });
 
@@ -876,7 +878,7 @@ describe('LexicalNode tests', () => {
         );
 
         await editor.update(() => {
-          const barTextNode = new TextNode(`bar`).toggleDirectionless();
+          const barTextNode = new TextNode(`bar`).toggleDetail('directionless');
           textNode.insertAfter(barTextNode);
         });
 
@@ -929,11 +931,11 @@ describe('LexicalNode tests', () => {
           block2 = new ParagraphNode();
           block3 = new ParagraphNode();
           text1 = new TextNode('A');
-          text1.toggleUnmergeable();
+          text1.toggleDetail('unmergeable');
           text2 = new TextNode('B');
-          text2.toggleUnmergeable();
+          text2.toggleDetail('unmergeable');
           text3 = new TextNode('C');
-          text3.toggleUnmergeable();
+          text3.toggleDetail('unmergeable');
           block1.append(text1);
           block2.append(text2);
           block3.append(text3);
@@ -1045,7 +1047,7 @@ describe('LexicalNode tests', () => {
         );
 
         await editor.update(() => {
-          const barTextNode = new TextNode(`bar`).toggleDirectionless();
+          const barTextNode = new TextNode(`bar`).toggleDetail('directionless');
           textNode.insertBefore(barTextNode);
         });
 

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -496,16 +496,13 @@ export class TextNode extends LexicalNode {
     return;
   }
 
-  // TODO 0.5 This should just be a `string`.
-  setFormat(format: TextFormatType | number): this {
+  setFormat(format: number): this {
     const self = this.getWritable();
-    self.__format =
-      typeof format === 'string' ? TEXT_TYPE_TO_FORMAT[format] : format;
+    self.__format = format;
     return self;
   }
 
-  // TODO 0.5 This should just be a `string`.
-  setDetail(detail: TextDetailType | number): this {
+  setDetail(detail: number): this {
     const self = this.getWritable();
     self.__detail =
       typeof detail === 'string' ? DETAIL_TYPE_TO_DETAIL[detail] : detail;

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -28,7 +28,6 @@ import {
   DETAIL_TYPE_TO_DETAIL,
   IS_BOLD,
   IS_CODE,
-  IS_DIRECTIONLESS,
   IS_ITALIC,
   IS_SEGMENTED,
   IS_STRIKETHROUGH,
@@ -36,7 +35,6 @@ import {
   IS_SUPERSCRIPT,
   IS_TOKEN,
   IS_UNDERLINE,
-  IS_UNMERGEABLE,
   TEXT_MODE_TO_TYPE,
   TEXT_TYPE_TO_FORMAT,
   TEXT_TYPE_TO_MODE,
@@ -69,7 +67,7 @@ export type SerializedTextNode = Spread<
   SerializedLexicalNode
 >;
 
-export type TextDetailType = 'directionless' | 'unmergable';
+export type TextDetailType = 'directionless' | 'unmergeable';
 
 export type TextFormatType =
   | 'bold'
@@ -311,19 +309,14 @@ export class TextNode extends LexicalNode {
     return self.__mode === IS_SEGMENTED;
   }
 
-  isDirectionless(): boolean {
-    const self = this.getLatest();
-    return (self.__detail & IS_DIRECTIONLESS) !== 0;
-  }
-
-  isUnmergeable(): boolean {
-    const self = this.getLatest();
-    return (self.__detail & IS_UNMERGEABLE) !== 0;
-  }
-
   hasFormat(type: TextFormatType): boolean {
     const formatFlag = TEXT_TYPE_TO_FORMAT[type];
     return (this.getFormat() & formatFlag) !== 0;
+  }
+
+  hasDetail(type: TextDetailType): boolean {
+    const detailFlag = DETAIL_TYPE_TO_DETAIL[type];
+    return (this.getDetail() & detailFlag) !== 0;
   }
 
   isSimpleText(): boolean {
@@ -504,8 +497,7 @@ export class TextNode extends LexicalNode {
 
   setDetail(detail: number): this {
     const self = this.getWritable();
-    self.__detail =
-      typeof detail === 'string' ? DETAIL_TYPE_TO_DETAIL[detail] : detail;
+    self.__detail = detail;
     return self;
   }
 
@@ -520,16 +512,9 @@ export class TextNode extends LexicalNode {
     return this.setFormat(this.getFormat() ^ formatFlag);
   }
 
-  toggleDirectionless(): this {
-    const self = this.getWritable();
-    self.__detail ^= IS_DIRECTIONLESS;
-    return self;
-  }
-
-  toggleUnmergeable(): this {
-    const self = this.getWritable();
-    self.__detail ^= IS_UNMERGEABLE;
-    return self;
+  toggleDetail(detail: TextDetailType): this {
+    const detailFlag = DETAIL_TYPE_TO_DETAIL[detail];
+    return this.setDetail(this.getDetail() ^ detailFlag);
   }
 
   setMode(type: TextModeType): this {

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -105,7 +105,7 @@ describe('LexicalTextNode tests', () => {
     await update(() => {
       const paragraph = $createParagraphNode();
       const text = $createTextNode();
-      text.toggleUnmergeable();
+      text.toggleDetail('unmergeable');
       paragraph.append(text);
       $getRoot().append(paragraph);
     });
@@ -164,12 +164,12 @@ describe('LexicalTextNode tests', () => {
 
     test('prepend node', async () => {
       await update(() => {
-        const textNode = $createTextNode('World').toggleUnmergeable();
+        const textNode = $createTextNode('World').toggleDetail('unmergeable');
         $getRoot().getFirstChild<ElementNode>().append(textNode);
       });
 
       await update(() => {
-        const textNode = $createTextNode('Hello ').toggleUnmergeable();
+        const textNode = $createTextNode('Hello ').toggleDetail('unmergeable');
         const previousTextNode = $getRoot()
           .getFirstChild<ElementNode>()
           .getFirstChild();


### PR DESCRIPTION
Initially I thought it was best to do a full replacement in favor for constants https://github.com/facebook/lexical/pull/3037 just like we have for commands now. Constants are easy to follow and type.

I quitted for two reasons:
1. User churn
2. No bundle size win as I expected. Unfortunately there's no good way to minimize ES Module bundles and the constant names have a decent size

However, what we have now is still not professional. A setter and a getter should return the same value, ideally what we store on the node.

In this PR I'm making setFormat and setFormat to work exclusively with numbers and additional provide the toggle and has functions for both.

Closes https://github.com/facebook/lexical/pull/3037