### PR TITLE
add onlyOnTopLevelElements option to markdown plugin

### DIFF
--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -34,12 +34,14 @@ function runElementTransformers(
   anchorNode: TextNode,
   anchorOffset: number,
   elementTransformers: ReadonlyArray<ElementTransformer>,
+  onlyOnTopLevelElements: boolean,
 ): boolean {
   const grandParentNode = parentNode.getParent();
 
   if (
-    !$isRootOrShadowRoot(grandParentNode) ||
-    parentNode.getFirstChild() !== anchorNode
+    onlyOnTopLevelElements &&
+    (!$isRootOrShadowRoot(grandParentNode) ||
+      parentNode.getFirstChild() !== anchorNode)
   ) {
     return false;
   }
@@ -323,6 +325,7 @@ function isEqualSubString(
 export function registerMarkdownShortcuts(
   editor: LexicalEditor,
   transformers: Array<Transformer> = TRANSFORMERS,
+  onlyOnTopLevelElements = true,
 ): () => void {
   const byType = transformersByType(transformers);
   const textFormatTransformersIndex = indexBy(
@@ -358,6 +361,7 @@ export function registerMarkdownShortcuts(
         anchorNode,
         anchorOffset,
         byType.element,
+        onlyOnTopLevelElements,
       )
     ) {
       return;

--- a/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.tsx
+++ b/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.tsx
@@ -42,14 +42,20 @@ export const DEFAULT_TRANSFORMERS = [HR, ...TRANSFORMERS];
 
 export function MarkdownShortcutPlugin({
   transformers = DEFAULT_TRANSFORMERS,
+  onlyOnTopLevelElements = true,
 }: Readonly<{
   transformers?: Array<Transformer>;
+  onlyOnTopLevelElements?: boolean;
 }>): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    return registerMarkdownShortcuts(editor, transformers);
-  }, [editor, transformers]);
+    return registerMarkdownShortcuts(
+      editor,
+      transformers,
+      onlyOnTopLevelElements,
+    );
+  }, [editor, transformers, onlyOnTopLevelElements]);
 
   return null;
 }


### PR DESCRIPTION
I would like to be able to use Markdown shortcuts on nested elements. The `isRootOrShadowRoot` is currently blocking this. This PR makes this behaviour configurable.

Two questions:
- I wasn't sure what `parentNode.getFirstChild() !== anchorNode` is used for. For now the check is omitted when `onlyOnTopLevelElements === false`, but maybe this is wrong
- Unrelated to this PR, but why is the `HR` ElementTransformer defined in `@lexical/react` and not part of `TRANSFORMERS`?