### PR TITLE
Typeaheads: Remove hard-coded "bottom" alignment (Breaking change)

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -250,13 +250,14 @@ pre::-webkit-scrollbar-thumb {
   background-image: url(images/icons/download.svg);
 }
 
-#typeahead-menu {
+.typeahead-popover {
   background: #fff;
   box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.3);
   border-radius: 8px;
+  margin-top: 25px;
 }
 
-#typeahead-menu ul {
+.typeahead-popover ul {
   padding: 0;
   list-style: none;
   margin: 0;
@@ -265,16 +266,16 @@ pre::-webkit-scrollbar-thumb {
   overflow-y: scroll;
 }
 
-#typeahead-menu ul::-webkit-scrollbar {
+.typeahead-popover ul::-webkit-scrollbar {
   display: none;
 }
 
-#typeahead-menu ul {
+.typeahead-popover ul {
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
 
-#typeahead-menu ul li {
+.typeahead-popover ul li {
   margin: 0;
   min-width: 180px;
   font-size: 14px;
@@ -283,11 +284,11 @@ pre::-webkit-scrollbar-thumb {
   border-radius: 8px;
 }
 
-#typeahead-menu ul li.selected {
+.typeahead-popover ul li.selected {
   background: #eee;
 }
 
-#typeahead-menu li {
+.typeahead-popover li {
   margin: 0 8px 0 8px;
   padding: 8px;
   color: #050505;
@@ -304,33 +305,33 @@ pre::-webkit-scrollbar-thumb {
   max-width: 250px;
 }
 
-#typeahead-menu li.active {
+.typeahead-popover li.active {
   display: flex;
   width: 20px;
   height: 20px;
   background-size: contain;
 }
 
-#typeahead-menu li:first-child {
+.typeahead-popover li:first-child {
   border-radius: 8px 8px 0px 0px;
 }
 
-#typeahead-menu li:last-child {
+.typeahead-popover li:last-child {
   border-radius: 0px 0px 8px 8px;
 }
 
-#typeahead-menu li:hover {
+.typeahead-popover li:hover {
   background-color: #eee;
 }
 
-#typeahead-menu li .text {
+.typeahead-popover li .text {
   display: flex;
   line-height: 20px;
   flex-grow: 1;
   min-width: 150px;
 }
 
-#typeahead-menu li .icon {
+.typeahead-popover li .icon {
   display: flex;
   width: 20px;
   height: 20px;

--- a/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
@@ -12,13 +12,13 @@ import {
   AutoEmbedOption,
   EmbedConfig,
   EmbedMatchResult,
-  EmbedMenuProps,
   LexicalAutoEmbedPlugin,
   URL_MATCHER,
 } from '@lexical/react/LexicalAutoEmbedPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useState} from 'react';
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 
 import useModal from '../../hooks/useModal';
 import Button from '../../ui/Button';
@@ -189,20 +189,27 @@ function AutoEmbedMenu({
   selectedItemIndex,
   onOptionClick,
   onOptionMouseEnter,
-}: EmbedMenuProps) {
+}: {
+  selectedItemIndex: number | null;
+  onOptionClick: (option: AutoEmbedOption, index: number) => void;
+  onOptionMouseEnter: (index: number) => void;
+  options: Array<AutoEmbedOption>;
+}) {
   return (
-    <ul>
-      {options.map((option: AutoEmbedOption, i: number) => (
-        <AutoEmbedMenuItem
-          index={i}
-          isSelected={selectedItemIndex === i}
-          onClick={() => onOptionClick(option, i)}
-          onMouseEnter={() => onOptionMouseEnter(i)}
-          key={option.key}
-          option={option}
-        />
-      ))}
-    </ul>
+    <div className="typeahead-popover">
+      <ul>
+        {options.map((option: AutoEmbedOption, i: number) => (
+          <AutoEmbedMenuItem
+            index={i}
+            isSelected={selectedItemIndex === i}
+            onClick={() => onOptionClick(option, i)}
+            onMouseEnter={() => onOptionMouseEnter(i)}
+            key={option.key}
+            option={option}
+          />
+        ))}
+      </ul>
+    </div>
   );
 }
 
@@ -284,7 +291,27 @@ export default function AutoEmbedPlugin(): JSX.Element {
         embedConfigs={EmbedConfigs}
         onOpenEmbedModalForConfig={openEmbedModal}
         getMenuOptions={getMenuOptions}
-        menuComponent={AutoEmbedMenu}
+        menuRenderFn={(
+          anchorElement,
+          {selectedIndex, options, selectOptionAndCleanUp, setHighlightedIndex},
+        ) =>
+          anchorElement
+            ? ReactDOM.createPortal(
+                <AutoEmbedMenu
+                  options={options}
+                  selectedItemIndex={selectedIndex}
+                  onOptionClick={(option: AutoEmbedOption, index: number) => {
+                    setHighlightedIndex(index);
+                    selectOptionAndCleanUp(option);
+                  }}
+                  onOptionMouseEnter={(index: number) => {
+                    setHighlightedIndex(index);
+                  }}
+                />,
+                anchorElement,
+              )
+            : null
+        }
       />
     </>
   );

--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -375,23 +375,25 @@ export default function ComponentPickerMenuPlugin(): JSX.Element {
         ) =>
           anchorElement && options.length
             ? ReactDOM.createPortal(
-                <ul>
-                  {options.map((option, i: number) => (
-                    <ComponentPickerMenuItem
-                      index={i}
-                      isSelected={selectedIndex === i}
-                      onClick={() => {
-                        setHighlightedIndex(i);
-                        selectOptionAndCleanUp(option);
-                      }}
-                      onMouseEnter={() => {
-                        setHighlightedIndex(i);
-                      }}
-                      key={option.key}
-                      option={option}
-                    />
-                  ))}
-                </ul>,
+                <div className="typeahead-popover">
+                  <ul>
+                    {options.map((option, i: number) => (
+                      <ComponentPickerMenuItem
+                        index={i}
+                        isSelected={selectedIndex === i}
+                        onClick={() => {
+                          setHighlightedIndex(i);
+                          selectOptionAndCleanUp(option);
+                        }}
+                        onMouseEnter={() => {
+                          setHighlightedIndex(i);
+                        }}
+                        key={option.key}
+                        option={option}
+                      />
+                    ))}
+                  </ul>
+                </div>,
                 anchorElement,
               )
             : null

--- a/packages/lexical-playground/src/plugins/MentionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/MentionsPlugin/index.tsx
@@ -693,23 +693,25 @@ export default function NewMentionsPlugin(): JSX.Element | null {
       ) =>
         anchorElement && results.length
           ? ReactDOM.createPortal(
-              <ul>
-                {options.map((option, i: number) => (
-                  <MentionsTypeaheadMenuItem
-                    index={i}
-                    isSelected={selectedIndex === i}
-                    onClick={() => {
-                      setHighlightedIndex(i);
-                      selectOptionAndCleanUp(option);
-                    }}
-                    onMouseEnter={() => {
-                      setHighlightedIndex(i);
-                    }}
-                    key={option.key}
-                    option={option}
-                  />
-                ))}
-              </ul>,
+              <div className="typeahead-popover">
+                <ul>
+                  {options.map((option, i: number) => (
+                    <MentionsTypeaheadMenuItem
+                      index={i}
+                      isSelected={selectedIndex === i}
+                      onClick={() => {
+                        setHighlightedIndex(i);
+                        selectOptionAndCleanUp(option);
+                      }}
+                      onMouseEnter={() => {
+                        setHighlightedIndex(i);
+                      }}
+                      key={option.key}
+                      option={option}
+                    />
+                  ))}
+                </ul>
+              </div>,
               anchorElement,
             )
           : null

--- a/packages/lexical-react/flow/LexicalAutoEmbedPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalAutoEmbedPlugin.js.flow
@@ -34,19 +34,9 @@ export const URL_MATCHER: RegExp =
 export const INSERT_EMBED_COMMAND: LexicalCommand<EmbedConfig['type']> =
   createCommand();
 
-export type EmbedMenuProps = {
-  selectedItemIndex: number | null,
-  onOptionClick: (option: AutoEmbedOption, index: number) => void,
-  onOptionMouseEnter: (index: number) => void,
-  options: Array<AutoEmbedOption>,
-};
-
-export type EmbedMenuComponent = React.ComponentType<EmbedMenuProps>;
-
 type LexicalAutoEmbedPluginProps<TEmbedConfig> = {
   embedConfigs: Array<TEmbedConfig>,
   onOpenEmbedModalForConfig: (embedConfig: TEmbedConfig) => void,
-  menuComponent: EmbedMenuComponent,
   getMenuOptions: (
     activeEmbedConfig: TEmbedConfig,
     embedFn: () => void,

--- a/packages/lexical-react/flow/LexicalAutoEmbedPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalAutoEmbedPlugin.js.flow
@@ -13,6 +13,7 @@ import {TypeaheadOption} from '@lexical/react/LexicalTypeaheadMenuPlugin';
 import type {LexicalCommand, LexicalEditor, NodeKey, TextNode} from 'lexical';
 import * as React from 'react';
 import {createCommand} from 'lexical';
+import type {MenuRenderFn} from './LexicalTypeaheadMenuPlugin';
 
 export type EmbedMatchResult = {
   url: string,
@@ -42,6 +43,7 @@ type LexicalAutoEmbedPluginProps<TEmbedConfig> = {
     embedFn: () => void,
     dismissFn: () => void,
   ) => Array<AutoEmbedOption>,
+  menuRenderFn: MenuRenderFn<AutoEmbedOption>,
 };
 
 declare export class AutoEmbedOption extends TypeaheadOption {

--- a/packages/lexical-react/flow/LexicalTypeaheadMenuPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalTypeaheadMenuPlugin.js.flow
@@ -37,6 +37,7 @@ export type MenuRenderFn<TOption> = (
     selectedIndex: number | null,
     selectOptionAndCleanUp: (option: TOption) => void,
     setHighlightedIndex: (index: number) => void,
+    options: Array<TOption>,
   },
   matchingString: string,
 ) => React.Portal | React.MixedElement | null;

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -221,17 +221,19 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
       ) =>
         anchorElement && nodeKey != null
           ? ReactDOM.createPortal(
-              <MenuComponent
-                options={options}
-                selectedItemIndex={selectedIndex}
-                onOptionClick={(option: AutoEmbedOption, index: number) => {
-                  setHighlightedIndex(index);
-                  selectOptionAndCleanUp(option);
-                }}
-                onOptionMouseEnter={(index: number) => {
-                  setHighlightedIndex(index);
-                }}
-              />,
+              <div className="typeahead-popover">
+                <MenuComponent
+                  options={options}
+                  selectedItemIndex={selectedIndex}
+                  onOptionClick={(option: AutoEmbedOption, index: number) => {
+                    setHighlightedIndex(index);
+                    selectOptionAndCleanUp(option);
+                  }}
+                  onOptionMouseEnter={(index: number) => {
+                    setHighlightedIndex(index);
+                  }}
+                />
+              </div>,
               anchorElement,
             )
           : null

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -11,6 +11,7 @@ import {$isLinkNode, AutoLinkNode, LinkNode} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   LexicalNodeMenuPlugin,
+  MenuRenderFn,
   TypeaheadOption,
 } from '@lexical/react/LexicalTypeaheadMenuPlugin';
 import {mergeRegister} from '@lexical/utils';
@@ -25,7 +26,6 @@ import {
 } from 'lexical';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 
 export type EmbedMatchResult = {
   url: string;
@@ -47,15 +47,6 @@ export const URL_MATCHER =
 export const INSERT_EMBED_COMMAND: LexicalCommand<EmbedConfig['type']> =
   createCommand();
 
-export type EmbedMenuProps = {
-  selectedItemIndex: number | null;
-  onOptionClick: (option: AutoEmbedOption, index: number) => void;
-  onOptionMouseEnter: (index: number) => void;
-  options: Array<AutoEmbedOption>;
-};
-
-export type EmbedMenuComponent = React.ComponentType<EmbedMenuProps>;
-
 export class AutoEmbedOption extends TypeaheadOption {
   title: string;
   onSelect: (targetNode: LexicalNode | null) => void;
@@ -74,19 +65,19 @@ export class AutoEmbedOption extends TypeaheadOption {
 type LexicalAutoEmbedPluginProps<TEmbedConfig extends EmbedConfig> = {
   embedConfigs: Array<TEmbedConfig>;
   onOpenEmbedModalForConfig: (embedConfig: TEmbedConfig) => void;
-  menuComponent: EmbedMenuComponent;
   getMenuOptions: (
     activeEmbedConfig: TEmbedConfig,
     embedFn: () => void,
     dismissFn: () => void,
   ) => Array<AutoEmbedOption>;
+  menuRenderFn: MenuRenderFn<AutoEmbedOption>;
 };
 
 export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
   embedConfigs,
   onOpenEmbedModalForConfig,
   getMenuOptions,
-  menuComponent: MenuComponent,
+  menuRenderFn,
 }: LexicalAutoEmbedPluginProps<TEmbedConfig>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
 
@@ -215,29 +206,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
       onClose={reset}
       onSelectOption={onSelectOption}
       options={options}
-      menuRenderFn={(
-        anchorElement,
-        {selectedIndex, selectOptionAndCleanUp, setHighlightedIndex},
-      ) =>
-        anchorElement && nodeKey != null
-          ? ReactDOM.createPortal(
-              <div className="typeahead-popover">
-                <MenuComponent
-                  options={options}
-                  selectedItemIndex={selectedIndex}
-                  onOptionClick={(option: AutoEmbedOption, index: number) => {
-                    setHighlightedIndex(index);
-                    selectOptionAndCleanUp(option);
-                  }}
-                  onOptionMouseEnter={(index: number) => {
-                    setHighlightedIndex(index);
-                  }}
-                />
-              </div>,
-              anchorElement,
-            )
-          : null
-      }
+      menuRenderFn={menuRenderFn}
     />
   ) : null;
 }

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -72,6 +72,7 @@ export type MenuRenderFn<TOption extends TypeaheadOption> = (
     selectedIndex: number | null;
     selectOptionAndCleanUp: (option: TOption) => void;
     setHighlightedIndex: (index: number) => void;
+    options: Array<TOption>;
   },
   matchingString: string,
 ) => ReactPortal | JSX.Element | null;
@@ -497,11 +498,12 @@ function LexicalPopoverMenu<TOption extends TypeaheadOption>({
 
   const listItemProps = useMemo(
     () => ({
+      options,
       selectOptionAndCleanUp,
       selectedIndex,
       setHighlightedIndex,
     }),
-    [selectOptionAndCleanUp, selectedIndex],
+    [selectOptionAndCleanUp, selectedIndex, options],
   );
 
   return menuRenderFn(
@@ -547,11 +549,6 @@ export function useBasicTypeaheadTriggerMatch(
     [maxLength, minLength, trigger],
   );
 }
-
-type AnchorConfig = {
-  position?: 'start' | 'end';
-  paddingTop?: number;
-};
 
 function useMenuAnchorRef(
   resolution: Resolution | null,
@@ -621,7 +618,6 @@ function useMenuAnchorRef(
 }
 
 export type TypeaheadMenuPluginProps<TOption extends TypeaheadOption> = {
-  anchorConfig?: AnchorConfig;
   onQueryChange: (matchingString: string | null) => void;
   onSelectOption: (
     option: TOption,
@@ -745,7 +741,6 @@ export function LexicalTypeaheadMenuPlugin<TOption extends TypeaheadOption>({
 }
 
 type NodeMenuPluginProps<TOption extends TypeaheadOption> = {
-  anchorConfig?: AnchorConfig;
   onSelectOption: (
     option: TOption,
     textNodeContainingQuery: TextNode | null,
@@ -761,7 +756,6 @@ type NodeMenuPluginProps<TOption extends TypeaheadOption> = {
 };
 
 export function LexicalNodeMenuPlugin<TOption extends TypeaheadOption>({
-  anchorConfig,
   options,
   nodeKey,
   position = 'end',

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -548,6 +548,11 @@ export function useBasicTypeaheadTriggerMatch(
   );
 }
 
+type AnchorConfig = {
+  position?: 'start' | 'end';
+  paddingTop?: number;
+};
+
 function useMenuAnchorRef(
   resolution: Resolution | null,
   setResolution: (r: Resolution | null) => void,
@@ -561,12 +566,13 @@ function useMenuAnchorRef(
 
     if (rootElement !== null && resolution !== null) {
       const {left, top, width, height} = resolution.getRect();
-      containerDiv.style.top = `${top + height + 5 + window.pageYOffset}px`;
+      containerDiv.style.top = `${top + window.pageYOffset}px`;
       containerDiv.style.left = `${
         left +
         (resolution.position === 'start' ? 0 : width) +
         window.pageXOffset
       }px`;
+      containerDiv.style.height = `${height}px`;
 
       if (!containerDiv.isConnected) {
         containerDiv.setAttribute('aria-label', 'Typeahead menu');
@@ -615,6 +621,7 @@ function useMenuAnchorRef(
 }
 
 export type TypeaheadMenuPluginProps<TOption extends TypeaheadOption> = {
+  anchorConfig?: AnchorConfig;
   onQueryChange: (matchingString: string | null) => void;
   onSelectOption: (
     option: TOption,
@@ -738,6 +745,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends TypeaheadOption>({
 }
 
 type NodeMenuPluginProps<TOption extends TypeaheadOption> = {
+  anchorConfig?: AnchorConfig;
   onSelectOption: (
     option: TOption,
     textNodeContainingQuery: TextNode | null,
@@ -753,6 +761,7 @@ type NodeMenuPluginProps<TOption extends TypeaheadOption> = {
 };
 
 export function LexicalNodeMenuPlugin<TOption extends TypeaheadOption>({
+  anchorConfig,
   options,
   nodeKey,
   position = 'end',


### PR DESCRIPTION
Lexical is a rich text editing framework, not a popover framework, so it's a slippery slope to start including dynamic positioning with our plugins. It should be up to the developer to wire our `anchor` to a popover solution of their choice or use a React Portal and menu with some basic margin.

When this plugin was originally created it was designed with the common "bottom" alignment hard coded by forcing the `anchor` to be positioned below the line (see red box below).

<img width="273" alt="image" src="https://user-images.githubusercontent.com/13852400/193692967-866716bd-ca6f-4a6e-bd15-f965b99aeba2.png">

This works for common use cases but quickly gets in the way as soon as you want to use a popover with auto alignment that may shift positioning to the top of the anchor when it'd otherwise be off screen.

Now the `anchor` is positioned "over" the selection so you can handle the menu positioning however you'd like.

<img width="246" alt="image" src="https://user-images.githubusercontent.com/13852400/193692462-60b93b1e-65b4-4951-8e5b-3a894d0d5a0e.png">

