### PR TITLE
Fix Chrome beforeinput race condition on large docs

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -12,7 +12,6 @@ import type {LexicalNode, NodeKey} from './LexicalNode';
 import type {ElementNode} from './nodes/LexicalElementNode';
 import type {TextFormatType} from './nodes/LexicalTextNode';
 
-import {IS_CHROME} from 'shared/environment';
 import invariant from 'shared/invariant';
 
 import {
@@ -2941,30 +2940,12 @@ export function updateDOMSelection(
   // Apply the updated selection to the DOM. Note: this will trigger
   // a "selectionchange" event, although it will be asynchronous.
   try {
-    // When updating more than 1000 nodes on Chrome, it's actually better to defer
-    // updating the selection till the next frame. This is because Chrome's
-    // Blink engine has hard limit on how many DOM nodes it can redraw in
-    // a single cycle, so keeping it to the next frame improves performance.
-    // The downside is that is makes the computation within Lexical more
-    // complex, as now, we've sync update the DOM, but selection no longer
-    // matches.
-    if (IS_CHROME && nodeCount > 1000) {
-      window.requestAnimationFrame(() =>
-        domSelection.setBaseAndExtent(
-          nextAnchorNode as Node,
-          nextAnchorOffset,
-          nextFocusNode as Node,
-          nextFocusOffset,
-        ),
-      );
-    } else {
-      domSelection.setBaseAndExtent(
-        nextAnchorNode,
-        nextAnchorOffset,
-        nextFocusNode,
-        nextFocusOffset,
-      );
-    }
+    domSelection.setBaseAndExtent(
+      nextAnchorNode,
+      nextAnchorOffset,
+      nextFocusNode,
+      nextFocusOffset,
+    );
   } catch (error) {
     // If we encounter an error, continue. This can sometimes
     // occur with FF and there's no good reason as to why it


### PR DESCRIPTION
The Chrome selection performance optimization in #3478 will never play well with non-controlled beforeinput events that do not understand Lexical and it's nearly impossible to properly handle with controlled.

**Why?**

Beforeinput consists of two mechanisms: the data itself and the range. Range is computed by the browser based on the type of the event (i.e. text input or Mac character replacement) and the current DOM selection.

When we defer we selection, we are lying to the browser sharing the wrong insertion coordinates.

For non-controlled that's impossible to fix because the point of non-controlled operation is that we don't interfere, for controlled it's nearly impossible because we can't predict with accuracy what the browser would've done wih a correct selection. We know that for most cases selection should shift to the next position by one (a single character insertion) but this heuristic would be very flaky.

**Even if we landed the fix**

It's unlikely to have huge impact on performance. The common case is non-controlled mode, most controlled operations tend to be just fine with some additional ms latency.

Closes #4015

Race condition goes away 

https://user-images.githubusercontent.com/193447/222573885-52cb248a-e7f4-4c0c-a037-7ff9ba251d3e.mov

