### PR TITLE
Bugfix: typing a hashtag at the end of a line in a new style inserts keystrokes in the wrong order

### DIFF
--- a/packages/lexical-text/src/index.ts
+++ b/packages/lexical-text/src/index.ts
@@ -193,7 +193,6 @@ export function registerLexicalTextEntity<T extends TextNode>(
           if (diff > 0) {
             const concatText = text.slice(0, diff);
             const newTextContent = previousText + concatText;
-            prevSibling.select();
             prevSibling.setTextContent(newTextContent);
 
             if (diff === text.length) {

--- a/packages/lexical-text/src/index.ts
+++ b/packages/lexical-text/src/index.ts
@@ -194,7 +194,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
             const concatText = text.slice(0, diff);
             const newTextContent = previousText + concatText;
             prevSibling.setTextContent(newTextContent);
-
+            prevSibling.select();
             if (diff === text.length) {
               node.remove();
             } else {


### PR DESCRIPTION
bug is described in this issue : #3965 
### New behaviour :

https://user-images.githubusercontent.com/67844770/221477063-f4468b28-30cc-484a-ab69-42de0ab9744e.mov


