### PR TITLE
Release on matching tag push to main

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -2,7 +2,7 @@ name: Nightly Release Branch
 on:
   schedule:
     # Run daily at 2:30am UTC
-    - cron: '30 2 * * *'
+    - cron: '30 2 * * 1-5'
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -2,8 +2,10 @@ name: Publish to NPM
 on:
   push:
     branches:
-      - next
-      - latest
+      - main
+    tags:
+      - 'v**-next.**'
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -16,6 +18,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run prepare-release
-      - run: node ./scripts/npm/release.js --non-interactive --dry-run=${{ secrets.RELEASE_DRY_RUN }} --channel $GITHUB_REF_NAME
+      - run: node ./scripts/npm/release.js --non-interactive --dry-run=${{ secrets.RELEASE_DRY_RUN }} --channel next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This makes it so that commits tagged with the prerelease "-next" suffix will trigger a release when merged into main. This might finally make nightly releases work, but we'll have to merge the PRs each day to trigger the release. Full automation would require taking branch protections off of main, which I don't want to do yet (looking for alternatives).

This also makes the PRs only generate Mon-Fri.