### PR TITLE
Fix insertNode insertion for inline Elements inside empty Elements

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -18,6 +18,7 @@ import {
   $getNodeByKey,
   $getRoot,
   $getSelection,
+  $insertNodes,
   $isNodeSelection,
   $isRangeSelection,
   RangeSelection,
@@ -2516,6 +2517,45 @@ describe('LexicalSelectionHelpers tests', () => {
           '<p dir="ltr"><a href="https://" dir="ltr"><span data-lexical-text="true">link</span></a><span data-lexical-text="true">foo</span></p>',
         );
       });
+    });
+
+    test('Can insert link into empty paragraph', async () => {
+      const editor = createTestEditor();
+      const element = document.createElement('div');
+      editor.setRootElement(element);
+
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
+        const linkNode = $createLinkNode('https://lexical.dev');
+        const linkTextNode = $createTextNode('Lexical');
+        linkNode.append(linkTextNode);
+        $insertNodes([linkNode]);
+      });
+      expect(element.innerHTML).toBe(
+        '<p><a href="https://lexical.dev" dir="ltr"><span data-lexical-text="true">Lexical</span></a></p>',
+      );
+    });
+
+    test('Can insert link into empty paragraph (2)', async () => {
+      const editor = createTestEditor();
+      const element = document.createElement('div');
+      editor.setRootElement(element);
+
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
+        const linkNode = $createLinkNode('https://lexical.dev');
+        const linkTextNode = $createTextNode('Lexical');
+        linkNode.append(linkTextNode);
+        const textNode2 = $createTextNode('...');
+        $insertNodes([linkNode, textNode2]);
+      });
+      expect(element.innerHTML).toBe(
+        '<p><a href="https://lexical.dev" dir="ltr"><span data-lexical-text="true">Lexical</span></a><span data-lexical-text="true">...</span></p>',
+      );
     });
   });
 });

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1467,6 +1467,9 @@ export class RangeSelection implements BaseSelection {
               target.append(node);
             }
             target = node;
+          } else if (node.isInline()) {
+            target.append(node);
+            target = node;
           } else {
             target = target.insertAfter(node, false);
           }


### PR DESCRIPTION
This branch was never handled by `insertNodes` and these Elements were treated like non-inline. Hence, being inserted after the `target`.

Closes #4017