### PR TITLE
Improve element splicing and node removal

### DIFF
--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -44,6 +44,9 @@ function $updateElementNodeProperties<T extends ElementNode>(
   source: ElementNode,
 ): T {
   target.__children = Array.from(source.__children);
+  target.__first = source.__first;
+  target.__last = source.__last;
+  target.__size = source.__size;
   target.__format = source.__format;
   target.__indent = source.__indent;
   target.__dir = source.__dir;
@@ -67,6 +70,8 @@ export function $cloneWithProperties<T extends LexicalNode>(node: T): T {
   // @ts-expect-error
   const clone: T = constructor.clone(latest);
   clone.__parent = latest.__parent;
+  clone.__next = latest.__next;
+  clone.__prev = latest.__prev;
 
   if ($isElementNode(latest) && $isElementNode(clone)) {
     return $updateElementNodeProperties(clone, latest);

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -363,8 +363,14 @@ function unstable_internalCreateNodeFromParse(
   if ($isElementNode(node)) {
     const children = parsedNode.__children;
 
+    let prevNode = null;
     for (let i = 0; i < children.length; i++) {
       const childKey = children[i];
+      if (i === 0) {
+        node.__first = childKey;
+      } else if (i === children.length - 1) {
+        node.__last = childKey;
+      }
       const parsedChild = parsedNodeMap.get(childKey);
 
       if (parsedChild !== undefined) {
@@ -376,8 +382,12 @@ function unstable_internalCreateNodeFromParse(
           activeEditorState,
         );
         const newChildKey = child.__key;
-
+        if (prevNode !== null) {
+          child.__prev = prevNode.__key;
+          prevNode.__next = newChildKey;
+        }
         node.__children.push(newChildKey);
+        prevNode = child;
       }
     }
 

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -84,11 +84,18 @@ export function removeNode(
       selectionMoved = true;
     }
   }
+
   const writableParent = parent.getWritable();
   const parentChildren = writableParent.__children;
   const index = parentChildren.indexOf(key);
+  if (index === -1) {
+    invariant(false, 'Node is not a child of its parent');
+  }
+  internalMarkSiblingsAsDirty(nodeToRemove);
+  parentChildren.splice(index, 1);
   const writableNodeToRemove = nodeToRemove.getWritable();
-  removeFromParent(writableNodeToRemove);
+  writableNodeToRemove.__parent = null;
+  removeFromParent(writableNodeToRemove)
 
   if ($isRangeSelection(selection) && restoreSelection && !selectionMoved) {
     $updateElementSelectionOnCreateDeleteNode(selection, parent, index, -1);

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -95,7 +95,7 @@ export function removeNode(
   parentChildren.splice(index, 1);
   const writableNodeToRemove = nodeToRemove.getWritable();
   writableNodeToRemove.__parent = null;
-  removeFromParent(writableNodeToRemove)
+  removeFromParent(writableNodeToRemove);
 
   if ($isRangeSelection(selection) && restoreSelection && !selectionMoved) {
     $updateElementSelectionOnCreateDeleteNode(selection, parent, index, -1);

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -91,10 +91,8 @@ export function removeNode(
   if (index === -1) {
     invariant(false, 'Node is not a child of its parent');
   }
-  internalMarkSiblingsAsDirty(nodeToRemove);
-  parentChildren.splice(index, 1);
   const writableNodeToRemove = nodeToRemove.getWritable();
-  writableNodeToRemove.__parent = null;
+  internalMarkSiblingsAsDirty(nodeToRemove);
   removeFromParent(writableNodeToRemove);
 
   if ($isRangeSelection(selection) && restoreSelection && !selectionMoved) {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -264,6 +264,7 @@ export function removeFromParent(writableNode: LexicalNode): void {
     }
     internalMarkSiblingsAsDirty(writableNode);
     children.splice(index, 1);
+    writableNode.__parent = null;
   }
 }
 
@@ -1290,4 +1291,16 @@ export function errorOnInsertTextNodeOnRoot(
       'Only element or decorator nodes can be inserted in to the root node',
     );
   }
+}
+
+export function $getNodeByKeyOrThrow<N extends LexicalNode>(key: NodeKey): N {
+  const node = $getNodeByKey<N>(key);
+  if (node === null) {
+    invariant(
+      false,
+      "Expected node with key %s to exist but it's not in the nodeMap.",
+      key,
+    );
+  }
+  return node;
 }

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -392,23 +392,9 @@ export class ElementNode extends LexicalNode {
       if ($isRangeSelection(selection)) {
         const nodesToRemoveKeySet = new Set(nodesToRemoveKeys);
         const nodesToInsertKeySet = new Set(nodesToInsertKeys);
-        const isPointRemoved = (point: PointType): boolean => {
-          let node: ElementNode | TextNode | null = point.getNode();
-          while (node) {
-            const nodeKey = node.__key;
-            if (
-              nodesToRemoveKeySet.has(nodeKey) &&
-              !nodesToInsertKeySet.has(nodeKey)
-            ) {
-              return true;
-            }
-            node = node.getParent();
-          }
-          return false;
-        };
 
         const {anchor, focus} = selection;
-        if (isPointRemoved(anchor)) {
+        if (isPointRemoved(anchor, nodesToRemoveKeySet, nodesToInsertKeySet)) {
           moveSelectionPointToSibling(
             anchor,
             anchor.getNode(),
@@ -417,7 +403,7 @@ export class ElementNode extends LexicalNode {
             nodeAfterRange,
           );
         }
-        if (isPointRemoved(focus)) {
+        if (isPointRemoved(focus, nodesToRemoveKeySet, nodesToInsertKeySet)) {
           moveSelectionPointToSibling(
             focus,
             focus.getNode(),
@@ -526,4 +512,20 @@ export function $isElementNode(
   node: LexicalNode | null | undefined,
 ): node is ElementNode {
   return node instanceof ElementNode;
+}
+
+function isPointRemoved(
+  point: PointType,
+  nodesToRemoveKeySet: Set<NodeKey>,
+  nodesToInsertKeySet: Set<NodeKey>,
+): boolean {
+  let node: ElementNode | TextNode | null = point.getNode();
+  while (node) {
+    const nodeKey = node.__key;
+    if (nodesToRemoveKeySet.has(nodeKey) && !nodesToInsertKeySet.has(nodeKey)) {
+      return true;
+    }
+    node = node.getParent();
+  }
+  return false;
 }


### PR DESCRIPTION
`ElementNode.splice` is a very hot method that gets called often. Looking at some profile traces, it seems that we can improve the runtime by moving out `isPointRemoved` as a nested closure, so it doesn't get created each time the method is called. I also noticed in cloning that we weren't cloning the linked list properties, so I snuck that in this PR too.