### PR TITLE
fix(lexical-clipboard): pasting from google docs

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -198,15 +198,22 @@ function $basicInsertStrategy(
       list = null;
     }
 
+    const isLineBreakNode = $isLineBreakNode(node);
+
     if (
+      isLineBreakNode ||
       ($isDecoratorNode(node) && node.isInline()) ||
       ($isElementNode(node) && node.isInline()) ||
-      $isTextNode(node) ||
-      $isLineBreakNode(node)
+      $isTextNode(node)
     ) {
       if (currentBlock === null) {
         currentBlock = $createParagraphNode();
         topLevelBlocks.push(currentBlock);
+        // In the case of LineBreakNode, we just need to
+        // add an empty ParagraphNode to the topLevelBlocks.
+        if (isLineBreakNode) {
+          continue;
+        }
       }
 
       if (currentBlock !== null) {

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -2168,7 +2168,6 @@ test.describe('CopyAndPaste', () => {
         </p>
         <p class="PlaygroundEditorTheme__paragraph">
           <br />
-          <br />
         </p>
       `,
     );


### PR DESCRIPTION
## Description
Fix pasting from google docs adds extra paragraphs / linebreaks

Closes: #3058 