### PR TITLE
Fix content loss when setEditorState + update race condition

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -791,8 +791,9 @@ function beginUpdate(
   let editorStateWasCloned = false;
 
   if (pendingEditorState === null || pendingEditorState._readOnly) {
-    pendingEditorState = editor._pendingEditorState =
-      cloneEditorState(currentEditorState);
+    pendingEditorState = editor._pendingEditorState = cloneEditorState(
+      pendingEditorState || currentEditorState,
+    );
     editorStateWasCloned = true;
   }
   pendingEditorState._flushSync = discrete;

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -902,6 +902,28 @@ describe('LexicalEditor tests', () => {
     );
   });
 
+  for (const editable of [true, false]) {
+    it(`Retains pendingEditor while rootNode is not set (${
+      editable ? 'editable' : 'non-editable'
+    })`, async () => {
+      const JSON_EDITOR_STATE =
+        '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"123","type":"text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}';
+      init();
+      const contentEditable = editor.getRootElement();
+      editor.setEditable(editable);
+      editor.setRootElement(null);
+      const editorState = editor.parseEditorState(JSON_EDITOR_STATE);
+      editor.setEditorState(editorState);
+      editor.update(() => {
+        //
+      });
+      editor.setRootElement(contentEditable);
+      expect(JSON.stringify(editor.getEditorState().toJSON())).toBe(
+        JSON_EDITOR_STATE,
+      );
+    });
+  }
+
   describe('With node decorators', () => {
     function useDecorators() {
       const [decorators, setDecorators] = useState(() =>


### PR DESCRIPTION
It turns out that a small mistake on `beginUpdate` causes the pendingEditorState to be lost when the rootElement has not yet been set. This rarely happens with React, but it turns out it can be reproable when dynamically switching editors.