### PR TITLE
Docs: fix "node" type in "Node Overrides" example code

### DIFF
--- a/packages/lexical-website/docs/concepts/node-replacement.md
+++ b/packages/lexical-website/docs/concepts/node-replacement.md
@@ -9,7 +9,7 @@ Node Overrides allow you to replace all instances of a given node in your editor
 ```
 const editorConfig = {
     ...
-    nodes={
+    nodes=[
         // Don't forget to register your custom node separately!
         CustomParagraphNode,
         {
@@ -18,7 +18,7 @@ const editorConfig = {
                 return new CustomParagraphNode();
             }
         }
-    }
+    ]
 }
 ```
 


### PR DESCRIPTION
Change the type of the `node` config param in the [Node Overrides](https://lexical.dev/docs/concepts/node-replacement) example from an object to array. This matches the actual node type as defined in [EditorConfig](https://lexical.dev/docs/api/classes/lexical.LexicalEditor#_nodes).

<img width="862" alt="Screenshot 2022-12-09 at 10 30 55 AM" src="https://user-images.githubusercontent.com/739390/206759662-ee723440-6c1c-438c-bd89-01bd961ffc1d.png">
