### PR TITLE
Fix nested editor cut

### DIFF
--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -374,12 +374,15 @@ async function onCutForRichText(
   event: CommandPayloadType<typeof CUT_COMMAND>,
   editor: LexicalEditor,
 ): Promise<void> {
+  const selection = editor.getEditorState().read(() => $getSelection());
+  if (selection == null) {
+    return;
+  }
   await copyToClipboard__EXPERIMENTAL(
     editor,
     event instanceof ClipboardEvent ? event : null,
   );
   editor.update(() => {
-    const selection = $getSelection();
     if ($isRangeSelection(selection)) {
       selection.removeText();
     } else if ($isNodeSelection(selection)) {


### PR DESCRIPTION
Null check got lost when moving to experimental copy helper. It avoids cut/copy event from being handled in non-active editor (e.g., when running cut in nested editor)