### PR TITLE
Ignore mutations which do not have target node

### DIFF
--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -143,7 +143,10 @@ export function $flushMutations(
           currentEditorState,
         );
 
-        if ($isDecoratorNode(targetNode)) {
+        if (
+          (targetNode === null && targetDOM !== rootElement) ||
+          $isDecoratorNode(targetNode)
+        ) {
           continue;
         }
 


### PR DESCRIPTION
## Problem

DOM mutations inside inputs of decorator nodes sometimes do not resolve to the correct state.

### Steps to reproduce
https://user-images.githubusercontent.com/1575198/194123575-fa20d99d-0d5e-494d-bf1b-be4b614b79cd.mov

**Discord related thread:** https://discord.com/channels/953974421008293909/955972012541628456/1027227449278349385


**Note:**
This does not seem to be fixing the problem with nested lexical editors, but it fixes the problem when decorator nodes have other non-lexical fields, i.e. a custom `contentEditable` element.

Here are steps to reproduce the issue in this specific use case:
1. Replace lexical caption field on the ImageNode with a `conentEditable` field

```diff
diff --git a/packages/lexical-playground/src/nodes/ImageComponent.tsx b/packages/lexical-playground/src/nodes/ImageComponent.tsx
index 7e2f59c9..f2ba2a6b 100644
--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -327,7 +327,8 @@ export default function ImageComponent({
         </div>
         {showCaption && (
           <div className="image-caption-container">
-            <LexicalNestedComposer initialEditor={caption}>
+            <div contentEditable="true"></div>
+            {/* <LexicalNestedComposer initialEditor={caption}>
               <AutoFocusPlugin />
               <MentionsPlugin />
               <LinkPlugin />
@@ -354,7 +355,7 @@ export default function ImageComponent({
                 }
               />
               {showNestedEditorTreeView === true ? <TreeViewPlugin /> : null}
-            </LexicalNestedComposer>
+            </LexicalNestedComposer> */}
           </div>
         )}
         {resizable && $isNodeSelection(selection) && isFocused && (
```
2. Follow the steps from this video:
https://user-images.githubusercontent.com/1575198/194130367-6bc4e00f-0dab-46cf-9719-a48ce7b923d6.mov
