### PR TITLE
Improve selection performance on large updates

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -79,6 +79,25 @@ jest.mock('shared/environment', () => {
   return {...originalModule, IS_FIREFOX: true};
 });
 
+Range.prototype.getBoundingClientRect = function (): DOMRect {
+  const rect = {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+  };
+  return {
+    ...rect,
+    toJSON() {
+      return rect;
+    },
+  };
+};
+
 describe('LexicalSelection tests', () => {
   let container = null;
 

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -30,6 +30,25 @@ import {
 
 import {setAnchorPoint, setFocusPoint} from '../utils';
 
+Range.prototype.getBoundingClientRect = function (): DOMRect {
+  const rect = {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+  };
+  return {
+    ...rect,
+    toJSON() {
+      return rect;
+    },
+  };
+};
+
 function createParagraphWithNodes(editor, nodes) {
   const paragraph = $createParagraphNode();
   const nodeMap = editor._pendingEditorState._nodeMap;

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -34,6 +34,25 @@ jest.mock('shared/environment', () => {
 
 initializeClipboard();
 
+Range.prototype.getBoundingClientRect = function (): DOMRect {
+  const rect = {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+  };
+  return {
+    ...rect,
+    toJSON() {
+      return rect;
+    },
+  };
+};
+
 describe('LexicalEventHelpers', () => {
   let container = null;
 

--- a/packages/lexical/src/LexicalGC.ts
+++ b/packages/lexical/src/LexicalGC.ts
@@ -40,37 +40,31 @@ export function $garbageCollectDetachedDecorators(
 
 function $garbageCollectDetachedDeepChildNodes(
   node: ElementNode,
-  parentKey: NodeKey,
   prevNodeMap: NodeMap,
   nodeMap: NodeMap,
   dirtyNodes: Map<NodeKey, IntentionallyMarkedAsDirtyElement>,
 ): void {
-  const children = node.__children;
-  const childrenLength = children.length;
+  let child = node.getFirstChild();
 
-  for (let i = 0; i < childrenLength; i++) {
-    const childKey = children[i];
-    const child = nodeMap.get(childKey);
-
-    if (child !== undefined && child.__parent === parentKey) {
-      if ($isElementNode(child)) {
-        $garbageCollectDetachedDeepChildNodes(
-          child,
-          childKey,
-          prevNodeMap,
-          nodeMap,
-          dirtyNodes,
-        );
-      }
-
-      // If we have created a node and it was dereferenced, then also
-      // remove it from out dirty nodes Set.
-      if (!prevNodeMap.has(childKey)) {
-        dirtyNodes.delete(childKey);
-      }
-
-      nodeMap.delete(childKey);
+  while (child !== null) {
+    const childKey = child.__key;
+    const nextSibling = child.getNextSibling();
+    if ($isElementNode(child)) {
+      $garbageCollectDetachedDeepChildNodes(
+        child,
+        prevNodeMap,
+        nodeMap,
+        dirtyNodes,
+      );
     }
+
+    // If we have created a node and it was dereferenced, then also
+    // remove it from out dirty nodes Set.
+    if (!prevNodeMap.has(childKey)) {
+      dirtyNodes.delete(childKey);
+    }
+    nodeMap.delete(childKey);
+    child = nextSibling;
   }
 }
 
@@ -104,7 +98,6 @@ export function $garbageCollectDetachedNodes(
         if ($isElementNode(node)) {
           $garbageCollectDetachedDeepChildNodes(
             node,
-            nodeKey,
             prevNodeMap,
             nodeMap,
             dirtyElements,

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -12,6 +12,7 @@ import type {LexicalNode, NodeKey} from './LexicalNode';
 import type {ElementNode} from './nodes/LexicalElementNode';
 import type {TextFormatType} from './nodes/LexicalTextNode';
 
+import { IS_CHROME } from 'shared/environment';
 import getDOMSelection from 'shared/getDOMSelection';
 import invariant from 'shared/invariant';
 
@@ -2806,14 +2807,14 @@ export function updateDOMSelection(
     // Apply the updated selection to the DOM. Note: this will trigger
     // a "selectionchange" event, although it will be asynchronous.
     try {
-      // When updating more than 1000 nodes, it's actually better to defer
+      // When updating more than 1000 nodes on Chrome, it's actually better to defer
       // updating the selection till the next frame. This is because Chrome's
       // Blink engine has hard limit on how many DOM nodes it can redraw in
       // a single cycle, so keeping it to the next frame improves performance.
       // The downside is that is makes the computation within Lexical more
       // complex, as now, we've sync update the DOM, but selection no longer
       // matches.
-      if (dirtyLeavesCount > 1000) {
+      if (IS_CHROME && dirtyLeavesCount > 1000) {
         window.requestAnimationFrame(() =>
           domSelection.setBaseAndExtent(
             nextAnchorNode as Node,

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -12,7 +12,7 @@ import type {LexicalNode, NodeKey} from './LexicalNode';
 import type {ElementNode} from './nodes/LexicalElementNode';
 import type {TextFormatType} from './nodes/LexicalTextNode';
 
-import { IS_CHROME } from 'shared/environment';
+import {IS_CHROME} from 'shared/environment';
 import getDOMSelection from 'shared/getDOMSelection';
 import invariant from 'shared/invariant';
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2701,21 +2701,6 @@ export function adjustPointOffsetForMergedSibling(
   }
 }
 
-function applyDOMSelection(
-  domSelection: Selection,
-  nextAnchorNode: Node,
-  nextAnchorOffset: number,
-  nextFocusNode: Node,
-  nextFocusOffset: number,
-): void {
-  domSelection.setBaseAndExtent(
-    nextAnchorNode,
-    nextAnchorOffset,
-    nextFocusNode,
-    nextFocusOffset,
-  );
-}
-
 export function updateDOMSelection(
   prevSelection: RangeSelection | NodeSelection | GridSelection | null,
   nextSelection: RangeSelection | NodeSelection | GridSelection | null,
@@ -2830,8 +2815,7 @@ export function updateDOMSelection(
       // matches.
       if (dirtyLeavesCount > 1000) {
         window.requestAnimationFrame(() =>
-          applyDOMSelection(
-            domSelection,
+          domSelection.setBaseAndExtent(
             nextAnchorNode as Node,
             nextAnchorOffset,
             nextFocusNode as Node,
@@ -2839,8 +2823,7 @@ export function updateDOMSelection(
           ),
         );
       } else {
-        applyDOMSelection(
-          domSelection,
+        domSelection.setBaseAndExtent(
           nextAnchorNode,
           nextAnchorOffset,
           nextFocusNode,

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -510,6 +510,7 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
   const normalizedNodes = editor._normalizedNodes;
   const tags = editor._updateTags;
   const deferred = editor._deferred;
+  const dirtyLeavesCount = dirtyLeaves.size;
 
   if (needsUpdate) {
     editor._dirtyType = NO_DIRTY_NODES;
@@ -545,6 +546,7 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
         domSelection,
         tags,
         rootElement as HTMLElement,
+        dirtyLeavesCount,
       );
     } finally {
       activeEditor = previousActiveEditor;

--- a/packages/shared/src/environment.ts
+++ b/packages/shared/src/environment.ts
@@ -42,5 +42,5 @@ export const IS_IOS: boolean =
 
 // Keep these in case we need to use them in the future.
 // export const IS_WINDOWS: boolean = CAN_USE_DOM && /Win/.test(navigator.platform);
-// export const IS_CHROME: boolean = CAN_USE_DOM && /^(?=.*Chrome).*/i.test(navigator.userAgent);
+export const IS_CHROME: boolean = CAN_USE_DOM && /^(?=.*Chrome).*/i.test(navigator.userAgent);
 // export const canUseTextInputEvent: boolean = CAN_USE_DOM && 'TextEvent' in window && !documentMode;

--- a/packages/shared/src/environment.ts
+++ b/packages/shared/src/environment.ts
@@ -42,5 +42,6 @@ export const IS_IOS: boolean =
 
 // Keep these in case we need to use them in the future.
 // export const IS_WINDOWS: boolean = CAN_USE_DOM && /Win/.test(navigator.platform);
-export const IS_CHROME: boolean = CAN_USE_DOM && /^(?=.*Chrome).*/i.test(navigator.userAgent);
+export const IS_CHROME: boolean =
+  CAN_USE_DOM && /^(?=.*Chrome).*/i.test(navigator.userAgent);
 // export const canUseTextInputEvent: boolean = CAN_USE_DOM && 'TextEvent' in window && !documentMode;


### PR DESCRIPTION
Moving selection on large DOM sets is not cheap in Chrome. It's actually one of the most expensive things you can do on Webkit/Chromium. In order to improve performance, you can separate DOM mutations, and in doing so make it easier for the recalculation of DOM layers to apply to selection.

The easiest way to approach tackling this problem is using a simple `requestAnimationFrame` however, this then moves much of the intended logic for dealing with problems within Lexical to being async. In reality, we don't always need this to be async and in most cases sync is fine. For when we do have async, Lexical can gradually pick-up, but this is mostly an edge-case.