### PR TITLE
Add $splitNode & $copyNode

### DIFF
--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -70,3 +70,5 @@ declare export function $wrapNodeInElement(
   node: LexicalNode,
   createElementNode: () => ElementNode,
 ): ElementNode;
+
+declare export function $splitNode<T: LexicalNode>(node: T): T;

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {ElementNode, LexicalEditor} from 'lexical';
+
+import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
+import {$getRoot, $isElementNode} from 'lexical';
+import {createTestEditor} from 'lexical/src/__tests__/utils';
+
+import {$splitNode} from '../../index';
+
+describe('LexicalUtils#splitNode', () => {
+  let editor: LexicalEditor;
+
+  const update = async (updateFn) => {
+    editor.update(updateFn);
+    await Promise.resolve();
+  };
+
+  beforeEach(async () => {
+    editor = createTestEditor();
+    editor._headless = true;
+  });
+
+  const testCases: Array<{
+    _: string;
+    expectedHtml: string;
+    initialHtml: string;
+    splitPath: Array<number>;
+    splitOffset: number;
+    only?: boolean;
+  }> = [
+    {
+      _: 'split paragraph in between two text nodes',
+      expectedHtml: '<p><span>Hello</span></p><p><span>world</span></p>',
+      initialHtml: '<p><span>Hello</span><span>world</span></p>',
+      splitOffset: 1,
+      splitPath: [0],
+    },
+    {
+      _: 'split paragraph before the first text node',
+      expectedHtml: '<p><br></p><p><span>Hello</span><span>world</span></p>',
+      initialHtml: '<p><span>Hello</span><span>world</span></p>',
+      splitOffset: 0,
+      splitPath: [0],
+    },
+    {
+      _: 'split paragraph after the last text node',
+      expectedHtml: '<p><span>Hello</span><span>world</span></p><p><br></p>',
+      initialHtml: '<p><span>Hello</span><span>world</span></p>',
+      splitOffset: 2, // Any offset that is higher than children size
+      splitPath: [0],
+    },
+    {
+      _: 'split list items between two text nodes',
+      expectedHtml:
+        '<ul><li><span>Hello</span></li></ul>' +
+        '<ul><li><span>world</span></li></ul>',
+      initialHtml: '<ul><li><span>Hello</span><span>world</span></li></ul>',
+      splitOffset: 1, // Any offset that is higher than children size
+      splitPath: [0, 0],
+    },
+    {
+      _: 'split list items before the first text node',
+      expectedHtml:
+        '<ul><li></li></ul>' +
+        '<ul><li><span>Hello</span><span>world</span></li></ul>',
+      initialHtml: '<ul><li><span>Hello</span><span>world</span></li></ul>',
+      splitOffset: 0, // Any offset that is higher than children size
+      splitPath: [0, 0],
+    },
+    {
+      _: 'split nested list items',
+      expectedHtml:
+        '<ul>' +
+        '<li><span>Before</span></li>' +
+        '<li><ul><li><span>Hello</span></li></ul></li>' +
+        '</ul>' +
+        '<ul>' +
+        '<li><ul><li><span>world</span></li></ul></li>' +
+        '<li><span>After</span></li>' +
+        '</ul>',
+      initialHtml:
+        '<ul>' +
+        '<li><span>Before</span></li>' +
+        '<ul><li><span>Hello</span><span>world</span></li></ul>' +
+        '<li><span>After</span></li>' +
+        '</ul>',
+      splitOffset: 1, // Any offset that is higher than children size
+      splitPath: [0, 1, 0, 0],
+    },
+  ];
+
+  for (const testCase of testCases) {
+    it(testCase._, async () => {
+      await update(() => {
+        // Running init, update, assert in the same update loop
+        // to skip text nodes normalization (then separate text
+        // nodes will still be separate and represented by its own
+        // spans in html output) and make assertions more precise
+        const parser = new DOMParser();
+        const dom = parser.parseFromString(testCase.initialHtml, 'text/html');
+        const nodesToInsert = $generateNodesFromDOM(editor, dom);
+        $getRoot()
+          .clear()
+          .append(...nodesToInsert);
+
+        let nodeToSplit: ElementNode = $getRoot();
+        for (const index of testCase.splitPath) {
+          nodeToSplit = nodeToSplit.getChildAtIndex(index);
+          if (!$isElementNode(nodeToSplit)) {
+            throw new Error('Expected node to be element');
+          }
+        }
+
+        $splitNode(nodeToSplit, testCase.splitOffset);
+
+        // Cleaning up list value attributes as it's not really needed in this test
+        // and it clutters expected output
+        const actualHtml = $generateHtmlFromNodes(editor).replace(
+          /\svalue="\d{1,}"/g,
+          '',
+        );
+        expect(actualHtml).toEqual(testCase.expectedHtml);
+      });
+    });
+  }
+});

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -825,6 +825,10 @@ declare export function $hasAncestor(
   child: LexicalNode,
   targetNode: LexicalNode,
 ): boolean;
+declare export function $copyNode(
+  node: ElementNode,
+  offset: number,
+): [ElementNode, ElementNode];
 
 /**
  * LexicalVersion

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1256,3 +1256,10 @@ export function $getNearestRootOrShadowRoot(
 export function $isRootOrShadowRoot(node: null | LexicalNode): boolean {
   return $isRootNode(node) || ($isElementNode(node) && node.isShadowRoot());
 }
+
+export function $copyNode<T extends LexicalNode>(node: T): T {
+  // @ts-ignore
+  const copy = node.constructor.clone(node);
+  $setNodeKey(copy, null);
+  return copy;
+}

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -128,6 +128,7 @@ export {
 export {$parseSerializedNode} from './LexicalUpdates';
 export {
   $addUpdateTag,
+  $copyNode,
   $getDecoratorNode,
   $getNearestNodeFromDOMNode,
   $getNearestRootOrShadowRoot,


### PR DESCRIPTION
1. `$splitNode` would allow splitting current tree up until root or shadow root and enhance insertions. As of now `$insertNodeoNearestRoot` takes nearest top-level child and appends node after it, which is not very precise. Here's an example with nested lists:
```
- Top level
    - Text before <split here> text after
    - More nested items
- More top level items
```
with selection on `<split here>`, `$insertNodeoNearestRoot` would insert node after the whole list. `$splitNode` aims to allow splitting nested trees to insert where user would expect, e.g. calling `$splitNode(listItem, 1)` would split it into two separate lists:

```
- Top level
    - Text before

-
    - text after
    - More nested items
- More top level items
```

It should address limitation of #2322 and allow splitting any arbitrary nested structure vs only dealing with 1-2 levels


2. `$copyNode` is needed for `$splitNode` implementation, and is already used internally (with a hacky workaround), so adding it to the official API

Follow up PR will update `$insertNodeoNearestRoot` to use splitText & splitNode to insert block level nodes more precise