### PR TITLE
Fix bad import into core

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -12,7 +12,6 @@ import type {LexicalNode, NodeKey} from './LexicalNode';
 import type {ElementNode} from './nodes/LexicalElementNode';
 import type {TextFormatType} from './nodes/LexicalTextNode';
 
-import {$splitNode} from '@lexical/utils';
 import {IS_CHROME} from 'shared/environment';
 import invariant from 'shared/invariant';
 
@@ -57,6 +56,7 @@ import {
   $isRootOrShadowRoot,
   $isTokenOrSegmented,
   $setCompositionKey,
+  $splitNode,
   doesContainGrapheme,
   getDOMSelection,
   getDOMTextNode,

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1500,3 +1500,50 @@ export function updateDOMBlockCursorElement(
 export function getDOMSelection(targetWindow: null | Window): null | Selection {
   return !CAN_USE_DOM ? null : (targetWindow || window).getSelection();
 }
+
+export function $splitNode(
+  node: ElementNode,
+  offset: number,
+): [ElementNode | null, ElementNode] {
+  let startNode = node.getChildAtIndex(offset);
+  if (startNode == null) {
+    startNode = node;
+  }
+
+  invariant(
+    !$isRootOrShadowRoot(node),
+    'Can not call $splitNode() on root element',
+  );
+
+  const recurse = (
+    currentNode: LexicalNode,
+  ): [ElementNode, ElementNode, LexicalNode] => {
+    const parent = currentNode.getParentOrThrow();
+    const isParentRoot = $isRootOrShadowRoot(parent);
+    // The node we start split from (leaf) is moved, but its recursive
+    // parents are copied to create separate tree
+    const nodeToMove =
+      currentNode === startNode && !isParentRoot
+        ? currentNode
+        : $copyNode(currentNode);
+
+    if (isParentRoot) {
+      currentNode.insertAfter(nodeToMove);
+      return [
+        currentNode as ElementNode,
+        nodeToMove as ElementNode,
+        nodeToMove,
+      ];
+    } else {
+      const [leftTree, rightTree, newParent] = recurse(parent);
+      const nextSiblings = currentNode.getNextSiblings();
+
+      newParent.append(nodeToMove, ...nextSiblings);
+      return [leftTree, rightTree, nodeToMove];
+    }
+  };
+
+  const [leftTree, rightTree] = recurse(startNode);
+
+  return [leftTree, rightTree];
+}

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -141,6 +141,7 @@ export {
   $nodesOfType,
   $setCompositionKey,
   $setSelection,
+  $splitNode,
   isSelectionWithinEditor,
 } from './LexicalUtils';
 export {$isDecoratorNode, DecoratorNode} from './nodes/LexicalDecoratorNode';


### PR DESCRIPTION
https://github.com/facebook/lexical/pull/3238 introduced an import to a third party in core, which obviously doesn't work. In order to make this work without reverting that PR, I had to bring `$splitNode` into core.

Fixes https://github.com/facebook/lexical/issues/3860.