### PR TITLE
Lower key navigation command priority for Tables

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -8,6 +8,15 @@
 
 import type {TableNode} from './LexicalTableNode';
 import type {Cell, Cells, Grid} from './LexicalTableSelection';
+import type {
+  GridSelection,
+  LexicalCommand,
+  LexicalEditor,
+  LexicalNode,
+  NodeSelection,
+  RangeSelection,
+  TextFormatType,
+} from 'lexical';
 
 import {TableCellNode} from '@lexical/table';
 import {$findMatchingParent} from '@lexical/utils';
@@ -32,7 +41,6 @@ import {
   DEPRECATED_$isGridSelection,
   FOCUS_COMMAND,
   FORMAT_TEXT_COMMAND,
-  GridSelection,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
@@ -40,13 +48,7 @@ import {
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
   KEY_TAB_COMMAND,
-  LexicalCommand,
-  LexicalEditor,
-  LexicalNode,
-  NodeSelection,
-  RangeSelection,
   SELECTION_CHANGE_COMMAND,
-  TextFormatType,
 } from 'lexical';
 
 import {$isTableCellNode} from './LexicalTableCellNode';

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -8,15 +8,6 @@
 
 import type {TableNode} from './LexicalTableNode';
 import type {Cell, Cells, Grid} from './LexicalTableSelection';
-import type {
-  GridSelection,
-  LexicalCommand,
-  LexicalEditor,
-  LexicalNode,
-  NodeSelection,
-  RangeSelection,
-  TextFormatType,
-} from 'lexical';
 
 import {TableCellNode} from '@lexical/table';
 import {$findMatchingParent} from '@lexical/utils';
@@ -32,6 +23,7 @@ import {
   $isRangeSelection,
   $setSelection,
   COMMAND_PRIORITY_CRITICAL,
+  COMMAND_PRIORITY_HIGH,
   CONTROLLED_TEXT_INSERTION_COMMAND,
   DELETE_CHARACTER_COMMAND,
   DELETE_LINE_COMMAND,
@@ -40,6 +32,7 @@ import {
   DEPRECATED_$isGridSelection,
   FOCUS_COMMAND,
   FORMAT_TEXT_COMMAND,
+  GridSelection,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
@@ -47,7 +40,13 @@ import {
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
   KEY_TAB_COMMAND,
+  LexicalCommand,
+  LexicalEditor,
+  LexicalNode,
+  NodeSelection,
+  RangeSelection,
   SELECTION_CHANGE_COMMAND,
+  TextFormatType,
 } from 'lexical';
 
 import {$isTableCellNode} from './LexicalTableCellNode';
@@ -291,7 +290,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      COMMAND_PRIORITY_CRITICAL,
+      COMMAND_PRIORITY_HIGH,
     ),
   );
 
@@ -396,7 +395,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      COMMAND_PRIORITY_CRITICAL,
+      COMMAND_PRIORITY_HIGH,
     ),
   );
 
@@ -496,7 +495,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      COMMAND_PRIORITY_CRITICAL,
+      COMMAND_PRIORITY_HIGH,
     ),
   );
 
@@ -600,7 +599,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      COMMAND_PRIORITY_CRITICAL,
+      COMMAND_PRIORITY_HIGH,
     ),
   );
 
@@ -860,7 +859,7 @@ export function applyTableHandlers(
 
         return false;
       },
-      COMMAND_PRIORITY_CRITICAL,
+      COMMAND_PRIORITY_HIGH,
     ),
   );
 
@@ -870,7 +869,7 @@ export function applyTableHandlers(
       (payload) => {
         return tableNode.isSelected();
       },
-      COMMAND_PRIORITY_CRITICAL,
+      COMMAND_PRIORITY_HIGH,
     ),
   );
 


### PR DESCRIPTION
There was an issue reported where Table key navigation took priority over Typeaheads that were open inside of them. This PR and #3106 solve this.