### PR TITLE
Add list-style-position:inside

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -277,30 +277,36 @@
 .PlaygroundEditorTheme__ol1 {
   padding: 0;
   margin: 0;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol2 {
   padding: 0;
   margin: 0;
   list-style-type: upper-alpha;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol3 {
   padding: 0;
   margin: 0;
   list-style-type: lower-alpha;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol4 {
   padding: 0;
   margin: 0;
   list-style-type: upper-roman;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol5 {
   padding: 0;
   margin: 0;
   list-style-type: lower-roman;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ul {
   padding: 0;
   margin: 0;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__listItem {
   margin: 0 32px;


### PR DESCRIPTION
Re-add `list-style-position:inside` to fix regression caused by removing it as part of the fix for #3752.

I've added a Webkit bug report for the initial issue: https://bugs.webkit.org/show_bug.cgi?id=251681

Closes #3807 