### PR TITLE
Update listener in toc

### DIFF
--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -26,6 +26,22 @@ function indent(tagName: HeadingTagType) {
   }
 }
 
+function isHeadingAtTheTopOfThePage(element: HTMLElement): boolean {
+  const elementYPosition = element?.getClientRects()[0].y;
+  return (
+    elementYPosition >= MARGIN_ABOVE_EDITOR &&
+    elementYPosition <= MARGIN_ABOVE_EDITOR + HEADING_WIDTH
+  );
+}
+function isHeadingAboveViewport(element: HTMLElement): boolean {
+  const elementYPosition = element?.getClientRects()[0].y;
+  return elementYPosition < MARGIN_ABOVE_EDITOR;
+}
+function isHeadingBelowTheTopOfThePage(element: HTMLElement): boolean {
+  const elementYPosition = element?.getClientRects()[0].y;
+  return elementYPosition >= MARGIN_ABOVE_EDITOR + HEADING_WIDTH;
+}
+
 function TableOfContentsList({
   tableOfContents,
 }: {
@@ -44,21 +60,6 @@ function TableOfContentsList({
         selectedIndex.current = currIndex;
       }
     });
-  }
-  function isHeadingAtTheTopOfThePage(element: HTMLElement): boolean {
-    const elementYPosition = element?.getClientRects()[0].y;
-    return (
-      elementYPosition >= MARGIN_ABOVE_EDITOR &&
-      elementYPosition <= MARGIN_ABOVE_EDITOR + HEADING_WIDTH
-    );
-  }
-  function isHeadingAboveViewport(element: HTMLElement): boolean {
-    const elementYPosition = element?.getClientRects()[0].y;
-    return elementYPosition < MARGIN_ABOVE_EDITOR;
-  }
-  function isHeadingBelowTheTopOfThePage(element: HTMLElement): boolean {
-    const elementYPosition = element?.getClientRects()[0].y;
-    return elementYPosition >= MARGIN_ABOVE_EDITOR + HEADING_WIDTH;
   }
 
   useEffect(() => {


### PR DESCRIPTION
Previously, the Table of Contents plugin didn't update correctly if a heading was updated. For example, if you enable ToC on the Lexical Playground and drag one heading after another (with the `DraggableBlockPlugin`), the ToC didn't update.

This PR adds handling of such events and includes minor code cleanup:

- Create a separate TS type for ToC that can be used throughout the plugin without needing to duplicate
- Introduces a utility function to transform a heading node to an array to be included in the ToC
- Updates the ToC only once per listener trigger - previously it was updated once for each mutation

