### PR TITLE
[0.8] Apply node transform not only to the original node but also to the overriding node

### DIFF
--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -64,6 +64,7 @@ export function LexicalNestedComposer({
           initialEditor._nodes.set(type, {
             klass: entry.klass,
             replace: entry.replace,
+            replaceWithKlass: entry.replaceWithKlass,
             transforms: new Set(),
           });
         }
@@ -73,6 +74,7 @@ export function LexicalNestedComposer({
           initialEditor._nodes.set(type, {
             klass,
             replace: null,
+            replaceWithKlass: null,
             transforms: new Set(),
           });
         }

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -145,6 +145,7 @@ export type RegisteredNode = {
   klass: Klass<LexicalNode>;
   transforms: Set<Transform<LexicalNode>>;
   replace: null | ((node: LexicalNode) => LexicalNode);
+  replaceWithKlass: null | Klass<LexicalNode>;
 };
 
 export type Transform<T extends LexicalNode> = (node: T) => void;
@@ -346,6 +347,8 @@ export function createEditor(editorConfig?: {
         with: <T extends {new (...args: any): any}>(
           node: InstanceType<T>,
         ) => LexicalNode;
+
+        withKlass?: Klass<LexicalNode>;
       }
   >;
   onError?: ErrorHandler;
@@ -382,11 +385,13 @@ export function createEditor(editorConfig?: {
     for (let i = 0; i < nodes.length; i++) {
       let klass = nodes[i];
       let replacementClass = null;
+      let replacementKlass = null;
 
       if (typeof klass !== 'function') {
         const options = klass;
         klass = options.replace;
         replacementClass = options.with;
+        replacementKlass = options.withKlass ? options.withKlass : null;
       }
       // Ensure custom nodes implement required methods.
       if (__DEV__) {
@@ -439,6 +444,7 @@ export function createEditor(editorConfig?: {
       registeredNodes.set(type, {
         klass,
         replace: replacementClass,
+        replaceWithKlass: replacementKlass,
         transforms: new Set(),
       });
     }
@@ -676,23 +682,38 @@ export class LexicalEditor {
     klass: Klass<T>,
     listener: Transform<T>,
   ): () => void {
-    const type = klass.getType();
+    const register = <U extends LexicalNode>(kls: Klass<U>): RegisteredNode => {
+      const type = kls.getType();
 
-    const registeredNode = this._nodes.get(type);
+      const registeredNode = this._nodes.get(type);
 
-    if (registeredNode === undefined) {
-      invariant(
-        false,
-        'Node %s has not been registered. Ensure node has been passed to createEditor.',
-        klass.name,
-      );
+      if (registeredNode === undefined) {
+        invariant(
+          false,
+          'Node %s has not been registered. Ensure node has been passed to createEditor.',
+          kls.name,
+        );
+      }
+      const transforms = registeredNode.transforms;
+      transforms.add(listener as Transform<LexicalNode>);
+
+      return registeredNode;
+    };
+
+    const registered = register(klass);
+    const registeredNodes = [registered];
+
+    const replaceWithKlass = registered.replaceWithKlass;
+    if (replaceWithKlass != null) {
+      const registeredReplaceWithNode = register(replaceWithKlass);
+      registeredNodes.push(registeredReplaceWithNode);
     }
 
-    const transforms = registeredNode.transforms;
-    transforms.add(listener as Transform<LexicalNode>);
-    markAllNodesAsDirty(this, type);
+    markAllNodesAsDirty(this, klass.getType());
     return () => {
-      transforms.delete(listener as Transform<LexicalNode>);
+      registeredNodes.forEach((node) =>
+        node.transforms.delete(listener as Transform<LexicalNode>),
+      );
     };
   }
 


### PR DESCRIPTION
This PR extends the node overrides: when "withKlass" is specified, node transforms are registered with both nodes by registerNodeTransform. 


### Background of this PR

Due to the implementation of Node Transforms, it is applied only to the exact same type of registered node.

According to [here](https://github.com/facebook/lexical/blob/main/packages/lexical/src/LexicalEditor.ts#L679), it seems to determine nodes to apply the transform by the result of static LexicalNode#getType().

[Node overrides](https://lexical.dev/docs/concepts/node-replacement) is very powerful but due to the above implementation, Node Transforms added by some plugins do not work with Node overrides.