### PR TITLE
Fix paste for LexicalLinkPlugin

### DIFF
--- a/packages/lexical-react/src/LexicalLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalLinkPlugin.ts
@@ -11,6 +11,7 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
 import {
   $getSelection,
+  $isElementNode,
   $isRangeSelection,
   COMMAND_PRIORITY_LOW,
   PASTE_COMMAND,
@@ -66,9 +67,13 @@ export function LinkPlugin({validateUrl}: Props): null {
               if (!validateUrl(clipboardText)) {
                 return false;
               }
-              editor.dispatchCommand(TOGGLE_LINK_COMMAND, clipboardText);
-              event.preventDefault();
-              return true;
+              // If we select nodes that are elements then avoid applying the link.
+              if (!selection.getNodes().find(node => $isElementNode(node))) {
+                editor.dispatchCommand(TOGGLE_LINK_COMMAND, clipboardText);
+                event.preventDefault();
+                return true;
+              }
+              return false;
             },
             COMMAND_PRIORITY_LOW,
           )

--- a/packages/lexical-react/src/LexicalLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalLinkPlugin.ts
@@ -68,7 +68,7 @@ export function LinkPlugin({validateUrl}: Props): null {
                 return false;
               }
               // If we select nodes that are elements then avoid applying the link.
-              if (!selection.getNodes().find(node => $isElementNode(node))) {
+              if (!selection.getNodes().some(node => $isElementNode(node))) {
                 editor.dispatchCommand(TOGGLE_LINK_COMMAND, clipboardText);
                 event.preventDefault();
                 return true;

--- a/packages/lexical-react/src/LexicalLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalLinkPlugin.ts
@@ -68,7 +68,7 @@ export function LinkPlugin({validateUrl}: Props): null {
                 return false;
               }
               // If we select nodes that are elements then avoid applying the link.
-              if (!selection.getNodes().some(node => $isElementNode(node))) {
+              if (!selection.getNodes().some((node) => $isElementNode(node))) {
                 editor.dispatchCommand(TOGGLE_LINK_COMMAND, clipboardText);
                 event.preventDefault();
                 return true;


### PR DESCRIPTION
If we're trying to paste content in over a range of selection that contains an element, then avoid applying the link logic.