### PR TITLE
Add poll and speech-to-text plugin examples

### DIFF
--- a/packages/lexical-website/docs/demos/plugins/markdown.md
+++ b/packages/lexical-website/docs/demos/plugins/markdown.md
@@ -10,6 +10,8 @@ The editor already has some prepopulated text, and you can press the button on t
 
 Currently, for the purposes of simplicity, the link plugin is very basic, so you will have to press twice on the links to see the URL and edit it. You can further import the AutoLink and ClickableLink plugins to be able to click on the link to jump straight to the website of your preference. 
 
+This plugin is also a part of the actions plugin. You can check out the other tools (e.g., delete all, lock/unlock text) by exploring the playground's source code.
+
 <iframe src="https://codesandbox.io/embed/lexical-markdown-plugin-example-4076jq?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/MarkdownTransformers.ts,/src/plugins/ActionsPlugin.tsx&theme=dark&view=split"
      style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
      title="lexical-markdown-plugin-example"

--- a/packages/lexical-website/docs/demos/plugins/poll.md
+++ b/packages/lexical-website/docs/demos/plugins/poll.md
@@ -1,0 +1,16 @@
+---
+id: "poll"
+title: "Poll Plugin"
+sidebar_label: "Poll Plugin"
+---
+
+This page focuses on implementing the poll plugin and the code you need to add a poll to your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+
+You can add as many options as you want and select them by checking the box on the left side of each option. You can also change the CSS of the poll in `styles.css`.
+
+<iframe src="https://codesandbox.io/embed/lexical-poll-plugin-example-2yf2g2?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/PollPlugin.tsx,/src/nodes/PollNode.tsx&theme=dark&view=split"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-poll-plugin-example"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>

--- a/packages/lexical-website/docs/demos/plugins/speech-to-text.md
+++ b/packages/lexical-website/docs/demos/plugins/speech-to-text.md
@@ -1,0 +1,16 @@
+---
+id: "speech-to-text"
+title: "Speech-to-Text Plugin"
+sidebar_label: "Speech-to-Text Plugin"
+---
+
+This page focuses on implementing the speech-to-text plugin and the code you need to add a speech-to-text tool to your editor. You can check out the CodeSandbox directly or view, edit and try out the code in real-time inside the embed. 
+
+This plugin is a part of the actions plugin. You can check out the other tools (e.g., delete all, lock/unlock text) by exploring the playground's source code.
+
+<iframe src="https://codesandbox.io/embed/lexical-speech-to-text-plugin-example-m4xk63?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/SpeechToTextPlugin.ts,/src/plugins/ActionsPlugin.tsx&theme=dark&view=split"
+     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="lexical-speech-to-text-plugin-example"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>


### PR DESCRIPTION

- [x] created a CodeSandbox example for the poll plugin [here](https://codesandbox.io/embed/lexical-poll-plugin-example-2yf2g2)
- [x] created a CodeSandbox example for the speech-to-text plugin [here](https://codesandbox.io/embed/lexical-speech-to-text-plugin-example-m4xk63)
- [x] added the new pages and examples on the website (under “/docs/demos/plugins/poll” and “/docs/demos/plugins/speech-to-text”)

![Poll Plugin](https://user-images.githubusercontent.com/47840436/205421344-004e4fa6-0eb7-4594-8268-3f6ed156857a.png)

![Speech-to-Text Plugin](https://user-images.githubusercontent.com/47840436/205421346-d1ae3443-c0e8-4fd4-a87a-737c54cd44e1.png)

Issue https://github.com/facebook/lexical/issues/2886
