### PR TITLE
Fix composition text boundary for canInsertTextAfter

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -628,6 +628,9 @@ function $previousSiblingDoesNotAcceptText(node: TextNode): boolean {
   );
 }
 
+// This function is connected to $shouldPreventDefaultAndInsertText and determines whether the
+// TextNode boundaries are writable or we should use the previous/next sibling instead. For example,
+// in the case of a LinkNode, boundaries are not writable.
 function $shouldInsertTextAfterOrBeforeTextNode(
   selection: RangeSelection,
   node: TextNode,
@@ -641,16 +644,20 @@ function $shouldInsertTextAfterOrBeforeTextNode(
   const offset = selection.anchor.offset;
   const parent = node.getParentOrThrow();
   const isToken = node.isToken();
-  const shouldInsertTextBefore =
-    offset === 0 &&
-    (!node.canInsertTextBefore() ||
+  if (offset === 0) {
+    return (
+      !node.canInsertTextBefore() ||
       !parent.canInsertTextBefore() ||
       isToken ||
-      $previousSiblingDoesNotAcceptText(node));
-  const shouldInsertTextAfter =
-    node.getTextContentSize() === offset &&
-    (!node.canInsertTextBefore() || !parent.canInsertTextBefore() || isToken);
-  return shouldInsertTextBefore || shouldInsertTextAfter;
+      $previousSiblingDoesNotAcceptText(node)
+    );
+  } else if (offset === node.getTextContentSize()) {
+    return (
+      !node.canInsertTextAfter() || !parent.canInsertTextAfter() || isToken
+    );
+  } else {
+    return false;
+  }
 }
 
 // This function is used to determine if Lexical should attempt to override
@@ -659,7 +666,6 @@ function $shouldInsertTextAfterOrBeforeTextNode(
 // work as intended between different browsers and across word, line and character
 // boundary/formats. It also is important for text replacement, node schemas and
 // composition mechanics.
-
 export function $shouldPreventDefaultAndInsertText(
   selection: RangeSelection,
   text: string,


### PR DESCRIPTION
The `$shouldInsertTextAfterOrBeforeTextNode` condition was not correct

Before

https://user-images.githubusercontent.com/193447/191381565-012a9ae1-184a-446c-ae31-96b3275317a8.mov

After

https://user-images.githubusercontent.com/193447/191381566-f0156ef3-5c84-4c8c-b4df-919a06ac0c83.mov

Closes https://github.com/facebook/lexical/issues/3044

*Tried writing an E2E test but our custom Playwright IME doesn't work exactly the same way as the browser and I couldn't get it to repro there, we have to look into this at some other point*