### PR TITLE
Filter out mixed files + content copy pasting

### DIFF
--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -407,7 +407,7 @@ async function onCutForRichText(
 // control this with the first boolean flag.
 export function eventFiles(
   event: DragEvent | PasteCommandType,
-): [boolean, Array<File>] {
+): [boolean, Array<File>, boolean] {
   let dataTransfer: null | DataTransfer = null;
   if (event instanceof DragEvent) {
     dataTransfer = event.dataTransfer;
@@ -416,9 +416,14 @@ export function eventFiles(
   }
 
   if (dataTransfer === null) {
-    return [false, []];
+    return [false, [], false];
   }
-  return [dataTransfer.types.includes('Files'), Array.from(dataTransfer.files)];
+
+  const types = dataTransfer.types;
+  const hasFiles = types.includes('Files');
+  const hasContent =
+    types.includes('text/html') || types.includes('text/plain');
+  return [hasFiles, Array.from(dataTransfer.files), hasContent];
 }
 
 function handleIndentAndOutdent(
@@ -934,8 +939,8 @@ export function registerRichText(editor: LexicalEditor): () => void {
     editor.registerCommand(
       PASTE_COMMAND,
       (event) => {
-        const [, files] = eventFiles(event);
-        if (files !== null && files.length > 0) {
+        const [, files, hasTextContent] = eventFiles(event);
+        if (files.length > 0 && !hasTextContent) {
           editor.dispatchCommand(DRAG_DROP_PASTE, files);
           return true;
         }


### PR DESCRIPTION
When copying, MSWord adds content as an image to the clipboard (apart from various text formats data), and our file copy/pasting logic which is executed before text content parsing inserts that image instead of actual text content:


https://user-images.githubusercontent.com/132642/200468353-3922b892-8045-43eb-86bd-45b445798900.mov

