### PR TITLE
Fix a couple of bugs with Headings creation

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Headings.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Headings.spec.mjs
@@ -17,7 +17,10 @@ import {
 } from '../utils/index.mjs';
 
 test.describe('Headings', () => {
-  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+  test.beforeEach(({isPlainText, isCollab, page}) => {
+    test.skip(isPlainText);
+    initialize({isCollab, page});
+  });
 
   test('Stays as a heading when you backspace at the start of a heading with no previous sibling nodes present', async ({
     page,

--- a/packages/lexical-playground/__tests__/e2e/Headings.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Headings.spec.mjs
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {moveRight, moveToEditorBeginning} from '../keyboardShortcuts/index.mjs';
+import {
+  assertHTML,
+  click,
+  focusEditor,
+  html,
+  initialize,
+  test,
+} from '../utils/index.mjs';
+
+test.describe('Headings', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+
+  test('Stays as a heading when you backspace at the start of a heading with no previous sibling nodes present', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    await click(page, '.block-controls');
+    await click(page, '.dropdown .icon.h1');
+
+    await page.keyboard.type('Welcome to the playground');
+
+    await assertHTML(
+      page,
+      html`
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Welcome to the playground</span>
+        </h1>
+      `,
+    );
+
+    await moveToEditorBeginning(page);
+
+    await page.keyboard.press('Backspace');
+
+    await assertHTML(
+      page,
+      html`
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Welcome to the playground</span>
+        </h1>
+      `,
+    );
+  });
+
+  test('Stays as a heading when you press enter in the middle of a heading', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    await click(page, '.block-controls');
+    await click(page, '.dropdown .icon.h1');
+
+    await page.keyboard.type('Welcome to the playground');
+
+    await assertHTML(
+      page,
+      html`
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Welcome to the playground</span>
+        </h1>
+      `,
+    );
+
+    await moveToEditorBeginning(page);
+
+    await moveRight(page, 5);
+
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Welco</span>
+        </h1>
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">me to the playground</span>
+        </h1>
+      `,
+    );
+  });
+
+  test('Changes to a paragraphwhen you press enter at the end of a heading', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    await click(page, '.block-controls');
+    await click(page, '.dropdown .icon.h1');
+
+    await page.keyboard.type('Welcome to the playground');
+
+    await assertHTML(
+      page,
+      html`
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Welcome to the playground</span>
+        </h1>
+      `,
+    );
+
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Welcome to the playground</span>
+        </h1>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+});

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
@@ -11,7 +11,7 @@ import {
   $isHeadingNode,
   HeadingNode,
 } from '@lexical/rich-text';
-import {$createTextNode, $getRoot, ParagraphNode} from 'lexical';
+import {$createTextNode, $getRoot, $getSelection, ParagraphNode} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 
 const editorConfig = Object.freeze({
@@ -91,7 +91,8 @@ describe('LexicalHeadingNode tests', () => {
         '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><h1><br></h1></div>',
       );
       await editor.update(() => {
-        const result = headingNode.insertNewAfter();
+        const selection = $getSelection();
+        const result = headingNode.insertNewAfter(selection);
         expect(result).toBeInstanceOf(ParagraphNode);
         expect(result.getDirection()).toEqual(headingNode.getDirection());
       });
@@ -142,7 +143,8 @@ describe('LexicalHeadingNode tests', () => {
         `<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><h2 dir="ltr"><span data-lexical-text="true">${text}</span></h2></div>`,
       );
       await editor.update(() => {
-        const result = headingNode.insertNewAfter();
+        const selection = $getSelection();
+        const result = headingNode.insertNewAfter(selection);
         expect(result).toBeInstanceOf(ParagraphNode);
         expect(result.getDirection()).toEqual(headingNode.getDirection());
       });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -299,8 +299,9 @@ export class HeadingNode extends ElementNode {
 
   // Mutation
   insertNewAfter(selection?: RangeSelection): ParagraphNode | HeadingNode {
+    const selectionOffset = selection ? selection.anchor.offset : 0;
     const newElement =
-      selection && selection.anchor.offset < this.getTextContentSize()
+      selectionOffset < this.getTextContentSize() && selectionOffset > 0
         ? $createHeadingNode(this.getTag())
         : $createParagraphNode();
     const direction = this.getDirection();

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -298,9 +298,9 @@ export class HeadingNode extends ElementNode {
   }
 
   // Mutation
-  insertNewAfter(selection: RangeSelection): ParagraphNode | HeadingNode {
+  insertNewAfter(selection?: RangeSelection): ParagraphNode | HeadingNode {
     const newElement =
-      selection.anchor.offset < this.getTextContentSize()
+      selection && selection.anchor.offset < this.getTextContentSize()
         ? $createHeadingNode(this.getTag())
         : $createParagraphNode();
     const direction = this.getDirection();
@@ -309,9 +309,9 @@ export class HeadingNode extends ElementNode {
     return newElement;
   }
 
-  collapseAtStart(selection: RangeSelection): true {
+  collapseAtStart(selection?: RangeSelection): true {
     const newElement =
-      selection.anchor.offset < this.getTextContentSize()
+      selection && selection.anchor.offset < this.getTextContentSize()
         ? $createHeadingNode(this.getTag())
         : $createParagraphNode();
     const children = this.getChildren();

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -304,19 +304,26 @@ export class HeadingNode extends ElementNode {
         ? $createHeadingNode(this.getTag())
         : $createParagraphNode();
     const direction = this.getDirection();
+
     newElement.setDirection(direction);
     this.insertAfter(newElement);
+
     return newElement;
   }
 
-  collapseAtStart(selection?: RangeSelection): true {
-    const newElement =
-      selection && selection.anchor.offset < this.getTextContentSize()
-        ? $createHeadingNode(this.getTag())
-        : $createParagraphNode();
+  collapseAtStart(): true {
+    const previousSibling = this.getPreviousSibling();
+    const isPreviouSiblingEmpty =
+      !previousSibling ||
+      (previousSibling && previousSibling.getTextContentSize() === 0);
+    const newElement = isPreviouSiblingEmpty
+      ? $createHeadingNode(this.getTag())
+      : $createParagraphNode();
     const children = this.getChildren();
+
     children.forEach((child) => newElement.append(child));
     this.replace(newElement);
+
     return true;
   }
 

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -19,6 +19,7 @@ import type {
   NodeKey,
   ParagraphNode,
   PasteCommandType,
+  RangeSelection,
   SerializedElementNode,
   Spread,
   TextFormatType,
@@ -297,20 +298,25 @@ export class HeadingNode extends ElementNode {
   }
 
   // Mutation
-
-  insertNewAfter(): ParagraphNode {
-    const newElement = $createParagraphNode();
+  insertNewAfter(selection: RangeSelection): ParagraphNode | HeadingNode {
+    const newElement =
+      selection.anchor.offset < this.getTextContentSize()
+        ? $createHeadingNode(this.getTag())
+        : $createParagraphNode();
     const direction = this.getDirection();
     newElement.setDirection(direction);
     this.insertAfter(newElement);
     return newElement;
   }
 
-  collapseAtStart(): true {
-    const paragraph = $createParagraphNode();
+  collapseAtStart(selection: RangeSelection): true {
+    const newElement =
+      selection.anchor.offset < this.getTextContentSize()
+        ? $createHeadingNode(this.getTag())
+        : $createParagraphNode();
     const children = this.getChildren();
-    children.forEach((child) => paragraph.append(child));
-    this.replace(paragraph);
+    children.forEach((child) => newElement.append(child));
+    this.replace(newElement);
     return true;
   }
 

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -494,7 +494,6 @@ type TextPointType = {
   getNode: () => TextNode,
   set: (key: NodeKey, offset: number, type: 'text' | 'element') => void,
   getCharacterOffset: () => number,
-  isAtNodeEnd: () => boolean,
 };
 export type ElementPoint = ElementPointType;
 type ElementPointType = {
@@ -505,7 +504,6 @@ type ElementPointType = {
   isBefore: (PointType) => boolean,
   getNode: () => ElementNode,
   set: (key: NodeKey, offset: number, type: 'text' | 'element') => void,
-  isAtNodeEnd: () => boolean,
 };
 export type Point = PointType;
 type PointType = TextPointType | ElementPointType;

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -70,7 +70,6 @@ export type TextPointType = {
   _selection: RangeSelection | GridSelection;
   getNode: () => TextNode;
   is: (point: PointType) => boolean;
-  isAtNodeEnd: () => boolean;
   isBefore: (point: PointType) => boolean;
   key: NodeKey;
   offset: number;
@@ -82,7 +81,6 @@ export type ElementPointType = {
   _selection: RangeSelection | GridSelection;
   getNode: () => ElementNode;
   is: (point: PointType) => boolean;
-  isAtNodeEnd: () => boolean;
   isBefore: (point: PointType) => boolean;
   key: NodeKey;
   offset: number;
@@ -104,6 +102,7 @@ export class Point {
     this.offset = offset;
     this.type = type;
   }
+
   is(point: PointType): boolean {
     return (
       this.key === point.key &&
@@ -111,6 +110,7 @@ export class Point {
       this.type === point.type
     );
   }
+
   isBefore(b: PointType): boolean {
     let aNode = this.getNode();
     let bNode = b.getNode();
@@ -130,6 +130,7 @@ export class Point {
     }
     return aNode.isBefore(bNode);
   }
+
   getNode(): LexicalNode {
     const key = this.key;
     const node = $getNodeByKey(key);
@@ -138,6 +139,7 @@ export class Point {
     }
     return node;
   }
+
   set(key: NodeKey, offset: number, type: 'text' | 'element'): void {
     const selection = this._selection;
     const oldKey = this.key;


### PR DESCRIPTION
On backspace at the start of heading, they shouldn't collapse into a paragraph, and on enter in the middle of a heading, they should stay as a heading.

Closes #1170 #1158

Before 

https://user-images.githubusercontent.com/7748470/204026666-11d75e18-8890-438b-b284-f01853005c62.mov



After

https://user-images.githubusercontent.com/7748470/204026688-55507bcc-3e83-4b5d-91c4-252789c2f894.mov


