### PR TITLE
Add collaboration-init tag when initializeEditor for yjs collaboration

### DIFF
--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -303,11 +303,15 @@ function initializeEditor(
             case 'string': {
               const parsedEditorState =
                 editor.parseEditorState(initialEditorState);
-              editor.setEditorState(parsedEditorState, {tag: 'history-merge'});
+              editor.setEditorState(parsedEditorState, {
+                tag: 'collaboration-init',
+              });
               break;
             }
             case 'object': {
-              editor.setEditorState(initialEditorState, {tag: 'history-merge'});
+              editor.setEditorState(initialEditorState, {
+                tag: 'collaboration-init',
+              });
               break;
             }
             case 'function': {
@@ -318,7 +322,7 @@ function initializeEditor(
                     initialEditorState(editor);
                   }
                 },
-                {tag: 'history-merge'},
+                {tag: 'collaboration-init'},
               );
               break;
             }
@@ -339,7 +343,7 @@ function initializeEditor(
       }
     },
     {
-      tag: 'history-merge',
+      tag: 'collaboration-init',
     },
   );
 }


### PR DESCRIPTION
Follow up to:
- #3520 

This will allow having a hook that will tell when the editor has initiated the collaboration.

```js
/**
 * @param {boolean} shouldRegisterEvent - pass isCollabEnabled
 * @returns {boolean} true when lexical editor has content from the collaboration session
 */
export const useEditorIsInCollab = (shouldRegisterEvent: boolean): boolean => {
  const [editor] = useLexicalComposerContext();
  const [isInCollab, setIsInCollab] = useState(false);

  useEffect(() => {
    if (!shouldRegisterEvent || isInCollab) {
      return undefined;
    }
    return editor.registerUpdateListener(({ tags }) => {
      if (tags.has('collaboration') || tags.has('collaboration-init')) {
        setIsInCollab(true);
      }
    });
  }, [editor, isInCollab, shouldRegisterEvent]);
}
```

