### PR TITLE
Add check that target is not the root node

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1296,6 +1296,7 @@ export class RangeSelection implements BaseSelection {
     for (let i = 0; i < nodes.length; i++) {
       const node = nodes[i];
       if (
+        !$isRootOrShadowRoot(target) &&
         !$isDecoratorNode(target) &&
         $isElementNode(node) &&
         !node.isInline()


### PR DESCRIPTION
When the target is the root node, we want to ensure that it hits [this bit of logic a little further down instead](https://github.com/facebook/lexical/blob/main/packages/lexical/src/LexicalSelection.ts#L1418-L1428).

Ensure that the nodes can be inserted correctly at the start: 

<img width="1728" alt="Screenshot 2023-01-31 at 11 08 20" src="https://user-images.githubusercontent.com/7748470/215751290-3a34dac1-5595-4afc-b74d-07d85c9de8e7.png">


Closes #3606.