### PR TITLE
Change the plugin to `OnChangePlugin` in the React Editor State Example

### DIFF
--- a/packages/lexical-website/docs/concepts/editor-state.md
+++ b/packages/lexical-website/docs/concepts/editor-state.md
@@ -58,7 +58,7 @@ const editorStateRef = useRef();
   editorState: initialEditorState
 }}>
   <LexicalRichTextPlugin />
-  <LexicalOnChangePlugin onChange={editorState => editorStateRef.current = editorState} />
+  <OnChangePlugin onChange={editorState => editorStateRef.current = editorState} />
   <Button label="Save" onPress={() => {
     if (editorStateRef.current) {
       saveContent(JSON.stringify(editorStateRef.current))


### PR DESCRIPTION
I just noticed that the `RichTextPlugin` also has a `Lexical` prefix, so this was probably done intentionally.

Feel free to close this PR.  (Just found importing `LexicalOnChangePlugin` confusing at first.)