### PR TITLE
$splitNode & $insertNodeToNearestRoot for root selection

### DIFF
--- a/packages/lexical-playground/src/plugins/HorizontalRulePlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/HorizontalRulePlugin/index.ts
@@ -11,6 +11,7 @@ import {
   $createHorizontalRuleNode,
   INSERT_HORIZONTAL_RULE_COMMAND,
 } from '@lexical/react/LexicalHorizontalRuleNode';
+import {$insertNodeToNearestRoot} from '@lexical/utils';
 import {
   $getSelection,
   $isRangeSelection,
@@ -35,11 +36,7 @@ export default function HorizontalRulePlugin(): null {
 
         if (focusNode !== null) {
           const horizontalRuleNode = $createHorizontalRuleNode();
-          selection.insertParagraph();
-          selection.focus
-            .getNode()
-            .getTopLevelElementOrThrow()
-            .insertBefore(horizontalRuleNode);
+          $insertNodeToNearestRoot(horizontalRuleNode);
         }
 
         return true;

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
@@ -130,4 +130,10 @@ describe('LexicalUtils#splitNode', () => {
       });
     });
   }
+
+  it('throws when splitting root', async () => {
+    await update(() => {
+      expect(() => $splitNode($getRoot(), 0)).toThrow();
+    });
+  });
 });

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -473,23 +473,33 @@ export function $insertNodeToNearestRoot<T extends LexicalNode>(node: T): T {
     const {focus} = selection;
     const focusNode = focus.getNode();
     const focusOffset = focus.offset;
-    let splitNode: ElementNode;
-    let splitOffset: number;
 
-    if ($isTextNode(focusNode)) {
-      splitNode = focusNode.getParentOrThrow();
-      splitOffset = focusNode.getIndexWithinParent();
-      if (focusOffset > 0) {
-        splitOffset += 1;
-        focusNode.splitText(focusOffset);
+    if ($isRootOrShadowRoot(focusNode)) {
+      const focusChild = focusNode.getChildAtIndex(focusOffset);
+      if (focusChild == null) {
+        focusNode.append(node);
+      } else {
+        focusChild.insertBefore(node);
       }
+      node.selectNext();
     } else {
-      splitNode = focusNode;
-      splitOffset = focusOffset;
+      let splitNode: ElementNode;
+      let splitOffset: number;
+      if ($isTextNode(focusNode)) {
+        splitNode = focusNode.getParentOrThrow();
+        splitOffset = focusNode.getIndexWithinParent();
+        if (focusOffset > 0) {
+          splitOffset += 1;
+          focusNode.splitText(focusOffset);
+        }
+      } else {
+        splitNode = focusNode;
+        splitOffset = focusOffset;
+      }
+      const [, rightTree] = $splitNode(splitNode, splitOffset);
+      rightTree.insertBefore(node);
+      rightTree.selectStart();
     }
-    const [, rightTree] = $splitNode(splitNode, splitOffset);
-    rightTree.insertBefore(node);
-    rightTree.selectStart();
   } else {
     if ($isNodeSelection(selection) || DEPRECATED_$isGridSelection(selection)) {
       const nodes = selection.getNodes();
@@ -523,6 +533,11 @@ export function $splitNode(
   if (startNode == null) {
     startNode = node;
   }
+
+  invariant(
+    !$isRootOrShadowRoot(node),
+    'Can not call $splitNode() on root element',
+  );
 
   const recurse = (
     currentNode: LexicalNode,

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -155,6 +155,10 @@ export function $createTestElementNode(): TestElementNode {
   return new TestElementNode();
 }
 
+type SerializedTestTextNode = Spread<
+  {type: 'test_text'; version: 1},
+  SerializedTextNode
+>;
 export class TestTextNode extends TextNode {
   static getType() {
     return 'test_text';
@@ -163,6 +167,19 @@ export class TestTextNode extends TextNode {
   static clone(node: TestTextNode): TestTextNode {
     // @ts-ignore
     return new TestTextNode(node.__text, node.__key);
+  }
+
+  static importJSON(serializedNode: SerializedTestTextNode): TestTextNode {
+    // @ts-ignore
+    return new TestTextNode(serializedNode.__text);
+  }
+
+  exportJSON(): SerializedTestTextNode {
+    return {
+      ...super.exportJSON(),
+      type: 'test_text',
+      version: 1,
+    };
   }
 }
 
@@ -342,7 +359,7 @@ export class TestDecoratorNode extends DecoratorNode<JSX.Element> {
     };
   }
 
-  importDOM() {
+  static importDOM() {
     return {
       'test-decorator': (domNode: HTMLElement) => {
         return {

--- a/packages/shared/src/invariant.ts
+++ b/packages/shared/src/invariant.ts
@@ -20,6 +20,7 @@ export default function invariant(
 
   throw new Error(
     'Internal Lexical error: invariant() is meant to be replaced at compile ' +
-      'time. There is no runtime version.',
+      'time. There is no runtime version. Error: ' +
+      message,
   );
 }


### PR DESCRIPTION
- Update `$splitNode` to thrown if called on root

It's possible to keep `$splitNode` working with root. E.g., if we have root with 2 children, and trying to call `$splitNode(root, 1)`, it'll return `[firstRootChild, secondRootChild]` without modifying (splitting) the tree. But then it means those children might be elements or decorators, so it would require API call site to check return type. Plus, there's no guarantee that there will be left or/and right tree at all since root can be empty. Supporting all of these will make `$splitNode` return type too vague (`[null | ElementNode | DecoratorNode, null | ElementNode | DecoratorNode]`) and it seems easier to handle root separately instead 

- Add root selection case for `$insertNodeToNearestRoot`
- Some test utils fixes (import/export) to reduce warnings noise for unit tests
- Add original error message to invariant stub, as otherwise errors in tests are not readable