### PR TITLE
Add LexicalNodeEventPlugin to @lexical/react

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -83,6 +83,7 @@ module.name_mapper='^@lexical/react/LexicalTablePlugin' -> '<PROJECT_ROOT>/packa
 module.name_mapper='^@lexical/react/LexicalLinkPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalLinkPlugin.js.flow'
 module.name_mapper='^@lexical/react/LexicalAutoLinkPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalAutoLinkPlugin.js.flow'
 module.name_mapper='^@lexical/react/LexicalAutoEmbedPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalAutoEmbedPlugin.js.flow'
+module.name_mapper='^@lexical/react/LexicalNodeEventPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalNodeEventPlugin.js.flow'
 
 module.name_mapper='^@lexical/react/LexicalListPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalListPlugin.js.flow'
 module.name_mapper='^@lexical/react/LexicalCheckListPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalCheckListPlugin.js.flow'

--- a/packages/lexical-playground/src/ui/Modal.tsx
+++ b/packages/lexical-playground/src/ui/Modal.tsx
@@ -48,10 +48,11 @@ function PortalImpl({
         onClose();
       }
     };
-    if (modalRef.current !== null) {
-      modalOverlayElement = modalRef.current?.parentElement;
+    const modelElement = modalRef.current;
+    if (modelElement !== null) {
+      modalOverlayElement = modelElement.parentElement;
       if (modalOverlayElement !== null) {
-        modalOverlayElement?.addEventListener('click', clickOutsideHandler);
+        modalOverlayElement.addEventListener('click', clickOutsideHandler);
       }
     }
 

--- a/packages/lexical-playground/vite.config.js
+++ b/packages/lexical-playground/vite.config.js
@@ -141,6 +141,7 @@ const moduleResolution = [
   'LexicalAutoLinkPlugin',
   'LexicalAutoEmbedPlugin',
   'LexicalOnChangePlugin',
+  'LexicalNodeEventPlugin',
 ].forEach((module) => {
   let resolvedPath = path.resolve(`../lexical-react/src/${module}.ts`);
 

--- a/packages/lexical-playground/vite.prod.config.js
+++ b/packages/lexical-playground/vite.prod.config.js
@@ -141,6 +141,7 @@ const moduleResolution = [
   'LexicalAutoLinkPlugin',
   'LexicalAutoEmbedPlugin',
   'LexicalOnChangePlugin',
+  'LexicalNodeEventPlugin',
 ].forEach((module) => {
   let resolvedPath = path.resolve(`../lexical-react/dist/${module}.js`);
   moduleResolution.push({

--- a/packages/lexical-react/src/LexicalNodeEventPlugin.ts
+++ b/packages/lexical-react/src/LexicalNodeEventPlugin.ts
@@ -7,7 +7,12 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {type Klass, type LexicalNode, type NodeKey} from 'lexical';
+import {
+  type Klass,
+  type LexicalEditor,
+  type LexicalNode,
+  type NodeKey,
+} from 'lexical';
 import {useRef} from 'react';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
@@ -18,7 +23,11 @@ export function NodeEventPlugin({
 }: {
   nodeType: Klass<LexicalNode>;
   eventType: string;
-  eventListener: (event: Event, nodeKey: NodeKey) => void;
+  eventListener: (
+    event: Event,
+    editor: LexicalEditor,
+    nodeKey: NodeKey,
+  ) => void;
 }): null {
   const [editor] = useLexicalComposerContext();
   const listenerRef = useRef(eventListener);
@@ -33,7 +42,7 @@ export function NodeEventPlugin({
 
           if (mutation === 'created' && element !== null) {
             element.addEventListener(eventType, (event: Event) => {
-              listenerRef.current(event, key);
+              listenerRef.current(event, editor, key);
             });
           }
         }

--- a/packages/lexical-react/src/LexicalNodeEventPlugin.ts
+++ b/packages/lexical-react/src/LexicalNodeEventPlugin.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {type Klass, type LexicalNode, type NodeKey} from 'lexical';
+import {useRef} from 'react';
+import useLayoutEffect from 'shared/useLayoutEffect';
+
+export function NodeEventPlugin({
+  nodeType,
+  eventType,
+  eventListener,
+}: {
+  nodeType: Klass<LexicalNode>;
+  eventType: string;
+  eventListener: (event: Event, nodeKey: NodeKey) => void;
+}): null {
+  const [editor] = useLexicalComposerContext();
+  const listenerRef = useRef(eventListener);
+
+  listenerRef.current = eventListener;
+
+  useLayoutEffect(() => {
+    return editor.registerMutationListener(nodeType, (mutations) => {
+      editor.getEditorState().read(() => {
+        for (const [key, mutation] of mutations) {
+          const element: null | HTMLElement = editor.getElementByKey(key);
+
+          if (mutation === 'created' && element !== null) {
+            element.addEventListener(eventType, (event: Event) => {
+              listenerRef.current(event, key);
+            });
+          }
+        }
+      });
+    });
+    // wW intentionally don't respect changes to eventType.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor, nodeType]);
+
+  return null;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -114,6 +114,9 @@
       "@lexical/react/LexicalOnChangePlugin": [
         "./packages/lexical-react/src/LexicalOnChangePlugin.ts"
       ],
+      "@lexical/react/LexicalNodeEventPlugin": [
+        "./packages/lexical-react/src/LexicalNodeEventPlugin.ts"
+      ],
       "@lexical/react/LexicalHashtagPlugin": [
         "./packages/lexical-react/src/LexicalHashtagPlugin.ts"
       ],


### PR DESCRIPTION
This plugin makes it easy and simple to attach event listeners to specific types of Lexical node without needing to manually do the wiring.