### PR TITLE
Add markdown plugin example

### DIFF
--- a/packages/lexical-website/docs/demos/plugins/images.md
+++ b/packages/lexical-website/docs/demos/plugins/images.md
@@ -6,7 +6,7 @@ sidebar_label: "Images Plugin"
 
 This page focuses on the implementation of the images plugin and the code you need for image insertion from a sample or URL into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
 
-<iframe src="https://codesandbox.io/embed/lexical-image-plugin-example-iy2bc5?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/ImagesPlugin.ts,/src/plugins/ImageToolbar.tsx&theme=dark&view=split"
+<iframe src="https://codesandbox.io/embed/lexical-image-plugin-example-iy2bc5?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/ImagePlugin.ts,/src/plugins/ImageToolbar.tsx&theme=dark&view=split"
      style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
      title="lexical-image-plugin-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/packages/lexical-website/docs/demos/plugins/markdown.md
+++ b/packages/lexical-website/docs/demos/plugins/markdown.md
@@ -8,7 +8,7 @@ This page focuses on implementing the markdown plugin and the code you need to i
 
 The editor already has some prepopulated text, and you can press the button on the bottom right to turn the current text into Markdown text. If you press again, it will turn back to standard editor text. This is a rich text editor example, and you can see most of the formatting functionality (e.g., bold, italic, underlined text).
 
-Currently, for simplicity purposes, the link plugin is very basic, so you will have to press twice on the links to see the URL and edit it. You can further import the AutoLink and ClickableLink plugins to be able to click on the link to jump straight to the website of your preference. 
+Currently, for the purposes of simplicity, the link plugin is very basic, so you will have to press twice on the links to see the URL and edit it. You can further import the AutoLink and ClickableLink plugins to be able to click on the link to jump straight to the website of your preference. 
 
 <iframe src="https://codesandbox.io/embed/lexical-markdown-plugin-example-4076jq?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/MarkdownTransformers.ts,/src/plugins/ActionsPlugin.tsx&theme=dark&view=split"
      style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}

--- a/packages/lexical-website/docs/demos/plugins/markdown.md
+++ b/packages/lexical-website/docs/demos/plugins/markdown.md
@@ -1,0 +1,18 @@
+---
+id: "markdown"
+title: "Markdown Plugin"
+sidebar_label: "Markdown Plugin"
+---
+
+This page focuses on implementing the markdown plugin and the code you need to incorporate markdown support into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+
+The editor already has some prepopulated text, and you can press the button on the bottom right to turn the current text into Markdown text. If you press again, it will turn back to standard editor text. This is a rich text editor example, and you can see most of the formatting functionality (e.g., bold, italic, underlined text).
+
+Currently, for simplicity purposes, the link plugin is very basic, so you will have to press twice on the links to see the URL and edit it. You can further import the AutoLink and ClickableLink plugins to be able to click on the link to jump straight to the website of your preference. 
+
+<iframe src="https://codesandbox.io/embed/lexical-markdown-plugin-example-4076jq?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/MarkdownTransformers.ts,/src/plugins/ActionsPlugin.tsx&theme=dark&view=split"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-markdown-plugin-example"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>


### PR DESCRIPTION

- [x] created a CodeSandbox example for the markdown plugin [here](https://codesandbox.io/s/lexical-markdown-plugin-example-4076jq)
- [x] added a new page and the example on the website (under “/docs/demos/plugins/markdown”)

<img width="721" alt="Markdown Plugin" src="https://user-images.githubusercontent.com/47840436/201453982-d6e50a5d-863c-4ba4-8569-67410593b405.png">

Issue https://github.com/facebook/lexical/issues/2886
