### PR TITLE
Add style properties to RangeSelection

### DIFF
--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -298,7 +298,9 @@ function printRangeSelection(selection: RangeSelection): string {
 
   const formatText = printFormatProperties(selection);
 
-  res += `: range ${formatText !== '' ? `{ ${formatText} }` : ''}`;
+  res += `: range ${formatText !== '' ? `{ ${formatText} }` : ''} ${
+    selection.style !== '' ? `{ style: ${selection.style} } ` : ''
+  }`;
 
   const anchor = selection.anchor;
   const focus = selection.focus;

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -269,7 +269,7 @@ function $patchNodeStyle(
 }
 
 export function $patchStyleText(
-  selection: RangeSelection | GridSelection,
+  selection: RangeSelection,
   patch: Record<string, string | null>,
 ): void {
   const selectedNodes = selection.getNodes();
@@ -279,6 +279,15 @@ export function $patchStyleText(
   let lastNode = selectedNodes[lastIndex];
 
   if (selection.isCollapsed()) {
+    const styles = getStyleObjectFromCSS(selection.style);
+    Object.entries(patch).forEach(([key, value]) => {
+      if (value !== null) {
+        styles[key] = value;
+      }
+      return styles;
+    });
+    const style = getCSSFromStyleObject(styles);
+    selection.setStyle(style);
     return;
   }
 


### PR DESCRIPTION
Today it's really difficult to use the custom font color, font size etc properties because selection has no internal heuristic to manage those expectations – leading to a bad user experience. This PR adds support for them on RangeSelection, so like formatting, we can persist and allow for styling through rich text.