### PR TITLE
Revert "Fix $restoreEditorState"

### DIFF
--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -309,13 +309,8 @@ export function $restoreEditorState(
   editorState: EditorState,
 ): void {
   const FULL_RECONCILE = 2;
-  const nodeMap = new Map();
+  const nodeMap = new Map(editorState._nodeMap);
   const activeEditorState = editor._pendingEditorState;
-
-  for (const [key, node] of editorState._nodeMap) {
-    // @ts-ignore
-    nodeMap.set(key, node.constructor.clone(node));
-  }
 
   if (activeEditorState) {
     activeEditorState._nodeMap = nodeMap;


### PR DESCRIPTION
This is causing MaxLength E2Es to fail

Reverts facebook/lexical#3842