### PR TITLE
Fix initial content tables initialization

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -75,7 +75,6 @@ header h1 {
 
 .editor-scroller {
   min-height: 150px;
-  height: 360px;
   border: 0;
   resize: none;
   cursor: text;


### PR DESCRIPTION
This PR would fix initializing tables that are a part of initial content. The problem is that mutation listeners are not called for existing nodes, hence if table is inserted as initial content, it won't get its selection + listeners initialized causing multiple bugs (around columns/rows management and selection). 

My first attempt was to replace it with node transform, but it when it runs, table DOM element is not yet created (for newly inserted node) so it can't initialize all DOM listeners.

So instead, it would still use mutation listener, but also run through existing nodes on mount to initialize it as well.

Before

https://user-images.githubusercontent.com/132642/198669600-b16bf448-3ed5-40fc-a669-1c5feaca90f6.mov

After

https://user-images.githubusercontent.com/132642/198669590-850c9492-cdff-420c-b805-a9c65194e0a4.mov

