### PR TITLE
Fix dom inline style not work

### DIFF
--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -862,6 +862,8 @@ function convertSpanElement(domNode: Node): DOMConversionOutput {
         lexicalNode.toggleFormat('superscript');
       }
 
+      lexicalNode.setStyle(span.style.cssText);
+
       return lexicalNode;
     },
     node: null,


### PR DESCRIPTION
fix when transform html to lexical, the inline style not work. 

for example, when the html string is 

```html
<p class="PlaygroundEditorTheme__paragraph" dir="ltr"><span style="background-color: rgb(208, 2, 27);">a</span><span style="background-color: rgb(255, 255, 255); color: rgb(208, 2, 27);">a</span><span style="background-color: rgb(255, 255, 255); font-size: 10px;">a</span></p>
```

and run 
```js
      const parser = new DOMParser();
      const dom = parser.parseFromString('<p class="PlaygroundEditorTheme__paragraph" dir="ltr"><span style="background-color: rgb(208, 2, 27);">a</span><span style="background-color: rgb(255, 255, 255); color: rgb(208, 2, 27);">a</span><span style="background-color: rgb(255, 255, 255); font-size: 10px;">a</span></p>', 'text/html');
      const nodes = $generateNodesFromDOM(editor, dom);
      $getRoot().select();
      $insertNodes(nodes);
```

lexical will behave like this without the inline style
![image](https://user-images.githubusercontent.com/38412001/207833508-390c8404-6920-4fe1-b225-65ec809383bf.png)

while the normal case should behave like this

![image](https://user-images.githubusercontent.com/38412001/207833754-89c0c778-003f-4089-b6dd-ef04d1f211b5.png)

