### PR TITLE
Fix $generateJSONFromSelectedNodes with a custom selection passed in

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -398,7 +398,8 @@ function $appendNodesToJSON(
   currentNode: LexicalNode,
   targetArray: Array<BaseSerializedNode> = [],
 ): boolean {
-  let shouldInclude = selection != null ? currentNode.isSelected() : true;
+  let shouldInclude =
+    selection != null ? currentNode.isSelected(selection) : true;
   const shouldExclude =
     $isElementNode(currentNode) && currentNode.excludeFromCopy('html');
   let target = currentNode;

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -8,7 +8,11 @@
 
 /* eslint-disable no-constant-condition */
 import type {EditorConfig, LexicalEditor} from './LexicalEditor';
-import type {RangeSelection} from './LexicalSelection';
+import type {
+  GridSelection,
+  NodeSelection,
+  RangeSelection,
+} from './LexicalSelection';
 import type {Klass} from 'lexical';
 
 import invariant from 'shared/invariant';
@@ -222,8 +226,10 @@ export class LexicalNode {
     return false;
   }
 
-  isSelected(): boolean {
-    const selection = $getSelection();
+  isSelected(
+    _selection?: null | RangeSelection | NodeSelection | GridSelection,
+  ): boolean {
+    const selection = _selection || $getSelection();
     if (selection == null) {
       return false;
     }

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -14,6 +14,7 @@ import {
   TextNode,
 } from 'lexical';
 
+import {$createRangeSelection} from '../..';
 import {LexicalNode} from '../../LexicalNode';
 import {$createParagraphNode} from '../../nodes/LexicalParagraphNode';
 import {$createTextNode} from '../../nodes/LexicalTextNode';
@@ -215,6 +216,41 @@ describe('LexicalNode tests', () => {
           expect(newParagraphNode.isSelected()).toBe(true);
           expect(newTextNode.isSelected()).toBe(true);
         });
+      });
+
+      test('LexicalNode.isSelected(): with custom range selection', async () => {
+        const {editor} = testEnv;
+        let newParagraphNode;
+        let newTextNode;
+
+        await editor.update(() => {
+          expect(paragraphNode.isSelected()).toBe(false);
+          expect(textNode.isSelected()).toBe(false);
+          newParagraphNode = new ParagraphNode();
+          newTextNode = new TextNode('bar');
+          newParagraphNode.append(newTextNode);
+          paragraphNode.insertAfter(newParagraphNode);
+          expect(newParagraphNode.isSelected()).toBe(false);
+          expect(newTextNode.isSelected()).toBe(false);
+        });
+
+        await editor.update(() => {
+          const rangeSelection = $createRangeSelection();
+
+          rangeSelection.anchor.type = 'text';
+          rangeSelection.anchor.offset = 1;
+          rangeSelection.anchor.key = textNode.getKey();
+          rangeSelection.focus.type = 'text';
+          rangeSelection.focus.offset = 1;
+          rangeSelection.focus.key = newTextNode.getKey();
+
+          expect(paragraphNode.isSelected(rangeSelection)).toBe(true);
+          expect(textNode.isSelected(rangeSelection)).toBe(true);
+          expect(newParagraphNode.isSelected(rangeSelection)).toBe(true);
+          expect(newTextNode.isSelected(rangeSelection)).toBe(true);
+        });
+
+        await Promise.resolve().then();
       });
 
       test('LexicalNode.getKey()', async () => {


### PR DESCRIPTION
Fixes #3745 

Previously, passing in a Selection into `$generateJSONFromSelectedNodes` would result in the wrong JSON because the the main selection from `$getSelection()` was being used. We should be using the target selection that was passed in instead of the main editor selection.