### PR TITLE
Discard empty TextNode that can creep into appendJSON

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -425,7 +425,7 @@ function $appendNodesToJSON(
     // if an uncollapsed selection ends or starts at the end of a line of specialized text
     // nodes, such as code tokens, we will get a 'blank' text node here, i.e., one with
     // text of length 0. we don't want this, it makes for a confusing mess. reset!
-    if ($isTextNode(target) && target.__text.length > 0) {
+    if (target.__text.length > 0) {
       (serializedNode as SerializedTextNode).text = target.__text;
     } else {
       shouldInclude = false;

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -422,7 +422,14 @@ function $appendNodesToJSON(
   // We need a way to create a clone of a Node in memory with it's own key, but
   // until then this hack will work for the selected text extract use case.
   if ($isTextNode(target)) {
-    (serializedNode as SerializedTextNode).text = target.__text;
+    // if the selection is at the end of a line of specialized text nodes, such as
+    // code tokens, we may have a 'blank' text node here, i.e., a node with no-
+    // size text). we don't want this, it makes for a confusing mess.
+    if ($isTextNode(target) && target.__text.length > 0) {
+      (serializedNode as SerializedTextNode).text = target.__text;
+    } else {
+      shouldInclude = false;
+    }
   }
 
   for (let i = 0; i < children.length; i++) {

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -422,9 +422,9 @@ function $appendNodesToJSON(
   // We need a way to create a clone of a Node in memory with it's own key, but
   // until then this hack will work for the selected text extract use case.
   if ($isTextNode(target)) {
-    // if the selection is at the end of a line of specialized text nodes, such as
-    // code tokens, we may have a 'blank' text node here, i.e., a node with no-
-    // size text). we don't want this, it makes for a confusing mess.
+    // if an uncollapsed selection ends or starts at the end of a line of specialized text
+    // nodes, such as code tokens, we will get a 'blank' text node here, i.e., one with
+    // text of length 0. we don't want this, it makes for a confusing mess. reset!
     if ($isTextNode(target) && target.__text.length > 0) {
       (serializedNode as SerializedTextNode).text = target.__text;
     } else {

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -422,9 +422,9 @@ function $appendNodesToJSON(
   // We need a way to create a clone of a Node in memory with it's own key, but
   // until then this hack will work for the selected text extract use case.
   if ($isTextNode(target)) {
-    // if an uncollapsed selection ends or starts at the end of a line of specialized text
-    // nodes, such as code tokens, we will get a 'blank' text node here, i.e., one with
-    // text of length 0. we don't want this, it makes for a confusing mess. reset!
+    // If an uncollapsed selection ends or starts at the end of a line of specialized,
+    // TextNodes, such as code tokens, we will get a 'blank' TextNode here, i.e., one
+    // with text of length 0. We don't want this, it makes a confusing mess. Reset!
     if (target.__text.length > 0) {
       (serializedNode as SerializedTextNode).text = target.__text;
     } else {

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -422,11 +422,12 @@ function $appendNodesToJSON(
   // We need a way to create a clone of a Node in memory with it's own key, but
   // until then this hack will work for the selected text extract use case.
   if ($isTextNode(target)) {
+    const text = target.__text;
     // If an uncollapsed selection ends or starts at the end of a line of specialized,
     // TextNodes, such as code tokens, we will get a 'blank' TextNode here, i.e., one
     // with text of length 0. We don't want this, it makes a confusing mess. Reset!
-    if (target.__text.length > 0) {
-      (serializedNode as SerializedTextNode).text = target.__text;
+    if (text.length > 0) {
+      (serializedNode as SerializedTextNode).text = text;
     } else {
       shouldInclude = false;
     }


### PR DESCRIPTION
If an uncollapsed selection ends or starts at the end of a line of specialized TextNodes, such as code tokens, we will get a 'blank' TextNode in `$appendNodesToJSON`. In other words, we'll get a TextNode with a text length of 0 (`''`). 

We do not want empty TextNodes, per @trueadm. He calls it an anti-pattern. 

So, this PR filters the occasional empty TextNode out of JSON, should it appear. 

I am not filtering it out of the sibling function, `$appendNodesToDOM`, however, as this can be handled via the exportDOM method instead. It is a more flexible method than exportJSON, so can be leveraged a little more surgically. 

Filtering could be added to the `$appendNodesToDOM` method, however, it might be a little more involved. You might have to add a line break (a br?). I was very ginger about function, as I didn't want to break half the planet by accident.

I encountered this problem while building a LinedCodeNode. This PR is 2/2 that will let it work without patches.

-j