### PR TITLE
Fix exportJSON return types for ParagraphNode and LineBreakNode

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -626,7 +626,8 @@ declare export class LineBreakNode extends LexicalNode {
   static importJSON(
     serializedLineBreakNode: SerializedLineBreakNode,
   ): LineBreakNode;
-  exportJSON(): SerializedLexicalNode;
+  // $FlowExpectedError[incompatible-extend] 'linebreak' is a literal string
+  exportJSON(): SerializedLineBreakNode;
 }
 declare export function $createLineBreakNode(): LineBreakNode;
 declare export function $isLineBreakNode(
@@ -753,7 +754,8 @@ declare export class ParagraphNode extends ElementNode {
   static importJSON(
     serializedParagraphNode: SerializedParagraphNode,
   ): ParagraphNode;
-  exportJSON(): SerializedElementNode;
+  // $FlowExpectedError[incompatible-extend] 'paragraph' is a literal string
+  exportJSON(): SerializedParagraphNode;
 }
 declare export function $createParagraphNode(): ParagraphNode;
 declare export function $isParagraphNode(

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -75,7 +75,7 @@ export class LineBreakNode extends LexicalNode {
     return $createLineBreakNode();
   }
 
-  exportJSON(): SerializedLexicalNode {
+  exportJSON(): SerializedLineBreakNode {
     return {
       type: 'linebreak',
       version: 1,

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -97,7 +97,7 @@ export class ParagraphNode extends ElementNode {
     return node;
   }
 
-  exportJSON(): SerializedElementNode {
+  exportJSON(): SerializedParagraphNode {
     return {
       ...super.exportJSON(),
       type: 'paragraph',


### PR DESCRIPTION
The `exportJSON()` types for `ParagraphNode` and `LineBreakNode` did not match the `importJSON()` types for those nodes. This PR makes the `exportJSON()` return type consistent with the expected type for `importJSON()` - the same way as it is for all other nodes.

The Flow file was also updated with the types, but this caused an error as the type `type` in `SerializedLexicalNode` is a string, but the `SerializedParagraphNode` and `SerializedLineBreakNode` types use the literal strings `'paragraph'` and `'linebreak'` respectively and so `$FlowExpectedError` was added with a justification.