### PR TITLE
copyToClipboard to return success

### DIFF
--- a/packages/lexical-clipboard/flow/LexicalClipboard.js.flow
+++ b/packages/lexical-clipboard/flow/LexicalClipboard.js.flow
@@ -61,3 +61,8 @@ declare export function $generateJSONFromSelectedNodes<
 declare export function $generateNodesFromSerializedNodes(
   serializedNodes: Array<BaseSerializedNode>,
 ): Array<LexicalNode>;
+
+declare export function copyToClipboard__EXPERIMENTAL(
+  editor: LexicalEditor,
+  event: null | ClipboardEvent,
+): Promise<boolean>;

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -370,20 +370,22 @@ function onPasteForRichText(
   );
 }
 
-function onCutForRichText(
+async function onCutForRichText(
   event: CommandPayloadType<typeof CUT_COMMAND>,
   editor: LexicalEditor,
-): void {
-  copyToClipboard__EXPERIMENTAL(
+): Promise<void> {
+  await copyToClipboard__EXPERIMENTAL(
     editor,
     event instanceof ClipboardEvent ? event : null,
   );
-  const selection = $getSelection();
-  if ($isRangeSelection(selection)) {
-    selection.removeText();
-  } else if ($isNodeSelection(selection)) {
-    selection.getNodes().forEach((node) => node.remove());
-  }
+  editor.update(() => {
+    const selection = $getSelection();
+    if ($isRangeSelection(selection)) {
+      selection.removeText();
+    } else if ($isNodeSelection(selection)) {
+      selection.getNodes().forEach((node) => node.remove());
+    }
+  });
 }
 
 function handleIndentAndOutdent(


### PR DESCRIPTION
`copyToClipboard` is an asynchronous operation. Moreover, it can fail on certain selection or browser conditions. This PR makes it so that it returns a `Promise<boolean>` which should help the user handle the response appropriately.

For our immediate use case, cut, this helps us understand when the clipboard operation is complete so that we can remove the content safely from the screen (fixes race condition).

Closes https://github.com/facebook/lexical/issues/3103