### PR TITLE
fix: align center fill caret icon on `CollapsiblePlugin`

### DIFF
--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/Collapsible.css
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/Collapsible.css
@@ -37,12 +37,13 @@
   content: '';
   position: absolute;
   left: 7px;
-  top: 15px;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .Collapsible__container[open] .Collapsible__title:before {
   border-color: transparent;
-  border-width: 6px 4px 6px 4px;
+  border-width: 6px 4px 0 4px;
   border-top-color: #000;
 }
 


### PR DESCRIPTION
Polish CSS styling fill caret icon.
Result:
![Screenshot 2022-11-02 at 3 41 02 PM](https://user-images.githubusercontent.com/50004497/199441100-f3e830ed-3468-459b-bcfc-d258517f0ce4.png)
![Screenshot 2022-11-02 at 3 40 48 PM](https://user-images.githubusercontent.com/50004497/199441105-b490fc0e-cddc-4576-b7e4-54d032c49bfa.png)
