### PR TITLE
fix: fixed dual text appearance problem and removed outline scrollbar

### DIFF
--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -218,9 +218,6 @@ export default function Editor(): JSX.Element {
         )}
         {isAutocomplete && <AutocompletePlugin />}
         <div>{showTableOfContents && <TableOfContentsPlugin />}</div>
-        <div className="toc">
-          {showTableOfContents && <TableOfContentsPlugin />}
-        </div>
         <ActionsPlugin isRichText={isRichText} />
       </div>
       {showTreeView && <TreeViewPlugin />}

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.css
@@ -35,7 +35,7 @@
   color: #65676b;
   position: fixed;
   top: 200px;
-  right: 100px;
+  right: -35px;
   padding: 10px;
   width: 250px;
   display: flex;
@@ -57,10 +57,17 @@
   margin-left: 10px;
   padding: 0;
   overflow: scroll;
-  width: 100%;
+  width: 200px;
   height: 220px;
   overflow-x: hidden;
   overflow-y: auto;
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+.headings::-webkit-scrollbar {
+  display: none;
 }
 
 .headings::before {

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -54,7 +54,6 @@ function TableOfContentsList({
   }
   function isHeadingAboveViewport(element: HTMLElement): boolean {
     const elementYPosition = element?.getClientRects()[0].y;
-    // console.log(editor, elementYPosition);
     return elementYPosition < MARGIN_ABOVE_EDITOR;
   }
   function isHeadingBelowTheTopOfThePage(element: HTMLElement): boolean {

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -15,6 +15,9 @@ import LexicalTableOfContents__EXPERIMENTAL from '@lexical/react/LexicalTableOfC
 import {useEffect, useRef, useState} from 'react';
 import * as React from 'react';
 
+const MARGIN_ABOVE_EDITOR = 624;
+const HEADING_WIDTH = 9;
+
 function indent(tagName: HeadingTagType) {
   if (tagName === 'h2') {
     return 'heading2';
@@ -44,15 +47,19 @@ function TableOfContentsList({
   }
   function isHeadingAtTheTopOfThePage(element: HTMLElement): boolean {
     const elementYPosition = element?.getClientRects()[0].y;
-    return elementYPosition >= 0.26 && elementYPosition <= 9;
+    return (
+      elementYPosition >= MARGIN_ABOVE_EDITOR &&
+      elementYPosition <= MARGIN_ABOVE_EDITOR + HEADING_WIDTH
+    );
   }
   function isHeadingAboveViewport(element: HTMLElement): boolean {
     const elementYPosition = element?.getClientRects()[0].y;
-    return elementYPosition <= 0;
+    // console.log(editor, elementYPosition);
+    return elementYPosition < MARGIN_ABOVE_EDITOR;
   }
   function isHeadingBelowTheTopOfThePage(element: HTMLElement): boolean {
     const elementYPosition = element?.getClientRects()[0].y;
-    return elementYPosition > 9;
+    return elementYPosition >= MARGIN_ABOVE_EDITOR + HEADING_WIDTH;
   }
 
   useEffect(() => {


### PR DESCRIPTION
* The outline had a problem where it rendered headings text twice. This was due to the plugin being called two times - merge conflict side effect or something? 
* Hid the outline scrollbar, and decreased its width so it fits next to the editor.
* Moved the scroll callback numbers to constants for better readability and modularity.

