### PR TITLE
Fix Dynamic Table Options on Playground Component Picker

### DIFF
--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -127,8 +127,8 @@ export default function ComponentPickerMenuPlugin(): JSX.Element {
       return options;
     }
 
-    const fullTableRegex = new RegExp(/([1-9]|10)x([1-9]|10)$/);
-    const partialTableRegex = new RegExp(/([1-9]|10)x?$/);
+    const fullTableRegex = new RegExp(/^([1-9]|10)x([1-9]|10)$/);
+    const partialTableRegex = new RegExp(/^([1-9]|10)x?$/);
 
     const fullTableMatch = fullTableRegex.exec(queryString);
     const partialTableMatch = partialTableRegex.exec(queryString);


### PR DESCRIPTION
Previously the string `h1` would match the dynamic table options in the component picker.

Before:
<img width="259" alt="image" src="https://user-images.githubusercontent.com/13852400/194372716-41f196a1-544f-47c9-8977-78fe8f3c6195.png">

After:
<img width="247" alt="image" src="https://user-images.githubusercontent.com/13852400/194372840-738a7d53-0195-4761-bfa0-61bda5dcd358.png">
