### PR TITLE
perf(playground): load prettier and its parsers on demand in code block

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CodeActionMenu.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CodeActionMenu.spec.mjs
@@ -216,6 +216,8 @@ test.describe('CodeActionMenu', () => {
     await mouseMoveToSelector(page, 'code.PlaygroundEditorTheme__code');
     await click(page, 'button[aria-label=prettier]');
 
+    await page.waitForTimeout(3000);
+
     await assertHTML(
       page,
       `

--- a/packages/lexical-playground/__tests__/e2e/CodeActionMenu.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CodeActionMenu.spec.mjs
@@ -286,6 +286,8 @@ test.describe('CodeActionMenu', () => {
     await mouseMoveToSelector(page, 'code.PlaygroundEditorTheme__code');
     await click(page, 'button[aria-label=prettier]');
 
+    await page.waitForTimeout(3000);
+
     expect(await page.$('i.format.prettier-error')).toBeTruthy();
 
     const errorTips = await page.$('pre.code-error-tips');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2019",
     "lib": ["esnext", "dom", "dom.iterable"],
+    "module": "esnext",
     "jsx": "react-jsx",
     "moduleResolution": "node",
     "downlevelIteration": true,


### PR DESCRIPTION
## Description
- Dynamically loaded prettier and its parsers in code block on click of prettier icon.

- Reduced around **1170.37KB (1.17MB)** from main bundle and created respective chunks which will be loaded only on demand


Ran `yarn build-playground-prod`


### Playground production build output

|Before|After|
|---|----|
|![before](https://user-images.githubusercontent.com/42532987/209449958-c784bdd2-9428-4a4c-971e-3afc73dc95be.png)|![after](https://user-images.githubusercontent.com/42532987/209449953-cb6e0932-5e80-430c-a0e5-24aa2a1e426e.png)|



### Network calls (In Development)


<details>

<summary>Before</summary>

[before.webm](https://user-images.githubusercontent.com/42532987/209450098-df7fbb71-3e6b-4086-b867-84413f20aa83.webm)

Prettier and all its parsers are loaded initially

</details>

<details>

<summary>After</summary>

[after.webm](https://user-images.githubusercontent.com/42532987/209450102-1319e6fd-0db9-45a1-9742-45d3fccf0714.webm)

Prettier will be loaded only on click of the prettier button
</details>




### New Chunks created

- parser-html
- parser-postcss
- parser-markdown
- parser-babel
- standalone 

### Main bundle size

|Before|After|
|----|----|
|**2141.87** KB/ gzip: **643.98** KB|**974.13** KB/ gzip: **300.74** KB |

