### PR TITLE
Change release workflows

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,20 +1,20 @@
-name: Dev Publish to NPM
-on:
-  push:
-    branches:
-      - main
-jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm install
-      - run: npm run prepare-release
-      - run: node ./scripts/npm/release.js --non-interactive --dry-run=${{ secrets.RELEASE_DRY_RUN }} --channel dev
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+# name: Dev Publish to NPM
+# on:
+#   push:
+#     branches:
+#       - main
+# jobs:
+#   release:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+#       # Setup .npmrc file to publish to npm
+#       - uses: actions/setup-node@v3
+#         with:
+#           node-version: '16.x'
+#           registry-url: 'https://registry.npmjs.org'
+#       - run: npm install
+#       - run: npm run prepare-release
+#       - run: node ./scripts/npm/release.js --non-interactive --dry-run=${{ secrets.RELEASE_DRY_RUN }} --channel dev
+#         env:
+#           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,4 +1,4 @@
-name: Nightly Publish to NPM
+name: Nightly Release Branch
 on:
   schedule:
     # Run daily at 2:30am UTC
@@ -8,13 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.SSH_KEY }}
+          fetch-depth: 0
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
+      - run: |
+          git config user.name "Lexical GitHub Actions Bot"
+          git config user.email "<>"
       - run: npm install
-      - run: npm run prepare-release
-      - run: node ./scripts/npm/release.js --non-interactive --dry-run=${{ secrets.RELEASE_DRY_RUN }} --channel nightly
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm run increment-version -- --i prerelease
+      - run: git push -u git@github.com:facebook/lexical.git --follow-tags


### PR DESCRIPTION
The last change wasn't quite right - the workflow is now that a pre-release branch should be created every night, then the team will need to merge that into main, then into next to actually release. We can fully automate IF we are willing to drop branch push protections.