### PR TITLE
Fix calling backspace on beginning of editor in front of decorator node

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1243,6 +1243,10 @@ export function $isInlineElementOrDecoratorNode(node: LexicalNode): boolean {
 export function $getNearestRootOrShadowRoot(
   node: LexicalNode,
 ): RootNode | ElementNode {
+  if ($isRootNode(node) || ($isElementNode(node) && node.isShadowRoot())) {
+    return node;
+  }
+
   let parent = node.getParentOrThrow();
   while (parent !== null) {
     if ($isRootOrShadowRoot(parent)) {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1243,18 +1243,14 @@ export function $isInlineElementOrDecoratorNode(node: LexicalNode): boolean {
 export function $getNearestRootOrShadowRoot(
   node: LexicalNode,
 ): RootNode | ElementNode {
-  if ($isRootNode(node) || ($isElementNode(node) && node.isShadowRoot())) {
-    return node;
-  }
-
-  let parent = node.getParentOrThrow();
+  let parent = node;
   while (parent !== null) {
     if ($isRootOrShadowRoot(parent)) {
-      return parent;
+      return parent as RootNode | ElementNode;
     }
     parent = parent.getParentOrThrow();
   }
-  return parent;
+  return parent as RootNode | ElementNode;
 }
 
 export function $isRootOrShadowRoot(node: null | LexicalNode): boolean {

--- a/packages/lexical/src/nodes/LexicalRootNode.ts
+++ b/packages/lexical/src/nodes/LexicalRootNode.ts
@@ -94,6 +94,10 @@ export class RootNode extends ElementNode {
     return super.append(...nodesToAppend);
   }
 
+  collapseAtStart(): true {
+    return true;
+  }
+
   static importJSON(serializedNode: SerializedRootNode): RootNode {
     // We don't create a root, and instead use the existing root.
     const node = $getRoot();


### PR DESCRIPTION
Related to : https://github.com/facebook/lexical/issues/3370

## Steps To Reproduce

1. Remove all content from the editor
2. Add horizontal line
3. Press arrow up
4. Press backspace three times

https://user-images.githubusercontent.com/4542049/202450551-517b0a60-eb9c-492f-bfab-1567cae99a9d.mov


This error gets thrown: 
```
App.tsx:128 Uncaught Error: Expected node root to have a parent.
    at RootNode.getParentOrThrow (LexicalNode.ts:284:26)
    at $getNearestRootOrShadowRoot (LexicalUtils.ts:1246:21)
    at RangeSelection.modify (LexicalSelection.ts:1784:20)
    at RangeSelection.deleteCharacter (LexicalSelection.ts:1855:12)
    at Array.<anonymous> (index.ts:477:19)
    at triggerCommandListeners (LexicalUpdates.ts:676:17)
    at dispatchCommand (LexicalUtils.ts:1111:10)
    at LexicalEditor.dispatchCommand (LexicalEditor.ts:692:12)
    at Array.<anonymous> (index.ts:764:23)
    at triggerCommandListeners (LexicalUpdates.ts:676:17)
```

### Solution: 
Update `$getNearestRootOrShadowRoot()` so it is able to handle root as param. 