### PR TITLE
Optional decorator nodes selection with keyboard navigation

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -734,7 +734,7 @@ declare export class DecoratorNode<X> extends LexicalNode {
   decorate(editor: LexicalEditor, config: EditorConfig): X;
   isIsolated(): boolean;
   isInline(): boolean;
-  isSelectable(): boolean;
+  isKeyboardSelectable(): boolean;
 }
 declare export function $isDecoratorNode(
   node: ?LexicalNode,

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -734,6 +734,7 @@ declare export class DecoratorNode<X> extends LexicalNode {
   decorate(editor: LexicalEditor, config: EditorConfig): X;
   isIsolated(): boolean;
   isInline(): boolean;
+  isSelectable(): boolean;
 }
 declare export function $isDecoratorNode(
   node: ?LexicalNode,

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1715,7 +1715,7 @@ export class RangeSelection implements BaseSelection {
     if ($isDecoratorNode(possibleNode) && !possibleNode.isIsolated()) {
       // Make it possible to move selection from range selection to
       // node selection on the node.
-      if (collapse && possibleNode.isSelectable()) {
+      if (collapse && possibleNode.isKeyboardSelectable()) {
         const nodeSelection = $createNodeSelection();
         nodeSelection.add(possibleNode.__key);
         $setSelection(nodeSelection);

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1715,7 +1715,7 @@ export class RangeSelection implements BaseSelection {
     if ($isDecoratorNode(possibleNode) && !possibleNode.isIsolated()) {
       // Make it possible to move selection from range selection to
       // node selection on the node.
-      if (collapse) {
+      if (collapse && possibleNode.isSelectable()) {
         const nodeSelection = $createNodeSelection();
         nodeSelection.add(possibleNode.__key);
         $setSelection(nodeSelection);

--- a/packages/lexical/src/nodes/LexicalDecoratorNode.ts
+++ b/packages/lexical/src/nodes/LexicalDecoratorNode.ts
@@ -31,6 +31,10 @@ export class DecoratorNode<T> extends LexicalNode {
   isInline(): boolean {
     return true;
   }
+
+  isSelectable(): boolean {
+    return true;
+  }
 }
 
 export function $isDecoratorNode<T>(

--- a/packages/lexical/src/nodes/LexicalDecoratorNode.ts
+++ b/packages/lexical/src/nodes/LexicalDecoratorNode.ts
@@ -32,7 +32,7 @@ export class DecoratorNode<T> extends LexicalNode {
     return true;
   }
 
-  isSelectable(): boolean {
+  isKeyboardSelectable(): boolean {
     return true;
   }
 }


### PR DESCRIPTION
## Problem

While navigating within the editor using keyboard keys (Arrow Left/Right) it automatically captures decorator nodes as a selection step. Whereas it is a cool feature, in some products such behavior can be not the desired one.
There is no easy way to override this behavior as it mostly requires reimplementing lexical's [selection modify](https://github.com/facebook/lexical/blob/a2d745fa10f593600938c0c0670f2c8b373935a5/packages/lexical/src/LexicalSelection.ts#L1704) handler to be able to handle text selection correctly.

## Solution

Add a new flag to allow optionally disable automatic selection as a step of keyboard selection navigation.

**Note:** This is different from `isIsolated` which prevents selection altogether.