### PR TITLE
Letting other nodes with priority 1 to try to convert div elements if the element is not a codeNode

### DIFF
--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -142,10 +142,17 @@ export class CodeNode extends ElementNode {
             }
           : null;
       },
-      div: (node: Node) => ({
-        conversion: convertDivElement,
-        priority: 1,
-      }),
+      div: (node: Node) => {
+        // domNode is a <div> since we matched it by nodeName
+        const div = node as HTMLDivElement;
+        if (!isCodeElement(div)){
+          return null;
+        }
+        return {
+          conversion: convertDivElement,
+          priority: 1,
+        }
+      },
       pre: (node: Node) => ({
         conversion: convertPreElement,
         priority: 0,

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -145,13 +145,13 @@ export class CodeNode extends ElementNode {
       div: (node: Node) => {
         // domNode is a <div> since we matched it by nodeName
         const div = node as HTMLDivElement;
-        if (!isCodeElement(div)){
+        if (!isCodeElement(div)) {
           return null;
         }
         return {
           conversion: convertDivElement,
           priority: 1,
-        }
+        };
       },
       pre: (node: Node) => ({
         conversion: convertPreElement,


### PR DESCRIPTION
According to the docs the function mapped to a element name should return null if it's able to convert the html element to its node type. The codeNode only does this check inside the conversion function for `<div>` elements. So it does not let other nodes with priority 1 to try to convert the element to their type.