### PR TITLE
Add YouTube, Figma and Twitter plugin examples 

### DIFF
--- a/packages/lexical-website/docs/demos/plugins/embeds/_category_.yml
+++ b/packages/lexical-website/docs/demos/plugins/embeds/_category_.yml
@@ -1,0 +1,2 @@
+label: 'Embed Plugins'
+position: 1

--- a/packages/lexical-website/docs/demos/plugins/embeds/figma.md
+++ b/packages/lexical-website/docs/demos/plugins/embeds/figma.md
@@ -1,0 +1,18 @@
+---
+id: "figma"
+title: "Figma Plugin"
+sidebar_label: "Figma Plugin"
+---
+
+This page focuses on implementing the Figma plugin and the code you need to embed Figma files into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+
+To use, enter the URL of the relevant file, and it will get embedded into the editor. If the URL is wrong or doesn't exist, an empty Figma file will get embedded and show an error. 
+
+The example here is very simplified, so you can create your own logic for handling wrong URLs or canceling the embedding. The size of the embed is also adjustable. 
+
+<iframe src="https://codesandbox.io/embed/lexical-figma-plugin-example-0dphp4?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/FigmaPlugin.tsx,/src/nodes/FigmaNode.tsx&theme=dark&view=split"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-figma-plugin-example"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>

--- a/packages/lexical-website/docs/demos/plugins/embeds/twitter.md
+++ b/packages/lexical-website/docs/demos/plugins/embeds/twitter.md
@@ -1,0 +1,18 @@
+---
+id: "twitter"
+title: "Twitter Plugin"
+sidebar_label: "Twitter Plugin"
+---
+
+This page focuses on implementing the Twitter plugin and the code you need to embed tweets into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+
+To use, enter the URL of the relevant tweet, and it will get embedded into the editor. You will not see any additional embeds if the URL is wrong or doesn't exist.
+
+The example here is very simplified, so you can create your own logic for handling wrong URLs or canceling the embedding. The size of the embed is also adjustable. 
+
+<iframe src="https://codesandbox.io/embed/lexical-twitter-plugin-example-6lh3jg?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/TwitterPlugin.ts,/src/nodes/TweetNode.tsx&theme=dark&view=split"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-twitter-plugin-example"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>

--- a/packages/lexical-website/docs/demos/plugins/embeds/youtube.md
+++ b/packages/lexical-website/docs/demos/plugins/embeds/youtube.md
@@ -1,0 +1,18 @@
+---
+id: "youtube"
+title: "YouTube Plugin"
+sidebar_label: "YouTube Plugin"
+---
+
+This page focuses on the implementation of the YouTube plugin and the code you need to embed YouTube videos into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+
+To use, enter the URL of the relevant video, and it will get embedded into the editor. If the URL is wrong or doesn't exist, an empty YouTube video will get embedded and show an error when playing the video. 
+
+The example here is very simplified, so you can create your own logic for handling wrong URLs or canceling the embedding. The size of the embed is also adjustable. 
+
+<iframe src="https://codesandbox.io/embed/lexical-youtube-plugin-example-5unxt3?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/YouTubePlugin.ts,/src/nodes/YouTubeNode.tsx&theme=dark&view=split"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-youtube-plugin-example"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>


### PR DESCRIPTION
- [x] created a CodeSandbox example for the YouTube plugin [here](https://codesandbox.io/s/lexical-youtube-plugin-example-5unxt3)
- [x] created a CodeSandbox example for the Twitter plugin [here](https://codesandbox.io/s/lexical-twitter-plugin-example-6lh3jg)
- [x] created a CodeSandbox example for the Figma plugin [here](https://codesandbox.io/s/lexical-figma-plugin-example-0dphp4)
- [x] added the new pages and the examples on the website (under “/docs/demos/plugins/embeds/”)

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/47840436/201786370-87636c88-aeb4-4cbc-a8cc-67fb87f4569b.png">

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/47840436/201786249-7a05c494-326d-4403-a503-b2fe431dbbc9.png">

<img width="1440" alt="Screen Shot 2022-11-14 at 6 00 19 PM" src="https://user-images.githubusercontent.com/47840436/201785857-2a78a7ee-6e32-4cd5-8efd-1562ecfd9e78.png">

Issue https://github.com/facebook/lexical/issues/2886
