### PR TITLE
Playground : Adding a wrapper div to support alignment (left, center, right) for Youtube Video. Adding exportDom function to the FigmaNode.

### DIFF
--- a/packages/lexical-playground/src/nodes/FigmaNode.tsx
+++ b/packages/lexical-playground/src/nodes/FigmaNode.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {
+  DOMExportOutput,
   EditorConfig,
   ElementFormatType,
   LexicalEditor,
@@ -87,6 +88,22 @@ export class FigmaNode extends DecoratorBlockNode {
       type: 'figma',
       version: 1,
     };
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement('div');
+    element.style.textAlign = this.__format;
+    const iframeElement = document.createElement('iframe');
+    iframeElement.setAttribute('data-lexical-figma', this.__id);
+    iframeElement.setAttribute('width', '560');
+    iframeElement.setAttribute('height', '315');
+    iframeElement.setAttribute(
+      'src',
+      `https://www.figma.com/embed?embed_host=lexical&url=https://www.figma.com/file/${this.__id}`,
+    );
+    iframeElement.setAttribute('frameborder', '0');
+    element.append(iframeElement);
+    return {element};
   }
 
   constructor(id: string, format?: ElementFormatType, key?: NodeKey) {

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -111,18 +111,24 @@ export class YouTubeNode extends DecoratorBlockNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement('iframe');
-    element.setAttribute('data-lexical-youtube', this.__id);
-    element.setAttribute('width', '560');
-    element.setAttribute('height', '315');
-    element.setAttribute('src', `https://www.youtube.com/embed/${this.__id}`);
-    element.setAttribute('frameborder', '0');
-    element.setAttribute(
+    const element = document.createElement('div');
+    element.style.textAlign = this.__format;
+    const iframeElement = document.createElement('iframe');
+    iframeElement.setAttribute('data-lexical-youtube', this.__id);
+    iframeElement.setAttribute('width', '560');
+    iframeElement.setAttribute('height', '315');
+    iframeElement.setAttribute(
+      'src',
+      `https://www.youtube.com/embed/${this.__id}`,
+    );
+    iframeElement.setAttribute('frameborder', '0');
+    iframeElement.setAttribute(
       'allow',
       'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
     );
-    element.setAttribute('allowfullscreen', 'true');
-    element.setAttribute('title', 'YouTube video');
+    iframeElement.setAttribute('allowfullscreen', 'true');
+    iframeElement.setAttribute('title', 'YouTube video');
+    element.append(iframeElement);
     return {element};
   }
 


### PR DESCRIPTION
PLayground : I added exportDom to FigmaNode, and modified little bit the existing exportDom in Youtube Node to support alignment (left, center, right), because we could align it in the editor, but it was not reflected in the HTML output.