### PR TITLE
Allow focus/blur propagation in useYjsFocusTracking

### DIFF
--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -228,17 +228,17 @@ export function useYjsFocusTracking(
     return mergeRegister(
       editor.registerCommand(
         FOCUS_COMMAND,
-        (payload) => {
+        () => {
           setLocalStateFocus(provider, name, color, true);
-          return true;
+          return false;
         },
         COMMAND_PRIORITY_EDITOR,
       ),
       editor.registerCommand(
         BLUR_COMMAND,
-        (payload) => {
+        () => {
           setLocalStateFocus(provider, name, color, false);
-          return true;
+          return false;
         },
         COMMAND_PRIORITY_EDITOR,
       ),


### PR DESCRIPTION
I don't believe we ever meant to stop propagation in these command listeners. It blocks the default behavior happening on the plain/rich text plugins.