### PR TITLE
Improved link editor UX

### DIFF
--- a/packages/lexical-playground/src/appSettings.ts
+++ b/packages/lexical-playground/src/appSettings.ts
@@ -18,6 +18,7 @@ export type SettingName =
   | 'showTreeView'
   | 'showNestedEditorTreeView'
   | 'emptyEditor'
+  | 'enableLinkPreviews'
   | 'showTableOfContents';
 
 export type Settings = Record<SettingName, boolean>;
@@ -30,6 +31,7 @@ export const isDevPlayground: boolean =
 export const DEFAULT_SETTINGS: Settings = {
   disableBeforeInput: false,
   emptyEditor: isDevPlayground,
+  enableLinkPreviews: false,
   isAutocomplete: false,
   isCharLimit: false,
   isCharLimitUtf8: false,

--- a/packages/lexical-playground/src/images/icons/success-alt.svg
+++ b/packages/lexical-playground/src/images/icons/success-alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50"><circle cx="25" cy="25" r="25" fill="#000"/><path fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M38 15 22 33l-10-8"/></svg>

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -559,12 +559,26 @@ i.prettier-error {
 
 .link-editor .link-input {
   display: block;
-  width: calc(100% - 24px);
+  width: calc(100% - 75px);
   box-sizing: border-box;
-  margin: 8px 12px;
+  margin: 12px 12px;
   padding: 8px 12px;
   border-radius: 15px;
   background-color: #eee;
+  font-size: 15px;
+  color: rgb(5, 5, 5);
+  border: 0;
+  outline: 0;
+  position: relative;
+  font-family: inherit;
+}
+
+.link-editor .link-view {
+  display: block;
+  width: calc(100% - 24px);
+  margin: 8px 12px;
+  padding: 8px 12px;
+  border-radius: 15px;
   font-size: 15px;
   color: rgb(5, 5, 5);
   border: 0;
@@ -587,10 +601,39 @@ i.prettier-error {
   cursor: pointer;
 }
 
+.link-editor div.link-cancel {
+  background-image: url(images/icons/close.svg);
+  background-size: 16px;
+  background-position: center;
+  background-repeat: no-repeat;
+  width: 35px;
+  vertical-align: -0.25em;
+  margin-right: 28px;
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  cursor: pointer;
+}
+
+.link-editor div.link-confirm {
+  background-image: url(images/icons/success-alt.svg);
+  background-size: 16px;
+  background-position: center;
+  background-repeat: no-repeat;
+  width: 35px;
+  vertical-align: -0.25em;
+  margin-right: 2px;
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  cursor: pointer;
+}
+
 .link-editor .link-input a {
   color: rgb(33, 111, 219);
-  text-decoration: none;
-  display: block;
+  text-decoration: underline;
   white-space: nowrap;
   overflow: hidden;
   margin-right: 30px;
@@ -612,6 +655,10 @@ i.prettier-error {
   border: none;
   background-color: rgba(0, 0, 0, 0.075);
   border-radius: 4px;
+}
+
+.ContentEditable__root .PlaygroundEditorTheme__link {
+  pointer-events: none;
 }
 
 .mention:focus {

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.css
@@ -1,4 +1,5 @@
 .link-editor {
+  display: flex;
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -27,6 +27,7 @@ import {Dispatch, useCallback, useEffect, useRef, useState} from 'react';
 import * as React from 'react';
 import {createPortal} from 'react-dom';
 
+import {useSettings} from '../../context/SettingsContext';
 import LinkPreview from '../../ui/LinkPreview';
 import {getSelectedNode} from '../../utils/getSelectedNode';
 import {setFloatingElemPosition} from '../../utils/setFloatingElemPosition';
@@ -43,6 +44,9 @@ function FloatingLinkEditor({
   setIsLink: Dispatch<boolean>;
   anchorElem: HTMLElement;
 }): JSX.Element {
+  const {
+    settings: {enableLinkPreviews},
+  } = useSettings();
   const editorRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [linkUrl, setLinkUrl] = useState('');
@@ -270,7 +274,7 @@ function FloatingLinkEditor({
               }}
             />
           </div>
-          <LinkPreview url={linkUrl} />
+          {enableLinkPreviews ? <LinkPreview url={linkUrl} /> : ''}
         </>
       )}
     </div>

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -197,7 +197,9 @@ function FloatingLinkEditor({
     }
   }, [isEditMode]);
 
-  const monitorInputInteraction = (event) => {
+  const monitorInputInteraction = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
     if (event.key === 'Enter') {
       event.preventDefault();
       handleLinkSubmission();

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -46,6 +46,7 @@ function FloatingLinkEditor({
   const editorRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [linkUrl, setLinkUrl] = useState('');
+  const [editedLinkUrl, setEditedLinkUrl] = useState('');
   const [isEditMode, setEditMode] = useState(false);
   const [lastSelection, setLastSelection] = useState<
     RangeSelection | GridSelection | NodeSelection | null
@@ -196,34 +197,63 @@ function FloatingLinkEditor({
     }
   }, [isEditMode]);
 
+  const monitorInputInteraction = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleLinkSubmission();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      setEditMode(false);
+    }
+  };
+
+  const handleLinkSubmission = () => {
+    if (lastSelection !== null) {
+      if (linkUrl !== '') {
+        editor.dispatchCommand(TOGGLE_LINK_COMMAND, sanitizeUrl(editedLinkUrl));
+      }
+      setEditMode(false);
+    }
+  };
+
   return (
     <div ref={editorRef} className="link-editor">
       {!isLink ? null : isEditMode ? (
-        <input
-          ref={inputRef}
-          className="link-input"
-          value={linkUrl}
-          onChange={(event) => {
-            setLinkUrl(event.target.value);
-          }}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter' || event.key === 'Escape') {
-              event.preventDefault();
-              if (lastSelection !== null) {
-                if (linkUrl !== '') {
-                  editor.dispatchCommand(
-                    TOGGLE_LINK_COMMAND,
-                    sanitizeUrl(linkUrl),
-                  );
-                }
+        <>
+          <input
+            ref={inputRef}
+            className="link-input"
+            value={editedLinkUrl}
+            onChange={(event) => {
+              setEditedLinkUrl(event.target.value);
+            }}
+            onKeyDown={(event) => {
+              monitorInputInteraction(event);
+            }}
+          />
+          <div>
+            <div
+              className="link-cancel"
+              role="button"
+              tabIndex={0}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => {
                 setEditMode(false);
-              }
-            }
-          }}
-        />
+              }}
+            />
+
+            <div
+              className="link-confirm"
+              role="button"
+              tabIndex={0}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={handleLinkSubmission}
+            />
+          </div>
+        </>
       ) : (
         <>
-          <div className="link-input">
+          <div className="link-view">
             <a href={linkUrl} target="_blank" rel="noopener noreferrer">
               {linkUrl}
             </a>
@@ -233,6 +263,7 @@ function FloatingLinkEditor({
               tabIndex={0}
               onMouseDown={(event) => event.preventDefault()}
               onClick={() => {
+                setEditedLinkUrl(linkUrl);
                 setEditMode(true);
               }}
             />


### PR DESCRIPTION
**Summary of Changes:**

- Toggling editMode results in less jarring transition by attempting to reconcile height differences between elements.
- Reduced link-input width to allow for new buttons controlling submission and cancellation (in addition to keyboard commands).
- Escape key now exits without saving the link changes, Enter continues to submit.
- Disabled the ability to open the link when in the editor. Prior to this you could accidentally open the link when trying to move your cursor on the text by clicking. You can still click the link from the link-editor itself to test it. The link will still become clickable if you try to export it elsewhere because this only applies to things nested under ContentEditable__root.
- link-editor is flex.
- Split the state of linkUrl to not immediately register the changes until a submit event.
- Created new functions to handle key presses and submission.
- Removed background highlighting for initial view. This implied it was a clickable area, but usually resulted in you accidentally opening the link.
- New app settings to disable LinkPreview by default

<hr/>

_LinkPreview_

Because LinkPreview is not completely configured in the Playground and uses a Suspense it causes weird visual glitches as the component changes dimensions for a brief moment until deciding preview is null and it should not display anything. The setting to disable LinkPreview from attempting to render when it will 404 (because there's no endpoint) should avoid this issue.

<hr/>

**Demo:**

https://user-images.githubusercontent.com/29527680/222849931-51c5e8fd-826b-4451-ab46-3e58d3abdaab.mov

**Issues:**

This problem is prior to my current changes. Removing this code fixes it, but might reintroduce the original problem.

#4013: You cannot click and drag to highlight text anymore @LuciNyan 

```
useEffect(() => {
    function mouseMoveListener(e: MouseEvent) {
      if (editorRef?.current && (e.buttons === 1 || e.buttons === 3)) {
        editorRef.current.style.pointerEvents = 'none';
      }
    }
    function mouseUpListener(e: MouseEvent) {
      if (editorRef?.current) {
        editorRef.current.style.pointerEvents = 'auto';
      }
    }

    if (editorRef?.current) {
      document.addEventListener('mousemove', mouseMoveListener);
      document.addEventListener('mouseup', mouseUpListener);

      return () => {
        document.removeEventListener('mousemove', mouseMoveListener);
        document.removeEventListener('mouseup', mouseUpListener);
      };
    }
  }, [editorRef]);
```

