### PR TITLE
Add width and height to serialized image nodes

### DIFF
--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -42,8 +42,8 @@ export interface ImagePayload {
 
 function convertImageElement(domNode: Node): null | DOMConversionOutput {
   if (domNode instanceof HTMLImageElement) {
-    const {alt: altText, src} = domNode;
-    const node = $createImageNode({altText, src});
+    const {alt: altText, src, width, height} = domNode;
+    const node = $createImageNode({altText, height, src, width});
     return {node};
   }
   return null;
@@ -116,6 +116,8 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     const element = document.createElement('img');
     element.setAttribute('src', this.__src);
     element.setAttribute('alt', this.__altText);
+    element.setAttribute('width', this.__width.toString());
+    element.setAttribute('height', this.__height.toString());
     return {element};
   }
 


### PR DESCRIPTION
This PR adds width and height to image nodes when they are serialized or get converted back to Lexical nodes.