### PR TITLE
Improve Auto Embed

### DIFF
--- a/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
@@ -228,17 +228,19 @@ export function AutoEmbedDialog({
 
   const validateText = useMemo(
     () =>
-      debounce(() => {
-        const urlMatch = URL_MATCHER.exec(text);
-        if (embedConfig != null && text != null && urlMatch != null) {
-          Promise.resolve(embedConfig.parseUrl(text)).then((parseResult) => {
-            setEmbedResult(parseResult);
-          });
+      debounce((inputText) => {
+        const urlMatch = URL_MATCHER.exec(inputText);
+        if (embedConfig != null && inputText != null && urlMatch != null) {
+          Promise.resolve(embedConfig.parseUrl(inputText)).then(
+            (parseResult) => {
+              setEmbedResult(parseResult);
+            },
+          );
         } else if (embedResult != null) {
           setEmbedResult(null);
         }
       }, 200),
-    [embedConfig, embedResult, text],
+    [embedConfig, embedResult],
   );
 
   const onClick = () => {
@@ -258,8 +260,9 @@ export function AutoEmbedDialog({
           value={text}
           data-test-id={`${embedConfig.type}-embed-modal-url`}
           onChange={(e) => {
-            setText(e.target.value);
-            validateText();
+            const {value} = e.target;
+            setText(value);
+            validateText(value);
           }}
         />
       </div>

--- a/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
@@ -16,7 +16,6 @@ import {
   URL_MATCHER,
 } from '@lexical/react/LexicalAutoEmbedPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {debounce} from 'lodash-es';
 import {useMemo, useState} from 'react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -215,6 +214,16 @@ function AutoEmbedMenu({
   );
 }
 
+const debounce = (callback: (text: string) => void, delay: number) => {
+  let timeoutId: number;
+  return (text: string) => {
+    window.clearTimeout(timeoutId);
+    timeoutId = window.setTimeout(() => {
+      callback(text);
+    }, delay);
+  };
+};
+
 export function AutoEmbedDialog({
   embedConfig,
   onClose,
@@ -228,7 +237,7 @@ export function AutoEmbedDialog({
 
   const validateText = useMemo(
     () =>
-      debounce((inputText) => {
+      debounce((inputText: string) => {
         const urlMatch = URL_MATCHER.exec(inputText);
         if (embedConfig != null && inputText != null && urlMatch != null) {
           Promise.resolve(embedConfig.parseUrl(inputText)).then(

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -27,20 +27,24 @@ import {
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import * as React from 'react';
 
-export type EmbedMatchResult = {
+export type EmbedMatchResult<TEmbedMatchResult = unknown> = {
   url: string;
   id: string;
+  data?: TEmbedMatchResult;
 };
 
-export interface EmbedConfig {
+export interface EmbedConfig<
+  TEmbedMatchResultData = unknown,
+  TEmbedMatchResult = EmbedMatchResult<TEmbedMatchResultData>,
+> {
   // Used to identify this config e.g. youtube, tweet, google-maps.
   type: string;
   // Determine if a given URL is a match and return url data.
   parseUrl: (
     text: string,
-  ) => Promise<EmbedMatchResult | null> | EmbedMatchResult | null;
+  ) => Promise<TEmbedMatchResult | null> | TEmbedMatchResult | null;
   // Create the Lexical embed node from the url data.
-  insertNode: (editor: LexicalEditor, result: EmbedMatchResult) => void;
+  insertNode: (editor: LexicalEditor, result: TEmbedMatchResult) => void;
 }
 
 export const URL_MATCHER =

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -178,9 +178,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
           editor.update(() => {
             activeEmbedConfig.insertNode(editor, result);
             if (linkNode.isAttached()) {
-              editor.update(() => {
-                linkNode.remove();
-              });
+              linkNode.remove();
             }
           });
         }

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -36,7 +36,7 @@ export interface EmbedConfig {
   // Used to identify this config e.g. youtube, tweet, google-maps.
   type: string;
   // Determine if a given URL is a match and return url data.
-  parseUrl: (text: string) => EmbedMatchResult | null;
+  parseUrl: (text: string) => Promise<EmbedMatchResult | null>;
   // Create the Lexical embed node from the url data.
   insertNode: (editor: LexicalEditor, result: EmbedMatchResult) => void;
 }
@@ -92,15 +92,20 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
 
   const checkIfLinkNodeIsEmbeddable = useCallback(
     (key: NodeKey) => {
-      editor.getEditorState().read(() => {
+      editor.getEditorState().read(async () => {
         const linkNode = $getNodeByKey(key);
         if ($isLinkNode(linkNode)) {
-          const embedConfigMatch = embedConfigs.find((embedConfig) =>
-            embedConfig.parseUrl(linkNode.__url),
-          );
-          if (embedConfigMatch != null) {
-            setActiveEmbedConfig(embedConfigMatch);
-            setNodeKey(linkNode.getKey());
+          for (let i = 0; i < embedConfigs.length; i++) {
+            const embedConfig = embedConfigs[i];
+
+            const urlMatch = await Promise.resolve(
+              embedConfig.parseUrl(linkNode.__url),
+            );
+
+            if (urlMatch != null) {
+              setActiveEmbedConfig(embedConfig);
+              setNodeKey(linkNode.getKey());
+            }
           }
         }
       });
@@ -149,7 +154,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
     );
   }, [editor, embedConfigs, onOpenEmbedModalForConfig]);
 
-  const embedLinkViaActiveEmbedConfig = useCallback(() => {
+  const embedLinkViaActiveEmbedConfig = useCallback(async () => {
     if (activeEmbedConfig != null && nodeKey != null) {
       const linkNode = editor.getEditorState().read(() => {
         const node = $getNodeByKey(nodeKey);
@@ -159,7 +164,9 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
         return null;
       });
       if ($isLinkNode(linkNode)) {
-        const result = activeEmbedConfig.parseUrl(linkNode.__url);
+        const result = await Promise.resolve(
+          activeEmbedConfig.parseUrl(linkNode.__url),
+        );
         if (result != null) {
           editor.update(() => {
             activeEmbedConfig.insertNode(editor, result);

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -36,7 +36,9 @@ export interface EmbedConfig {
   // Used to identify this config e.g. youtube, tweet, google-maps.
   type: string;
   // Determine if a given URL is a match and return url data.
-  parseUrl: (text: string) => Promise<EmbedMatchResult | null>;
+  parseUrl: (
+    text: string,
+  ) => Promise<EmbedMatchResult | null> | EmbedMatchResult | null;
   // Create the Lexical embed node from the url data.
   insertNode: (editor: LexicalEditor, result: EmbedMatchResult) => void;
 }

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -169,6 +169,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
         }
         return null;
       });
+
       if ($isLinkNode(linkNode)) {
         const result = await Promise.resolve(
           activeEmbedConfig.parseUrl(linkNode.__url),
@@ -176,12 +177,12 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
         if (result != null) {
           editor.update(() => {
             activeEmbedConfig.insertNode(editor, result);
+            if (linkNode.isAttached()) {
+              editor.update(() => {
+                linkNode.remove();
+              });
+            }
           });
-          if (linkNode.isAttached()) {
-            editor.update(() => {
-              linkNode.remove();
-            });
-          }
         }
       }
     }


### PR DESCRIPTION
This PR adds support for async parseURL calls, which may be necessary for making sure something is embeddable. It also lets parse URL add arbitrary data to its match result which may be useful for caching async results.

Most of the changed lines here relate to adding async support on the playground.