### PR TITLE
Fix deleting empty paragraphs

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
@@ -350,8 +350,9 @@ test.describe('HorizontalRule', () => {
     page,
     browserName,
     isPlainText,
+    isCollab,
   }) => {
-    test.skip(isPlainText);
+    test.skip(isPlainText || isCollab);
 
     await focusEditor(page);
 
@@ -363,12 +364,7 @@ test.describe('HorizontalRule', () => {
       page,
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-        <div
-          contenteditable="false"
-          style="display: contents;"
-          data-lexical-decorator="true">
-          <hr />
-        </div>
+        <hr class="" contenteditable="false" data-lexical-decorator="true" />
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
       `,
     );
@@ -388,12 +384,10 @@ test.describe('HorizontalRule', () => {
       page,
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-        <div
+        <hr
+          class="selected"
           contenteditable="false"
-          style="display: contents;"
-          data-lexical-decorator="true">
-          <hr class="selected" />
-        </div>
+          data-lexical-decorator="true" />
       `,
     );
 
@@ -419,12 +413,10 @@ test.describe('HorizontalRule', () => {
     await assertHTML(
       page,
       html`
-        <div
+        <hr
+          class="selected"
           contenteditable="false"
-          style="display: contents;"
-          data-lexical-decorator="true">
-          <hr class="selected" />
-        </div>
+          data-lexical-decorator="true" />
       `,
     );
 

--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
@@ -345,4 +345,94 @@ test.describe('HorizontalRule', () => {
       focusPath: [2],
     });
   });
+
+  test('Can delete remove paragraph after a horizontal rule without deleting a horizontal rule', async ({
+    page,
+    browserName,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await selectFromInsertDropdown(page, '.horizontal-rule');
+
+    await waitForSelector(page, 'hr');
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <div
+          contenteditable="false"
+          style="display: contents;"
+          data-lexical-decorator="true">
+          <hr />
+        </div>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [2],
+      focusOffset: 0,
+      focusPath: [2],
+    });
+
+    // Delete content
+    await page.keyboard.press('Backspace');
+
+    await focusEditor(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <div
+          contenteditable="false"
+          style="display: contents;"
+          data-lexical-decorator="true">
+          <hr class="selected" />
+        </div>
+      `,
+    );
+
+    if (browserName === 'webkit' || browserName === 'firefox') {
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [],
+        focusOffset: 0,
+        focusPath: [],
+      });
+    } else {
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0],
+        focusOffset: 0,
+        focusPath: [0],
+      });
+    }
+
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('Delete');
+
+    await assertHTML(
+      page,
+      html`
+        <div
+          contenteditable="false"
+          style="display: contents;"
+          data-lexical-decorator="true">
+          <hr class="selected" />
+        </div>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [],
+      focusOffset: 0,
+      focusPath: [],
+    });
+  });
 });


### PR DESCRIPTION
Fixes: https://github.com/facebook/lexical/issues/3155
## Problem
When the cursor focus is set on a paragraph next to a decorator node (not inline) pressing the "Delete" ("Backspace") key removes the node.


## Note
Fixing deletion behavior makes bug described here a bit more noticeable: https://github.com/facebook/lexical/issues/3156