### PR TITLE
Allow skipping auto-scroll action on selection change

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2742,6 +2742,7 @@ export function updateDOMSelection(
     );
 
     if (
+      !tags.has('skip-scroll-into-view') &&
       nextSelection.isCollapsed() &&
       rootElement !== null &&
       rootElement === activeElement


### PR DESCRIPTION
## Problem

Lexical does not provide a way to control whether it should auto-scroll or not when the selection changes.

**Context:**

I am working on the implementation of a "click to set cursor near decorator nodes" feature https://github.com/facebook/lexical/issues/3157. I am using lexical selection to detect where the custom caret is supposed to be. Since lexical (which matches with the native APIs) does not allow distinguish if the caret is set before or after an element, I chose to treat such selection as "after the previous node" (as opposed to "before the current/offset node") because input changes from this state create a new block between the nodes, so it feels natural to visually indicate the caret at the end of "the previous node".

```
node1[caret]
node2
```

_any input changes format the content as_

```
node1
[whatever is typed or pasted from being in the previous state]
node2
```

Such positioning of the fake caret leads to misleading auto-scroll, e.g. if the click action is called near the `node1` it auto-scrolls to `node2` which is confusing because the fake caret is set near the `node1`.

**Other issues:**

Possibly can be used to fix other issues https://github.com/facebook/lexical/issues/2495

## Solution
Add a new `skip-scroll-into-view` tag to be able to skip auto-scroll behavior while selection updates.

```js
editor.update(() => {
  // selection updates that are not supposed to auto-scroll
}, { tag: 'skip-scroll-into-view' });
```