### PR TITLE
Fix dom-less reconciliation

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -417,9 +417,9 @@ function handleDEVOnlyPendingUpdateGuarantees(
 export function commitPendingUpdates(editor: LexicalEditor): void {
   const pendingEditorState = editor._pendingEditorState;
   const rootElement = editor._rootElement;
-  const headless = editor._headless;
+  const shouldSkipDOM = editor._headless || rootElement === null;
 
-  if ((rootElement === null && !headless) || pendingEditorState === null) {
+  if (pendingEditorState === null) {
     return;
   }
 
@@ -440,7 +440,7 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
   editor._pendingEditorState = null;
   editor._editorState = pendingEditorState;
 
-  if (!headless && needsUpdate && observer !== null) {
+  if (!shouldSkipDOM && needsUpdate && observer !== null) {
     activeEditor = editor;
     activeEditorState = pendingEditorState;
     isReadOnlyMode = false;
@@ -525,7 +525,7 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
   // Reconciliation has finished. Now update selection and trigger listeners.
   // ======
 
-  const domSelection = headless ? null : getDOMSelection();
+  const domSelection = shouldSkipDOM ? null : getDOMSelection();
 
   // Attempt to update the DOM selection, including focusing of the root element,
   // and scroll into view if needed.

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2288,4 +2288,14 @@ describe('LexicalEditor tests', () => {
       expect(text.getTextContent()).toBe('123');
     });
   });
+
+  it('reconciles state without root element', () => {
+    editor = createTestEditor({});
+    const state = editor.parseEditorState(
+      `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Hello world","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+    );
+    editor.setEditorState(state);
+    expect(editor._editorState).toBe(state);
+    expect(editor._pendingEditorState).toBe(null);
+  });
 });


### PR DESCRIPTION
There's an issue with editor.setEditorState with unset root element. We've discovered it with nested editors when nested LexicalComposer was conditionally hidden, but it's easy to reproduce with a regular one too by creating an instance and setting some editor state and skipping `setRootElement` call:

```
const editor = createEditor({ ... });
editor.setEditorState(initialState);
```

Although it seems fine, editor won't have its state reconciled due if it does not have root element set due to reconciler condition and will keep having `editor._pendingEditorState` equal to `initialState` and `editor._editorState` set to empty state. This could lead to unexpected results, e.g., if you try to serialize editor right after that (without setting root element), it will use previous editor state since `setEditorState` reconciliation has never actually finished.

This PR changes reconciler a bit by treating headless and rootElement-less editors the same way: it runs all listeners, state pointer updates and just skips dom-related paths.

There's alternative approach (that might be safer), to allow dom-less reconciliation for nested editors that don't have root element, but their parent does. But it means that calling `createEditor, setEditorState, toJSON` like example above would still produce unexpected result. One concern that I have is whether it might cause any race conditions given now setEditorState for editor that is not yet linked to content editable would trigger all listeners (before it would not due to root element check)