### PR TITLE
Skip checking dom window

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -56,7 +56,7 @@ export function $generateHtmlFromNodes(
   editor: LexicalEditor,
   selection?: RangeSelection | NodeSelection | GridSelection | null,
 ): string {
-  if (typeof document === 'undefined' || typeof window === 'undefined') {
+  if (typeof document === 'undefined') {
     throw new Error(
       'To use $generateHtmlFromNodes in headless mode please initialize a headless browser implementation such as JSDom before calling this function.',
     );


### PR DESCRIPTION
Skip checking `window` to avoid defining both `global.window` and `global.document` in headless mode.