### PR TITLE
Add collapsible container plugin example

### DIFF
--- a/packages/lexical-website/docs/demos/plugins/collapsible-container.md
+++ b/packages/lexical-website/docs/demos/plugins/collapsible-container.md
@@ -1,0 +1,16 @@
+---
+id: "collapsible-container"
+title: "Collapsible Container Plugin"
+sidebar_label: "Collapsible Container Plugin"
+---
+
+This page focuses on implementing the collapsible container plugin and the code you need to add a collapsible container to your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+
+Note that the first line is the container's title and has bold text formatting, while the lines below are meant for the content of the collapsible container, which will be hidden if you press the arrow on the left. 
+
+<iframe src="https://codesandbox.io/embed/lexical-collapsible-container-plugin-example-90nt6t?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/CollapsiblePlugin.ts,/src/nodes/CollapsibleContainerNode.ts&theme=dark&view=split"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-collapsible-container-plugin-example"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>


### PR DESCRIPTION
- [x] created a CodeSandbox example for the collapsible container plugin [here](https://codesandbox.io/s/lexical-collapsible-container-plugin-example-90nt6t)
- [x] added a new page and the example on the website (under “/docs/demos/plugins/collapsible-container”)

<img width="1440" alt="Collapsible Container Plugin" src="https://user-images.githubusercontent.com/47840436/202315064-d79c937d-5178-4c2e-a762-89a93ffba689.png">

Issue https://github.com/facebook/lexical/issues/2886
