### PR TITLE
Export getElementByKeyOrThrow to lexical

### DIFF
--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -145,6 +145,7 @@ export {
   $setSelection,
   $splitNode,
   isSelectionWithinEditor,
+  getElementByKeyOrThrow
 } from './LexicalUtils';
 export {$isDecoratorNode, DecoratorNode} from './nodes/LexicalDecoratorNode';
 export {$isElementNode, ElementNode} from './nodes/LexicalElementNode';


### PR DESCRIPTION
To fix: 

In the process of using lexical, I've noticed that there's a good method to getting an element by NodeKey

- [getElementByKeyOrThrow](https://github.com/facebook/lexical/blob/f8a0ba22a169b6e2b9e6b973a02b6a08318a4d53/packages/lexical/src/LexicalUtils.ts#L1176-L1188)

But , I am very curious why this method was not exposed in [lexical](https://github.com/facebook/lexical/blob/f8a0ba22a169b6e2b9e6b973a02b6a08318a4d53/packages/lexical/src/index.ts#L130-L148)

And it seems that there are other ways to get the element through Node

So i did this change

Closes: #3947 