### PR TITLE
Improve insertBefore, insertAfter, replace selection restoration logic

### DIFF
--- a/packages/lexical-code/flow/LexicalCode.js.flow
+++ b/packages/lexical-code/flow/LexicalCode.js.flow
@@ -27,6 +27,7 @@ declare export class CodeNode extends ElementNode {
   updateDOM(prevNode: CodeNode, dom: HTMLElement): boolean;
   insertNewAfter(
     selection: RangeSelection,
+    restoreSelection?: boolean,
   ): null | ParagraphNode | CodeHighlightNode;
   canInsertTab(): boolean;
   collapseAtStart(): true;

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -214,6 +214,7 @@ export class CodeNode extends ElementNode {
   // Mutation
   insertNewAfter(
     selection: RangeSelection,
+    restoreSelection = true,
   ): null | ParagraphNode | CodeHighlightNode {
     const children = this.getChildren();
     const childrenLength = children.length;
@@ -229,7 +230,7 @@ export class CodeNode extends ElementNode {
       children[childrenLength - 1].remove();
       children[childrenLength - 2].remove();
       const newElement = $createParagraphNode();
-      this.insertAfter(newElement);
+      this.insertAfter(newElement, restoreSelection);
       return newElement;
     }
 

--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -47,7 +47,10 @@ declare export class LinkNode extends ElementNode {
   setTarget(target: null | string): void;
   getRel(): null | string;
   setRel(rel: null | string): void;
-  insertNewAfter(selection: RangeSelection): null | ElementNode;
+  insertNewAfter(
+    selection: RangeSelection,
+    restoreSelection?: boolean,
+  ): null | ElementNode;
   canInsertTextBefore(): false;
   canInsertTextAfter(): false;
   canBeEmpty(): false;
@@ -64,7 +67,10 @@ declare export class AutoLinkNode extends LinkNode {
   static getType(): string;
   // $FlowFixMe clone method inheritance
   static clone(node: AutoLinkNode): AutoLinkNode;
-  insertNewAfter(selection: RangeSelection): null | ElementNode;
+  insertNewAfter(
+    selection: RangeSelection,
+    restoreSelection?: boolean,
+  ): null | ElementNode;
 }
 declare export function $createAutoLinkNode(
   url: string,

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -176,8 +176,14 @@ export class LinkNode extends ElementNode {
     writable.__rel = rel;
   }
 
-  insertNewAfter(selection: RangeSelection): null | ElementNode {
-    const element = this.getParentOrThrow().insertNewAfter(selection);
+  insertNewAfter(
+    selection: RangeSelection,
+    restoreSelection = true,
+  ): null | ElementNode {
+    const element = this.getParentOrThrow().insertNewAfter(
+      selection,
+      restoreSelection,
+    );
     if ($isElementNode(element)) {
       const linkNode = $createLinkNode(this.__url, {
         rel: this.__rel,
@@ -299,8 +305,14 @@ export class AutoLinkNode extends LinkNode {
     };
   }
 
-  insertNewAfter(selection: RangeSelection): null | ElementNode {
-    const element = this.getParentOrThrow().insertNewAfter(selection);
+  insertNewAfter(
+    selection: RangeSelection,
+    restoreSelection = true,
+  ): null | ElementNode {
+    const element = this.getParentOrThrow().insertNewAfter(
+      selection,
+      restoreSelection,
+    );
     if ($isElementNode(element)) {
       const linkNode = $createAutoLinkNode(this.__url, {
         rel: this._rel,

--- a/packages/lexical-list/flow/LexicalList.js.flow
+++ b/packages/lexical-list/flow/LexicalList.js.flow
@@ -42,7 +42,7 @@ declare export function insertList(
 declare export class ListItemNode extends ElementNode {
   append(...nodes: LexicalNode[]): this;
   replace<N: LexicalNode>(replaceWithNode: N): N;
-  insertAfter(node: LexicalNode): LexicalNode;
+  insertAfter(node: LexicalNode, restoreSelection?: boolean): LexicalNode;
   insertNewAfter(): ListItemNode | ParagraphNode;
   collapseAtStart(selection: RangeSelection): true;
   getIndent(): number;

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -188,7 +188,7 @@ export class ListItemNode extends ElementNode {
     return replaceWithNode;
   }
 
-  insertAfter(node: LexicalNode): LexicalNode {
+  insertAfter(node: LexicalNode, restoreSelection = true): LexicalNode {
     const listNode = this.getParentOrThrow();
 
     if (!$isListNode(listNode)) {
@@ -201,7 +201,7 @@ export class ListItemNode extends ElementNode {
     const siblings = this.getNextSiblings();
 
     if ($isListItemNode(node)) {
-      const after = super.insertAfter(node);
+      const after = super.insertAfter(node, restoreSelection);
       const afterListNode = node.getParentOrThrow();
 
       if ($isListNode(afterListNode)) {
@@ -220,7 +220,7 @@ export class ListItemNode extends ElementNode {
       for (let i = children.length - 1; i >= 0; i--) {
         child = children[i];
 
-        this.insertAfter(child);
+        this.insertAfter(child, restoreSelection);
       }
 
       return child;
@@ -228,14 +228,14 @@ export class ListItemNode extends ElementNode {
 
     // Otherwise, split the list
     // Split the lists and insert the node in between them
-    listNode.insertAfter(node);
+    listNode.insertAfter(node, restoreSelection);
 
     if (siblings.length !== 0) {
       const newListNode = $createListNode(listNode.getListType());
 
       siblings.forEach((sibling) => newListNode.append(sibling));
 
-      node.insertAfter(newListNode);
+      node.insertAfter(newListNode, restoreSelection);
     }
 
     return node;
@@ -254,11 +254,14 @@ export class ListItemNode extends ElementNode {
     }
   }
 
-  insertNewAfter(): ListItemNode | ParagraphNode {
+  insertNewAfter(
+    _: RangeSelection,
+    restoreSelection = true,
+  ): ListItemNode | ParagraphNode {
     const newElement = $createListItemNode(
       this.__checked == null ? undefined : false,
     );
-    this.insertAfter(newElement);
+    this.insertAfter(newElement, restoreSelection);
 
     return newElement;
   }

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -150,8 +150,14 @@ export class MarkNode extends ElementNode {
     }
   }
 
-  insertNewAfter(selection: RangeSelection): null | ElementNode {
-    const element = this.getParentOrThrow().insertNewAfter(selection);
+  insertNewAfter(
+    selection: RangeSelection,
+    restoreSelection = true,
+  ): null | ElementNode {
+    const element = this.getParentOrThrow().insertNewAfter(
+      selection,
+      restoreSelection,
+    );
     if ($isElementNode(element)) {
       const markNode = $createMarkNode(this.__ids);
       element.append(markNode);

--- a/packages/lexical-overflow/src/index.ts
+++ b/packages/lexical-overflow/src/index.ts
@@ -69,9 +69,12 @@ export class OverflowNode extends ElementNode {
     return false;
   }
 
-  insertNewAfter(selection: RangeSelection): null | LexicalNode {
+  insertNewAfter(
+    selection: RangeSelection,
+    restoreSelection = true,
+  ): null | LexicalNode {
     const parent = this.getParentOrThrow();
-    return parent.insertNewAfter(selection);
+    return parent.insertNewAfter(selection, restoreSelection);
   }
 
   excludeFromCopy(): boolean {

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
@@ -72,7 +72,7 @@ export class CollapsibleTitleNode extends ElementNode {
     return true;
   }
 
-  insertNewAfter(): ElementNode {
+  insertNewAfter(_: RangeSelection, restoreSelection = true): ElementNode {
     const containerNode = this.getParentOrThrow();
 
     if (!$isCollapsibleContainerNode(containerNode)) {
@@ -99,7 +99,7 @@ export class CollapsibleTitleNode extends ElementNode {
       }
     } else {
       const paragraph = $createParagraphNode();
-      containerNode.insertAfter(paragraph);
+      containerNode.insertAfter(paragraph, restoreSelection);
       return paragraph;
     }
   }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -160,11 +160,11 @@ export class QuoteNode extends ElementNode {
 
   // Mutation
 
-  insertNewAfter(): ParagraphNode {
+  insertNewAfter(_: RangeSelection, restoreSelection?: boolean): ParagraphNode {
     const newBlock = $createParagraphNode();
     const direction = this.getDirection();
     newBlock.setDirection(direction);
-    this.insertAfter(newBlock);
+    this.insertAfter(newBlock, restoreSelection);
     return newBlock;
   }
 
@@ -300,7 +300,10 @@ export class HeadingNode extends ElementNode {
   }
 
   // Mutation
-  insertNewAfter(selection?: RangeSelection): ParagraphNode | HeadingNode {
+  insertNewAfter(
+    selection?: RangeSelection,
+    restoreSelection = true,
+  ): ParagraphNode | HeadingNode {
     const anchorOffet = selection ? selection.anchor.offset : 0;
     const newElement =
       anchorOffet > 0 && anchorOffet < this.getTextContentSize()
@@ -308,7 +311,7 @@ export class HeadingNode extends ElementNode {
         : $createParagraphNode();
     const direction = this.getDirection();
     newElement.setDirection(direction);
-    this.insertAfter(newElement);
+    this.insertAfter(newElement, restoreSelection);
     return newElement;
   }
 

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -709,7 +709,10 @@ declare export class ElementNode extends LexicalNode {
   setDirection(direction: 'ltr' | 'rtl' | null): this;
   setFormat(type: ElementFormatType): this;
   setIndent(indentLevel: number): this;
-  insertNewAfter(selection: RangeSelection): null | LexicalNode;
+  insertNewAfter(
+    selection: RangeSelection,
+    restoreSelection?: boolean,
+  ): null | LexicalNode;
   canInsertTab(): boolean;
   canIndent(): boolean;
   collapseAtStart(selection: RangeSelection): boolean;

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -716,7 +716,6 @@ export class LexicalNode {
     writableNodeToInsert.__prev = writableSelf.__key;
     writableNodeToInsert.__parent = writableSelf.__parent;
     if (restoreSelection && $isRangeSelection(selection)) {
-      debugger;
       const index = this.getIndexWithinParent();
       $updateElementSelectionOnCreateDeleteNode(
         selection,

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -623,7 +623,7 @@ export class LexicalNode {
     removeNode(this, true, preserveEmptyParent);
   }
 
-  replace<N extends LexicalNode>(replaceWith: N): N {
+  replace<N extends LexicalNode>(replaceWith: N, restoreSelection = true): N {
     errorOnReadOnly();
     errorOnInsertTextNodeOnRoot(this, replaceWith);
     const self = this.getLatest();
@@ -657,7 +657,7 @@ export class LexicalNode {
     writableReplaceWith.__parent = parentKey;
     writableParent.__size = size;
     const selection = $getSelection();
-    if ($isRangeSelection(selection)) {
+    if ($isRangeSelection(selection) && restoreSelection) {
       const anchor = selection.anchor;
       const focus = selection.focus;
       if (anchor.key === toReplaceKey) {
@@ -673,7 +673,7 @@ export class LexicalNode {
     return writableReplaceWith;
   }
 
-  insertAfter(nodeToInsert: LexicalNode): LexicalNode {
+  insertAfter(nodeToInsert: LexicalNode, restoreSelection = true): LexicalNode {
     errorOnReadOnly();
     errorOnInsertTextNodeOnRoot(this, nodeToInsert);
     const writableSelf = this.getWritable();
@@ -704,10 +704,8 @@ export class LexicalNode {
     const writableParent = this.getParentOrThrow().getWritable();
     const insertKey = writableNodeToInsert.__key;
     const nextKey = writableSelf.__next;
-    let isAppending = false;
     if (nextSibling === null) {
       writableParent.__last = insertKey;
-      isAppending = true;
     } else {
       const writableNextSibling = nextSibling.getWritable();
       writableNextSibling.__prev = insertKey;
@@ -717,12 +715,8 @@ export class LexicalNode {
     writableNodeToInsert.__next = nextKey;
     writableNodeToInsert.__prev = writableSelf.__key;
     writableNodeToInsert.__parent = writableSelf.__parent;
-    if (
-      $isRangeSelection(selection) &&
-      (!isAppending ||
-        elementFocusSelectionOnNode ||
-        selection.anchor.type === 'element')
-    ) {
+    if (restoreSelection && $isRangeSelection(selection)) {
+      debugger;
       const index = this.getIndexWithinParent();
       $updateElementSelectionOnCreateDeleteNode(
         selection,
@@ -740,7 +734,10 @@ export class LexicalNode {
     return nodeToInsert;
   }
 
-  insertBefore(nodeToInsert: LexicalNode): LexicalNode {
+  insertBefore(
+    nodeToInsert: LexicalNode,
+    restoreSelection = true,
+  ): LexicalNode {
     errorOnReadOnly();
     errorOnInsertTextNodeOnRoot(this, nodeToInsert);
     const writableSelf = this.getWritable();
@@ -764,7 +761,7 @@ export class LexicalNode {
     writableNodeToInsert.__next = writableSelf.__key;
     writableNodeToInsert.__parent = writableSelf.__parent;
     const selection = $getSelection();
-    if ($isRangeSelection(selection)) {
+    if (restoreSelection && $isRangeSelection(selection)) {
       const parent = this.getParentOrThrow();
       $updateElementSelectionOnCreateDeleteNode(selection, parent, index);
     }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -883,10 +883,10 @@ export class RangeSelection implements BaseSelection {
           textNode.setFormat(format);
           textNode.select();
           if (startOffset === 0) {
-            firstNode.insertBefore(textNode);
+            firstNode.insertBefore(textNode, false);
           } else {
             const [targetNode] = firstNode.splitText(startOffset);
-            targetNode.insertAfter(textNode);
+            targetNode.insertAfter(textNode, false);
           }
           // When composing, we need to adjust the anchor offset so that
           // we correctly replace that right range.
@@ -952,7 +952,7 @@ export class RangeSelection implements BaseSelection {
         ) {
           if (lastNode.isSegmented()) {
             const textNode = $createTextNode(lastNode.getTextContent());
-            lastNode.replace(textNode);
+            lastNode.replace(textNode, false);
             lastNode = textNode;
           }
           lastNode = (lastNode as TextNode).spliceText(0, endOffset, '');
@@ -1006,7 +1006,7 @@ export class RangeSelection implements BaseSelection {
             lastNodeChild.is(lastElementChild)
           ) {
             if (!firstAndLastElementsAreEqual) {
-              insertionTarget.insertAfter(lastNodeChild);
+              insertionTarget.insertAfter(lastNodeChild, false);
             }
           } else {
             lastNodeChild.remove();
@@ -1056,7 +1056,7 @@ export class RangeSelection implements BaseSelection {
       } else {
         const textNode = $createTextNode(text);
         textNode.select();
-        firstNode.replace(textNode);
+        firstNode.replace(textNode, false);
       }
 
       // Remove all selected nodes that haven't already been removed.
@@ -1402,7 +1402,7 @@ export class RangeSelection implements BaseSelection {
       if ($isElementNode(target) && !target.isInline()) {
         lastNode = node;
         if ($isDecoratorNode(node) && !node.isInline()) {
-          target = target.insertAfter(node);
+          target = target.insertAfter(node, false);
         } else if (!$isElementNode(node)) {
           const firstChild = target.getFirstChild();
           if (firstChild !== null) {
@@ -1424,7 +1424,7 @@ export class RangeSelection implements BaseSelection {
             }
             target = node;
           } else {
-            target = target.insertAfter(node);
+            target = target.insertAfter(node, false);
           }
         }
       } else if (
@@ -1433,7 +1433,7 @@ export class RangeSelection implements BaseSelection {
         ($isDecoratorNode(target) && !target.isInline())
       ) {
         lastNode = node;
-        target = target.insertAfter(node);
+        target = target.insertAfter(node, false);
       } else {
         const nextTarget: ElementNode = target.getParentOrThrow();
         // if we're inserting an Element after a LineBreak, we want to move the target to the parent
@@ -1584,7 +1584,7 @@ export class RangeSelection implements BaseSelection {
         const child = currentElement.getChildAtIndex(anchorOffset);
         paragraph.select();
         if (child !== null) {
-          child.insertBefore(paragraph);
+          child.insertBefore(paragraph, false);
         } else {
           currentElement.append(paragraph);
         }
@@ -1599,7 +1599,7 @@ export class RangeSelection implements BaseSelection {
       currentElement.isInline()
     ) {
       const parent = currentElement.getParentOrThrow();
-      const newElement = parent.insertNewAfter(this);
+      const newElement = parent.insertNewAfter(this, false);
       if ($isElementNode(newElement)) {
         const children = parent.getChildren();
         for (let i = 0; i < children.length; i++) {
@@ -1608,7 +1608,7 @@ export class RangeSelection implements BaseSelection {
       }
       return;
     }
-    const newElement = currentElement.insertNewAfter(this);
+    const newElement = currentElement.insertNewAfter(this, false);
     if (newElement === null) {
       // Handle as a line break insertion
       this.insertLineBreak();

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -506,7 +506,10 @@ export class ElementNode extends LexicalNode {
     };
   }
   // These are intended to be extends for specific element heuristics.
-  insertNewAfter(selection: RangeSelection): null | LexicalNode {
+  insertNewAfter(
+    selection: RangeSelection,
+    restoreSelection?: boolean,
+  ): null | LexicalNode {
     return null;
   }
   canInsertTab(): boolean {

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -14,7 +14,7 @@ import type {
   LexicalNode,
 } from '../LexicalNode';
 import type {SerializedElementNode} from './LexicalElementNode';
-import type {Spread} from 'lexical';
+import type {RangeSelection, Spread} from 'lexical';
 
 import {$applyNodeReplacement, getCachedClassNameArray} from '../LexicalUtils';
 import {ElementNode} from './LexicalElementNode';
@@ -107,11 +107,11 @@ export class ParagraphNode extends ElementNode {
 
   // Mutation
 
-  insertNewAfter(): ParagraphNode {
+  insertNewAfter(_: RangeSelection, restoreSelection: boolean): ParagraphNode {
     const newElement = $createParagraphNode();
     const direction = this.getDirection();
     newElement.setDirection(direction);
-    this.insertAfter(newElement);
+    this.insertAfter(newElement, restoreSelection);
     return newElement;
   }
 


### PR DESCRIPTION
This PR adds an optional `restoreSelection` argument to the `insertBefore`, `insertAfter`, `replace` APIs, avoiding doing O(n) selection restoration, which allows for far greater performance when selection is handled automatically at the end of a given operation.