### PR TITLE
fix: change tablecell return type for TableCellNode

### DIFF
--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -40,7 +40,7 @@ export type TableCellHeaderState =
 export type SerializedTableCellNode = Spread<
   {
     headerState: TableCellHeaderState;
-    type: 'tablecell';
+    type: string;
     width?: number;
   },
   SerializedGridCellNode

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -53,7 +53,7 @@ export class TableCellNode extends DEPRECATED_GridCellNode {
   /** @internal */
   __width?: number;
 
-  static getType(): 'tablecell' {
+  static getType(): string {
     return 'tablecell';
   }
 

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -44,7 +44,7 @@ export class TableNode extends DEPRECATED_GridNode {
   /** @internal */
   __grid?: Grid;
 
-  static getType(): 'table' {
+  static getType(): string {
     return 'table';
   }
 

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -23,7 +23,7 @@ import {
 export type SerializedTableRowNode = Spread<
   {
     height: number;
-    type: 'tablerow';
+    type: string;
     version: 1;
   },
   SerializedElementNode

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -34,7 +34,7 @@ export class TableRowNode extends DEPRECATED_GridRowNode {
   /** @internal */
   __height?: number;
 
-  static getType(): 'tablerow' {
+  static getType(): string {
     return 'tablerow';
   }
 


### PR DESCRIPTION
Actually, if i use the node override like [that](https://lexical.dev/docs/concepts/node-replacement). 
i can't pass something else than "tablecell" in getType function. (Or i have to change with a as or to use a // @ts-ignore)

```tsx
export class CustomTableCellNode extends TableCellNode {

  public static getType(): 'tablecell' {
    return 'tablecell';
  }

  public static clone(node: TableCellNode): TableCellNode {
    return new CustomTableCellNode(
      node.__headerState,
      node.__colSpan,
      node.__width,
      node.__key,
    );
  }

  public createDOM(config: EditorConfig): HTMLElement {
    const dom = super.createDOM(config);
    return dom;
  }
}
```

```tsx
  public static getType(): 'tablecell' {
    console.log('getType called');
    // @ts-ignore
    return 'custom-tablecell';
  }
```

With this, now we should be able to use a string while extending TableCellNode.
Let me know if its good for you!

