### PR TITLE
fix: deleting forward on the last decorate node

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1882,9 +1882,10 @@ export class RangeSelection implements BaseSelection {
           (anchor.type === 'text' &&
             anchor.offset === anchorNode.getTextContentSize()))
       ) {
+        const parent = anchorNode.getParent();
         const nextSibling =
           anchorNode.getNextSibling() ||
-          anchorNode.getParentOrThrow().getNextSibling();
+          (parent === null ? null : parent.getNextSibling());
 
         if ($isElementNode(nextSibling) && !nextSibling.canExtractContents()) {
           return;


### PR DESCRIPTION
Resolves: https://github.com/facebook/lexical/issues/3563

## Issue
If the emulated cursor (added in https://github.com/facebook/lexical/pull/3434) is the last one in the editor state and you try to delete forward, then you will get an error `Uncaught Error: Minified Lexical error #66.`

## Fix
Check if the current selection node has a parent.