### PR TITLE
Fix equation transformer in Playground

### DIFF
--- a/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
+++ b/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
@@ -105,8 +105,8 @@ export const EQUATION: TextMatchTransformer = {
 
     return `$${node.getEquation()}$`;
   },
-  importRegExp: /\$([^$].+?)\$/,
-  regExp: /\$([^$].+?)\$$/,
+  importRegExp: /\$([^$]+?)\$/,
+  regExp: /\$([^$]+?)\$$/,
   replace: (textNode, match) => {
     const [, equation] = match;
     const equationNode = $createEquationNode(equation, true);


### PR DESCRIPTION
The equation markdown transformer is not working when your LaTeX is only one character long.  For instance, you can use this text:
```
What is the $x$-intercept of line $k$?
```

**Current Result**
<img width="297" alt="image" src="https://user-images.githubusercontent.com/3316818/213753460-15765782-9369-4043-b970-e8e372a652f5.png">


**Expected**
<img width="349" alt="image" src="https://user-images.githubusercontent.com/3316818/213753294-82e65c2d-50d3-4dc0-8bb0-e6249e8a2cab.png">

You can take a look at the new RegEx [here](https://regex101.com/r/2GgxP1/1)
