### PR TITLE
Handle left part of match

### DIFF
--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -289,14 +289,22 @@ function importTextMatchTransformers(
 
       const startIndex = match.index || 0;
       const endIndex = startIndex + match[0].length;
-      let replaceNode;
+      let replaceNode, leftTextNode, rightTextNode;
 
       if (startIndex === 0) {
         [replaceNode, textNode] = textNode.splitText(endIndex);
       } else {
-        [, replaceNode, textNode] = textNode.splitText(startIndex, endIndex);
+        [leftTextNode, replaceNode, rightTextNode] = textNode.splitText(
+          startIndex,
+          endIndex,
+        );
       }
-
+      if (leftTextNode) {
+        importTextMatchTransformers(leftTextNode, textMatchTransformers);
+      }
+      if (rightTextNode) {
+        textNode = rightTextNode;
+      }
       transformer.replace(replaceNode, match);
       continue mainLoop;
     }

--- a/packages/lexical-markdown/src/__tests__/unit/MarkdownImport.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/MarkdownImport.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+// eslint-disable-next-line simple-import-sort/imports
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+
+import {$createTextNode, $getRoot} from 'lexical';
+import {ImageNode} from './../../../../lexical-playground/src/nodes/ImageNode';
+import {EquationNode} from './../../../../lexical-playground/src/nodes/EquationNode';
+import {createMarkdownImport} from './../../MarkdownImport';
+import {ELEMENT_TRANSFORMERS, TEXT_FORMAT_TRANSFORMERS} from './../..';
+import {TextMatchTransformer, Transformer} from './../../MarkdownTransformers';
+
+const URL =
+  'https://design.agorapulse.com/assets/img/style/logos/logo-blue.svg';
+const markdown = `First part of message then ![${URL}](${URL}) then an $equation$ in the middle of it, plus an image. ![${URL}](${URL}) ok?`;
+const expectedTextContent =
+  'First part of message then https://design.agorapulse.com/assets/img/style/logos/logo-blue.svg then an equation in the middle of it, plus an image. https://design.agorapulse.com/assets/img/style/logos/logo-blue.svg ok?';
+
+const IMAGE: TextMatchTransformer = {
+  dependencies: [ImageNode],
+  export: (node, exportChildren, exportFormat) => {
+    return `![${node.getAltText()}](${node.getSrc()})`;
+  },
+  importRegExp: /!(?:\[([^[]*)\])(?:\(([^(]+)\))/,
+  regExp: /!(?:\[([^[]*)\])(?:\(([^(]+)\))$/,
+  replace: (textNode, match) => {
+    const [, , src] = match;
+    const newTextNode = $createTextNode(src);
+    textNode.replace(newTextNode);
+  },
+  trigger: ')',
+  type: 'text-match',
+};
+
+const EQUATION: TextMatchTransformer = {
+  dependencies: [EquationNode],
+  export: (node, exportChildren, exportFormat) => {
+    return `$${node.getEquation()}$`;
+  },
+  importRegExp: /\$([^$].+?)\$/,
+  regExp: /\$([^$].+?)\$$/,
+  replace: (textNode, match) => {
+    const [, equation] = match;
+    const equationNode = $createTextNode(equation);
+    textNode.replace(equationNode);
+  },
+  trigger: '$',
+  type: 'text-match',
+};
+
+const transformers: Array<Transformer> = [
+  IMAGE,
+  EQUATION,
+  ...ELEMENT_TRANSFORMERS,
+  ...TEXT_FORMAT_TRANSFORMERS,
+];
+
+describe('MarkdownImport tests', () => {
+  initializeUnitTest(
+    (testEnv) => {
+      describe('convertFromMarkdownString', () => {
+        let createMarkdownResult;
+
+        test('createMarkdownImport', async () => {
+          const {editor} = testEnv;
+
+          await editor.update(() => {
+            createMarkdownResult = createMarkdownImport(transformers);
+          });
+        });
+
+        test('importMarkdown', async () => {
+          const {editor} = testEnv;
+
+          await editor.update(() => {
+            createMarkdownResult(markdown);
+            const root = $getRoot();
+            const paragraph = root.getFirstChild();
+            const textContent = paragraph.getTextContent();
+            expect(textContent).toEqual(expectedTextContent);
+          });
+        });
+      });
+    },
+    {
+      namespace: '',
+      nodes: [EquationNode, ImageNode],
+      theme: {},
+    },
+  );
+});


### PR DESCRIPTION
The`importTextMatchTransformers` use the splitText method to handle the match and continue the loop. 
However it never use the left part of the match as the split text method returns an array of text node. 
Thus if you have a future textMatchTransformers match in the left part (before the replaceNode) it won't be caught.

I just catch the left part of the match and do a recursive call to the same method to handle this.

Let me know if there any other way of doing it.