### PR TITLE
Fix v0.8.9 typo in changelog, should be v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.8.9 (2023-02-09)
+## v0.8.0 (2023-02-09)
 
 This release includes some breaking changes, including: 
     - Remove of `indentList` and `outdentList` from `@lexical/list`.


### PR DESCRIPTION
Since the latest release is v0.8.0 I would assume this was a typo in the changelog. 