### PR TITLE
added docsfeature-button in lexical playground issue#3918

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lexical/monorepo",
-  "version": "0.7.8",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/monorepo",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -22454,36 +22454,36 @@
       }
     },
     "packages/lexical": {
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT"
     },
     "packages/lexical-clipboard": {
       "name": "@lexical/clipboard",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.7.8",
-        "@lexical/list": "0.7.8",
-        "@lexical/selection": "0.7.8",
-        "@lexical/utils": "0.7.8"
+        "@lexical/html": "0.8.0",
+        "@lexical/list": "0.8.0",
+        "@lexical/selection": "0.8.0",
+        "@lexical/utils": "0.8.0"
       },
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-code": {
       "name": "@lexical/code",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.7.8",
+        "@lexical/utils": "0.8.0",
         "prismjs": "^1.27.0"
       },
       "devDependencies": {
         "@types/prismjs": "^1.26.0"
       },
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-devtools": {
@@ -22521,157 +22521,157 @@
     },
     "packages/lexical-dragon": {
       "name": "@lexical/dragon",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-file": {
       "name": "@lexical/file",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-hashtag": {
       "name": "@lexical/hashtag",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.7.8"
+        "@lexical/utils": "0.8.0"
       },
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-headless": {
       "name": "@lexical/headless",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-history": {
       "name": "@lexical/history",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.7.8"
+        "@lexical/utils": "0.8.0"
       },
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-html": {
       "name": "@lexical/html",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.7.8"
+        "@lexical/selection": "0.8.0"
       },
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-link": {
       "name": "@lexical/link",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.7.8"
+        "@lexical/utils": "0.8.0"
       },
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-list": {
       "name": "@lexical/list",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.7.8"
+        "@lexical/utils": "0.8.0"
       },
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-mark": {
       "name": "@lexical/mark",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.7.8"
+        "@lexical/utils": "0.8.0"
       },
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-markdown": {
       "name": "@lexical/markdown",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.7.8",
