### PR TITLE
Add `createParentElementNode` method on LexicalNode to fix copy/paste issues with clipboard

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -189,10 +189,10 @@ function $basicInsertStrategy(
       ($isDecoratorNode(node) && node.isInline()) ||
       ($isElementNode(node) && node.isInline()) ||
       $isTextNode(node) ||
-      node.hasRequiredParent()
+      node.isParentRequired()
     ) {
       if (currentBlock === null) {
-        currentBlock = node.isParentRequired();
+        currentBlock = node.createParentElementNode();
         topLevelBlocks.push(currentBlock);
         // In the case of LineBreakNode, we just need to
         // add an empty ParagraphNode to the topLevelBlocks.

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -192,7 +192,7 @@ function $basicInsertStrategy(
       node.hasRequiredParent()
     ) {
       if (currentBlock === null) {
-        currentBlock = node.createParentElementNode();
+        currentBlock = node.isParentRequired();
         topLevelBlocks.push(currentBlock);
         // In the case of LineBreakNode, we just need to
         // add an empty ParagraphNode to the topLevelBlocks.

--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -196,7 +196,7 @@ export class CodeHighlightNode extends TextNode {
     return true;
   }
 
-  createParentElementNode(): ElementNode {
+  isParentRequired(): ElementNode {
     return $createCodeNode();
   }
 }

--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -192,11 +192,11 @@ export class CodeHighlightNode extends TextNode {
     return this;
   }
 
-  hasRequiredParent(): true {
+  isParentRequired(): true {
     return true;
   }
 
-  isParentRequired(): ElementNode {
+  createParentElementNode(): ElementNode {
     return $createCodeNode();
   }
 }

--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -17,6 +17,7 @@ import {
   type SerializedTextNode,
   type Spread,
   TextNode,
+  ElementNode,
 } from 'lexical';
 
 import * as Prism from 'prismjs';
@@ -38,6 +39,7 @@ import {
   addClassNamesToElement,
   removeClassNamesFromElement,
 } from '@lexical/utils';
+import {$createCodeNode} from './CodeNode';
 
 export const DEFAULT_CODE_LANGUAGE = 'javascript';
 
@@ -188,6 +190,14 @@ export class CodeHighlightNode extends TextNode {
   // Prevent formatting (bold, underline, etc)
   setFormat(format: number): this {
     return this;
+  }
+
+  hasRequiredParent(): true {
+    return true;
+  }
+
+  createParentElementNode(): ElementNode {
+    return $createCodeNode();
   }
 }
 

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -424,7 +424,7 @@ export class ListItemNode extends ElementNode {
     return true;
   }
 
-  createParentElementNode(): ElementNode {
+  isParentRequired(): ElementNode {
     return $createListNode('bullet');
   }
 }

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -420,11 +420,11 @@ export class ListItemNode extends ElementNode {
     );
   }
 
-  hasRequiredParent(): true {
+  isParentRequired(): true {
     return true;
   }
 
-  isParentRequired(): ElementNode {
+  createParentElementNode(): ElementNode {
     return $createListNode('bullet');
   }
 }

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -419,6 +419,14 @@ export class ListItemNode extends ElementNode {
       this.getTextContent().length === selection.getTextContent().length
     );
   }
+
+  hasRequiredParent(): true {
+    return true;
+  }
+
+  createParentElementNode(): ElementNode {
+    return $createListNode('bullet');
+  }
 }
 
 function $setListItemThemeClassNames(

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -17,7 +17,13 @@ import type {Klass} from 'lexical';
 
 import invariant from 'shared/invariant';
 
-import {$isElementNode, $isRootNode, $isTextNode, ElementNode} from '.';
+import {
+  $createParagraphNode,
+  $isElementNode,
+  $isRootNode,
+  $isTextNode,
+  ElementNode,
+} from '.';
 import {
   $getSelection,
   $isRangeSelection,
@@ -785,6 +791,14 @@ export class LexicalNode {
       $updateElementSelectionOnCreateDeleteNode(selection, parent, index);
     }
     return nodeToInsert;
+  }
+
+  hasRequiredParent(): boolean {
+    return false;
+  }
+
+  createParentElementNode(): ElementNode {
+    return $createParagraphNode();
   }
 
   selectPrevious(anchorOffset?: number, focusOffset?: number): RangeSelection {

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -793,11 +793,11 @@ export class LexicalNode {
     return nodeToInsert;
   }
 
-  hasRequiredParent(): boolean {
+  isParentRequired(): boolean {
     return false;
   }
 
-  isParentRequired(): ElementNode {
+  createParentElementNode(): ElementNode {
     return $createParagraphNode();
   }
 

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -797,7 +797,7 @@ export class LexicalNode {
     return false;
   }
 
-  createParentElementNode(): ElementNode {
+  isParentRequired(): ElementNode {
     return $createParagraphNode();
   }
 


### PR DESCRIPTION
Whilst we await for schemas, this PR adds in the functionality to Lexical nodes to create a wrapping parent which is then used in the clipboard to normalize partial matches

Ensure partial list item nodes on the clipboard are correctly wrapped in a list node.

https://user-images.githubusercontent.com/7748470/215815295-d9032624-bbfa-4c82-a4b7-32788673f8b5.mov

Closes #3743