### PR TITLE
Add collapsible container plugin

### DIFF
--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -33,6 +33,7 @@ import AutoLinkPlugin from './plugins/AutoLinkPlugin';
 import ClickableLinkPlugin from './plugins/ClickableLinkPlugin';
 import CodeActionMenuPlugin from './plugins/CodeActionMenuPlugin';
 import CodeHighlightPlugin from './plugins/CodeHighlightPlugin';
+import CollapsiblePlugin from './plugins/CollapsiblePlugin';
 import CommentPlugin from './plugins/CommentPlugin';
 import ComponentPickerPlugin from './plugins/ComponentPickerPlugin';
 import DraggableBlockPlugin from './plugins/DraggableBlockPlugin';
@@ -184,6 +185,7 @@ export default function Editor(): JSX.Element {
             <EquationsPlugin />
             <ExcalidrawPlugin />
             <TabFocusPlugin />
+            <CollapsiblePlugin />
             {floatingAnchorElem && (
               <>
                 <DraggableBlockPlugin anchorElem={floatingAnchorElem} />

--- a/packages/lexical-playground/src/images/icons/caret-right-fill.svg
+++ b/packages/lexical-playground/src/images/icons/caret-right-fill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right-fill" viewBox="0 0 16 16">
+  <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
+</svg>

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -394,6 +394,10 @@ i.horizontal-rule {
   background-image: url(images/icons/plus.svg);
 }
 
+.icon.caret-right {
+  background-image: url(images/icons/caret-right-fill.svg);
+}
+
 .icon.dropdown-more {
   background-image: url(images/icons/dropdown-more.svg);
 }

--- a/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
+++ b/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
@@ -18,6 +18,9 @@ import {HorizontalRuleNode} from '@lexical/react/LexicalHorizontalRuleNode';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
 
+import {CollapsibleContainerNode} from '../plugins/CollapsiblePlugin/CollapsibleContainerNode';
+import {CollapsibleContentNode} from '../plugins/CollapsiblePlugin/CollapsibleContentNode';
+import {CollapsibleTitleNode} from '../plugins/CollapsiblePlugin/CollapsibleTitleNode';
 import {AutocompleteNode} from './AutocompleteNode';
 import {EmojiNode} from './EmojiNode';
 import {EquationNode} from './EquationNode';
@@ -61,6 +64,9 @@ const PlaygroundNodes: Array<Klass<LexicalNode>> = [
   YouTubeNode,
   FigmaNode,
   MarkNode,
+  CollapsibleContainerNode,
+  CollapsibleContentNode,
+  CollapsibleTitleNode,
 ];
 
 export default PlaygroundNodes;

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/Collapsible.css
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/Collapsible.css
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+.Collapsible__container {
+  background: #fcfcfc;
+  border: 1px solid #eee;
+  border-radius: 10px;
+  margin-bottom: 8px;
+}
+
+.Collapsible__title {
+  cursor: pointer;
+  padding: 5px 5px 5px 20px;
+  position: relative;
+  font-weight: bold;
+}
+
+.Collapsible__title:before {
+  border-style: solid;
+  border-color: transparent;
+  border-width: 6px 4px 6px 4px;
+  border-top-color: #000;
+  display: block;
+  content: '';
+  position: absolute;
+  left: 7px;
+  top: 15px;
+}
+
+.Collapsible__content {
+  padding: 0 5px 5px 20px;
+}
+
+.Collapsible__collapsed .Collapsible__content {
+  display: none;
+  user-select: none;
+}
+
+.Collapsible__collapsed .Collapsible__title:before {
+  transform: rotate(-90deg);
+  top: 12px;
+  left: 10px;
+}

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/Collapsible.css
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/Collapsible.css
@@ -19,18 +19,31 @@
   padding: 5px 5px 5px 20px;
   position: relative;
   font-weight: bold;
+  list-style: none;
+  outline: none;
+}
+
+.Collapsible__title::marker,
+.Collapsible__title::-webkit-details-marker {
+  display: none;
 }
 
 .Collapsible__title:before {
   border-style: solid;
   border-color: transparent;
-  border-width: 6px 4px 6px 4px;
-  border-top-color: #000;
+  border-width: 4px 6px 4px 6px;
+  border-left-color: #000;
   display: block;
   content: '';
   position: absolute;
   left: 7px;
   top: 15px;
+}
+
+.Collapsible__container[open] .Collapsible__title:before {
+  border-color: transparent;
+  border-width: 6px 4px 6px 4px;
+  border-top-color: #000;
 }
 
 .Collapsible__content {
@@ -40,10 +53,4 @@
 .Collapsible__collapsed .Collapsible__content {
   display: none;
   user-select: none;
-}
-
-.Collapsible__collapsed .Collapsible__title:before {
-  transform: rotate(-90deg);
-  top: 12px;
-  left: 10px;
 }

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  DOMConversionMap,
+  EditorConfig,
+  ElementNode,
+  LexicalNode,
+  NodeKey,
+  SerializedElementNode,
+  Spread,
+} from 'lexical';
+
+type SerializedCollapsibleContainerNode = Spread<
+  {
+    collapsed: boolean;
+    type: 'collapsible-container';
+    version: 1;
+  },
+  SerializedElementNode
+>;
+
+export class CollapsibleContainerNode extends ElementNode {
+  __collapsed: boolean;
+
+  constructor(collapsed: boolean, key?: NodeKey) {
+    super(key);
+    this.__collapsed = collapsed !== false;
+  }
+
+  static getType(): string {
+    return 'collapsible-container';
+  }
+
+  static clone(node: CollapsibleContainerNode): CollapsibleContainerNode {
+    return new CollapsibleContainerNode(node.__collapsed, node.__key);
+  }
+
+  createDOM(config: EditorConfig): HTMLElement {
+    const dom = document.createElement('div');
+    dom.classList.add('Collapsible__container');
+    if (this.__collapsed) {
+      dom.classList.add('Collapsible__collapsed');
+    }
+    return dom;
+  }
+
+  updateDOM(prevNode: CollapsibleContainerNode, dom: HTMLElement): boolean {
+    if (prevNode.__collapsed !== this.__collapsed) {
+      if (this.__collapsed) {
+        dom.classList.add('Collapsible__collapsed');
+      } else {
+        dom.classList.remove('Collapsible__collapsed');
+      }
+    }
+
+    return false;
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {};
+  }
+
+  static importJSON(
+    serializedNode: SerializedCollapsibleContainerNode,
+  ): CollapsibleContainerNode {
+    const node = $createCollapsibleContainerNode();
+    node.setCollapsed(serializedNode.collapsed);
+    return node;
+  }
+
+  exportJSON(): SerializedCollapsibleContainerNode {
+    return {
+      ...super.exportJSON(),
+      collapsed: this.getCollapsed(),
+      type: 'collapsible-container',
+      version: 1,
+    };
+  }
+
+  setCollapsed(collapsed: boolean): void {
+    const writable = this.getWritable();
+    writable.__collapsed = collapsed;
+  }
+
+  getCollapsed(): boolean {
+    return this.__collapsed;
+  }
+}
+
+export function $createCollapsibleContainerNode(): CollapsibleContainerNode {
+  return new CollapsibleContainerNode(false);
+}
+
+export function $isCollapsibleContainerNode(
+  node: LexicalNode | null | undefined,
+): node is CollapsibleContainerNode {
+  return node instanceof CollapsibleContainerNode;
+}

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -18,7 +18,6 @@ import {
 
 type SerializedCollapsibleContainerNode = Spread<
   {
-    collapsed: boolean;
     type: 'collapsible-container';
     version: 1;
   },
@@ -26,11 +25,11 @@ type SerializedCollapsibleContainerNode = Spread<
 >;
 
 export class CollapsibleContainerNode extends ElementNode {
-  __collapsed: boolean;
+  __open: boolean;
 
-  constructor(collapsed: boolean, key?: NodeKey) {
+  constructor(open: boolean, key?: NodeKey) {
     super(key);
-    this.__collapsed = collapsed !== false;
+    this.__open = open;
   }
 
   static getType(): string {
@@ -38,25 +37,22 @@ export class CollapsibleContainerNode extends ElementNode {
   }
 
   static clone(node: CollapsibleContainerNode): CollapsibleContainerNode {
-    return new CollapsibleContainerNode(node.__collapsed, node.__key);
+    return new CollapsibleContainerNode(node.__open, node.__key);
   }
 
   createDOM(config: EditorConfig): HTMLElement {
-    const dom = document.createElement('div');
+    const dom = document.createElement('details');
     dom.classList.add('Collapsible__container');
-    if (this.__collapsed) {
-      dom.classList.add('Collapsible__collapsed');
-    }
+    dom.open = this.__open;
     return dom;
   }
 
-  updateDOM(prevNode: CollapsibleContainerNode, dom: HTMLElement): boolean {
-    if (prevNode.__collapsed !== this.__collapsed) {
-      if (this.__collapsed) {
-        dom.classList.add('Collapsible__collapsed');
-      } else {
-        dom.classList.remove('Collapsible__collapsed');
-      }
+  updateDOM(
+    prevNode: CollapsibleContainerNode,
+    dom: HTMLDetailsElement,
+  ): boolean {
+    if (prevNode.__open !== this.__open) {
+      dom.open = this.__open;
     }
 
     return false;
@@ -70,31 +66,33 @@ export class CollapsibleContainerNode extends ElementNode {
     serializedNode: SerializedCollapsibleContainerNode,
   ): CollapsibleContainerNode {
     const node = $createCollapsibleContainerNode();
-    node.setCollapsed(serializedNode.collapsed);
     return node;
   }
 
   exportJSON(): SerializedCollapsibleContainerNode {
     return {
       ...super.exportJSON(),
-      collapsed: this.getCollapsed(),
       type: 'collapsible-container',
       version: 1,
     };
   }
 
-  setCollapsed(collapsed: boolean): void {
+  setOpen(open: boolean): void {
     const writable = this.getWritable();
-    writable.__collapsed = collapsed;
+    writable.__open = open;
   }
 
-  getCollapsed(): boolean {
-    return this.__collapsed;
+  getOpen(): boolean {
+    return this.__open;
+  }
+
+  toggleOpen(): void {
+    this.setOpen(!this.getOpen());
   }
 }
 
 export function $createCollapsibleContainerNode(): CollapsibleContainerNode {
-  return new CollapsibleContainerNode(false);
+  return new CollapsibleContainerNode(true);
 }
 
 export function $isCollapsibleContainerNode(

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  DOMConversionMap,
+  EditorConfig,
+  ElementNode,
+  LexicalNode,
+  SerializedElementNode,
+  Spread,
+} from 'lexical';
+
+type SerializedCollapsibleContentNode = Spread<
+  {
+    type: 'collapsible-content';
+    version: 1;
+  },
+  SerializedElementNode
+>;
+
+export class CollapsibleContentNode extends ElementNode {
+  static getType(): string {
+    return 'collapsible-content';
+  }
+
+  static clone(node: CollapsibleContentNode): CollapsibleContentNode {
+    return new CollapsibleContentNode(node.__key);
+  }
+
+  createDOM(config: EditorConfig): HTMLElement {
+    const dom = document.createElement('div');
+    dom.classList.add('Collapsible__content');
+    return dom;
+  }
+
+  updateDOM(prevNode: CollapsibleContentNode, dom: HTMLElement): boolean {
+    return false;
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {};
+  }
+
+  static importJSON(
+    serializedNode: SerializedCollapsibleContentNode,
+  ): CollapsibleContentNode {
+    return $createCollapsibleContentNode();
+  }
+
+  isShadowRoot(): boolean {
+    return true;
+  }
+
+  exportJSON(): SerializedCollapsibleContentNode {
+    return {
+      ...super.exportJSON(),
+      type: 'collapsible-content',
+      version: 1,
+    };
+  }
+}
+
+export function $createCollapsibleContentNode(): CollapsibleContentNode {
+  return new CollapsibleContentNode();
+}
+
+export function $isCollapsibleContentNode(
+  node: LexicalNode | null | undefined,
+): node is CollapsibleContentNode {
+  return node instanceof CollapsibleContentNode;
+}

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
@@ -9,6 +9,7 @@
 import {
   $createParagraphNode,
   $getSelection,
+  $isElementNode,
   $isRangeSelection,
   DOMConversionMap,
   EditorConfig,
@@ -21,10 +22,7 @@ import {
 } from 'lexical';
 
 import {TOGGLE_COLLAPSIBLE_COMMAND} from '.';
-import {
-  $createCollapsibleContentNode,
-  $isCollapsibleContentNode,
-} from './CollapsibleContentNode';
+import {$isCollapsibleContentNode} from './CollapsibleContentNode';
 
 type SerializedCollapsibleTitleNode = Spread<
   {
@@ -95,14 +93,21 @@ export class CollapsibleTitleNode extends ElementNode {
       containerNode.insertAfter(paragraph);
       return paragraph;
     } else {
-      let contentNode = this.getNextSibling();
+      const contentNode = this.getNextSibling();
       if (!$isCollapsibleContentNode(contentNode)) {
-        contentNode = $createCollapsibleContentNode();
+        throw new Error(
+          'CollapsibleTitleNode expects to have CollapsibleContentNode sibling',
+        );
       }
 
-      const paragraph = $createParagraphNode();
-      contentNode.append(paragraph);
-      return paragraph;
+      const firstChild = contentNode.getFirstChild();
+      if ($isElementNode(firstChild)) {
+        return firstChild;
+      } else {
+        const paragraph = $createParagraphNode();
+        contentNode.append(paragraph);
+        return paragraph;
+      }
     }
   }
 }

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createParagraphNode,
+  $getSelection,
+  $isRangeSelection,
+  DOMConversionMap,
+  EditorConfig,
+  ElementNode,
+  LexicalEditor,
+  LexicalNode,
+  RangeSelection,
+  SerializedElementNode,
+  Spread,
+} from 'lexical';
+
+import {TOGGLE_COLLAPSIBLE_COMMAND} from '.';
+import {
+  $createCollapsibleContentNode,
+  $isCollapsibleContentNode,
+} from './CollapsibleContentNode';
+
+type SerializedCollapsibleTitleNode = Spread<
+  {
+    type: 'collapsible-title';
+    version: 1;
+  },
+  SerializedElementNode
+>;
+
+export class CollapsibleTitleNode extends ElementNode {
+  static getType(): string {
+    return 'collapsible-title';
+  }
+
+  static clone(node: CollapsibleTitleNode): CollapsibleTitleNode {
+    return new CollapsibleTitleNode(node.__key);
+  }
+
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
+    const dom = document.createElement('div');
+    dom.addEventListener('click', () => {
+      editor.getEditorState().read(() => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection) && selection.isCollapsed()) {
+          editor.dispatchCommand(
+            TOGGLE_COLLAPSIBLE_COMMAND,
+            this.getParentOrThrow().getKey(),
+          );
+        }
+      });
+    });
+    dom.classList.add('Collapsible__title');
+    return dom;
+  }
+
+  updateDOM(prevNode: CollapsibleTitleNode, dom: HTMLElement): boolean {
+    return false;
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {};
+  }
+
+  static importJSON(
+    serializedNode: SerializedCollapsibleTitleNode,
+  ): CollapsibleTitleNode {
+    return $createCollapsibleTitleNode();
+  }
+
+  exportJSON(): SerializedCollapsibleTitleNode {
+    return {
+      ...super.exportJSON(),
+      type: 'collapsible-title',
+      version: 1,
+    };
+  }
+
+  collapseAtStart(_selection: RangeSelection): boolean {
+    this.getParentOrThrow().insertBefore(this);
+    return true;
+  }
+
+  insertNewAfter(): ElementNode {
+    const containerNode = this.getParentOrThrow();
+
+    if (containerNode.getCollapsed()) {
+      const paragraph = $createParagraphNode();
+      containerNode.insertAfter(paragraph);
+      return paragraph;
+    } else {
+      let contentNode = this.getNextSibling();
+      if (!$isCollapsibleContentNode(contentNode)) {
+        contentNode = $createCollapsibleContentNode();
+      }
+
+      const paragraph = $createParagraphNode();
+      contentNode.append(paragraph);
+      return paragraph;
+    }
+  }
+}
+
+export function $createCollapsibleTitleNode(): CollapsibleTitleNode {
+  return new CollapsibleTitleNode();
+}
+
+export function $isCollapsibleTitleNode(
+  node: LexicalNode | null | undefined,
+): node is CollapsibleTitleNode {
+  return node instanceof CollapsibleTitleNode;
+}

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
@@ -118,14 +118,11 @@ export default function CollapsiblePlugin(): JSX.Element | null {
           }
 
           const container = topLevelElement.getPreviousSibling();
-          if (
-            !$isCollapsibleContainerNode(container) ||
-            !container.getCollapsed()
-          ) {
+          if (!$isCollapsibleContainerNode(container) || container.getOpen()) {
             return false;
           }
 
-          container.setCollapsed(false);
+          container.setOpen(true);
           return true;
         },
         COMMAND_PRIORITY_LOW,
@@ -181,7 +178,7 @@ export default function CollapsiblePlugin(): JSX.Element | null {
               if ($isCollapsibleTitleNode(parent)) {
                 const container = parent.getParent();
                 if ($isCollapsibleContainerNode(container)) {
-                  container.setCollapsed(!container.getCollapsed());
+                  container.toggleOpen();
                   $setSelection(selection.clone());
                   return true;
                 }
@@ -225,7 +222,7 @@ export default function CollapsiblePlugin(): JSX.Element | null {
           editor.update(() => {
             const containerNode = $getNodeByKey(key);
             if ($isCollapsibleContainerNode(containerNode)) {
-              containerNode.setCollapsed(!containerNode.getCollapsed());
+              containerNode.toggleOpen();
             }
           });
 

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
@@ -204,7 +204,9 @@ export default function CollapsiblePlugin(): JSX.Element | null {
             }
 
             const title = $createCollapsibleTitleNode();
-            const content = $createCollapsibleContentNode();
+            const content = $createCollapsibleContentNode().append(
+              $createParagraphNode(),
+            );
             const container = $createCollapsibleContainerNode().append(
               title,
               content,

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
@@ -1,0 +1,237 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import './Collapsible.css';
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$findMatchingParent, mergeRegister} from '@lexical/utils';
+import {
+  $createParagraphNode,
+  $getNodeByKey,
+  $getPreviousSelection,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  $setSelection,
+  COMMAND_PRIORITY_EDITOR,
+  COMMAND_PRIORITY_LOW,
+  createCommand,
+  DELETE_CHARACTER_COMMAND,
+  INSERT_PARAGRAPH_COMMAND,
+  KEY_ARROW_DOWN_COMMAND,
+  NodeKey,
+} from 'lexical';
+import {useEffect} from 'react';
+
+import {
+  $createCollapsibleContainerNode,
+  $isCollapsibleContainerNode,
+  CollapsibleContainerNode,
+} from './CollapsibleContainerNode';
+import {
+  $createCollapsibleContentNode,
+  $isCollapsibleContentNode,
+  CollapsibleContentNode,
+} from './CollapsibleContentNode';
+import {
+  $createCollapsibleTitleNode,
+  $isCollapsibleTitleNode,
+  CollapsibleTitleNode,
+} from './CollapsibleTitleNode';
+
+export const INSERT_COLLAPSIBLE_COMMAND = createCommand<void>();
+export const TOGGLE_COLLAPSIBLE_COMMAND = createCommand<NodeKey>();
+
+export default function CollapsiblePlugin(): JSX.Element | null {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    if (
+      !editor.hasNodes([
+        CollapsibleContainerNode,
+        CollapsibleTitleNode,
+        CollapsibleContentNode,
+      ])
+    ) {
+      throw new Error(
+        'CollapsiblePlugin: CollapsibleContainerNode, CollapsibleTitleNode, or CollapsibleContentNode not registered on editor',
+      );
+    }
+
+    return mergeRegister(
+      // Structure enforcing transformers for each node type. In case nesting structure is not
+      // "Container > Title + Content" it'll unwrap nodes and convert it back
+      // to regular content.
+      editor.registerNodeTransform(CollapsibleContentNode, (node) => {
+        const parent = node.getParent();
+        if (!$isCollapsibleContainerNode(parent)) {
+          const children = node.getChildren();
+          for (const child of children) {
+            node.insertAfter(child);
+          }
+          node.remove();
+        }
+      }),
+      editor.registerNodeTransform(CollapsibleTitleNode, (node) => {
+        const parent = node.getParent();
+        if (!$isCollapsibleContainerNode(parent)) {
+          node.replace($createParagraphNode().append(...node.getChildren()));
+        }
+      }),
+      editor.registerNodeTransform(CollapsibleContainerNode, (node) => {
+        const children = node.getChildren();
+        if (
+          children.length !== 2 ||
+          !$isCollapsibleTitleNode(children[0]) ||
+          !$isCollapsibleContentNode(children[1])
+        ) {
+          for (const child of children) {
+            node.insertAfter(child);
+          }
+          node.remove();
+        }
+      }),
+      // This handles the case when container is collapsed and we delete its previous sibling
+      // into it, it would cause collapsed content deleted (since it's display: none, and selection
+      // swallows it when deletes single char). Instead we expand container, which is although
+      // not perfect, but avoids bigger problem
+      editor.registerCommand(
+        DELETE_CHARACTER_COMMAND,
+        () => {
+          const selection = $getSelection();
+          if (
+            !$isRangeSelection(selection) ||
+            !selection.isCollapsed() ||
+            selection.anchor.offset !== 0
+          ) {
+            return false;
+          }
+
+          const anchorNode = selection.anchor.getNode();
+          const topLevelElement = anchorNode.getTopLevelElement();
+          if (topLevelElement === null) {
+            return false;
+          }
+
+          const container = topLevelElement.getPreviousSibling();
+          if (
+            !$isCollapsibleContainerNode(container) ||
+            !container.getCollapsed()
+          ) {
+            return false;
+          }
+
+          container.setCollapsed(false);
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+      // When collapsible is the last child pressing down arrow will insert paragraph
+      // below it to allow adding more content. It's similar what $insertBlockNode
+      // (mainly for decorators), except it'll always be possible to continue adding
+      // new content even if trailing paragraph is accidentally deleted
+      editor.registerCommand(
+        KEY_ARROW_DOWN_COMMAND,
+        () => {
+          const selection = $getSelection();
+          if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+            return false;
+          }
+
+          const container = $findMatchingParent(
+            selection.anchor.getNode(),
+            $isCollapsibleContainerNode,
+          );
+
+          if (container === null) {
+            return false;
+          }
+
+          const parent = container.getParent();
+          if (parent !== null && parent.getLastChild() === container) {
+            parent.append($createParagraphNode());
+          }
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+      // Handling CMD+Enter to toggle collapsible element collapsed state
+      editor.registerCommand(
+        INSERT_PARAGRAPH_COMMAND,
+        () => {
+          // @ts-ignore
+          const windowEvent: KeyboardEvent | undefined = editor._window?.event;
+
+          if (
+            windowEvent &&
+            (windowEvent.ctrlKey || windowEvent.metaKey) &&
+            windowEvent.key === 'Enter'
+          ) {
+            const selection = $getPreviousSelection();
+            if ($isRangeSelection(selection) && selection.isCollapsed()) {
+              const parent = $findMatchingParent(
+                selection.anchor.getNode(),
+                (node) => $isElementNode(node) && !node.isInline(),
+              );
+
+              if ($isCollapsibleTitleNode(parent)) {
+                const container = parent.getParent();
+                if ($isCollapsibleContainerNode(container)) {
+                  container.setCollapsed(!container.getCollapsed());
+                  $setSelection(selection.clone());
+                  return true;
+                }
+              }
+            }
+          }
+
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        INSERT_COLLAPSIBLE_COMMAND,
+        () => {
+          editor.update(() => {
+            const selection = $getSelection();
+
+            if (!$isRangeSelection(selection)) {
+              return;
+            }
+
+            const title = $createCollapsibleTitleNode();
+            const content = $createCollapsibleContentNode();
+            const container = $createCollapsibleContainerNode().append(
+              title,
+              content,
+            );
+            selection.insertNodes([container]);
+            title.selectStart();
+          });
+
+          return true;
+        },
+        COMMAND_PRIORITY_EDITOR,
+      ),
+      editor.registerCommand(
+        TOGGLE_COLLAPSIBLE_COMMAND,
+        (key: NodeKey) => {
+          editor.update(() => {
+            const containerNode = $getNodeByKey(key);
+            if ($isCollapsibleContainerNode(containerNode)) {
+              containerNode.setCollapsed(!containerNode.getCollapsed());
+            }
+          });
+
+          return true;
+        },
+        COMMAND_PRIORITY_EDITOR,
+      ),
+    );
+  }, [editor]);
+  return null;
+}

--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -37,6 +37,7 @@ import * as ReactDOM from 'react-dom';
 import useModal from '../../hooks/useModal';
 import catTypingGif from '../../images/cat-typing.gif';
 import {EmbedConfigs} from '../AutoEmbedPlugin';
+import {INSERT_COLLAPSIBLE_COMMAND} from '../CollapsiblePlugin';
 import {INSERT_EXCALIDRAW_COMMAND} from '../ExcalidrawPlugin';
 import {INSERT_IMAGE_COMMAND} from '../ImagesPlugin';
 import {
@@ -306,6 +307,12 @@ export default function ComponentPickerMenuPlugin(): JSX.Element {
           showModal('Insert Image', (onClose) => (
             <InsertImageDialog activeEditor={editor} onClose={onClose} />
           )),
+      }),
+      new ComponentPickerOption('Collapsible', {
+        icon: <i className="icon caret-right" />,
+        keywords: ['collapse', 'collapsible', 'toggle'],
+        onSelect: () =>
+          editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND, undefined),
       }),
       ...['left', 'center', 'right', 'justify'].map(
         (alignment) =>

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -88,6 +88,7 @@ import TextInput from '../../ui/TextInput';
 import {getSelectedNode} from '../../utils/getSelectedNode';
 import {sanitizeUrl} from '../../utils/sanitizeUrl';
 import {EmbedConfigs} from '../AutoEmbedPlugin';
+import {INSERT_COLLAPSIBLE_COMMAND} from '../CollapsiblePlugin';
 import {INSERT_EQUATION_COMMAND} from '../EquationsPlugin';
 import {INSERT_EXCALIDRAW_COMMAND} from '../ExcalidrawPlugin';
 import {INSERT_IMAGE_COMMAND} from '../ImagesPlugin';
@@ -1120,6 +1121,14 @@ export default function ToolbarPlugin(): JSX.Element {
               className="item">
               <i className="icon sticky" />
               <span className="text">Sticky Note</span>
+            </DropDownItem>
+            <DropDownItem
+              onClick={() => {
+                editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND, undefined);
+              }}
+              className="item">
+              <i className="icon plus" />
+              <span className="text">Collapsible container</span>
             </DropDownItem>
             {EmbedConfigs.map((embedConfig) => (
               <DropDownItem

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -1127,7 +1127,7 @@ export default function ToolbarPlugin(): JSX.Element {
                 editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND, undefined);
               }}
               className="item">
-              <i className="icon plus" />
+              <i className="icon caret-right" />
               <span className="text">Collapsible container</span>
             </DropDownItem>
             {EmbedConfigs.map((embedConfig) => (


### PR DESCRIPTION
Kind of an experiment with nested elements (vs going w/decorator and nested editors). Main part is in transformers that enforce nesting structure (and if it's violated unwrap content and convert collapsible content into regular paragraphs)
```
CollapsibleContainer
  > CollapsibleTitle
  > CollapsibleContent[isShadowRoot]
    > Paragraph
    > Heading
    > ...
```

https://user-images.githubusercontent.com/132642/192806800-292aa729-c5e6-41d1-9ba6-02259f1d9d6e.mov

