### PR TITLE
Create range on each listener invocation in Typeahead

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -709,11 +709,9 @@ export function LexicalTypeaheadMenuPlugin<TOption extends TypeaheadOption>({
   );
 
   useEffect(() => {
-    let activeRange: Range | null = document.createRange();
-
     const updateListener = () => {
       editor.getEditorState().read(() => {
-        const range = activeRange;
+        const range = document.createRange();
         const selection = $getSelection();
         const text = getQueryTextForSearch(editor);
 
@@ -752,7 +750,6 @@ export function LexicalTypeaheadMenuPlugin<TOption extends TypeaheadOption>({
     const removeUpdateListener = editor.registerUpdateListener(updateListener);
 
     return () => {
-      activeRange = null;
       removeUpdateListener();
     };
   }, [


### PR DESCRIPTION
Trying to cache it between re-renders is causing a race condition where the activeRange can be nulled when the listener triggers.