### PR TITLE
Add flow vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "NuclleaR.vscode-extension-auto-import"
+    "NuclleaR.vscode-extension-auto-import",
+    "flowtype.flow-for-vscode"
   ]
 }


### PR DESCRIPTION
If the repository has a file with a flow extension, but does not have an extension, syntax of that file is not supported, making it difficult to read.

As a result, developers have to find and install related extensions themselves. To improve this, add it to the extension list.