### PR TITLE
Do not capture trailing node while wrapping nodes when it is on the edge of the selection

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -221,4 +221,51 @@ test.describe('Selection', () => {
       focusPath: [0, 1, 0, 0],
     });
   });
+
+  test('Deselects trailing edge that starts on the next line when converts block', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    await page.keyboard.type('First paragraph');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Second paragraph');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Third paragraph');
+
+    await moveToLineBeginning(page);
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.up('Shift');
+
+    await selectFromFormatDropdown(page, '.h1');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">First paragraph</span>
+        </p>
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Second paragraph</span>
+        </h1>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Third paragraph</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0, 1, 0],
+      focusOffset: 0,
+      focusPath: [0, 2, 0],
+    });
+  });
 });

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -53,21 +53,7 @@ function isPointAttached(point: Point): boolean {
   return point.getNode().isAttached();
 }
 
-/**
- * Attempts to wrap all nodes in the Selection in ElementNodes returned from createElement.
- * If wrappingElement is provided, all of the wrapped leaves are appended to the wrappingElement.
- * It attempts to append the resulting sub-tree to the nearest safe insertion target.
- *
- * @param selection
- * @param createElement
- * @param wrappingElement
- * @returns
- */
-export function $wrapNodes(
-  selection: RangeSelection | GridSelection,
-  createElement: () => ElementNode,
-  wrappingElement: null | ElementNode = null,
-): void {
+function trimBoundaries(selection: RangeSelection | GridSelection): void {
   const selectionEnd = selection.isBackward()
     ? selection.anchor
     : selection.focus;
@@ -98,6 +84,23 @@ export function $wrapNodes(
       }
     }
   }
+}
+/**
+ * Attempts to wrap all nodes in the Selection in ElementNodes returned from createElement.
+ * If wrappingElement is provided, all of the wrapped leaves are appended to the wrappingElement.
+ * It attempts to append the resulting sub-tree to the nearest safe insertion target.
+ *
+ * @param selection
+ * @param createElement
+ * @param wrappingElement
+ * @returns
+ */
+export function $wrapNodes(
+  selection: RangeSelection | GridSelection,
+  createElement: () => ElementNode,
+  wrappingElement: null | ElementNode = null,
+): void {
+  trimBoundaries(selection);
 
   const nodes = selection.getNodes();
   const nodesLength = nodes.length;

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -84,8 +84,8 @@ export function $wrapNodes(
       if ($isRootOrShadowRoot(trailingNode)) {
         if (selection.isBackward()) {
           const collapsedEndSelection = selection.clone();
-          collapsedEndSelection.focus = collapsedEndSelection.anchor;
-          $moveCharacter(collapsedEndSelection, false, true);
+          collapsedEndSelection.modify('move', false, 'character');
+          collapsedEndSelection.modify('move', true, 'character');
           selection.anchor = collapsedEndSelection.anchor;
         } else {
           $moveCharacter(selection, true, true);


### PR DESCRIPTION
Resolves https://github.com/facebook/lexical/issues/2648

TODOs:
- [ ] Fix unit tests
- [x] Add backward direction selection case 