### PR TITLE
chore: add new `eslint-plugin` with rule `no-optional-chaining` locally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,7 +84,11 @@ module.exports = {
       },
     },
     {
-      files: ['packages/**/src/__tests__/**', 'packages/lexical-playground/**'],
+      files: [
+        'packages/**/src/__tests__/**',
+        'packages/lexical-playground/**',
+        'packages/lexical-devtools/**',
+      ],
       rules: {
         'lexical/no-optional-chaining': OFF,
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,12 @@ const ERROR = 2;
 
 module.exports = {
   // Prettier must be last so it can override other configs (https://github.com/prettier/eslint-config-prettier#installation)
-  extends: ['fbjs', 'plugin:react-hooks/recommended', 'prettier'],
+  extends: [
+    'fbjs',
+    'plugin:react-hooks/recommended',
+    'plugin:lexical/all',
+    'prettier',
+  ],
 
   globals: {
     JSX: true,
@@ -101,6 +106,7 @@ module.exports = {
     'no-function-declare-after-return',
     'react',
     'no-only-tests',
+    'lexical',
   ],
 
   // Stop ESLint from looking for a configuration file in parent folders

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,6 +83,12 @@ module.exports = {
         'header/header': OFF,
       },
     },
+    {
+      files: ['packages/**/src/__tests__/**', 'packages/lexical-playground/**'],
+      rules: {
+        'lexical/no-optional-chaining': OFF,
+      },
+    },
   ],
 
   parser: 'babel-eslint',

--- a/eslint-plugin/package.json
+++ b/eslint-plugin/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "eslint-plugin-lexical",
+  "version": "1.0.0",
+  "description": "ESLint plugin for lexical",
+  "main": "src/index.js",
+  "peerDependencies": {
+    "eslint": ">=4.19.1"
+  }
+}

--- a/eslint-plugin/src/index.js
+++ b/eslint-plugin/src/index.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+const rules = require('./rules');
+
+module.exports = {
+  configs: {
+    all: {
+      rules: {
+        'lexical/no-optional-chaining': 'error',
+      },
+    },
+    recommended: {
+      rules: {
+        'lexical/no-optional-chaining': 'error',
+      },
+    },
+  },
+  rules,
+};

--- a/eslint-plugin/src/rules/index.js
+++ b/eslint-plugin/src/rules/index.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+const noOptionalChaining = require('./no-optional-chaining');
+
+module.exports = {
+  'no-optional-chaining': noOptionalChaining,
+};

--- a/eslint-plugin/src/rules/no-optional-chaining.js
+++ b/eslint-plugin/src/rules/no-optional-chaining.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    /**
+     * Checks if the given token is a `?.` token or not.
+     * @param {Token} token The token to check.
+     * @returns {boolean} `true` if the token is a `?.` token.
+     */
+    function isQuestionDotToken(token) {
+      return (
+        token.value === '?.' &&
+        (token.type === 'Punctuator' || // espree has been parsed well.
+          // espree@7.1.0 doesn't parse "?." tokens well. Therefore, get the string from the source code and check it.
+          sourceCode.getText(token) === '?.')
+      );
+    }
+
+    return {
+      'CallExpression[optional=true]'(node) {
+        context.report({
+          messageId: 'forbidden',
+          node: sourceCode.getTokenAfter(node.callee, isQuestionDotToken),
+        });
+      },
+      'MemberExpression[optional=true]'(node) {
+        context.report({
+          messageId: 'forbidden',
+          node: sourceCode.getTokenAfter(node.object, isQuestionDotToken),
+        });
+      },
+    };
+  },
+  meta: {
+    docs: {
+      description: 'disallow optional chaining',
+      recommended: true,
+    },
+    messages: {
+      forbidden: 'Avoid using optional chaining',
+    },
+    schema: [],
+    type: 'problem',
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jest": "^24.4.0",
         "eslint-plugin-jsx-a11y": "^6.4.1",
+        "eslint-plugin-lexical": "file:./eslint-plugin",
         "eslint-plugin-no-function-declare-after-return": "^1.1.0",
         "eslint-plugin-no-only-tests": "^2.6.0",
         "eslint-plugin-react": "^7.24.0",
@@ -80,6 +81,13 @@
       "engines": {
         "npm": ">=8.2.3",
         "yarn": ">=1"
+      }
+    },
+    "eslint-plugin": {
+      "version": "1.0.0",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -8811,6 +8819,10 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/eslint-plugin-lexical": {
+      "resolved": "eslint-plugin",
+      "link": true
     },
     "node_modules/eslint-plugin-no-function-declare-after-return": {
       "version": "1.1.0",
@@ -21912,36 +21924,36 @@
       }
     },
     "packages/lexical": {
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT"
     },
     "packages/lexical-clipboard": {
       "name": "@lexical/clipboard",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/utils": "0.5.0"
+        "@lexical/html": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-code": {
       "name": "@lexical/code",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0",
+        "@lexical/utils": "0.5.1-next.0",
         "prismjs": "^1.27.0"
       },
       "devDependencies": {
         "@types/prismjs": "^1.26.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-devtools": {
@@ -21979,157 +21991,157 @@
     },
     "packages/lexical-dragon": {
       "name": "@lexical/dragon",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-file": {
       "name": "@lexical/file",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-hashtag": {
       "name": "@lexical/hashtag",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-headless": {
       "name": "@lexical/headless",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-history": {
       "name": "@lexical/history",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-html": {
       "name": "@lexical/html",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.5.0"
+        "@lexical/selection": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-link": {
       "name": "@lexical/link",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-list": {
       "name": "@lexical/list",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-mark": {
       "name": "@lexical/mark",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-markdown": {
       "name": "@lexical/markdown",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.5.0",
-        "@lexical/link": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/rich-text": "0.5.0",
-        "@lexical/text": "0.5.0",
-        "@lexical/utils": "0.5.0"
+        "@lexical/code": "0.5.1-next.0",
+        "@lexical/link": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/rich-text": "0.5.1-next.0",
+        "@lexical/text": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-offset": {
       "name": "@lexical/offset",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-overflow": {
       "name": "@lexical/overflow",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-plain-text": {
       "name": "@lexical/plain-text",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "@lexical/clipboard": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/utils": "0.5.0",
-        "lexical": "0.5.0"
+        "@lexical/clipboard": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0",
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-playground": {
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "dependencies": {
         "@excalidraw/excalidraw": "0.11.0",
-        "@lexical/clipboard": "0.5.0",
-        "@lexical/code": "0.5.0",
-        "@lexical/file": "0.5.0",
-        "@lexical/hashtag": "0.5.0",
-        "@lexical/link": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/mark": "0.5.0",
-        "@lexical/overflow": "0.5.0",
-        "@lexical/plain-text": "0.5.0",
-        "@lexical/react": "0.5.0",
-        "@lexical/rich-text": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/table": "0.5.0",
-        "@lexical/utils": "0.5.0",
+        "@lexical/clipboard": "0.5.1-next.0",
+        "@lexical/code": "0.5.1-next.0",
+        "@lexical/file": "0.5.1-next.0",
+        "@lexical/hashtag": "0.5.1-next.0",
+        "@lexical/link": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/mark": "0.5.1-next.0",
+        "@lexical/overflow": "0.5.1-next.0",
+        "@lexical/plain-text": "0.5.1-next.0",
+        "@lexical/react": "0.5.1-next.0",
+        "@lexical/rich-text": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/table": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0",
         "katex": "^0.15.2",
-        "lexical": "0.5.0",
+        "lexical": "0.5.1-next.0",
         "lodash-es": "^4.17.21",
         "prettier": "^2.3.2",
         "react": "^18.2.0",
@@ -22147,81 +22159,81 @@
     },
     "packages/lexical-react": {
       "name": "@lexical/react",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.5.0",
-        "@lexical/code": "0.5.0",
-        "@lexical/dragon": "0.5.0",
-        "@lexical/hashtag": "0.5.0",
-        "@lexical/history": "0.5.0",
-        "@lexical/link": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/mark": "0.5.0",
-        "@lexical/markdown": "0.5.0",
-        "@lexical/overflow": "0.5.0",
-        "@lexical/plain-text": "0.5.0",
-        "@lexical/rich-text": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/table": "0.5.0",
-        "@lexical/text": "0.5.0",
-        "@lexical/utils": "0.5.0",
-        "@lexical/yjs": "0.5.0"
+        "@lexical/clipboard": "0.5.1-next.0",
+        "@lexical/code": "0.5.1-next.0",
+        "@lexical/dragon": "0.5.1-next.0",
+        "@lexical/hashtag": "0.5.1-next.0",
+        "@lexical/history": "0.5.1-next.0",
+        "@lexical/link": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/mark": "0.5.1-next.0",
+        "@lexical/markdown": "0.5.1-next.0",
+        "@lexical/overflow": "0.5.1-next.0",
+        "@lexical/plain-text": "0.5.1-next.0",
+        "@lexical/rich-text": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/table": "0.5.1-next.0",
+        "@lexical/text": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0",
+        "@lexical/yjs": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0",
+        "lexical": "0.5.1-next.0",
         "react": ">=17.x",
         "react-dom": ">=17.x"
       }
     },
     "packages/lexical-rich-text": {
       "name": "@lexical/rich-text",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "@lexical/clipboard": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/utils": "0.5.0",
-        "lexical": "0.5.0"
+        "@lexical/clipboard": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0",
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-selection": {
       "name": "@lexical/selection",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-table": {
       "name": "@lexical/table",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-text": {
       "name": "@lexical/text",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-utils": {
       "name": "@lexical/utils",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.5.0",
-        "@lexical/table": "0.5.0"
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/table": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "packages/lexical-website": {
@@ -23202,13 +23214,13 @@
     },
     "packages/lexical-yjs": {
       "name": "@lexical/yjs",
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.5.0"
+        "@lexical/offset": "0.5.1-next.0"
       },
       "peerDependencies": {
-        "lexical": "0.5.0",
+        "lexical": "0.5.1-next.0",
         "yjs": ">=13.5.22"
       }
     },
