### PR TITLE
Expose Tokenizer interface to accept custom tokenizer other than Prism at @lexical/code

### DIFF
--- a/packages/lexical-code/flow/LexicalCode.js.flow
+++ b/packages/lexical-code/flow/LexicalCode.js.flow
@@ -64,6 +64,16 @@ declare export class CodeHighlightNode extends TextNode {
   ): boolean;
   setFormat(format: number): this;
 }
+
+type TokenContent = string | Token | (string | Token)[];
+export interface Token {
+  type: string;
+  content: TokenContent;
+}
+export interface Tokenizer {
+  tokenize(code: string, language?: string): (string | Token)[];
+}
+
 declare function getHighlightThemeClass(
   theme: EditorThemeClasses,
   highlightType: ?string,
@@ -78,4 +88,5 @@ declare export function $isCodeHighlightNode(
 
 declare export function registerCodeHighlighting(
   editor: LexicalEditor,
+  tokenizer?: Tokenizer,
 ): () => void;

--- a/packages/lexical-code/src/index.ts
+++ b/packages/lexical-code/src/index.ts
@@ -11,6 +11,7 @@
 export {
   getEndOfCodeInLine,
   getStartOfCodeInLine,
+  PrismTokenizer,
   registerCodeHighlighting,
 } from './CodeHighlighter';
 export {


### PR DESCRIPTION

Prism has powerful functionality to handle various languages including custom language, 
but some other tools like [ANTLR](https://www.antlr.org) have their own grammar definition and parser generator.

This PR exposes the Tokenizer interface at `registerCodeHighlighting` in @lexical/code plugin to handle such a case.