### PR TITLE
Fix(#3716,#3815): Prevent layout shift while using typeahead menu

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -80,24 +80,26 @@ export type MenuRenderFn<TOption extends TypeaheadOption> = (
 
 const scrollIntoViewIfNeeded = (target: HTMLElement) => {
   const container = document.getElementById('typeahead-menu');
+  if (!container) return;
 
-  if (container) {
-    const parentNode = target.parentNode as HTMLElement | null;
+  const typeaheadContainerNode = container.querySelector('.typeahead-popover');
+  if (!typeaheadContainerNode) return;
 
-    if (
-      parentNode &&
-      /auto|scroll/.test(getComputedStyle(parentNode).overflow)
-    ) {
-      const parentRect = parentNode.getBoundingClientRect();
+  const typeaheadRect = typeaheadContainerNode.getBoundingClientRect();
 
-      if (parentRect.top + parentRect.height > window.innerHeight) {
-        parentNode.scrollIntoView(false);
-      }
-      parentNode.scrollTop = target.offsetTop - target.clientHeight;
-    } else {
-      target.scrollIntoView(false);
-    }
+  if (typeaheadRect.top + typeaheadRect.height > window.innerHeight) {
+    typeaheadContainerNode.scrollIntoView({
+      block: 'center',
+    });
   }
+
+  if (typeaheadRect.top < 0) {
+    typeaheadContainerNode.scrollIntoView({
+      block: 'center',
+    });
+  }
+
+  target.scrollIntoView({block: 'nearest'});
 };
 
 function getTextUpToAnchor(selection: RangeSelection): string | null {


### PR DESCRIPTION
resolve #3716 and  #3815 

# Problem
When the amount of a document is more than one page and when users use the typeahead menu in the middle of the document, the layout shifts

# Solution
![Kapture 2023-02-05 at 22 33 28](https://user-images.githubusercontent.com/10705018/216822623-04d6fe05-3288-4756-af53-dfa8ec48e287.gif)

# Note
1. I changed the `if else statement` into an early return statement

2. I removed `parentNode`, because the previous `parentNode` was very similar to the target node. 
3. I made `typeaheadContainerNode`  for detecting the typeahead menu out of the viewport 