### PR TITLE
Show caret while drag&drop

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -547,7 +547,6 @@ test.describe('Images', () => {
     await page.keyboard.press('Enter');
 
     await insertSampleImage(page);
-    await page.pause();
 
     await dragImage(page, 'span[data-lexical-text="true"]');
 

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -34,6 +34,7 @@ import {
   $setSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
+  DRAGSTART_COMMAND,
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
   KEY_ENTER_COMMAND,
@@ -237,6 +238,19 @@ export default function ImageComponent({
             return true;
           }
 
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        DRAGSTART_COMMAND,
+        (event) => {
+          if (event.target === imageRef.current) {
+            // TODO This is just a temporary workaround for FF to behave like other browsers.
+            // Ideally, this handles drag & drop too (and all browsers).
+            event.preventDefault();
+            return true;
+          }
           return false;
         },
         COMMAND_PRIORITY_LOW,

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -862,29 +862,18 @@ export function registerRichText(editor: LexicalEditor): () => void {
           const y = event.clientY;
           const eventRange = caretFromPoint(x, y);
           if (eventRange !== null) {
-            const {startOffset, endOffset, startContainer, endContainer} =
-              eventRange;
-            const startNode = $getNearestNodeFromDOMNode(startContainer);
-            const endNode = $getNearestNodeFromDOMNode(endContainer);
-            if (startNode !== null && endNode !== null) {
+            const {offset: domOffset, node: domNode} = eventRange;
+            const node = $getNearestNodeFromDOMNode(domNode);
+            if (node !== null) {
               const selection = $createRangeSelection();
-              if ($isTextNode(startNode)) {
-                selection.anchor.set(startNode.getKey(), startOffset, 'text');
+              if ($isTextNode(node)) {
+                selection.anchor.set(node.getKey(), domOffset, 'text');
+                selection.focus.set(node.getKey(), domOffset, 'text');
               } else {
-                selection.anchor.set(
-                  startNode.getParentOrThrow().getKey(),
-                  startNode.getIndexWithinParent() + 1,
-                  'element',
-                );
-              }
-              if ($isTextNode(endNode)) {
-                selection.focus.set(endNode.getKey(), endOffset, 'text');
-              } else {
-                selection.focus.set(
-                  endNode.getParentOrThrow().getKey(),
-                  endNode.getIndexWithinParent() + 1,
-                  'element',
-                );
+                const parentKey = node.getParentOrThrow().getKey();
+                const offset = node.getIndexWithinParent() + 1;
+                selection.anchor.set(parentKey, offset, 'element');
+                selection.focus.set(parentKey, offset, 'element');
               }
               const normalizedSelection =
                 $normalizeSelection__EXPERIMENTAL(selection);
@@ -913,7 +902,6 @@ export function registerRichText(editor: LexicalEditor): () => void {
         if (isFileTransfer && !$isRangeSelection(selection)) {
           return false;
         }
-        event.preventDefault();
         return true;
       },
       COMMAND_PRIORITY_EDITOR,
@@ -926,7 +914,17 @@ export function registerRichText(editor: LexicalEditor): () => void {
         if (isFileTransfer && !$isRangeSelection(selection)) {
           return false;
         }
-        event.preventDefault();
+        const x = event.clientX;
+        const y = event.clientY;
+        const eventRange = caretFromPoint(x, y);
+        if (eventRange !== null) {
+          const node = $getNearestNodeFromDOMNode(eventRange.node);
+          if ($isDecoratorNode(node)) {
+            // Show browser caret as the user is dragging the media across the screen. Won't work
+            // for DecoratorNode nor it's relevant.
+            event.preventDefault();
+          }
+        }
         return true;
       },
       COMMAND_PRIORITY_EDITOR,

--- a/packages/shared/src/caretFromPoint.ts
+++ b/packages/shared/src/caretFromPoint.ts
@@ -6,13 +6,33 @@
  *
  */
 
-export default function caretFromPoint(x: number, y: number): null | Range {
+export default function caretFromPoint(
+  x: number,
+  y: number,
+): null | {
+  offset: number;
+  node: Node;
+} {
   if (typeof document.caretRangeFromPoint !== 'undefined') {
-    return document.caretRangeFromPoint(x, y);
+    const range = document.caretRangeFromPoint(x, y);
+    if (range === null) {
+      return null;
+    }
+    return {
+      node: range.startContainer,
+      offset: range.startOffset,
+    };
     // @ts-ignore
   } else if (document.caretPositionFromPoint !== 'undefined') {
     // @ts-ignore FF - no types
-    return document.caretPositionFromPoint(x, y);
+    const range = document.caretPositionFromPoint(x, y);
+    if (range === null) {
+      return null;
+    }
+    return {
+      node: range.offsetNode,
+      offset: range.offset,
+    };
   } else {
     // Gracefully handle IE
     return null;


### PR DESCRIPTION
This PR polishes the current drag&drop experience
1. Shows caret while dragging and dropping
2. Simplifies the code
3. Fixes insert position for Firefox

Before (1)

https://user-images.githubusercontent.com/193447/199136886-b6c1dfda-48e6-481b-b053-1ce1aa7970ea.mov

After (1)

https://user-images.githubusercontent.com/193447/199136909-40755c8c-1858-44f0-ad06-2de31ddc516f.mov


