### PR TITLE
Don't throw if getPreviousSiblings can't find a parent

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -337,7 +337,10 @@ export class LexicalNode {
 
   getPreviousSiblings<T extends LexicalNode>(): Array<T> {
     const siblings: Array<T> = [];
-    const parent = this.getParentOrThrow();
+    const parent = this.getParent();
+    if (parent === null) {
+      return siblings;
+    }
     let node: null | T = parent.getFirstChild();
     while (node !== null) {
       if (node.is(this)) {


### PR DESCRIPTION
This method used to safely return an empty list instead of throwing if the parent isn't found. This changes it back to that approach, so the API matches similar methods and the linked list change remains an implementation detail.