### PR TITLE
List node export dom with css classes

### DIFF
--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -136,12 +136,14 @@ export class ListNode extends ElementNode {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = document.createElement(this.__tag);
-    if (this.__start !== 1) {
-      element.setAttribute('start', String(this.__start));
-    }
-    if (this.__listType === 'check') {
-      element.setAttribute('__lexicalListType', 'check');
+    const {element} = super.exportDOM(editor);
+    if (element) {
+      if (this.__start !== 1) {
+        element.setAttribute('start', String(this.__start));
+      }
+      if (this.__listType === 'check') {
+        element.setAttribute('__lexicalListType', 'check');
+      }
     }
     return {
       element,


### PR DESCRIPTION
ListNode's exportDOM ignored its theme classes unlike other core nodes. Using super.exportDOM preserves it since it uses createDOM under the hood