### PR TITLE
Add horizontal rule plugin

### DIFF
--- a/packages/lexical-website/docs/demos/plugins/excalidraw.md
+++ b/packages/lexical-website/docs/demos/plugins/excalidraw.md
@@ -4,9 +4,9 @@ title: "Excalidraw Plugin"
 sidebar_label: "Excalidraw Plugin"
 ---
 
-This page focuses on implementing the Excalidraw plugin and the code you need to embed Excalidraw into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+This page focuses on implementing the Excalidraw plugin and the code you need to embed Excalidraw into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. You can also add image resizing functionality to resize the plot, but it is not implemented in the below example to simplify the code. 
 
-You can also add image resizing functionality to resize the plot, but it is not implemented in the below example to simplify the code. 
+**Note**: If the code is not working due to an import error, try opening the CodeSandbox in a separate tab (this should solve the problem).
 
 <iframe src="https://codesandbox.io/embed/lexical-excalidraw-plugin-example-4q08cv?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/ExcalidrawPlugin.ts,/src/nodes/ExcalidrawNode.tsx&theme=dark&view=split"
      style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}

--- a/packages/lexical-website/docs/demos/plugins/horizontal-rule.md
+++ b/packages/lexical-website/docs/demos/plugins/horizontal-rule.md
@@ -1,0 +1,17 @@
+---
+id: "horizontal-rule"
+title: "Horizontal Rule Plugin"
+sidebar_label: "Horizontal Rule  Plugin"
+---
+
+This page focuses on implementing the horizontal rule plugin and the code you need to embed a horizontal rule into your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+
+To add a horizontal rule in a sample text (i.e., check out the list plugin example and the prepopulated text inside of the editor), use ```$createHorizontalRuleNode``` or check out the source code on GitHub.
+
+<iframe src="https://codesandbox.io/embed/lexical-horizontal-rule-plugin-example-t30p3t?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/HorizontalRulePlugin.ts,/src/plugins/PluginToolbar.tsx&theme=dark&view=split"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-horizontal-rule-plugin-example"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
+


### PR DESCRIPTION
- [x] created a CodeSandbox example for the horizontal rule plugin [here](https://codesandbox.io/embed/lexical-horizontal-rule-plugin-example-t30p3t)
- [x] added a new page and the example on the website (under “/docs/demos/plugins/horizontal-rule”)
- [x] removed the headers (i.e., name of the plugin in h1) from all of the Sandbox examples for clarity 

<img width="1440" alt="Horizontal Rule Plugin" src="https://user-images.githubusercontent.com/47840436/204432693-d9c7a68a-c927-40a7-b4bb-09a11a3b873a.png">

Issue https://github.com/facebook/lexical/issues/2886