### PR TITLE
Fix pasting top level nodes inline

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -3012,4 +3012,70 @@ test.describe('CopyAndPaste', () => {
       `,
     );
   });
+
+  test('Paste top level element in the middle of list', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    // Add three list items
+    await page.keyboard.type('- one');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('two');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('three');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('four');
+
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
+    await pasteFromClipboard(page, {
+      'text/html': `<hr />`,
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">one</span>
+          </li>
+          <li
+            value="2"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">two</span>
+          </li>
+        </ul>
+        <div
+          contenteditable="false"
+          style="display: contents"
+          data-lexical-decorator="true">
+          <hr />
+        </div>
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">three</span>
+          </li>
+          <li
+            value="2"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">four</span>
+          </li>
+        </ul>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
 });

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -2981,8 +2981,9 @@ test.describe('CopyAndPaste', () => {
   test('Paste top level element in the middle of paragraph', async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
-    test.skip(isPlainText);
+    test.skip(isPlainText || isCollab);
     await focusEditor(page);
     await page.keyboard.type('Hello world');
     await moveToPrevWord(page);
@@ -2998,12 +2999,7 @@ test.describe('CopyAndPaste', () => {
           dir="ltr">
           <span data-lexical-text="true">Hello</span>
         </p>
-        <div
-          contenteditable="false"
-          style="display: contents"
-          data-lexical-decorator="true">
-          <hr />
-        </div>
+        <hr class="" contenteditable="false" data-lexical-decorator="true" />
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
           dir="ltr">
@@ -3016,8 +3012,9 @@ test.describe('CopyAndPaste', () => {
   test('Paste top level element in the middle of list', async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
-    test.skip(isPlainText);
+    test.skip(isPlainText || isCollab);
     await focusEditor(page);
     // Add three list items
     await page.keyboard.type('- one');
@@ -3031,6 +3028,7 @@ test.describe('CopyAndPaste', () => {
     await page.keyboard.press('Enter');
     await page.keyboard.press('Enter');
     await page.keyboard.press('ArrowUp');
+    await moveLeft(page, 4);
     await page.keyboard.press('ArrowUp');
     await page.keyboard.press('ArrowUp');
     await pasteFromClipboard(page, {
@@ -3054,12 +3052,11 @@ test.describe('CopyAndPaste', () => {
             <span data-lexical-text="true">two</span>
           </li>
         </ul>
+        <hr class="" contenteditable="false" data-lexical-decorator="true" />
         <div
+          class="PlaygroundEditorTheme__blockCursor"
           contenteditable="false"
-          style="display: contents"
-          data-lexical-decorator="true">
-          <hr />
-        </div>
+          data-lexical-cursor="true"></div>
         <ul class="PlaygroundEditorTheme__ul">
           <li
             value="1"

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -2977,4 +2977,39 @@ test.describe('CopyAndPaste', () => {
       focusPath: [2, 0, 0],
     });
   });
+
+  test('Paste top level element in the middle of paragraph', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    await page.keyboard.type('Hello world');
+    await moveToPrevWord(page);
+    await pasteFromClipboard(page, {
+      'text/html': `<hr />`,
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello</span>
+        </p>
+        <div
+          contenteditable="false"
+          style="display: contents"
+          data-lexical-decorator="true">
+          <hr />
+        </div>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+    );
+  });
 });

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -14,7 +14,6 @@ import type {TextFormatType} from './nodes/LexicalTextNode';
 
 import {$splitNode} from '@lexical/utils';
 import {IS_CHROME} from 'shared/environment';
-import getDOMSelection from 'shared/getDOMSelection';
 import invariant from 'shared/invariant';
 
 import {

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1438,7 +1438,8 @@ export class RangeSelection implements BaseSelection {
         if (
           $isRangeSelection(this) &&
           $isDecoratorNode(node) &&
-          !node.isInline()
+          !node.isInline() &&
+          $isTextNode(target)
         ) {
           this.insertParagraph();
           target = this.focus

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1433,7 +1433,21 @@ export class RangeSelection implements BaseSelection {
         ($isDecoratorNode(target) && !target.isInline())
       ) {
         lastNode = node;
-        target = target.insertAfter(node, false);
+        // when pasting top level node in the middle of paragraph
+        // we need to split paragraph instead of placing it inline
+        if (
+          $isRangeSelection(this) &&
+          $isDecoratorNode(node) &&
+          !node.isInline()
+        ) {
+          this.insertParagraph();
+          target = this.focus
+            .getNode()
+            .getTopLevelElementOrThrow()
+            .insertBefore(node);
+        } else {
+          target = target.insertAfter(node, false);
+        }
       } else {
         const nextTarget: ElementNode = target.getParentOrThrow();
         // if we're inserting an Element after a LineBreak, we want to move the target to the parent

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1440,11 +1440,11 @@ export class RangeSelection implements BaseSelection {
         if (
           $isRangeSelection(this) &&
           $isDecoratorNode(node) &&
-          !$isDecoratorNode(target) &&
+          ($isElementNode(target) || $isTextNode(target)) &&
           !node.isInline()
         ) {
-          let splitNode;
-          let splitOffset;
+          let splitNode: ElementNode;
+          let splitOffset: number;
 
           if ($isTextNode(target)) {
             splitNode = target.getParentOrThrow();
@@ -1455,7 +1455,7 @@ export class RangeSelection implements BaseSelection {
             splitOffset = anchorOffset;
           }
           const [, rightTree] = $splitNode(splitNode, splitOffset);
-          rightTree.insertBefore(node);
+          target = rightTree.insertBefore(node);
         } else {
           target = target.insertAfter(node, false);
         }


### PR DESCRIPTION
Resoves: https://github.com/facebook/lexical/issues/3041
## Problem
Pasting top level nodes (isInline set to `false`) within a paragraph places node in paragraph instead of breaking paragraph and placing node between.

### Steps to reproduce 
https://user-images.githubusercontent.com/4542049/197205190-a048afb8-059c-4934-9cc8-5827b491bf60.mov

## Solution
https://user-images.githubusercontent.com/4542049/197206901-6afc13cc-7a12-416b-9fc3-c0b9ae3140a3.mov


## Note
This is still partially broken for `headings` and `quotes` because when they get broken the second part becomes paragraph instead of whatever node it originally was but it is still an improvement on current behavior.