### PR TITLE
Handle bad list item children gracefully

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -369,7 +369,7 @@ export class ListItemNode extends ElementNode {
       const parent = this.getParentOrThrow();
 
       if ($isListNode(parent)) {
-        const siblings = this.getNextSiblings<ListItemNode>();
+        const siblings = this.getNextSiblings();
         updateChildrenListItemValue(parent, siblings);
       }
     }

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -283,10 +283,6 @@ export function updateChildrenListItemValue(
         if (prevValue !== nextValue) {
           child.setValue(nextValue);
         }
-      } else {
-        if (__DEV__) {
-          invariant(false, 'Expected ListNode child to be a ListItemNode');
-        }
       }
     }
   }

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -270,16 +270,26 @@ export function removeList(editor: LexicalEditor): void {
 
 export function updateChildrenListItemValue(
   list: ListNode,
-  children?: Array<ListItemNode>,
+  children?: Array<LexicalNode>,
 ): void {
-  (children || list.getChildren()).forEach((child: ListItemNode) => {
-    const prevValue = child.getValue();
-    const nextValue = $getListItemValue(child);
+  const childrenOrExisting = children || list.getChildren();
+  if (childrenOrExisting !== undefined) {
+    for (let i = 0; i < childrenOrExisting.length; i++) {
+      const child = childrenOrExisting[i];
+      if ($isListItemNode(child)) {
+        const prevValue = child.getValue();
+        const nextValue = $getListItemValue(child);
 
-    if (prevValue !== nextValue) {
-      child.setValue(nextValue);
+        if (prevValue !== nextValue) {
+          child.setValue(nextValue);
+        }
+      } else {
+        if (__DEV__) {
+          invariant(false, 'Expected ListNode child to be a ListItemNode');
+        }
+      }
     }
-  });
+  }
 }
 
 export function $handleIndent(listItemNodes: Array<ListItemNode>): void {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -94,5 +94,7 @@
   "92": "syncChildrenFromYjs: cound not find element node",
   "93": "syncChildrenFromYjs: expected text, element, decorator, or linebreak collab node",
   "94": "splice: could not find collab element node",
-  "95": "splice: expected offset to be greater than zero"
+  "95": "splice: expected offset to be greater than zero",
+  "96": "Expected node %s to have a last child.",
+  "97": "Expected ListNode child to be a ListItemNode"
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -95,6 +95,5 @@
   "93": "syncChildrenFromYjs: expected text, element, decorator, or linebreak collab node",
   "94": "splice: could not find collab element node",
   "95": "splice: expected offset to be greater than zero",
-  "96": "Expected node %s to have a last child.",
-  "97": "Expected ListNode child to be a ListItemNode"
+  "96": "Expected node %s to have a last child."
 }


### PR DESCRIPTION
Generics are a lie https://github.com/facebook/lexical/issues/3152#issuecomment-1273576531

Turns out there is a way to make this fail.. we need to investigate the root of the problem. Fixing the existing crash scenario

---

See https://github.com/facebook/lexical/issues/3227