### PR TITLE
Fix bug in reconciler sub-tree text content cache

### DIFF
--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -176,6 +176,9 @@ function createNode(
       const endIndex = childrenSize - 1;
       const children = createChildrenArray(node, activeNextNodeMap);
       createChildrenWithDirection(children, endIndex, node, dom);
+      if ($textContentRequiresDoubleLinebreakAtEnd(node)) {
+        subTreeTextContent += DOUBLE_LINE_BREAK;
+      }
     }
     const format = node.__format;
 
@@ -613,7 +616,7 @@ function reconcileNode(
     $isRootNode(nextNode) &&
     nextNode.__cachedText !== editorTextContent
   ) {
-    // Cache the latest text content.
+        // Cache the latest text content.
     nextNode = nextNode.getWritable();
     nextNode.__cachedText = editorTextContent;
   }

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -178,6 +178,8 @@ function createNode(
       createChildrenWithDirection(children, endIndex, node, dom);
       if ($textContentRequiresDoubleLinebreakAtEnd(node)) {
         subTreeTextContent += DOUBLE_LINE_BREAK;
+        // @ts-expect-error: internal field
+        dom.__lexicalTextContent = subTreeTextContent;
       }
     }
     const format = node.__format;

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -616,7 +616,7 @@ function reconcileNode(
     $isRootNode(nextNode) &&
     nextNode.__cachedText !== editorTextContent
   ) {
-        // Cache the latest text content.
+    // Cache the latest text content.
     nextNode = nextNode.getWritable();
     nextNode.__cachedText = editorTextContent;
   }

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1663,6 +1663,33 @@ describe('LexicalEditor tests', () => {
 
     expect(fn).toHaveBeenCalledTimes(2);
     expect(fn).toHaveBeenCalledWith('foobar\n');
+
+    await editor.update(() => {
+      const root = $getRoot();
+      root.clear();
+      const paragraph = $createParagraphNode();
+      const paragraph2 = $createParagraphNode();
+      root.append(paragraph);
+      paragraph.append($createTextNode('bar'))
+      paragraph2.append($createTextNode('yar'))
+      paragraph.insertAfter(paragraph2);
+    });
+
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(fn).toHaveBeenCalledWith('bar\n\nyar');
+
+    await editor.update(() => {
+      const root = $getRoot();
+      const paragraph = $createParagraphNode();
+      const paragraph2 = $createParagraphNode();
+      root.getLastChild().insertAfter(paragraph);
+      paragraph.append($createTextNode('bar2'))
+      paragraph2.append($createTextNode('yar2'))
+      paragraph.insertAfter(paragraph2);
+    });
+
+    expect(fn).toHaveBeenCalledTimes(4);
+    expect(fn).toHaveBeenCalledWith('bar\n\nyar\n\nbar2\n\nyar2');
   });
 
   it('mutation listener', async () => {

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1670,8 +1670,8 @@ describe('LexicalEditor tests', () => {
       const paragraph = $createParagraphNode();
       const paragraph2 = $createParagraphNode();
       root.append(paragraph);
-      paragraph.append($createTextNode('bar'))
-      paragraph2.append($createTextNode('yar'))
+      paragraph.append($createTextNode('bar'));
+      paragraph2.append($createTextNode('yar'));
       paragraph.insertAfter(paragraph2);
     });
 
@@ -1683,8 +1683,8 @@ describe('LexicalEditor tests', () => {
       const paragraph = $createParagraphNode();
       const paragraph2 = $createParagraphNode();
       root.getLastChild().insertAfter(paragraph);
-      paragraph.append($createTextNode('bar2'))
-      paragraph2.append($createTextNode('yar2'))
+      paragraph.append($createTextNode('bar2'));
+      paragraph2.append($createTextNode('yar2'));
       paragraph.insertAfter(paragraph2);
     });
 


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/3602.

I think a bit of logic was missed from https://github.com/facebook/lexical/pull/1993. It's hard to fully know though. Would be good to have the eyes of @zurfyx on this.