### PR TITLE
Fix typo in documentation

### DIFF
--- a/packages/lexical-website/docs/concepts/editor-state.md
+++ b/packages/lexical-website/docs/concepts/editor-state.md
@@ -87,7 +87,7 @@ Here's an example of how you can update an editor instance:
 
 ```js
 import {$getRoot, $getSelection} from 'lexical';
-import {$createParagraphNode} from 'lexical/PargraphNode';
+import {$createParagraphNode} from 'lexical';
 
 // Inside the `editor.update` you can use special $ prefixed helper functions.
 // These functions cannot be used outside the closure, and will error if you try.


### PR DESCRIPTION
says `lexical/PargraphNode` which is mispelling of "paragraph"
In any case seems this node is imported from `lexical` anyways in the playground example