### PR TITLE
Add config to updateDOM in ParagraphNode 

### DIFF
--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -49,7 +49,11 @@ export class ParagraphNode extends ElementNode {
     }
     return dom;
   }
-  updateDOM(prevNode: ParagraphNode, dom: HTMLElement): boolean {
+  updateDOM(
+    prevNode: ParagraphNode,
+    dom: HTMLElement,
+    config: EditorConfig,
+  ): boolean {
     return false;
   }
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalParagraphNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalParagraphNode.test.ts
@@ -85,7 +85,11 @@ describe('LexicalParagraphNode tests', () => {
         expect(domElement.outerHTML).toBe('<p class="my-paragraph-class"></p>');
 
         const newParagraphNode = new ParagraphNode();
-        const result = newParagraphNode.updateDOM(paragraphNode, domElement);
+        const result = newParagraphNode.updateDOM(
+          paragraphNode,
+          domElement,
+          editorConfig,
+        );
 
         expect(result).toBe(false);
         expect(domElement.outerHTML).toBe('<p class="my-paragraph-class"></p>');


### PR DESCRIPTION
The standard ParagraphNode does not expose the config property available to its updateDOM method. 

This can make for a nasty TypeScript problem when creating a custom ParagraphNode for the replacement API. The reason is that TypeScript will insist that there's no such config property. But there is. This PR will convince TS otherwise!

I encountered this problem while building a LinedCodeNode. This PR is 1/2 that will let it work without patches. 

-j