### PR TITLE
Remove innerHTML injection from table selection

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1158,6 +1158,22 @@ i.prettier-error {
   background-image: url(images/icons/plug-fill.svg);
 }
 
+table.disable-selection {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+table.disable-selection span::selection {
+  background-color: transparent;
+}
+table.disable-selection br::selection {
+  background-color: transparent;
+}
+
 .table-cell-action-button-container {
   position: absolute;
   top: 0;

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1170,6 +1170,7 @@ table.disable-selection {
 table.disable-selection span::selection {
   background-color: transparent;
 }
+
 table.disable-selection br::selection {
   background-color: transparent;
 }

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -55,31 +55,6 @@ export type Grid = {
 const getDOMSelection = (targetWindow: Window | null): Selection | null =>
   CAN_USE_DOM ? (targetWindow || window).getSelection() : null;
 
-if (CAN_USE_DOM) {
-  const disableNativeSelectionUi = document.createElement('style');
-  disableNativeSelectionUi.innerHTML = `
-    table.disable-selection {
-      -webkit-touch-callout: none;
-      -webkit-user-select: none; 
-      -khtml-user-select: none; 
-      -moz-user-select: none; 
-      -ms-user-select: none; 
-      user-select: none;
-    }
-  
-    .disable-selection span::selection{
-      background-color: transparent;
-    }
-    .disable-selection br::selection{
-      background-color: transparent;
-    }
-  `;
-
-  if (document.body) {
-    document.body.append(disableNativeSelectionUi);
-  }
-}
-
 export class TableSelection {
   focusX: number;
   focusY: number;


### PR DESCRIPTION
This doesn't break any core selection functionality. It just moves the logic for reseting the default browser selection styles into the custom stylesheet.  

This is because injecting it into the DOM via innerHTML causes a CSP rule issue as detailed in the below issue.

What is looks like without the resets applied: 

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/7748470/216016040-74496cb4-87e3-42a7-b671-c1bb741eb739.png">

With the reset applied:

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/7748470/216016230-314b0a54-8b96-4d0f-b5ba-0ecb44d71247.png">


Closes #3477