### PR TITLE
Change heading to paragraph when heading is empty

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Headings.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Headings.spec.mjs
@@ -103,7 +103,7 @@ test.describe('Headings', () => {
     );
   });
 
-  test('Changes to a paragraphwhen you press enter at the end of a heading', async ({
+  test('Changes to a paragraph when you press enter at the end of a heading', async ({
     page,
   }) => {
     await focusEditor(page);

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
@@ -143,8 +143,7 @@ describe('LexicalHeadingNode tests', () => {
         `<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><h2 dir="ltr"><span data-lexical-text="true">${text}</span></h2></div>`,
       );
       await editor.update(() => {
-        const selection = $getSelection();
-        const result = headingNode.insertNewAfter(selection);
+        const result = headingNode.insertNewAfter();
         expect(result).toBeInstanceOf(ParagraphNode);
         expect(result.getDirection()).toEqual(headingNode.getDirection());
       });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -299,32 +299,23 @@ export class HeadingNode extends ElementNode {
 
   // Mutation
   insertNewAfter(selection?: RangeSelection): ParagraphNode | HeadingNode {
-    const selectionOffset = selection ? selection.anchor.offset : 0;
     const newElement =
-      selectionOffset < this.getTextContentSize() && selectionOffset > 0
+      selection && selection.anchor.offset < this.getTextContentSize()
         ? $createHeadingNode(this.getTag())
         : $createParagraphNode();
     const direction = this.getDirection();
-
     newElement.setDirection(direction);
     this.insertAfter(newElement);
-
     return newElement;
   }
 
   collapseAtStart(): true {
-    const previousSibling = this.getPreviousSibling();
-    const isPreviouSiblingEmpty =
-      !previousSibling ||
-      (previousSibling && previousSibling.getTextContentSize() === 0);
-    const newElement = isPreviouSiblingEmpty
+    const newElement = !this.isEmpty()
       ? $createHeadingNode(this.getTag())
       : $createParagraphNode();
     const children = this.getChildren();
-
     children.forEach((child) => newElement.append(child));
     this.replace(newElement);
-
     return true;
   }
 

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -299,8 +299,9 @@ export class HeadingNode extends ElementNode {
 
   // Mutation
   insertNewAfter(selection?: RangeSelection): ParagraphNode | HeadingNode {
+    const anchorOffet = selection ? selection.anchor.offset : 0;
     const newElement =
-      selection && selection.anchor.offset < this.getTextContentSize()
+      anchorOffet > 0 && anchorOffet < this.getTextContentSize()
         ? $createHeadingNode(this.getTag())
         : $createParagraphNode();
     const direction = this.getDirection();


### PR DESCRIPTION
Follow up to #3441 to allow collapsing a heading to a paragraph when the editor is empty. Simplifies some of the logic from the previous PR as well.

https://user-images.githubusercontent.com/7748470/204591618-52a788b5-6b68-40c4-a223-dfdae4bea029.mov

