### PR TITLE
insert node after parent when selection at the end

### DIFF
--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -350,9 +350,19 @@ export function $insertNodeToNearestRoot<T extends LexicalNode>(node: T): T {
         splitNode = focusNode;
         splitOffset = focusOffset;
       }
-      const [, rightTree] = $splitNode(splitNode, splitOffset);
-      rightTree.insertBefore(node);
-      rightTree.selectStart();
+      const selectionAtLastOffset = focusNode.__text.length === focusOffset;
+      if (
+        splitNode.__type === 'listitem' &&
+        splitNode.__next == null &&
+        selectionAtLastOffset
+      ) {
+        const parentNode = splitNode.getParentOrThrow();
+        parentNode.insertAfter(node);
+      } else {
+        const [, rightTree] = $splitNode(splitNode, splitOffset);
+        rightTree.insertBefore(node);
+        rightTree.selectStart();
+      }
     }
   } else {
     if ($isNodeSelection(selection) || DEPRECATED_$isGridSelection(selection)) {


### PR DESCRIPTION
This PR fixes inserting the divider before list item when the selection is at the end of the last list item. 

Fixes #3681 
