### PR TITLE
Allow subclass node of equivalent type to override the lexical default node

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -830,13 +830,15 @@ function errorOnTypeKlassMismatch(
     );
   }
   const editorKlass = registeredNode.klass;
-  if (editorKlass !== klass) {
+  if (editorKlass !== klass && !(editorKlass.prototype instanceof klass)) {
     invariant(
       false,
-      'Create node: Type %s in node %s does not match registered node %s with the same type',
+      'Create node: Type %s in node %s does not match registered node %s with the same type or %s is not a subclass of %s',
       type,
       klass.name,
       editorKlass.name,
+      editorKlass.name,
+      klass.name
     );
   }
 }


### PR DESCRIPTION
currently I use all the lexical package except `lexical-playground` to build my editor, and as the product requirement, I need to store html string and pass the value to lexical editor, and thus I will use the [html---lexical](https://lexical.dev/docs/concepts/serialization#html---lexical) api to init my editor value.

however, the `importDom` api in `TextNode` and `ParagraphNode` do not satisfy all scenarios, such as, inline style not work for `TextNode`, can refer to [#3558](https://github.com/facebook/lexical/pull/3558) and [#3017](https://github.com/facebook/lexical/pull/3017)

Then I found a way to overwrite the TextNode

``` js

class CustomTextNode extends TextNode {
    static importDOM(): DOMConversionMap | null {
        // custom logic
    }
}

const PlaygroundNodes: Array<
  | Klass<LexicalNode>
  | {
      replace: Klass<LexicalNode>;
      // eslint-disable-next-line @typescript-eslint/no-explicit-any
      with: <T extends { new (...args: any): any }>(node: InstanceType<T>) => LexicalNode;
    }
> = [
  {
    replace: CustomTextNode,
    with: (node: TextNode) => {
      return new CustomTextNode(node.__text);
    },
  },
  HeadingNode,
  ListNode,
  ListItemNode,
  ...
]
```

in this way, I can rewrite `importDOM` function to fix the deserialization problem in my case. But it will cause error as the snapshot below

![image](https://user-images.githubusercontent.com/38412001/207920858-c2b2e5cb-870e-44c4-9e9e-6f1a12327cf0.png)

So I submit this pull request to fix it. If not, do you have any idea how to solve this deserialization problem gracefully? thank you for your time.