### PR TITLE
Preserve selection for pending state

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -809,6 +809,8 @@ function beginUpdate(
   try {
     if (editorStateWasCloned && !editor._headless) {
       pendingEditorState._selection = internalCreateSelection(editor);
+    } else if (editor._headless && currentEditorState._selection != null) {
+      pendingEditorState._selection = currentEditorState._selection.clone();
     }
 
     const startingCompositionKey = editor._compositionKey;


### PR DESCRIPTION
In non-headless mode there's a separate logic that either reuses previous selection or relies on dom. For headless we just copy previous selection