### PR TITLE
Add isEditable listener to nested composer

### DIFF
--- a/packages/lexical-react/src/LexicalComposerContext.ts
+++ b/packages/lexical-react/src/LexicalComposerContext.ts
@@ -20,11 +20,8 @@ export type LexicalComposerContextWithEditor = [
   LexicalComposerContextType,
 ];
 
-export const LexicalComposerContext: React.Context<
-  LexicalComposerContextWithEditor | null | undefined
-> = createReactContext<LexicalComposerContextWithEditor | null | undefined>(
-  null,
-);
+export const LexicalComposerContext: React.Context<LexicalComposerContextWithEditor | null> =
+  createReactContext<LexicalComposerContextWithEditor | null>(null);
 
 export function createLexicalComposerContext(
   parent: LexicalComposerContextWithEditor | null | undefined,

--- a/packages/lexical-react/src/LexicalComposerContext.ts
+++ b/packages/lexical-react/src/LexicalComposerContext.ts
@@ -20,8 +20,11 @@ export type LexicalComposerContextWithEditor = [
   LexicalComposerContextType,
 ];
 
-export const LexicalComposerContext: React.Context<LexicalComposerContextWithEditor | null> =
-  createReactContext<LexicalComposerContextWithEditor | null>(null);
+export const LexicalComposerContext: React.Context<
+  LexicalComposerContextWithEditor | null | undefined
+> = createReactContext<LexicalComposerContextWithEditor | null | undefined>(
+  null,
+);
 
 export function createLexicalComposerContext(
   parent: LexicalComposerContextWithEditor | null | undefined,

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -7,18 +7,13 @@
  */
 
 import type {LexicalComposerContextType} from '@lexical/react/LexicalComposerContext';
-import type {
-  EditorThemeClasses,
-  Klass,
-  LexicalEditor,
-  LexicalNode,
-} from 'lexical';
 
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {
   createLexicalComposerContext,
   LexicalComposerContext,
 } from '@lexical/react/LexicalComposerContext';
+import {EditorThemeClasses, Klass, LexicalEditor, LexicalNode} from 'lexical';
 import * as React from 'react';
 import {ReactNode, useContext, useEffect, useMemo, useRef} from 'react';
 import invariant from 'shared/invariant';
@@ -43,11 +38,12 @@ export function LexicalNestedComposer({
     invariant(false, 'Unexpected parent context null on a nested composer');
   }
 
+  const [parentEditor, {getTheme: getParentTheme}] = parentContext;
+
   const composerContext: [LexicalEditor, LexicalComposerContextType] = useMemo(
     () => {
-      const [parentEditor, parentContextContext] = parentContext;
       const composerTheme: EditorThemeClasses | undefined =
-        initialTheme || parentContextContext.getTheme() || undefined;
+        initialTheme || getParentTheme() || undefined;
 
       const context: LexicalComposerContextType = createLexicalComposerContext(
         parentContext,
@@ -91,9 +87,9 @@ export function LexicalNestedComposer({
     [],
   );
 
-  // If collaboration is enabled, make sure we don't render the children
-  // until the collaboration subdocument is ready.
+  // If collaboration is enabled, make sure we don't render the children until the collaboration subdocument is ready.
   const {isCollabActive, yjsDocMap} = useCollaborationContext();
+
   const isCollabReady =
     skipCollabChecks ||
     wasCollabPreviouslyReadyRef.current ||
@@ -104,6 +100,13 @@ export function LexicalNestedComposer({
       wasCollabPreviouslyReadyRef.current = true;
     }
   }, [isCollabReady]);
+
+  // Update `isEditable` state of nested editor in response to the same change on parent editor.
+  useEffect(() => {
+    return parentEditor.registerEditableListener((editable) => {
+      initialEditor.setEditable(editable);
+    });
+  }, [initialEditor, parentEditor]);
 
   return (
     <LexicalComposerContext.Provider value={composerContext}>


### PR DESCRIPTION
Confirmed you can't type in caption below when `isEditable`  is `true` on parent.

<img width="904" alt="image" src="https://user-images.githubusercontent.com/7748470/204389886-adfbb5db-a002-4e4c-8ebd-b159731946cd.png">

Closes #1546