### PR TITLE
fix editor crash when importing editorState with nested stickyNote

### DIFF
--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -55,9 +55,9 @@ export default function StickyComponent({
   y,
   nodeKey,
   color,
-  editorCaption,
+  captionEditor,
 }: {
-  editorCaption: LexicalEditor;
+  captionEditor: LexicalEditor;
   color: 'pink' | 'yellow';
   nodeKey: NodeKey;
   x: number;
@@ -236,11 +236,11 @@ export default function StickyComponent({
           <i className="bucket" />
         </button>
         <LexicalNestedComposer
-          initialEditor={editorCaption}
+          initialEditor={captionEditor}
           initialTheme={StickyEditorTheme}>
           {isCollabActive ? (
             <CollaborationPlugin
-              id={editorCaption.getKey()}
+              id={captionEditor.getKey()}
               providerFactory={createWebsocketProvider}
               shouldBootstrap={true}
             />

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -55,9 +55,9 @@ export default function StickyComponent({
   y,
   nodeKey,
   color,
-  caption,
+  editorCaption,
 }: {
-  caption: LexicalEditor;
+  editorCaption: LexicalEditor;
   color: 'pink' | 'yellow';
   nodeKey: NodeKey;
   x: number;
@@ -236,11 +236,11 @@ export default function StickyComponent({
           <i className="bucket" />
         </button>
         <LexicalNestedComposer
-          initialEditor={caption}
+          initialEditor={editorCaption}
           initialTheme={StickyEditorTheme}>
           {isCollabActive ? (
             <CollaborationPlugin
-              id={caption.getKey()}
+              id={editorCaption.getKey()}
               providerFactory={createWebsocketProvider}
               shouldBootstrap={true}
             />

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -59,7 +59,6 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
       node.__y,
       node.__color,
       node.__caption,
-      node.__editor,
       node.__key,
     );
   }
@@ -77,21 +76,18 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
     y: number,
     color: 'pink' | 'yellow',
     caption?: Caption,
-    editor?: LexicalEditor,
     key?: NodeKey,
   ) {
     super(key);
     this.__x = x;
     this.__y = y;
     this.__color = color;
+    this.__captionEditor = createEditor();
     if (caption !== undefined) {
-      this.__editor = createEditor();
-      const editorState = this.__editor.parseEditorState(
+      const editorState = this.__captionEditor.parseEditorState(
         JSON.stringify(caption.editorState),
       );
-      this.__editor.setEditorState(editorState);
-    } else {
-      this.__editor = editor;
+      this.__captionEditor.setEditorState(editorState);
     }
   }
 
@@ -136,7 +132,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
           x={this.__x}
           y={this.__y}
           nodeKey={this.getKey()}
-          editorCaption={this.__editor}
+          captionEditor={this.__captionEditor}
         />
       </Suspense>,
       document.body,

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -82,6 +82,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
     this.__x = x;
     this.__y = y;
     this.__color = color;
+    this.__caption = caption;
     this.__captionEditor = createEditor();
     if (caption !== undefined) {
       const editorState = this.__captionEditor.parseEditorState(


### PR DESCRIPTION
This is to fix issue #3240 

Looks like the StickyNote class expects to receive a `caption` of type `LexicalEditor`, but actually gets a `Caption` type - an `EditorState` wrapped inside an object. This causes the editor to crash as it tries to access properties which `Caption` type doesn't have. Though we can use the `editorState` inside the newly defined `Caption` type to create a new Lexical editor.