### PR TITLE
Fix bug in convertTextFormatElement

### DIFF
--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -968,7 +968,7 @@ function convertTextFormatElement(domNode: Node): DOMConversionOutput {
   }
   return {
     forChild: (lexicalNode) => {
-      if ($isTextNode(lexicalNode)) {
+      if ($isTextNode(lexicalNode) && !lexicalNode.hasFormat(format)) {
         lexicalNode.toggleFormat(format);
       }
 


### PR DESCRIPTION
This fixes a bug where if you had the HTML `<em><em>foo</em></em>` it would first be italic for the first `<em>` but then undo itself on the next `<em>`. Ouch.

Turns out we were never checking if it was already toggled!