### PR TITLE
Add more configuration for heading in INSERT_TABLE_COMMAND

### DIFF
--- a/packages/lexical-playground/src/plugins/TablePlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TablePlugin.tsx
@@ -102,7 +102,11 @@ export function InsertTableDialog({
   const [columns, setColumns] = useState('5');
 
   const onClick = () => {
-    activeEditor.dispatchCommand(INSERT_TABLE_COMMAND, {columns, rows});
+    activeEditor.dispatchCommand(INSERT_TABLE_COMMAND, {
+      columns,
+      rows,
+    });
+
     onClose();
   };
 

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -13,6 +13,7 @@ import {$findMatchingParent} from '@lexical/utils';
 import {$createParagraphNode, $createTextNode} from 'lexical';
 import invariant from 'shared/invariant';
 
+import {InsertTableCommandPayloadHeaders} from '.';
 import {
   $createTableCellNode,
   $isTableCellNode,
@@ -29,7 +30,7 @@ import {
 export function $createTableNodeWithDimensions(
   rowCount: number,
   columnCount: number,
-  includeHeaders = true,
+  includeHeaders: InsertTableCommandPayloadHeaders = true,
 ): TableNode {
   const tableNode = $createTableNode();
 
@@ -39,7 +40,12 @@ export function $createTableNodeWithDimensions(
     for (let iColumn = 0; iColumn < columnCount; iColumn++) {
       let headerState = TableCellHeaderStates.NO_STATUS;
 
-      if (includeHeaders) {
+      if (typeof includeHeaders === 'object') {
+        if (iRow === 0 && includeHeaders.rows)
+          headerState |= TableCellHeaderStates.ROW;
+        if (iColumn === 0 && includeHeaders.columns)
+          headerState |= TableCellHeaderStates.COLUMN;
+      } else if (includeHeaders) {
         if (iRow === 0) headerState |= TableCellHeaderStates.ROW;
         if (iColumn === 0) headerState |= TableCellHeaderStates.COLUMN;
       }

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -88,10 +88,17 @@ export type {
   SerializedTableRowNode,
 };
 
+export type InsertTableCommandPayloadHeaders =
+  | Readonly<{
+      rows: boolean;
+      columns: boolean;
+    }>
+  | boolean;
+
 export type InsertTableCommandPayload = Readonly<{
   columns: string;
   rows: string;
-  includeHeaders?: boolean;
+  includeHeaders?: InsertTableCommandPayloadHeaders;
 }>;
 
 export const INSERT_TABLE_COMMAND: LexicalCommand<InsertTableCommandPayload> =


### PR DESCRIPTION
The idea behind this changement is to allow the user of the API to choice if the header will be only row, column or Both.

For example: 
```tsx
function onClick() {
  activeEditor.dispatchCommand(INSERT_TABLE_COMMAND, {
    columns,
    includeHeaders: true,
    rows,
  });
}
```

This will make the header as column and row like before.
![image](https://user-images.githubusercontent.com/30870051/217299220-045eed0d-9341-4f7b-ad90-71a08b2eb3c1.png)

but, if you add columns and row as an object for includeHeaders like that:
```tsx
function onClick() {
  activeEditor.dispatchCommand(INSERT_TABLE_COMMAND, {
    columns,
    includeHeaders: {columns: false, rows: true},
    rows,
  });
}
```
![CleanShot 2023-02-07 at 17 10 42](https://user-images.githubusercontent.com/30870051/217299542-be3056f4-b307-4446-a1e0-49c342ff2d93.png)

Or like that if you make columns as true and rows as false 
![image](https://user-images.githubusercontent.com/30870051/217299772-83fc2a3f-5ebf-45d4-baf5-6902be5e0c76.png)

Do this functionnality looks good for you ? 