-        "@lexical/link": "0.7.8",
-        "@lexical/list": "0.7.8",
-        "@lexical/rich-text": "0.7.8",
-        "@lexical/text": "0.7.8",
-        "@lexical/utils": "0.7.8"
+        "@lexical/code": "0.8.0",
+        "@lexical/link": "0.8.0",
+        "@lexical/list": "0.8.0",
+        "@lexical/rich-text": "0.8.0",
+        "@lexical/text": "0.8.0",
+        "@lexical/utils": "0.8.0"
       },
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-offset": {
       "name": "@lexical/offset",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-overflow": {
       "name": "@lexical/overflow",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-plain-text": {
       "name": "@lexical/plain-text",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "peerDependencies": {
-        "@lexical/clipboard": "0.7.8",
-        "@lexical/selection": "0.7.8",
-        "@lexical/utils": "0.7.8",
-        "lexical": "0.7.8"
+        "@lexical/clipboard": "0.8.0",
+        "@lexical/selection": "0.8.0",
+        "@lexical/utils": "0.8.0",
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-playground": {
-      "version": "0.7.8",
+      "version": "0.8.0",
       "dependencies": {
         "@excalidraw/excalidraw": "0.11.0",
-        "@lexical/clipboard": "0.7.8",
-        "@lexical/code": "0.7.8",
-        "@lexical/file": "0.7.8",
-        "@lexical/hashtag": "0.7.8",
-        "@lexical/link": "0.7.8",
-        "@lexical/list": "0.7.8",
-        "@lexical/mark": "0.7.8",
-        "@lexical/overflow": "0.7.8",
-        "@lexical/plain-text": "0.7.8",
-        "@lexical/react": "0.7.8",
-        "@lexical/rich-text": "0.7.8",
-        "@lexical/selection": "0.7.8",
-        "@lexical/table": "0.7.8",
-        "@lexical/utils": "0.7.8",
+        "@lexical/clipboard": "0.8.0",
+        "@lexical/code": "0.8.0",
+        "@lexical/file": "0.8.0",
+        "@lexical/hashtag": "0.8.0",
+        "@lexical/link": "0.8.0",
+        "@lexical/list": "0.8.0",
+        "@lexical/mark": "0.8.0",
+        "@lexical/overflow": "0.8.0",
+        "@lexical/plain-text": "0.8.0",
+        "@lexical/react": "0.8.0",
+        "@lexical/rich-text": "0.8.0",
+        "@lexical/selection": "0.8.0",
+        "@lexical/table": "0.8.0",
+        "@lexical/utils": "0.8.0",
         "katex": "^0.15.2",
-        "lexical": "0.7.8",
+        "lexical": "0.8.0",
         "lodash-es": "^4.17.21",
         "prettier": "^2.3.2",
         "react": "^18.2.0",
@@ -22689,82 +22689,83 @@
     },
     "packages/lexical-react": {
       "name": "@lexical/react",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.7.8",
-        "@lexical/code": "0.7.8",
-        "@lexical/dragon": "0.7.8",
-        "@lexical/hashtag": "0.7.8",
-        "@lexical/history": "0.7.8",
-        "@lexical/link": "0.7.8",
-        "@lexical/list": "0.7.8",
-        "@lexical/mark": "0.7.8",
-        "@lexical/markdown": "0.7.8",
-        "@lexical/overflow": "0.7.8",
-        "@lexical/plain-text": "0.7.8",
-        "@lexical/rich-text": "0.7.8",
-        "@lexical/selection": "0.7.8",
-        "@lexical/table": "0.7.8",
-        "@lexical/text": "0.7.8",
-        "@lexical/utils": "0.7.8",
-        "@lexical/yjs": "0.7.8",
+        "@lexical/clipboard": "0.8.0",
+        "@lexical/code": "0.8.0",
+        "@lexical/dragon": "0.8.0",
+        "@lexical/hashtag": "0.8.0",
+        "@lexical/history": "0.8.0",
+        "@lexical/link": "0.8.0",
+        "@lexical/list": "0.8.0",
+        "@lexical/mark": "0.8.0",
+        "@lexical/markdown": "0.8.0",
+        "@lexical/overflow": "0.8.0",
+        "@lexical/plain-text": "0.8.0",
+        "@lexical/rich-text": "0.8.0",
+        "@lexical/selection": "0.8.0",
+        "@lexical/table": "0.8.0",
+        "@lexical/text": "0.8.0",
+        "@lexical/utils": "0.8.0",
+        "@lexical/yjs": "0.8.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
-        "lexical": "0.7.8",
+        "lexical": "0.8.0",
         "react": ">=17.x",
         "react-dom": ">=17.x"
       }
     },
     "packages/lexical-rich-text": {
       "name": "@lexical/rich-text",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "peerDependencies": {
-        "@lexical/clipboard": "0.7.8",
-        "@lexical/selection": "0.7.8",
-        "@lexical/utils": "0.7.8",
-        "lexical": "0.7.8"
+        "@lexical/clipboard": "0.8.0",
+        "@lexical/selection": "0.8.0",
+        "@lexical/utils": "0.8.0",
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-selection": {
       "name": "@lexical/selection",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-table": {
       "name": "@lexical/table",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.7.8"
+        "@lexical/utils": "0.8.0"
       },
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-text": {
       "name": "@lexical/text",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-utils": {
       "name": "@lexical/utils",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.7.8",
-        "@lexical/table": "0.7.8"
+        "@lexical/list": "0.8.0",
+        "@lexical/selection": "0.8.0",
+        "@lexical/table": "0.8.0"
       },
       "peerDependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "packages/lexical-website": {
@@ -23745,13 +23746,13 @@
     },
     "packages/lexical-yjs": {
       "name": "@lexical/yjs",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.7.8"
+        "@lexical/offset": "0.8.0"
       },
       "peerDependencies": {
-        "lexical": "0.7.8",
+        "lexical": "0.8.0",
         "yjs": ">=13.5.22"
       }
     },
@@ -23780,10 +23781,10 @@
       }
     },
     "packages/shared": {
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     }
   },