@@ -23237,10 +23249,10 @@
       }
     },
     "packages/shared": {
-      "version": "0.5.0",
+      "version": "0.5.1-next.0",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     }
   },
@@ -25512,16 +25524,16 @@
     "@lexical/clipboard": {
       "version": "file:packages/lexical-clipboard",
       "requires": {
-        "@lexical/html": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/utils": "0.5.0"
+        "@lexical/html": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/code": {
       "version": "file:packages/lexical-code",
       "requires": {
-        "@lexical/utils": "0.5.0",
+        "@lexical/utils": "0.5.1-next.0",
         "@types/prismjs": "^1.26.0",
         "prismjs": "^1.27.0"
       }
@@ -25535,7 +25547,7 @@
     "@lexical/hashtag": {
       "version": "file:packages/lexical-hashtag",
       "requires": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/headless": {
@@ -25544,42 +25556,42 @@
     "@lexical/history": {
       "version": "file:packages/lexical-history",
       "requires": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/html": {
       "version": "file:packages/lexical-html",
       "requires": {
-        "@lexical/selection": "0.5.0"
+        "@lexical/selection": "0.5.1-next.0"
       }
     },
     "@lexical/link": {
       "version": "file:packages/lexical-link",
       "requires": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/list": {
       "version": "file:packages/lexical-list",
       "requires": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/mark": {
       "version": "file:packages/lexical-mark",
       "requires": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/markdown": {
       "version": "file:packages/lexical-markdown",
       "requires": {
-        "@lexical/code": "0.5.0",
-        "@lexical/link": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/rich-text": "0.5.0",
-        "@lexical/text": "0.5.0",
-        "@lexical/utils": "0.5.0"
+        "@lexical/code": "0.5.1-next.0",
+        "@lexical/link": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/rich-text": "0.5.1-next.0",
+        "@lexical/text": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/offset": {
@@ -25594,23 +25606,23 @@
     "@lexical/react": {
       "version": "file:packages/lexical-react",
       "requires": {
-        "@lexical/clipboard": "0.5.0",
-        "@lexical/code": "0.5.0",
-        "@lexical/dragon": "0.5.0",
-        "@lexical/hashtag": "0.5.0",
-        "@lexical/history": "0.5.0",
-        "@lexical/link": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/mark": "0.5.0",
-        "@lexical/markdown": "0.5.0",
-        "@lexical/overflow": "0.5.0",
-        "@lexical/plain-text": "0.5.0",
-        "@lexical/rich-text": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/table": "0.5.0",
-        "@lexical/text": "0.5.0",
-        "@lexical/utils": "0.5.0",
-        "@lexical/yjs": "0.5.0"
+        "@lexical/clipboard": "0.5.1-next.0",
+        "@lexical/code": "0.5.1-next.0",
+        "@lexical/dragon": "0.5.1-next.0",
+        "@lexical/hashtag": "0.5.1-next.0",
+        "@lexical/history": "0.5.1-next.0",
+        "@lexical/link": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/mark": "0.5.1-next.0",
+        "@lexical/markdown": "0.5.1-next.0",
+        "@lexical/overflow": "0.5.1-next.0",
+        "@lexical/plain-text": "0.5.1-next.0",
+        "@lexical/rich-text": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/table": "0.5.1-next.0",
+        "@lexical/text": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0",
+        "@lexical/yjs": "0.5.1-next.0"
       }
     },
     "@lexical/rich-text": {
@@ -25622,7 +25634,7 @@
     "@lexical/table": {
       "version": "file:packages/lexical-table",
       "requires": {
-        "@lexical/utils": "0.5.0"
+        "@lexical/utils": "0.5.1-next.0"
       }
     },
     "@lexical/text": {
@@ -25631,8 +25643,8 @@
     "@lexical/utils": {
       "version": "file:packages/lexical-utils",
       "requires": {
-        "@lexical/list": "0.5.0",
-        "@lexical/table": "0.5.0"
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/table": "0.5.1-next.0"
       }
     },
     "@lexical/website": {
@@ -26340,7 +26352,7 @@
     "@lexical/yjs": {
       "version": "file:packages/lexical-yjs",
       "requires": {
-        "@lexical/offset": "0.5.0"
+        "@lexical/offset": "0.5.1-next.0"
       }
     },
     "@mdx-js/mdx": {
@@ -30453,6 +30465,9 @@
         }
       }
     },
+    "eslint-plugin-lexical": {
+      "version": "file:eslint-plugin"
+    },
     "eslint-plugin-no-function-declare-after-return": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-function-declare-after-return/-/eslint-plugin-no-function-declare-after-return-1.1.0.tgz",
@@ -34477,24 +34492,24 @@
       "version": "file:packages/lexical-playground",
       "requires": {
         "@excalidraw/excalidraw": "0.11.0",
-        "@lexical/clipboard": "0.5.0",
-        "@lexical/code": "0.5.0",
-        "@lexical/file": "0.5.0",
-        "@lexical/hashtag": "0.5.0",
-        "@lexical/link": "0.5.0",
-        "@lexical/list": "0.5.0",
-        "@lexical/mark": "0.5.0",
-        "@lexical/overflow": "0.5.0",
-        "@lexical/plain-text": "0.5.0",
-        "@lexical/react": "0.5.0",
-        "@lexical/rich-text": "0.5.0",
-        "@lexical/selection": "0.5.0",
-        "@lexical/table": "0.5.0",
-        "@lexical/utils": "0.5.0",
+        "@lexical/clipboard": "0.5.1-next.0",
+        "@lexical/code": "0.5.1-next.0",
+        "@lexical/file": "0.5.1-next.0",
+        "@lexical/hashtag": "0.5.1-next.0",
+        "@lexical/link": "0.5.1-next.0",
+        "@lexical/list": "0.5.1-next.0",
+        "@lexical/mark": "0.5.1-next.0",
+        "@lexical/overflow": "0.5.1-next.0",
+        "@lexical/plain-text": "0.5.1-next.0",
+        "@lexical/react": "0.5.1-next.0",
+        "@lexical/rich-text": "0.5.1-next.0",
+        "@lexical/selection": "0.5.1-next.0",
+        "@lexical/table": "0.5.1-next.0",
+        "@lexical/utils": "0.5.1-next.0",
         "@types/lodash-es": "^4.14.182",
         "@vitejs/plugin-react": "^1.0.7",
         "katex": "^0.15.2",
-        "lexical": "0.5.0",
+        "lexical": "0.5.1-next.0",
         "lodash-es": "^4.17.21",
         "prettier": "^2.3.2",
         "react": "^18.2.0",
@@ -37608,7 +37623,7 @@
     "shared": {
       "version": "file:packages/shared",
       "requires": {
-        "lexical": "0.5.0"
+        "lexical": "0.5.1-next.0"
       }
     },
     "shebang-command": {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-sort-keys-fix": "^1.1.2",
+    "eslint-plugin-lexical": "file:./eslint-plugin",
     "flow-bin": "^0.171.0",
     "fs-extra": "^10.0.0",
     "gen-flow-files": "^0.4.11",


### PR DESCRIPTION
Resolves #3074

1. Created a new `eslint-plugin` inside the project directory and added a new rule (`no-optional-chaining`) in it.
2. Added the plugin in `.eslintrc.js` to detect the usage of optional chaining
3. Added the locally created `eslint-plugin-lexical` to _package.json_

Rule reference: https://github.com/mysticatea/eslint-plugin-es/blob/master/lib/rules/no-optional-chaining.js