### PR TITLE
Disable table addons on non-editable

### DIFF
--- a/packages/lexical-playground/src/hooks/useLexicalEditable.ts
+++ b/packages/lexical-playground/src/hooks/useLexicalEditable.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {LexicalSubscription} from './useLexicalSubscription';
+import type {LexicalEditor} from 'lexical';
+
+import useLexicalSubscription from './useLexicalSubscription';
+
+function subscription(editor: LexicalEditor): LexicalSubscription<boolean> {
+  return {
+    initialValueFn: () => editor.isEditable(),
+    subscribe: (callback) => {
+      return editor.registerEditableListener(callback);
+    },
+  };
+}
+
+export default function useLexicalEditable(): boolean {
+  return useLexicalSubscription(subscription);
+}

--- a/packages/lexical-playground/src/hooks/useLexicalSubscription.tsx
+++ b/packages/lexical-playground/src/hooks/useLexicalSubscription.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {LexicalEditor} from 'lexical';
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useMemo, useRef, useState} from 'react';
+import useLayoutEffect from 'shared/useLayoutEffect';
+
+export type LexicalSubscription<T> = {
+  initialValueFn: () => T;
+  subscribe: (callback: (value: T) => void) => () => void;
+};
+
+/**
+ * Shortcut to Lexical subscriptions when values are used for render.
+ *
+ * useMLCSubscription(mlcFocusSubscription);
+ */
+export default function useLexicalSubscription<T>(
+  subscription: (editor: LexicalEditor) => LexicalSubscription<T>,
+): T {
+  const [editor] = useLexicalComposerContext();
+  const initializedSubscription = useMemo(
+    () => subscription(editor),
+    [editor, subscription],
+  );
+  const valueRef = useRef<T>(initializedSubscription.initialValueFn());
+  const [value, setValue] = useState<T>(valueRef.current);
+  useLayoutEffect(() => {
+    const {initialValueFn, subscribe} = initializedSubscription;
+    const currentValue = initialValueFn();
+    if (valueRef.current !== currentValue) {
+      valueRef.current = currentValue;
+      setValue(currentValue);
+    }
+
+    return subscribe((newValue: T) => {
+      valueRef.current = newValue;
+      setValue(newValue);
+    });
+  }, [initializedSubscription, subscription]);
+
+  return value;
+}

--- a/packages/lexical-playground/src/hooks/useLexicalSubscription.tsx
+++ b/packages/lexical-playground/src/hooks/useLexicalSubscription.tsx
@@ -19,8 +19,6 @@ export type LexicalSubscription<T> = {
 
 /**
  * Shortcut to Lexical subscriptions when values are used for render.
- *
- * useMLCSubscription(mlcFocusSubscription);
  */
 export default function useLexicalSubscription<T>(
   subscription: (editor: LexicalEditor) => LexicalSubscription<T>,

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -34,6 +34,8 @@ import * as React from 'react';
 import {ReactPortal, useCallback, useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 
+import useLexicalEditable from '../../hooks/useLexicalEditable';
+
 type TableCellActionMenuProps = Readonly<{
   contextRef: {current: null | HTMLElement};
   onClose: () => void;
@@ -537,9 +539,12 @@ export default function TableActionMenuPlugin({
   anchorElem = document.body,
 }: {
   anchorElem?: HTMLElement;
-}): ReactPortal {
+}): null | ReactPortal {
+  const isEditable = useLexicalEditable();
   return createPortal(
-    <TableCellActionMenuContainer anchorElem={anchorElem} />,
+    isEditable ? (
+      <TableCellActionMenuContainer anchorElem={anchorElem} />
+    ) : null,
     anchorElem,
   );
 }

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -38,6 +38,8 @@ import {
 } from 'react';
 import {createPortal} from 'react-dom';
 
+import useLexicalEditable from '../../hooks/useLexicalEditable';
+
 type MousePosition = {
   x: number;
   y: number;
@@ -371,11 +373,15 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
   );
 }
 
-export default function TableCellResizerPlugin(): ReactPortal {
+export default function TableCellResizerPlugin(): null | ReactPortal {
   const [editor] = useLexicalComposerContext();
+  const isEditable = useLexicalEditable();
 
   return useMemo(
-    () => createPortal(<TableCellResizer editor={editor} />, document.body),
-    [editor],
+    () =>
+      isEditable
+        ? createPortal(<TableCellResizer editor={editor} />, document.body)
+        : null,
+    [editor, isEditable],
   );
 }


### PR DESCRIPTION
Resizer and menu shouldn't be available on non-editable

Porting useLexicalSubscription from internal, may eventually move to @lexical/react