### PR TITLE
Add root theme class

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -27,6 +27,7 @@ import {
 import {
   createUID,
   dispatchCommand,
+  getCachedClassNameArray,
   getDefaultView,
   markAllNodesAsDirty,
 } from './LexicalUtils';
@@ -707,6 +708,7 @@ export class LexicalEditor {
     const prevRootElement = this._rootElement;
 
     if (nextRootElement !== prevRootElement) {
+      const classNames = getCachedClassNameArray(this._config.theme, 'root');
       const pendingEditorState = this._pendingEditorState || this._editorState;
       this._rootElement = nextRootElement;
       resetEditor(this, prevRootElement, nextRootElement, pendingEditorState);
@@ -715,6 +717,9 @@ export class LexicalEditor {
         // TODO: remove this flag once we no longer use UEv2 internally
         if (!this._config.disableEvents) {
           removeRootElementEvents(prevRootElement);
+        }
+        if (classNames != null) {
+          prevRootElement.classList.remove(...classNames);
         }
       }
 
@@ -736,6 +741,9 @@ export class LexicalEditor {
         // TODO: remove this flag once we no longer use UEv2 internally
         if (!this._config.disableEvents) {
           addRootElementEvents(nextRootElement, this);
+        }
+        if (classNames != null) {
+          nextRootElement.classList.add(...classNames);
         }
       } else {
         this._window = null;


### PR DESCRIPTION
We already had `root` theme class but it was never applied to root node, it's quite useful for font styles (especially for nested editors which otherwise might inherit styles from its decorator)