### PR TITLE
Add TabIndentationPlugin to playground.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -86,6 +86,7 @@ module.name_mapper='^@lexical/react/LexicalLinkPlugin' -> '<PROJECT_ROOT>/packag
 module.name_mapper='^@lexical/react/LexicalAutoLinkPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalAutoLinkPlugin.js.flow'
 module.name_mapper='^@lexical/react/LexicalAutoEmbedPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalAutoEmbedPlugin.js.flow'
 module.name_mapper='^@lexical/react/LexicalNodeEventPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalNodeEventPlugin.js.flow'
+module.name_mapper='^@lexical/react/LexicalTabIndentationPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalTabIndentationPlugin.js.flow'
 
 module.name_mapper='^@lexical/react/LexicalListPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalListPlugin.js.flow'
 module.name_mapper='^@lexical/react/LexicalCheckListPlugin' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalCheckListPlugin.js.flow'

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -17,6 +17,7 @@ import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {ListPlugin} from '@lexical/react/LexicalListPlugin';
 import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {TabIndentationPlugin} from '@lexical/react/LexicalTabIndentationPlugin';
 import {TablePlugin} from '@lexical/react/LexicalTablePlugin';
 import * as React from 'react';
 import {useState} from 'react';
@@ -188,6 +189,7 @@ export default function Editor(): JSX.Element {
             <EquationsPlugin />
             <ExcalidrawPlugin />
             <TabFocusPlugin />
+            <TabIndentationPlugin />
             <CollapsiblePlugin />
             {floatingAnchorElem && (
               <>

--- a/packages/lexical-playground/vite.config.js
+++ b/packages/lexical-playground/vite.config.js
@@ -144,6 +144,7 @@ const moduleResolution = [
   'LexicalAutoEmbedPlugin',
   'LexicalOnChangePlugin',
   'LexicalNodeEventPlugin',
+  'LexicalTabIndentationPlugin',
 ].forEach((module) => {
   let resolvedPath = path.resolve(`../lexical-react/src/${module}.ts`);
 

--- a/packages/lexical-playground/vite.prod.config.js
+++ b/packages/lexical-playground/vite.prod.config.js
@@ -144,6 +144,7 @@ const moduleResolution = [
   'LexicalAutoEmbedPlugin',
   'LexicalOnChangePlugin',
   'LexicalNodeEventPlugin',
+  'LexicalTabIndentationPlugin'
 ].forEach((module) => {
   let resolvedPath = path.resolve(`../lexical-react/dist/${module}.js`);
   moduleResolution.push({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -171,6 +171,9 @@
       "@lexical/react/LexicalCheckListPlugin": [
         "./packages/lexical-react/src/LexicalCheckListPlugin.tsx"
       ],
+      "@lexical/react/LexicalTabIndentationPlugin": [
+        "./pakcages/lexical-react/src/LexicalTabIndentationPlugin.tsx"
+      ],
 
       "@lexical/dragon/LexicalDragon": ["./packages/lexical-dragon/src/"],
       "@lexical/history/LexicalHistory": ["./packages/lexical-history/src/"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -172,7 +172,7 @@
         "./packages/lexical-react/src/LexicalCheckListPlugin.tsx"
       ],
       "@lexical/react/LexicalTabIndentationPlugin": [
-        "./pakcages/lexical-react/src/LexicalTabIndentationPlugin.tsx"
+        "./packages/lexical-react/src/LexicalTabIndentationPlugin.tsx"
       ],
 
       "@lexical/dragon/LexicalDragon": ["./packages/lexical-dragon/src/"],


### PR DESCRIPTION
It's pretty annoying not having this on the playground and it degrades the editing experience for the majority of users. We factored this out to make tab behavior more configurable, but I think we want our public-facing default to include this behavior.