### PR TITLE
fix playground Sticky Note export/import causing crash

### DIFF
--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -55,9 +55,9 @@ export default function StickyComponent({
   y,
   nodeKey,
   color,
-  caption,
+  captionEditor,
 }: {
-  caption: LexicalEditor;
+  captionEditor: LexicalEditor;
   color: 'pink' | 'yellow';
   nodeKey: NodeKey;
   x: number;
@@ -236,11 +236,11 @@ export default function StickyComponent({
           <i className="bucket" />
         </button>
         <LexicalNestedComposer
-          initialEditor={caption}
+          initialEditor={captionEditor}
           initialTheme={StickyEditorTheme}>
           {isCollabActive ? (
             <CollaborationPlugin
-              id={caption.getKey()}
+              id={captionEditor.getKey()}
               providerFactory={createWebsocketProvider}
               shouldBootstrap={true}
             />

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -55,9 +55,9 @@ export default function StickyComponent({
   y,
   nodeKey,
   color,
-  captionEditor,
+  caption,
 }: {
-  captionEditor: LexicalEditor;
+  caption: LexicalEditor;
   color: 'pink' | 'yellow';
   nodeKey: NodeKey;
   x: number;
@@ -236,11 +236,11 @@ export default function StickyComponent({
           <i className="bucket" />
         </button>
         <LexicalNestedComposer
-          initialEditor={captionEditor}
+          initialEditor={caption}
           initialTheme={StickyEditorTheme}>
           {isCollabActive ? (
             <CollaborationPlugin
-              id={captionEditor.getKey()}
+              id={caption.getKey()}
               providerFactory={createWebsocketProvider}
               shouldBootstrap={true}
             />

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -44,7 +44,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
   __x: number;
   __y: number;
   __color: StickyNoteColor;
-  __captionEditor: LexicalEditor;
+  __caption: LexicalEditor;
 
   static getType(): string {
     return 'sticky';
@@ -55,7 +55,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
       node.__x,
       node.__y,
       node.__color,
-      node.__captionEditor,
+      node.__caption,
       node.__key,
     );
   }
@@ -87,13 +87,13 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
     super(key);
     this.__x = x;
     this.__y = y;
-    this.__captionEditor = caption || createEditor();
+    this.__caption = caption || createEditor();
     this.__color = color;
   }
 
   exportJSON(): SerializedStickyNode {
     return {
-      caption: this.__captionEditor.toJSON(),
+      caption: this.__caption.toJSON(),
       color: this.__color,
       type: 'sticky',
       version: 1,
@@ -132,7 +132,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
           x={this.__x}
           y={this.__y}
           nodeKey={this.getKey()}
-          caption={this.__captionEditor}
+          caption={this.__caption}
         />
       </Suspense>,
       document.body,

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -8,10 +8,10 @@
 
 import type {
   EditorConfig,
-  EditorState,
   LexicalEditor,
   LexicalNode,
   NodeKey,
+  SerializedEditor,
   SerializedLexicalNode,
   Spread,
 } from 'lexical';
@@ -33,7 +33,7 @@ export type SerializedStickyNode = Spread<
     xOffset: number;
     yOffset: number;
     color: StickyNoteColor;
-    caption: EditorState;
+    caption: SerializedEditor;
     type: 'sticky';
     version: 1;
   },
@@ -93,7 +93,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
 
   exportJSON(): SerializedStickyNode {
     return {
-      caption: this.__captionEditor.getEditorState(),
+      caption: this.__captionEditor.toJSON(),
       color: this.__color,
       type: 'sticky',
       version: 1,
@@ -132,7 +132,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
           x={this.__x}
           y={this.__y}
           nodeKey={this.getKey()}
-          captionEditor={this.__captionEditor}
+          caption={this.__captionEditor}
         />
       </Suspense>,
       document.body,

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -81,13 +81,13 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
     x: number,
     y: number,
     color: 'pink' | 'yellow',
-    captionEditor?: LexicalEditor,
+    caption?: LexicalEditor,
     key?: NodeKey,
   ) {
     super(key);
     this.__x = x;
     this.__y = y;
-    this.__captionEditor = captionEditor || createEditor();
+    this.__captionEditor = caption || createEditor();
     this.__color = color;
   }
 

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -63,7 +63,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
     const captionEditor = createEditor();
     if (serializedNode.caption !== undefined) {
       const editorState = captionEditor.parseEditorState(
-        JSON.stringify(serializedNode.caption),
+        JSON.stringify(serializedNode.caption.editorState),
       );
       if (!editorState.isEmpty()) {
         captionEditor.setEditorState(editorState);

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -8,10 +8,10 @@
 
 import type {
   EditorConfig,
+  EditorState,
   LexicalEditor,
   LexicalNode,
   NodeKey,
-  SerializedEditorState,
   SerializedLexicalNode,
   Spread,
 } from 'lexical';
@@ -33,7 +33,7 @@ export type SerializedStickyNode = Spread<
     xOffset: number;
     yOffset: number;
     color: StickyNoteColor;
-    caption: SerializedEditorState;
+    caption: EditorState;
     type: 'sticky';
     version: 1;
   },
@@ -63,7 +63,7 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
     const captionEditor = createEditor();
     if (serializedNode.caption !== undefined) {
       const editorState = captionEditor.parseEditorState(
-        serializedNode.caption,
+        JSON.stringify(serializedNode.caption),
       );
       if (!editorState.isEmpty()) {
         captionEditor.setEditorState(editorState);


### PR DESCRIPTION
Fixes issue #3240 where export/import of StickyNote crashes Playground. Now with working state export/restore.