### PR TITLE
Cleanup excessive use of WebsocketProvider for types

### DIFF
--- a/packages/lexical-playground/src/collaboration.ts
+++ b/packages/lexical-playground/src/collaboration.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {Provider} from '@lexical/yjs';
 import {WebsocketProvider} from 'y-websocket';
 import {Doc} from 'yjs';
 
@@ -20,7 +21,7 @@ const WEBSOCKET_ID = params.get('collabId') || '0';
 export function createWebsocketProvider(
   id: string,
   yjsDocMap: Map<string, Doc>,
-): WebsocketProvider {
+): Provider {
   let doc = yjsDocMap.get(id);
 
   if (doc === undefined) {
@@ -30,6 +31,7 @@ export function createWebsocketProvider(
     doc.load();
   }
 
+  // @ts-ignore
   return new WebsocketProvider(
     WEBSOCKET_ENDPOINT,
     WEBSOCKET_SLUG + '/' + WEBSOCKET_ID + '/' + id,

--- a/packages/lexical-playground/src/commenting/index.ts
+++ b/packages/lexical-playground/src/commenting/index.ts
@@ -8,10 +8,9 @@
 
 import type {LexicalEditor} from 'lexical';
 
-import {TOGGLE_CONNECT_COMMAND} from '@lexical/yjs';
+import {Provider, TOGGLE_CONNECT_COMMAND} from '@lexical/yjs';
 import {COMMAND_PRIORITY_LOW} from 'lexical';
 import {useEffect, useState} from 'react';
-import {WebsocketProvider} from 'y-websocket';
 import {
   Array as YArray,
   Map as YMap,
@@ -106,7 +105,7 @@ export class CommentStore {
   _editor: LexicalEditor;
   _comments: Comments;
   _changeListeners: Set<() => void>;
-  _collabProvider: null | WebsocketProvider;
+  _collabProvider: null | Provider;
 
   constructor(editor: LexicalEditor) {
     this._comments = [];
@@ -283,7 +282,7 @@ export class CommentStore {
     return sharedMap;
   }
 
-  registerCollaboration(provider: WebsocketProvider): () => void {
+  registerCollaboration(provider: Provider): () => void {
     this._collabProvider = provider;
     const sharedCommentsArray = this._getCollabComments();
 

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import type {Provider} from '@lexical/yjs';
 import type {
   EditorState,
   LexicalCommand,
@@ -50,7 +51,6 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import * as React from 'react';
 import {createPortal} from 'react-dom';
 import useLayoutEffect from 'shared/useLayoutEffect';
-import {WebsocketProvider} from 'y-websocket';
 
 import {
   Comment,
@@ -700,10 +700,7 @@ function useCollabAuthorName(): string {
 export default function CommentPlugin({
   providerFactory,
 }: {
-  providerFactory?: (
-    id: string,
-    yjsDocMap: Map<string, Doc>,
-  ) => WebsocketProvider;
+  providerFactory?: (id: string, yjsDocMap: Map<string, Doc>) => Provider;
 }): JSX.Element {
   const collabContext = useCollaborationContext();
   const [editor] = useLexicalComposerContext();

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.ts
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.ts
@@ -10,8 +10,8 @@ import type {Doc} from 'yjs';
 
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {Provider} from '@lexical/yjs';
 import {useEffect, useMemo} from 'react';
-import {WebsocketProvider} from 'y-websocket';
 
 import {InitialEditorStateType} from './LexicalComposer';
 import {
@@ -35,7 +35,7 @@ export function CollaborationPlugin({
     // eslint-disable-next-line no-shadow
     id: string,
     yjsDocMap: Map<string, Doc>,
-  ) => WebsocketProvider;
+  ) => Provider;
   shouldBootstrap: boolean;
   username?: string;
   cursorColor?: string;

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import type {Binding} from '@lexical/yjs';
+import type {Binding, Provider} from '@lexical/yjs';
 import type {LexicalEditor} from 'lexical';
 
 import {mergeRegister} from '@lexical/utils';
@@ -34,7 +34,6 @@ import {
 import * as React from 'react';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
-import {WebsocketProvider} from 'y-websocket';
 import {Doc, Transaction, UndoManager, YEvent} from 'yjs';
 
 import {InitialEditorStateType} from '../LexicalComposer';
@@ -44,7 +43,7 @@ export type CursorsContainerRef = React.MutableRefObject<HTMLElement | null>;
 export function useYjsCollaboration(
   editor: LexicalEditor,
   id: string,
-  provider: WebsocketProvider,
+  provider: Provider,
   docMap: Map<string, Doc>,
   name: string,
   color: string,
@@ -222,7 +221,7 @@ export function useYjsCollaboration(
 
 export function useYjsFocusTracking(
   editor: LexicalEditor,
-  provider: WebsocketProvider,
+  provider: Provider,
   name: string,
   color: string,
 ) {

--- a/packages/lexical-yjs/src/Bindings.ts
+++ b/packages/lexical-yjs/src/Bindings.ts
@@ -15,9 +15,9 @@ import type {LexicalEditor, NodeKey} from 'lexical';
 import type {Doc} from 'yjs';
 
 import invariant from 'shared/invariant';
-import {WebsocketProvider} from 'y-websocket';
 import {XmlText} from 'yjs';
 
+import {Provider} from '.';
 import {$createCollabElementNode} from './CollabElementNode';
 
 export type ClientID = number;
@@ -42,7 +42,7 @@ export type Binding = {
 
 export function createBinding(
   editor: LexicalEditor,
-  provider: WebsocketProvider,
+  provider: Provider,
   id: string,
   doc: Doc | null | undefined,
   docMap: Map<string, Doc>,

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -26,13 +26,13 @@ import {
   $isRangeSelection,
   $isTextNode,
 } from 'lexical';
-import {WebsocketProvider} from 'y-websocket';
 import {
   compareRelativePositions,
   createAbsolutePositionFromRelativePosition,
   createRelativePositionFromTypeIndex,
 } from 'yjs';
 
+import {Provider} from '.';
 import {CollabDecoratorNode} from './CollabDecoratorNode';
 import {CollabElementNode} from './CollabElementNode';
 import {CollabLineBreakNode} from './CollabLineBreakNode';
@@ -302,7 +302,7 @@ function updateCursor(
 
 export function syncLocalCursorPosition(
   binding: Binding,
-  provider: WebsocketProvider,
+  provider: Provider,
 ): void {
   const awareness = provider.awareness;
   const localState = awareness.getLocalState();
@@ -403,7 +403,7 @@ function getCollabNodeAndOffset(
 
 export function syncCursorPositions(
   binding: Binding,
-  provider: WebsocketProvider,
+  provider: Provider,
 ): void {
   const awarenessStates = Array.from(provider.awareness.getStates());
   const localClientID = binding.clientID;
@@ -489,7 +489,7 @@ export function syncCursorPositions(
 
 export function syncLexicalSelectionToYjs(
   binding: Binding,
-  provider: WebsocketProvider,
+  provider: Provider,
   prevSelection: null | RangeSelection | NodeSelection | GridSelection,
   nextSelection: null | RangeSelection | NodeSelection | GridSelection,
 ): void {

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -19,10 +19,9 @@ import {
   $setSelection,
 } from 'lexical';
 import invariant from 'shared/invariant';
-import {WebsocketProvider} from 'y-websocket';
 import {Text as YText, YEvent, YMapEvent, YTextEvent, YXmlEvent} from 'yjs';
 
-import {Binding} from '.';
+import {Binding, Provider} from '.';
 import {CollabDecoratorNode} from './CollabDecoratorNode';
 import {CollabElementNode} from './CollabElementNode';
 import {CollabTextNode} from './CollabTextNode';
@@ -82,7 +81,7 @@ function syncEvent(binding: Binding, event: any): void {
 
 export function syncYjsChangesToLexical(
   binding: Binding,
-  provider: WebsocketProvider,
+  provider: Provider,
   events: Array<YEvent<YText>>,
   isFromUndoManger: boolean,
 ): void {
@@ -218,7 +217,7 @@ type IntentionallyMarkedAsDirtyElement = boolean;
 
 export function syncLexicalUpdateToYjs(
   binding: Binding,
-  provider: WebsocketProvider,
+  provider: Provider,
   prevEditorState: EditorState,
   currEditorState: EditorState,
   dirtyElements: Map<NodeKey, IntentionallyMarkedAsDirtyElement>,

--- a/packages/lexical-yjs/src/index.ts
+++ b/packages/lexical-yjs/src/index.ts
@@ -9,7 +9,6 @@
 
 import type {Binding} from './Bindings';
 import type {LexicalCommand} from 'lexical';
-import type {WebsocketProvider} from 'y-websocket';
 import type {Doc, RelativePosition, UndoManager, XmlText} from 'yjs';
 
 import {createCommand} from 'lexical';
@@ -70,7 +69,7 @@ export function createUndoManager(
 }
 
 export function initLocalState(
-  provider: WebsocketProvider,
+  provider: Provider,
   name: string,
   color: string,
   focusing: boolean,
@@ -85,7 +84,7 @@ export function initLocalState(
 }
 
 export function setLocalStateFocus(
-  provider: WebsocketProvider,
+  provider: Provider,
   name: string,
   color: string,
   focusing: boolean,


### PR DESCRIPTION
We always use `WebsocketProvider` as an example, but are not tied to this specific implementation and it also creates confusion for users as they assume collab provider works only with WS (#3085)