### PR TITLE
Support TypeScript language in code nodes

### DIFF
--- a/libdefs/prismjs.js
+++ b/libdefs/prismjs.js
@@ -70,3 +70,7 @@ declare module 'prismjs/components/prism-rust' {
 declare module 'prismjs/components/prism-swift' {
   declare module.exports: {};
 }
+
+declare module 'prismjs/components/prism-typescript' {
+  declare module.exports: {};
+}

--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -32,6 +32,7 @@ import 'prismjs/components/prism-sql';
 import 'prismjs/components/prism-python';
 import 'prismjs/components/prism-rust';
 import 'prismjs/components/prism-swift';
+import 'prismjs/components/prism-typescript';
 
 import {
   addClassNamesToElement,
@@ -62,6 +63,7 @@ export const CODE_LANGUAGE_FRIENDLY_NAME_MAP: Record<string, string> = {
   rust: 'Rust',
   sql: 'SQL',
   swift: 'Swift',
+  typescript: 'TypeScript',
   xml: 'XML',
 };
 
@@ -71,6 +73,7 @@ export const CODE_LANGUAGE_MAP: Record<string, string> = {
   plaintext: 'plain',
   python: 'py',
   text: 'plain',
+  ts: 'typescript',
 };
 
 export function normalizeCodeLang(lang: string) {

--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -27,6 +27,7 @@ import 'prismjs/components/prism-sql';
 import 'prismjs/components/prism-python';
 import 'prismjs/components/prism-rust';
 import 'prismjs/components/prism-swift';
+import 'prismjs/components/prism-typescript';
 
 import {mergeRegister} from '@lexical/utils';
 import {

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -31,6 +31,7 @@ import 'prismjs/components/prism-sql';
 import 'prismjs/components/prism-python';
 import 'prismjs/components/prism-rust';
 import 'prismjs/components/prism-swift';
+import 'prismjs/components/prism-typescript';
 
 import {addClassNamesToElement} from '@lexical/utils';
 import {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -101,6 +101,7 @@ const externals = [
   'prismjs/components/prism-python',
   'prismjs/components/prism-rust',
   'prismjs/components/prism-swift',
+  'prismjs/components/prism-typescript',
   '@lexical/list',
   '@lexical/table',
   '@lexical/file',


### PR DESCRIPTION
* Add support for `typescript` language in code nodes
* Add `ts` => `typescript` mapping
* Include Prism Typescript highlighting