### PR TITLE
Fix autocapitalization

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Events.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Events.spec.mjs
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  assertHTML,
+  evaluate,
+  focusEditor,
+  html,
+  initialize,
+  test,
+} from '../utils/index.mjs';
+
+test.describe('Events', () => {
+  test.beforeEach(({isCollab, page}) =>
+    initialize({isAutocomplete: true, isCollab, page}),
+  );
+  test('Autocapitalization (MacOS specific)', async ({page, isPlainText}) => {
+    await focusEditor(page);
+    await page.keyboard.type('i');
+    await evaluate(page, () => {
+      const editable = document.querySelector('[contenteditable="true"]');
+      const span = editable.querySelector('span');
+      const textNode = span.firstChild;
+      function singleRangeFn(
+        startContainer,
+        startOffset,
+        endContainer,
+        endOffset,
+      ) {
+        return () => [
+          new StaticRange({
+            endContainer,
+            endOffset,
+            startContainer,
+            startOffset,
+          }),
+        ];
+      }
+      const character = 'S'; // S for space because the space itself gets trimmed in the assertHTML
+      const dataTransfer = new DataTransfer();
+      dataTransfer.setData('text/plain', 'I');
+      dataTransfer.setData('text/html', 'I');
+      const characterBeforeInputEvent = new InputEvent('beforeinput', {
+        bubbles: true,
+        cancelable: true,
+        data: character,
+        inputType: 'insertText',
+      });
+      characterBeforeInputEvent.getTargetRanges = singleRangeFn(
+        textNode,
+        1,
+        textNode,
+        1,
+      );
+      const replacementBeforeInputEvent = new InputEvent('beforeinput', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+        inputType: 'insertReplacementText',
+      });
+      replacementBeforeInputEvent.getTargetRanges = singleRangeFn(
+        textNode,
+        0,
+        textNode,
+        1,
+      );
+      const characterInputEvent = new InputEvent('input', {
+        bubbles: true,
+        cancelable: true,
+        data: character,
+        inputType: 'insertText',
+      });
+      editable.dispatchEvent(characterBeforeInputEvent);
+      textNode.textContent += character;
+      // Selection should be set with the event; this won't quite work, but not sure how to fix it..
+      // document.getSelection().setBaseAndExtent(textNode, 2, textNode, 2);
+      editable.dispatchEvent(replacementBeforeInputEvent);
+      editable.dispatchEvent(characterInputEvent);
+      // Lexical will prevent default for the replacement input event via the clipboard logic; we
+      // will assume this is correct
+      // editable.dispatchEvent(replacementInputEvent);
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">IS</span>
+        </p>
+      `,
+    );
+  });
+});

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -158,6 +158,7 @@ if (CAN_USE_BEFORE_INPUT) {
 let lastKeyDownTimeStamp = 0;
 let lastKeyCode = 0;
 let lastBeforeInputInsertTextTimeStamp = 0;
+let unprocessedBeforeInputData: null | string = null;
 let rootElementsRegistered = 0;
 let isSelectionChangeFromDOMUpdate = false;
 let isSelectionChangeFromMouseDown = false;
@@ -492,13 +493,26 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
 
     const data = event.data;
 
+    // This represents the case when two beforeinput events are triggered at the same time (without a
+    // full event loop ending at input). This happens with MacOS with the default keyboard settings,
+    // a combination of autocorrection + autocapitalization.
+    // Having Lexical run everything in controlled mode would fix the issue without additional code
+    // but this would kill the massive performance win from the most common typing event.
+    // Alternative, when this happens we can prematurely update our EditorState based on the DOM
+    // content, a job that would usually be the input event's responsibility.
+    if (unprocessedBeforeInputData !== null) {
+      $updateSelectedTextFromDOM(false, editor, unprocessedBeforeInputData);
+    }
+
     if (
-      !selection.dirty &&
+      (!selection.dirty || unprocessedBeforeInputData !== null) &&
       selection.isCollapsed() &&
       !$isRootNode(selection.anchor.getNode())
     ) {
       $applyTargetRange(selection, event);
     }
+
+    unprocessedBeforeInputData = null;
 
     const anchor = selection.anchor;
     const focus = selection.focus;
@@ -528,6 +542,8 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
       ) {
         event.preventDefault();
         dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, data);
+      } else {
+        unprocessedBeforeInputData = data;
       }
       lastBeforeInputInsertTextTimeStamp = event.timeStamp;
       return;
@@ -740,6 +756,7 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
     // since the change.
     $flushMutations();
   });
+  unprocessedBeforeInputData = null;
 }
 
 function onCompositionStart(


### PR DESCRIPTION
This PR fixes autocapitalization on Mac #3880.

It turns out that MacOS with Safari can trigger a double `beforeInput` before `input`, which causes our the `insertText` `beforeInput` to get lost and never processed (we wait until onInput to detect the content that has been inputted via beforeInput - this is intentional to boost the performance of the most common operation (we let the browser do its own thing)).

We can fix this by processing the previous beforeInput when this rarely event happens.

Copying from the code comments

```
    // This represents the case when two beforeinput events are triggered at the same time (without a
    // full event loop ending at input). This happens with MacOS with the default keyboard settings,
    // a combination of autocorrection + autocapitalization.
    // Having Lexical run everything in controlled mode would fix the issue without additional code
    // but this would kill the massive performance win from the most common typing event.
    // Alternative, when this happens we can prematurely update our EditorState based on the DOM
    // content, a job that would usually be the input event's responsibility.
```

https://user-images.githubusercontent.com/193447/218163360-403d50cb-23b2-424d-a3a1-52a8f46341fb.mov



