### PR TITLE
Prevent creation of malformed ordered lists

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -258,7 +258,7 @@ export const ORDERED_LIST: ElementTransformer = {
   export: (node, exportChildren) => {
     return $isListNode(node) ? listExport(node, exportChildren, 0) : null;
   },
-  regExp: /^(\s*)(\d{1,})\.\s/,
+  regExp: /^(\s*)1\.\s/,
   replace: listReplace('number'),
   type: 'element',
 };


### PR DESCRIPTION
The existing regex for ordered lists matches on any numeric number, which then triggers parsing errors when attempting to parse the generated editor state JSON.