### PR TITLE
fix(lexical-playground): read-only mode

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1308,7 +1308,10 @@ button.action-button:disabled {
   opacity: 0.6;
 }
 
-.toolbar button.toolbar-item:disabled i.format {
+.toolbar button.toolbar-item:disabled .icon,
+.toolbar button.toolbar-item:disabled .text,
+.toolbar button.toolbar-item:disabled i.format,
+.toolbar button.toolbar-item:disabled .chevron-down {
   opacity: 0.2;
 }
 

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -408,9 +408,11 @@ function dropDownActiveClass(active: boolean) {
 function BlockFormatDropDown({
   editor,
   blockType,
+  disabled = false,
 }: {
   blockType: keyof typeof blockTypeToBlockName;
   editor: LexicalEditor;
+  disabled?: boolean;
 }): JSX.Element {
   const formatParagraph = () => {
     if (blockType !== 'paragraph') {
@@ -493,6 +495,7 @@ function BlockFormatDropDown({
 
   return (
     <DropDown
+      disabled={disabled}
       buttonClassName="toolbar-item block-controls"
       buttonIconClassName={'icon block-type ' + blockType}
       buttonLabel={blockTypeToBlockName[blockType]}
@@ -563,10 +566,12 @@ function FontDropDown({
   editor,
   value,
   style,
+  disabled = false,
 }: {
   editor: LexicalEditor;
   value: string;
   style: string;
+  disabled?: boolean;
 }): JSX.Element {
   const handleClick = useCallback(
     (option: string) => {
@@ -589,6 +594,7 @@ function FontDropDown({
 
   return (
     <DropDown
+      disabled={disabled}
       buttonClassName={'toolbar-item ' + style}
       buttonLabel={value}
       buttonIconClassName={
@@ -636,6 +642,7 @@ export default function ToolbarPlugin(): JSX.Element {
   const [modal, showModal] = useModal();
   const [isRTL, setIsRTL] = useState(false);
   const [codeLanguage, setCodeLanguage] = useState<string>('');
+  const [isEditable, setIsEditable] = useState(() => editor.isEditable());
 
   const updateToolbar = useCallback(() => {
     const selection = $getSelection();
@@ -737,6 +744,9 @@ export default function ToolbarPlugin(): JSX.Element {
 
   useEffect(() => {
     return mergeRegister(
+      editor.registerEditableListener((editable) => {
+        setIsEditable(editable);
+      }),
       activeEditor.registerUpdateListener(({editorState}) => {
         editorState.read(() => {
           updateToolbar();
@@ -834,7 +844,7 @@ export default function ToolbarPlugin(): JSX.Element {
   return (
     <div className="toolbar">
       <button
-        disabled={!canUndo}
+        disabled={!canUndo || !isEditable}
         onClick={() => {
           activeEditor.dispatchCommand(UNDO_COMMAND, undefined);
         }}
@@ -844,7 +854,7 @@ export default function ToolbarPlugin(): JSX.Element {
         <i className="format undo" />
       </button>
       <button
-        disabled={!canRedo}
+        disabled={!canRedo || !isEditable}
         onClick={() => {
           activeEditor.dispatchCommand(REDO_COMMAND, undefined);
         }}
@@ -856,13 +866,18 @@ export default function ToolbarPlugin(): JSX.Element {
       <Divider />
       {blockType in blockTypeToBlockName && activeEditor === editor && (
         <>
-          <BlockFormatDropDown blockType={blockType} editor={editor} />
+          <BlockFormatDropDown
+            disabled={!isEditable}
+            blockType={blockType}
+            editor={editor}
+          />
           <Divider />
         </>
       )}
       {blockType === 'code' ? (
         <>
           <DropDown
+            disabled={!isEditable}
             buttonClassName="toolbar-item code-language"
             buttonLabel={getLanguageFriendlyName(codeLanguage)}
             buttonAriaLabel="Select language">
@@ -883,13 +898,20 @@ export default function ToolbarPlugin(): JSX.Element {
       ) : (
         <>
           <FontDropDown
+            disabled={!isEditable}
             style={'font-family'}
             value={fontFamily}
             editor={editor}
           />
-          <FontDropDown style={'font-size'} value={fontSize} editor={editor} />
+          <FontDropDown
+            disabled={!isEditable}
+            style={'font-size'}
+            value={fontSize}
+            editor={editor}
+          />
           <Divider />
           <button
+            disabled={!isEditable}
             onClick={() => {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
             }}
@@ -901,6 +923,7 @@ export default function ToolbarPlugin(): JSX.Element {
             <i className="format bold" />
           </button>
           <button
+            disabled={!isEditable}
             onClick={() => {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
             }}
@@ -912,6 +935,7 @@ export default function ToolbarPlugin(): JSX.Element {
             <i className="format italic" />
           </button>
           <button
+            disabled={!isEditable}
             onClick={() => {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
             }}
@@ -923,6 +947,7 @@ export default function ToolbarPlugin(): JSX.Element {
             <i className="format underline" />
           </button>
           <button
+            disabled={!isEditable}
             onClick={() => {
               activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
             }}
@@ -932,6 +957,7 @@ export default function ToolbarPlugin(): JSX.Element {
             <i className="format code" />
           </button>
           <button
+            disabled={!isEditable}
             onClick={insertLink}
             className={'toolbar-item spaced ' + (isLink ? 'active' : '')}
             aria-label="Insert link"
@@ -939,6 +965,7 @@ export default function ToolbarPlugin(): JSX.Element {
             <i className="format link" />
           </button>
           <ColorPicker
+            disabled={!isEditable}
             buttonClassName="toolbar-item color-picker"
             buttonAriaLabel="Formatting text color"
             buttonIconClassName="icon font-color"
@@ -947,6 +974,7 @@ export default function ToolbarPlugin(): JSX.Element {
             title="text color"
           />
           <ColorPicker
+            disabled={!isEditable}
             buttonClassName="toolbar-item color-picker"
             buttonAriaLabel="Formatting background color"
             buttonIconClassName="icon bg-color"
@@ -955,6 +983,7 @@ export default function ToolbarPlugin(): JSX.Element {
             title="bg color"
           />
           <DropDown
+            disabled={!isEditable}
             buttonClassName="toolbar-item spaced"
             buttonLabel=""
             buttonAriaLabel="Formatting options for additional text styles"
@@ -1006,6 +1035,7 @@ export default function ToolbarPlugin(): JSX.Element {
           </DropDown>
           <Divider />
           <DropDown
+            disabled={!isEditable}
             buttonClassName="toolbar-item spaced"
             buttonLabel="Insert"
             buttonAriaLabel="Insert specialized editor node"
@@ -1140,6 +1170,7 @@ export default function ToolbarPlugin(): JSX.Element {
       )}
       <Divider />
       <DropDown
+        disabled={!isEditable}
         buttonLabel="Align"
         buttonIconClassName="icon left-align"
         buttonClassName="toolbar-item spaced alignment"

--- a/packages/lexical-playground/src/ui/ColorPicker.tsx
+++ b/packages/lexical-playground/src/ui/ColorPicker.tsx
@@ -15,6 +15,7 @@ import DropDown from './DropDown';
 import TextInput from './TextInput';
 
 interface ColorPickerProps {
+  disabled?: boolean;
   buttonAriaLabel?: string;
   buttonClassName: string;
   buttonIconClassName?: string;
@@ -50,6 +51,7 @@ export default function ColorPicker({
   color,
   children,
   onChange,
+  disabled = false,
   ...rest
 }: Readonly<ColorPickerProps>): JSX.Element {
   const [selfColor, setSelfColor] = useState(transformColor('hex', color));
@@ -114,7 +116,7 @@ export default function ColorPicker({
   }, [color]);
 
   return (
-    <DropDown {...rest} stopCloseOnClickSelf={true}>
+    <DropDown {...rest} disabled={disabled} stopCloseOnClickSelf={true}>
       <div
         className="color-picker-wrapper"
         style={{width: WIDTH}}

--- a/packages/lexical-playground/src/ui/DropDown.tsx
+++ b/packages/lexical-playground/src/ui/DropDown.tsx
@@ -129,6 +129,7 @@ function DropDownItems({
 }
 
 export default function DropDown({
+  disabled = false,
   buttonLabel,
   buttonAriaLabel,
   buttonClassName,
@@ -136,6 +137,7 @@ export default function DropDown({
   children,
   stopCloseOnClickSelf,
 }: {
+  disabled?: boolean;
   buttonAriaLabel?: string;
   buttonClassName: string;
   buttonIconClassName?: string;
@@ -196,6 +198,7 @@ export default function DropDown({
   return (
     <>
       <button
+        disabled={disabled}
         aria-label={buttonAriaLabel || buttonLabel}
         className={buttonClassName}
         onClick={() => setShowDropDown(!showDropDown)}


### PR DESCRIPTION
## Description
Added support for readonly mode in toolbar

Closes: #3065


https://user-images.githubusercontent.com/22126563/192739816-f2deec60-f231-4b83-b63c-dd5f937c9bfa.mov

