### PR TITLE
Select end if root has no children in focus logic

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -816,12 +816,10 @@ export class LexicalEditor {
           if (selection !== null) {
             // Marking the selection dirty will force the selection back to it
             selection.dirty = true;
-          } else if (root.getChildrenSize() !== 0) {
-            if (options.defaultSelection === 'rootStart') {
-              root.selectStart();
-            } else {
-              root.selectEnd();
-            }
+          } else if (options.defaultSelection === 'rootStart') {
+            root.selectStart();
+          } else {
+            root.selectEnd();
           }
         },
         {


### PR DESCRIPTION
It shouldn't matter if the editor is empty when called `editor.focus`. The cursor should still appear somewhere in the editor when the method is called.