### PR TITLE
Refine Typeahead isOpen logic.

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -532,7 +532,6 @@ export function LexicalTypeaheadMenuPlugin<TOption extends TypeaheadOption>({
 
   useEffect(() => {
     let activeRange: Range | null = document.createRange();
-    let previousText: string | null = null;
 
     const updateListener = () => {
       editor.getEditorState().read(() => {
@@ -543,14 +542,12 @@ export function LexicalTypeaheadMenuPlugin<TOption extends TypeaheadOption>({
         if (
           !$isRangeSelection(selection) ||
           !selection.isCollapsed() ||
-          text === previousText ||
           text === null ||
           range === null
         ) {
           setResolution(null);
           return;
         }
-        previousText = text;
 
         const match = triggerFn(text, editor);
         onQueryChange(match ? match.matchingString : null);


### PR DESCRIPTION
It was flagged to me that sometimes the node will "update" but the text will be the same. This should not result in the typeahead menu closing so I've removed the line.

Manually tested and the behavior seems identical. Unsure why this line was there in the first place.