### PR TITLE
Image gets stuck in resizing state fix (#3562)

### DIFF
--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -319,7 +319,7 @@ export default function ImageComponent({
     settings: {showNestedEditorTreeView},
   } = useSettings();
 
-  const draggable = isSelected && $isNodeSelection(selection);
+  const draggable = isSelected && $isNodeSelection(selection) && !isResizing;
   const isFocused = isSelected || isResizing;
   return (
     <Suspense fallback={null}>


### PR DESCRIPTION
Resolves : #3562

Issue: When resizing an Image over a long distance in lexical playground, the draggable event of the image is getting triggered. This causes the image to be stuck in the resizing state.

https://user-images.githubusercontent.com/27125472/207942913-2fa4b848-9d2d-48d4-abe3-11d291958643.mp4


Fix: Added a condition to not set the draggable flag if the image is in resizing state. 


https://user-images.githubusercontent.com/27125472/207944605-6c161d87-f56f-44f0-90be-971e40e23187.mp4




