### PR TITLE
docs: Fixed broken link

### DIFF
--- a/packages/lexical-website/docs/concepts/commands.md
+++ b/packages/lexical-website/docs/concepts/commands.md
@@ -55,7 +55,7 @@ const formatBulletList = () => {
 };
 ```
 
-Which is later handled in [`useList`](https://github.com/facebook/lexical/blob/1f62ace08e15d55515f3750840133efecd6d7d01/packages/lexical-react/src/shared/useList.ts#L65) to insert the list into the editor.
+Which is later handled in [`useList`](https://github.com/facebook/lexical/blob/1f62ace08e15d55515f3750840133efecd6d7d01/packages/lexical-react/src/shared/useList.js#L65) to insert the list into the editor.
 
 ```js
 editor.registerCommand(


### PR DESCRIPTION
Fixed faulty file extension in the url for the useList example in the Commands docs, ending in a 404 page.
Changed the file extension from .ts to .js.