### PR TITLE
Fix bug in selectPointOnNode

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -182,6 +182,7 @@ function selectPointOnNode(point: PointType, node: LexicalNode): void {
     if ($isTextNode(nextSibling)) {
       key = nextSibling.__key;
       offset = 0;
+      type = 'text';
     } else {
       const parentNode = node.getParent();
       if (parentNode) {


### PR DESCRIPTION
This bug fix was extracted from https://github.com/facebook/lexical/pull/3434. We were never defining the type as "text" meaning text nodes could be improperly represented.