### PR TITLE
Hide commenting controls on mobile screen sizes

### DIFF
--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.css
@@ -43,6 +43,12 @@ i.add-comment {
   background-image: url(../../images/icons/chat-left-text.svg);
 }
 
+@media (max-width: 1024px) {
+  .CommentPlugin_AddCommentBox {
+    display: none;
+  }
+}
+
 .CommentPlugin_CommentInputBox {
   display: block;
   position: fixed;
@@ -156,6 +162,12 @@ i.comments {
   background-image: url(../../images/icons/comments.svg);
   opacity: 0.5;
   transition: opacity 0.2s linear;
+}
+
+@media (max-width: 1024px) {
+  .CommentPlugin_ShowCommentsButton {
+    display: none;
+  }
 }
 
 .CommentPlugin_ShowCommentsButton:hover i.comments {

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.css
@@ -128,3 +128,10 @@
   background-color: #eee;
   margin: 0 4px;
 }
+
+
+@media (max-width: 1024px) {
+  .floating-text-format-popup button.insert-comment {
+    display: none;
+  }
+}

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.css
@@ -129,7 +129,6 @@
   margin: 0 4px;
 }
 
-
 @media (max-width: 1024px) {
   .floating-text-format-popup button.insert-comment {
     display: none;

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -207,7 +207,7 @@ function TextFormatFloatingToolbar({
       )}
       <button
         onClick={insertComment}
-        className={'popup-item spaced'}
+        className={'popup-item spaced insert-comment'}
         aria-label="Insert comment">
         <i className="format add-comment" />
       </button>


### PR DESCRIPTION
This isn't really a solution, however the commenting UI isn't really approachable on mobile and needs a big rework before we should show it again.