### PR TITLE
Fix pasting text near decorator nodes

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -2804,4 +2804,74 @@ test.describe('CopyAndPaste', () => {
       `,
     );
   });
+
+  test('HTML Copy + paste a paragraph element between horizontal rules', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    let clipboard = {'text/html': '<hr/><hr/>'};
+
+    await pasteFromClipboard(page, clipboard);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <div
+          contenteditable="false"
+          style="display: contents;"
+          data-lexical-decorator="true">
+          <hr />
+        </div>
+        <div
+          contenteditable="false"
+          style="display: contents;"
+          data-lexical-decorator="true">
+          <hr />
+        </div>
+      `,
+    );
+
+    await moveToEditorBeginning(page);
+    // selects first HR
+    await page.keyboard.press('ArrowRight');
+    // sets focus between HRs
+    await page.keyboard.press('ArrowRight');
+
+    clipboard = {'text/html': '<p>Text between HRs</p>'};
+
+    await pasteFromClipboard(page, clipboard);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <div
+          contenteditable="false"
+          style="display: contents;"
+          data-lexical-decorator="true">
+          <hr />
+        </div>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Text between HRs</span>
+        </p>
+        <div
+          contenteditable="false"
+          style="display: contents;"
+          data-lexical-decorator="true">
+          <hr />
+        </div>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 16,
+      anchorPath: [2, 0, 0],
+      focusOffset: 16,
+      focusPath: [2, 0, 0],
+    });
+  });
 });

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -2834,10 +2834,8 @@ test.describe('CopyAndPaste', () => {
         </div>
       `,
     );
+    await click(page, 'hr:first-of-type');
 
-    await moveToEditorBeginning(page);
-    // selects first HR
-    await page.keyboard.press('ArrowRight');
     // sets focus between HRs
     await page.keyboard.press('ArrowRight');
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1290,7 +1290,11 @@ export class RangeSelection implements BaseSelection {
     // Time to insert the nodes!
     for (let i = 0; i < nodes.length; i++) {
       const node = nodes[i];
-      if ($isElementNode(node) && !node.isInline()) {
+      if (
+        !$isDecoratorNode(target) &&
+        $isElementNode(node) &&
+        !node.isInline()
+      ) {
         // -----
         // Heuristics for the replacement or merging of elements
         // -----


### PR DESCRIPTION
## Problem
Pasting text near decorator nodes loses the parent element and inserts children nodes inline as direct children of the root node.

**Steps to reproduce:**
https://user-images.githubusercontent.com/1575198/198649730-9be20a68-687d-47cc-b759-c6f26a2589fb.mov

(**Note:** There is a visual glitch where the cursor is set near the last HR whereas in fact it is set between the nodes. This is reported separately here https://github.com/facebook/lexical/issues/3156)


