### PR TITLE
Preserve empty parent during replacement

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -645,7 +645,7 @@ export class LexicalNode {
     const prevKey = self.__prev;
     const nextKey = self.__next;
     const parentKey = self.__parent;
-    removeNode(self, false);
+    removeNode(self, false, true);
 
     if (prevSibling === null) {
       writableParent.__first = key;

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -15,7 +15,14 @@ import {
 } from 'lexical';
 
 import {LexicalNode} from '../../LexicalNode';
-import {initializeUnitTest, TestElementNode} from '../utils';
+import {$createParagraphNode} from '../../nodes/LexicalParagraphNode';
+import {$createTextNode} from '../../nodes/LexicalTextNode';
+import {
+  $createTestInlineElementNode,
+  initializeUnitTest,
+  TestElementNode,
+  TestInlineElementNode,
+} from '../utils';
 
 class TestNode extends LexicalNode {
   static getType(): string {
@@ -820,6 +827,32 @@ describe('LexicalNode tests', () => {
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p><span data-lexical-text="true">bar</span></p></div>',
         );
         // TODO: add text direction validations
+      });
+
+      test('LexicalNode.replace() within canBeEmpty: false', async () => {
+        const {editor} = testEnv;
+
+        jest
+          .spyOn(TestInlineElementNode.prototype, 'canBeEmpty')
+          .mockReturnValue(false);
+
+        await editor.update(() => {
+          textNode = $createTextNode('Hello');
+
+          $getRoot()
+            .clear()
+            .append(
+              $createParagraphNode().append(
+                $createTestInlineElementNode().append(textNode),
+              ),
+            );
+
+          textNode.replace($createTextNode('world'));
+        });
+
+        expect(testEnv.outerHTML).toBe(
+          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p><a dir="ltr"><span data-lexical-text="true">world</span></a></p></div>',
+        );
       });
 
       test('LexicalNode.insertAfter()', async () => {


### PR DESCRIPTION
When node is being replaced we should preserve its empty parent (in case it has `canBeEmpty: false`), as otherwise parent might be deleted and replacement fail. E.g., LinkNode has `canBeEmpty: false` and attempting to replace its text node child would fail. 

~~*Will add test, want to see CI results in case I've missed anything*~~