### PR TITLE
Fix lexical-offset

### DIFF
--- a/packages/lexical-offset/src/index.ts
+++ b/packages/lexical-offset/src/index.ts
@@ -438,7 +438,7 @@ function $createOffsetNode(
   const start = state.offset;
 
   if ($isElementNode(node)) {
-    const childKeys = node.getChildrenKeys();
+    const childKeys = createChildrenArray(node, nodeMap);
     const blockIsEmpty = childKeys.length === 0;
     const child = blockIsEmpty
       ? null


### PR DESCRIPTION
I created a function called `createChildrenArray` that does the same thing, except doesn't need an active editor. We should be using that instead here.