### PR TITLE
Edit CSS to fix marker alignment issue in Safari

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -277,42 +277,30 @@
 .PlaygroundEditorTheme__ol1 {
   padding: 0;
   margin: 0;
-  margin-left: 16px;
-  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol2 {
   padding: 0;
   margin: 0;
-  margin-left: 16px;
   list-style-type: upper-alpha;
-  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol3 {
   padding: 0;
   margin: 0;
-  margin-left: 16px;
   list-style-type: lower-alpha;
-  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol4 {
   padding: 0;
   margin: 0;
-  margin-left: 16px;
   list-style-type: upper-roman;
-  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol5 {
   padding: 0;
   margin: 0;
-  margin-left: 16px;
   list-style-type: lower-roman;
-  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ul {
   padding: 0;
   margin: 0;
-  margin-left: 16px;
-  list-style-position: inside;
 }
 .PlaygroundEditorTheme__listItem {
   margin: 0 32px;


### PR DESCRIPTION
There appears to be some issues with `list-style-position: inside;` on Safari, but we can probably just remove it as we're setting a margin-left any way. It's the same as putting the marker on the outside.

Closes #3752 