### PR TITLE
Add anchor dirty node check for text length less than 2 chars

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -711,9 +711,7 @@ test.describe('Links', () => {
     await assertHTML(
       page,
       html`
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
+        <p class="PlaygroundEditorTheme__paragraph">
           <span data-lexical-text="true"></span>
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -705,13 +705,14 @@ test.describe('Links', () => {
     );
 
     await moveRight(page, 1);
-    await selectCharacters(page, 'right', 1);
     await page.keyboard.type('a');
 
     await assertHTML(
       page,
       html`
-        <p class="PlaygroundEditorTheme__paragraph">
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
           <span data-lexical-text="true"></span>
           <a
             class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
@@ -734,6 +735,7 @@ test.describe('Links', () => {
         </p>
       `,
     );
+
     await assertSelection(page, {
       anchorOffset: 1,
       anchorPath: [0, 2, 0],

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -204,7 +204,7 @@ function $shouldPreventDefaultAndInsertText(
         // 50ms then we proceed as normal. However, if there is not, then this is likely
         // a dangling `input` event caused by execCommand('insertText').
         lastBeforeInputInsertTextTimeStamp < timeStamp + 50)) ||
-      textLength < 2 ||
+      (anchorNode.isDirty() && textLength < 2) ||
       doesContainGrapheme(text)) &&
       anchor.offset !== focus.offset &&
       !anchorNode.isComposing()) ||


### PR DESCRIPTION
Repro Steps:
1. Load Workplace on desktop
2. Navigate to system preferences >> keyboard >> text
3. Set "i" to replace with "I"
4. Navigate to playground
5. Type "i"+" " 
6. Check if "i" is replaced to "I " or not.

Bug observed: Observe that, the text "i" is replaced to "I" instead of "I " when typed "i"+" ".