### PR TITLE
Typeaheads: Add scroll command and increase priority

### DIFF
--- a/packages/lexical-react/flow/LexicalTypeaheadMenuPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalTypeaheadMenuPlugin.js.flow
@@ -7,6 +7,7 @@
  * @flow strict
  */
 
+import type {LexicalCommand} from '../../lexical/flow/Lexical';
 import type {LexicalEditor, NodeKey, TextNode} from 'lexical';
 import * as React from 'react';
 
@@ -30,6 +31,11 @@ declare export class TypeaheadOption {
   constructor(key: string): void;
   setRefElement(element: HTMLElement | null): void;
 }
+
+declare export var SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND: LexicalCommand<{
+  index: number,
+  option: TypeaheadOption,
+}>;
 
 export type MenuRenderFn<TOption> = (
   anchorElement: HTMLElement | null,

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -13,12 +13,14 @@ import {
   $getSelection,
   $isRangeSelection,
   $isTextNode,
-  COMMAND_PRIORITY_NORMAL,
+  COMMAND_PRIORITY_CRITICAL,
+  createCommand,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_UP_COMMAND,
   KEY_ENTER_COMMAND,
   KEY_ESCAPE_COMMAND,
   KEY_TAB_COMMAND,
+  LexicalCommand,
   LexicalEditor,
   NodeKey,
   RangeSelection,
@@ -319,6 +321,11 @@ export function useDynamicPositioning(
   }, [targetElement, editor, onVisibilityChange, onReposition, resolution]);
 }
 
+export const SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND: LexicalCommand<{
+  index: number;
+  option: TypeaheadOption;
+}> = createCommand();
+
 function LexicalPopoverMenu<TOption extends TypeaheadOption>({
   close,
   editor,
@@ -399,6 +406,23 @@ function LexicalPopoverMenu<TOption extends TypeaheadOption>({
 
   useEffect(() => {
     return mergeRegister(
+      editor.registerCommand(
+        SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND,
+        ({option}) => {
+          if (option.ref && option.ref.current != null) {
+            scrollIntoViewIfNeeded(option.ref.current);
+            return true;
+          }
+
+          return false;
+        },
+        COMMAND_PRIORITY_CRITICAL,
+      ),
+    );
+  }, [editor, updateSelectedIndex]);
+
+  useEffect(() => {
+    return mergeRegister(
       editor.registerCommand<KeyboardEvent>(
         KEY_ARROW_DOWN_COMMAND,
         (payload) => {
@@ -409,14 +433,20 @@ function LexicalPopoverMenu<TOption extends TypeaheadOption>({
             updateSelectedIndex(newSelectedIndex);
             const option = options[newSelectedIndex];
             if (option.ref != null && option.ref.current) {
-              scrollIntoViewIfNeeded(option.ref.current);
+              editor.dispatchCommand(
+                SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND,
+                {
+                  index: newSelectedIndex,
+                  option,
+                },
+              );
             }
             event.preventDefault();
             event.stopImmediatePropagation();
           }
           return true;
         },
-        COMMAND_PRIORITY_NORMAL,
+        COMMAND_PRIORITY_CRITICAL,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_ARROW_UP_COMMAND,
@@ -435,7 +465,7 @@ function LexicalPopoverMenu<TOption extends TypeaheadOption>({
           }
           return true;
         },
-        COMMAND_PRIORITY_NORMAL,
+        COMMAND_PRIORITY_CRITICAL,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_ESCAPE_COMMAND,
@@ -446,7 +476,7 @@ function LexicalPopoverMenu<TOption extends TypeaheadOption>({
           close();
           return true;
         },
-        COMMAND_PRIORITY_NORMAL,
+        COMMAND_PRIORITY_CRITICAL,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_TAB_COMMAND,
@@ -464,7 +494,7 @@ function LexicalPopoverMenu<TOption extends TypeaheadOption>({
           selectOptionAndCleanUp(options[selectedIndex]);
           return true;
         },
-        COMMAND_PRIORITY_NORMAL,
+        COMMAND_PRIORITY_CRITICAL,
       ),
       editor.registerCommand(
         KEY_ENTER_COMMAND,
@@ -483,7 +513,7 @@ function LexicalPopoverMenu<TOption extends TypeaheadOption>({
           selectOptionAndCleanUp(options[selectedIndex]);
           return true;
         },
-        COMMAND_PRIORITY_NORMAL,
+        COMMAND_PRIORITY_CRITICAL,
       ),
     );
   }, [

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -14,6 +14,7 @@ import {
   $isRangeSelection,
   $isTextNode,
   COMMAND_PRIORITY_CRITICAL,
+  COMMAND_PRIORITY_LOW,
   createCommand,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_UP_COMMAND,
@@ -416,7 +417,7 @@ function LexicalPopoverMenu<TOption extends TypeaheadOption>({
 
           return false;
         },
-        COMMAND_PRIORITY_CRITICAL,
+        COMMAND_PRIORITY_LOW,
       ),
     );
   }, [editor, updateSelectedIndex]);


### PR DESCRIPTION
When using virtualization or other special rendering methods you may want to listen for the `SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND` command.

This PR also increases the priority of typeahead command listeners since when the menu is open any keystrokes may be relevant to the typeahead's internal behavior. For example, there was an issue reported where Table key navigation took priority over Typeaheads that were open inside of them. This PR and #3107 solve this.
