### PR TITLE
Add fixme annotation to flaky collab tests

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Extensions.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Extensions.spec.mjs
@@ -18,9 +18,7 @@ import {
 
 test.describe('Extensions', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-  test(`document.execCommand("insertText")`, async ({isCollab, page}) => {
-    // This test is flaky in collab #3915
-    test.fixme(isCollab);
+  test(`document.execCommand("insertText")`, async ({page}) => {
     await focusEditor(page);
 
     await evaluate(
@@ -198,8 +196,11 @@ test.describe('Extensions', () => {
 
   test(`document.execCommand("insertText") with selection`, async ({
     page,
+    isCollab,
     isPlainText,
   }) => {
+    // This test is flaky in collab #3915
+    test.fixme(isCollab);
     test.skip(isPlainText);
     await focusEditor(page);
 

--- a/packages/lexical-playground/__tests__/e2e/Extensions.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Extensions.spec.mjs
@@ -18,7 +18,9 @@ import {
 
 test.describe('Extensions', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-  test(`document.execCommand("insertText")`, async ({page}) => {
+  test(`document.execCommand("insertText")`, async ({isCollab, page}) => {
+    // This test is flaky in collab #3915
+    test.fixme(isCollab);
     await focusEditor(page);
 
     await evaluate(

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -585,6 +585,8 @@ test.describe('Images', () => {
     browserName,
     isCollab,
   }) => {
+    // This test is flaky in collab #3915
+    test.fixme(isCollab);
     test.skip(isPlainText);
 
     await page.setViewportSize({


### PR DESCRIPTION
Tracking long-term fix here: https://github.com/facebook/lexical/issues/3915

These need to be disabled for now as they're causing us to waste a ton of time with investigating low-signal CI failures.