### PR TITLE
Nested composers should initialize with parent editor editable state

### DIFF
--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -79,7 +79,10 @@ export function LexicalNestedComposer({
           });
         }
       }
+
       initialEditor._config.namespace = parentEditor._config.namespace;
+
+      initialEditor._editable = parentEditor._editable;
 
       return [initialEditor, context];
     },


### PR DESCRIPTION
We update editable state of nested composer on parent editor `editable` change [here](https://github.com/facebook/lexical/blob/main/packages/lexical-react/src/LexicalNestedComposer.tsx#L106-L111). These values should also be consistent on initialization.

Closes #3995