### PR TITLE
Added Chinese character support for native webkit

### DIFF
--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -27,7 +27,7 @@ import {
   $isParagraphNode,
   $isTextNode,
 } from 'lexical';
-import {IS_IOS, IS_SAFARI} from 'shared/environment';
+import {IS_APPLE_WEBKIT, IS_IOS, IS_SAFARI} from 'shared/environment';
 
 import {PUNCTUATION_OR_SPACE, transformersByType} from './utils';
 
@@ -372,7 +372,7 @@ function createTextFormatTransformersIndex(
     const tagRegExp = tag.replace(/(\*|\^|\+)/g, '\\$1');
     openTagsRegExp.push(tagRegExp);
 
-    if (IS_SAFARI || IS_IOS) {
+    if (IS_SAFARI || IS_IOS || IS_APPLE_WEBKIT) {
       fullMatchRegExpByTag[tag] = new RegExp(
         `(${tagRegExp})(?![${tagRegExp}\\s])(.*?[^${tagRegExp}\\s])${tagRegExp}(?!${tagRegExp})`,
       );
@@ -388,7 +388,7 @@ function createTextFormatTransformersIndex(
     fullMatchRegExpByTag,
     // Reg exp to find opening tags
     openTagsRegExp: new RegExp(
-      (IS_SAFARI || IS_IOS ? '' : `${escapeRegExp}`) +
+      (IS_SAFARI || IS_IOS || IS_APPLE_WEBKIT ? '' : `${escapeRegExp}`) +
         '(' +
         openTagsRegExp.join('|') +
         ')',

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -40,7 +40,12 @@ import {
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
 } from 'lexical';
-import {CAN_USE_BEFORE_INPUT, IS_IOS, IS_SAFARI} from 'shared/environment';
+import {
+  CAN_USE_BEFORE_INPUT,
+  IS_APPLE_WEBKIT,
+  IS_IOS,
+  IS_SAFARI,
+} from 'shared/environment';
 
 function onCopyForPlainText(
   event: CommandPayloadType<typeof COPY_COMMAND>,
@@ -305,7 +310,10 @@ export function registerPlainText(editor: LexicalEditor): () => void {
           // This can also cause a strange performance issue in
           // Safari, where there is a noticeable pause due to
           // preventing the key down of enter.
-          if ((IS_IOS || IS_SAFARI) && CAN_USE_BEFORE_INPUT) {
+          if (
+            (IS_IOS || IS_SAFARI || IS_APPLE_WEBKIT) &&
+            CAN_USE_BEFORE_INPUT
+          ) {
             return false;
           }
 

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -86,7 +86,12 @@ import {
   REMOVE_TEXT_COMMAND,
 } from 'lexical';
 import caretFromPoint from 'shared/caretFromPoint';
-import {CAN_USE_BEFORE_INPUT, IS_IOS, IS_SAFARI} from 'shared/environment';
+import {
+  CAN_USE_BEFORE_INPUT,
+  IS_APPLE_WEBKIT,
+  IS_IOS,
+  IS_SAFARI,
+} from 'shared/environment';
 
 export type SerializedHeadingNode = Spread<
   {
@@ -850,7 +855,10 @@ export function registerRichText(editor: LexicalEditor): () => void {
           // This can also cause a strange performance issue in
           // Safari, where there is a noticeable pause due to
           // preventing the key down of enter.
-          if ((IS_IOS || IS_SAFARI) && CAN_USE_BEFORE_INPUT) {
+          if (
+            (IS_IOS || IS_SAFARI || IS_APPLE_WEBKIT) &&
+            CAN_USE_BEFORE_INPUT
+          ) {
             return false;
           }
           event.preventDefault();

--- a/packages/lexical/src/LexicalConstants.ts
+++ b/packages/lexical/src/LexicalConstants.ts
@@ -13,7 +13,12 @@ import type {
   TextModeType,
 } from './nodes/LexicalTextNode';
 
-import {IS_FIREFOX, IS_IOS, IS_SAFARI} from 'shared/environment';
+import {
+  IS_APPLE_WEBKIT,
+  IS_FIREFOX,
+  IS_IOS,
+  IS_SAFARI,
+} from 'shared/environment';
 
 // DOM
 export const DOM_ELEMENT_TYPE = 1;
@@ -69,7 +74,9 @@ const ZERO_WIDTH_SPACE = '\u200b';
 // For iOS/Safari we use a non breaking space, otherwise the cursor appears
 // overlapping the composed text.
 export const COMPOSITION_SUFFIX: string =
-  IS_SAFARI || IS_IOS ? NON_BREAKING_SPACE : ZERO_WIDTH_SPACE;
+  IS_SAFARI || IS_IOS || IS_APPLE_WEBKIT
+    ? NON_BREAKING_SPACE
+    : ZERO_WIDTH_SPACE;
 export const DOUBLE_LINE_BREAK = '\n\n';
 
 // For FF, we need to use a non-breaking space, or it gets composition

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -13,6 +13,7 @@ import type {TextNode} from './nodes/LexicalTextNode';
 
 import {
   CAN_USE_BEFORE_INPUT,
+  IS_APPLE_WEBKIT,
   IS_FIREFOX,
   IS_IOS,
   IS_SAFARI,
@@ -729,7 +730,7 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
       }
 
       // This ensures consistency on Android.
-      if (!IS_SAFARI && !IS_IOS && editor.isComposing()) {
+      if (!IS_SAFARI && !IS_IOS && !IS_APPLE_WEBKIT && editor.isComposing()) {
         lastKeyDownTimeStamp = 0;
         $setCompositionKey(null);
       }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -30,7 +30,7 @@ import type {RootNode} from './nodes/LexicalRootNode';
 import type {TextFormatType, TextNode} from './nodes/LexicalTextNode';
 
 import {CAN_USE_DOM} from 'shared/canUseDOM';
-import {IS_APPLE, IS_IOS, IS_SAFARI} from 'shared/environment';
+import {IS_APPLE, IS_APPLE_WEBKIT, IS_IOS, IS_SAFARI} from 'shared/environment';
 import invariant from 'shared/invariant';
 
 import {
@@ -653,7 +653,7 @@ export function $updateTextNodeFromDOMContent(
     if (compositionEnd || normalizedTextContent !== prevTextContent) {
       if (normalizedTextContent === '') {
         $setCompositionKey(null);
-        if (!IS_SAFARI && !IS_IOS) {
+        if (!IS_SAFARI && !IS_IOS && !IS_APPLE_WEBKIT) {
           // For composition (mainly Android), we have to remove the node on a later update
           const editor = getActiveEditor();
           setTimeout(() => {

--- a/packages/shared/src/environment.ts
+++ b/packages/shared/src/environment.ts
@@ -45,3 +45,6 @@ export const IS_IOS: boolean =
 export const IS_CHROME: boolean =
   CAN_USE_DOM && /^(?=.*Chrome).*/i.test(navigator.userAgent);
 // export const canUseTextInputEvent: boolean = CAN_USE_DOM && 'TextEvent' in window && !documentMode;
+
+export const IS_APPLE_WEBKIT =
+  CAN_USE_DOM && /AppleWebKit\/[\d.]+/.test(navigator.userAgent) && !IS_CHROME;


### PR DESCRIPTION
Native webkit doesn't add Safari version in the useragent string. This PR checks for the existence of webkit engine in that string. This fixes a varity of issues including autocompleting Chinese characters.


Before:

https://user-images.githubusercontent.com/59730495/217489536-0593dc29-7f9f-47e3-8c9a-6d3b02579005.mov


After:

https://user-images.githubusercontent.com/59730495/217489590-cb2ac870-1e33-41dd-988f-a54328a27118.mov






