### PR TITLE
Beforeinput prevent default on mismatching targetRanges

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Events.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Events.spec.mjs
@@ -17,9 +17,8 @@ import {
 } from '../utils/index.mjs';
 
 test.describe('Events', () => {
-  test.beforeEach(({isCollab, page}) =>
-    initialize({isAutocomplete: true, isCollab, page}),
-  );
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+
   test('Autocapitalization (MacOS specific)', async ({page, isPlainText}) => {
     if (LEGACY_EVENTS) {
       return;
@@ -95,6 +94,82 @@ test.describe('Events', () => {
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
           dir="ltr">
           <span data-lexical-text="true">IS</span>
+        </p>
+      `,
+    );
+  });
+
+  test('Add period with double-space after emoji (MacOS specific) #3953', async ({
+    page,
+    isPlainText,
+  }) => {
+    if (LEGACY_EVENTS) {
+      return;
+    }
+    await focusEditor(page);
+    await page.keyboard.type(':)');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span class="emoji happysmile" data-lexical-text="true">
+            <span class="emoji-inner">🙂</span>
+          </span>
+        </p>
+      `,
+    );
+    await page.keyboard.type(' ');
+
+    await evaluate(page, () => {
+      const editable = document.querySelector('[contenteditable="true"]');
+      const spans = editable.querySelectorAll('span');
+      const lastSpan = spans[spans.length - 1];
+      const lastSpanTextNode = lastSpan.firstChild;
+      function singleRangeFn(
+        startContainer,
+        startOffset,
+        endContainer,
+        endOffset,
+      ) {
+        return () => [
+          new StaticRange({
+            endContainer,
+            endOffset,
+            startContainer,
+            startOffset,
+          }),
+        ];
+      }
+      const characterBeforeInputEvent = new InputEvent('beforeinput', {
+        bubbles: true,
+        cancelable: true,
+        data: '. ',
+        inputType: 'insertText',
+      });
+      characterBeforeInputEvent.getTargetRanges = singleRangeFn(
+        lastSpanTextNode,
+        0,
+        lastSpanTextNode,
+        1,
+      );
+      // We don't do textNode.textContent += character; intentionally; if the code prevents default
+      // Lexical should add it via controlled mode.
+      editable.dispatchEvent(characterBeforeInputEvent);
+    });
+    await page.pause();
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span class="emoji happysmile" data-lexical-text="true">
+            <span class="emoji-inner">🙂</span>
+          </span>
+          <span data-lexical-text="true">.</span>
         </p>
       `,
     );


### PR DESCRIPTION
The "Add period with double-space after emoji" Mac feature misbehaves when triggered immediately after a node on Chrome. My hunch is that this is a Chrome-specific bug, as Safari does it correcty.

However, what brought me to this fix is the fact that this can lead to a more generic issue. We allow anyting to happen on the DOM on beforeinput. In this case, Mac is saying insert `. ` which covers the immediately previous 2 position but the targetRange could be completely arbitrary, overriding some of our other DOM elements.

Given that this is rare, it's worth switching to controlled mode when this happens and it will have no impact whatsoever on the performance.

Alternatively, we could handle it in the MutationObserver, trying to intercept what has been modified and what-not but given that MutationObserver triggers after beforeinput (when we handle the input) this overcomplicates the solution for an edge case for a neglible performance gain.

Fixes #3953