### PR TITLE
Escape plus signs of the tag in MarkdownImport, fixes #3596

### DIFF
--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -369,7 +369,7 @@ function createTextFormatTransformersIndex(
   for (const transformer of textTransformers) {
     const {tag} = transformer;
     transformersByTag[tag] = transformer;
-    const tagRegExp = tag.replace(/(\*|\^)/g, '\\$1');
+    const tagRegExp = tag.replace(/(\*|\^|\+)/g, '\\$1');
     openTagsRegExp.push(tagRegExp);
 
     if (IS_SAFARI || IS_IOS) {


### PR DESCRIPTION
While `MarkdownImport` already escapes some special characters of the `tag` in `TextTransformer`s, it seems that plus sign is one that's missing and therefore you can't use `+` character in your custom `TextTransformer.tag`.

This PR attempts to fix the issue by adding the plus sign to the list of characters to escape. Fixes #3596.