### PR TITLE
Fix typeahead ref typedef

### DIFF
--- a/packages/lexical-react/flow/LexicalTypeaheadMenuPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalTypeaheadMenuPlugin.js.flow
@@ -26,7 +26,7 @@ export const PUNCTUATION: string =
 
 declare export class TypeaheadOption {
   key: string;
-  ref: React$ElementRef<HTMLElement | null>;
+  ref: {current: HTMLElement | null};
   constructor(key: string): void;
   setRefElement(element: HTMLElement | null): void;
 }
@@ -37,7 +37,7 @@ declare export var SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND: LexicalCommand<{
 }>;
 
 export type MenuRenderFn<TOption> = (
-  anchorElementRef: React$ElementRef<HTMLElement | null>,
+  anchorElementRef: {current: HTMLElement | null},
   itemProps: {
     selectedIndex: number | null,
     selectOptionAndCleanUp: (option: TOption) => void,


### PR DESCRIPTION
React$ElementRef requires to use react component not the dom element ref, hence the change