### PR TITLE
extend type for SerializedElementNode

### DIFF
--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -39,7 +39,7 @@ import {
 
 export type SerializedElementNode = Spread<
   {
-    children: Array<SerializedLexicalNode>;
+    children: Array<SerializedLexicalNode & Record<string, unknown>>;
     direction: 'ltr' | 'rtl' | null;
     format: ElementFormatType;
     indent: number;


### PR DESCRIPTION
There can be use cases when you need to create an object of the type `SerializedEditorState`

```js
ort const serializedEditorState: SerializedEditorState = {
  root: {
    children: [
      {
        children: [{ text: 'test', type: 'text', version: 1 }],
        format: '',
        type: 'paragraph',
        version: 1,
      },
    ],
    direction: 'ltr',
    format: '',
    indent: 0,
    type: 'root',
    version: 1,
  },
};
```

```
Type '{ children: { text: string; type: string; version: number; }[]; format: string; type: string; version: number; }' is not assignable to type 'SerializedLexicalNode'.
  Object literal may only specify known properties, and 'children' does not exist in type 'SerializedLexicalNode'
```

---

An alternative solution is to always create `serializedEditorState` with an instance of the lexical editor.

But still looks like that type for `SerializedElementNode.children` should extend `SerializedLexicalNode`.