### PR TITLE
docs: set `ErrorBoundary` props to `PlainTextPlugin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 
 const theme = {
   // Theme styling goes here
@@ -114,6 +115,7 @@ function Editor() {
       <PlainTextPlugin
         contentEditable={<ContentEditable />}
         placeholder={<div>Enter some text...</div>}
+        ErrorBoundary={LexicalErrorBoundary}
       />
       <OnChangePlugin onChange={onChange} />
       <HistoryPlugin />

--- a/packages/lexical-website/docs/getting-started/react.md
+++ b/packages/lexical-website/docs/getting-started/react.md
@@ -22,6 +22,7 @@ import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 
 const theme = {
   // Theme styling goes here
@@ -74,6 +75,7 @@ function Editor() {
       <PlainTextPlugin
         contentEditable={<ContentEditable />}
         placeholder={<div>Enter some text...</div>}
+        ErrorBoundary={LexicalErrorBoundary}
       />
       <OnChangePlugin onChange={onChange} />
       <HistoryPlugin />

--- a/packages/lexical-website/docs/react/plugins.md
+++ b/packages/lexical-website/docs/react/plugins.md
@@ -51,6 +51,7 @@ React wrapper for `@lexical/plain-text` that adds major features for plain text 
 <PlainTextPlugin
   contentEditable={<ContentEditable />}
   placeholder={<div>Enter some text...</div>}
+  ErrorBoundary={LexicalErrorBoundary}
 />
 ```
 


### PR DESCRIPTION
This pr fixes missing `ErrorBoundary` props to `PlainTextPlugin` in docs and README.md.