### PR TITLE
Fix wrapping nodes with nested leaf nodes

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -2590,5 +2590,52 @@ describe('LexicalSelection tests', () => {
         );
       });
     });
+
+    test('Paragraph with links to heading with links', async () => {
+      const testEditor = createTestEditor();
+      const element = document.createElement('div');
+      testEditor.setRootElement(element);
+
+      await testEditor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        const text1 = $createTextNode('Links: ');
+        const text2 = $createTextNode('link1');
+        const text3 = $createTextNode('link2');
+        root.append(
+          paragraph.append(
+            text1,
+            $createLinkNode('https://lexical.dev').append(text2),
+            $createTextNode(' '),
+            $createLinkNode('https://playground.lexical.dev').append(text3),
+          ),
+        );
+
+        const paragraphChildrenKeys = [...paragraph.getChildrenKeys()];
+        const selection = $createRangeSelection();
+        $setSelection(selection);
+        setAnchorPoint({
+          key: text1.getKey(),
+          offset: 1,
+          type: 'text',
+        });
+        setFocusPoint({
+          key: text3.getKey(),
+          offset: 1,
+          type: 'text',
+        });
+
+        $wrapNodes(selection, () => {
+          return $createHeadingNode('h1');
+        });
+
+        const rootChildren = root.getChildren();
+        expect(rootChildren.length).toBe(1);
+        expect(rootChildren[0].getType()).toBe('heading');
+        expect(rootChildren[0].getChildrenKeys()).toEqual(
+          paragraphChildrenKeys,
+        );
+      });
+    });
   });
 });

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -194,7 +194,7 @@ export function $wrapNodesImpl(
     }
   }
 
-  const movedLeafNodes: Set<NodeKey> = new Set();
+  const movedNodes: Set<NodeKey> = new Set();
 
   // Move out all leaf nodes into our elements array.
   // If we find a top level empty element, also move make
@@ -210,7 +210,7 @@ export function $wrapNodesImpl(
     if (
       parent !== null &&
       $isLeafNode(node) &&
-      !movedLeafNodes.has(node.getKey())
+      !movedNodes.has(node.getKey())
     ) {
       const parentKey = parent.getKey();
 
@@ -224,9 +224,10 @@ export function $wrapNodesImpl(
         // element.
         parent.getChildren().forEach((child) => {
           targetElement.append(child);
-          movedLeafNodes.add(child.getKey());
+          movedNodes.add(child.getKey());
           if ($isElementNode(child)) {
-            child.getChildrenKeys().forEach((key) => movedLeafNodes.add(key));
+            // Skip nested leaf nodes if the parent has already been moved
+            child.getChildrenKeys().forEach((key) => movedNodes.add(key));
           }
         });
         $removeParentEmptyElements(parent);

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -225,6 +225,9 @@ export function $wrapNodesImpl(
         parent.getChildren().forEach((child) => {
           targetElement.append(child);
           movedLeafNodes.add(child.getKey());
+          if ($isElementNode(child)) {
+            child.getChildrenKeys().forEach((key) => movedLeafNodes.add(key));
+          }
         });
         $removeParentEmptyElements(parent);
       }


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/2647

The wrapping nodes function should skip nested leaf nodes if their parents are already wrapped (appended).