### PR TITLE
Move default language setting to Tokenizer

### DIFF
--- a/packages/lexical-code/flow/LexicalCode.js.flow
+++ b/packages/lexical-code/flow/LexicalCode.js.flow
@@ -22,7 +22,7 @@ import {ElementNode, TextNode} from 'lexical';
 declare export class CodeNode extends ElementNode {
   static getType(): string;
   static clone(node: CodeNode): CodeNode;
-  constructor(key?: NodeKey): void;
+  constructor(language: ?string, key?: NodeKey): void;
   createDOM(config: EditorConfig): HTMLElement;
   updateDOM(prevNode: CodeNode, dom: HTMLElement): boolean;
   insertNewAfter(
@@ -33,7 +33,7 @@ declare export class CodeNode extends ElementNode {
   setLanguage(language: string): void;
   getLanguage(): string | void;
 }
-declare export function $createCodeNode(language?: string): CodeNode;
+declare export function $createCodeNode(language: ?string): CodeNode;
 declare export function $isCodeNode(
   node: ?LexicalNode,
 ): boolean %checks(node instanceof CodeNode);
@@ -71,6 +71,7 @@ export interface Token {
   content: TokenContent;
 }
 export interface Tokenizer {
+  defaultLanguage: string;
   tokenize(code: string, language?: string): (string | Token)[];
 }
 

--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -66,14 +66,16 @@ export interface Token {
 }
 
 export interface Tokenizer {
+  defaultLanguage: string;
   tokenize(code: string, language?: string): (string | Token)[];
 }
 
 export const PrismTokenizer: Tokenizer = {
+  defaultLanguage: DEFAULT_CODE_LANGUAGE,
   tokenize(code: string, language?: string): (string | Token)[] {
     return Prism.tokenize(
       code,
-      Prism.languages[language || ''] || Prism.languages[DEFAULT_CODE_LANGUAGE],
+      Prism.languages[language || ''] || Prism.languages[this.defaultLanguage],
     );
   },
 };
@@ -272,7 +274,7 @@ function codeNodeTransform(
 
   // When new code block inserted it might not have language selected
   if (node.getLanguage() === undefined) {
-    node.setLanguage(DEFAULT_CODE_LANGUAGE);
+    node.setLanguage(tokenizer.defaultLanguage);
   }
 
   // Using nested update call to pass `skipTransforms` since we don't want
@@ -290,7 +292,7 @@ function codeNodeTransform(
         const code = currentNode.getTextContent();
         const tokens = tokenizer.tokenize(
           code,
-          currentNode.getLanguage() || DEFAULT_CODE_LANGUAGE,
+          currentNode.getLanguage() || tokenizer.defaultLanguage,
         );
         const highlightNodes = getHighlightNodes(tokens);
         const diffRange = getDiffRange(


### PR DESCRIPTION
### ~1. Add a preserve feature to CodeNode~

~In the original implementation, CodeNode is removed when the backward deletion occurs at the beginning of the Node.~
~In some use cases, implementing a code editor, such behavior is not needed.~
~The "Preserve" setting is for making it controllable.~

### 2. Move the default language setting to Tokenizer 

The former PR #3243 enabled to use arbitrary Tokenizer other than Prism and 'javascript' is not always appropriate to the default so make it a Tokenizer setting.

This PR contains 2 changes but I'm happy to divide them if required.

