### PR TITLE
[0.8] feat: set the update tag from yjs based on the origin

### DIFF
--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -8,7 +8,6 @@
 
 import type {Binding} from '@lexical/yjs';
 import type {LexicalEditor} from 'lexical';
-import {Doc, Transaction, UndoManager, YEvent} from 'yjs';
 
 import {mergeRegister} from '@lexical/utils';
 import {
@@ -36,6 +35,7 @@ import * as React from 'react';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {WebsocketProvider} from 'y-websocket';
+import {Doc, Transaction, UndoManager, YEvent} from 'yjs';
 
 import {InitialEditorStateType} from '../LexicalComposer';
 

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -104,9 +104,9 @@ export function useYjsCollaboration(
       events: Array<YEvent<any>>,
       transaction: Transaction,
     ) => {
-      const origin = transaction.origin 
+      const origin = transaction.origin;
       if (origin !== binding) {
-        const isFromUndoManger = origin instanceof UndoManager
+        const isFromUndoManger = origin instanceof UndoManager;
         syncYjsChangesToLexical(binding, provider, events, isFromUndoManger);
       }
     };

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -8,7 +8,7 @@
 
 import type {Binding} from '@lexical/yjs';
 import type {LexicalEditor} from 'lexical';
-import type {Doc, Transaction, YEvent} from 'yjs';
+import {Doc, Transaction, UndoManager, YEvent} from 'yjs';
 
 import {mergeRegister} from '@lexical/utils';
 import {
@@ -104,8 +104,9 @@ export function useYjsCollaboration(
       events: Array<YEvent<any>>,
       transaction: Transaction,
     ) => {
+      const isFromUndoManger = transaction.origin instanceof UndoManager
       if (transaction.origin !== binding) {
-        syncYjsChangesToLexical(binding, provider, events);
+        syncYjsChangesToLexical(binding, provider, events, isFromUndoManger);
       }
     };
 

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -104,8 +104,9 @@ export function useYjsCollaboration(
       events: Array<YEvent<any>>,
       transaction: Transaction,
     ) => {
-      const isFromUndoManger = transaction.origin instanceof UndoManager
-      if (transaction.origin !== binding) {
+      const origin = transaction.origin 
+      if (origin !== binding) {
+        const isFromUndoManger = origin instanceof UndoManager
         syncYjsChangesToLexical(binding, provider, events, isFromUndoManger);
       }
     };

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -162,7 +162,7 @@ export function syncYjsChangesToLexical(
         syncCursorPositions(binding, provider);
       },
       skipTransforms: true,
-      tag: isFromUndoManger ? 'collaboration-history' : 'collaboration',
+      tag: isFromUndoManger ? 'historic' : 'collaboration',
     },
   );
 }
@@ -235,7 +235,7 @@ export function syncLexicalUpdateToYjs(
       // types a character and we get it, we don't want to then insert
       // the same character again. The exception to this heuristic is
       // when we need to handle normalization merge conflicts.
-      if (tags.has('collaboration')) {
+      if (tags.has('collaboration') || tags.has('historic')) {
         if (normalizedNodes.size > 0) {
           handleNormalizationMergeConflicts(binding, normalizedNodes);
         }

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -84,7 +84,7 @@ export function syncYjsChangesToLexical(
   binding: Binding,
   provider: WebsocketProvider,
   events: Array<YEvent<YText>>,
-  isFromUndoManger: boolean
+  isFromUndoManger: boolean,
 ): void {
   const editor = binding.editor;
   const currentEditorState = editor._editorState;

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -84,6 +84,7 @@ export function syncYjsChangesToLexical(
   binding: Binding,
   provider: WebsocketProvider,
   events: Array<YEvent<YText>>,
+  isFromUndoManger: boolean
 ): void {
   const editor = binding.editor;
   const currentEditorState = editor._editorState;
@@ -161,7 +162,7 @@ export function syncYjsChangesToLexical(
         syncCursorPositions(binding, provider);
       },
       skipTransforms: true,
-      tag: 'collaboration',
+      tag: isFromUndoManger ? 'collaboration-history' : 'collaboration',
     },
   );
 }


### PR DESCRIPTION
This PR makes the updates tags for updates coming from yjs change based on origin, so if the changes came from UndoManger the tag is set to `collaboration-history` and if the updates came from other places like websocket the tag is set to `collaboration`, 

this is to be able to know which updates came from the user's interaction and which updates came from other users through yjs

