### PR TITLE
[0.8] Update ContentEditable types

### DIFF
--- a/packages/lexical-react/flow/LexicalContentEditable.js.flow
+++ b/packages/lexical-react/flow/LexicalContentEditable.js.flow
@@ -7,27 +7,21 @@
  * @flow strict
  */
 
-export type Props = $ReadOnly<{
-  ariaActiveDescendantID?: string,
-  ariaAutoComplete?: string,
-  ariaControls?: string,
-  ariaDescribedBy?: string,
-  ariaExpanded?: boolean,
-  ariaLabel?: string,
-  ariaLabelledBy?: string,
-  ariaMultiline?: boolean,
-  ariaOwneeID?: string,
-  ariaRequired?: string,
-  autoCapitalize?: boolean,
-  autoComplete?: boolean,
-  autoCorrect?: boolean,
-  className?: string,
-  readOnly?: boolean,
-  role?: string,
-  style?: $Shape<{[string]: string | number}>,
-  spellCheck?: boolean,
-  tabIndex?: number,
-  testid?: string,
-}>;
+import * as React from 'react';
+
+export type Props = {
+  ariaActiveDescendant?: React$Element['aria-activedescendant'];
+  ariaAutoComplete?: React.AriaAttributes['aria-autocomplete'];
+  ariaControls?: React.AriaAttributes['aria-controls'];
+  ariaDescribedBy?: React.AriaAttributes['aria-describedby'];
+  ariaExpanded?: React.AriaAttributes['aria-expanded'];
+  ariaLabel?: React.AriaAttributes['aria-label'];
+  ariaLabelledBy?: React.AriaAttributes['aria-labelledby'];
+  ariaMultiline?: React.AriaAttributes['aria-multiline'];
+  ariaOwns?: React.AriaAttributes['aria-owns'];
+  ariaRequired?: React.AriaAttributes['aria-required'];
+  autoCapitalize?: HTMLDivElement['autocapitalize'];
+  'data-testid'?: string | null | undefined;
+} & React.AllHTMLAttributes<HTMLDivElement>;
 
 declare export function ContentEditable(props: Props): React$Node;

--- a/packages/lexical-react/flow/LexicalContentEditable.js.flow
+++ b/packages/lexical-react/flow/LexicalContentEditable.js.flow
@@ -9,19 +9,20 @@
 
 import * as React from 'react';
 
-export type Props = {
-  ariaActiveDescendant?: React$Element['aria-activedescendant'];
-  ariaAutoComplete?: React.AriaAttributes['aria-autocomplete'];
-  ariaControls?: React.AriaAttributes['aria-controls'];
-  ariaDescribedBy?: React.AriaAttributes['aria-describedby'];
-  ariaExpanded?: React.AriaAttributes['aria-expanded'];
-  ariaLabel?: React.AriaAttributes['aria-label'];
-  ariaLabelledBy?: React.AriaAttributes['aria-labelledby'];
-  ariaMultiline?: React.AriaAttributes['aria-multiline'];
-  ariaOwns?: React.AriaAttributes['aria-owns'];
-  ariaRequired?: React.AriaAttributes['aria-required'];
-  autoCapitalize?: HTMLDivElement['autocapitalize'];
-  'data-testid'?: string | null | undefined;
-} & React.AllHTMLAttributes<HTMLDivElement>;
+export type Props = $ReadOnly<{
+  ...$Partial<HTMLDivElement>,
+  ariaActiveDescendant?: HTMLDivElement['aria-activedescendant'],
+  ariaAutoComplete?: HTMLDivElement['aria-autocomplete'],
+  ariaControls?: HTMLDivElement['aria-controls'],
+  ariaDescribedBy?: HTMLDivElement['aria-describedby'],
+  ariaExpanded?: HTMLDivElement['aria-expanded'],
+  ariaLabel?: HTMLDivElement['aria-label'],
+  ariaLabelledBy?: HTMLDivElement['aria-labelledby'],
+  ariaMultiline?: HTMLDivElement['aria-multiline'],
+  ariaOwns?: HTMLDivElement['aria-owns'],
+  ariaRequired?: HTMLDivElement['aria-required'],
+  autoCapitalize?: HTMLDivElement['autocapitalize'],
+  'data-testid'?: string | null,
+}>;
 
 declare export function ContentEditable(props: Props): React$Node;

