### PR TITLE
updated typo

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -520,7 +520,7 @@ export class LexicalNode {
     if (latest === null) {
       invariant(
         false,
-        'Lexical node does not exist in active editor state. Avoid using the same node references between nested closures from editor.read/editor.update.',
+        'Lexical node does not exist in active editor state. Avoid using the same node references between nested closures from editorState.read/editor.update.',
       );
     }
     return latest;


### PR DESCRIPTION
This fixes a typo in LexicalNode for method getLatest.
editor.read doesn't exist, it's editorState.read