### PR TITLE
Inform users that they need to install headless

### DIFF
--- a/packages/lexical-headless/README.md
+++ b/packages/lexical-headless/README.md
@@ -4,6 +4,12 @@ This package allows you to use interact with Lexical in a headless environment (
 main features like editor.update(), editor.registerNodeTransform(), editor.registerUpdateListener()
 to create, update or traverse state.
 
+Install `@lexical/headless`:
+
+```
+npm install --save @lexical/headless
+```
+
 ```js
 const { createHeadlessEditor } = require('@lexical/headless');
 


### PR DESCRIPTION
Currently, it's not obvious that `@lexical/headless` needs to be installed. Other packages like rich-text don't need to be installed. This is a simple PR to make docs a little more clear.