### PR TITLE
Remove condition for history merge on null prev selection

### DIFF
--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -284,11 +284,10 @@ function createMergeActionGetter(
       }
 
       const selection = nextEditorState._selection;
-      const prevSelection = prevEditorState._selection;
       const hasDirtyNodes = dirtyLeaves.size > 0 || dirtyElements.size > 0;
 
       if (!hasDirtyNodes) {
-        if (prevSelection === null && selection !== null) {
+        if (selection !== null) {
           return HISTORY_MERGE;
         }
 

--- a/packages/lexical-playground/__tests__/e2e/History.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/History.spec.mjs
@@ -325,9 +325,9 @@ test.describe('History', () => {
         `,
       );
       await assertSelection(page, {
-        anchorOffset: 17,
+        anchorOffset: 11,
         anchorPath: [1, 0, 0],
-        focusOffset: 17,
+        focusOffset: 11,
         focusPath: [1, 0, 0],
       });
     } else {

--- a/packages/lexical-playground/__tests__/e2e/History.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/History.spec.mjs
@@ -344,9 +344,9 @@ test.describe('History', () => {
         `,
       );
       await assertSelection(page, {
-        anchorOffset: 17,
+        anchorOffset: 11,
         anchorPath: [0, 2, 0],
-        focusOffset: 17,
+        focusOffset: 11,
         focusPath: [0, 2, 0],
       });
     }


### PR DESCRIPTION
This appears to fix the undo functionality in situations where the editorState is initialized with a Selection. Previously, the first entry would be discarded, rather than merged (since prevSelection was non-null) leading historyState.current to still be empty, meaning the first actual change to the content would not be placed onto the undo stack.

Fixes #3912 