### PR TITLE
Doc: initial execution of listener function

### DIFF
--- a/packages/lexical-website/docs/concepts/listeners.md
+++ b/packages/lexical-website/docs/concepts/listeners.md
@@ -134,7 +134,7 @@ removeDecoratorListener();
 ## `registerRootListener`
 
 Get notified when the editor's root DOM element (the content editable Lexical attaches to) changes. This is primarily used to
-attach event listeners to the root element.
+attach event listeners to the root element. *The root listener function is executed directly upon registration and then on any subsequent update.*
 
 ```js
 const removeRootListener = editor.registerRootListener(


### PR DESCRIPTION
Updating the documentation to state that the root listener function is executed directly upon registration (see [implementation](https://github.com/facebook/lexical/blob/924b729deaab492736badd72089ef9831f00568e/packages/lexical/src/LexicalEditor.ts#L610)), as this  is unexpected behaviour for event listeners.