### PR TITLE
Add start and end as format types

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -661,7 +661,14 @@ declare export function $isRootNode(
 /**
  * LexicalElementNode
  */
-export type ElementFormatType = 'left' | 'center' | 'right' | 'justify' | '';
+export type ElementFormatType =
+  | 'left'
+  | 'start'
+  | 'center'
+  | 'right'
+  | 'end'
+  | 'justify'
+  | '';
 declare export class ElementNode extends LexicalNode {
   __children: Array<NodeKey>;
   __format: number;

--- a/packages/lexical/src/LexicalConstants.ts
+++ b/packages/lexical/src/LexicalConstants.ts
@@ -57,6 +57,8 @@ export const IS_ALIGN_LEFT = 1;
 export const IS_ALIGN_CENTER = 2;
 export const IS_ALIGN_RIGHT = 3;
 export const IS_ALIGN_JUSTIFY = 4;
+export const IS_ALIGN_START = 5;
+export const IS_ALIGN_END = 6;
 
 // Reconciliation
 export const NON_BREAKING_SPACE = '\u00A0';
@@ -104,16 +106,20 @@ export const ELEMENT_TYPE_TO_FORMAT: Record<
   number
 > = {
   center: IS_ALIGN_CENTER,
+  end: IS_ALIGN_END,
   justify: IS_ALIGN_JUSTIFY,
   left: IS_ALIGN_LEFT,
   right: IS_ALIGN_RIGHT,
+  start: IS_ALIGN_START,
 };
 
 export const ELEMENT_FORMAT_TO_TYPE: Record<number, ElementFormatType> = {
   [IS_ALIGN_CENTER]: 'center',
+  [IS_ALIGN_END]: 'end',
   [IS_ALIGN_JUSTIFY]: 'justify',
   [IS_ALIGN_LEFT]: 'left',
   [IS_ALIGN_RIGHT]: 'right',
+  [IS_ALIGN_START]: 'start',
 };
 
 export const TEXT_MODE_TO_TYPE: Record<TextModeType, 0 | 1 | 2> = {

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -30,9 +30,11 @@ import {
   DOUBLE_LINE_BREAK,
   FULL_RECONCILE,
   IS_ALIGN_CENTER,
+  IS_ALIGN_END,
   IS_ALIGN_JUSTIFY,
   IS_ALIGN_LEFT,
   IS_ALIGN_RIGHT,
+  IS_ALIGN_START,
 } from './LexicalConstants';
 import {EditorState} from './LexicalEditorState';
 import {
@@ -131,6 +133,10 @@ function setElementFormat(dom: HTMLElement, format: number): void {
     setTextAlign(domStyle, 'right');
   } else if (format === IS_ALIGN_JUSTIFY) {
     setTextAlign(domStyle, 'justify');
+  } else if (format === IS_ALIGN_START) {
+    setTextAlign(domStyle, 'start');
+  } else if (format === IS_ALIGN_END) {
+    setTextAlign(domStyle, 'end');
   }
 }
 

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -48,7 +48,14 @@ export type SerializedElementNode = Spread<
   SerializedLexicalNode
 >;
 
-export type ElementFormatType = 'left' | 'center' | 'right' | 'justify' | '';
+export type ElementFormatType =
+  | 'left'
+  | 'start'
+  | 'center'
+  | 'right'
+  | 'end'
+  | 'justify'
+  | '';
 
 /** @noInheritDoc */
 export class ElementNode extends LexicalNode {


### PR DESCRIPTION
This PR adds `start` and `end` as valid format alignment types.

Closes #3467

Ensured text alignment end gets applied to the paragraph block:

<img width="1717" alt="image" src="https://user-images.githubusercontent.com/7748470/204900026-1081f00e-8336-4bd8-aee6-723f1273c95b.png">
