### PR TITLE
Add flushSync option to update()

### DIFF
--- a/packages/lexical-playground/src/nodes/TableComponent.tsx
+++ b/packages/lexical-playground/src/nodes/TableComponent.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import type {EditorState, RangeSelection, TextFormatType} from 'lexical';
+import type {RangeSelection, TextFormatType} from 'lexical';
 
 import {
   $generateJSONFromSelectedNodes,
@@ -204,13 +204,7 @@ function $updateCells(
       const editorState = cellEditor.parseEditorState(cell.json);
       cellEditor._headless = true;
       cellEditor.setEditorState(editorState);
-      cellEditor.update(() => {
-        // Complete hack for now
-        const pendingEditorState =
-          cellEditor._pendingEditorState as EditorState;
-        pendingEditorState._flushSync = true;
-        fn();
-      });
+      cellEditor.update(fn, {flushSync: true});
       cellEditor._headless = false;
       const newJSON = JSON.stringify(cellEditor.getEditorState());
       updateTableNode((tableNode) => {

--- a/packages/lexical-playground/src/nodes/TableComponent.tsx
+++ b/packages/lexical-playground/src/nodes/TableComponent.tsx
@@ -204,7 +204,7 @@ function $updateCells(
       const editorState = cellEditor.parseEditorState(cell.json);
       cellEditor._headless = true;
       cellEditor.setEditorState(editorState);
-      cellEditor.update(fn, {flushSync: true});
+      cellEditor.update(fn, {discrete: true});
       cellEditor._headless = false;
       const newJSON = JSON.stringify(cellEditor.getEditorState());
       updateTableNode((tableNode) => {

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -182,6 +182,7 @@ type EditorUpdateOptions = {
   onUpdate?: () => void,
   tag?: string,
   skipTransforms?: true,
+  flushSync?: true,
 };
 type EditorFocusOptions = {
   defaultSelection?: 'rootStart' | 'rootEnd',

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -182,7 +182,7 @@ type EditorUpdateOptions = {
   onUpdate?: () => void,
   tag?: string,
   skipTransforms?: true,
-  flushSync?: true,
+  discrete?: true,
 };
 type EditorFocusOptions = {
   defaultSelection?: 'rootStart' | 'rootEnd',

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -60,6 +60,7 @@ export type EditorUpdateOptions = {
   onUpdate?: () => void;
   skipTransforms?: true;
   tag?: string;
+  flushSync?: true;
 };
 
 export type EditorSetOptions = {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -60,7 +60,7 @@ export type EditorUpdateOptions = {
   onUpdate?: () => void;
   skipTransforms?: true;
   tag?: string;
-  flushSync?: true;
+  discrete?: true;
 };
 
 export type EditorSetOptions = {

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -765,7 +765,7 @@ function beginUpdate(
   let onUpdate;
   let tag;
   let skipTransforms = false;
-  let flushSync = false;
+  let discrete = false;
 
   if (options !== undefined) {
     onUpdate = options.onUpdate;
@@ -776,7 +776,7 @@ function beginUpdate(
     }
 
     skipTransforms = options.skipTransforms || false;
-    flushSync = options.flushSync || false;
+    discrete = options.discrete || false;
   }
 
   if (onUpdate) {
@@ -792,7 +792,7 @@ function beginUpdate(
       cloneEditorState(currentEditorState);
     editorStateWasCloned = true;
   }
-  pendingEditorState._flushSync = flushSync;
+  pendingEditorState._flushSync = discrete;
 
   const previousActiveEditorState = activeEditorState;
   const previousReadOnlyMode = isReadOnlyMode;

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -765,6 +765,7 @@ function beginUpdate(
   let onUpdate;
   let tag;
   let skipTransforms = false;
+  let flushSync = false;
 
   if (options !== undefined) {
     onUpdate = options.onUpdate;
@@ -775,6 +776,7 @@ function beginUpdate(
     }
 
     skipTransforms = options.skipTransforms || false;
+    flushSync = options.flushSync || false;
   }
 
   if (onUpdate) {
@@ -790,6 +792,7 @@ function beginUpdate(
       cloneEditorState(currentEditorState);
     editorStateWasCloned = true;
   }
+  pendingEditorState._flushSync = flushSync;
 
   const previousActiveEditorState = activeEditorState;
   const previousReadOnlyMode = isReadOnlyMode;

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2154,7 +2154,7 @@ describe('LexicalEditor tests', () => {
         );
       },
       {
-        flushSync: true,
+        discrete: true,
       },
     );
 

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2142,4 +2142,26 @@ describe('LexicalEditor tests', () => {
     expect(nodeTransformListener).toHaveBeenCalledTimes(1);
     expect(mutationListener).toHaveBeenCalledTimes(1);
   });
+
+  it('can use flushSync for synchronous updates', () => {
+    init();
+    const onUpdate = jest.fn();
+    editor.registerUpdateListener(onUpdate);
+    editor.update(
+      () => {
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('Sync update')),
+        );
+      },
+      {
+        flushSync: true,
+      },
+    );
+
+    const textContent = editor
+      .getEditorState()
+      .read(() => $getRoot().getTextContent());
+    expect(textContent).toBe('Sync update');
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
This would allow synchronous updates (e.g. for tests and some cases of headless mode):
```js
editor.update(() => {
  ...
}, { flushSync: true });

// Update and listeners are already executed

```