### PR TITLE
Check if parent node is root in order to remove it in trimTextContentFromAnchor

### DIFF
--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -23,6 +23,7 @@ import {
   $isElementNode,
   $isRangeSelection,
   $isTextNode,
+  $isRootNode,
   DEPRECATED_$isGridSelection,
 } from 'lexical';
 
@@ -183,7 +184,7 @@ export function trimTextContentFromAnchor(
     if (!$isTextNode(currentNode) || remaining >= textNodeSize) {
       const parent = currentNode.getParent();
       currentNode.remove();
-      if (parent != null && parent.getChildrenSize() === 0) {
+      if (parent != null && parent.getChildrenSize() === 0 && !$isRootNode(parent)) {
         parent.remove();
       }
       remaining -= textNodeSize + additionalElementWhitespace;


### PR DESCRIPTION
Fixes #3650

I have added an extra condition in trimTextContentFromAnchor to only remove parent node if it is not the `RootNode`