### PR TITLE
Double-trigger hack for high-fidelity Node/Grid selection

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -185,8 +185,7 @@ function $basicInsertStrategy(
 
     /**
      * There's no good way to add this to importDOM or importJSON directly,
-     * so this is here in order to safely correct faultimport { copyToClipboard__EXPERIMENTAL } from './clipboard';
-y clipboard data
+     * so this is here in order to safely correct faulty clipboard data
      * that we can't control and avoid crashing the app.
      * https://github.com/facebook/lexical/issues/2405
      */
@@ -574,6 +573,7 @@ export function copyToClipboard__EXPERIMENTAL(
       clipboardEventTimeout = null;
     }, EVENT_LATENCY);
     document.execCommand('copy');
+    element.remove();
   }
 }
 

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -6,15 +6,6 @@
  *
  */
 
-import type {
-  GridSelection,
-  LexicalEditor,
-  LexicalNode,
-  NodeSelection,
-  RangeSelection,
-  SerializedTextNode,
-} from 'lexical';
-
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
 import {$createListNode, $isListItemNode} from '@lexical/list';
 import {
@@ -34,18 +25,26 @@ import {
   $isTextNode,
   $parseSerializedNode,
   $setSelection,
+  COMMAND_PRIORITY_CRITICAL,
+  COPY_COMMAND,
   DEPRECATED_$createGridSelection,
   DEPRECATED_$isGridCellNode,
   DEPRECATED_$isGridNode,
   DEPRECATED_$isGridRowNode,
   DEPRECATED_$isGridSelection,
   DEPRECATED_GridNode,
+  GridSelection,
+  LexicalEditor,
+  LexicalNode,
+  NodeSelection,
+  RangeSelection,
   SELECTION_CHANGE_COMMAND,
+  SerializedTextNode,
 } from 'lexical';
 import {IS_FIREFOX} from 'shared/environment';
 import invariant from 'shared/invariant';
 
-export function $getHtmlContent(editor: LexicalEditor): string | null {
+export function $getHtmlContent(editor: LexicalEditor): string {
   const selection = $getSelection();
 
   if (selection == null) {
@@ -57,13 +56,15 @@ export function $getHtmlContent(editor: LexicalEditor): string | null {
     ($isRangeSelection(selection) && selection.isCollapsed()) ||
     selection.getNodes().length === 0
   ) {
-    return null;
+    return '';
   }
 
   return $generateHtmlFromNodes(editor, selection);
 }
 
-export function $getLexicalContent(editor: LexicalEditor): string | null {
+// TODO Return a blank string instead
+// TODO Rename to $getJSON
+export function $getLexicalContent(editor: LexicalEditor): null | string {
   const selection = $getSelection();
 
   if (selection == null) {
@@ -184,7 +185,8 @@ function $basicInsertStrategy(
 
     /**
      * There's no good way to add this to importDOM or importJSON directly,
-     * so this is here in order to safely correct faulty clipboard data
+     * so this is here in order to safely correct faultimport { copyToClipboard__EXPERIMENTAL } from './clipboard';
+y clipboard data
      * that we can't control and avoid crashing the app.
      * https://github.com/facebook/lexical/issues/2405
      */
@@ -456,6 +458,7 @@ function $appendNodesToJSON(
   return shouldInclude;
 }
 
+// TODO why $ function with Editor instance?
 export function $generateJSONFromSelectedNodes<
   SerializedNode extends BaseSerializedNode,
 >(
@@ -493,62 +496,108 @@ export function $generateNodesFromSerializedNodes(
   return nodes;
 }
 
-// API is very likely to change; ideally we provide hooks for custom selection and don't enforce
-// editor selection
+const EVENT_LATENCY = 50;
+let clipboardEventTimeout: null | number = null;
+
+// TODO custom selection
+// TODO return Promise<boolean>
+// TODO potentially have a node customizable version for plain text
 export function copyToClipboard__EXPERIMENTAL(
   editor: LexicalEditor,
   event: null | ClipboardEvent,
-): boolean {
-  console.info('copy');
-  const selection = $getSelection();
-  if (selection === null) {
-    return false;
+): void {
+  if (clipboardEventTimeout !== null) {
+    // Prevent weird conditions for now that can happen when this function is run multiple times
+    // synchronously. In the future, we can do better if we work with a Promise<boolean> or even
+    // Promise<void>
+    return;
   }
-  let clipboardData = null;
   if (event !== null) {
-    event.preventDefault();
-    clipboardData = event.clipboardData;
+    editor.update(() => {
+      $copyToClipboardEvent(editor, event);
+    });
+    return;
   }
-  const htmlString = $getHtmlContent(editor);
-  const lexicalString = $getLexicalContent(editor);
 
+  if (IS_FIREFOX) {
+    // ClipboardItem is not yet as good as ClipboardEvent. Most browsers only support a single
+    // item in the clipboard at one time but FF doesn't support the execCommand hack
+    if (typeof ClipboardItem !== 'undefined') {
+      const htmlString = $getHtmlContent(editor);
+      const clipboard = navigator.clipboard;
+      if (clipboard != null) {
+        // If we have to choose just one item, HTML > rest
+        const data = [
+          new ClipboardItem({
+            'text/html': new Blob([htmlString as BlobPart], {
+              type: 'text/html',
+            }),
+          }),
+        ];
+        clipboard.write(data);
+      }
+    }
+    return;
+  }
+
+  const rootElement = editor.getRootElement();
+  const domSelection = document.getSelection();
+  if (rootElement !== null && domSelection !== null) {
+    const element = document.createElement('span');
+    element.style.cssText = 'position: fixed; top: -1000px;';
+    element.append(document.createTextNode('#'));
+    rootElement.append(element);
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    domSelection.removeAllRanges();
+    domSelection.addRange(range);
+    const removeListener = editor.registerCommand(
+      COPY_COMMAND,
+      (secondEvent) => {
+        if (secondEvent instanceof ClipboardEvent) {
+          removeListener();
+          if (clipboardEventTimeout !== null) {
+            window.clearTimeout(clipboardEventTimeout);
+            clipboardEventTimeout = null;
+          }
+          $copyToClipboardEvent(editor, secondEvent);
+        }
+        // Block the entire copy flow while we wait for the next ClipboardEvent
+        return true;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+    // If the above hack execCommand hack works, this timeout code should never fire. Otherwise,
+    // the listener will be quickly freed so that the user can reuse it again
+    clipboardEventTimeout = window.setTimeout(() => {
+      removeListener();
+      clipboardEventTimeout = null;
+    }, EVENT_LATENCY);
+    document.execCommand('copy');
+  }
+}
+
+// TODO shouldn't pass editor (pass namespace directly)
+function $copyToClipboardEvent(
+  editor: LexicalEditor,
+  event: ClipboardEvent,
+): void {
+  event.preventDefault();
+  const clipboardData = event.clipboardData;
   if (clipboardData !== null) {
+    const selection = $getSelection();
+    const htmlString = $getHtmlContent(editor);
+    const lexicalString = $getLexicalContent(editor);
+    let plainString = '';
+    if (selection !== null) {
+      plainString = selection.getTextContent();
+    }
     if (htmlString !== null) {
       clipboardData.setData('text/html', htmlString);
     }
     if (lexicalString !== null) {
       clipboardData.setData('application/x-lexical-editor', lexicalString);
     }
-    const plainString = selection.getTextContent();
     clipboardData.setData('text/plain', plainString);
-  } else if (IS_FIREFOX && ClipboardItem) {
-    const clipboard = navigator.clipboard;
-    if (clipboard != null) {
-      // Most browsers only support a single item in the clipboard at one time.
-      // So we optimize by only putting in HTML.
-      const data = [
-        new ClipboardItem({
-          'text/html': new Blob([htmlString as BlobPart], {
-            type: 'text/html',
-          }),
-        }),
-      ];
-      clipboard.write(data);
-    }
-  } else {
-    const rootElement = editor.getRootElement();
-    const domSelection = document.getSelection();
-    if (rootElement !== null && domSelection !== null) {
-      const element = document.createElement('span');
-      element.style.cssText = 'position: fixed; top: -1000px;';
-      element.append(document.createTextNode('#'));
-      rootElement.append(element);
-      const range = document.createRange();
-      range.selectNodeContents(element);
-      domSelection.removeAllRanges();
-      domSelection.addRange(range);
-      document.execCommand('copy');
-    }
   }
-  return true;
 }

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -62,8 +62,8 @@ export function $getHtmlContent(editor: LexicalEditor): string {
   return $generateHtmlFromNodes(editor, selection);
 }
 
-// TODO Return a blank string instead
-// TODO Rename to $getJSON
+// TODO 0.6.0 Return a blank string instead
+// TODO 0.6.0 Rename to $getJSON
 export function $getLexicalContent(editor: LexicalEditor): null | string {
   const selection = $getSelection();
 

--- a/packages/lexical-clipboard/src/index.ts
+++ b/packages/lexical-clipboard/src/index.ts
@@ -7,16 +7,6 @@
  *
  */
 
-import {
-  $generateJSONFromSelectedNodes,
-  $generateNodesFromSerializedNodes,
-  $getHtmlContent,
-  $getLexicalContent,
-  $insertDataTransferForPlainText,
-  $insertDataTransferForRichText,
-  $insertGeneratedNodes,
-} from './clipboard';
-
 export {
   $generateJSONFromSelectedNodes,
   $generateNodesFromSerializedNodes,
@@ -25,4 +15,5 @@ export {
   $insertDataTransferForPlainText,
   $insertDataTransferForRichText,
   $insertGeneratedNodes,
-};
+  copyToClipboard__EXPERIMENTAL,
+} from './clipboard';

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -173,10 +173,8 @@ export class TweetNode extends DecoratorBlockNode {
   }
 
   exportDOM(): DOMExportOutput {
-    console.info('asdf');
     const element = document.createElement('div');
     element.setAttribute('data-lexical-tweet-id', this.__id);
-    element.innerText = this.getTextContent();
     return {element};
   }
 

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -173,8 +173,10 @@ export class TweetNode extends DecoratorBlockNode {
   }
 
   exportDOM(): DOMExportOutput {
+    console.info('asdf');
     const element = document.createElement('div');
     element.setAttribute('data-lexical-tweet-id', this.__id);
+    element.innerText = this.getTextContent();
     return {element};
   }
 

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -74,7 +74,6 @@ import {
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
 } from 'lexical';
-import {$copyToClipboard} from 'packages/lexical-clipboard/src/clipboard';
 import {CAN_USE_BEFORE_INPUT, IS_IOS, IS_SAFARI} from 'shared/environment';
 
 export type SerializedHeadingNode = Spread<
@@ -375,7 +374,10 @@ function onCutForRichText(
   event: CommandPayloadType<typeof CUT_COMMAND>,
   editor: LexicalEditor,
 ): void {
-  onCopyForRichText(event, editor);
+  copyToClipboard__EXPERIMENTAL(
+    editor,
+    event instanceof ClipboardEvent ? event : null,
+  );
   const selection = $getSelection();
   if ($isRangeSelection(selection)) {
     selection.removeText();
@@ -824,10 +826,11 @@ export function registerRichText(editor: LexicalEditor): () => void {
     editor.registerCommand(
       COPY_COMMAND,
       (event) => {
-        return copyToClipboard__EXPERIMENTAL(
+        copyToClipboard__EXPERIMENTAL(
           editor,
           event instanceof ClipboardEvent ? event : null,
         );
+        return true;
       },
       COMMAND_PRIORITY_EDITOR,
     ),

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2733,3 +2733,11 @@ export function $insertNodes(
   }
   return selection.insertNodes(nodes, selectStart);
 }
+
+export function $getTextContent(): string {
+  const selection = $getSelection();
+  if (selection === null) {
+    return '';
+  }
+  return selection.getTextContent();
+}

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -116,6 +116,7 @@ export {
   $createRangeSelection,
   $getPreviousSelection,
   $getSelection,
+  $getTextContent,
   $insertNodes,
   $isNodeSelection,
   $isRangeSelection,


### PR DESCRIPTION
## Problem

Copying a Node will only store `text/html` into the clipboard. This differs from copying a RangeSelection when we copy `text/plain`, `text/html` and `application/x-lexical-editor` to fulfill a wider range of use cases. For example, when pasting content we would rather have the JSON serialized content as its the exact copy (most fidelity) Lexical can offer.

The current Node and Grid selection copy relies on the Clipboard API that is still relatively new, to the point that even some everly green browsers do not support setting more than one item at once.

At the same time, the fact that only the newest browsers can rely on Clipboard means that older browsers that we still want to support will be unable to copy Node or Grid.

## Technical problem

The main difference between a RangeSelection and a NodeSelection comes down the DOMSelection. A RangeSelection copy will trigger a ClipboardEvent (via the RootNode copy event listener) whereas the "fake" selection we performs on DecoratorNodes has to be captured via KeyboardEvent. **A KeyboardEvent does not give us access to ClipboardEvent** that ultimately can set arbitrary data onto the clipboard.

## Double-trigger hack

Through experimentation, it turns out we can do better. We can programmatically trigger a copy event after programmatically remapping the selection to a valid range selection.

This hack gives us a second copy event we can now remap just like a normal RangeSelection.

<img width="883" alt="Screen Shot 2022-09-27 at 4 26 01 pm" src="https://user-images.githubusercontent.com/193447/192668772-c91ac790-7543-4c15-9405-a5182a3cf836.png">
<img width="884" alt="Screen Shot 2022-09-27 at 4 26 21 pm" src="https://user-images.githubusercontent.com/193447/192668775-d11093ca-a175-449f-aada-aa720793bcb3.png">


## Limitations

While it has wider browser version support it still doesn't work with Firefox. It turns out that neither Clipboard nor this hack work. For Firefox, we'll have to rely on Clipboard once it moves away from the experimental `dom.events.asyncClipboard.clipboardItem`

<img width="889" alt="Screen Shot 2022-09-27 at 4 30 35 pm" src="https://user-images.githubusercontent.com/193447/192668799-df03df90-996b-4eeb-830f-a27abd154ff9.png">

## Future work

I already moved this method onto @lexical/clipboard because I think that it has the potential to:
1. Handle custom selection
2. Programmatically trigger copy events (i.e. from toolbar)
3. Plain text to leverage this method to enable use cases such as copy-paste for MentionNodes