### PR TITLE
Fix copy paste wrong order in TableOfContents

### DIFF
--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -143,10 +143,9 @@ function TableOfContentsList({
         {tableOfContents.map(([key, text, tag], index) => {
           if (index === 0) {
             return (
-              <div className="normal-heading-wrapper">
+              <div className="normal-heading-wrapper" key={key}>
                 <div
                   className="first-heading"
-                  key={key}
                   onClick={() => scrollToNode(key, index)}
                   role="button"
                   tabIndex={0}>
@@ -162,9 +161,9 @@ function TableOfContentsList({
               <div
                 className={`normal-heading-wrapper ${
                   selectedKey === key ? 'selected-heading-wrapper' : ''
-                }`}>
+                }`}
+                key={key}>
                 <div
-                  key={key}
                   onClick={() => scrollToNode(key, index)}
                   role="button"
                   className={indent(tag)}

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -11,7 +11,9 @@ import type {NodeKey} from 'lexical';
 import './index.css';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import LexicalTableOfContents__EXPERIMENTAL from '@lexical/react/LexicalTableOfContents__EXPERIMENTAL';
+import LexicalTableOfContents__EXPERIMENTAL, {
+  TableOfContentsEntry,
+} from '@lexical/react/LexicalTableOfContents__EXPERIMENTAL';
 import {useEffect, useRef, useState} from 'react';
 import * as React from 'react';
 
@@ -45,7 +47,7 @@ function isHeadingBelowTheTopOfThePage(element: HTMLElement): boolean {
 function TableOfContentsList({
   tableOfContents,
 }: {
-  tableOfContents: Array<[key: NodeKey, text: string, tag: HeadingTagType]>;
+  tableOfContents: Array<TableOfContentsEntry>;
 }): JSX.Element {
   const [selectedKey, setSelectedKey] = useState('');
   const selectedIndex = useRef(0);

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -5,15 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import type {TableOfContentsEntry} from '@lexical/react/LexicalTableOfContents__EXPERIMENTAL';
 import type {HeadingTagType} from '@lexical/rich-text';
 import type {NodeKey} from 'lexical';
 
 import './index.css';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import LexicalTableOfContents__EXPERIMENTAL, {
-  TableOfContentsEntry,
-} from '@lexical/react/LexicalTableOfContents__EXPERIMENTAL';
+import LexicalTableOfContents__EXPERIMENTAL from '@lexical/react/LexicalTableOfContents__EXPERIMENTAL';
 import {useEffect, useRef, useState} from 'react';
 import * as React from 'react';
 

--- a/packages/lexical-react/src/LexicalTableOfContents__EXPERIMENTAL.tsx
+++ b/packages/lexical-react/src/LexicalTableOfContents__EXPERIMENTAL.tsx
@@ -76,7 +76,7 @@ function $updateHeadingInTableOfContents(
  * is undefined, `heading` is placed at the start of table of contents
  */
 function $updateHeadingPosition(
-  prevHeading: HeadingNode | undefined,
+  prevHeading: HeadingNode | null,
   heading: HeadingNode,
   currentTableOfContents: Array<TableOfContentsEntry>,
 ): Array<TableOfContentsEntry> {
@@ -158,9 +158,10 @@ export default function LexicalTableOfContentsPlugin({
             } else if (mutation === 'updated') {
               const newHeading = $getNodeByKey<HeadingNode>(nodeKey);
               if (newHeading !== null) {
-                const prevHeading = newHeading
-                  .getPreviousSiblings()
-                  .find($isHeadingNode);
+                let prevHeading = newHeading.getPreviousSibling();
+                while (prevHeading && !$isHeadingNode(prevHeading)) {
+                  prevHeading = prevHeading.getPreviousSibling();
+                }
                 currentTableOfContents = $updateHeadingPosition(
                   prevHeading,
                   newHeading,

--- a/packages/lexical-react/src/LexicalTableOfContents__EXPERIMENTAL.tsx
+++ b/packages/lexical-react/src/LexicalTableOfContents__EXPERIMENTAL.tsx
@@ -145,7 +145,7 @@ export default function LexicalTableOfContentsPlugin({
               const newHeading = $getNodeByKey<HeadingNode>(nodeKey);
               if (newHeading !== null) {
                 let prevHeading = newHeading.getPreviousSibling();
-                while (prevHeading && !$isHeadingNode(prevHeading)) {
+                while (prevHeading !== null && !$isHeadingNode(prevHeading)) {
                   prevHeading = prevHeading.getPreviousSibling();
                 }
                 currentTableOfContents = $insertHeadingIntoTableOfContents(
@@ -163,7 +163,7 @@ export default function LexicalTableOfContentsPlugin({
               const newHeading = $getNodeByKey<HeadingNode>(nodeKey);
               if (newHeading !== null) {
                 let prevHeading = newHeading.getPreviousSibling();
-                while (prevHeading && !$isHeadingNode(prevHeading)) {
+                while (prevHeading !== null && !$isHeadingNode(prevHeading)) {
                   prevHeading = prevHeading.getPreviousSibling();
                 }
                 currentTableOfContents = $updateHeadingPosition(

--- a/packages/lexical-react/src/LexicalTableOfContents__EXPERIMENTAL.tsx
+++ b/packages/lexical-react/src/LexicalTableOfContents__EXPERIMENTAL.tsx
@@ -13,7 +13,11 @@ import {$isHeadingNode, HeadingNode, HeadingTagType} from '@lexical/rich-text';
 import {$getNodeByKey, $getRoot, TextNode} from 'lexical';
 import {useEffect, useState} from 'react';
 
-type TableOfContentsEntry = [key: NodeKey, text: string, tag: HeadingTagType];
+export type TableOfContentsEntry = [
+  key: NodeKey,
+  text: string,
+  tag: HeadingTagType,
+];
 
 function toEntry(heading: HeadingNode): TableOfContentsEntry {
   return [heading.getKey(), heading.getTextContent(), heading.getTag()];


### PR DESCRIPTION
Fixes a bug where the TableOfContents would display the wrong order of headings if the user cuts/copy and pastes headers.
It seems `getPreviousSiblings` does not return the correct order, so iterate over the siblings instead.

To reproduce:

- Enter a few headings and enable ToC in playground.
- Copy or cut one heading
- Paste the heading above or below another heading
- ToC will have the wrong order

Also cleans up the code a little bit:

- Don't redefine TableOfContentsEntry type in the TableOfContent Plugin. Just export the already existing type and use this instead.
- Wrong keys in heading render map. Keys should be attached to the direct childs.