### PR TITLE
fix(lexical-playground): NewTablePlugin is not draggable

### DIFF
--- a/packages/lexical-playground/src/nodes/TableNode.tsx
+++ b/packages/lexical-playground/src/nodes/TableNode.tsx
@@ -232,9 +232,7 @@ export class TableNode extends DecoratorNode<JSX.Element> {
   }
 
   createDOM(): HTMLElement {
-    const div = document.createElement('div');
-    div.style.display = 'contents';
-    return div;
+    return document.createElement('div');
   }
 
   updateDOM(): false {


### PR DESCRIPTION
The Lexical Playground environment has two components, Table and Table (Experimental), the former draggable but not the latter.
I thought it would be desirable to have a component that is draggable like the Table component, so I fixed this as a bug.

<details>
<summary>Before/After</summary>

Before:
![before-newtableplugin-is-not-draggable](https://user-images.githubusercontent.com/31314668/213170818-c778fa80-9910-4f54-b626-3db678e1cefc.gif)

After:
![after-newtableplugin-is-not-draggable](https://user-images.githubusercontent.com/31314668/213170842-da32f26b-bc81-4684-9880-fcfc06daea7a.gif)

</details>