--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -8,35 +8,26 @@
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
-import {CSSProperties, useCallback, useState} from 'react';
+import {useCallback, useState} from 'react';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
-export type Props = Readonly<{
-  ariaActiveDescendantID?: string;
-  ariaAutoComplete?: string;
-  ariaControls?: string;
-  ariaDescribedBy?: string;
-  ariaExpanded?: boolean;
-  ariaLabel?: string;
-  ariaLabelledBy?: string;
-  ariaMultiline?: boolean;
-  ariaOwneeID?: string;
-  ariaRequired?: string;
-  autoCapitalize?: boolean;
-  autoComplete?: boolean;
-  autoCorrect?: boolean;
-  className?: string;
-  id?: string;
-  readOnly?: boolean;
-  role?: string;
-  spellCheck?: boolean;
-  style?: CSSProperties;
-  tabIndex?: number;
-  testid?: string;
-}>;
+export type Props = {
+  ariaActiveDescendant?: React.AriaAttributes['aria-activedescendant'];
+  ariaAutoComplete?: React.AriaAttributes['aria-autocomplete'];
+  ariaControls?: React.AriaAttributes['aria-controls'];
+  ariaDescribedBy?: React.AriaAttributes['aria-describedby'];
+  ariaExpanded?: React.AriaAttributes['aria-expanded'];
+  ariaLabel?: React.AriaAttributes['aria-label'];
+  ariaLabelledBy?: React.AriaAttributes['aria-labelledby'];
+  ariaMultiline?: React.AriaAttributes['aria-multiline'];
+  ariaOwns?: React.AriaAttributes['aria-owns'];
+  ariaRequired?: React.AriaAttributes['aria-required'];
+  autoCapitalize?: HTMLDivElement['autocapitalize'];
+  'data-testid'?: string | null | undefined;
+} & React.AllHTMLAttributes<HTMLDivElement>;
 
 export function ContentEditable({
-  ariaActiveDescendantID,
+  ariaActiveDescendant,
   ariaAutoComplete,
   ariaControls,
   ariaDescribedBy,
@@ -44,18 +35,16 @@ export function ContentEditable({
   ariaLabel,
   ariaLabelledBy,
   ariaMultiline,
-  ariaOwneeID,
+  ariaOwns,
   ariaRequired,
   autoCapitalize,
-  autoComplete,
-  autoCorrect,
   className,
   id,
   role = 'textbox',
   spellCheck = true,
   style,
   tabIndex,
-  testid,
+  'data-testid': testid,
 }: Props): JSX.Element {
   const [editor] = useLexicalComposerContext();
   const [isEditable, setEditable] = useState(false);
@@ -76,24 +65,25 @@ export function ContentEditable({
 
   return (
     <div
-      aria-activedescendant={!isEditable ? null : ariaActiveDescendantID}
-      aria-autocomplete={!isEditable ? null : ariaAutoComplete}
-      aria-controls={!isEditable ? null : ariaControls}
+      aria-activedescendant={!isEditable ? undefined : ariaActiveDescendant}
+      aria-autocomplete={!isEditable ? 'none' : ariaAutoComplete}
+      aria-controls={!isEditable ? undefined : ariaControls}
       aria-describedby={ariaDescribedBy}
       aria-expanded={
-        !isEditable ? null : role === 'combobox' ? !!ariaExpanded : null
+        !isEditable
+          ? undefined
+          : role === 'combobox'
+          ? !!ariaExpanded
+          : undefined
       }
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
       aria-multiline={ariaMultiline}
-      aria-owns={!isEditable ? null : ariaOwneeID}
+      aria-owns={!isEditable ? undefined : ariaOwns}
       aria-required={ariaRequired}
       autoCapitalize={
         autoCapitalize !== undefined ? String(autoCapitalize) : undefined
       }
-      // @ts-ignore This is a valid attribute
-      autoComplete={autoComplete}
-      autoCorrect={autoCorrect !== undefined ? String(autoCorrect) : undefined}
       className={className}
       contentEditable={isEditable}
       data-testid={testid}

--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -81,9 +81,7 @@ export function ContentEditable({
       aria-multiline={ariaMultiline}
       aria-owns={!isEditable ? undefined : ariaOwns}
       aria-required={ariaRequired}
-      autoCapitalize={
-        autoCapitalize !== undefined ? String(autoCapitalize) : undefined
-      }
+      autoCapitalize={autoCapitalize}
       className={className}
       contentEditable={isEditable}
       data-testid={testid}


### PR DESCRIPTION
The `@ts-ignore` amongst the ContentEditable props was masking for incorrect type issues. 

Tested Flow types internally to validate that they work correctly.

Closes #3550 
Closes #3658