### PR TITLE
Stabilize WeakMap in NodeEventPlugin

### DIFF
--- a/packages/lexical-react/src/LexicalNodeEventPlugin.ts
+++ b/packages/lexical-react/src/LexicalNodeEventPlugin.ts
@@ -35,9 +35,9 @@ export function NodeEventPlugin({
   listenerRef.current = eventListener;
 
   useLayoutEffect(() => {
-    return editor.registerMutationListener(nodeType, (mutations) => {
-      const registedElements: WeakSet<HTMLElement> = new WeakSet();
+    const registedElements: WeakSet<HTMLElement> = new WeakSet();
 
+    return editor.registerMutationListener(nodeType, (mutations) => {
       editor.getEditorState().read(() => {
         for (const [key, mutation] of mutations) {
           const element: null | HTMLElement = editor.getElementByKey(key);


### PR DESCRIPTION
Today, while using the supremely useful `NodeEventPlugin`, I watched as the number of "click" event listeners on my code lines exponentially increased on every click. 

After some hunting and pecking, I discovered that the WeakMap that tracks elements in this plugin was being reset on every render. In other words, it reset to {} on each click. I therefore moved the WeakMap up a line, placing it outside the scope of the `registerMutationListener` function that makes use of it. 

Hark! The exponential increase ceased, the WeakMap stabilized, and a whole bunch of my code went from "bad" to "good."

@trueadm I see you worked heavily on this plugin, is this OK?

I have run `npm run test-unit` and observed Greenland. I am rolling the dice on the e2es, as I'm still not confident in them.

This LinedCodeNode-related pull request is sibling to:

https://github.com/facebook/lexical/pull/3770
https://github.com/facebook/lexical/pull/3769
https://github.com/facebook/lexical/pull/3695
https://github.com/facebook/lexical/pull/3731
https://github.com/facebook/lexical/pull/3695
https://github.com/facebook/lexical/pull/3693