### PR TITLE
feat: add export/import DOM for horizontal rule node

### DIFF
--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -7,6 +7,9 @@
  */
 
 import type {
+  DOMConversionMap,
+  DOMConversionOutput,
+  DOMExportOutput,
   LexicalCommand,
   LexicalNode,
   NodeKey,
@@ -110,11 +113,24 @@ export class HorizontalRuleNode extends DecoratorNode<JSX.Element> {
     return $createHorizontalRuleNode();
   }
 
+  static importDOM(): DOMConversionMap | null {
+    return {
+      hr: () => ({
+        conversion: convertHorizontalRuleElement,
+        priority: 0,
+      }),
+    };
+  }
+
   exportJSON(): SerializedLexicalNode {
     return {
       type: 'horizontalrule',
       version: 1,
     };
+  }
+
+  exportDOM(): DOMExportOutput {
+    return {element: document.createElement('hr')};
   }
 
   createDOM(): HTMLElement {
@@ -138,6 +154,10 @@ export class HorizontalRuleNode extends DecoratorNode<JSX.Element> {
   decorate(): JSX.Element {
     return <HorizontalRuleComponent nodeKey={this.__key} />;
   }
+}
+
+function convertHorizontalRuleElement(): DOMConversionOutput {
+  return {node: $createHorizontalRuleNode()};
 }
 
 export function $createHorizontalRuleNode(): HorizontalRuleNode {


### PR DESCRIPTION
Hi the team,

Feel free to reject this pull request if you had a reason to remove exportDOM/importDOM for HorizontalRuleNode here https://github.com/facebook/lexical/pull/2324.

Currently, we lose the information during import/export since the horizontal rule is replaced by a div due to the DecoratorNode type (the root decorated with the React Component)