@@ -26055,16 +26056,16 @@
     "@lexical/clipboard": {
       "version": "file:packages/lexical-clipboard",
       "requires": {
-        "@lexical/html": "0.7.8",
-        "@lexical/list": "0.7.8",
-        "@lexical/selection": "0.7.8",
-        "@lexical/utils": "0.7.8"
+        "@lexical/html": "0.8.0",
+        "@lexical/list": "0.8.0",
+        "@lexical/selection": "0.8.0",
+        "@lexical/utils": "0.8.0"
       }
     },
     "@lexical/code": {
       "version": "file:packages/lexical-code",
       "requires": {
-        "@lexical/utils": "0.7.8",
+        "@lexical/utils": "0.8.0",
         "@types/prismjs": "^1.26.0",
         "prismjs": "^1.27.0"
       }
@@ -26078,7 +26079,7 @@
     "@lexical/hashtag": {
       "version": "file:packages/lexical-hashtag",
       "requires": {
-        "@lexical/utils": "0.7.8"
+        "@lexical/utils": "0.8.0"
       }
     },
     "@lexical/headless": {
@@ -26087,42 +26088,42 @@
     "@lexical/history": {
       "version": "file:packages/lexical-history",
       "requires": {
-        "@lexical/utils": "0.7.8"
+        "@lexical/utils": "0.8.0"
       }
     },
     "@lexical/html": {
       "version": "file:packages/lexical-html",
       "requires": {
-        "@lexical/selection": "0.7.8"
+        "@lexical/selection": "0.8.0"
       }
     },
     "@lexical/link": {
       "version": "file:packages/lexical-link",
       "requires": {
-        "@lexical/utils": "0.7.8"
+        "@lexical/utils": "0.8.0"
       }
     },
     "@lexical/list": {
       "version": "file:packages/lexical-list",
       "requires": {
-        "@lexical/utils": "0.7.8"
+        "@lexical/utils": "0.8.0"
       }
     },
     "@lexical/mark": {
       "version": "file:packages/lexical-mark",
       "requires": {
-        "@lexical/utils": "0.7.8"
+        "@lexical/utils": "0.8.0"
       }
     },
     "@lexical/markdown": {
       "version": "file:packages/lexical-markdown",
       "requires": {
-        "@lexical/code": "0.7.8",
-        "@lexical/link": "0.7.8",
-        "@lexical/list": "0.7.8",
-        "@lexical/rich-text": "0.7.8",
-        "@lexical/text": "0.7.8",
-        "@lexical/utils": "0.7.8"
+        "@lexical/code": "0.8.0",
+        "@lexical/link": "0.8.0",
+        "@lexical/list": "0.8.0",
+        "@lexical/rich-text": "0.8.0",
+        "@lexical/text": "0.8.0",
+        "@lexical/utils": "0.8.0"
       }
     },
     "@lexical/offset": {
@@ -26137,23 +26138,23 @@
     "@lexical/react": {
       "version": "file:packages/lexical-react",
       "requires": {
-        "@lexical/clipboard": "0.7.8",
-        "@lexical/code": "0.7.8",
-        "@lexical/dragon": "0.7.8",
-        "@lexical/hashtag": "0.7.8",
-        "@lexical/history": "0.7.8",
-        "@lexical/link": "0.7.8",
-        "@lexical/list": "0.7.8",
-        "@lexical/mark": "0.7.8",
-        "@lexical/markdown": "0.7.8",
-        "@lexical/overflow": "0.7.8",
-        "@lexical/plain-text": "0.7.8",
-        "@lexical/rich-text": "0.7.8",
-        "@lexical/selection": "0.7.8",
-        "@lexical/table": "0.7.8",
-        "@lexical/text": "0.7.8",
-        "@lexical/utils": "0.7.8",
-        "@lexical/yjs": "0.7.8",
+        "@lexical/clipboard": "0.8.0",
+        "@lexical/code": "0.8.0",
+        "@lexical/dragon": "0.8.0",
+        "@lexical/hashtag": "0.8.0",
+        "@lexical/history": "0.8.0",
+        "@lexical/link": "0.8.0",
+        "@lexical/list": "0.8.0",
+        "@lexical/mark": "0.8.0",
+        "@lexical/markdown": "0.8.0",
+        "@lexical/overflow": "0.8.0",
+        "@lexical/plain-text": "0.8.0",
+        "@lexical/rich-text": "0.8.0",
+        "@lexical/selection": "0.8.0",
+        "@lexical/table": "0.8.0",
+        "@lexical/text": "0.8.0",
+        "@lexical/utils": "0.8.0",
+        "@lexical/yjs": "0.8.0",
         "react-error-boundary": "^3.1.4"
       }
     },
@@ -26166,7 +26167,7 @@
     "@lexical/table": {
       "version": "file:packages/lexical-table",
       "requires": {
-        "@lexical/utils": "0.7.8"
+        "@lexical/utils": "0.8.0"
       }
     },
     "@lexical/text": {
@@ -26175,8 +26176,9 @@
     "@lexical/utils": {
       "version": "file:packages/lexical-utils",
       "requires": {
-        "@lexical/list": "0.7.8",
-        "@lexical/table": "0.7.8"
+        "@lexical/list": "0.8.0",
+        "@lexical/selection": "0.8.0",
+        "@lexical/table": "0.8.0"
       }
     },
     "@lexical/website": {
@@ -26884,7 +26886,7 @@
     "@lexical/yjs": {
       "version": "file:packages/lexical-yjs",
       "requires": {
-        "@lexical/offset": "0.7.8"
+        "@lexical/offset": "0.8.0"
       }
     },
     "@mdx-js/mdx": {
@@ -35267,24 +35269,24 @@
       "version": "file:packages/lexical-playground",
       "requires": {
         "@excalidraw/excalidraw": "0.11.0",
-        "@lexical/clipboard": "0.7.8",
-        "@lexical/code": "0.7.8",
-        "@lexical/file": "0.7.8",
-        "@lexical/hashtag": "0.7.8",
-        "@lexical/link": "0.7.8",
-        "@lexical/list": "0.7.8",
-        "@lexical/mark": "0.7.8",
-        "@lexical/overflow": "0.7.8",
-        "@lexical/plain-text": "0.7.8",
-        "@lexical/react": "0.7.8",
-        "@lexical/rich-text": "0.7.8",
-        "@lexical/selection": "0.7.8",
-        "@lexical/table": "0.7.8",
-        "@lexical/utils": "0.7.8",
+        "@lexical/clipboard": "0.8.0",
+        "@lexical/code": "0.8.0",
+        "@lexical/file": "0.8.0",
+        "@lexical/hashtag": "0.8.0",
+        "@lexical/link": "0.8.0",
+        "@lexical/list": "0.8.0",
+        "@lexical/mark": "0.8.0",
+        "@lexical/overflow": "0.8.0",
+        "@lexical/plain-text": "0.8.0",
+        "@lexical/react": "0.8.0",
+        "@lexical/rich-text": "0.8.0",
+        "@lexical/selection": "0.8.0",
+        "@lexical/table": "0.8.0",
+        "@lexical/utils": "0.8.0",
         "@types/lodash-es": "^4.14.182",
         "@vitejs/plugin-react": "^1.0.7",
         "katex": "^0.15.2",
-        "lexical": "0.7.8",
+        "lexical": "0.8.0",
         "lodash-es": "^4.17.21",
         "prettier": "^2.3.2",
         "react": "^18.2.0",
@@ -38453,7 +38455,7 @@
     "shared": {
       "version": "file:packages/shared",
       "requires": {
-        "lexical": "0.7.8"
+        "lexical": "0.8.0"
       }
     },
     "shebang-command": {

--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -20,6 +20,7 @@ import {SharedHistoryContext} from './context/SharedHistoryContext';
 import Editor from './Editor';
 import logo from './images/logo.svg';
 import PlaygroundNodes from './nodes/PlaygroundNodes';
+import DocsPlugin from './plugins/DocsPlugin';
 import PasteLogPlugin from './plugins/PasteLogPlugin';
 import {TableContext} from './plugins/TablePlugin';
 import TestRecorderPlugin from './plugins/TestRecorderPlugin';
@@ -144,8 +145,10 @@ function App(): JSX.Element {
               <Editor />
             </div>
             <Settings />
+            {isDevPlayground ? <DocsPlugin /> : null}
             {isDevPlayground ? <PasteLogPlugin /> : null}
             {isDevPlayground ? <TestRecorderPlugin /> : null}
+
             {measureTypingPerf ? <TypingPerfPlugin /> : null}
           </SharedAutocompleteContext>
         </TableContext>

--- a/packages/lexical-playground/src/images/icons/file-earmark-text.svg
+++ b/packages/lexical-playground/src/images/icons/file-earmark-text.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-text" viewBox="0 0 16 16">
+  <path d="M5.5 7a.5.5 0 0 0 0 1h5a.5.5 0 0 0 0-1h-5zM5 9.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 0 1h-2a.5.5 0 0 1-.5-.5z"/>
+  <path d="M9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4.5L9.5 0zm0 1v2A1.5 1.5 0 0 0 11 4.5h2V14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h5.5z"/>
+</svg>

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -221,6 +221,12 @@ pre::-webkit-scrollbar-thumb {
   bottom: 20px;
 }
 
+#docs-button {
+  position: fixed;
+  left: 170px;
+  bottom: 20px;
+}
+
 #options-button::after {
   background-image: url(images/icons/gear.svg);
 }
@@ -231,6 +237,10 @@ pre::-webkit-scrollbar-thumb {
 
 #paste-log-button::after {
   background-image: url(images/icons/clipboard.svg);
+}
+
+#docs-button::after {
+  background-image: url(images/icons/file-earmark-text.svg);
 }
 
 #test-recorder-button-snapshot {

--- a/packages/lexical-playground/src/plugins/DocsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DocsPlugin/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import * as React from 'react';
+
+export default function DocsPlugin(): JSX.Element {
+  return (
+    <a target="__blank" href="https://lexical.dev/docs/intro">
+      <button
+        id="docs-button"
+        className="editor-dev-button"
+        title="Lexical Docs"
+      />
+    </a>
+  );
+}


### PR DESCRIPTION
## Closes issue
This PR closes the issue #3918 

## What is changed?
Added <b>Docs Button</b> in Lexical Playground that links to the official documentation of lexical.
This feature makes handy to have the docs a click away when you're exploring the playground as mentioned in issue #3918 


