### PR TITLE
Ensure that inline text transforms running for any nested elements

### DIFF
--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -24,6 +24,7 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  $isElementNode,
   $isParagraphNode,
   $isTextNode,
 } from 'lexical';
@@ -78,6 +79,7 @@ export function createMarkdownImport(
     // Removing empty paragraphs as md does not really
     // allow empty lines and uses them as dilimiter
     const children = root.getChildren();
+    importTextNodes(children, textFormatTransformersIndex, byType.textMatch);
     for (const child of children) {
       if (isEmptyParagraph(child)) {
         child.remove();
@@ -125,12 +127,6 @@ function importBlocks(
     }
   }
 
-  importTextFormatTransformers(
-    textNode,
-    textFormatTransformersIndex,
-    textMatchTransformers,
-  );
-
   // If no transformer found and we left with original paragraph node
   // can check if its content can be appended to the previous node
   // if it's a paragraph, quote or list
@@ -159,6 +155,28 @@ function importBlocks(
         ]);
         elementNode.remove();
       }
+    }
+  }
+}
+
+function importTextNodes(
+  nodes: Array<LexicalNode>,
+  textFormatTransformersIndex: TextFormatTransformersIndex,
+  textMatchTransformers: Array<TextMatchTransformer>,
+) {
+  for (const node of nodes) {
+    if ($isElementNode(node)) {
+      importTextNodes(
+        node.getChildren(),
+        textFormatTransformersIndex,
+        textMatchTransformers,
+      );
+    } else if ($isTextNode(node)) {
+      importTextFormatTransformers(
+        node,
+        textFormatTransformersIndex,
+        textMatchTransformers,
+      );
     }
   }
 }


### PR DESCRIPTION
Changing order of block -> inline elements processing. The current version parses block and then tries to parse its original text node to find any inline matches (like "*" or links). It works for regular blocks where whole line is converted to a single element node (e.g., ">" converted to quote, but fails for tables where single line is converted into multiple elements (table with rows and cells).

Updated approach parses blocks first and then recursively runs through all text nodes to find those inline matches, so it does not matter what kind of elements structure blocks would produce as all text nodes will be checked