### PR TITLE
Trigger `CAN_REDO_COMMAND` as false when `redoStack` goes down to 0

### DIFF
--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -20,6 +20,7 @@ import {
   CLEAR_HISTORY_COMMAND,
   COMMAND_PRIORITY_CRITICAL,
   LexicalEditor,
+  REDO_COMMAND,
   SerializedElementNode,
   SerializedTextNode,
   UNDO_COMMAND,
@@ -178,6 +179,91 @@ describe('LexicalHistory tests', () => {
     expect(JSON.stringify(initialJSONState)).toBe(
       JSON.stringify(editor.getEditorState().toJSON()),
     );
+  });
+
+  test('LexicalHistory in sequence: change, undo, redo, undo, change', async () => {
+    let canRedo = false;
+    let canUndo = false;
+
+    ReactTestUtils.act(() => {
+      reactRoot.render(<Test key="smth" />);
+    });
+
+    editor.registerCommand<boolean>(
+      CAN_REDO_COMMAND,
+      (payload) => {
+        canRedo = payload;
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+
+    editor.registerCommand<boolean>(
+      CAN_UNDO_COMMAND,
+      (payload) => {
+        canUndo = payload;
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+
+    // focus (needs the focus to initialize)
+    await ReactTestUtils.act(async () => {
+      editor.focus();
+    });
+
+    expect(canRedo).toBe(false);
+    expect(canUndo).toBe(false);
+
+    // change
+    await ReactTestUtils.act(async () => {
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = createParagraphNode('foo');
+        root.append(paragraph);
+      });
+    });
+    expect(canRedo).toBe(false);
+    expect(canUndo).toBe(true);
+
+    // undo
+    await ReactTestUtils.act(async () => {
+      await editor.update(() => {
+        editor.dispatchCommand(UNDO_COMMAND, undefined);
+      });
+    });
+    expect(canRedo).toBe(true);
+    expect(canUndo).toBe(false);
+
+    // redo
+    await ReactTestUtils.act(async () => {
+      await editor.update(() => {
+        editor.dispatchCommand(REDO_COMMAND, undefined);
+      });
+    });
+    expect(canRedo).toBe(false);
+    expect(canUndo).toBe(true);
+
+    // undo
+    await ReactTestUtils.act(async () => {
+      await editor.update(() => {
+        editor.dispatchCommand(UNDO_COMMAND, undefined);
+      });
+    });
+    expect(canRedo).toBe(true);
+    expect(canUndo).toBe(false);
+
+    // change
+    await ReactTestUtils.act(async () => {
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = createParagraphNode('foo');
+        root.append(paragraph);
+      });
+    });
+
+    expect(canRedo).toBe(false);
+    expect(canUndo).toBe(true);
   });
 });
 

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -431,6 +431,7 @@ export function registerHistory(
     if (mergeAction === HISTORY_PUSH) {
       if (redoStack.length !== 0) {
         historyState.redoStack = [];
+        editor.dispatchCommand(CAN_REDO_COMMAND, false);
       }
 
       if (current !== null) {


### PR DESCRIPTION
This fixes an issue in the lexical history plugin that does not notify that the redo action is unavailable when the user performs an update.

There is no bug reported that I can find, so here is the steps to reproduce the issue:

```
Steps to reproduce:
- Go to https://playground.lexical.dev/
- Make a change
- Undo
- Make another change

Expected: the redo button is disabled

Actual: the redo button is enabled
```

I've added a unit test to test a full sequence (probably more of that is needed for this PR but there were not enough tests for this plugin I believe).

Let me know if you need to open an issue and I will do it.