### PR TITLE
Add HTML paste support for checklists

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -518,8 +518,9 @@ function updateListItemChecked(
 }
 
 function convertListItemElement(domNode: Node): DOMConversionOutput {
-  // @ts-ignore-next-line
-  const checked = domNode['aria-checked'] === 'true';
+  const checked =
+    domNode instanceof HTMLElement &&
+    domNode.getAttribute('aria-checked') === 'true';
   return {node: $createListItemNode(checked)};
 }
 

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -518,7 +518,9 @@ function updateListItemChecked(
 }
 
 function convertListItemElement(domNode: Node): DOMConversionOutput {
-  return {node: $createListItemNode()};
+  // @ts-ignore-next-line
+  const checked = domNode['aria-checked'] === 'true';
+  return {node: $createListItemNode(checked)};
 }
 
 export function $createListItemNode(checked?: boolean): ListItemNode {

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -16,6 +16,7 @@ import {
   $isElementNode,
   DOMConversionMap,
   DOMConversionOutput,
+  DOMExportOutput,
   EditorConfig,
   EditorThemeClasses,
   ElementNode,
@@ -132,6 +133,19 @@ export class ListNode extends ElementNode {
     node.setIndent(serializedNode.indent);
     node.setDirection(serializedNode.direction);
     return node;
+  }
+
+  exportDOM(editor: LexicalEditor): DOMExportOutput {
+    const element = document.createElement(this.__tag);
+    if (this.__start !== 1) {
+      element.setAttribute('start', String(this.__start));
+    }
+    if (this.__listType === 'check') {
+      element.setAttribute('__lexicalListType', 'check');
+    }
+    return {
+      element,
+    };
   }
 
   exportJSON(): SerializedListNode {
@@ -264,15 +278,17 @@ function normalizeChildren(nodes: Array<LexicalNode>): Array<ListItemNode> {
 function convertListNode(domNode: Node): DOMConversionOutput {
   const nodeName = domNode.nodeName.toLowerCase();
   let node = null;
-
   if (nodeName === 'ol') {
     node = $createListNode('number');
   } else if (nodeName === 'ul') {
-    // @ts-ignore-next-line this prop might exist
-    if (domNode.__lexicalListType === 'check') {
+    if (
+      domNode instanceof HTMLElement &&
+      domNode.getAttribute('__lexicallisttype') === 'check'
+    ) {
       node = $createListNode('check');
+    } else {
+      node = $createListNode('bullet');
     }
-    node = $createListNode('bullet');
   }
 
   return {

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -268,6 +268,10 @@ function convertListNode(domNode: Node): DOMConversionOutput {
   if (nodeName === 'ol') {
     node = $createListNode('number');
   } else if (nodeName === 'ul') {
+    // @ts-ignore-next-line this prop might exist
+    if (domNode.__lexicalListType === 'check') {
+      node = $createListNode('check');
+    }
     node = $createListNode('bullet');
   }
 

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -2577,6 +2577,80 @@ test.describe('CopyAndPaste', () => {
     );
   });
 
+  test('HTML Copy + paste a checklist', async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    const clipboard = {
+      'text/html': `<meta charset='utf-8'><ul __lexicallisttype="check"><li role="checkbox" tabindex="-1" aria-checked="false" value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__listItemUnchecked"><span>Hello</span></li><li role="checkbox" tabindex="-1" aria-checked="false" value="2" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__listItemUnchecked"><span>world</span></li></ul>`,
+    };
+
+    await pasteFromClipboard(page, clipboard);
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            role="checkbox"
+            tabindex="-1"
+            aria-checked="false"
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__listItemUnchecked PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Hello</span>
+          </li>
+          <li
+            role="checkbox"
+            tabindex="-1"
+            aria-checked="false"
+            value="2"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__listItemUnchecked PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">world</span>
+          </li>
+        </ul>
+      `,
+    );
+
+    await clearEditor(page);
+    await focusEditor(page);
+
+    // Ensure we preserve checked status.
+    clipboard[
+      'text/html'
+    ] = `<meta charset='utf-8'><ul __lexicallisttype="check"><li role="checkbox" tabindex="-1" aria-checked="true" value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__listItemChecked"><span>Hello</span></li><li role="checkbox" tabindex="-1" aria-checked="false" value="2" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__listItemUnchecked"><span>world</span></li></ul>`;
+
+    await pasteFromClipboard(page, clipboard);
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            role="checkbox"
+            tabindex="-1"
+            aria-checked="true"
+            value="1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__listItemChecked PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Hello</span>
+          </li>
+          <li
+            role="checkbox"
+            tabindex="-1"
+            aria-checked="false"
+            value="2"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__listItemUnchecked PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">world</span>
+          </li>
+        </ul>
+      `,
+    );
+  });
+
   test('HTML Copy + paste a code block with BR', async ({
     page,
     isPlainText,


### PR DESCRIPTION
Adds support for HTML copy+paste of checklists into @lexical/list.

We still need to figure out how to support checklists from GDocs and Quip - or if we even want to. Is that something you should have to turn off or turn on?