### PR TITLE
Expand the actionable empty playground editor text area via flex

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -86,7 +86,7 @@ header h1 {
 }
 
 .editor {
-  flex: 1 1 auto;
+  flex: auto;
   position: relative;
 }
 

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -78,7 +78,7 @@ header h1 {
   border: 0;
   resize: none;
   cursor: text;
-  display: block;
+  display: flex;
   position: relative;
   outline: 0;
   overflow: auto;
@@ -86,7 +86,7 @@ header h1 {
 }
 
 .editor {
-  height: 100%;
+  flex: 1 1 auto;
   position: relative;
 }
 


### PR DESCRIPTION
**Before:**

Unable to begin typing text unless clicking in this narrow area. Clicking toward the bottom will not activate the text area.

<img width="1140" alt="Screenshot 2023-02-10 at 12 58 48 PM" src="https://user-images.githubusercontent.com/29527680/218186653-7bcfda84-7591-40fe-b747-5adbed8089b6.png">
<hr/>

**After:**

You can now activate the text area with a click in a larger area that fills the available space.

<img width="1140" alt="Screenshot 2023-02-10 at 12 59 17 PM" src="https://user-images.githubusercontent.com/29527680/218186985-cc107939-06a4-490b-ab29-269b6bd8edde.png">

<hr/>

**Potential Concerns:**

None at the moment. Seems to be working well in my limited testing.

