### PR TITLE
Remove preventDefault from $copyToClipboardEvent

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -34,6 +34,7 @@ import {
   DEPRECATED_$isGridSelection,
   DEPRECATED_GridNode,
   GridSelection,
+  isSelectionWithinEditor,
   LexicalEditor,
   LexicalNode,
   NodeSelection,
@@ -572,6 +573,20 @@ function $copyToClipboardEvent(
   editor: LexicalEditor,
   event: ClipboardEvent,
 ): boolean {
+  const domSelection = window.getSelection();
+  if (!domSelection) {
+    return false;
+  }
+  const anchorDOM = domSelection.anchorNode;
+  const focusDOM = domSelection.focusNode;
+  if (
+    anchorDOM == null ||
+    focusDOM == null ||
+    !isSelectionWithinEditor(editor, anchorDOM, focusDOM)
+  ) {
+    return false;
+  }
+  event.preventDefault();
   const clipboardData = event.clipboardData;
   if (clipboardData === null) {
     return false;

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -47,7 +47,7 @@ export function $getHtmlContent(editor: LexicalEditor): string {
   const selection = $getSelection();
 
   if (selection == null) {
-    throw new Error('Expected valid LexicalSelection');
+    return '';
   }
 
   // If we haven't selected anything
@@ -67,7 +67,7 @@ export function $getLexicalContent(editor: LexicalEditor): null | string {
   const selection = $getSelection();
 
   if (selection == null) {
-    throw new Error('Expected valid LexicalSelection');
+    return null;
   }
 
   // If we haven't selected anything
@@ -572,7 +572,6 @@ function $copyToClipboardEvent(
   editor: LexicalEditor,
   event: ClipboardEvent,
 ): boolean {
-  event.preventDefault();
   const clipboardData = event.clipboardData;
   if (clipboardData === null) {
     return false;

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -580,8 +580,8 @@ function $copyToClipboardEvent(
   const anchorDOM = domSelection.anchorNode;
   const focusDOM = domSelection.focusNode;
   if (
-    anchorDOM == null ||
-    focusDOM == null ||
+    anchorDOM !== null &&
+    focusDOM !== null &&
     !isSelectionWithinEditor(editor, anchorDOM, focusDOM)
   ) {
     return false;

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -48,7 +48,7 @@ export function $getHtmlContent(editor: LexicalEditor): string {
   const selection = $getSelection();
 
   if (selection == null) {
-    return '';
+    throw new Error('Expected valid LexicalSelection');
   }
 
   // If we haven't selected anything
@@ -68,7 +68,7 @@ export function $getLexicalContent(editor: LexicalEditor): null | string {
   const selection = $getSelection();
 
   if (selection == null) {
-    return null;
+    throw new Error('Expected valid LexicalSelection');
   }
 
   // If we haven't selected anything

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -141,6 +141,7 @@ export {
   $nodesOfType,
   $setCompositionKey,
   $setSelection,
+  isSelectionWithinEditor,
 } from './LexicalUtils';
 export {$isDecoratorNode, DecoratorNode} from './nodes/LexicalDecoratorNode';
 export {$isElementNode, ElementNode} from './nodes/LexicalElementNode';


### PR DESCRIPTION
The error logic and prevent default in $copyToClipboardEvent is causing an issue for input or textareas in within decorator nodes. The native selection is overridden, but when no Lexical selection is found, an error is thrown.

Closes #3717 
Closes #3698 

https://user-images.githubusercontent.com/7748470/212957866-84e70cce-3f58-4f2d-8e20-7f391a53cace.mov

