### PR TITLE
Revert "Select end if root has no children in focus logic"

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -816,10 +816,12 @@ export class LexicalEditor {
           if (selection !== null) {
             // Marking the selection dirty will force the selection back to it
             selection.dirty = true;
-          } else if (options.defaultSelection === 'rootStart') {
-            root.selectStart();
-          } else {
-            root.selectEnd();
+          } else if (root.getChildrenSize() !== 0) {
+            if (options.defaultSelection === 'rootStart') {
+              root.selectStart();
+            } else {
+              root.selectEnd();
+            }
           }
         },
         {


### PR DESCRIPTION
Reverts facebook/lexical#3254

Looks like this fails some collab tests:

https://github.com/facebook/lexical/actions/runs/3322384417/jobs/5492978426