### PR TITLE
Add table plugin example

### DIFF
--- a/packages/lexical-website/docs/demos/plugins/images.md
+++ b/packages/lexical-website/docs/demos/plugins/images.md
@@ -7,8 +7,8 @@ sidebar_label: "Images Plugin"
 This page focuses on the implementation of the images plugin and the code you need for image insertion from a sample or URL into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
 
 <iframe src="https://codesandbox.io/embed/lexical-image-plugin-example-iy2bc5?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/ImagesPlugin.ts,/src/plugins/ImageToolbar.tsx&theme=dark&view=split"
-     style={{width:100+"%", height:700+"px", border:0, "border-radius": 4+"px", overflow:"hidden"}}
-     title="lexical-plain-text-example (forked)"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-image-plugin-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>

--- a/packages/lexical-website/docs/demos/plugins/lists.md
+++ b/packages/lexical-website/docs/demos/plugins/lists.md
@@ -9,8 +9,8 @@ This page focuses on implementing the list plugin and the code you need to incor
 You can create new lists by selecting relevant text and playing around with the buttons in the toolbar. 
 
 <iframe src="https://codesandbox.io/embed/lexical-list-plugin-example-00d642?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/ListToolbar.tsx&theme=dark&view=split"
-     style={{width:100+"%", height:700+"px", border:0, "border-radius": 4+"px", overflow:"hidden"}}
-     title="lexical-plain-text-example (forked)"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-list-plugin-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>

--- a/packages/lexical-website/docs/demos/plugins/mentions.md
+++ b/packages/lexical-website/docs/demos/plugins/mentions.md
@@ -11,8 +11,8 @@ In the simplified example below, there are dummy mentions, so you can change the
 **How to use**: type @ and any letter. If there is a name associated with the letters you typed, it will be shown in the typeahead below the text. If the mention is successful, it will be highlighted.
 
 <iframe src="https://codesandbox.io/embed/lexical-mention-plugin-example-ojn42n?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/MentionsPlugin.tsx,/src/nodes/MentionNode.ts&theme=dark&view=split"
-     style={{width:100+"%", height:700+"px", border:0, "border-radius": 4+"px", overflow:"hidden"}}
-     title="lexical-plain-text-example (forked)"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-mentions-plugin-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>

--- a/packages/lexical-website/docs/demos/plugins/tables.md
+++ b/packages/lexical-website/docs/demos/plugins/tables.md
@@ -9,8 +9,8 @@ This page focuses on implementing the table plugin and the code you need to inco
 The below example has all the basic functionality of the tables (e.g., inserting and removing columns and creating headers). Note that the header text is bold, and you can either hardcode it to be simple text or import the relevant styles from Lexical (e.g., italic, bold, underlined) to change the format. There are quite some files to be included and CSS, but they cover most of the table functionality. 
 
 <iframe src="https://codesandbox.io/embed/lexical-table-plugin-example-zd6k44?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/TableToolbar.tsx,/src/plugins/TablePlugin.tsx&theme=dark&view=split"
-     style={{width:100+"%", height:700+"px", border:0, "border-radius": 4+"px", overflow:"hidden"}}
-     title="lexical-plain-text-example (forked)"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-table-plugin-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>

--- a/packages/lexical-website/docs/demos/plugins/tables.md
+++ b/packages/lexical-website/docs/demos/plugins/tables.md
@@ -1,0 +1,16 @@
+---
+id: "tables"
+title: "Table Plugin"
+sidebar_label: "Table Plugin"
+---
+
+This page focuses on implementing the table plugin and the code you need to incorporate tables into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+
+The below example has all the basic functionality of the tables (e.g., inserting and removing columns and creating headers). Note that the header text is bold, and you can either hardcode it to be simple text or import the relevant styles from Lexical (e.g., italic, bold, underlined) to change the format. There are quite some files to be included and CSS, but they cover most of the table functionality. 
+
+<iframe src="https://codesandbox.io/embed/lexical-table-plugin-example-zd6k44?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/TableToolbar.tsx,/src/plugins/TablePlugin.tsx&theme=dark&view=split"
+     style={{width:100+"%", height:700+"px", border:0, "border-radius": 4+"px", overflow:"hidden"}}
+     title="lexical-plain-text-example (forked)"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>


### PR DESCRIPTION
- [x] created a CodeSandbox example for the table plugin [here](https://codesandbox.io/s/lexical-table-plugin-example-zd6k44)
- [x] added a new page and the example on the website (under “/docs/demos/plugins/tables”)

<img width="1440" alt="Table Plugin" src="https://user-images.githubusercontent.com/47840436/200742473-fda62ff4-6e65-4568-9461-d3ad27d432dd.png">

Issue https://github.com/facebook/lexical/issues/2886