### PR TITLE
Listen to Collapsible Section toggle event

### DIFF
--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -91,7 +91,7 @@ export class CollapsibleContainerNode extends ElementNode {
 
   exportDOM(): DOMExportOutput {
     const element = document.createElement('details');
-    element.open = this.__open;
+    element.setAttribute('open', this.__open.toString());
     return {element};
   }
 

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -12,6 +12,7 @@ import {
   DOMExportOutput,
   EditorConfig,
   ElementNode,
+  LexicalEditor,
   LexicalNode,
   NodeKey,
   SerializedElementNode,
@@ -53,10 +54,16 @@ export class CollapsibleContainerNode extends ElementNode {
     return new CollapsibleContainerNode(node.__open, node.__key);
   }
 
-  createDOM(config: EditorConfig): HTMLElement {
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     const dom = document.createElement('details');
     dom.classList.add('Collapsible__container');
     dom.open = this.__open;
+    dom.addEventListener('toggle', () => {
+      const open = editor.getEditorState().read(() => this.getOpen());
+      if (open !== dom.open) {
+        editor.update(() => this.toggleOpen());
+      }
+    });
     return dom;
   }
 
@@ -110,7 +117,7 @@ export class CollapsibleContainerNode extends ElementNode {
   }
 
   getOpen(): boolean {
-    return this.__open;
+    return this.getLatest().__open;
   }
 
   toggleOpen(): void {

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
@@ -12,6 +12,7 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
   $createParagraphNode,
+  $getNearestNodeFromDOMNode,
   $getNodeByKey,
   $getPreviousSelection,
   $getSelection,
@@ -49,6 +50,24 @@ export const TOGGLE_COLLAPSIBLE_COMMAND = createCommand<NodeKey>();
 
 export default function CollapsiblePlugin(): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    const toggleArrowClick = (event: Event) => {
+      const domNode = event.target as HTMLElement;
+      if (editor !== null && editor.isEditable()) {
+        editor.update(() => {
+          const node = $getNearestNodeFromDOMNode(domNode);
+          if ($isCollapsibleContainerNode(node)) {
+            node.toggleOpen();
+          }
+        });
+      }
+    };
+
+    window.addEventListener('toggle', toggleArrowClick, true);
+    return () => window.removeEventListener('toggle', toggleArrowClick, true);
+  }, [editor]);
+
   useEffect(() => {
     if (
       !editor.hasNodes([

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
@@ -12,7 +12,6 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
   $createParagraphNode,
-  $getNearestNodeFromDOMNode,
   $getNodeByKey,
   $getPreviousSelection,
   $getSelection,
@@ -50,23 +49,6 @@ export const TOGGLE_COLLAPSIBLE_COMMAND = createCommand<NodeKey>();
 
 export default function CollapsiblePlugin(): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
-
-  useEffect(() => {
-    const toggleArrowClick = (event: Event) => {
-      const domNode = event.target as HTMLElement;
-      if (editor !== null && editor.isEditable()) {
-        editor.update(() => {
-          const node = $getNearestNodeFromDOMNode(domNode);
-          if ($isCollapsibleContainerNode(node)) {
-            node.toggleOpen();
-          }
-        });
-      }
-    };
-
-    window.addEventListener('toggle', toggleArrowClick, true);
-    return () => window.removeEventListener('toggle', toggleArrowClick, true);
-  }, [editor]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
Fixes: #3906 

Before:
![before](https://user-images.githubusercontent.com/7893468/221435355-acae3d61-bd2a-4f5a-aa5a-0ac27d2f77e7.gif)

After:
![after](https://user-images.githubusercontent.com/7893468/221435356-689d45d6-a79b-4f88-aa8a-8d3665d105b6.gif)

Need assistance, to understand what's wrong with the definition of the useEffect that triggers this constant re-render until the first click. Secondly, is listening on window the right approach here or should I be using a rootListener? Thanks.