### PR TITLE
Don't cache empty strings

### DIFF
--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -166,6 +166,9 @@ export function getStyleObjectFromRawCSS(css: string): Record<string, string> {
 }
 
 export function getStyleObjectFromCSS(css: string): Record<string, string> {
+  if (css === '') {
+    return {};
+  }
   let value = CSS_TO_STYLES.get(css);
   if (value === undefined) {
     value = getStyleObjectFromRawCSS(css);


### PR DESCRIPTION
https://github.com/facebook/lexical/pull/3247 revealed a gnarly bug in the style logic. We were sharing references across keys. this should only happen in the case of an empty string though, so this fixes it.