### PR TITLE
Fix error boundary fallback

### DIFF
--- a/packages/lexical-react/src/DEPRECATED_useLexicalDecorators.tsx
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalDecorators.tsx
@@ -13,6 +13,8 @@ import * as React from 'react';
 import {ErrorBoundary as ReactErrorBoundary} from './shared/ReactErrorBoundary';
 import {ErrorBoundaryType, useDecorators} from './shared/useDecorators';
 
+const fallbackRenderer = () => null;
+
 const DefaultErrorBoundary = ({
   children,
   onError,
@@ -20,7 +22,7 @@ const DefaultErrorBoundary = ({
   children: JSX.Element;
   onError: (error: Error) => void;
 }) => (
-  <ReactErrorBoundary fallback={null} onError={onError}>
+  <ReactErrorBoundary fallbackRender={fallbackRenderer} onError={onError}>
     {children}
   </ReactErrorBoundary>
 );

--- a/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
@@ -14,6 +14,8 @@ import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 import {ErrorBoundaryType, useDecorators} from './shared/useDecorators';
 import {usePlainTextSetup} from './shared/usePlainTextSetup';
 
+const fallbackRenderer = () => null;
+
 const DefaultErrorBoundary = ({
   children,
   onError,
@@ -21,7 +23,7 @@ const DefaultErrorBoundary = ({
   children: JSX.Element;
   onError: (error: Error) => void;
 }) => (
-  <ReactErrorBoundary fallback={null} onError={onError}>
+  <ReactErrorBoundary fallbackRender={fallbackRenderer} onError={onError}>
     {children}
   </ReactErrorBoundary>
 );

--- a/packages/lexical-react/src/LexicalRichTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalRichTextPlugin.tsx
@@ -14,6 +14,8 @@ import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 import {ErrorBoundaryType, useDecorators} from './shared/useDecorators';
 import {useRichTextSetup} from './shared/useRichTextSetup';
 
+const fallbackRenderer = () => null;
+
 const DefaultErrorBoundary = ({
   children,
   onError,
@@ -21,7 +23,7 @@ const DefaultErrorBoundary = ({
   children: JSX.Element;
   onError: (error: Error) => void;
 }) => (
-  <ReactErrorBoundary fallback={null} onError={onError}>
+  <ReactErrorBoundary fallbackRender={fallbackRenderer} onError={onError}>
     {children}
   </ReactErrorBoundary>
 );

--- a/packages/lexical-react/src/shared/useDecorators.tsx
+++ b/packages/lexical-react/src/shared/useDecorators.tsx
@@ -23,6 +23,8 @@ export type ErrorBoundaryType =
   | React.ComponentClass<ErrorBoundaryProps>
   | React.FC<ErrorBoundaryProps>;
 
+const fallbackRenderer = () => null;
+
 const DefaultErrorBoundary = ({
   children,
   onError,
@@ -30,7 +32,7 @@ const DefaultErrorBoundary = ({
   children: JSX.Element;
   onError: (error: Error) => void;
 }) => (
-  <ReactErrorBoundary fallback={null} onError={onError}>
+  <ReactErrorBoundary fallbackRender={fallbackRenderer} onError={onError}>
     {children}
   </ReactErrorBoundary>
 );


### PR DESCRIPTION
`<ErrorBoundary fallback={null} />` fails (in contrast with `<Suspense fallback={null} />`), so changing to `<ErrorBoundary fallbackRender={() => null} />` 