### PR TITLE
Remove ts-ignore for createContext

### DIFF
--- a/packages/lexical-playground/src/plugins/TablePlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TablePlugin.tsx
@@ -58,8 +58,7 @@ export type CellEditorConfig = Readonly<{
 export const INSERT_NEW_TABLE_COMMAND: LexicalCommand<InsertTableCommandPayload> =
   createCommand('INSERT_NEW_TABLE_COMMAND');
 
-// @ts-ignore: not sure why TS doesn't like using null as the value?
-export const CellContext: React.Context<CellContextShape> = createContext({
+export const CellContext = createContext<CellContextShape>({
   cellEditorConfig: null,
   cellEditorPlugins: null,
   set: () => {


### PR DESCRIPTION
The reason tsc complains is that createContext is a generic function. Not sure if other similar calls need to be fixed. They look good.