### PR TITLE
Improve Collab cursor, add custom cursorColor

### DIFF
--- a/packages/lexical-react/src/LexicalCollaborationContext.ts
+++ b/packages/lexical-react/src/LexicalCollaborationContext.ts
@@ -19,22 +19,22 @@ type CollaborationContextType = {
 };
 
 const entries = [
-  ['Cat', '255,165,0'],
-  ['Dog', '0,200,55'],
-  ['Rabbit', '160,0,200'],
-  ['Frog', '0,172,200'],
-  ['Fox', '197,200,0'],
-  ['Hedgehog', '31,200,0'],
-  ['Pigeon', '200,0,0'],
-  ['Squirrel', '200,0,148'],
-  ['Bear', '255,235,0'],
-  ['Tiger', '86,255,0'],
-  ['Leopard', '0,255,208'],
-  ['Zebra', '0,243,255'],
-  ['Wolf', '0,102,255'],
-  ['Owl', '147,0,255'],
-  ['Gull', '255,0,153'],
-  ['Squid', '0,220,255'],
+  ['Cat', 'rgb(255,165,0)'],
+  ['Dog', 'rgb(0,200,55)'],
+  ['Rabbit', 'rgb(160,0,200)'],
+  ['Frog', 'rgb(0,172,200)'],
+  ['Fox', 'rgb(197,200,0)'],
+  ['Hedgehog', 'rgb(31,200,0)'],
+  ['Pigeon', 'rgb(200,0,0)'],
+  ['Squirrel', 'rgb(200,0,148)'],
+  ['Bear', 'rgb(255,235,0)'],
+  ['Tiger', 'rgb(86,255,0)'],
+  ['Leopard', 'rgb(0,255,208)'],
+  ['Zebra', 'rgb(0,243,255)'],
+  ['Wolf', 'rgb(0,102,255)'],
+  ['Owl', 'rgb(147,0,255)'],
+  ['Gull', 'rgb(255,0,153)'],
+  ['Squid', 'rgb(0,220,255)'],
 ];
 
 const randomEntry = entries[Math.floor(Math.random() * entries.length)];
@@ -48,11 +48,16 @@ export const CollaborationContext = createContext<CollaborationContextType>({
 
 export function useCollaborationContext(
   username?: string,
+  color?: string,
 ): CollaborationContextType {
   const collabContext = useContext(CollaborationContext);
 
   if (username != null) {
     collabContext.name = username;
+  }
+
+  if (color != null) {
+    collabContext.color = color;
   }
 
   return collabContext;

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.ts
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.ts
@@ -26,6 +26,7 @@ export function CollaborationPlugin({
   providerFactory,
   shouldBootstrap,
   username,
+  cursorColor,
   cursorsContainerRef,
   initialEditorState,
 }: {
@@ -37,10 +38,11 @@ export function CollaborationPlugin({
   ) => WebsocketProvider;
   shouldBootstrap: boolean;
   username?: string;
+  cursorColor?: string;
   cursorsContainerRef?: CursorsContainerRef;
   initialEditorState?: InitialEditorStateType;
 }): JSX.Element {
-  const collabContext = useCollaborationContext(username);
+  const collabContext = useCollaborationContext(username, cursorColor);
 
   const {yjsDocMap, name, color} = collabContext;
 

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -148,10 +148,10 @@ function createCursorSelection(
 ): CursorSelection {
   const color = cursor.color;
   const caret = document.createElement('span');
-  caret.style.cssText = `position:absolute;top:0;bottom:0;right:-1px;width:1px;background-color:rgb(${color});z-index:10;`;
+  caret.style.cssText = `position:absolute;top:0;bottom:0;right:-1px;width:1px;background-color:${color};z-index:10;`;
   const name = document.createElement('span');
   name.textContent = cursor.name;
-  name.style.cssText = `position:absolute;left:-2px;top:-16px;background-color:rgb(${color});color:#fff;line-height:12px;font-size:12px;padding:2px;font-family:Arial;font-weight:bold;white-space:nowrap;`;
+  name.style.cssText = `position:absolute;left:-2px;top:-16px;background-color:${color};color:#fff;line-height:12px;font-size:12px;padding:2px;font-family:Arial;font-weight:bold;white-space:nowrap;`;
   caret.appendChild(name);
   return {
     anchor: {
@@ -240,13 +240,19 @@ function updateCursor(
     if (selection === undefined) {
       selection = document.createElement('span');
       selections[i] = selection;
+      const selectionBg = document.createElement('span');
+      selection.appendChild(selectionBg);
       cursorsContainer.appendChild(selection);
     }
 
     const top = selectionRect.top - containerRect.top;
     const left = selectionRect.left - containerRect.left;
-    const style = `position:absolute;top:${top}px;left:${left}px;height:${selectionRect.height}px;width:${selectionRect.width}px;background-color:rgba(${color}, 0.3);pointer-events:none;z-index:5;`;
+    const style = `position:absolute;top:${top}px;left:${left}px;height:${selectionRect.height}px;width:${selectionRect.width}px;pointer-events:none;z-index:5;`;
     selection.style.cssText = style;
+
+    (
+      selection.firstChild as HTMLSpanElement
+    ).style.cssText = `${style}left:0;top:0;background-color:${color};opacity:0.3;`;
 
     if (i === selectionRectsLength - 1) {
       if (caret.parentNode !== selection) {

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -151,7 +151,7 @@ function createCursorSelection(
   caret.style.cssText = `position:absolute;top:0;bottom:0;right:-1px;width:1px;background-color:rgb(${color});z-index:10;`;
   const name = document.createElement('span');
   name.textContent = cursor.name;
-  name.style.cssText = `position:absolute;left:-2px;top:-16px;background-color:rgb(${color});color:#fff;line-height:12px;height:12px;font-size:12px;padding:2px;font-family:Arial;font-weight:bold;white-space:nowrap;`;
+  name.style.cssText = `position:absolute;left:-2px;top:-16px;background-color:rgb(${color});color:#fff;line-height:12px;font-size:12px;padding:2px;font-family:Arial;font-weight:bold;white-space:nowrap;`;
   caret.appendChild(name);
   return {
     anchor: {


### PR DESCRIPTION


- fix(lexical-yjs): remove height from collab cursor name

We remove the selection height because it does not work with a common CSS style

```css
* {
  box-sizing: border-box;
}
```

<img width="455" alt="Screenshot 2022-10-24 at 16 47 26" src="https://user-images.githubusercontent.com/16056918/197578298-2360fa12-2bfb-4e49-b672-4bad4764f816.png">

when we remove the height it works

<img width="541" alt="Screenshot 2022-10-24 at 16 50 22" src="https://user-images.githubusercontent.com/16056918/197578810-2314d2e0-19a2-404d-91e5-8132f407317f.png">

---

- feat(collab): add cursorColor prop for LexicalCollaborationPlugin

I had to create a sibling for the caret span in order to give devs the possibility to provide any color for the caret, name, and selection.

---

Also, I think that we should add the possibility to specify a className (for the name at least) to give more freedom.

CC @fantactuka 