### PR TITLE
Handle quotes in increment-version changelog

### DIFF
--- a/scripts/npm/increment-version.js
+++ b/scripts/npm/increment-version.js
@@ -12,7 +12,7 @@
 
 const {exec} = require('child-process-promise');
 const argv = require('minimist')(process.argv.slice(2));
-const increment = argv.i;
+const increment = argv._[0];
 const validIncrements = new Set(['minor', 'patch', 'prerelease']);
 if (!validIncrements.has(increment)) {
   console.error(`Invalid value for increment: ${increment}`);

--- a/scripts/npm/update-changelog.js
+++ b/scripts/npm/update-changelog.js
@@ -24,7 +24,9 @@ async function updateChangelog() {
     await exec(
       `git --no-pager log --oneline ${previousReleaseHash}...HEAD~1 --pretty=format:\"- %s %an\"`,
     )
-  ).stdout.trim();
+  ).stdout
+    .replace(/"/g, '\\"')
+    .trim();
   const tmpFilePath = './changelog-tmp';
   await exec(`echo "${header}\n" >> ${tmpFilePath}`);
   await exec(`echo "${changelogContent}\n" >> ${tmpFilePath}`);


### PR DESCRIPTION
Fix `npm run increment-version` to handle commit messages with quotes

Additionally, simplified the argument so that it's `npm run increase-version minor` instead of `npm run increase-version -- -i minor`