### PR TITLE
Inherit headless flag from parent editor

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -550,7 +550,7 @@ export class LexicalEditor {
     // We don't actually make use of the `editable` argument above.
     // Doing so, causes e2e tests around the lock to fail.
     this._editable = true;
-    this._headless = false;
+    this._headless = parentEditor !== null && parentEditor._headless;
     this._window = null;
   }
 


### PR DESCRIPTION
Nested editors should inherit headless flag from its parent. It fixes issues with headless conversion logic, where nested editors keep having `_pendingEditorState` as they are not reconciled properly due to missing headless flag