### PR TITLE
Add overridable method to cancel markdown

### DIFF
--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -419,7 +419,11 @@ export function registerMarkdownShortcuts(
 
         const parentNode = anchorNode.getParent();
 
-        if (parentNode === null || $isCodeNode(parentNode)) {
+        if (
+          parentNode === null ||
+          !anchorNode.canContainMarkdown() ||
+          $isCodeNode(parentNode)
+        ) {
           return;
         }
 

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -707,6 +707,10 @@ export class TextNode extends LexicalNode {
     return false;
   }
 
+  canContainMarkdown(): boolean {
+    return true;
+  }
+
   splitText(...splitOffsets: Array<number>): Array<TextNode> {
     errorOnReadOnly();
     const self = this.getLatest();


### PR DESCRIPTION
@trueadm — I'm following your pattern for this PR, so thought I'd tag you.

This Pull Request allows the `TextNode` — and its overrides and extensions — to cancel Markdown shortcuts at will. 

I need it so my `LinedCodeNode` can block accidental Markdown usage within each line. 

Unfortunately, the Markdown plugin currently assumes that code will either have the 'code' format or a `CodeNode` parent. 

- In the first case, the current `code` package doesn't tag code with the format of 'code' (surprising, I know.)
    - I experimented with adding the 'code' format to my `LinedCodeTextNodes`, but the styling gets weird (monospacing).
    - I'm sure no one — including me — wants to _have_ to add the CSS necessary to combat that.
- In the second case, the `LinedCodeNode` puts `LinedCodeTextNodes` in divs, AKA, lines. _Their_ parent is a `CodeNode`, meaning the current test fails.

Rather than try to add something specific, I've added `canContainMarkdown` to the `TextNode`. It's `true` by default. My `LinedCodeTextNode` overrides it and sets it to `false`. As a result, Markdown won't appear in lines — a shocking sight!

The pattern is the same as my recent `canContainTabs` pull request. It's nice because it's generic and succinct.

This LinedCodeNode-related pull request is sibling to:

https://github.com/facebook/lexical/pull/3770
https://github.com/facebook/lexical/pull/3769
https://github.com/facebook/lexical/pull/3695
https://github.com/facebook/lexical/pull/3731
https://github.com/facebook/lexical/pull/3695
https://github.com/facebook/lexical/pull/3693