### PR TITLE
Ensure we do not render br after non inline decorators

### DIFF
--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -277,7 +277,7 @@ function isLastChildLineBreakOrDecorator(
 ): boolean {
   const childKey = children[children.length - 1];
   const node = nodeMap.get(childKey);
-  return $isLineBreakNode(node) || $isDecoratorNode(node);
+  return $isLineBreakNode(node) || ($isDecoratorNode(node) && node.isInline());
 }
 
 // If we end an element with a LineBreakNode, then we need to add an additional <br>


### PR DESCRIPTION
We already apply this logic in other places in the reconciler, so we just needed to apply it to one more place.