### PR TITLE
Tweak CodeNode to allow for overrides

### DIFF
--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -129,7 +129,7 @@ export class CodeNode extends ElementNode {
     return {
       // Typically <pre> is used for code blocks, and <code> for inline code styles
       // but if it's a multi line <code> we'll create a block. Pass through to
-      // inline format handled by TextNode otherwise
+      // inline format handled by TextNode otherwise.
       code: (node: Node) => {
         const isMultiLine =
           node.textContent != null &&

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -156,7 +156,7 @@ export class CodeNode extends ElementNode {
         if (isGitHubCodeTable(table as HTMLTableElement)) {
           return {
             conversion: convertTableElement,
-            priority: 4,
+            priority: 3,
           };
         }
         return null;
@@ -169,7 +169,7 @@ export class CodeNode extends ElementNode {
         if (isGitHubCodeCell(td)) {
           return {
             conversion: convertTableCellElement,
-            priority: 4,
+            priority: 3,
           };
         }
         if (table && isGitHubCodeTable(table)) {
@@ -177,7 +177,7 @@ export class CodeNode extends ElementNode {
           // Otherwise it'll fall back to the T
           return {
             conversion: convertCodeNoop,
-            priority: 4,
+            priority: 3,
           };
         }
 
@@ -190,7 +190,7 @@ export class CodeNode extends ElementNode {
         if (table && isGitHubCodeTable(table)) {
           return {
             conversion: convertCodeNoop,
-            priority: 4,
+            priority: 3,
           };
         }
         return null;

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -107,7 +107,11 @@ export class CodeNode extends ElementNode {
     }
     return element;
   }
-  updateDOM(prevNode: CodeNode, dom: HTMLElement): boolean {
+  updateDOM(
+    prevNode: CodeNode,
+    dom: HTMLElement,
+    config: EditorConfig,
+  ): boolean {
     const language = this.__language;
     const prevLanguage = prevNode.__language;
 
@@ -273,7 +277,7 @@ export class CodeNode extends ElementNode {
     return false;
   }
 
-  collapseAtStart(): true {
+  collapseAtStart(): boolean {
     const paragraph = $createParagraphNode();
     const children = this.getChildren();
     children.forEach((child) => paragraph.append(child));

--- a/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
+++ b/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
@@ -64,7 +64,11 @@ describe('LexicalCodeNode tests', () => {
           theme: {},
         });
         expect(domElement.outerHTML).toBe('<code spellcheck="false"></code>');
-        const result = newCodeNode.updateDOM(codeNode, domElement);
+        const result = newCodeNode.updateDOM(
+          codeNode,
+          domElement,
+          editorConfig,
+        );
         expect(result).toBe(false);
         expect(domElement.outerHTML).toBe('<code spellcheck="false"></code>');
       });

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -131,7 +131,7 @@ static importDOM(): DOMConversionMap | null {
       if (isGitHubCodeTable(node as HTMLTableElement)) {
         return {
           conversion: convertTableElement,
-          priority: 4,
+          priority: 3,
         };
       }
       return null;


### PR DESCRIPTION
This pull request is the first of at least two that are also needed to implement my LinedCodeNode without patches. 

I've extended my work on this node to allow it to override the official CodeNode via the override API so it can work with — I hope — Lexical's existing core library packages, notably @lexical/markdown.

_In this pull request:_ 

- Reduced priority level for several importDOM converters so an overriding CodeNode can take over
  - Without this, the official CodeNode will win the race to control how importDOM elements are handled
- Exposed the editor config in the CodeNode's updateDOM method
- Added a more generic return type to the CodeNode's collapseAtStart method so CodeNode overrides can apply more nuanced logic

Coming soon-ish:

A pull request to make the new `setBlocksType_experimental` function more flexible.

Recent related pull requests:

https://github.com/facebook/lexical/pull/3693
https://github.com/facebook/lexical/pull/3695