### PR TITLE
Select node after updating text content to ensure cursor position at end

### DIFF
--- a/packages/lexical-text/src/index.ts
+++ b/packages/lexical-text/src/index.ts
@@ -193,8 +193,8 @@ export function registerLexicalTextEntity<T extends TextNode>(
           if (diff > 0) {
             const concatText = text.slice(0, diff);
             const newTextContent = previousText + concatText;
-            prevSibling.select();
             prevSibling.setTextContent(newTextContent);
+            prevSibling.select();
 
             if (diff === text.length) {
               node.remove();


### PR DESCRIPTION
Problem I was getting was that `prevSibiling.setTextContent(newTextContent)` was moving the cursor back to the end of `previousText` (ie. the middle of the `newTextContent` string).

So if `newTextContent = previousText + concatText = "users" + ".firstname"`, then the existing code causes the cursor to jump back to the middle after the 's' (eg. `users|.firstname` where '|' is the cursor) instead of the end of the word (`users.firstname|` where it should be)

```
[prevSibiling]node
[users.]firstNa|
[users.]firstNam|
[users.|firstName]
```

Selecting `prevSibiling` after updating the text content seems to fix this.