### PR TITLE
Fix mutation listener for when DOM moves occur

### DIFF
--- a/packages/lexical-react/src/LexicalNodeEventPlugin.ts
+++ b/packages/lexical-react/src/LexicalNodeEventPlugin.ts
@@ -36,11 +36,20 @@ export function NodeEventPlugin({
 
   useLayoutEffect(() => {
     return editor.registerMutationListener(nodeType, (mutations) => {
+      const registedElements: WeakSet<HTMLElement> = new WeakSet();
+
       editor.getEditorState().read(() => {
         for (const [key, mutation] of mutations) {
           const element: null | HTMLElement = editor.getElementByKey(key);
 
-          if (mutation === 'created' && element !== null) {
+          if (
+            // Updated might be a move, so that might mean a new DOM element
+            // is created. In this case, we need to add and event listener too.
+            (mutation === 'created' || mutation === 'updated') &&
+            element !== null &&
+            !registedElements.has(element)
+          ) {
+            registedElements.add(element);
             element.addEventListener(eventType, (event: Event) => {
               listenerRef.current(event, editor, key);
             });

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -983,8 +983,14 @@ export function setMutatedNode(
     mutatedNodesByType = new Map();
     mutatedNodes.set(klass, mutatedNodesByType);
   }
-  if (!mutatedNodesByType.has(nodeKey)) {
-    mutatedNodesByType.set(nodeKey, mutation);
+  const prevMutation = mutatedNodesByType.get(nodeKey);
+  // If the node has already been "destroyed", yet we are
+  // re-making it, then this means a move likely happened.
+  // We should change the mutation to be that of "updated"
+  // instead.
+  const isMove = prevMutation === 'destroyed' && mutation === 'created';
+  if (prevMutation === undefined || isMove) {
+    mutatedNodesByType.set(nodeKey, isMove ? 'updated' : mutation);
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/3490. It seems that we didn't have a codepath for when the reconciler does a move – a destroy from one parent and create in another. This should be an update.