### PR TITLE
[0.8] Allow the format property to be omitted

### DIFF
--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -32,7 +32,7 @@ import {ReactNode, useCallback, useEffect, useRef} from 'react';
 
 type Props = Readonly<{
   children: ReactNode;
-  format: ElementFormatType | null | undefined;
+  format?: ElementFormatType | null;
   nodeKey: NodeKey;
   className: Readonly<{
     base: string;


### PR DESCRIPTION
## The current behavior

The format property allows undefined, but cannot be omitted because it is not optional.

https://github.com/facebook/lexical/blob/98bba10e112c750779b174278556a14608a39df4/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx#L35

```tsx
class LinkCardNode extends DecoratorNode<React.ReactElement> {
  public decorate(editor: LexicalEditor, config: EditorConfig): React.ReactElement {
    return (
      <BlockWithAlignableContents
        className={className}
        format={undefined} // undefined must be specified.
        nodeKey={this.getKey()}
      >
        text
      </BlockWithAlignableContents>
    );
  }
}
```

## The expected behavior

Change the format property to optional so that it can be omitted.

```ts
type Props = Readonly<{
  format?: ElementFormatType | null;
}>;
```

```tsx
class LinkCardNode extends DecoratorNode<React.ReactElement> {
  public decorate(editor: LexicalEditor, config: EditorConfig): React.ReactElement {
    return (
      <BlockWithAlignableContents
        className={className}
        nodeKey={this.getKey()}
      >
        text
      </BlockWithAlignableContents>
    );
  }
}
```
