### PR TITLE
Fix getSelectedNode logic for forward selection

### DIFF
--- a/packages/lexical-playground/src/utils/getSelectedNode.ts
+++ b/packages/lexical-playground/src/utils/getSelectedNode.ts
@@ -22,6 +22,6 @@ export function getSelectedNode(
   if (isBackward) {
     return $isAtNodeEnd(focus) ? anchorNode : focusNode;
   } else {
-    return $isAtNodeEnd(anchor) ? focusNode : anchorNode;
+    return $isAtNodeEnd(anchor) ? anchorNode : focusNode;
   }
 }


### PR DESCRIPTION
Fixes `getSelectedNode` logic for forward selection.