### PR TITLE
Add IS_HIGHLIGHT format to combined formats to properly calculate format

### DIFF
--- a/packages/lexical/src/LexicalConstants.ts
+++ b/packages/lexical/src/LexicalConstants.ts
@@ -47,7 +47,8 @@ export const IS_ALL_FORMATTING =
   IS_UNDERLINE |
   IS_CODE |
   IS_SUBSCRIPT |
-  IS_SUPERSCRIPT;
+  IS_SUPERSCRIPT |
+  IS_HIGHLIGHT;
 
 // Text node details
 export const IS_DIRECTIONLESS = 1;


### PR DESCRIPTION
Add IS_HIGHLIGHT format to combined formats to properly calculate format. 

This fixes an issue with `selection` not having the correct format.