### PR TITLE
Fix: wrong variable used as index in nested for loop

### DIFF
--- a/packages/lexical-text/src/index.ts
+++ b/packages/lexical-text/src/index.ts
@@ -127,7 +127,7 @@ export function $canShowPlaceholder(isComposing: boolean): boolean {
       const topBlockChildrenLength = topBlockChildren.length;
 
       for (let s = 0; s < topBlockChildrenLength; s++) {
-        const child = topBlockChildren[i];
+        const child = topBlockChildren[s];
 
         if (!$isTextNode(child)) {
           return false;


### PR DESCRIPTION
Wrong variable used as index in nested for loop