### PR TITLE
Fix nodesOfType return type

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1026,21 +1026,19 @@ export function setMutatedNode(
   }
 }
 
-export function $nodesOfType<T extends LexicalNode>(
-  klass: Klass<T>,
-): Array<LexicalNode> {
+export function $nodesOfType<T extends LexicalNode>(klass: Klass<T>): Array<T> {
   const editorState = getActiveEditorState();
   const readOnly = editorState._readOnly;
   const klassType = klass.getType();
   const nodes = editorState._nodeMap;
-  const nodesOfType = [];
+  const nodesOfType: Array<T> = [];
   for (const [, node] of nodes) {
     if (
       node instanceof klass &&
       node.__type === klassType &&
       (readOnly || node.isAttached())
     ) {
-      nodesOfType.push(node);
+      nodesOfType.push(node as T);
     }
   }
   return nodesOfType;


### PR DESCRIPTION
This is a little more complicated than I thought, but I think the issue is that the TS compiler isn't convinced by the instanceof and __type checks that nodesOfType will actually return T and not a different subtype of LexicalNode. My solution is to cast to T, because these checks should verify that all nodesOfType are of the same subtype of LexicalNode at runtime.