### PR TITLE
Fix a bug that caused the Node to be regenerated when editing the end of an AutoLinkNode

### DIFF
--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -220,18 +220,24 @@ function handleLinkEdit(
 
 // Bad neighbours are edits in neighbor nodes that make AutoLinks incompatible.
 // Given the creation preconditions, these can only be simple text nodes.
-function handleBadNeighbors(textNode: TextNode, onChange: ChangeHandler): void {
+function handleBadNeighbors(
+  textNode: TextNode,
+  matchers: Array<LinkMatcher>,
+  onChange: ChangeHandler,
+): void {
   const previousSibling = textNode.getPreviousSibling();
   const nextSibling = textNode.getNextSibling();
   const text = textNode.getTextContent();
 
   if ($isAutoLinkNode(previousSibling) && !startsWithSeparator(text)) {
-    replaceWithChildren(previousSibling);
+    previousSibling.append(textNode);
+    handleLinkEdit(previousSibling, matchers, onChange);
     onChange(null, previousSibling.getURL());
   }
 
   if ($isAutoLinkNode(nextSibling) && !endsWithSeparator(text)) {
-    replaceWithChildren(nextSibling);
+    nextSibling.append(textNode);
+    handleLinkEdit(nextSibling, matchers, onChange);
     onChange(null, nextSibling.getURL());
   }
 }
@@ -270,14 +276,15 @@ function useAutoLink(
     return mergeRegister(
       editor.registerNodeTransform(TextNode, (textNode: TextNode) => {
         const parent = textNode.getParentOrThrow();
+        const previous = textNode.getPreviousSibling();
         if ($isAutoLinkNode(parent)) {
           handleLinkEdit(parent, matchers, onChangeWrapped);
         } else if (!$isLinkNode(parent)) {
-          if (textNode.isSimpleText()) {
+          if (textNode.isSimpleText() && !$isAutoLinkNode(previous)) {
             handleLinkCreation(textNode, matchers, onChangeWrapped);
           }
 
-          handleBadNeighbors(textNode, onChangeWrapped);
+          handleBadNeighbors(textNode, matchers, onChangeWrapped);
         }
       }),
     );

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -280,7 +280,11 @@ function useAutoLink(
         if ($isAutoLinkNode(parent)) {
           handleLinkEdit(parent, matchers, onChangeWrapped);
         } else if (!$isLinkNode(parent)) {
-          if (textNode.isSimpleText() && !$isAutoLinkNode(previous)) {
+          if (
+            textNode.isSimpleText() &&
+            (startsWithSeparator(textNode.getTextContent()) ||
+              !$isAutoLinkNode(previous))
+          ) {
             handleLinkCreation(textNode, matchers, onChangeWrapped);
           }
 

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -236,7 +236,7 @@ function handleBadNeighbors(
   }
 
   if ($isAutoLinkNode(nextSibling) && !endsWithSeparator(text)) {
-    nextSibling.append(textNode);
+    replaceWithChildren(nextSibling);
     handleLinkEdit(nextSibling, matchers, onChange);
     onChange(null, nextSibling.getURL());
   }


### PR DESCRIPTION
close #3825 

https://user-images.githubusercontent.com/40270352/216878308-06bc05e5-422c-4b3e-aed9-8602ce005ee9.mov

