### PR TITLE
Add demos section to the navbar

### DIFF
--- a/packages/lexical-website/docusaurus.config.js
+++ b/packages/lexical-website/docusaurus.config.js
@@ -181,6 +181,12 @@ const config = {
             sidebarId: 'api',
             type: 'docSidebar',
           },
+          {
+            label: 'Demos',
+            position: 'left',
+            sidebarId: 'demos',
+            type: 'docSidebar',
+          },
           {label: 'Community', position: 'left', to: '/community'},
           {
             href: GITHUB_REPO_URL,

--- a/packages/lexical-website/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/packages/lexical-website/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -15,6 +15,10 @@
     "message": "Getting Started",
     "description": "The label for category Getting Started in sidebar tutorialSidebar"
   },
+  "sidebar.tutorialSidebar.category.Demos": {
+    "message": "Demos",
+    "description": "The label for category Demo in sidebar tutorialSidebar"
+  },
   "sidebar.tutorialSidebar.category.Concepts": {
     "message": "Concepts",
     "description": "The label for category Concepts in sidebar tutorialSidebar"

--- a/packages/lexical-website/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/packages/lexical-website/i18n/en/docusaurus-theme-classic/navbar.json
@@ -18,5 +18,9 @@
   "item.label.GitHub": {
     "message": "GitHub",
     "description": "Navbar item with label GitHub"
+  },
+  "item.label.Demos": {
+    "message": "Demos",
+    "description": "Navbar item with label Demos"
   }
 }


### PR DESCRIPTION
- [x] added the demos section to the navbar and sidebar 

![image](https://user-images.githubusercontent.com/47840436/206086370-8efb130c-8fd1-4404-86c7-aeeb275ba6da.png)

Issue https://github.com/facebook/lexical/issues/2886