### PR TITLE
Add rel noopener by default

### DIFF
--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -334,7 +334,8 @@ export function toggleLink(
   url: null | string,
   attributes: LinkAttributes = {},
 ): void {
-  const {target, rel} = attributes;
+  const {target} = attributes;
+  const rel = attributes.rel === undefined ? 'noopener' : attributes.rel;
   const selection = $getSelection();
 
   if (!$isRangeSelection(selection)) {
@@ -371,7 +372,9 @@ export function toggleLink(
         if (target !== undefined) {
           linkNode.setTarget(target);
         }
-        linkNode.setRel(rel || 'noopener');
+        if (rel !== null) {
+          linkNode.setRel(rel);
+        }
         return;
       }
     }
@@ -396,8 +399,8 @@ export function toggleLink(
         if (target !== undefined) {
           parent.setTarget(target);
         }
-        if (rel !== undefined) {
-          parent.setRel(rel);
+        if (rel !== null) {
+          linkNode.setRel(rel);
         }
         return;
       }

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -371,9 +371,7 @@ export function toggleLink(
         if (target !== undefined) {
           linkNode.setTarget(target);
         }
-        if (rel !== undefined) {
-          linkNode.setRel(rel);
-        }
+        linkNode.setRel(rel || 'noopener');
         return;
       }
     }

--- a/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
@@ -168,7 +168,7 @@ test.describe('Auto Links', () => {
       page,
       html`
         <p dir="ltr">
-          <a href="https://" dir="ltr">
+          <a href="https://" dir="ltr" rel="noopener">
             <span data-lexical-text="true">hm</span>
           </a>
         </p>
@@ -183,7 +183,7 @@ test.describe('Auto Links', () => {
       page,
       html`
         <p dir="ltr">
-          <a href="https://" dir="ltr">
+          <a href="https://" dir="ltr" rel="noopener">
             <span data-lexical-text="true">https://facebook.com</span>
           </a>
         </p>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -1556,6 +1556,7 @@ test.describe('CopyAndPaste', () => {
         <p class="PlaygroundEditorTheme__paragraph">
           <a
             href="https://facebook.com"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">Facebook!</span>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -1423,6 +1423,7 @@ test.describe('CopyAndPaste', () => {
           dir="ltr">
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">Hello</span>
@@ -1430,6 +1431,7 @@ test.describe('CopyAndPaste', () => {
           <span data-lexical-text="true">World</span>
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">Hello</span>
@@ -2738,7 +2740,8 @@ test.describe('CopyAndPaste', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://lexical.dev">
+            href="https://lexical.dev"
+            rel="noopener">
             <span data-lexical-text="true">Lexical</span>
           </a>
           <span data-lexical-text="true">in the wild</span>

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -62,6 +62,7 @@ test.describe('Links', () => {
           dir="ltr">
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">Hello</span>
@@ -88,6 +89,7 @@ test.describe('Links', () => {
           dir="ltr">
           <a
             href="https://facebook.com"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">Hello</span>
@@ -196,7 +198,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">abc</span>
             <strong
               class="PlaygroundEditorTheme__textBold"
@@ -224,7 +227,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://facebook.com">
+            href="https://facebook.com"
+            rel="noopener">
             <span data-lexical-text="true">abc</span>
             <strong
               class="PlaygroundEditorTheme__textBold"
@@ -314,7 +318,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">abc</span>
             <strong
               class="PlaygroundEditorTheme__textBold"
@@ -342,7 +347,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://facebook.com">
+            href="https://facebook.com"
+            rel="noopener">
             <span data-lexical-text="true">abc</span>
             <strong
               class="PlaygroundEditorTheme__textBold"
@@ -384,7 +390,8 @@ test.describe('Links', () => {
             <a
               class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
               dir="ltr"
-              href="https://">
+              href="https://"
+              rel="noopener">
               <span data-lexical-text="true">hello</span>
             </a>
           </li>
@@ -403,7 +410,8 @@ test.describe('Links', () => {
             <a
               class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
               dir="ltr"
-              href="https://">
+              href="https://"
+              rel="noopener">
               <span data-lexical-text="true">hello</span>
             </a>
           </li>
@@ -433,7 +441,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">abc</span>
           </a>
           <span data-lexical-text="true">def</span>
@@ -453,7 +462,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">ab</span>
           </a>
         </p>
@@ -463,7 +473,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">c</span>
           </a>
           <span data-lexical-text="true">def</span>
@@ -483,13 +494,15 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">ab</span>
           </a>
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">c</span>
           </a>
           <span data-lexical-text="true">def</span>
@@ -516,7 +529,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">abc</span>
           </a>
           <span data-lexical-text="true"></span>
@@ -590,7 +604,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">a</span>
           </a>
           <span data-lexical-text="true">a</span>
@@ -670,7 +685,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">abc</span>
             <strong
               class="PlaygroundEditorTheme__textBold"
@@ -702,7 +718,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">abc</span>
             <strong
               class="PlaygroundEditorTheme__textBold"
@@ -749,7 +766,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">${linkText}</span>
           </a>
         </p>
@@ -775,7 +793,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">This is the</span>
             <strong
               class="PlaygroundEditorTheme__textBold"
@@ -803,7 +822,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">This is the</span>
             <strong
               class="PlaygroundEditorTheme__textBold"
@@ -839,7 +859,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">${linkText}</span>
           </a>
         </p>
@@ -866,7 +887,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">This is a</span>
             <strong
               class="PlaygroundEditorTheme__textBold"
@@ -896,7 +918,8 @@ test.describe('Links', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">This is the</span>
             <strong
               class="PlaygroundEditorTheme__textBold"
@@ -924,7 +947,8 @@ test.describe('Links', () => {
     <a
       class=\"PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr\"
       dir=\"ltr\"
-      href=\"https://\">
+      href=\"https://\"
+      rel=\"noopener\">
       <span data-lexical-text=\"true\">A link</span>
     </a>
   </p>`,
@@ -941,7 +965,8 @@ test.describe('Links', () => {
     <a
       class=\"PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr\"
       dir=\"ltr\"
-      href=\"https://facebook.com\">
+      href=\"https://facebook.com\"
+      rel=\"noopener\">
       <span data-lexical-text=\"true\">A link</span>
     </a>
   </p>`,
@@ -972,6 +997,7 @@ test.describe('Links', () => {
           dir="ltr">
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">An Awesome Website</span>
@@ -994,6 +1020,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">Hey, check this out:</span>
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">An Awesome Website</span>
@@ -1035,6 +1062,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">This is an</span>
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">Awesome Website</span>
@@ -1059,6 +1087,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">This is an</span>
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">Awesome Website</span>
@@ -1102,6 +1131,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">Hello</span>
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">world</span>
@@ -1136,6 +1166,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">Hello</span>
           <a
             href="https://facebook.com"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">world</span>
@@ -1214,6 +1245,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">Hello</span>
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">world</span>
@@ -1249,6 +1281,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">Hello</span>
           <a
             href="https://facebook.com"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">world</span>
@@ -1315,6 +1348,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">Hello</span>
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">world</span>
@@ -1337,6 +1371,7 @@ test.describe('Links', () => {
           <span data-lexical-text="true">Hello</span>
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">world</span>
@@ -1362,17 +1397,17 @@ test.describe('Links', () => {
       page,
       html`
         <p dir="ltr">
-          <a dir="ltr" href="https://">
+          <a dir="ltr" href="https://" rel="noopener">
             <span data-lexical-text="true">Hello world</span>
           </a>
         </p>
         <p dir="ltr">
-          <a dir="ltr" href="https://">
+          <a dir="ltr" href="https://" rel="noopener">
             <span data-lexical-text="true">Hello world</span>
           </a>
         </p>
         <p dir="ltr">
-          <a dir="ltr" href="https://">
+          <a dir="ltr" href="https://" rel="noopener">
             <span data-lexical-text="true">Hello world</span>
           </a>
         </p>
@@ -1399,12 +1434,12 @@ test.describe('Links', () => {
       page,
       html`
         <p dir="ltr">
-          <a dir="ltr" href="https://">
+          <a dir="ltr" href="https://" rel="noopener">
             <span data-lexical-text="true">Hello</span>
           </a>
         </p>
         <p dir="ltr">
-          <a dir="ltr" href="https://">
+          <a dir="ltr" href="https://" rel="noopener">
             <span data-lexical-text="true">awesome</span>
           </a>
           <span data-lexical-text="true">world</span>
@@ -1438,12 +1473,12 @@ test.describe('Links', () => {
       page,
       html`
         <p dir="ltr">
-          <a dir="ltr" href="https://">
+          <a dir="ltr" href="https://" rel="noopener">
             <span data-lexical-text="true">Hello</span>
           </a>
         </p>
         <p dir="ltr">
-          <a dir="ltr" href="https://">
+          <a dir="ltr" href="https://" rel="noopener">
             <strong data-lexical-text="true">awe</strong>
             <span data-lexical-text="true">some</span>
           </a>
@@ -1473,7 +1508,7 @@ test.describe('Links', () => {
       html`
         <p><br /></p>
         <p dir="ltr">
-          <a dir="ltr" href="https://">
+          <a dir="ltr" href="https://" rel="noopener">
             <span data-lexical-text="true">Hello awesome</span>
           </a>
           <span data-lexical-text="true">world</span>
@@ -1500,7 +1535,7 @@ test.describe('Links', () => {
       page,
       html`
         <p dir="ltr">
-          <a dir="ltr" href="https://">
+          <a dir="ltr" href="https://" rel="noopener">
             <span data-lexical-text="true">Hello awesome</span>
           </a>
         </p>

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -563,6 +563,7 @@ test.describe('Nested List', () => {
           <span data-lexical-text="true">One</span>
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">two</span>
@@ -579,7 +580,7 @@ test.describe('Nested List', () => {
 
     await assertHTML(
       page,
-      '<ul class="PlaygroundEditorTheme__ul"><li class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr" value="1"><span data-lexical-text="true">One </span><a href="https://" class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">two</span></a><span data-lexical-text="true"> three</span></li></ul>',
+      '<ul class="PlaygroundEditorTheme__ul"><li class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr" value="1"><span data-lexical-text="true">One </span><a href="https://" rel="noopener" class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">two</span></a><span data-lexical-text="true"> three</span></li></ul>',
     );
 
     await toggleBulletList(page);
@@ -593,6 +594,7 @@ test.describe('Nested List', () => {
           <span data-lexical-text="true">One</span>
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">two</span>

--- a/packages/lexical-playground/__tests__/regression/1083-backspace-with-element-at-front.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/1083-backspace-with-element-at-front.spec.mjs
@@ -44,6 +44,7 @@ test.describe('Regression test #1083', () => {
           dir="ltr">
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">Hello</span>
@@ -89,6 +90,7 @@ test.describe('Regression test #1083', () => {
           <span data-lexical-text="true">Say</span>
           <a
             href="https://"
+            rel="noopener"
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr">
             <span data-lexical-text="true">Hello</span>

--- a/packages/lexical-playground/__tests__/regression/3136-insert-nodes-adjacent-to-inline.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/3136-insert-nodes-adjacent-to-inline.spec.mjs
@@ -57,7 +57,8 @@ test.describe('Regression test #3136', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">link</span>
           </a>
         </p>
@@ -99,7 +100,8 @@ test.describe('Regression test #3136', () => {
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
             dir="ltr"
-            href="https://">
+            href="https://"
+            rel="noopener">
             <span data-lexical-text="true">link</span>
           </a>
           <span data-lexical-text="true">replaced</span>


### PR DESCRIPTION
This prevents lexical links from being vulnerable to reverse tabnabbing by default.