### PR TITLE
Add sticky notes plugin example

### DIFF
--- a/packages/lexical-website/docs/demos/plugins/sticky-notes.md
+++ b/packages/lexical-website/docs/demos/plugins/sticky-notes.md
@@ -1,0 +1,16 @@
+---
+id: "sticky-notes"
+title: "Sticky Notes Plugin"
+sidebar_label: "Sticky Notes Plugin"
+---
+
+This page focuses on implementing the sticky notes plugin and the code you need to incorporate sticky notes into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+
+You can move the sticky notes around and change their color (i.e., yellow and pink are currently available, but it is easily changeable).
+
+<iframe src="https://codesandbox.io/embed/lexical-sticky-notes-plugin-example-zifhtf?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/StickyToolbar.tsx,/src/nodes/StickyNode.tsx&theme=dark&view=split"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-sticky-notes-plugin-example"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>


### PR DESCRIPTION
- [x] created a CodeSandbox example for the sticky notes plugin [here](https://codesandbox.io/s/lexical-sticky-notes-plugin-example-zifhtf)
- [x] added a new page and the example on the website (under “/docs/demos/plugins/sticky-notes”)

<img width="1439" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/47840436/200963748-2fc5f89c-1cd7-4147-9fb0-d2a40847ca61.png">

Issue https://github.com/facebook/lexical/issues/2886