### PR TITLE
Adjust playground CSS to fix vertical resize being disabled in select scenarios

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -78,7 +78,6 @@ header h1 {
   border: 0;
   resize: none;
   cursor: text;
-  display: flex;
   position: relative;
   outline: 0;
   overflow: auto;
@@ -1102,7 +1101,7 @@ i.prettier-error {
 .actions {
   position: absolute;
   text-align: right;
-  padding: 10px;
+  margin: 10px;
   bottom: 0;
   right: 0;
 }

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -78,8 +78,10 @@ header h1 {
   border: 0;
   resize: none;
   cursor: text;
+  display: flex;
   position: relative;
   outline: 0;
+  z-index: 0;
   overflow: auto;
   resize: vertical;
 }


### PR DESCRIPTION
It looks to me like these elements are covering the grabber or disallowing you to resize again after some initial resizing. It's odd how the resize tends to work initially, and then breaks usually after the introduction or exit of the scrollbar. 

Moving the actions to margin creates a small gap, and applying any sort of z-index seems to raise it to the top such that the flex editor underneath isn't interfering. Another alternative is to not use flex and do something like height 98% to leave a small gap... but then we can't utilize the full real estate.

A z-index above 0 can lead to odd behavior between the action buttons and text in the editor. Hopefully this approach plays nice with other nodes / plugins.

**Current Behavior (without fixes):**

https://user-images.githubusercontent.com/29527680/221933432-64bfd12e-4a18-4621-8c78-e95ab8d7b29d.mov

**Behavior w/ ONLY margin fix on actions:**

https://user-images.githubusercontent.com/29527680/221933731-4788218a-7ba9-48a9-9fdc-3e708866d9e2.mov

**Behavior w/ ONLY z-index addition on editor-scroller:**

https://user-images.githubusercontent.com/29527680/221940837-7a2fc199-03ef-4074-b727-7bb64d8f8c59.mov

**Behavior After Changes:**

https://user-images.githubusercontent.com/29527680/221938275-a5a42d11-9794-4e3c-bd8d-fa00a164cf0d.mov




