### PR TITLE
Adds type exports for various SerializedNodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "playwright": "1.23.0-next-alpha-trueadm-fork",
         "prettier": "^2.3.2",
         "prettier-plugin-organize-attributes": "^0.0.5",
+        "prettier-plugin-organize-imports": "^3.2.1",
         "react-test-renderer": "^17.0.2",
         "rollup": "^2.75.5",
         "tmp": "^0.2.1",
@@ -16825,6 +16826,26 @@
       },
       "peerDependencies": {
         "prettier": "^2.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.1.tgz",
+      "integrity": "sha512-bty7C2Ecard5EOXirtzeCAqj4FU4epeuWrQt/Z+sh8UVEpBlBZ3m3KNPz2kFu7KgRTQx/C9o4/TdquPD1jOqjQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@volar/vue-language-plugin-pug": "^1.0.4",
+        "@volar/vue-typescript": "^1.0.4",
+        "prettier": ">=2.0",
+        "typescript": ">=2.9"
+      },
+      "peerDependenciesMeta": {
+        "@volar/vue-language-plugin-pug": {
+          "optional": true
+        },
+        "@volar/vue-typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-error": {
@@ -36172,6 +36193,12 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/prettier-plugin-organize-attributes/-/prettier-plugin-organize-attributes-0.0.5.tgz",
       "integrity": "sha512-dSts16q8wd+oq8Zwk5mwmYXo1aN3B+ZkEJqx/ar5fedNHdOvx7S4XDMH/pNK7rmBW0bPXkp/kJX5gAANsWzh3A==",
+      "dev": true
+    },
+    "prettier-plugin-organize-imports": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.1.tgz",
+      "integrity": "sha512-bty7C2Ecard5EOXirtzeCAqj4FU4epeuWrQt/Z+sh8UVEpBlBZ3m3KNPz2kFu7KgRTQx/C9o4/TdquPD1jOqjQ==",
       "dev": true
     },
     "pretty-error": {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "playwright": "1.23.0-next-alpha-trueadm-fork",
     "prettier": "^2.3.2",
     "prettier-plugin-organize-attributes": "^0.0.5",
+    "prettier-plugin-organize-imports": "^3.2.1",
     "react-test-renderer": "^17.0.2",
     "rollup": "^2.75.5",
     "tmp": "^0.2.1",

--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -10,27 +10,27 @@
 import {
   $applyNodeReplacement,
   $isLineBreakNode,
+  TextNode,
   type EditorConfig,
   type EditorThemeClasses,
   type LexicalNode,
   type NodeKey,
   type SerializedTextNode,
   type Spread,
-  TextNode,
 } from 'lexical';
 
 import * as Prism from 'prismjs';
 
-import 'prismjs/components/prism-clike';
-import 'prismjs/components/prism-javascript';
-import 'prismjs/components/prism-markup';
-import 'prismjs/components/prism-markdown';
 import 'prismjs/components/prism-c';
+import 'prismjs/components/prism-clike';
 import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-markdown';
+import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-objectivec';
-import 'prismjs/components/prism-sql';
 import 'prismjs/components/prism-python';
 import 'prismjs/components/prism-rust';
+import 'prismjs/components/prism-sql';
 import 'prismjs/components/prism-swift';
 
 import {

--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -16,16 +16,16 @@ import type {
 
 import * as Prism from 'prismjs';
 
-import 'prismjs/components/prism-clike';
-import 'prismjs/components/prism-javascript';
-import 'prismjs/components/prism-markup';
-import 'prismjs/components/prism-markdown';
 import 'prismjs/components/prism-c';
+import 'prismjs/components/prism-clike';
 import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-markdown';
+import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-objectivec';
-import 'prismjs/components/prism-sql';
 import 'prismjs/components/prism-python';
 import 'prismjs/components/prism-rust';
+import 'prismjs/components/prism-sql';
 import 'prismjs/components/prism-swift';
 
 import {mergeRegister} from '@lexical/utils';

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -47,7 +47,7 @@ import {
 } from './CodeHighlightNode';
 import * as Prism from 'prismjs';
 
-type SerializedCodeNode = Spread<
+export type SerializedCodeNode = Spread<
   {
     language: string | null | undefined;
     type: 'code';

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -7,6 +7,7 @@
  */
 
 // eslint-disable-next-line simple-import-sort/imports
+import type {CodeHighlightNode} from '@lexical/code';
 import type {
   DOMConversionMap,
   DOMConversionOutput,
@@ -18,18 +19,17 @@ import type {
   SerializedElementNode,
   Spread,
 } from 'lexical';
-import type {CodeHighlightNode} from '@lexical/code';
 
-import 'prismjs/components/prism-clike';
-import 'prismjs/components/prism-javascript';
-import 'prismjs/components/prism-markup';
-import 'prismjs/components/prism-markdown';
 import 'prismjs/components/prism-c';
+import 'prismjs/components/prism-clike';
 import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-markdown';
+import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-objectivec';
-import 'prismjs/components/prism-sql';
 import 'prismjs/components/prism-python';
 import 'prismjs/components/prism-rust';
+import 'prismjs/components/prism-sql';
 import 'prismjs/components/prism-swift';
 
 import {addClassNamesToElement} from '@lexical/utils';
@@ -41,11 +41,11 @@ import {
   $isRangeSelection,
   ElementNode,
 } from 'lexical';
+import * as Prism from 'prismjs';
 import {
   $createCodeHighlightNode,
   getFirstCodeHighlightNodeOfLine,
 } from './CodeHighlightNode';
-import * as Prism from 'prismjs';
 
 export type SerializedCodeNode = Spread<
   {

--- a/packages/lexical-code/src/index.ts
+++ b/packages/lexical-code/src/index.ts
@@ -28,4 +28,9 @@ export {
   getLastCodeHighlightNodeOfLine,
   normalizeCodeLang,
 } from './CodeHighlightNode';
-export {$createCodeNode, $isCodeNode, CodeNode} from './CodeNode';
+export {
+  $createCodeNode,
+  $isCodeNode,
+  CodeNode,
+  SerializedCodeNode,
+} from './CodeNode';

--- a/packages/lexical-code/src/index.ts
+++ b/packages/lexical-code/src/index.ts
@@ -17,9 +17,9 @@ export {
 export {
   $createCodeHighlightNode,
   $isCodeHighlightNode,
+  CodeHighlightNode,
   CODE_LANGUAGE_FRIENDLY_NAME_MAP,
   CODE_LANGUAGE_MAP,
-  CodeHighlightNode,
   DEFAULT_CODE_LANGUAGE,
   getCodeLanguages,
   getDefaultCodeLanguage,

--- a/packages/lexical-devtools/src/components/App/index.tsx
+++ b/packages/lexical-devtools/src/components/App/index.tsx
@@ -12,7 +12,6 @@ import {
   DevToolsTree,
   NodeProperties,
 } from 'packages/lexical-devtools/types';
-import * as React from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 import InspectedElementView from '../InspectedElementView';

--- a/packages/lexical-devtools/src/components/InspectedElementRow/index.tsx
+++ b/packages/lexical-devtools/src/components/InspectedElementRow/index.tsx
@@ -8,7 +8,6 @@
 import './index.css';
 
 import {NodeProperty} from 'packages/lexical-devtools/types';
-import * as React from 'react';
 
 function InspectedElementRow({
   propName,

--- a/packages/lexical-devtools/src/components/InspectedElementView/index.tsx
+++ b/packages/lexical-devtools/src/components/InspectedElementView/index.tsx
@@ -8,7 +8,6 @@
 import './index.css';
 
 import {NodeProperties} from 'packages/lexical-devtools/types';
-import * as React from 'react';
 
 import InspectedElementRow from '../InspectedElementRow';
 

--- a/packages/lexical-devtools/src/components/SelectionView/index.tsx
+++ b/packages/lexical-devtools/src/components/SelectionView/index.tsx
@@ -8,7 +8,6 @@
 import './index.css';
 
 import {DevToolsSelection} from 'packages/lexical-devtools/types';
-import * as React from 'react';
 
 function SelectionView({selection}: {selection: DevToolsSelection | null}) {
   const anchor =

--- a/packages/lexical-devtools/src/components/TimeTravelView/index.tsx
+++ b/packages/lexical-devtools/src/components/TimeTravelView/index.tsx
@@ -7,8 +7,6 @@
  */
 import './index.css';
 
-import * as React from 'react';
-
 function TimeTravelView() {
   return <div className="time-travel-view" />;
 }

--- a/packages/lexical-devtools/src/components/TreeView/index.tsx
+++ b/packages/lexical-devtools/src/components/TreeView/index.tsx
@@ -12,7 +12,6 @@ import {
   DevToolsTree,
   NodeProperties,
 } from 'packages/lexical-devtools/types';
-import * as React from 'react';
 
 import TreeNode from '../TreeNode';
 

--- a/packages/lexical-devtools/src/inject/index.ts
+++ b/packages/lexical-devtools/src/inject/index.ts
@@ -6,7 +6,6 @@
  *
  */
 import {EditorState, NodeSelection} from 'lexical';
-import {PointType} from 'packages/lexical/src/LexicalSelection';
 import {
   GridSelectionJSON,
   LexicalHTMLElement,
@@ -14,6 +13,7 @@ import {
   PointTypeJSON,
   RangeSelectionJSON,
 } from 'packages/lexical-devtools/types';
+import {PointType} from 'packages/lexical/src/LexicalSelection';
 
 let lexical: boolean;
 let editorDOMNode: LexicalHTMLElement | null, editorKey: string | null;

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -24,11 +24,10 @@ import {
   SerializedTextNode,
   UNDO_COMMAND,
 } from 'lexical/src';
-import {TestComposer} from 'lexical/src/__tests__/utils';
 import {$getRoot, $setSelection} from 'lexical/src/LexicalUtils';
 import {$createParagraphNode} from 'lexical/src/nodes/LexicalParagraphNode';
 import {$createTextNode} from 'lexical/src/nodes/LexicalTextNode';
-import React from 'react';
+import {TestComposer} from 'lexical/src/__tests__/utils';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import type {ListNode} from './';
 import type {
   DOMConversionMap,
   DOMConversionOutput,
@@ -21,6 +20,7 @@ import type {
   SerializedElementNode,
   Spread,
 } from 'lexical';
+import type {ListNode} from './';
 
 import {
   addClassNamesToElement,

--- a/packages/lexical-list/src/index.ts
+++ b/packages/lexical-list/src/index.ts
@@ -7,9 +7,9 @@
  *
  */
 
+import type {LexicalCommand} from 'lexical';
 import type {SerializedListItemNode} from './LexicalListItemNode';
 import type {ListType, SerializedListNode} from './LexicalListNode';
-import type {LexicalCommand} from 'lexical';
 
 import {createCommand} from 'lexical';
 

--- a/packages/lexical-mark/src/index.ts
+++ b/packages/lexical-mark/src/index.ts
@@ -7,8 +7,8 @@
  *
  */
 
-import type {SerializedMarkNode} from './MarkNode';
 import type {LexicalNode, RangeSelection, TextNode} from 'lexical';
+import type {SerializedMarkNode} from './MarkNode';
 
 import {$isElementNode, $isTextNode} from 'lexical';
 

--- a/packages/lexical-markdown/src/__tests__/unit/MarkdownImport.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/MarkdownImport.test.ts
@@ -9,10 +9,10 @@
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 
 import {$createTextNode, $getRoot} from 'lexical';
-import {ImageNode} from './../../../../lexical-playground/src/nodes/ImageNode';
-import {EquationNode} from './../../../../lexical-playground/src/nodes/EquationNode';
-import {createMarkdownImport} from './../../MarkdownImport';
 import {ELEMENT_TRANSFORMERS, TEXT_FORMAT_TRANSFORMERS} from './../..';
+import {EquationNode} from './../../../../lexical-playground/src/nodes/EquationNode';
+import {ImageNode} from './../../../../lexical-playground/src/nodes/ImageNode';
+import {createMarkdownImport} from './../../MarkdownImport';
 import {TextMatchTransformer, Transformer} from './../../MarkdownTransformers';
 
 const URL =

--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -11,7 +11,6 @@ import {$createListItemNode, $createListNode} from '@lexical/list';
 import {LexicalComposer} from '@lexical/react/LexicalComposer';
 import {$createHeadingNode, $createQuoteNode} from '@lexical/rich-text';
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
-import * as React from 'react';
 
 import {isDevPlayground} from './appSettings';
 import {SettingsContext, useSettings} from './context/SettingsContext';

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -18,7 +18,6 @@ import {ListPlugin} from '@lexical/react/LexicalListPlugin';
 import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
 import {TablePlugin} from '@lexical/react/LexicalTablePlugin';
-import * as React from 'react';
 import {useState} from 'react';
 
 import {createWebsocketProvider} from './collaboration';

--- a/packages/lexical-playground/src/Settings.tsx
+++ b/packages/lexical-playground/src/Settings.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import * as React from 'react';
 import {useMemo, useState} from 'react';
 
 import {isDevPlayground} from './appSettings';

--- a/packages/lexical-playground/src/hooks/useLexicalEditable.ts
+++ b/packages/lexical-playground/src/hooks/useLexicalEditable.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import type {LexicalSubscription} from './useLexicalSubscription';
 import type {LexicalEditor} from 'lexical';
+import type {LexicalSubscription} from './useLexicalSubscription';
 
 import useLexicalSubscription from './useLexicalSubscription';
 

--- a/packages/lexical-playground/src/hooks/useModal.tsx
+++ b/packages/lexical-playground/src/hooks/useModal.tsx
@@ -7,7 +7,6 @@
  */
 
 import {useCallback, useMemo, useState} from 'react';
-import * as React from 'react';
 
 import Modal from '../ui/Modal';
 

--- a/packages/lexical-playground/src/index.tsx
+++ b/packages/lexical-playground/src/index.tsx
@@ -6,8 +6,8 @@
  *
  */
 
-import './setupEnv';
 import './index.css';
+import './setupEnv';
 
 import * as React from 'react';
 import {createRoot} from 'react-dom/client';

--- a/packages/lexical-playground/src/nodes/AutocompleteNode.tsx
+++ b/packages/lexical-playground/src/nodes/AutocompleteNode.tsx
@@ -14,7 +14,6 @@ import {
   NodeKey,
   SerializedLexicalNode,
 } from 'lexical';
-import * as React from 'react';
 
 import {useSharedAutocompleteContext} from '../context/SharedAutocompleteContext';
 import {uuid as UUID} from '../plugins/AutocompletePlugin';

--- a/packages/lexical-playground/src/nodes/EquationComponent.tsx
+++ b/packages/lexical-playground/src/nodes/EquationComponent.tsx
@@ -18,7 +18,6 @@ import {
   KEY_ESCAPE_COMMAND,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
-import * as React from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 import EquationEditor from '../ui/EquationEditor';

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -6,8 +6,8 @@
  *
  */
 
-import type {ExcalidrawElementFragment} from './ExcalidrawModal';
 import type {NodeKey} from 'lexical';
+import type {ExcalidrawElementFragment} from './ExcalidrawModal';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
@@ -22,10 +22,9 @@ import {
   KEY_DELETE_COMMAND,
 } from 'lexical';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import * as React from 'react';
 
-import ImageResizer from '../../ui/ImageResizer';
 import {$isExcalidrawNode} from '.';
+import ImageResizer from '../../ui/ImageResizer';
 import ExcalidrawImage from './ExcalidrawImage';
 import ExcalidrawModal from './ExcalidrawModal';
 

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
@@ -12,7 +12,6 @@ import {
   NonDeleted,
 } from '@excalidraw/excalidraw/types/element/types';
 import {AppState} from '@excalidraw/excalidraw/types/types';
-import * as React from 'react';
 import {useEffect, useState} from 'react';
 
 type ImageType = 'svg' | 'canvas';

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
@@ -9,7 +9,6 @@
 import './ExcalidrawModal.css';
 
 import Excalidraw from '@excalidraw/excalidraw';
-import * as React from 'react';
 import {ReactPortal, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 

--- a/packages/lexical-playground/src/nodes/FigmaNode.tsx
+++ b/packages/lexical-playground/src/nodes/FigmaNode.tsx
@@ -20,7 +20,6 @@ import {
   DecoratorBlockNode,
   SerializedDecoratorBlockNode,
 } from '@lexical/react/LexicalDecoratorBlockNode';
-import * as React from 'react';
 
 type FigmaComponentProps = Readonly<{
   className: Readonly<{

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -40,7 +40,6 @@ import {
   KEY_ESCAPE_COMMAND,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
-import * as React from 'react';
 import {Suspense, useCallback, useEffect, useRef, useState} from 'react';
 
 import {createWebsocketProvider} from '../collaboration';

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -9,6 +9,8 @@
 import type {Spread} from 'lexical';
 
 import {
+  $applyNodeReplacement,
+  TextNode,
   type DOMConversionMap,
   type DOMConversionOutput,
   type DOMExportOutput,
@@ -16,8 +18,6 @@ import {
   type LexicalNode,
   type NodeKey,
   type SerializedTextNode,
-  $applyNodeReplacement,
-  TextNode,
 } from 'lexical';
 
 export type SerializedMentionNode = Spread<

--- a/packages/lexical-playground/src/nodes/PollComponent.tsx
+++ b/packages/lexical-playground/src/nodes/PollComponent.tsx
@@ -27,7 +27,6 @@ import {
   NodeSelection,
   RangeSelection,
 } from 'lexical';
-import * as React from 'react';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import Button from '../ui/Button';

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -18,7 +18,6 @@ import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {LexicalNestedComposer} from '@lexical/react/LexicalNestedComposer';
 import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
 import {$getNodeByKey} from 'lexical';
-import * as React from 'react';
 import {useEffect, useRef} from 'react';
 import useLayoutEffect from 'shared/useLayoutEffect';
 

--- a/packages/lexical-playground/src/nodes/TableComponent.tsx
+++ b/packages/lexical-playground/src/nodes/TableComponent.tsx
@@ -55,7 +55,6 @@ import {
   useRef,
   useState,
 } from 'react';
-import * as React from 'react';
 import {createPortal} from 'react-dom';
 import {IS_APPLE} from 'shared/environment';
 

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -23,7 +23,6 @@ import {
   DecoratorBlockNode,
   SerializedDecoratorBlockNode,
 } from '@lexical/react/LexicalDecoratorBlockNode';
-import * as React from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 const WIDGET_SCRIPT_URL = 'https://platform.twitter.com/widgets.js';

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -20,7 +20,6 @@ import {
   DecoratorBlockNode,
   SerializedDecoratorBlockNode,
 } from '@lexical/react/LexicalDecoratorBlockNode';
-import * as React from 'react';
 
 type YouTubeComponentProps = Readonly<{
   className: Readonly<{

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -25,7 +25,6 @@ import {
   CLEAR_EDITOR_COMMAND,
   COMMAND_PRIORITY_EDITOR,
 } from 'lexical';
-import * as React from 'react';
 import {useCallback, useEffect, useState} from 'react';
 
 import useModal from '../../hooks/useModal';

--- a/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
@@ -17,7 +17,6 @@ import {
 } from '@lexical/react/LexicalAutoEmbedPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useState} from 'react';
-import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import useModal from '../../hooks/useModal';

--- a/packages/lexical-playground/src/plugins/AutoLinkPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoLinkPlugin/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import {AutoLinkPlugin} from '@lexical/react/LexicalAutoLinkPlugin';
-import * as React from 'react';
 
 const URL_MATCHER =
   /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/CopyButton/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/CopyButton/index.tsx
@@ -12,7 +12,6 @@ import {
   $setSelection,
   LexicalEditor,
 } from 'lexical';
-import * as React from 'react';
 import {useState} from 'react';
 
 import {useDebounce} from '../../utils';

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/PrettierButton/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/PrettierButton/index.tsx
@@ -15,7 +15,6 @@ import * as htmlParser from 'prettier/parser-html';
 import * as markdownParser from 'prettier/parser-markdown';
 import * as cssParser from 'prettier/parser-postcss';
 import {format} from 'prettier/standalone';
-import * as React from 'react';
 import {useState} from 'react';
 
 interface Props {

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
@@ -16,8 +16,8 @@ import {
 } from '@lexical/code';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$getNearestNodeFromDOMNode} from 'lexical';
-import {useEffect, useRef, useState} from 'react';
 import * as React from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 
 import {CopyButton} from './components/CopyButton';

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -47,7 +47,6 @@ import {
   KEY_ESCAPE_COMMAND,
 } from 'lexical';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import * as React from 'react';
 import {createPortal} from 'react-dom';
 import useLayoutEffect from 'shared/useLayoutEffect';
 import {WebsocketProvider} from 'y-websocket';

--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -31,7 +31,6 @@ import {
   TextNode,
 } from 'lexical';
 import {useCallback, useMemo, useState} from 'react';
-import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import useModal from '../../hooks/useModal';
@@ -40,7 +39,7 @@ import {EmbedConfigs} from '../AutoEmbedPlugin';
 import {INSERT_COLLAPSIBLE_COMMAND} from '../CollapsiblePlugin';
 import {InsertEquationDialog} from '../EquationsPlugin';
 import {INSERT_EXCALIDRAW_COMMAND} from '../ExcalidrawPlugin';
-import {INSERT_IMAGE_COMMAND, InsertImageDialog} from '../ImagesPlugin';
+import {InsertImageDialog, INSERT_IMAGE_COMMAND} from '../ImagesPlugin';
 import {InsertPollDialog} from '../PollPlugin';
 import {InsertTableDialog} from '../TablePlugin';
 

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -19,7 +19,6 @@ import {
   DROP_COMMAND,
   LexicalEditor,
 } from 'lexical';
-import * as React from 'react';
 import {DragEvent as ReactDragEvent, useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 

--- a/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
@@ -18,7 +18,6 @@ import {
   $isRangeSelection,
   TextNode,
 } from 'lexical';
-import * as React from 'react';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import * as ReactDOM from 'react-dom';
 

--- a/packages/lexical-playground/src/plugins/EquationsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/EquationsPlugin/index.tsx
@@ -20,7 +20,6 @@ import {
   LexicalEditor,
 } from 'lexical';
 import {useCallback, useEffect} from 'react';
-import * as React from 'react';
 
 import {$createEquationNode, EquationNode} from '../../nodes/EquationNode';
 import KatexEquationAlterer from '../../ui/KatexEquationAlterer';

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -22,7 +22,6 @@ import {
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import {useCallback, useEffect, useRef, useState} from 'react';
-import * as React from 'react';
 import {createPortal} from 'react-dom';
 
 import LinkPreview from '../../ui/LinkPreview';

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -22,7 +22,6 @@ import {
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import {useCallback, useEffect, useRef, useState} from 'react';
-import * as React from 'react';
 import {createPortal} from 'react-dom';
 
 import {getDOMRangeRect} from '../../utils/getDOMRangeRect';

--- a/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
@@ -26,7 +26,6 @@ import {
   LexicalEditor,
 } from 'lexical';
 import {useEffect, useRef, useState} from 'react';
-import * as React from 'react';
 import getSelection from 'shared/getDOMSelection';
 
 import landscapeImage from '../../images/landscape.jpg';

--- a/packages/lexical-playground/src/plugins/LinkPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/LinkPlugin/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import {LinkPlugin as LexicalLinkPlugin} from '@lexical/react/LexicalLinkPlugin';
-import * as React from 'react';
 
 import {validateUrl} from '../../utils/url';
 

--- a/packages/lexical-playground/src/plugins/MarkdownShortcutPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/MarkdownShortcutPlugin/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import {MarkdownShortcutPlugin} from '@lexical/react/LexicalMarkdownShortcutPlugin';
-import * as React from 'react';
 
 import {PLAYGROUND_TRANSFORMERS} from '../MarkdownTransformers';
 

--- a/packages/lexical-playground/src/plugins/MentionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/MentionsPlugin/index.tsx
@@ -15,7 +15,6 @@ import {
 } from '@lexical/react/LexicalTypeaheadMenuPlugin';
 import {TextNode} from 'lexical';
 import {useCallback, useEffect, useMemo, useState} from 'react';
-import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import {$createMentionNode} from '../../nodes/MentionNode';

--- a/packages/lexical-playground/src/plugins/PasteLogPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/PasteLogPlugin/index.tsx
@@ -8,7 +8,6 @@
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {COMMAND_PRIORITY_NORMAL, PASTE_COMMAND} from 'lexical';
-import * as React from 'react';
 import {useEffect, useState} from 'react';
 
 export default function PasteLogPlugin(): JSX.Element {

--- a/packages/lexical-playground/src/plugins/PollPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/PollPlugin/index.tsx
@@ -18,7 +18,6 @@ import {
   LexicalEditor,
 } from 'lexical';
 import {useEffect, useState} from 'react';
-import * as React from 'react';
 
 import {$createPollNode, PollNode} from '../../nodes/PollNode';
 import Button from '../../ui/Button';

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -30,7 +30,6 @@ import {
   $isRangeSelection,
   DEPRECATED_$isGridSelection,
 } from 'lexical';
-import * as React from 'react';
 import {ReactPortal, useCallback, useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -26,7 +26,6 @@ import {
   DEPRECATED_$isGridSelection,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
-import * as React from 'react';
 import {
   MouseEventHandler,
   ReactPortal,

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -13,7 +13,6 @@ import './index.css';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import LexicalTableOfContents__EXPERIMENTAL from '@lexical/react/LexicalTableOfContents__EXPERIMENTAL';
 import {useEffect, useRef, useState} from 'react';
-import * as React from 'react';
 
 const MARGIN_ABOVE_EDITOR = 624;
 const HEADING_WIDTH = 9;

--- a/packages/lexical-playground/src/plugins/TablePlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TablePlugin.tsx
@@ -23,8 +23,8 @@ import {
   LexicalEditor,
   LexicalNode,
 } from 'lexical';
-import {createContext, useContext, useEffect, useMemo, useState} from 'react';
 import * as React from 'react';
+import {createContext, useContext, useEffect, useMemo, useState} from 'react';
 import invariant from 'shared/invariant';
 
 import {$createTableNodeWithDimensions, TableNode} from '../nodes/TableNode';

--- a/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
@@ -15,7 +15,6 @@ import type {
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
-import * as React from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {IS_APPLE} from 'shared/environment';
 import useLayoutEffect from 'shared/useLayoutEffect';

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -68,7 +68,6 @@ import {
   UNDO_COMMAND,
 } from 'lexical';
 import {useCallback, useEffect, useState} from 'react';
-import * as React from 'react';
 import {IS_APPLE} from 'shared/environment';
 
 import useModal from '../../hooks/useModal';
@@ -83,9 +82,9 @@ import {INSERT_COLLAPSIBLE_COMMAND} from '../CollapsiblePlugin';
 import {InsertEquationDialog} from '../EquationsPlugin';
 import {INSERT_EXCALIDRAW_COMMAND} from '../ExcalidrawPlugin';
 import {
-  INSERT_IMAGE_COMMAND,
   InsertImageDialog,
   InsertImagePayload,
+  INSERT_IMAGE_COMMAND,
 } from '../ImagesPlugin';
 import {InsertPollDialog} from '../PollPlugin';
 import {InsertNewTableDialog, InsertTableDialog} from '../TablePlugin';

--- a/packages/lexical-playground/src/plugins/TreeViewPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TreeViewPlugin/index.tsx
@@ -8,7 +8,6 @@
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {TreeView} from '@lexical/react/LexicalTreeView';
-import * as React from 'react';
 
 export default function TreeViewPlugin(): JSX.Element {
   const [editor] = useLexicalComposerContext();

--- a/packages/lexical-playground/src/ui/Button.tsx
+++ b/packages/lexical-playground/src/ui/Button.tsx
@@ -8,7 +8,6 @@
 
 import './Button.css';
 
-import * as React from 'react';
 import {ReactNode} from 'react';
 
 import joinClasses from '../utils/join-classes';

--- a/packages/lexical-playground/src/ui/ColorPicker.tsx
+++ b/packages/lexical-playground/src/ui/ColorPicker.tsx
@@ -8,8 +8,8 @@
 
 import './ColorPicker.css';
 
-import {ReactNode, useEffect, useMemo, useRef, useState} from 'react';
 import * as React from 'react';
+import {ReactNode, useEffect, useMemo, useRef, useState} from 'react';
 
 import DropDown from './DropDown';
 import TextInput from './TextInput';

--- a/packages/lexical-playground/src/ui/ContentEditable.tsx
+++ b/packages/lexical-playground/src/ui/ContentEditable.tsx
@@ -9,7 +9,6 @@
 import './ContentEditable.css';
 
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
-import * as React from 'react';
 
 export default function LexicalContentEditable({
   className,

--- a/packages/lexical-playground/src/ui/Dialog.tsx
+++ b/packages/lexical-playground/src/ui/Dialog.tsx
@@ -8,7 +8,6 @@
 
 import './Dialog.css';
 
-import * as React from 'react';
 import {ReactNode} from 'react';
 
 type Props = Readonly<{

--- a/packages/lexical-playground/src/ui/DropDown.tsx
+++ b/packages/lexical-playground/src/ui/DropDown.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import * as React from 'react';
 import {
   ReactNode,
   useCallback,
@@ -14,7 +15,6 @@ import {
   useRef,
   useState,
 } from 'react';
-import * as React from 'react';
 import {createPortal} from 'react-dom';
 
 type DropDownContextType = {

--- a/packages/lexical-playground/src/ui/EquationEditor.tsx
+++ b/packages/lexical-playground/src/ui/EquationEditor.tsx
@@ -8,7 +8,6 @@
 
 import './EquationEditor.css';
 
-import * as React from 'react';
 import {ChangeEvent, RefObject} from 'react';
 
 type BaseEquationEditorProps = {

--- a/packages/lexical-playground/src/ui/FileInput.tsx
+++ b/packages/lexical-playground/src/ui/FileInput.tsx
@@ -8,8 +8,6 @@
 
 import './Input.css';
 
-import * as React from 'react';
-
 type Props = Readonly<{
   'data-test-id'?: string;
   accept?: string;

--- a/packages/lexical-playground/src/ui/KatexEquationAlterer.tsx
+++ b/packages/lexical-playground/src/ui/KatexEquationAlterer.tsx
@@ -8,7 +8,6 @@
 
 import './KatexEquationAlterer.css';
 
-import * as React from 'react';
 import {useCallback, useState} from 'react';
 
 import Button from '../ui/Button';

--- a/packages/lexical-playground/src/ui/KatexRenderer.tsx
+++ b/packages/lexical-playground/src/ui/KatexRenderer.tsx
@@ -7,7 +7,6 @@
  */
 
 import katex from 'katex';
-import * as React from 'react';
 import {useEffect, useRef} from 'react';
 
 export default function KatexRenderer({

--- a/packages/lexical-playground/src/ui/LinkPreview.tsx
+++ b/packages/lexical-playground/src/ui/LinkPreview.tsx
@@ -8,7 +8,6 @@
 
 import './LinkPreview.css';
 
-import * as React from 'react';
 import {CSSProperties, Suspense} from 'react';
 
 type Preview = {

--- a/packages/lexical-playground/src/ui/Modal.tsx
+++ b/packages/lexical-playground/src/ui/Modal.tsx
@@ -8,7 +8,6 @@
 
 import './Modal.css';
 
-import * as React from 'react';
 import {ReactNode, useEffect, useRef} from 'react';
 import {createPortal} from 'react-dom';
 

--- a/packages/lexical-playground/src/ui/Placeholder.tsx
+++ b/packages/lexical-playground/src/ui/Placeholder.tsx
@@ -8,7 +8,6 @@
 
 import './Placeholder.css';
 
-import * as React from 'react';
 import {ReactNode} from 'react';
 
 export default function Placeholder({

--- a/packages/lexical-playground/src/ui/TextInput.tsx
+++ b/packages/lexical-playground/src/ui/TextInput.tsx
@@ -8,8 +8,6 @@
 
 import './Input.css';
 
-import * as React from 'react';
-
 type Props = Readonly<{
   'data-test-id'?: string;
   label: string;

--- a/packages/lexical-react/src/DEPRECATED_useLexicalEditorEvents.ts
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalEditorEvents.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import type {InputEvents} from './shared/useEditorEvents';
 import type {LexicalEditor} from 'lexical';
+import type {InputEvents} from './shared/useEditorEvents';
 
 import {useEditorEvents} from './shared/useEditorEvents';
 

--- a/packages/lexical-react/src/DEPRECATED_useLexicalHistory.ts
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalHistory.ts
@@ -12,7 +12,6 @@ import type {LexicalEditor} from 'lexical';
 import {useHistory} from './shared/useHistory';
 
 export {createEmptyHistoryState} from '@lexical/history';
-
 export type {HistoryState};
 
 export function useLexicalHistory(

--- a/packages/lexical-react/src/DEPRECATED_useLexicalPlainText.ts
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalPlainText.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import type {HistoryState} from './DEPRECATED_useLexicalHistory';
 import type {LexicalEditor} from 'lexical';
+import type {HistoryState} from './DEPRECATED_useLexicalHistory';
 
 import {useLexicalHistory} from './DEPRECATED_useLexicalHistory';
 import {usePlainTextSetup} from './shared/usePlainTextSetup';

--- a/packages/lexical-react/src/DEPRECATED_useLexicalRichText.ts
+++ b/packages/lexical-react/src/DEPRECATED_useLexicalRichText.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import type {HistoryState} from './DEPRECATED_useLexicalHistory';
 import type {LexicalEditor} from 'lexical';
+import type {HistoryState} from './DEPRECATED_useLexicalHistory';
 
 import {useLexicalHistory} from './DEPRECATED_useLexicalHistory';
 import {useRichTextSetup} from './shared/useRichTextSetup';

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -25,7 +25,6 @@ import {
   TextNode,
 } from 'lexical';
 import {useCallback, useEffect, useMemo, useState} from 'react';
-import * as React from 'react';
 
 export type EmbedMatchResult = {
   url: string;

--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -27,7 +27,6 @@ import {
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
 } from 'lexical';
-import * as React from 'react';
 import {ReactNode, useCallback, useEffect, useRef} from 'react';
 
 type Props = Readonly<{

--- a/packages/lexical-react/src/LexicalCharacterLimitPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCharacterLimitPlugin.tsx
@@ -7,7 +7,6 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import * as React from 'react';
 import {useMemo, useState} from 'react';
 
 import {useCharacterLimit} from './shared/useCharacterLimit';

--- a/packages/lexical-react/src/LexicalCheckListPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCheckListPlugin.tsx
@@ -12,8 +12,8 @@ import type {LexicalEditor} from 'lexical';
 import {
   $isListItemNode,
   $isListNode,
-  INSERT_CHECK_LIST_COMMAND,
   insertList,
+  INSERT_CHECK_LIST_COMMAND,
 } from '@lexical/list';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$findMatchingParent, mergeRegister} from '@lexical/utils';

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -24,7 +24,6 @@ import {
   LexicalNode,
 } from 'lexical';
 import {useMemo} from 'react';
-import * as React from 'react';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
 const HISTORY_MERGE_OPTIONS = {tag: 'history-merge'};

--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -7,7 +7,6 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import * as React from 'react';
 import {CSSProperties, useCallback, useState} from 'react';
 import useLayoutEffect from 'shared/useLayoutEffect';
 

--- a/packages/lexical-react/src/LexicalErrorBoundary.tsx
+++ b/packages/lexical-react/src/LexicalErrorBoundary.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import * as React from 'react';
 import {ErrorBoundary as ReactErrorBoundary} from 'react-error-boundary';
 
 export type LexicalErrorBoundaryProps = {

--- a/packages/lexical-react/src/LexicalHistoryPlugin.ts
+++ b/packages/lexical-react/src/LexicalHistoryPlugin.ts
@@ -13,7 +13,6 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useHistory} from './shared/useHistory';
 
 export {createEmptyHistoryState} from '@lexical/history';
-
 export type {HistoryState};
 
 export function HistoryPlugin({

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -31,7 +31,6 @@ import {
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
 } from 'lexical';
-import * as React from 'react';
 import {useCallback, useEffect} from 'react';
 
 export type SerializedHorizontalRuleNode = SerializedLexicalNode & {

--- a/packages/lexical-react/src/LexicalLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalLinkPlugin.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {LinkNode, TOGGLE_LINK_COMMAND, toggleLink} from '@lexical/link';
+import {LinkNode, toggleLink, TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
 import {

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -19,7 +19,6 @@ import {
   createLexicalComposerContext,
   LexicalComposerContext,
 } from '@lexical/react/LexicalComposerContext';
-import * as React from 'react';
 import {ReactNode, useContext, useEffect, useMemo, useRef} from 'react';
 import invariant from 'shared/invariant';
 

--- a/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
@@ -7,7 +7,6 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import * as React from 'react';
 
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 import {ErrorBoundaryType, useDecorators} from './shared/useDecorators';

--- a/packages/lexical-react/src/LexicalRichTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalRichTextPlugin.tsx
@@ -7,7 +7,6 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import * as React from 'react';
 
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 import {ErrorBoundaryType, useDecorators} from './shared/useDecorators';

--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -28,7 +28,6 @@ import {
   $isTextNode,
   DEPRECATED_$isGridSelection,
 } from 'lexical';
-import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
 
 const NON_SINGLE_WIDTH_CHARS_REPLACEMENT: Readonly<Record<string, string>> =

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -27,6 +27,7 @@ import {
   RangeSelection,
   TextNode,
 } from 'lexical';
+import * as React from 'react';
 import {
   MutableRefObject,
   ReactPortal,
@@ -36,7 +37,6 @@ import {
   useRef,
   useState,
 } from 'react';
-import * as React from 'react';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
 export type QueryMatch = {

--- a/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
@@ -7,7 +7,6 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import * as React from 'react';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 

--- a/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
@@ -23,7 +23,6 @@ import {
   $getSelection,
   $isNodeSelection,
 } from 'lexical';
-import * as React from 'react';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 

--- a/packages/lexical-react/src/__tests__/unit/utils.tsx
+++ b/packages/lexical-react/src/__tests__/unit/utils.tsx
@@ -9,7 +9,6 @@
 import {useLexicalComposerContext} from '@lexical/react/src/LexicalComposerContext';
 import LexicalErrorBoundary from '@lexical/react/src/LexicalErrorBoundary';
 import {LexicalEditor} from 'lexical';
-import * as React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as Y from 'yjs';

--- a/packages/lexical-react/src/shared/useDecorators.tsx
+++ b/packages/lexical-react/src/shared/useDecorators.tsx
@@ -8,8 +8,8 @@
 
 import type {LexicalEditor} from 'lexical';
 
-import {Suspense, useEffect, useMemo, useState} from 'react';
 import * as React from 'react';
+import {Suspense, useEffect, useMemo, useState} from 'react';
 import {createPortal, flushSync} from 'react-dom';
 import useLayoutEffect from 'shared/useLayoutEffect';
 

--- a/packages/lexical-react/src/shared/useList.ts
+++ b/packages/lexical-react/src/shared/useList.ts
@@ -11,12 +11,12 @@ import type {LexicalEditor} from 'lexical';
 import {
   $handleListInsertParagraph,
   indentList,
+  insertList,
   INSERT_ORDERED_LIST_COMMAND,
   INSERT_UNORDERED_LIST_COMMAND,
-  insertList,
   outdentList,
-  REMOVE_LIST_COMMAND,
   removeList,
+  REMOVE_LIST_COMMAND,
 } from '@lexical/list';
 import {mergeRegister} from '@lexical/utils';
 import {

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -39,7 +39,6 @@ import {
   initializeClipboard,
   TestComposer,
 } from 'lexical/src/__tests__/utils';
-import * as React from 'react';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 

--- a/packages/lexical-selection/src/grid-selection.ts
+++ b/packages/lexical-selection/src/grid-selection.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import type {ICloneSelectionContent} from './lexical-node';
 import type {GridSelection, LexicalNode, NodeKey} from 'lexical';
+import type {ICloneSelectionContent} from './lexical-node';
 
 import {$cloneWithProperties} from './lexical-node';
 

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -41,7 +41,6 @@ export {
   $sliceSelectedTextNodeContent,
   trimTextContentFromAnchor,
 };
-
 export {
   $getSelectionStyleValueForProperty,
   $isParentElementRTL,
@@ -52,5 +51,4 @@ export {
   $wrapNodes,
   $wrapNodesImpl,
 };
-
 export {createDOMRange, createRectsFromDOMRange, getStyleObjectFromCSS};

--- a/packages/lexical-selection/src/node-selection.ts
+++ b/packages/lexical-selection/src/node-selection.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import type {ICloneSelectionContent} from './lexical-node';
 import type {NodeSelection} from 'lexical';
+import type {ICloneSelectionContent} from './lexical-node';
 
 import invariant from 'shared/invariant';
 

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import type {ICloneSelectionContent} from './lexical-node';
 import type {
   ElementNode,
   GridSelection,
@@ -16,6 +15,7 @@ import type {
   RangeSelection,
   TextNode,
 } from 'lexical';
+import type {ICloneSelectionContent} from './lexical-node';
 
 import {
   $getDecoratorNode,

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -6,8 +6,6 @@
  *
  */
 
-import type {TableCellNode} from './LexicalTableCellNode';
-import type {Cell, Grid} from './LexicalTableSelection';
 import type {
   DOMConversionMap,
   DOMConversionOutput,
@@ -19,6 +17,8 @@ import type {
   SerializedElementNode,
   Spread,
 } from 'lexical';
+import type {TableCellNode} from './LexicalTableCellNode';
+import type {Cell, Grid} from './LexicalTableSelection';
 
 import {addClassNamesToElement} from '@lexical/utils';
 import {

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -6,8 +6,6 @@
  *
  */
 
-import type {TableNode} from './LexicalTableNode';
-import type {Cell, Cells, Grid} from './LexicalTableSelection';
 import type {
   GridSelection,
   LexicalCommand,
@@ -17,6 +15,8 @@ import type {
   RangeSelection,
   TextFormatType,
 } from 'lexical';
+import type {TableNode} from './LexicalTableNode';
+import type {Cell, Cells, Grid} from './LexicalTableSelection';
 
 import {TableCellNode} from '@lexical/table';
 import {$findMatchingParent} from '@lexical/utils';

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import type {Grid} from './LexicalTableSelection';
 import type {LexicalNode} from 'lexical';
+import type {Grid} from './LexicalTableSelection';
 
 import {$findMatchingParent} from '@lexical/utils';
 import {$createParagraphNode, $createTextNode} from 'lexical';

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -7,9 +7,9 @@
  *
  */
 
+import type {LexicalCommand} from 'lexical';
 import type {Cell} from './LexicalTableSelection';
 import type {HTMLTableElementWithWithTableSelectionState} from './LexicalTableSelectionHelpers';
-import type {LexicalCommand} from 'lexical';
 
 import {createCommand} from 'lexical';
 
@@ -81,7 +81,6 @@ export {
   TableRowNode,
   TableSelection,
 };
-
 export type {
   SerializedTableCellNode,
   SerializedTableNode,

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -23,7 +23,6 @@ import {
 } from '@lexical/selection/src/__tests__/utils';
 import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
 import {initializeClipboard, TestComposer} from 'lexical/src/__tests__/utils';
-import * as React from 'react';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 

--- a/packages/lexical-website/src/components/CommunityContributors/index.js
+++ b/packages/lexical-website/src/components/CommunityContributors/index.js
@@ -7,7 +7,6 @@
  */
 
 import Translate from '@docusaurus/Translate';
-import React from 'react';
 
 const CONTRIBUTORS = [
   {

--- a/packages/lexical-website/src/components/CommunityHeader/index.js
+++ b/packages/lexical-website/src/components/CommunityHeader/index.js
@@ -9,7 +9,6 @@
 import Translate from '@docusaurus/Translate';
 import CommunityHeaderSvg from '@site/static/img/community-header.svg';
 import clsx from 'clsx';
-import React from 'react';
 
 import styles from './styles.module.css';
 

--- a/packages/lexical-website/src/components/CommunityHowToContribute/index.js
+++ b/packages/lexical-website/src/components/CommunityHowToContribute/index.js
@@ -8,7 +8,6 @@
 
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
-import React from 'react';
 
 export default function CommunityHowToContribute() {
   return (

--- a/packages/lexical-website/src/components/CommunityLinks/index.js
+++ b/packages/lexical-website/src/components/CommunityLinks/index.js
@@ -9,7 +9,6 @@
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
 import clsx from 'clsx';
-import React from 'react';
 
 import ImageSwitcher from '../ImageSwitcher';
 import styles from './styles.module.css';

--- a/packages/lexical-website/src/components/HomepageExamples/index.js
+++ b/packages/lexical-website/src/components/HomepageExamples/index.js
@@ -9,7 +9,7 @@
 import Link from '@docusaurus/Link';
 import * as Tabs from '@radix-ui/react-tabs';
 import clsx from 'clsx';
-import React, {useState} from 'react';
+import {useState} from 'react';
 
 import styles from './styles.module.css';
 

--- a/packages/lexical-website/src/components/HomepageFeatures/index.js
+++ b/packages/lexical-website/src/components/HomepageFeatures/index.js
@@ -8,7 +8,6 @@
 
 import Translate from '@docusaurus/Translate';
 import clsx from 'clsx';
-import React from 'react';
 
 import styles from './styles.module.css';
 

--- a/packages/lexical-website/src/components/ImageSwitcher/index.js
+++ b/packages/lexical-website/src/components/ImageSwitcher/index.js
@@ -7,7 +7,6 @@
  */
 
 import {useColorMode} from '@docusaurus/theme-common';
-import React from 'react';
 
 export default function ImageSwitcher({light, dark}) {
   const Light = light;

--- a/packages/lexical-website/src/pages/community/index.js
+++ b/packages/lexical-website/src/pages/community/index.js
@@ -12,7 +12,6 @@ import CommunityHeader from '@site/src/components/CommunityHeader';
 import CommunityHowToContribute from '@site/src/components/CommunityHowToContribute';
 import CommunityLinks from '@site/src/components/CommunityLinks';
 import Layout from '@theme/Layout';
-import React from 'react';
 
 export default function Community() {
   const {siteConfig} = useDocusaurusContext();

--- a/packages/lexical-website/src/pages/docs/error/index.js
+++ b/packages/lexical-website/src/pages/docs/error/index.js
@@ -9,7 +9,7 @@
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import React, {useMemo} from 'react';
+import {useMemo} from 'react';
 
 import codes from '../../../../../../scripts/error-codes/codes.json';
 import styles from './styles.module.css';

--- a/packages/lexical-website/src/pages/index.js
+++ b/packages/lexical-website/src/pages/index.js
@@ -12,7 +12,6 @@ import HomepageExamples from '@site/src/components/HomepageExamples';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
-import React from 'react';
 
 import styles from './styles.module.css';
 

--- a/packages/lexical-yjs/src/Bindings.ts
+++ b/packages/lexical-yjs/src/Bindings.ts
@@ -6,13 +6,13 @@
  *
  */
 
+import type {LexicalEditor, NodeKey} from 'lexical';
+import type {Doc} from 'yjs';
 import type {CollabDecoratorNode} from './CollabDecoratorNode';
 import type {CollabElementNode} from './CollabElementNode';
 import type {CollabLineBreakNode} from './CollabLineBreakNode';
 import type {CollabTextNode} from './CollabTextNode';
 import type {Cursor} from './SyncCursors';
-import type {LexicalEditor, NodeKey} from 'lexical';
-import type {Doc} from 'yjs';
 
 import invariant from 'shared/invariant';
 import {WebsocketProvider} from 'y-websocket';

--- a/packages/lexical-yjs/src/CollabDecoratorNode.ts
+++ b/packages/lexical-yjs/src/CollabDecoratorNode.ts
@@ -6,10 +6,10 @@
  *
  */
 
-import type {Binding} from '.';
-import type {CollabElementNode} from './CollabElementNode';
 import type {DecoratorNode, NodeKey, NodeMap} from 'lexical';
 import type {XmlElement} from 'yjs';
+import type {Binding} from '.';
+import type {CollabElementNode} from './CollabElementNode';
 
 import {$getNodeByKey, $isDecoratorNode} from 'lexical';
 import invariant from 'shared/invariant';

--- a/packages/lexical-yjs/src/CollabElementNode.ts
+++ b/packages/lexical-yjs/src/CollabElementNode.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import type {Binding} from '.';
 import type {
   ElementNode,
   IntentionallyMarkedAsDirtyElement,
@@ -14,6 +13,7 @@ import type {
   NodeMap,
 } from 'lexical';
 import type {AbstractType, XmlElement, XmlText} from 'yjs';
+import type {Binding} from '.';
 
 import {
   $getNodeByKey,

--- a/packages/lexical-yjs/src/CollabLineBreakNode.ts
+++ b/packages/lexical-yjs/src/CollabLineBreakNode.ts
@@ -6,10 +6,10 @@
  *
  */
 
-import type {Binding} from '.';
-import type {CollabElementNode} from './CollabElementNode';
 import type {LineBreakNode, NodeKey} from 'lexical';
 import type {Map as YMap} from 'yjs';
+import type {Binding} from '.';
+import type {CollabElementNode} from './CollabElementNode';
 
 import {$getNodeByKey, $isLineBreakNode} from 'lexical';
 

--- a/packages/lexical-yjs/src/CollabTextNode.ts
+++ b/packages/lexical-yjs/src/CollabTextNode.ts
@@ -6,10 +6,10 @@
  *
  */
 
-import type {Binding} from '.';
-import type {CollabElementNode} from './CollabElementNode';
 import type {NodeKey, NodeMap, TextNode} from 'lexical';
 import type {Map as YMap} from 'yjs';
+import type {Binding} from '.';
+import type {CollabElementNode} from './CollabElementNode';
 
 import {
   $getNodeByKey,

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import type {Binding} from './Bindings';
 import type {
   GridSelection,
   NodeKey,
@@ -16,6 +15,7 @@ import type {
   RangeSelection,
 } from 'lexical';
 import type {AbsolutePosition, RelativePosition} from 'yjs';
+import type {Binding} from './Bindings';
 
 import {createDOMRange, createRectsFromDOMRange} from '@lexical/selection';
 import {

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import type {Binding, YjsNode} from '.';
 import type {
   DecoratorNode,
   ElementNode,
@@ -14,6 +13,7 @@ import type {
   RangeSelection,
   TextNode,
 } from 'lexical';
+import type {Binding, YjsNode} from '.';
 
 import {
   $getNodeByKey,

--- a/packages/lexical-yjs/src/index.ts
+++ b/packages/lexical-yjs/src/index.ts
@@ -7,10 +7,10 @@
  *
  */
 
-import type {Binding} from './Bindings';
 import type {LexicalCommand} from 'lexical';
 import type {WebsocketProvider} from 'y-websocket';
 import type {Doc, RelativePosition, UndoManager, XmlText} from 'yjs';
+import type {Binding} from './Bindings';
 
 import {createCommand} from 'lexical';
 import {UndoManager as YjsUndoManager} from 'yjs';
@@ -56,9 +56,14 @@ export type Operation = {
 export type Delta = Array<Operation>;
 export type YjsNode = Record<string, unknown>;
 export type YjsEvent = Record<string, unknown>;
-export type {Provider};
-export type {Binding, ClientID} from './Bindings';
 export {createBinding} from './Bindings';
+export type {Binding, ClientID} from './Bindings';
+export {syncCursorPositions} from './SyncCursors';
+export {
+  syncLexicalUpdateToYjs,
+  syncYjsChangesToLexical,
+} from './SyncEditorStates';
+export type {Provider};
 
 export function createUndoManager(
   binding: Binding,
@@ -106,8 +111,3 @@ export function setLocalStateFocus(
   localState.focusing = focusing;
   awareness.setLocalState(localState);
 }
-export {syncCursorPositions} from './SyncCursors';
-export {
-  syncLexicalUpdateToYjs,
-  syncYjsChangesToLexical,
-} from './SyncEditorStates';

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -7,9 +7,9 @@
  */
 
 /* eslint-disable no-constant-condition */
+import type {Klass} from 'lexical';
 import type {EditorConfig, LexicalEditor} from './LexicalEditor';
 import type {RangeSelection} from './LexicalSelection';
-import type {Klass} from 'lexical';
 
 import invariant from 'shared/invariant';
 

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -18,7 +18,6 @@ import {
   TableRowNode,
 } from '@lexical/table';
 import {
-  type LexicalNode,
   $createLineBreakNode,
   $createNodeSelection,
   $createParagraphNode,
@@ -38,8 +37,8 @@ import {
   NodeKey,
   ParagraphNode,
   TextNode,
+  type LexicalNode,
 } from 'lexical';
-import * as React from 'react';
 import {
   createRef,
   ReactNode,

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -7,65 +7,11 @@
  *
  */
 
-export type {PasteCommandType} from './LexicalCommands';
-export type {
-  CommandListenerPriority,
-  CommandPayloadType,
-  EditableListener,
-  EditorConfig,
-  EditorThemeClasses,
-  IntentionallyMarkedAsDirtyElement,
-  Klass,
-  LexicalCommand,
-  LexicalEditor,
-  MutationListener,
-  NodeMutation,
-  SerializedEditor,
-  Spread,
-} from './LexicalEditor';
-export type {EditorState, SerializedEditorState} from './LexicalEditorState';
-export type {
-  DOMChildConversion,
-  DOMConversion,
-  DOMConversionFn,
-  DOMConversionMap,
-  DOMConversionOutput,
-  DOMExportOutput,
-  LexicalNode,
-  NodeKey,
-  NodeMap,
-  SerializedLexicalNode,
-} from './LexicalNode';
-export type {
-  BaseSelection,
-  ElementPointType as ElementPoint,
-  GridSelection,
-  GridSelectionShape,
-  NodeSelection,
-  Point,
-  RangeSelection,
-  TextPointType as TextPoint,
-} from './LexicalSelection';
-export type {
-  ElementFormatType,
-  SerializedElementNode,
-} from './nodes/LexicalElementNode';
-export type {SerializedGridCellNode} from './nodes/LexicalGridCellNode';
-export type {SerializedRootNode} from './nodes/LexicalRootNode';
-export type {
-  SerializedTextNode,
-  TextFormatType,
-  TextModeType,
-} from './nodes/LexicalTextNode';
+export type {SerializedCodeNode} from './../../lexical-code/src';
 export type {
   SerializedAutoLinkNode,
   SerializedLinkNode,
 } from './../../lexical-link/src';
-export type {
-  SerializedTableCellNode,
-  SerializedTableNode,
-  SerializedTableRowNode,
-} from './../../lexical-table/src';
 export type {
   SerializedListItemNode,
   SerializedListNode,
@@ -74,8 +20,11 @@ export type {
   SerializedHeadingNode,
   SerializedQuoteNode,
 } from './../../lexical-rich-text/src';
-export type {SerializedCodeNode} from './../../lexical-code/src';
-
+export type {
+  SerializedTableCellNode,
+  SerializedTableNode,
+  SerializedTableRowNode,
+} from './../../lexical-table/src';
 // TODO Move this somewhere else and/or recheck if we still need this
 export {
   BLUR_COMMAND,
@@ -121,6 +70,7 @@ export {
   SELECTION_CHANGE_COMMAND,
   UNDO_COMMAND,
 } from './LexicalCommands';
+export type {PasteCommandType} from './LexicalCommands';
 export {
   COMMAND_PRIORITY_CRITICAL,
   COMMAND_PRIORITY_EDITOR,
@@ -129,7 +79,35 @@ export {
   COMMAND_PRIORITY_NORMAL,
   createEditor,
 } from './LexicalEditor';
+export type {
+  CommandListenerPriority,
+  CommandPayloadType,
+  EditableListener,
+  EditorConfig,
+  EditorThemeClasses,
+  IntentionallyMarkedAsDirtyElement,
+  Klass,
+  LexicalCommand,
+  LexicalEditor,
+  MutationListener,
+  NodeMutation,
+  SerializedEditor,
+  Spread,
+} from './LexicalEditor';
+export type {EditorState, SerializedEditorState} from './LexicalEditorState';
 export type {EventHandler} from './LexicalEvents';
+export type {
+  DOMChildConversion,
+  DOMConversion,
+  DOMConversionFn,
+  DOMConversionMap,
+  DOMConversionOutput,
+  DOMExportOutput,
+  LexicalNode,
+  NodeKey,
+  NodeMap,
+  SerializedLexicalNode,
+} from './LexicalNode';
 export {$normalizeSelection as $normalizeSelection__EXPERIMENTAL} from './LexicalNormalization';
 export {
   $createNodeSelection,
@@ -142,6 +120,16 @@ export {
   $isRangeSelection,
   DEPRECATED_$createGridSelection,
   DEPRECATED_$isGridSelection,
+} from './LexicalSelection';
+export type {
+  BaseSelection,
+  ElementPointType as ElementPoint,
+  GridSelection,
+  GridSelectionShape,
+  NodeSelection,
+  Point,
+  RangeSelection,
+  TextPointType as TextPoint,
 } from './LexicalSelection';
 export {$parseSerializedNode} from './LexicalUpdates';
 export {
@@ -164,10 +152,15 @@ export {
 export {VERSION} from './LexicalVersion';
 export {$isDecoratorNode, DecoratorNode} from './nodes/LexicalDecoratorNode';
 export {$isElementNode, ElementNode} from './nodes/LexicalElementNode';
+export type {
+  ElementFormatType,
+  SerializedElementNode,
+} from './nodes/LexicalElementNode';
 export {
   DEPRECATED_$isGridCellNode,
   DEPRECATED_GridCellNode,
 } from './nodes/LexicalGridCellNode';
+export type {SerializedGridCellNode} from './nodes/LexicalGridCellNode';
 export {
   DEPRECATED_$isGridNode,
   DEPRECATED_GridNode,
@@ -176,17 +169,23 @@ export {
   DEPRECATED_$isGridRowNode,
   DEPRECATED_GridRowNode,
 } from './nodes/LexicalGridRowNode';
-export type {SerializedLineBreakNode} from './nodes/LexicalLineBreakNode';
 export {
   $createLineBreakNode,
   $isLineBreakNode,
   LineBreakNode,
 } from './nodes/LexicalLineBreakNode';
-export type {SerializedParagraphNode} from './nodes/LexicalParagraphNode';
+export type {SerializedLineBreakNode} from './nodes/LexicalLineBreakNode';
 export {
   $createParagraphNode,
   $isParagraphNode,
   ParagraphNode,
 } from './nodes/LexicalParagraphNode';
+export type {SerializedParagraphNode} from './nodes/LexicalParagraphNode';
 export {$isRootNode, RootNode} from './nodes/LexicalRootNode';
+export type {SerializedRootNode} from './nodes/LexicalRootNode';
 export {$createTextNode, $isTextNode, TextNode} from './nodes/LexicalTextNode';
+export type {
+  SerializedTextNode,
+  TextFormatType,
+  TextModeType,
+} from './nodes/LexicalTextNode';

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -57,6 +57,24 @@ export type {
   TextFormatType,
   TextModeType,
 } from './nodes/LexicalTextNode';
+export type {
+  SerializedAutoLinkNode,
+  SerializedLinkNode,
+} from './../../lexical-link/src';
+export type {
+  SerializedTableCellNode,
+  SerializedTableNode,
+  SerializedTableRowNode,
+} from './../../lexical-table/src';
+export type {
+  SerializedListItemNode,
+  SerializedListNode,
+} from './../../lexical-list/src';
+export type {
+  SerializedHeadingNode,
+  SerializedQuoteNode,
+} from './../../lexical-rich-text/src';
+export type {SerializedCodeNode} from './../../lexical-code/src';
 
 // TODO Move this somewhere else and/or recheck if we still need this
 export {

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import type {Spread} from 'lexical';
 import type {NodeKey, SerializedLexicalNode} from '../LexicalNode';
 import type {
   GridSelection,
@@ -13,7 +14,6 @@ import type {
   PointType,
   RangeSelection,
 } from '../LexicalSelection';
-import type {Spread} from 'lexical';
 
 import invariant from 'shared/invariant';
 

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -6,13 +6,13 @@
  *
  */
 
+import type {Spread} from 'lexical';
 import type {
   DOMConversionMap,
   DOMConversionOutput,
   NodeKey,
   SerializedLexicalNode,
 } from '../LexicalNode';
-import type {Spread} from 'lexical';
 
 import {LexicalNode} from '../LexicalNode';
 import {$applyNodeReplacement} from '../LexicalUtils';

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import type {Spread} from 'lexical';
 import type {EditorConfig, LexicalEditor} from '../LexicalEditor';
 import type {
   DOMConversionMap,
@@ -14,7 +15,6 @@ import type {
   LexicalNode,
 } from '../LexicalNode';
 import type {SerializedElementNode} from './LexicalElementNode';
-import type {Spread} from 'lexical';
 
 import {$applyNodeReplacement, getCachedClassNameArray} from '../LexicalUtils';
 import {ElementNode} from './LexicalElementNode';

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import type {Spread} from 'lexical';
 import type {EditorConfig, TextNodeThemeClasses} from '../LexicalEditor';
 import type {
   DOMConversionMap,
@@ -18,7 +19,6 @@ import type {
   NodeSelection,
   RangeSelection,
 } from '../LexicalSelection';
-import type {Spread} from 'lexical';
 
 import {IS_FIREFOX} from 'shared/environment';
 import invariant from 'shared/invariant';

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -19,15 +19,10 @@ import {
   TextModeType,
   TextNode,
 } from 'lexical';
-import * as React from 'react';
 import {createRef, useEffect, useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 
-import {
-  $createTestSegmentedNode,
-  createTestEditor,
-} from '../../../__tests__/utils';
 import {
   IS_BOLD,
   IS_CODE,
@@ -40,6 +35,10 @@ import {
   $setCompositionKey,
   getEditorStateTextContent,
 } from '../../../LexicalUtils';
+import {
+  $createTestSegmentedNode,
+  createTestEditor,
+} from '../../../__tests__/utils';
 
 const editorConfig = Object.freeze({
   namespace: '',


### PR DESCRIPTION
Would be easier to be able to directly import all lexical serialized node types from the lexical packages instead of needing to install all the sub-packages just for the types.