### PR TITLE
Add excalidraw plugin example

### DIFF
--- a/packages/lexical-website/docs/demos/plugins/excalidraw.md
+++ b/packages/lexical-website/docs/demos/plugins/excalidraw.md
@@ -1,0 +1,16 @@
+---
+id: "excalidraw"
+title: "Excalidraw Plugin"
+sidebar_label: "Excalidraw Plugin"
+---
+
+This page focuses on implementing the Excalidraw plugin and the code you need to embed Excalidraw into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+
+You can also add image resizing functionality to resize the plot, but it is not implemented in the below example to simplify the code. 
+
+<iframe src="https://codesandbox.io/embed/lexical-excalidraw-plugin-example-4q08cv?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/ExcalidrawPlugin.ts,/src/nodes/ExcalidrawNode.tsx&theme=dark&view=split"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-excalidraw-plugin-example"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>

--- a/packages/lexical-website/docs/demos/plugins/images.md
+++ b/packages/lexical-website/docs/demos/plugins/images.md
@@ -4,7 +4,7 @@ title: "Images Plugin"
 sidebar_label: "Images Plugin"
 ---
 
-This page focuses on the implementation of the images plugin and the code you need for image insertion from a sample or URL into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+This page focuses on the implementation of the images plugin and the code you need for image insertion from a sample or URL into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. Note that you can also embed GIFs.
 
 <iframe src="https://codesandbox.io/embed/lexical-image-plugin-example-iy2bc5?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/ImagePlugin.ts,/src/plugins/ImageToolbar.tsx&theme=dark&view=split"
      style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}


### PR DESCRIPTION
- [x] created a CodeSandbox example for the Excalidraw plugin [here](https://codesandbox.io/embed/lexical-excalidraw-plugin-example-4q08cv)
- [x] added a new page and the example on the website (under “/docs/demos/plugins/excalidraw”)

<img width="1440" alt="Excalidraw Plugin" src="https://user-images.githubusercontent.com/47840436/203642673-161c1945-403f-44e6-a087-2c7d855ad5a5.png">
<img width="1436" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/47840436/203642679-524c97c1-21d9-40aa-953b-02ab1ac3d46c.png">

**Problem**: the example works in the CodeSandbox itself but not when it is embedded. I am not sure what the problem is.

Issue https://github.com/facebook/lexical/issues/2886
