### PR TITLE
Pass replaced node's key to new node

### DIFF
--- a/packages/lexical-website/docs/concepts/node-replacement.md
+++ b/packages/lexical-website/docs/concepts/node-replacement.md
@@ -15,7 +15,7 @@ const editorConfig = {
         {
             replace: ParagraphNode,
             with: (node: ParagraphNode) => {
-                return new CustomParagraphNode();
+                return new CustomParagraphNode(node.__key);
             }
         }
     ]


### PR DESCRIPTION
Fix for displaying placeholder text for CustomParagraphNode example