### PR TITLE
Make highlight code plugin movement optional

### DIFF
--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -693,6 +693,7 @@ function handleMoveTo(
 export function registerCodeHighlighting(
   editor: LexicalEditor,
   tokenizer?: Tokenizer,
+  withNativeMovement?: boolean,
 ): () => void {
   if (!editor.hasNodes([CodeNode, CodeHighlightNode])) {
     throw new Error(
@@ -704,7 +705,7 @@ export function registerCodeHighlighting(
     tokenizer = PrismTokenizer;
   }
 
-  return mergeRegister(
+  const listeners = [
     editor.registerMutationListener(CodeNode, (mutations) => {
       editor.update(() => {
         for (const [key, type] of mutations) {
@@ -746,15 +747,24 @@ export function registerCodeHighlighting(
       (payload): boolean => handleShiftLines(KEY_ARROW_DOWN_COMMAND, payload),
       COMMAND_PRIORITY_LOW,
     ),
-    editor.registerCommand(
-      MOVE_TO_END,
-      (payload): boolean => handleMoveTo(MOVE_TO_END, payload),
-      COMMAND_PRIORITY_LOW,
-    ),
-    editor.registerCommand(
-      MOVE_TO_START,
-      (payload): boolean => handleMoveTo(MOVE_TO_START, payload),
-      COMMAND_PRIORITY_LOW,
-    ),
-  );
+  ];
+
+  if (!withNativeMovement) {
+    listeners.push(
+      editor.registerCommand(
+        MOVE_TO_END,
+        (payload): boolean => handleMoveTo(MOVE_TO_END, payload),
+        COMMAND_PRIORITY_LOW,
+      ),
+    );
+    listeners.push(
+      editor.registerCommand(
+        MOVE_TO_START,
+        (payload): boolean => handleMoveTo(MOVE_TO_START, payload),
+        COMMAND_PRIORITY_LOW,
+      ),
+    );
+  }
+
+  return mergeRegister(...listeners);
 }

--- a/packages/lexical-playground/src/plugins/CodeHighlightPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/CodeHighlightPlugin/index.ts
@@ -19,7 +19,7 @@ export default function CodeHighlightPlugin({
 
   useEffect(() => {
     return registerCodeHighlighting(editor, undefined, withNativeMovement);
-  }, [editor]);
+  }, [editor, withNativeMovement]);
 
   return null;
 }

--- a/packages/lexical-playground/src/plugins/CodeHighlightPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/CodeHighlightPlugin/index.ts
@@ -10,11 +10,15 @@ import {registerCodeHighlighting} from '@lexical/code';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
 
-export default function CodeHighlightPlugin(): JSX.Element | null {
+export default function CodeHighlightPlugin({
+  withNativeMovement,
+}: {
+  withNativeMovement?: boolean;
+}): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    return registerCodeHighlighting(editor);
+    return registerCodeHighlighting(editor, undefined, withNativeMovement);
   }, [editor]);
 
   return null;


### PR DESCRIPTION
Add option to get movement across highlighted code behave as with normal text