### PR TITLE
selection.modify to respect ShadowRoot

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -6,7 +6,11 @@
  *
  */
 
-import {moveRight, selectAll} from '../keyboardShortcuts/index.mjs';
+import {
+  moveRight,
+  pressBackspace,
+  selectAll,
+} from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
   click,
@@ -2100,6 +2104,250 @@ test.describe('Tables', () => {
                 </span>
                 <span data-lexical-text="true">&lt;- it works!</span>
               </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test('Grid selection: can backspace lines, backspacing empty cell does not destroy it #3278', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await insertTable(page);
+
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await page.keyboard.type('cell one');
+    await moveRight(page, 1);
+    await page.keyboard.type('first line');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('second line');
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">cell one</span>
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">first line</span>
+              </p>
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">second line</span>
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    await pressBackspace(page, 50);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">cell one</span>
+              </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -469,7 +469,12 @@ export function $cloneRangeSelectionContent(
   const [anchorOffset, focusOffset] = selection.getCharacterOffsets();
   const nodes = selection.getNodes();
 
-  if (nodes.length === 0) {
+  if (
+    nodes.length === 0 ||
+    (nodes.length === 1 &&
+      $isElementNode(nodes[0]) &&
+      nodes[0].excludeFromCopy('clone'))
+  ) {
     return {
       nodeMap: [],
       range: [],

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -676,9 +676,8 @@ export function applyTableHandlers(
             children.forEach((child) => newParagraphNode.append(child));
             nearestElementNode.replace(newParagraphNode);
             nearestElementNode.getWritable().__parent = tableCellNode.getKey();
+            return true;
           }
-
-          return true;
         }
       }
     }

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -349,7 +349,6 @@ declare export class LexicalNode {
   getNextSibling<T: LexicalNode>(): T | null;
   getNextSiblings<T: LexicalNode>(): Array<T>;
   getCommonAncestor<T: ElementNode>(node: LexicalNode): T | null;
-  getRoot(): RootNode | ElementNode;
   is(object: ?LexicalNode): boolean;
   isBefore(targetNode: LexicalNode): boolean;
   isParentOf(targetNode: LexicalNode): boolean;
@@ -815,6 +814,9 @@ declare export function $isInlineElementOrDecoratorNode(
   node: LexicalNode,
 ): boolean %checks(node instanceof ElementNode ||
   node instanceof DecoratorNode);
+declare export function $getNearestRootOrShadowRoot(
+  node: LexicalNode,
+): RootNode | ElementNode;
 declare export function $isRootOrShadowRoot(
   node: LexicalNode,
 ): boolean %checks(node instanceof RootNode || node instanceof ElementNode);

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -349,6 +349,7 @@ declare export class LexicalNode {
   getNextSibling<T: LexicalNode>(): T | null;
   getNextSiblings<T: LexicalNode>(): Array<T>;
   getCommonAncestor<T: ElementNode>(node: LexicalNode): T | null;
+  getRoot(): RootNode | ElementNode;
   is(object: ?LexicalNode): boolean;
   isBefore(targetNode: LexicalNode): boolean;
   isParentOf(targetNode: LexicalNode): boolean;

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -9,7 +9,7 @@
 /* eslint-disable no-constant-condition */
 import type {EditorConfig, LexicalEditor} from './LexicalEditor';
 import type {RangeSelection} from './LexicalSelection';
-import type {Klass} from 'lexical';
+import type {Klass, RootNode} from 'lexical';
 
 import invariant from 'shared/invariant';
 
@@ -588,6 +588,20 @@ export class LexicalNode {
 
   getTextContentSize(): number {
     return this.getTextContent().length;
+  }
+
+  /**
+   * Returns the nearest ShadowRoot or RootNode
+   */
+  getRoot(): RootNode | ElementNode {
+    let parent = this.getParentOrThrow();
+    while (parent !== null) {
+      if ($isRootOrShadowRoot(parent)) {
+        return parent;
+      }
+      parent = parent.getParentOrThrow();
+    }
+    return parent;
   }
 
   // View

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -9,7 +9,7 @@
 /* eslint-disable no-constant-condition */
 import type {EditorConfig, LexicalEditor} from './LexicalEditor';
 import type {RangeSelection} from './LexicalSelection';
-import type {Klass, RootNode} from 'lexical';
+import type {Klass} from 'lexical';
 
 import invariant from 'shared/invariant';
 
@@ -588,20 +588,6 @@ export class LexicalNode {
 
   getTextContentSize(): number {
     return this.getTextContent().length;
-  }
-
-  /**
-   * Returns the nearest ShadowRoot or RootNode
-   */
-  getRoot(): RootNode | ElementNode {
-    let parent = this.getParentOrThrow();
-    while (parent !== null) {
-      if ($isRootOrShadowRoot(parent)) {
-        return parent;
-      }
-      parent = parent.getParentOrThrow();
-    }
-    return parent;
   }
 
   // View

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -50,6 +50,7 @@ import {
 import {
   $getCompositionKey,
   $getDecoratorNode,
+  $getNearestRootOrShadowRoot,
   $getNodeByKey,
   $getRoot,
   $hasAncestor,
@@ -1776,7 +1777,7 @@ export class RangeSelection implements BaseSelection {
     if (domSelection.rangeCount > 0) {
       const range = domSelection.getRangeAt(0);
       // Apply the DOM selection to our Lexical selection.
-      const root = this.anchor.getNode().getRoot();
+      const root = $getNearestRootOrShadowRoot(this.anchor.getNode());
       this.applyDOMRange(range);
       this.dirty = true;
       if (!collapse) {

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1779,7 +1779,7 @@ export class RangeSelection implements BaseSelection {
       const range = domSelection.getRangeAt(0);
       // Apply the DOM selection to our Lexical selection.
       const previousNodes = this.getNodes();
-      const root = previousNodes[0].getTopLevelElementOrThrow();
+      const root = previousNodes[0].getRoot();
       this.applyDOMRange(range);
       this.dirty = true;
       // Validate selection; make sure that the new selection respects shadow roots
@@ -1788,7 +1788,7 @@ export class RangeSelection implements BaseSelection {
       let shrinkSelection = false;
       for (let i = 0; i < nextNodes.length; i++) {
         const nextNode = nextNodes[i];
-        if (nextNode.getTopLevelElementOrThrow() === root) {
+        if (nextNode.getRoot() === root) {
           nextValidNodes.push(nextNode);
         } else {
           shrinkSelection = true;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1242,6 +1242,19 @@ export function $isInlineElementOrDecoratorNode(node: LexicalNode): boolean {
   );
 }
 
+export function $getNearestRootOrShadowRoot(
+  node: LexicalNode,
+): RootNode | ElementNode {
+  let parent = node.getParentOrThrow();
+  while (parent !== null) {
+    if ($isRootOrShadowRoot(parent)) {
+      return parent;
+    }
+    parent = parent.getParentOrThrow();
+  }
+  return parent;
+}
+
 export function $isRootOrShadowRoot(node: null | LexicalNode): boolean {
   return $isRootNode(node) || ($isElementNode(node) && node.isShadowRoot());
 }

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -128,6 +128,7 @@ export {
   $addUpdateTag,
   $getDecoratorNode,
   $getNearestNodeFromDOMNode,
+  $getNearestRootOrShadowRoot,
   $getNodeByKey,
   $getRoot,
   $hasAncestor,


### PR DESCRIPTION
Tables had some logic to override the deletion logic that was incomplete. This prevented new lines from being deleted.

However, when attempting to fix this (and switching the DELETE_CHARACTER command to be unhandled) it uncovered a bigger problem, the fact that selection can expand beyond a ShadowRoot and cause cells to be deleted. This shouldn't be the responsibility of tables, so I'm handling the ShadowRoot case appropriately in Selection but rather generic.

Closes https://github.com/facebook/lexical/issues/3278