### PR TITLE
fix: type-ahead menu scroll problem

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -84,7 +84,10 @@ const scrollIntoViewIfNeeded = (target: HTMLElement) => {
   if (container) {
     const parentNode = target.parentNode as HTMLElement | null;
 
-    if (parentNode) {
+    if (
+      parentNode &&
+      /auto|scroll/.test(getComputedStyle(parentNode).overflow)
+    ) {
       const parentRect = parentNode.getBoundingClientRect();
 
       if (parentRect.top + parentRect.height > window.innerHeight) {

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -80,13 +80,19 @@ export type MenuRenderFn<TOption extends TypeaheadOption> = (
 
 const scrollIntoViewIfNeeded = (target: HTMLElement) => {
   const container = document.getElementById('typeahead-menu');
+
   if (container) {
-    const containerRect = container.getBoundingClientRect();
-    const targetRect = target.getBoundingClientRect();
-    if (targetRect.bottom > containerRect.bottom) {
+    const parentNode = target.parentNode as HTMLElement | null;
+
+    if (parentNode) {
+      const parentRect = parentNode.getBoundingClientRect();
+
+      if (parentRect.top + parentRect.height > window.innerHeight) {
+        parentNode.scrollIntoView(false);
+      }
+      parentNode.scrollTop = target.offsetTop - target.clientHeight;
+    } else {
       target.scrollIntoView(false);
-    } else if (targetRect.top < containerRect.top) {
-      target.scrollIntoView();
     }
   }
 };


### PR DESCRIPTION
fix an issue where the menu would cause the editor to scroll.

#### before

https://user-images.githubusercontent.com/5945154/211185806-6659b340-cf12-4e52-bb32-716862ba0c44.mp4

#### after

Only scrollIntoView will be done when there are not enough positions.

https://user-images.githubusercontent.com/5945154/210514951-e3e60bdf-497a-4b8e-bd68-455842d38f73.mp4

