### PR TITLE
Fix is selected noop

### DIFF
--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -208,9 +208,12 @@ export default function ImageComponent({
   );
 
   useEffect(() => {
-    return mergeRegister(
+    let isMounted = true;
+    const unregister = mergeRegister(
       editor.registerUpdateListener(({editorState}) => {
-        setSelection(editorState.read(() => $getSelection()));
+        if (isMounted) {
+          setSelection(editorState.read(() => $getSelection()));
+        }
       }),
       editor.registerCommand(
         SELECTION_CHANGE_COMMAND,
@@ -272,6 +275,11 @@ export default function ImageComponent({
         COMMAND_PRIORITY_LOW,
       ),
     );
+
+    return () => {
+      isMounted = false;
+      unregister();
+    };
   }, [
     clearSelection,
     editor,

--- a/packages/lexical-react/src/useLexicalNodeSelection.ts
+++ b/packages/lexical-react/src/useLexicalNodeSelection.ts
@@ -40,9 +40,17 @@ export function useLexicalNodeSelection(
   );
 
   useEffect(() => {
-    return editor.registerUpdateListener(() => {
-      setIsSelected(isNodeSelected(editor, key));
+    let isMounted = true;
+    const unregister = editor.registerUpdateListener(() => {
+      if (isMounted) {
+        setIsSelected(isNodeSelected(editor, key));
+      }
     });
+
+    return () => {
+      isMounted = false;
+      unregister();
+    };
   }, [editor, key]);
 
   const setSelected = useCallback(


### PR DESCRIPTION
This pull request helps make editor instances more portable. 

If an editor instance is moved around the DOM via drag and drop, setState functions that are nested inside a Lexical listener can result in a noop warning. While Lexical lives on, the React components surrounding it will not. 

This pull request adds `isMounted` to one spot to prevent this from happening. 

A previous PR accidentally snuck the same code into ImageComponent, which also needed this fix. 