### PR TITLE
Enable CodeHighlightNode to hold token metadata

### DIFF
--- a/packages/lexical-code/flow/LexicalCode.js.flow
+++ b/packages/lexical-code/flow/LexicalCode.js.flow
@@ -51,8 +51,14 @@ declare export function getCodeLanguages(): Array<string>;
 
 declare export class CodeHighlightNode extends TextNode {
   __highlightType: ?string;
-  constructor(text: string, highlightType?: string, key?: NodeKey): void;
+  constructor(
+    text: string,
+    highlightType?: string,
+    meta?: SerializableMeta,
+    key?: NodeKey,
+  ): void;
   static getType(): string;
+  getMeta(): SerializableMeta;
   // $FlowFixMe
   static clone(node: CodeHighlightNode): CodeHighlightNode;
   createDOM(config: EditorConfig): HTMLElement;
@@ -69,10 +75,23 @@ type TokenContent = string | Token | (string | Token)[];
 export interface Token {
   type: string;
   content: TokenContent;
+  meta?: SerializableMeta;
 }
 export interface Tokenizer {
   tokenize(code: string, language?: string): (string | Token)[];
 }
+
+type Serializable =
+  | number
+  | string
+  | boolean
+  | null
+  | SerializableMeta
+  | Serializable[];
+
+export type SerializableMeta = {
+  [key: string]: Serializable,
+};
 
 declare function getHighlightThemeClass(
   theme: EditorThemeClasses,
@@ -81,6 +100,7 @@ declare function getHighlightThemeClass(
 declare export function $createCodeHighlightNode(
   text: string,
   highlightType?: string,
+  meta?: SerializableMeta,
 ): CodeHighlightNode;
 declare export function $isCodeHighlightNode(
   node: ?LexicalNode,

--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -54,6 +54,7 @@ import {
   DEFAULT_CODE_LANGUAGE,
   getFirstCodeHighlightNodeOfLine,
   getLastCodeHighlightNodeOfLine,
+  SerializableMeta,
 } from './CodeHighlightNode';
 
 import {$isCodeNode, CodeNode} from './CodeNode';
@@ -63,6 +64,7 @@ type TokenContent = string | Token | (string | Token)[];
 export interface Token {
   type: string;
   content: TokenContent;
+  meta?: SerializableMeta | null | undefined;
 }
 
 export interface Tokenizer {
@@ -334,13 +336,15 @@ function getHighlightNodes(tokens: (string | Token)[]): LexicalNode[] {
     } else {
       const {content} = token;
       if (typeof content === 'string') {
-        nodes.push($createCodeHighlightNode(content, token.type));
+        nodes.push($createCodeHighlightNode(content, token.type, token.meta));
       } else if (
         Array.isArray(content) &&
         content.length === 1 &&
         typeof content[0] === 'string'
       ) {
-        nodes.push($createCodeHighlightNode(content[0], token.type));
+        nodes.push(
+          $createCodeHighlightNode(content[0], token.type, token.meta),
+        );
       } else if (Array.isArray(content)) {
         nodes.push(...getHighlightNodes(content));
       }

--- a/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
+++ b/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
@@ -6,7 +6,11 @@
  *
  */
 
-import {$createCodeNode} from '@lexical/code';
+import {
+  $createCodeHighlightNode,
+  $createCodeNode,
+  CodeHighlightNode,
+} from '@lexical/code';
 import {
   $createParagraphNode,
   $createTextNode,
@@ -133,6 +137,57 @@ describe('LexicalCodeNode tests', () => {
         expect(codeNode.__type).toEqual(createdCodeNode.__type);
         expect(codeNode.__parent).toEqual(createdCodeNode.__parent);
         expect(codeNode.__key).not.toEqual(createdCodeNode.__key);
+      });
+    });
+
+    test('CodeHighlightNode.exportJSON() should serialize meta field and CodeHighlightNode.importJSON() should deserialize original metadata', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const node = $createCodeHighlightNode('(', 'leftparen', {
+          anotherEndTokenId: 'ID4',
+          arr: [
+            1,
+            2,
+            3,
+            {
+              bar: 'foo',
+            },
+          ],
+          isError: false,
+          obj: {
+            foo: 'bar',
+          },
+          offset: 3,
+          tokenId: 'ID1',
+        });
+
+        const json = node.exportJSON();
+        expect(json.highlightType).toEqual('leftparen');
+        expect(json.meta).toEqual({
+          anotherEndTokenId: 'ID4',
+          arr: [
+            1,
+            2,
+            3,
+            {
+              bar: 'foo',
+            },
+          ],
+          isError: false,
+          obj: {
+            foo: 'bar',
+          },
+          offset: 3,
+          tokenId: 'ID1',
+        });
+        expect(json.type).toEqual('code-highlight');
+        expect(json.version).toEqual(1);
+
+        const deserializedNode = CodeHighlightNode.importJSON(json);
+        expect(deserializedNode.__text).toEqual(node.__text);
+        expect(deserializedNode.__highlightType).toEqual(node.__highlightType);
+        expect(deserializedNode.__meta).toEqual(node.__meta);
       });
     });
   });


### PR DESCRIPTION
Tokenize process sometimes produces some other metadata than the token type.
For example, which 2 tokens are pair of braces.

To enable keeping such information at CodeHighlightNode adds a field to hold serializable metadata.

### TODO

- [ ] test
 
