### PR TITLE
Fix getNodes of RangeSelection

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -601,25 +601,27 @@ export class RangeSelection implements BaseSelection {
     const anchor = this.anchor;
     const focus = this.focus;
     const isBefore = anchor.isBefore(focus);
-    let firstNode = isBefore ? anchor.getNode() : focus.getNode();
-    let lastNode = isBefore ? focus.getNode() : anchor.getNode();
-    const firstOffset = isBefore ? anchor.offset : focus.offset;
-    const lastOffset = isBefore ? focus.offset : anchor.offset;
+    const firstPoint = isBefore ? anchor : focus;
+    const lastPoint = isBefore ? focus : anchor;
+    let firstNode = firstPoint.getNode();
+    let lastNode = lastPoint.getNode();
+    const startOffset = firstPoint.offset;
+    const endOffset = lastPoint.offset;
 
     if ($isElementNode(firstNode)) {
       const firstNodeDescendant =
-        firstNode.getDescendantByIndex<ElementNode>(firstOffset);
+        firstNode.getDescendantByIndex<ElementNode>(startOffset);
       firstNode = firstNodeDescendant != null ? firstNodeDescendant : firstNode;
     }
     if ($isElementNode(lastNode)) {
       let lastNodeDescendant =
-        lastNode.getDescendantByIndex<ElementNode>(lastOffset);
+        lastNode.getDescendantByIndex<ElementNode>(endOffset);
       // We don't want to over-select, as node selection infers the child before
       // the last descendant, not including that descendant.
       if (
         lastNodeDescendant !== null &&
         lastNodeDescendant !== firstNode &&
-        lastNode.getChildAtIndex(lastOffset) === lastNodeDescendant
+        lastNode.getChildAtIndex(endOffset) === lastNodeDescendant
       ) {
         lastNodeDescendant = lastNodeDescendant.getPreviousSibling();
       }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -601,15 +601,10 @@ export class RangeSelection implements BaseSelection {
     const anchor = this.anchor;
     const focus = this.focus;
     const isBefore = anchor.isBefore(focus);
-    let firstNode = anchor.getNode();
-    let lastNode = focus.getNode();
-    let firstOffset = anchor.offset;
-    let lastOffset = focus.offset;
-
-    if (!isBefore) {
-      [firstNode, lastNode] = [lastNode, firstNode];
-      [firstOffset, lastOffset] = [lastOffset, firstOffset];
-    }
+    let firstNode = isBefore ? anchor.getNode() : focus.getNode();
+    let lastNode = isBefore ? focus.getNode() : anchor.getNode();
+    const firstOffset = isBefore ? anchor.offset : focus.offset;
+    const lastOffset = isBefore ? focus.offset : anchor.offset;
 
     if ($isElementNode(firstNode)) {
       const firstNodeDescendant =

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -600,25 +600,31 @@ export class RangeSelection implements BaseSelection {
     }
     const anchor = this.anchor;
     const focus = this.focus;
+    const isBefore = anchor.isBefore(focus);
     let firstNode = anchor.getNode();
     let lastNode = focus.getNode();
+    let firstOffset = anchor.offset;
+    let lastOffset = focus.offset;
+
+    if (!isBefore) {
+      [firstNode, lastNode] = [lastNode, firstNode];
+      [firstOffset, lastOffset] = [lastOffset, firstOffset];
+    }
 
     if ($isElementNode(firstNode)) {
-      const firstNodeDescendant = firstNode.getDescendantByIndex<ElementNode>(
-        anchor.offset,
-      );
+      const firstNodeDescendant =
+        firstNode.getDescendantByIndex<ElementNode>(firstOffset);
       firstNode = firstNodeDescendant != null ? firstNodeDescendant : firstNode;
     }
     if ($isElementNode(lastNode)) {
-      let lastNodeDescendant = lastNode.getDescendantByIndex<ElementNode>(
-        focus.offset,
-      );
+      let lastNodeDescendant =
+        lastNode.getDescendantByIndex<ElementNode>(lastOffset);
       // We don't want to over-select, as node selection infers the child before
       // the last descendant, not including that descendant.
       if (
         lastNodeDescendant !== null &&
         lastNodeDescendant !== firstNode &&
-        lastNode.getChildAtIndex(focus.offset) === lastNodeDescendant
+        lastNode.getChildAtIndex(lastOffset) === lastNodeDescendant
       ) {
         lastNodeDescendant = lastNodeDescendant.getPreviousSibling();
       }


### PR DESCRIPTION
This fixes a problem in RangeSelection's getNodes method, which incorrectly retrieves the nodes when the anchor is after the focus.