### PR TITLE
feat: Extend support for link target and rel to lexical-react’s AutoLinkPlugin

### DIFF
--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -65,7 +65,13 @@ declare export class AutoLinkNode extends LinkNode {
   static clone(node: AutoLinkNode): AutoLinkNode;
   insertNewAfter(selection: RangeSelection): null | ElementNode;
 }
-declare export function $createAutoLinkNode(url: string): AutoLinkNode;
+declare export function $createAutoLinkNode(
+  url: string,
+  attributes?: {
+    rel?: null | string,
+    target?: null | string,
+  },
+): AutoLinkNode;
 declare export function $isAutoLinkNode(
   node: ?LexicalNode,
 ): boolean %checks(node instanceof AutoLinkNode);
@@ -81,6 +87,5 @@ declare export var TOGGLE_LINK_COMMAND: LexicalCommand<
 >;
 declare export function toggleLink(
   url: null | string,
-  target?: null | string,
-  rel?: null | string,
+  attributes: {target?: null | string, rel?: null | string},
 ): void;

--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -16,6 +16,10 @@ import type {
 } from 'lexical';
 import {addClassNamesToElement} from '@lexical/utils';
 import {$isElementNode, ElementNode} from 'lexical';
+export type LinkAttributes = {
+  rel?: null | string,
+  target?: null | string,
+};
 declare export class LinkNode extends ElementNode {
   __url: string;
   __target: null | string;
@@ -51,10 +55,7 @@ declare export class LinkNode extends ElementNode {
 }
 declare export function $createLinkNode(
   url: string,
-  attributes?: {
-    rel?: null | string,
-    target?: null | string,
-  },
+  attributes?: LinkAttributes,
 ): LinkNode;
 declare export function $isLinkNode(
   node: ?LexicalNode,
@@ -67,23 +68,14 @@ declare export class AutoLinkNode extends LinkNode {
 }
 declare export function $createAutoLinkNode(
   url: string,
-  attributes?: {
-    rel?: null | string,
-    target?: null | string,
-  },
+  attributes?: LinkAttributes,
 ): AutoLinkNode;
 declare export function $isAutoLinkNode(
   node: ?LexicalNode,
 ): boolean %checks(node instanceof AutoLinkNode);
 
 declare export var TOGGLE_LINK_COMMAND: LexicalCommand<
-  | string
-  | {
-      url: string,
-      target?: null | string,
-      rel?: null | string,
-    }
-  | null,
+  string | {url: string, ...LinkAttributes} | null,
 >;
 declare export function toggleLink(
   url: null | string,

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -30,15 +30,18 @@ import {
   Spread,
 } from 'lexical';
 
+export type LinkAttributes = {
+  rel?: null | string;
+  target?: null | string;
+};
+
 export type SerializedLinkNode = Spread<
   {
     type: 'link';
     url: string;
-    target?: null | string;
-    rel?: null | string;
     version: 1;
   },
-  SerializedElementNode
+  Spread<LinkAttributes, SerializedElementNode>
 >;
 
 /** @noInheritDoc */
@@ -62,14 +65,7 @@ export class LinkNode extends ElementNode {
     );
   }
 
-  constructor(
-    url: string,
-    attributes: {
-      target?: null | string;
-      rel?: null | string;
-    } = {},
-    key?: NodeKey,
-  ) {
+  constructor(url: string, attributes: LinkAttributes = {}, key?: NodeKey) {
     super(key);
     const {target = null, rel = null} = attributes;
     this.__url = url;
@@ -242,10 +238,7 @@ function convertAnchorElement(domNode: Node): DOMConversionOutput {
 
 export function $createLinkNode(
   url: string,
-  attributes?: {
-    target?: null | string;
-    rel?: null | string;
-  },
+  attributes?: LinkAttributes,
 ): LinkNode {
   return new LinkNode(url, attributes);
 }
@@ -319,10 +312,7 @@ export class AutoLinkNode extends LinkNode {
 
 export function $createAutoLinkNode(
   url: string,
-  attributes?: {
-    target?: null | string;
-    rel?: null | string;
-  },
+  attributes?: LinkAttributes,
 ): AutoLinkNode {
   return new AutoLinkNode(url, attributes);
 }
@@ -334,21 +324,12 @@ export function $isAutoLinkNode(
 }
 
 export const TOGGLE_LINK_COMMAND: LexicalCommand<
-  | string
-  | {
-      url: string;
-      target?: string;
-      rel?: string;
-    }
-  | null
+  string | ({url: string} & LinkAttributes) | null
 > = createCommand('TOGGLE_LINK_COMMAND');
 
 export function toggleLink(
   url: null | string,
-  attributes: {
-    target?: null | string;
-    rel?: null | string;
-  } = {},
+  attributes: LinkAttributes = {},
 ): void {
   const {target, rel} = attributes;
   const selection = $getSelection();

--- a/packages/lexical-react/flow/LexicalAutoLinkPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalAutoLinkPlugin.js.flow
@@ -7,13 +7,16 @@
  * @flow strict
  */
 
+import type {LinkAttributes} from '@lexical/link';
+
 type ChangeHandler = (url: string | null, prevUrl: string | null) => void;
 
 type LinkMatcherResult = {
+  attributes?: LinkAttributes,
+  index: number,
+  length: number,
   text: string,
   url: string,
-  length: number,
-  index: number,
 };
 
 export type LinkMatcher = (text: string) => LinkMatcherResult | null;

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import type {LinkAttributes} from '@lexical/link';
 import type {ElementNode, LexicalEditor, LexicalNode} from 'lexical';
 
 import {
@@ -29,6 +30,7 @@ import invariant from 'shared/invariant';
 type ChangeHandler = (url: string | null, prevUrl: string | null) => void;
 
 type LinkMatcherResult = {
+  attributes?: LinkAttributes;
   index: number;
   length: number;
   text: string;
@@ -146,7 +148,7 @@ function handleLinkCreation(
           invalidMatchEnd + matchStart + matchLength,
         );
       }
-      const linkNode = $createAutoLinkNode(match.url);
+      const linkNode = $createAutoLinkNode(match.url, match.attributes);
       const textNode = $createTextNode(match.text);
       textNode.setFormat(linkTextNode.getFormat());
       textNode.setDetail(linkTextNode.getDetail());
@@ -199,6 +201,20 @@ function handleLinkEdit(
   if (url !== match.url) {
     linkNode.setURL(match.url);
     onChange(match.url, url);
+  }
+
+  if (match.attributes) {
+    const rel = linkNode.getRel();
+    if (rel !== match.attributes.rel) {
+      linkNode.setRel(match.attributes.rel || null);
+      onChange(match.attributes.rel || null, rel);
+    }
+
+    const target = linkNode.getTarget();
+    if (target !== match.attributes.target) {
+      linkNode.setTarget(match.attributes.target || null);
+      onChange(match.attributes.target || null, target);
+    }
   }
 }
 

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -196,7 +196,7 @@ function handleLinkEdit(
   }
 
   const url = linkNode.getURL();
-  if (match !== null && url !== match.url) {
+  if (url !== match.url) {
     linkNode.setURL(match.url);
     onChange(match.url, url);
   }

--- a/packages/lexical-website/docs/react/plugins.md
+++ b/packages/lexical-website/docs/react/plugins.md
@@ -124,14 +124,16 @@ const URL_MATCHER =
 const MATCHERS = [
   (text) => {
     const match = URL_MATCHER.exec(text);
-    return (
-      match && {
-        index: match.index,
-        length: match[0].length,
-        text: match[0],
-        url: match[0],
-      }
-    );
+    if (match === null) {
+      return null;
+    }
+    const fullMatch = match[0];
+    return {
+      index: match.index,
+      length: fullMatch.length,
+      text: fullMatch,
+      url: fullMatch.startsWith('http') ? fullMatch : `https://${fullMatch}`,
+    };
   },
 ];
 

--- a/packages/lexical-website/docs/react/plugins.md
+++ b/packages/lexical-website/docs/react/plugins.md
@@ -16,7 +16,7 @@ import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
 
 ```jsx
 const initialConfig = {
-  namespace: 'MyEditor', 
+  namespace: 'MyEditor',
   theme,
   onError,
 };
@@ -36,7 +36,7 @@ const initialConfig = {
 
 ```jsx
 const initialConfig = {
-  namespace: 'MyEditor', 
+  namespace: 'MyEditor',
   theme,
   nodes: [ListNode, ListItemNode], // Pass the references to the nodes here
   onError,

--- a/packages/lexical-website/docs/react/plugins.md
+++ b/packages/lexical-website/docs/react/plugins.md
@@ -133,6 +133,7 @@ const MATCHERS = [
       length: fullMatch.length,
       text: fullMatch,
       url: fullMatch.startsWith('http') ? fullMatch : `https://${fullMatch}`,
+      // attributes: { rel: 'noopener', target: '_blank' }, // Optional link attributes
     };
   },
 ];


### PR DESCRIPTION
this is a follow-up to #2687 (which resolved issue #2671) that extends support for setting link target and rel to the `AutoLinkPlugin` component via its `matchers` prop. it adds optional `rel` and `target` fields to the `LinkMatcherResult` type and forwards those along to `$createAutoLinkNode`, or uses `linkNode.setRel` / `linkNode.setTarget` in `handleLinkEdit` if they have changed.

i also updated the lexical-react docs plugins page’s `AutoLinkPlugin` section to adopt the default protocol behavior introduced in #2654 and added commented-out example usage of the new LinkMatcher `rel` and `target` fields ([preview](https://lexical-git-fork-acusti-feat-link-node-with-ec78d1-fbopensource.vercel.app/docs/react/plugins#lexicalautolinkplugin)). i wasn’t sure how to properly document it, so if there is a better way (e.g. just a single comment at the beginning or ending of the LinkMatcher object mentioning the optional fields or something else entirely), please let me know.

i didn’t find an open issue for this, though there is a question about it in the original PR thread: https://github.com/facebook/lexical/pull/2687#issuecomment-1207463130. i’d be happy to open one if that would be helpful.