### PR TITLE
Account for children text content size in `ElementNode`'s `getTextContentSize`

### DIFF
--- a/packages/lexical-playground/src/plugins/MaxLengthPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/MaxLengthPlugin/index.tsx
@@ -24,20 +24,19 @@ export function MaxLengthPlugin({maxLength}: {maxLength: number}): null {
         return;
       }
       const prevEditorState = editor.getEditorState();
-      const prevTextContent = prevEditorState.read(() =>
-        rootNode.getTextContent(),
+      const prevTextContentSize = prevEditorState.read(() =>
+        rootNode.getTextContentSize(),
       );
-      const textContent = rootNode.getTextContent();
-      if (prevTextContent !== textContent) {
-        const textLength = textContent.length;
-        const delCount = textLength - maxLength;
+      const textContentSize = rootNode.getTextContentSize();
+      if (prevTextContentSize !== textContentSize) {
+        const delCount = textContentSize - maxLength;
         const anchor = selection.anchor;
 
         if (delCount > 0) {
           // Restore the old editor state instead if the last
           // text content was already at the limit.
           if (
-            prevTextContent.length === maxLength &&
+            prevTextContentSize === maxLength &&
             lastRestoredEditorState !== prevEditorState
           ) {
             lastRestoredEditorState = prevEditorState;

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -176,17 +176,15 @@ export function trimTextContentFromAnchor(
       // TODO: should this be handled in core?
       text = '\n\n';
     }
-    const textNodeSize = text.length;
-    const offset = textNodeSize - remaining;
-    const slicedText = text.slice(0, offset);
+    const currentNodeSize = currentNode.getTextContentSize();
 
-    if (!$isTextNode(currentNode) || remaining >= textNodeSize) {
+    if (!$isTextNode(currentNode) || remaining >= currentNodeSize) {
       const parent = currentNode.getParent();
       currentNode.remove();
       if (parent != null && parent.getChildrenSize() === 0) {
         parent.remove();
       }
-      remaining -= textNodeSize + additionalElementWhitespace;
+      remaining -= currentNodeSize + additionalElementWhitespace;
       currentNode = nextNode;
     } else {
       const key = currentNode.getKey();
@@ -200,6 +198,8 @@ export function trimTextContentFromAnchor(
           }
           return null;
         });
+      const offset = currentNodeSize - remaining;
+      const slicedText = text.slice(0, offset);
       if (prevTextContent !== null && prevTextContent !== text) {
         const prevSelection = $getPreviousSelection();
         let target = currentNode;
@@ -218,10 +218,10 @@ export function trimTextContentFromAnchor(
         // Split text
         const isSelected = anchor.key === key;
         let anchorOffset = anchor.offset;
-        // Move offset to end if it's less than the remaniing number, otherwise
+        // Move offset to end if it's less than the remaining number, otherwise
         // we'll have a negative splitStart.
         if (anchorOffset < remaining) {
-          anchorOffset = textNodeSize;
+          anchorOffset = currentNodeSize;
         }
         const splitStart = isSelected ? anchorOffset - remaining : 0;
         const splitEnd = isSelected ? anchorOffset : offset;

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -259,6 +259,23 @@ export class ElementNode extends LexicalNode {
     }
     return textContent;
   }
+  getTextContentSize(): number {
+    let textContentSize = 0;
+    const children = this.getChildren();
+    const childrenLength = children.length;
+    for (let i = 0; i < childrenLength; i++) {
+      const child = children[i];
+      textContentSize += child.getTextContentSize();
+      if (
+        $isElementNode(child) &&
+        i !== childrenLength - 1 &&
+        !child.isInline()
+      ) {
+        textContentSize += DOUBLE_LINE_BREAK.length;
+      }
+    }
+    return textContentSize;
+  }
   getDirection(): 'ltr' | 'rtl' | null {
     const self = this.getLatest();
     return self.__dir;

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -255,12 +255,12 @@ describe('LexicalElementNode tests', () => {
     test('basic', async () => {
       await update(() => {
         expect($getRoot().getFirstChild().getTextContentSize()).toBe(
-          'FooBarBaz'.length,
+          $getRoot().getFirstChild().getTextContent().length,
         );
       });
     });
 
-    test('child getTextContentSize() does not match getTextContent().length', async () => {
+    test('child node getTextContentSize() can be overridden and is then reflected when calling the same method on parent node', async () => {
       await update(() => {
         const block = $createTestElementNode();
         const text = $createTextNode('Foo');

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -251,6 +251,27 @@ describe('LexicalElementNode tests', () => {
     });
   });
 
+  describe('getTextContentSize()', () => {
+    test('basic', async () => {
+      await update(() => {
+        expect($getRoot().getFirstChild().getTextContentSize()).toBe(
+          'FooBarBaz'.length,
+        );
+      });
+    });
+
+    test('child getTextContentSize() does not match getTextContent().length', async () => {
+      await update(() => {
+        const block = $createTestElementNode();
+        const text = $createTextNode('Foo');
+        text.getTextContentSize = () => 1;
+        block.append(text);
+
+        expect(block.getTextContentSize()).toBe(1);
+      });
+    });
+  });
+
   describe('splice', () => {
     let block;
 


### PR DESCRIPTION
Fixes #3772 

In `ElementNode` I've duplicated the logic of `getTextContent` for `getTextContentSize()` to account for children where `getTextContentSize() !== getTextContent().length`.

I'm not sure that the changes are desirable.
In particular, `RootNode` overrides `getTextContent` to track the internal property `__cachedText`. 
`__cachedText` is changed manually when the editor is updated. I lack familiarity with the codebase but my guess is that it's a performance optimization.
In the current state of the PR, the same optimization is not applied to `getTextContentSize` in `RootNode`. 
What are the implications of this? I see that `getTextContentSize` is used internally in `LexicalSelection.ts`.