### PR TITLE
[Lexical] [WWW] Remove the extra space after the oncall shortname

### DIFF
--- a/scripts/www/rewriteImports.js
+++ b/scripts/www/rewriteImports.js
@@ -32,7 +32,7 @@ glob('packages/**/flow/*.flow', options, function (error1, files) {
       const result = data
         .replace(
           / \* @flow strict/g,
-          ' * @flow strict\n * @generated\n * @oncall lexical_web_text_editor ',
+          ' * @flow strict\n * @generated\n * @oncall lexical_web_text_editor',
         )
         .replace(/from 'lexical'/g, "from 'Lexical'")
         .replace(/from 'lexical'/g, "from 'Lexical'")


### PR DESCRIPTION
Summary:
There is an extra space found in the docblock comment of '@oncall'. This was brought into WWW files.
This diff removes the unnecessary trailing space.

Test Plan:
CI