### PR TITLE
Refine backspace handling in Tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21912,36 +21912,36 @@
       }
     },
     "packages/lexical": {
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT"
     },
     "packages/lexical-clipboard": {
       "name": "@lexical/clipboard",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.5.1-next.0",
-        "@lexical/list": "0.5.1-next.0",
-        "@lexical/selection": "0.5.1-next.0",
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/html": "0.5.0",
+        "@lexical/list": "0.5.0",
+        "@lexical/selection": "0.5.0",
+        "@lexical/utils": "0.5.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-code": {
       "name": "@lexical/code",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.1-next.0",
+        "@lexical/utils": "0.5.0",
         "prismjs": "^1.27.0"
       },
       "devDependencies": {
         "@types/prismjs": "^1.26.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-devtools": {
@@ -21979,157 +21979,157 @@
     },
     "packages/lexical-dragon": {
       "name": "@lexical/dragon",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-file": {
       "name": "@lexical/file",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-hashtag": {
       "name": "@lexical/hashtag",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/utils": "0.5.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-headless": {
       "name": "@lexical/headless",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-history": {
       "name": "@lexical/history",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/utils": "0.5.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-html": {
       "name": "@lexical/html",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.5.1-next.0"
+        "@lexical/selection": "0.5.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-link": {
       "name": "@lexical/link",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/utils": "0.5.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-list": {
       "name": "@lexical/list",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/utils": "0.5.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-mark": {
       "name": "@lexical/mark",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/utils": "0.5.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-markdown": {
       "name": "@lexical/markdown",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.5.1-next.0",
-        "@lexical/link": "0.5.1-next.0",
-        "@lexical/list": "0.5.1-next.0",
-        "@lexical/rich-text": "0.5.1-next.0",
-        "@lexical/text": "0.5.1-next.0",
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/code": "0.5.0",
+        "@lexical/link": "0.5.0",
+        "@lexical/list": "0.5.0",
+        "@lexical/rich-text": "0.5.0",
+        "@lexical/text": "0.5.0",
+        "@lexical/utils": "0.5.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-offset": {
       "name": "@lexical/offset",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-overflow": {
       "name": "@lexical/overflow",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-plain-text": {
       "name": "@lexical/plain-text",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
-        "@lexical/clipboard": "0.5.1-next.0",
-        "@lexical/selection": "0.5.1-next.0",
-        "@lexical/utils": "0.5.1-next.0",
-        "lexical": "0.5.1-next.0"
+        "@lexical/clipboard": "0.5.0",
+        "@lexical/selection": "0.5.0",
+        "@lexical/utils": "0.5.0",
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-playground": {
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "dependencies": {
         "@excalidraw/excalidraw": "0.11.0",
-        "@lexical/clipboard": "0.5.1-next.0",
-        "@lexical/code": "0.5.1-next.0",
-        "@lexical/file": "0.5.1-next.0",
-        "@lexical/hashtag": "0.5.1-next.0",
-        "@lexical/link": "0.5.1-next.0",
-        "@lexical/list": "0.5.1-next.0",
-        "@lexical/mark": "0.5.1-next.0",
-        "@lexical/overflow": "0.5.1-next.0",
-        "@lexical/plain-text": "0.5.1-next.0",
-        "@lexical/react": "0.5.1-next.0",
-        "@lexical/rich-text": "0.5.1-next.0",
-        "@lexical/selection": "0.5.1-next.0",
-        "@lexical/table": "0.5.1-next.0",
-        "@lexical/utils": "0.5.1-next.0",
+        "@lexical/clipboard": "0.5.0",
+        "@lexical/code": "0.5.0",
+        "@lexical/file": "0.5.0",
+        "@lexical/hashtag": "0.5.0",
+        "@lexical/link": "0.5.0",
+        "@lexical/list": "0.5.0",
+        "@lexical/mark": "0.5.0",
+        "@lexical/overflow": "0.5.0",
+        "@lexical/plain-text": "0.5.0",
+        "@lexical/react": "0.5.0",
+        "@lexical/rich-text": "0.5.0",
+        "@lexical/selection": "0.5.0",
+        "@lexical/table": "0.5.0",
+        "@lexical/utils": "0.5.0",
         "katex": "^0.15.2",
-        "lexical": "0.5.1-next.0",
+        "lexical": "0.5.0",
         "lodash-es": "^4.17.21",
         "prettier": "^2.3.2",
         "react": "^18.2.0",
@@ -22147,81 +22147,81 @@
     },
     "packages/lexical-react": {
       "name": "@lexical/react",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.5.1-next.0",
-        "@lexical/code": "0.5.1-next.0",
-        "@lexical/dragon": "0.5.1-next.0",
-        "@lexical/hashtag": "0.5.1-next.0",
-        "@lexical/history": "0.5.1-next.0",
-        "@lexical/link": "0.5.1-next.0",
-        "@lexical/list": "0.5.1-next.0",
-        "@lexical/mark": "0.5.1-next.0",
-        "@lexical/markdown": "0.5.1-next.0",
-        "@lexical/overflow": "0.5.1-next.0",
-        "@lexical/plain-text": "0.5.1-next.0",
-        "@lexical/rich-text": "0.5.1-next.0",
-        "@lexical/selection": "0.5.1-next.0",
-        "@lexical/table": "0.5.1-next.0",
-        "@lexical/text": "0.5.1-next.0",
-        "@lexical/utils": "0.5.1-next.0",
-        "@lexical/yjs": "0.5.1-next.0"
+        "@lexical/clipboard": "0.5.0",
+        "@lexical/code": "0.5.0",
+        "@lexical/dragon": "0.5.0",
+        "@lexical/hashtag": "0.5.0",
+        "@lexical/history": "0.5.0",
+        "@lexical/link": "0.5.0",
+        "@lexical/list": "0.5.0",
+        "@lexical/mark": "0.5.0",
+        "@lexical/markdown": "0.5.0",
+        "@lexical/overflow": "0.5.0",
+        "@lexical/plain-text": "0.5.0",
+        "@lexical/rich-text": "0.5.0",
+        "@lexical/selection": "0.5.0",
+        "@lexical/table": "0.5.0",
+        "@lexical/text": "0.5.0",
+        "@lexical/utils": "0.5.0",
+        "@lexical/yjs": "0.5.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0",
+        "lexical": "0.5.0",
         "react": ">=17.x",
         "react-dom": ">=17.x"
       }
     },
     "packages/lexical-rich-text": {
       "name": "@lexical/rich-text",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
-        "@lexical/clipboard": "0.5.1-next.0",
-        "@lexical/selection": "0.5.1-next.0",
-        "@lexical/utils": "0.5.1-next.0",
-        "lexical": "0.5.1-next.0"
+        "@lexical/clipboard": "0.5.0",
+        "@lexical/selection": "0.5.0",
+        "@lexical/utils": "0.5.0",
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-selection": {
       "name": "@lexical/selection",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-table": {
       "name": "@lexical/table",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/utils": "0.5.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-text": {
       "name": "@lexical/text",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-utils": {
       "name": "@lexical/utils",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.5.1-next.0",
-        "@lexical/table": "0.5.1-next.0"
+        "@lexical/list": "0.5.0",
+        "@lexical/table": "0.5.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "packages/lexical-website": {
@@ -23202,13 +23202,13 @@
     },
     "packages/lexical-yjs": {
       "name": "@lexical/yjs",
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.5.1-next.0"
+        "@lexical/offset": "0.5.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.1-next.0",
+        "lexical": "0.5.0",
         "yjs": ">=13.5.22"
       }
     },
@@ -23237,10 +23237,10 @@
       }
     },
     "packages/shared": {
-      "version": "0.5.1-next.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     }
   },
@@ -25512,16 +25512,16 @@
     "@lexical/clipboard": {
       "version": "file:packages/lexical-clipboard",
       "requires": {
-        "@lexical/html": "0.5.1-next.0",
-        "@lexical/list": "0.5.1-next.0",
-        "@lexical/selection": "0.5.1-next.0",
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/html": "0.5.0",
+        "@lexical/list": "0.5.0",
+        "@lexical/selection": "0.5.0",
+        "@lexical/utils": "0.5.0"
       }
     },
     "@lexical/code": {
       "version": "file:packages/lexical-code",
       "requires": {
-        "@lexical/utils": "0.5.1-next.0",
+        "@lexical/utils": "0.5.0",
         "@types/prismjs": "^1.26.0",
         "prismjs": "^1.27.0"
       }
@@ -25535,7 +25535,7 @@
     "@lexical/hashtag": {
       "version": "file:packages/lexical-hashtag",
       "requires": {
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/utils": "0.5.0"
       }
     },
     "@lexical/headless": {
@@ -25544,42 +25544,42 @@
     "@lexical/history": {
       "version": "file:packages/lexical-history",
       "requires": {
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/utils": "0.5.0"
       }
     },
     "@lexical/html": {
       "version": "file:packages/lexical-html",
       "requires": {
-        "@lexical/selection": "0.5.1-next.0"
+        "@lexical/selection": "0.5.0"
       }
     },
     "@lexical/link": {
       "version": "file:packages/lexical-link",
       "requires": {
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/utils": "0.5.0"
       }
     },
     "@lexical/list": {
       "version": "file:packages/lexical-list",
       "requires": {
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/utils": "0.5.0"
       }
     },
     "@lexical/mark": {
       "version": "file:packages/lexical-mark",
       "requires": {
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/utils": "0.5.0"
       }
     },
     "@lexical/markdown": {
       "version": "file:packages/lexical-markdown",
       "requires": {
-        "@lexical/code": "0.5.1-next.0",
-        "@lexical/link": "0.5.1-next.0",
-        "@lexical/list": "0.5.1-next.0",
-        "@lexical/rich-text": "0.5.1-next.0",
-        "@lexical/text": "0.5.1-next.0",
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/code": "0.5.0",
+        "@lexical/link": "0.5.0",
+        "@lexical/list": "0.5.0",
+        "@lexical/rich-text": "0.5.0",
+        "@lexical/text": "0.5.0",
+        "@lexical/utils": "0.5.0"
       }
     },
     "@lexical/offset": {
@@ -25594,23 +25594,23 @@
     "@lexical/react": {
       "version": "file:packages/lexical-react",
       "requires": {
-        "@lexical/clipboard": "0.5.1-next.0",
-        "@lexical/code": "0.5.1-next.0",
-        "@lexical/dragon": "0.5.1-next.0",
-        "@lexical/hashtag": "0.5.1-next.0",
-        "@lexical/history": "0.5.1-next.0",
-        "@lexical/link": "0.5.1-next.0",
-        "@lexical/list": "0.5.1-next.0",
-        "@lexical/mark": "0.5.1-next.0",
-        "@lexical/markdown": "0.5.1-next.0",
-        "@lexical/overflow": "0.5.1-next.0",
-        "@lexical/plain-text": "0.5.1-next.0",
-        "@lexical/rich-text": "0.5.1-next.0",
-        "@lexical/selection": "0.5.1-next.0",
-        "@lexical/table": "0.5.1-next.0",
-        "@lexical/text": "0.5.1-next.0",
-        "@lexical/utils": "0.5.1-next.0",
-        "@lexical/yjs": "0.5.1-next.0"
+        "@lexical/clipboard": "0.5.0",
+        "@lexical/code": "0.5.0",
+        "@lexical/dragon": "0.5.0",
+        "@lexical/hashtag": "0.5.0",
+        "@lexical/history": "0.5.0",
+        "@lexical/link": "0.5.0",
+        "@lexical/list": "0.5.0",
+        "@lexical/mark": "0.5.0",
+        "@lexical/markdown": "0.5.0",
+        "@lexical/overflow": "0.5.0",
+        "@lexical/plain-text": "0.5.0",
+        "@lexical/rich-text": "0.5.0",
+        "@lexical/selection": "0.5.0",
+        "@lexical/table": "0.5.0",
+        "@lexical/text": "0.5.0",
+        "@lexical/utils": "0.5.0",
+        "@lexical/yjs": "0.5.0"
       }
     },
     "@lexical/rich-text": {
@@ -25622,7 +25622,7 @@
     "@lexical/table": {
       "version": "file:packages/lexical-table",
       "requires": {
-        "@lexical/utils": "0.5.1-next.0"
+        "@lexical/utils": "0.5.0"
       }
     },
     "@lexical/text": {
@@ -25631,8 +25631,8 @@
     "@lexical/utils": {
       "version": "file:packages/lexical-utils",
       "requires": {
-        "@lexical/list": "0.5.1-next.0",
-        "@lexical/table": "0.5.1-next.0"
+        "@lexical/list": "0.5.0",
+        "@lexical/table": "0.5.0"
       }
     },
     "@lexical/website": {
@@ -26340,7 +26340,7 @@
     "@lexical/yjs": {
       "version": "file:packages/lexical-yjs",
       "requires": {
-        "@lexical/offset": "0.5.1-next.0"
+        "@lexical/offset": "0.5.0"
       }
     },
     "@mdx-js/mdx": {
@@ -34477,24 +34477,24 @@
       "version": "file:packages/lexical-playground",
       "requires": {
         "@excalidraw/excalidraw": "0.11.0",
-        "@lexical/clipboard": "0.5.1-next.0",
-        "@lexical/code": "0.5.1-next.0",
-        "@lexical/file": "0.5.1-next.0",
-        "@lexical/hashtag": "0.5.1-next.0",
-        "@lexical/link": "0.5.1-next.0",
-        "@lexical/list": "0.5.1-next.0",
-        "@lexical/mark": "0.5.1-next.0",
-        "@lexical/overflow": "0.5.1-next.0",
-        "@lexical/plain-text": "0.5.1-next.0",
-        "@lexical/react": "0.5.1-next.0",
-        "@lexical/rich-text": "0.5.1-next.0",
-        "@lexical/selection": "0.5.1-next.0",
-        "@lexical/table": "0.5.1-next.0",
-        "@lexical/utils": "0.5.1-next.0",
+        "@lexical/clipboard": "0.5.0",
+        "@lexical/code": "0.5.0",
+        "@lexical/file": "0.5.0",
+        "@lexical/hashtag": "0.5.0",
+        "@lexical/link": "0.5.0",
+        "@lexical/list": "0.5.0",
+        "@lexical/mark": "0.5.0",
+        "@lexical/overflow": "0.5.0",
+        "@lexical/plain-text": "0.5.0",
+        "@lexical/react": "0.5.0",
+        "@lexical/rich-text": "0.5.0",
+        "@lexical/selection": "0.5.0",
+        "@lexical/table": "0.5.0",
+        "@lexical/utils": "0.5.0",
         "@types/lodash-es": "^4.14.182",
         "@vitejs/plugin-react": "^1.0.7",
         "katex": "^0.15.2",
-        "lexical": "0.5.1-next.0",
+        "lexical": "0.5.0",
         "lodash-es": "^4.17.21",
         "prettier": "^2.3.2",
         "react": "^18.2.0",
@@ -37608,7 +37608,7 @@
     "shared": {
       "version": "file:packages/shared",
       "requires": {
-        "lexical": "0.5.1-next.0"
+        "lexical": "0.5.0"
       }
     },
     "shebang-command": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21912,36 +21912,36 @@
       }
     },
     "packages/lexical": {
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT"
     },
     "packages/lexical-clipboard": {
       "name": "@lexical/clipboard",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/utils": "0.5.0"
+        "@lexical/html": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-code": {
       "name": "@lexical/code",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0",
+        "@lexical/utils": "0.5.1-next.0",
         "prismjs": "^1.27.0"
       },
       "devDependencies": {
         "@types/prismjs": "^1.26.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-devtools": {
@@ -21979,157 +21979,157 @@
     },
     "packages/lexical-dragon": {
       "name": "@lexical/dragon",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-file": {
       "name": "@lexical/file",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-hashtag": {
       "name": "@lexical/hashtag",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-headless": {
       "name": "@lexical/headless",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-history": {
       "name": "@lexical/history",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-html": {
       "name": "@lexical/html",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.5.0"
+        "@lexical/selection": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-link": {
       "name": "@lexical/link",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-list": {
       "name": "@lexical/list",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-mark": {
       "name": "@lexical/mark",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-markdown": {
       "name": "@lexical/markdown",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.5.0",
-        "@lexical/link": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/rich-text": "0.5.0",
-        "@lexical/text": "0.5.0",
-        "@lexical/utils": "0.5.0"
+        "@lexical/code": "0.5.1-next.0",
+        "@lexical/link": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/rich-text": "0.5.1-next.0",
+        "@lexical/text": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-offset": {
       "name": "@lexical/offset",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-overflow": {
       "name": "@lexical/overflow",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-plain-text": {
       "name": "@lexical/plain-text",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "@lexical/clipboard": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/utils": "0.5.0",
-        "lexical": "0.5.0"
+        "@lexical/clipboard": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0",
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-playground": {
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "dependencies": {
         "@excalidraw/excalidraw": "0.11.0",
-        "@lexical/clipboard": "0.5.0",
-        "@lexical/code": "0.5.0",
-        "@lexical/file": "0.5.0",
-        "@lexical/hashtag": "0.5.0",
-        "@lexical/link": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/mark": "0.5.0",
-        "@lexical/overflow": "0.5.0",
-        "@lexical/plain-text": "0.5.0",
-        "@lexical/react": "0.5.0",
-        "@lexical/rich-text": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/table": "0.5.0",
-        "@lexical/utils": "0.5.0",
+        "@lexical/clipboard": "0.5.1-next.0",
+        "@lexical/code": "0.5.1-next.0",
+        "@lexical/file": "0.5.1-next.0",
+        "@lexical/hashtag": "0.5.1-next.0",
+        "@lexical/link": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/mark": "0.5.1-next.0",
+        "@lexical/overflow": "0.5.1-next.0",
+        "@lexical/plain-text": "0.5.1-next.0",
+        "@lexical/react": "0.5.1-next.0",
+        "@lexical/rich-text": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/table": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0",
         "katex": "^0.15.2",
-        "lexical": "0.5.0",
+        "lexical": "0.5.1-next.0",
         "lodash-es": "^4.17.21",
         "prettier": "^2.3.2",
         "react": "^18.2.0",
@@ -22147,81 +22147,81 @@
     },
     "packages/lexical-react": {
       "name": "@lexical/react",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.5.0",
-        "@lexical/code": "0.5.0",
-        "@lexical/dragon": "0.5.0",
-        "@lexical/hashtag": "0.5.0",
-        "@lexical/history": "0.5.0",
-        "@lexical/link": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/mark": "0.5.0",
-        "@lexical/markdown": "0.5.0",
-        "@lexical/overflow": "0.5.0",
-        "@lexical/plain-text": "0.5.0",
-        "@lexical/rich-text": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/table": "0.5.0",
-        "@lexical/text": "0.5.0",
-        "@lexical/utils": "0.5.0",
-        "@lexical/yjs": "0.5.0"
+        "@lexical/clipboard": "0.5.1-next.0",
+        "@lexical/code": "0.5.1-next.0",
+        "@lexical/dragon": "0.5.1-next.0",
+        "@lexical/hashtag": "0.5.1-next.0",
+        "@lexical/history": "0.5.1-next.0",
+        "@lexical/link": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/mark": "0.5.1-next.0",
+        "@lexical/markdown": "0.5.1-next.0",
+        "@lexical/overflow": "0.5.1-next.0",
+        "@lexical/plain-text": "0.5.1-next.0",
+        "@lexical/rich-text": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/table": "0.5.1-next.0",
+        "@lexical/text": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0",
+        "@lexical/yjs": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0",
+        "lexical": "0.5.1-next.0",
         "react": ">=17.x",
         "react-dom": ">=17.x"
       }
     },
     "packages/lexical-rich-text": {
       "name": "@lexical/rich-text",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "@lexical/clipboard": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/utils": "0.5.0",
-        "lexical": "0.5.0"
+        "@lexical/clipboard": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0",
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-selection": {
       "name": "@lexical/selection",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-table": {
       "name": "@lexical/table",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-text": {
       "name": "@lexical/text",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-utils": {
       "name": "@lexical/utils",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.5.0",
-        "@lexical/table": "0.5.0"
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/table": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-website": {
@@ -23202,13 +23202,13 @@
     },
     "packages/lexical-yjs": {
       "name": "@lexical/yjs",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.5.0"
+        "@lexical/offset": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0",
+        "lexical": "0.5.1-next.0",
         "yjs": ">=13.5.22"
       }
     },
@@ -23237,10 +23237,10 @@
       }
     },
     "packages/shared": {
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     }
   },
@@ -25512,16 +25512,16 @@
     "@lexical/clipboard": {
       "version": "file:packages/lexical-clipboard",
       "requires": {
-        "@lexical/html": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/utils": "0.5.0"
+        "@lexical/html": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/code": {
       "version": "file:packages/lexical-code",
       "requires": {
-        "@lexical/utils": "0.5.0",
+        "@lexical/utils": "0.5.1-next.0",
         "@types/prismjs": "^1.26.0",
         "prismjs": "^1.27.0"
       }
@@ -25535,7 +25535,7 @@
     "@lexical/hashtag": {
       "version": "file:packages/lexical-hashtag",
       "requires": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/headless": {
@@ -25544,42 +25544,42 @@
     "@lexical/history": {
       "version": "file:packages/lexical-history",
       "requires": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/html": {
       "version": "file:packages/lexical-html",
       "requires": {
-        "@lexical/selection": "0.5.0"
+        "@lexical/selection": "0.5.1-next.0"
       }
     },
     "@lexical/link": {
       "version": "file:packages/lexical-link",
       "requires": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/list": {
       "version": "file:packages/lexical-list",
       "requires": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/mark": {
       "version": "file:packages/lexical-mark",
       "requires": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/markdown": {
       "version": "file:packages/lexical-markdown",
       "requires": {
-        "@lexical/code": "0.5.0",
-        "@lexical/link": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/rich-text": "0.5.0",
-        "@lexical/text": "0.5.0",
-        "@lexical/utils": "0.5.0"
+        "@lexical/code": "0.5.1-next.0",
+        "@lexical/link": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/rich-text": "0.5.1-next.0",
+        "@lexical/text": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/offset": {
@@ -25594,23 +25594,23 @@
     "@lexical/react": {
       "version": "file:packages/lexical-react",
       "requires": {
-        "@lexical/clipboard": "0.5.0",
-        "@lexical/code": "0.5.0",
-        "@lexical/dragon": "0.5.0",
-        "@lexical/hashtag": "0.5.0",
-        "@lexical/history": "0.5.0",
-        "@lexical/link": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/mark": "0.5.0",
-        "@lexical/markdown": "0.5.0",
-        "@lexical/overflow": "0.5.0",
-        "@lexical/plain-text": "0.5.0",
-        "@lexical/rich-text": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/table": "0.5.0",
-        "@lexical/text": "0.5.0",
-        "@lexical/utils": "0.5.0",
-        "@lexical/yjs": "0.5.0"
+        "@lexical/clipboard": "0.5.1-next.0",
+        "@lexical/code": "0.5.1-next.0",
+        "@lexical/dragon": "0.5.1-next.0",
+        "@lexical/hashtag": "0.5.1-next.0",
+        "@lexical/history": "0.5.1-next.0",
+        "@lexical/link": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/mark": "0.5.1-next.0",
+        "@lexical/markdown": "0.5.1-next.0",
+        "@lexical/overflow": "0.5.1-next.0",
+        "@lexical/plain-text": "0.5.1-next.0",
+        "@lexical/rich-text": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/table": "0.5.1-next.0",
+        "@lexical/text": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0",
+        "@lexical/yjs": "0.5.1-next.0"
       }
     },
     "@lexical/rich-text": {
@@ -25622,7 +25622,7 @@
     "@lexical/table": {
       "version": "file:packages/lexical-table",
       "requires": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/text": {
@@ -25631,8 +25631,8 @@
     "@lexical/utils": {
       "version": "file:packages/lexical-utils",
       "requires": {
-        "@lexical/list": "0.5.0",
-        "@lexical/table": "0.5.0"
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/table": "0.5.1-next.0"
       }
     },
     "@lexical/website": {
@@ -26340,7 +26340,7 @@
     "@lexical/yjs": {
       "version": "file:packages/lexical-yjs",
       "requires": {
-        "@lexical/offset": "0.5.0"
+        "@lexical/offset": "0.5.1-next.0"
       }
     },
     "@mdx-js/mdx": {
@@ -34477,24 +34477,24 @@
       "version": "file:packages/lexical-playground",
       "requires": {
         "@excalidraw/excalidraw": "0.11.0",
-        "@lexical/clipboard": "0.5.0",
-        "@lexical/code": "0.5.0",
-        "@lexical/file": "0.5.0",
-        "@lexical/hashtag": "0.5.0",
-        "@lexical/link": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/mark": "0.5.0",
-        "@lexical/overflow": "0.5.0",
-        "@lexical/plain-text": "0.5.0",
-        "@lexical/react": "0.5.0",
-        "@lexical/rich-text": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/table": "0.5.0",
-        "@lexical/utils": "0.5.0",
+        "@lexical/clipboard": "0.5.1-next.0",
+        "@lexical/code": "0.5.1-next.0",
+        "@lexical/file": "0.5.1-next.0",
+        "@lexical/hashtag": "0.5.1-next.0",
+        "@lexical/link": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/mark": "0.5.1-next.0",
+        "@lexical/overflow": "0.5.1-next.0",
+        "@lexical/plain-text": "0.5.1-next.0",
+        "@lexical/react": "0.5.1-next.0",
+        "@lexical/rich-text": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/table": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0",
         "@types/lodash-es": "^4.14.182",
         "@vitejs/plugin-react": "^1.0.7",
         "katex": "^0.15.2",
-        "lexical": "0.5.0",
+        "lexical": "0.5.1-next.0",
         "lodash-es": "^4.17.21",
         "prettier": "^2.3.2",
         "react": "^18.2.0",
@@ -37608,7 +37608,7 @@
     "shared": {
       "version": "file:packages/shared",
       "requires": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "shebang-command": {

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -15,6 +15,7 @@ import {
   $isParagraphNode,
   $isRangeSelection,
   $isRootOrShadowRoot,
+  DEPRECATED_$isGridSelection,
   ElementNode,
   LexicalEditor,
   LexicalNode,
@@ -85,7 +86,10 @@ export function insertList(editor: LexicalEditor, listType: ListType): void {
   editor.update(() => {
     const selection = $getSelection();
 
-    if ($isRangeSelection(selection)) {
+    if (
+      $isRangeSelection(selection) ||
+      DEPRECATED_$isGridSelection(selection)
+    ) {
       const nodes = selection.getNodes();
       const anchor = selection.anchor;
       const anchorNode = anchor.getNode();

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -58,6 +58,7 @@ import {
   CAN_REDO_COMMAND,
   CAN_UNDO_COMMAND,
   COMMAND_PRIORITY_CRITICAL,
+  DEPRECATED_$isGridSelection,
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
   INDENT_CONTENT_COMMAND,
@@ -160,7 +161,10 @@ function BlockFormatDropDown({
       editor.update(() => {
         const selection = $getSelection();
 
-        if ($isRangeSelection(selection)) {
+        if (
+          $isRangeSelection(selection) ||
+          DEPRECATED_$isGridSelection(selection)
+        ) {
           $wrapNodes(selection, () => $createParagraphNode());
         }
       });
@@ -172,7 +176,10 @@ function BlockFormatDropDown({
       editor.update(() => {
         const selection = $getSelection();
 
-        if ($isRangeSelection(selection)) {
+        if (
+          $isRangeSelection(selection) ||
+          DEPRECATED_$isGridSelection(selection)
+        ) {
           $wrapNodes(selection, () => $createHeadingNode(headingSize));
         }
       });
@@ -208,7 +215,10 @@ function BlockFormatDropDown({
       editor.update(() => {
         const selection = $getSelection();
 
-        if ($isRangeSelection(selection)) {
+        if (
+          $isRangeSelection(selection) ||
+          DEPRECATED_$isGridSelection(selection)
+        ) {
           $wrapNodes(selection, () => $createQuoteNode());
         }
       });
@@ -220,7 +230,10 @@ function BlockFormatDropDown({
       editor.update(() => {
         const selection = $getSelection();
 
-        if ($isRangeSelection(selection)) {
+        if (
+          $isRangeSelection(selection) ||
+          DEPRECATED_$isGridSelection(selection)
+        ) {
           if (selection.isCollapsed()) {
             $wrapNodes(selection, () => $createCodeNode());
           } else {

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -9,6 +9,7 @@
 import type {ICloneSelectionContent} from './lexical-node';
 import type {
   ElementNode,
+  GridSelection,
   LexicalNode,
   NodeKey,
   Point,
@@ -63,7 +64,7 @@ function isPointAttached(point: Point): boolean {
  * @returns
  */
 export function $wrapNodes(
-  selection: RangeSelection,
+  selection: RangeSelection | GridSelection,
   createElement: () => ElementNode,
   wrappingElement: null | ElementNode = null,
 ): void {
@@ -140,7 +141,7 @@ export function $wrapNodes(
 }
 
 export function $wrapNodesImpl(
-  selection: RangeSelection,
+  selection: RangeSelection | GridSelection,
   nodes: LexicalNode[],
   nodesLength: number,
   createElement: () => ElementNode,

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -23,7 +23,6 @@ import {$findMatchingParent} from '@lexical/utils';
 import {
   $createParagraphNode,
   $createRangeSelection,
-  $createTextNode,
   $getNearestNodeFromDOMNode,
   $getPreviousSelection,
   $getSelection,
@@ -640,40 +639,30 @@ export function applyTableHandlers(
         return true;
       }
 
-      const parentElementNode = $findMatchingParent(
-        selection.anchor.getNode(),
-        (n) => $isElementNode(n) && $isTableCellNode(n.getParent()),
-      );
-
       const nearestElementNode = $findMatchingParent(
         selection.anchor.getNode(),
         (n) => $isElementNode(n),
       );
 
+      const topLevelCellElementNode =
+        nearestElementNode &&
+        $findMatchingParent(
+          nearestElementNode,
+          (n) => $isElementNode(n) && $isTableCellNode(n.getParent()),
+        );
+
       if (
-        !$isElementNode(parentElementNode) ||
+        !$isElementNode(topLevelCellElementNode) ||
         !$isElementNode(nearestElementNode)
       ) {
         return false;
       }
 
-      const clearCell = () => {
-        const newParagraphNode = $createParagraphNode();
-        const textNode = $createTextNode();
-        newParagraphNode.append(textNode);
-        tableCellNode.append(newParagraphNode);
-        tableCellNode.getChildren().forEach((child) => {
-          if (child !== newParagraphNode) {
-            child.remove();
-          }
-        });
-      };
-
       if (
         command === DELETE_LINE_COMMAND &&
-        parentElementNode.getPreviousSibling() === null
+        topLevelCellElementNode.getPreviousSibling() === null
       ) {
-        clearCell();
+        // TODO: Fix Delete Line in Table Cells.
         return true;
       }
 
@@ -681,20 +670,15 @@ export function applyTableHandlers(
         command === DELETE_CHARACTER_COMMAND ||
         command === DELETE_WORD_COMMAND
       ) {
-        if (
-          selection.isCollapsed() &&
-          selection.anchor.offset === 0 &&
-          parentElementNode === nearestElementNode &&
-          parentElementNode.getPreviousSibling() === null
-        ) {
-          return true;
-        }
+        if (selection.isCollapsed() && selection.anchor.offset === 0) {
+          if (nearestElementNode !== topLevelCellElementNode) {
+            const children = nearestElementNode.getChildren();
+            const newParagraphNode = $createParagraphNode();
+            children.forEach((child) => newParagraphNode.append(child));
+            nearestElementNode.replace(newParagraphNode);
+            nearestElementNode.getWritable().__parent = tableCellNode.getKey();
+          }
 
-        if (
-          !$isParagraphNode(parentElementNode) &&
-          parentElementNode.getTextContentSize() === 0
-        ) {
-          clearCell();
           return true;
         }
       }


### PR DESCRIPTION
This is a patch. The real solution is to refine [the way selection is modified after hitting backspace](https://github.com/facebook/lexical/blob/573a716ef97218927007943689c420a8749107ce/packages/lexical/src/LexicalSelection.ts#L1818). The focus should not be moved to a node with a different `shadowRoot`, but right now this is how native domSelection works.


Before:

https://user-images.githubusercontent.com/13852400/196534120-69f71430-b0b5-4686-bfac-2e4ed95b04d2.mov


After:

https://user-images.githubusercontent.com/13852400/196534211-dad4ada4-9db1-435d-b9ea-cb3ba433ba33.mov

