### PR TITLE
Dispatch CAN_{REDO,UNDO}_COMMAND after clearing history

### DIFF
--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -14,6 +14,10 @@ import {$createQuoteNode} from '@lexical/rich-text/src';
 import {$wrapNodes} from '@lexical/selection/src';
 import {
   $createRangeSelection,
+  CAN_REDO_COMMAND,
+  CAN_UNDO_COMMAND,
+  CLEAR_HISTORY_COMMAND,
+  COMMAND_PRIORITY_CRITICAL,
   LexicalEditor,
   SerializedElementNode,
   SerializedTextNode,
@@ -49,28 +53,64 @@ describe('LexicalHistory tests', () => {
   // Shared instance across tests
   let editor: LexicalEditor;
 
-  test('LexicalHistory.Redo after Quote Node', async () => {
-    function Test(): JSX.Element {
-      function TestPlugin() {
-        // Plugin used just to get our hands on the Editor object
-        [editor] = useLexicalComposerContext();
-        return null;
-      }
-
-      return (
-        <TestComposer>
-          <RichTextPlugin
-            contentEditable={<ContentEditable />}
-            placeholder={
-              <div className="editor-placeholder">Enter some text...</div>
-            }
-          />
-          <TestPlugin />
-          <HistoryPlugin />
-        </TestComposer>
-      );
+  function Test(): JSX.Element {
+    function TestPlugin() {
+      // Plugin used just to get our hands on the Editor object
+      [editor] = useLexicalComposerContext();
+      return null;
     }
 
+    return (
+      <TestComposer>
+        <RichTextPlugin
+          contentEditable={<ContentEditable />}
+          placeholder={
+            <div className="editor-placeholder">Enter some text...</div>
+          }
+        />
+        <TestPlugin />
+        <HistoryPlugin />
+      </TestComposer>
+    );
+  }
+
+  test('LexicalHistory after clearing', async () => {
+    let canRedo = true;
+    let canUndo = true;
+
+    ReactTestUtils.act(() => {
+      reactRoot.render(<Test key="smth" />);
+    });
+
+    editor.registerCommand<boolean>(
+      CAN_REDO_COMMAND,
+      (payload) => {
+        canRedo = payload;
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+
+    editor.registerCommand<boolean>(
+      CAN_UNDO_COMMAND,
+      (payload) => {
+        canUndo = payload;
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+
+    await Promise.resolve().then();
+
+    await ReactTestUtils.act(async () => {
+      editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
+    });
+
+    expect(canRedo).toBe(false);
+    expect(canUndo).toBe(false);
+  });
+
+  test('LexicalHistory.Redo after Quote Node', async () => {
     ReactTestUtils.act(() => {
       reactRoot.render(<Test key="smth" />);
     });

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -467,6 +467,8 @@ export function registerHistory(
       CLEAR_HISTORY_COMMAND,
       () => {
         clearHistory(historyState);
+        editor.dispatchCommand(CAN_REDO_COMMAND, false);
+        editor.dispatchCommand(CAN_UNDO_COMMAND, false);
         return true;
       },
       COMMAND_PRIORITY_EDITOR,


### PR DESCRIPTION
Without this, registered events to `CAN_REDO_COMMAND` and `CAN_UNDO_COMMAND` can have invalid true values after clearing the history.

You can replicate the bug by:

1. Opening the playground. Notice the redo/undo buttons are disabled by default.
2. Create an undo/redo history for the editor.
3. Now both the undo and redo buttons are enabled.
4. Hit the import button button and select a `.lexical` file.
5. After the import, both buttons are enabled even though clicking them doesn't change anything.

The UI was never notified that the editor can't undo/redo anymore because its history was cleared:

These were never called on `ToolbarPlugin`:

```ts
      activeEditor.registerCommand<boolean>(
        CAN_UNDO_COMMAND,
        (payload) => {
          setCanUndo(payload);
          return false;
        },
        COMMAND_PRIORITY_CRITICAL,
      ),
      activeEditor.registerCommand<boolean>(
        CAN_REDO_COMMAND,
        (payload) => {
          setCanRedo(payload);
          return false;
        },
        COMMAND_PRIORITY_CRITICAL,
      ),
```

This is my first day knowing about Lexical and first time writing typescript so sorry if there's any bugs.

Question, what is the difference between `CLEAR_EDITOR_COMMAND` and `CLEAR_HISTORY_COMMAND`. Should that also dispatch the `CAN_*_COMMAND`s?