### PR TITLE
Improve $insertNodeToNearestRoot

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -709,11 +709,9 @@ export function LexicalTypeaheadMenuPlugin<TOption extends TypeaheadOption>({
   );
 
   useEffect(() => {
-    let activeRange: Range | null = document.createRange();
-
     const updateListener = () => {
       editor.getEditorState().read(() => {
-        const range = activeRange;
+        const range = document.createRange();
         const selection = $getSelection();
         const text = getQueryTextForSearch(editor);
 
@@ -752,7 +750,6 @@ export function LexicalTypeaheadMenuPlugin<TOption extends TypeaheadOption>({
     const removeUpdateListener = editor.registerUpdateListener(updateListener);
 
     return () => {
-      activeRange = null;
       removeUpdateListener();
     };
   }, [

--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -70,3 +70,5 @@ declare export function $wrapNodeInElement(
   node: LexicalNode,
   createElementNode: () => ElementNode,
 ): ElementNode;
+
+declare export function $splitNode<T: LexicalNode>(node: T): T;

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {ElementNode, LexicalEditor} from 'lexical';
+
+import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
+import {$getRoot, $isElementNode} from 'lexical';
+import {createTestEditor} from 'lexical/src/__tests__/utils';
+
+import {$splitNode} from '../../index';
+
+describe('LexicalUtils#splitNode', () => {
+  let editor: LexicalEditor;
+
+  const update = async (updateFn) => {
+    editor.update(updateFn);
+    await Promise.resolve();
+  };
+
+  beforeEach(async () => {
+    editor = createTestEditor();
+    editor._headless = true;
+  });
+
+  const testCases: Array<{
+    _: string;
+    expectedHtml: string;
+    initialHtml: string;
+    splitPath: Array<number>;
+    splitOffset: number;
+    only?: boolean;
+  }> = [
+    {
+      _: 'split paragraph in between two text nodes',
+      expectedHtml: '<p><span>Hello</span></p><p><span>world</span></p>',
+      initialHtml: '<p><span>Hello</span><span>world</span></p>',
+      splitOffset: 1,
+      splitPath: [0],
+    },
+    {
+      _: 'split paragraph before the first text node',
+      expectedHtml: '<p><br></p><p><span>Hello</span><span>world</span></p>',
+      initialHtml: '<p><span>Hello</span><span>world</span></p>',
+      splitOffset: 0,
+      splitPath: [0],
+    },
+    {
+      _: 'split paragraph after the last text node',
+      expectedHtml: '<p><span>Hello</span><span>world</span></p><p><br></p>',
+      initialHtml: '<p><span>Hello</span><span>world</span></p>',
+      splitOffset: 2, // Any offset that is higher than children size
+      splitPath: [0],
+    },
+    {
+      _: 'split list items between two text nodes',
+      expectedHtml:
+        '<ul><li><span>Hello</span></li></ul>' +
+        '<ul><li><span>world</span></li></ul>',
+      initialHtml: '<ul><li><span>Hello</span><span>world</span></li></ul>',
+      splitOffset: 1, // Any offset that is higher than children size
+      splitPath: [0, 0],
+    },
+    {
+      _: 'split list items before the first text node',
+      expectedHtml:
+        '<ul><li></li></ul>' +
+        '<ul><li><span>Hello</span><span>world</span></li></ul>',
+      initialHtml: '<ul><li><span>Hello</span><span>world</span></li></ul>',
+      splitOffset: 0, // Any offset that is higher than children size
+      splitPath: [0, 0],
+    },
+    {
+      _: 'split nested list items',
+      expectedHtml:
+        '<ul>' +
+        '<li><span>Before</span></li>' +
+        '<li><ul><li><span>Hello</span></li></ul></li>' +
+        '</ul>' +
+        '<ul>' +
+        '<li><ul><li><span>world</span></li></ul></li>' +
+        '<li><span>After</span></li>' +
+        '</ul>',
+      initialHtml:
+        '<ul>' +
+        '<li><span>Before</span></li>' +
+        '<ul><li><span>Hello</span><span>world</span></li></ul>' +
+        '<li><span>After</span></li>' +
+        '</ul>',
+      splitOffset: 1, // Any offset that is higher than children size
+      splitPath: [0, 1, 0, 0],
+    },
+  ];
+
+  for (const testCase of testCases) {
+    it(testCase._, async () => {
+      await update(() => {
+        // Running init, update, assert in the same update loop
+        // to skip text nodes normalization (then separate text
+        // nodes will still be separate and represented by its own
+        // spans in html output) and make assertions more precise
+        const parser = new DOMParser();
+        const dom = parser.parseFromString(testCase.initialHtml, 'text/html');
+        const nodesToInsert = $generateNodesFromDOM(editor, dom);
+        $getRoot()
+          .clear()
+          .append(...nodesToInsert);
+
+        let nodeToSplit: ElementNode = $getRoot();
+        for (const index of testCase.splitPath) {
+          nodeToSplit = nodeToSplit.getChildAtIndex(index);
+          if (!$isElementNode(nodeToSplit)) {
+            throw new Error('Expected node to be element');
+          }
+        }
+
+        $splitNode(nodeToSplit, testCase.splitOffset);
+
+        // Cleaning up list value attributes as it's not really needed in this test
+        // and it clutters expected output
+        const actualHtml = $generateHtmlFromNodes(editor).replace(
+          /\svalue="\d{1,}"/g,
+          '',
+        );
+        expect(actualHtml).toEqual(testCase.expectedHtml);
+      });
+    });
+  }
+});

--- a/packages/lexical-utils/src/__tests__/unit/LexlcaiUtilsInsertNodeToNearestRoot.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexlcaiUtilsInsertNodeToNearestRoot.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {LexicalEditor, LexicalNode} from 'lexical';
+
+import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
+import {$getRoot, $isElementNode} from 'lexical';
+import {
+  $createTestDecoratorNode,
+  createTestEditor,
+} from 'lexical/src/__tests__/utils';
+
+import {$insertNodeToNearestRoot} from '../..';
+
+describe('LexicalUtils#insertNodeToNearestRoot', () => {
+  let editor: LexicalEditor;
+
+  const update = async (updateFn) => {
+    editor.update(updateFn);
+    await Promise.resolve();
+  };
+
+  beforeEach(async () => {
+    editor = createTestEditor();
+    editor._headless = true;
+  });
+
+  const testCases: Array<{
+    _: string;
+    expectedHtml: string;
+    initialHtml: string;
+    selectionPath: Array<number>;
+    selectionOffset: number;
+    only?: boolean;
+  }> = [
+    {
+      _: 'insert into paragraph in between two text nodes',
+      expectedHtml:
+        '<p><span>Hello</span></p><test-decorator></test-decorator><p><span>world</span></p>',
+      initialHtml: '<p><span>Helloworld</span></p>',
+      selectionOffset: 5, // Selection on text node after "Hello" world
+      selectionPath: [0, 0],
+    },
+    {
+      _: 'insert into nested list items',
+      expectedHtml:
+        '<ul>' +
+        '<li><span>Before</span></li>' +
+        '<li><ul><li><span>Hello</span></li></ul></li>' +
+        '</ul>' +
+        '<test-decorator></test-decorator>' +
+        '<ul>' +
+        '<li><ul><li><span>world</span></li></ul></li>' +
+        '<li><span>After</span></li>' +
+        '</ul>',
+      initialHtml:
+        '<ul>' +
+        '<li><span>Before</span></li>' +
+        '<ul><li><span>Helloworld</span></li></ul>' +
+        '<li><span>After</span></li>' +
+        '</ul>',
+      selectionOffset: 5, // Selection on text node after "Hello" world
+      selectionPath: [0, 1, 0, 0, 0],
+    },
+    {
+      _: 'insert into empty paragraph',
+      expectedHtml: '<p><br></p><test-decorator></test-decorator><p><br></p>',
+      initialHtml: '<p></p>',
+      selectionOffset: 0, // Selection on text node after "Hello" world
+      selectionPath: [0],
+    },
+    {
+      _: 'insert in the end of paragraph',
+      expectedHtml:
+        '<p><span>Hello world</span></p>' +
+        '<test-decorator></test-decorator>' +
+        '<p><br></p>',
+      initialHtml: '<p>Hello world</p>',
+      selectionOffset: 12, // Selection on text node after "Hello" world
+      selectionPath: [0, 0],
+    },
+    {
+      _: 'insert in the beginning of paragraph',
+      expectedHtml:
+        '<p><br></p>' +
+        '<test-decorator></test-decorator>' +
+        '<p><span>Hello world</span></p>',
+      initialHtml: '<p>Hello world</p>',
+      selectionOffset: 0, // Selection on text node after "Hello" world
+      selectionPath: [0, 0],
+    },
+  ];
+
+  for (const testCase of testCases) {
+    it(testCase._, async () => {
+      await update(() => {
+        // Running init, update, assert in the same update loop
+        // to skip text nodes normalization (then separate text
+        // nodes will still be separate and represented by its own
+        // spans in html output) and make assertions more precise
+        const parser = new DOMParser();
+        const dom = parser.parseFromString(testCase.initialHtml, 'text/html');
+        const nodesToInsert = $generateNodesFromDOM(editor, dom);
+        $getRoot()
+          .clear()
+          .append(...nodesToInsert);
+
+        let nodeToSplit: LexicalNode = $getRoot();
+        for (const index of testCase.selectionPath) {
+          if (!$isElementNode(nodeToSplit)) {
+            throw new Error(
+              'Expected node to be element (to traverse the tree)',
+            );
+          }
+          nodeToSplit = nodeToSplit.getChildAtIndex(index);
+        }
+
+        nodeToSplit.select(testCase.selectionOffset, testCase.selectionOffset);
+        $insertNodeToNearestRoot($createTestDecoratorNode());
+
+        // Cleaning up list value attributes as it's not really needed in this test
+        // and it clutters expected output
+        const actualHtml = $generateHtmlFromNodes(editor).replace(
+          /\svalue="\d{1,}"/g,
+          '',
+        );
+        expect(actualHtml).toEqual(testCase.expectedHtml);
+      });
+    });
+  }
+});

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -8,12 +8,14 @@
  */
 
 import {
+  $copyNode,
   $createParagraphNode,
   $getRoot,
   $getSelection,
   $isElementNode,
   $isNodeSelection,
   $isRangeSelection,
+  $isRootOrShadowRoot,
   $isTextNode,
   $setSelection,
   createEditor,
@@ -440,4 +442,46 @@ export function $wrapNodeInElement(
   node.replace(elementNode);
   elementNode.append(node);
   return elementNode;
+}
+
+export function $splitNode(
+  node: ElementNode,
+  offset: number,
+): [ElementNode | null, ElementNode] {
+  let startNode = node.getChildAtIndex(offset) as LexicalNode;
+  if (startNode == null) {
+    startNode = node;
+  }
+
+  const recurse = (
+    currentNode: LexicalNode,
+  ): [ElementNode, ElementNode, LexicalNode] => {
+    const parent = currentNode.getParentOrThrow();
+    const isParentRoot = $isRootOrShadowRoot(parent);
+    // The node we start split from (leaf) is moved, but its recursive
+    // parents are copied to create separate tree
+    const nodeToMove =
+      currentNode === startNode && !isParentRoot
+        ? currentNode
+        : $copyNode(currentNode);
+
+    if (isParentRoot) {
+      currentNode.insertAfter(nodeToMove);
+      return [
+        currentNode as ElementNode,
+        nodeToMove as ElementNode,
+        nodeToMove,
+      ];
+    } else {
+      const [leftTree, rightTree, newParent] = recurse(parent);
+      const nextSiblings = currentNode.getNextSiblings();
+
+      newParent.append(nodeToMove, ...nextSiblings);
+      return [leftTree, rightTree, nodeToMove];
+    }
+  };
+
+  const [leftTree, rightTree] = recurse(startNode);
+
+  return [leftTree, rightTree];
 }

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -416,21 +416,38 @@ export function $restoreEditorState(
 export function $insertNodeToNearestRoot<T extends LexicalNode>(node: T): T {
   const selection = $getSelection();
   if ($isRangeSelection(selection)) {
-    const focusNode = selection.focus.getNode();
-    focusNode.getTopLevelElementOrThrow().insertAfter(node);
-  } else if (
-    $isNodeSelection(selection) ||
-    DEPRECATED_$isGridSelection(selection)
-  ) {
-    const nodes = selection.getNodes();
-    nodes[nodes.length - 1].getTopLevelElementOrThrow().insertAfter(node);
+    const {focus} = selection;
+    const focusNode = focus.getNode();
+    const focusOffset = focus.offset;
+    let splitNode: ElementNode;
+    let splitOffset: number;
+
+    if ($isTextNode(focusNode)) {
+      splitNode = focusNode.getParentOrThrow();
+      splitOffset = focusNode.getIndexWithinParent();
+      if (focusOffset > 0) {
+        splitOffset += 1;
+        focusNode.splitText(focusOffset);
+      }
+    } else {
+      splitNode = focusNode;
+      splitOffset = focusOffset;
+    }
+    const [, rightTree] = $splitNode(splitNode, splitOffset);
+    rightTree.insertBefore(node);
+    rightTree.selectStart();
   } else {
-    const root = $getRoot();
-    root.append(node);
+    if ($isNodeSelection(selection) || DEPRECATED_$isGridSelection(selection)) {
+      const nodes = selection.getNodes();
+      nodes[nodes.length - 1].getTopLevelElementOrThrow().insertAfter(node);
+    } else {
+      const root = $getRoot();
+      root.append(node);
+    }
+    const paragraphNode = $createParagraphNode();
+    node.insertAfter(paragraphNode);
+    paragraphNode.select();
   }
-  const paragraphNode = $createParagraphNode();
-  node.insertAfter(paragraphNode);
-  paragraphNode.select();
   return node.getLatest();
 }
 

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -825,6 +825,10 @@ declare export function $hasAncestor(
   child: LexicalNode,
   targetNode: LexicalNode,
 ): boolean;
+declare export function $copyNode(
+  node: ElementNode,
+  offset: number,
+): [ElementNode, ElementNode];
 
 /**
  * LexicalVersion

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1256,3 +1256,10 @@ export function $getNearestRootOrShadowRoot(
 export function $isRootOrShadowRoot(node: null | LexicalNode): boolean {
   return $isRootNode(node) || ($isElementNode(node) && node.isShadowRoot());
 }
+
+export function $copyNode<T extends LexicalNode>(node: T): T {
+  // @ts-ignore
+  const copy = node.constructor.clone(node);
+  $setNodeKey(copy, null);
+  return copy;
+}

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -329,6 +329,22 @@ export class TestDecoratorNode extends DecoratorNode<JSX.Element> {
     };
   }
 
+  importDOM() {
+    return {
+      'test-decorator': (domNode: HTMLElement) => {
+        return {
+          conversion: () => ({node: $createTestDecoratorNode()}),
+        };
+      },
+    };
+  }
+
+  exportDOM() {
+    return {
+      element: document.createElement('test-decorator'),
+    };
+  }
+
   getTextContent() {
     return 'Hello world';
   }

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -128,6 +128,7 @@ export {
 export {$parseSerializedNode} from './LexicalUpdates';
 export {
   $addUpdateTag,
+  $copyNode,
   $getDecoratorNode,
   $getNearestNodeFromDOMNode,
   $getNearestRootOrShadowRoot,


### PR DESCRIPTION
Using `$splitNodes` allows insertion in the middle of the text with nodes tree being split up until nearest root:

https://user-images.githubusercontent.com/132642/200885233-6a0f0983-63fe-4be6-b12a-b1ef1a9c5946.mov

