### PR TITLE
Fix bug in scrollIntoViewIfNeeded

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2814,7 +2814,7 @@ export function updateDOMSelection(
       if (selectionTarget !== null) {
         // @ts-ignore Text nodes do have getBoundingClientRect
         const selectionRect = selectionTarget.getBoundingClientRect();
-        scrollIntoViewIfNeeded(editor, selectionRect, rootElement, tags);
+        scrollIntoViewIfNeeded(editor, selectionRect, rootElement);
       }
     }
 

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1134,11 +1134,18 @@ export function getElementByKeyOrThrow(
   return element;
 }
 
+export function getParentElement(element: HTMLElement): HTMLElement | null {
+  const parentElement =
+    (element as HTMLSlotElement).assignedSlot || element.parentElement;
+  return parentElement !== null && parentElement.nodeType === 11
+    ? ((parentElement as unknown as ShadowRoot).host as HTMLElement)
+    : parentElement;
+}
+
 export function scrollIntoViewIfNeeded(
   editor: LexicalEditor,
   selectionRect: DOMRect,
   rootElement: HTMLElement,
-  tags: Set<string>,
 ): void {
   const doc = rootElement.ownerDocument;
   const defaultView = doc.defaultView;
@@ -1181,7 +1188,10 @@ export function scrollIntoViewIfNeeded(
         currentBottom -= yOffset;
       }
     }
-    element = element.parentElement;
+    if (isBodyElement) {
+      break;
+    }
+    element = getParentElement(element);
   }
 }
 


### PR DESCRIPTION
This fixes two bugs reported:

- We were incorrectly finding the rects of the parents of the body element.
- We were not taking into account the Shadow DOM.