### PR TITLE
[0.8] List indentation simplified

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -360,21 +360,15 @@ export class ListItemNode extends ElementNode {
     let currentIndent = this.getIndent();
     while (currentIndent !== indent) {
       if (currentIndent < indent) {
-        $handleIndent([this]);
+        $handleIndent(this);
         currentIndent++;
       } else {
-        $handleOutdent([this]);
+        $handleOutdent(this);
         currentIndent--;
       }
     }
 
     return this;
-  }
-
-  canIndent(): false {
-    // Indent/outdent is handled specifically in the RichText logic.
-
-    return false;
   }
 
   insertBefore(nodeToInsert: LexicalNode): LexicalNode {

--- a/packages/lexical-list/src/index.ts
+++ b/packages/lexical-list/src/index.ts
@@ -13,13 +13,7 @@ import type {LexicalCommand} from 'lexical';
 
 import {createCommand} from 'lexical';
 
-import {
-  $handleListInsertParagraph,
-  indentList,
-  insertList,
-  outdentList,
-  removeList,
-} from './formatList';
+import {$handleListInsertParagraph, insertList, removeList} from './formatList';
 import {
   $createListItemNode,
   $isListItemNode,
@@ -35,12 +29,10 @@ export {
   $handleListInsertParagraph,
   $isListItemNode,
   $isListNode,
-  indentList,
   insertList,
   ListItemNode,
   ListNode,
   ListType,
-  outdentList,
   removeList,
   SerializedListItemNode,
   SerializedListNode,

--- a/packages/lexical-list/src/utils.ts
+++ b/packages/lexical-list/src/utils.ts
@@ -125,22 +125,6 @@ export function findNearestListItemNode(
   return null;
 }
 
-export function getUniqueListItemNodes(
-  nodeList: Array<LexicalNode>,
-): Array<ListItemNode> {
-  const keys = new Set<ListItemNode>();
-
-  for (let i = 0; i < nodeList.length; i++) {
-    const node = nodeList[i];
-
-    if ($isListItemNode(node)) {
-      keys.add(node);
-    }
-  }
-
-  return Array.from(keys);
-}
-
 export function $removeHighestEmptyListParent(
   sublist: ListItemNode | ListNode,
 ) {

--- a/packages/lexical-react/src/shared/useList.ts
+++ b/packages/lexical-react/src/shared/useList.ts
@@ -10,42 +10,19 @@ import type {LexicalEditor} from 'lexical';
 
 import {
   $handleListInsertParagraph,
-  indentList,
   INSERT_ORDERED_LIST_COMMAND,
   INSERT_UNORDERED_LIST_COMMAND,
   insertList,
-  outdentList,
   REMOVE_LIST_COMMAND,
   removeList,
 } from '@lexical/list';
 import {mergeRegister} from '@lexical/utils';
-import {
-  COMMAND_PRIORITY_LOW,
-  INDENT_CONTENT_COMMAND,
-  INSERT_PARAGRAPH_COMMAND,
-  OUTDENT_CONTENT_COMMAND,
-} from 'lexical';
+import {COMMAND_PRIORITY_LOW, INSERT_PARAGRAPH_COMMAND} from 'lexical';
 import {useEffect} from 'react';
 
 export function useList(editor: LexicalEditor): void {
   useEffect(() => {
     return mergeRegister(
-      editor.registerCommand(
-        INDENT_CONTENT_COMMAND,
-        () => {
-          indentList();
-          return false;
-        },
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand(
-        OUTDENT_CONTENT_COMMAND,
-        () => {
-          outdentList();
-          return false;
-        },
-        COMMAND_PRIORITY_LOW,
-      ),
       editor.registerCommand(
         INSERT_ORDERED_LIST_COMMAND,
         () => {


### PR DESCRIPTION
In $handleIndent and $handleOutdent the Github diff gets messy with line mapping. The only thing I did there was remove the for loop, and that's why the indentation of the whole function changed.

In fact, literally all I did in this PR was remove 100 unnecessary lines of code. Everything is still working fine.