### PR TITLE
Make one previous node be selected when deleting a block

### DIFF
--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -21,6 +21,7 @@ import {
   $isDecoratorNode,
   $isNodeSelection,
   $isRangeSelection,
+  $setSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   FORMAT_ELEMENT_COMMAND,
@@ -58,18 +59,18 @@ export function BlockWithAlignableContents({
         event.preventDefault();
         editor.update(() => {
           const node = $getNodeByKey(nodeKey);
+          if (node === null) return;
 
+          $setSelection(node.selectPrevious());
           if ($isDecoratorNode(node)) {
             node.remove();
           }
-
-          setSelected(false);
         });
       }
 
       return false;
     },
-    [editor, isSelected, nodeKey, setSelected],
+    [editor, isSelected, nodeKey],
   );
 
   useEffect(() => {


### PR DESCRIPTION
When a block is deleted, one previous node is selected.
This will improve the writing experience.

https://user-images.githubusercontent.com/40270352/221128816-4a476298-d177-46c2-a122-dc917d90d34b.mov

