### PR TITLE
Fix frozen selection

### DIFF
--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -374,8 +374,7 @@ async function onCutForRichText(
   event: CommandPayloadType<typeof CUT_COMMAND>,
   editor: LexicalEditor,
 ): Promise<void> {
-  const selection = editor.getEditorState().read(() => $getSelection());
-  if (selection == null) {
+  if (editor.getEditorState().read(() => $getSelection()) == null) {
     return;
   }
   await copyToClipboard__EXPERIMENTAL(
@@ -383,6 +382,7 @@ async function onCutForRichText(
     event instanceof ClipboardEvent ? event : null,
   );
   editor.update(() => {
+    const selection = $getSelection();
     if ($isRangeSelection(selection)) {
       selection.removeText();
     } else if ($isNodeSelection(selection)) {


### PR DESCRIPTION
Internal test fails because we freeze Selection in dev and  [this PR] (https://github.com/facebook/lexical/pull/3177/files) causes us to try to get a reference to the frozen one via read callback and then try to modify it in a subsequent update.