### PR TITLE
fix(lexical-playground): fix bugs related to ComponentPickerPlugin

### DIFF
--- a/packages/lexical-playground/src/nodes/TableComponent.tsx
+++ b/packages/lexical-playground/src/nodes/TableComponent.tsx
@@ -622,7 +622,6 @@ function TableCell({
       ) : (
         <>
           <div
-            style={{position: 'relative', zIndex: 3}}
             dangerouslySetInnerHTML={{
               __html:
                 editorStateJSON === ''

--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -42,7 +42,7 @@ import {InsertEquationDialog} from '../EquationsPlugin';
 import {INSERT_EXCALIDRAW_COMMAND} from '../ExcalidrawPlugin';
 import {INSERT_IMAGE_COMMAND, InsertImageDialog} from '../ImagesPlugin';
 import {InsertPollDialog} from '../PollPlugin';
-import {InsertTableDialog} from '../TablePlugin';
+import {InsertNewTableDialog, InsertTableDialog} from '../TablePlugin';
 
 class ComponentPickerOption extends TypeaheadOption {
   // What shows up in the editor
@@ -202,6 +202,14 @@ export default function ComponentPickerMenuPlugin(): JSX.Element {
         onSelect: () =>
           showModal('Insert Table', (onClose) => (
             <InsertTableDialog activeEditor={editor} onClose={onClose} />
+          )),
+      }),
+      new ComponentPickerOption('Table (Experimental)', {
+        icon: <i className="icon table" />,
+        keywords: ['table', 'grid', 'spreadsheet', 'rows', 'columns'],
+        onSelect: () =>
+          showModal('Insert Table', (onClose) => (
+            <InsertNewTableDialog activeEditor={editor} onClose={onClose} />
           )),
       }),
       new ComponentPickerOption('Numbered List', {


### PR DESCRIPTION
I have made the following two fixes:

1. https://github.com/facebook/lexical/commit/70eed93ed3231f24a12ae3dabf017a1035429772: When the ComponentPicker options are opened at a position overlapping the table, strings in the cell overlap and become difficult to read.
    * Intention: Another idea I had was to increase the z-index of the ComponentPicker options, but it doesn't feel right that only the table cells are floating, so I modified it as shown in PR.
1. https://github.com/facebook/lexical/commit/d67b6024ec0bb73d46b0b2d9a89d25baad291fe4: Missing `Table (Experimental)` in ComponentPicker options (maybe not a bug).

<details>
<summary>Before/After</summary>

### Before

![before-bug-related-component-picker-plugin](https://user-images.githubusercontent.com/31314668/215137627-10a7e058-4cf4-4057-a23f-5657fe824d74.png)

### After

![after-bug-related-component-picker-plugin](https://user-images.githubusercontent.com/31314668/215137649-e049e065-a037-4778-bfb7-f8a9b64a81b1.png)

</details>