### PR TITLE
Fix insertion when the existing anchor node is orphaned

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -223,6 +223,7 @@ function $shouldPreventDefaultAndInsertText(
     // If the DOM has not been updated for an input event
     (!isBeforeInput &&
       domAnchorNode &&
+      !anchorNode.isComposing() &&
       getInsertedText(selection, text) !==
         getAnchorTextFromDOM(domAnchorNode)) ||
     // Check if we're changing from bold to italics, or some other format.

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -713,6 +713,8 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
           getAnchorTextFromDOM(domSelection.anchorNode)
       ) {
         dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, data);
+      } else {
+        $updateSelectedTextFromDOM(false);
       }
 
       const textLength = data.length;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -510,6 +510,29 @@ export function getAnchorTextFromDOM(anchorNode: Node): null | string {
   return null;
 }
 
+export function getInsertedText(
+  selection: RangeSelection,
+  text: string,
+): null | string {
+  if (selection.anchor.key !== selection.focus.key) {
+    return null;
+  }
+
+  const anchor = selection.anchor;
+  const anchorNode = anchor.getNode();
+  if (!$isTextNode(anchorNode)) {
+    return null;
+  }
+
+  const existingText = anchorNode.getTextContent();
+
+  return (
+    existingText.slice(0, anchor.offset) +
+    text +
+    existingText.slice(anchor.offset + selection.focus.offset)
+  );
+}
+
 export function $updateSelectedTextFromDOM(
   isCompositionEnd: boolean,
   data?: string,


### PR DESCRIPTION
Fixes #3460.

Consists of three changes:

1. In #3429 we tweaked `$shouldPreventDefaultAndInsertText` so that the check for replacing a range with a single character or grapheme is only applied for input events (not beforeinput events) unless we determine that it is a dangling input event but we likely meant to `&&` that condition with the remaining conditions (not `||` it).

   See analysis here: https://github.com/facebook/lexical/issues/3460#issuecomment-1334744872

   This patch effectively changes the `||` to and `&&` (and drops a few no-longer-needed braces in the process).

2. We have observed in some circumstances (thought to be when using a newer version of Playwright) that Webkit can end up in a state where, during the input event, the DOM node for our lexical selection anchor has been orphaned.

   The second change in this patch makes `$shouldPreventDefaultAndInsertText` detect this case and return true (i.e. cause us to dispatch a controlled text insertion in this case).

3. Finally, in order to ensure that we do, in fact, dispatch a controlled text insertion in the case described in (2), this patch also alters the condition inside `onInput` to ensure we perform the insertion when the DOM node for our lexical anchor is orphaned.