### PR TITLE
After removing a ListItemNode, merge its siblings.

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -41,8 +41,10 @@ import {$createListNode, $isListNode} from './';
 import {
   $handleIndent,
   $handleOutdent,
+  mergeLists,
   updateChildrenListItemValue,
 } from './formatList';
+import {isNestedListNode} from './utils';
 
 export type SerializedListItemNode = Spread<
   {
@@ -243,10 +245,19 @@ export class ListItemNode extends ElementNode {
   }
 
   remove(preserveEmptyParent?: boolean): void {
+    const prevSibling = this.getPreviousSibling();
     const nextSibling = this.getNextSibling();
     super.remove(preserveEmptyParent);
 
-    if (nextSibling !== null) {
+    if (
+      prevSibling &&
+      nextSibling &&
+      isNestedListNode(prevSibling) &&
+      isNestedListNode(nextSibling)
+    ) {
+      mergeLists(prevSibling.getFirstChild(), nextSibling.getFirstChild());
+      nextSibling.remove();
+    } else if (nextSibling) {
       const parent = nextSibling.getParent();
 
       if ($isListNode(parent)) {

--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
@@ -15,6 +15,7 @@ import {
   ListItemNode,
   ListNode,
 } from '../..';
+import {expectHtmlToBeEqual, html} from '../utils';
 
 const editorConfig = Object.freeze({
   namespace: '',
@@ -27,10 +28,6 @@ const editorConfig = Object.freeze({
     },
   },
 });
-
-function stripLineBreaks(str: string): string {
-  return str.replace(/\n\s+/g, '');
-}
 
 describe('LexicalListItemNode tests', () => {
   initializeUnitTest((testEnv) => {
@@ -266,9 +263,13 @@ describe('LexicalListItemNode tests', () => {
           root.append(parent);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1" dir="ltr">
                   <span data-lexical-text="true">A</span>
@@ -281,14 +282,18 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
 
         await editor.update(() => x.remove());
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1" dir="ltr">
                   <span data-lexical-text="true">A</span>
@@ -298,7 +303,7 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
       });
 
@@ -330,9 +335,13 @@ describe('LexicalListItemNode tests', () => {
           root.append(parent);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1">
                   <ul>
@@ -349,14 +358,18 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
 
         await editor.update(() => x.remove());
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1">
                   <ul>
@@ -370,7 +383,7 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
       });
 
@@ -402,9 +415,13 @@ describe('LexicalListItemNode tests', () => {
           root.append(parent);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1" dir="ltr">
                   <span data-lexical-text="true">A</span>
@@ -421,14 +438,18 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
 
         await editor.update(() => x.remove());
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1" dir="ltr">
                   <span data-lexical-text="true">A</span>
@@ -442,7 +463,7 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
       });
 
@@ -478,9 +499,13 @@ describe('LexicalListItemNode tests', () => {
           root.append(parent);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1">
                   <ul>
@@ -501,14 +526,18 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
 
         await editor.update(() => x.remove());
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1">
                   <ul>
@@ -522,7 +551,7 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
       });
 
@@ -566,9 +595,13 @@ describe('LexicalListItemNode tests', () => {
           root.append(parent);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1">
                   <ul>
@@ -596,14 +629,18 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
 
         await editor.update(() => x.remove());
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1">
                   <ul>
@@ -624,7 +661,7 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
       });
 
@@ -668,9 +705,13 @@ describe('LexicalListItemNode tests', () => {
           root.append(parent);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1">
                   <ul>
@@ -698,14 +739,18 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
 
         await editor.update(() => x.remove());
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1">
                   <ul>
@@ -726,7 +771,7 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
       });
 
@@ -778,9 +823,13 @@ describe('LexicalListItemNode tests', () => {
           root.append(parent);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1">
                   <ul>
@@ -815,14 +864,18 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
 
         await editor.update(() => x.remove());
 
-        expect(testEnv.outerHTML).toBe(
-          stripLineBreaks(`
-            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
               <ul>
                 <li value="1">
                   <ul>
@@ -846,7 +899,7 @@ describe('LexicalListItemNode tests', () => {
                 </li>
               </ul>
             </div>
-          `),
+          `,
         );
       });
     });

--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
@@ -51,16 +51,22 @@ describe('LexicalListItemNode tests', () => {
       await editor.update(() => {
         const listItemNode = new ListItemNode();
 
-        expect(listItemNode.createDOM(editorConfig).outerHTML).toBe(
-          '<li value="1" class="my-listItem-item-class"></li>',
+        expectHtmlToBeEqual(
+          listItemNode.createDOM(editorConfig).outerHTML,
+          html`
+            <li value="1" class="my-listItem-item-class"></li>
+          `,
         );
 
-        expect(
+        expectHtmlToBeEqual(
           listItemNode.createDOM({
             namespace: '',
             theme: {},
           }).outerHTML,
-        ).toBe('<li value="1"></li>');
+          html`
+            <li value="1"></li>
+          `,
+        );
       });
     });
 
@@ -73,8 +79,11 @@ describe('LexicalListItemNode tests', () => {
 
           const domElement = listItemNode.createDOM(editorConfig);
 
-          expect(domElement.outerHTML).toBe(
-            '<li value="1" class="my-listItem-item-class"></li>',
+          expectHtmlToBeEqual(
+            domElement.outerHTML,
+            html`
+              <li value="1" class="my-listItem-item-class"></li>
+            `,
           );
           const newListItemNode = new ListItemNode();
 
@@ -86,8 +95,11 @@ describe('LexicalListItemNode tests', () => {
 
           expect(result).toBe(false);
 
-          expect(domElement.outerHTML).toBe(
-            '<li value="1" class="my-listItem-item-class"></li>',
+          expectHtmlToBeEqual(
+            domElement.outerHTML,
+            html`
+              <li value="1" class="my-listItem-item-class"></li>
+            `,
           );
         });
       });
@@ -102,8 +114,11 @@ describe('LexicalListItemNode tests', () => {
           parentListNode.append(parentlistItemNode);
           const domElement = parentlistItemNode.createDOM(editorConfig);
 
-          expect(domElement.outerHTML).toBe(
-            '<li value="1" class="my-listItem-item-class"></li>',
+          expectHtmlToBeEqual(
+            domElement.outerHTML,
+            html`
+              <li value="1" class="my-listItem-item-class"></li>
+            `,
           );
           const nestedListNode = new ListNode('bullet', 1);
           nestedListNode.append(new ListItemNode());
@@ -116,8 +131,13 @@ describe('LexicalListItemNode tests', () => {
 
           expect(result).toBe(false);
 
-          expect(domElement.outerHTML).toBe(
-            '<li value="1" class="my-listItem-item-class my-nested-list-listItem-class"></li>',
+          expectHtmlToBeEqual(
+            domElement.outerHTML,
+            html`
+              <li
+                value="1"
+                class="my-listItem-item-class my-nested-list-listItem-class"></li>
+            `,
           );
         });
       });
@@ -148,8 +168,26 @@ describe('LexicalListItemNode tests', () => {
           listNode.append(listItemNode1, listItemNode2, listItemNode3);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" dir="ltr"><span data-lexical-text="true">three</span></li></ul></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">one</span>
+                </li>
+                <li value="2" dir="ltr">
+                  <span data-lexical-text="true">two</span>
+                </li>
+                <li value="3" dir="ltr">
+                  <span data-lexical-text="true">three</span>
+                </li>
+              </ul>
+            </div>
+          `,
         );
       });
 
@@ -163,8 +201,26 @@ describe('LexicalListItemNode tests', () => {
           listItemNode1.replace(newListItemNode);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><ul><li value="1" dir="ltr"><span data-lexical-text="true">bar</span></li><li value="2" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" dir="ltr"><span data-lexical-text="true">three</span></li></ul></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">bar</span>
+                </li>
+                <li value="2" dir="ltr">
+                  <span data-lexical-text="true">two</span>
+                </li>
+                <li value="3" dir="ltr">
+                  <span data-lexical-text="true">three</span>
+                </li>
+              </ul>
+            </div>
+          `,
         );
       });
 
@@ -175,8 +231,26 @@ describe('LexicalListItemNode tests', () => {
           return;
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" dir="ltr"><span data-lexical-text="true">three</span></li></ul></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">one</span>
+                </li>
+                <li value="2" dir="ltr">
+                  <span data-lexical-text="true">two</span>
+                </li>
+                <li value="3" dir="ltr">
+                  <span data-lexical-text="true">three</span>
+                </li>
+              </ul>
+            </div>
+          `,
         );
 
         await editor.update(() => {
@@ -184,8 +258,24 @@ describe('LexicalListItemNode tests', () => {
           listItemNode1.replace(paragraphNode);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p><br></p><ul><li value="1" dir="ltr"><span data-lexical-text="true">two</span></li><li value="2" dir="ltr"><span data-lexical-text="true">three</span></li></ul></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <p><br /></p>
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">two</span>
+                </li>
+                <li value="2" dir="ltr">
+                  <span data-lexical-text="true">three</span>
+                </li>
+              </ul>
+            </div>
+          `,
         );
       });
 
@@ -197,8 +287,24 @@ describe('LexicalListItemNode tests', () => {
           listItemNode3.replace(paragraphNode);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" dir="ltr"><span data-lexical-text="true">two</span></li></ul><p><br></p></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">one</span>
+                </li>
+                <li value="2" dir="ltr">
+                  <span data-lexical-text="true">two</span>
+                </li>
+              </ul>
+              <p><br /></p>
+            </div>
+          `,
         );
       });
 
@@ -210,8 +316,26 @@ describe('LexicalListItemNode tests', () => {
           listItemNode2.replace(paragraphNode);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li></ul><p><br></p><ul><li value="1" dir="ltr"><span data-lexical-text="true">three</span></li></ul></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">one</span>
+                </li>
+              </ul>
+              <p><br /></p>
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">three</span>
+                </li>
+              </ul>
+            </div>
+          `,
         );
       });
 
@@ -223,8 +347,20 @@ describe('LexicalListItemNode tests', () => {
           listItemNode3.remove();
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li></ul></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">one</span>
+                </li>
+              </ul>
+            </div>
+          `,
         );
 
         await editor.update(() => {
@@ -232,8 +368,16 @@ describe('LexicalListItemNode tests', () => {
           listItemNode1.replace(paragraphNode);
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p><br></p></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <p><br /></p>
+            </div>
+          `,
         );
       });
     });
@@ -929,8 +1073,26 @@ describe('LexicalListItemNode tests', () => {
           listItemNode3.append(new TextNode('three'));
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" dir="ltr"><span data-lexical-text="true">three</span></li></ul></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">one</span>
+                </li>
+                <li value="2" dir="ltr">
+                  <span data-lexical-text="true">two</span>
+                </li>
+                <li value="3" dir="ltr">
+                  <span data-lexical-text="true">three</span>
+                </li>
+              </ul>
+            </div>
+          `,
         );
       });
 
@@ -941,8 +1103,27 @@ describe('LexicalListItemNode tests', () => {
           listItemNode1.insertNewAfter();
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2"><br></li><li value="3" dir="ltr"><span data-lexical-text="true">two</span></li><li value="4" dir="ltr"><span data-lexical-text="true">three</span></li></ul></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">one</span>
+                </li>
+                <li value="2"><br /></li>
+                <li value="3" dir="ltr">
+                  <span data-lexical-text="true">two</span>
+                </li>
+                <li value="4" dir="ltr">
+                  <span data-lexical-text="true">three</span>
+                </li>
+              </ul>
+            </div>
+          `,
         );
       });
 
@@ -953,8 +1134,27 @@ describe('LexicalListItemNode tests', () => {
           listItemNode3.insertNewAfter();
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4"><br></li></ul></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">one</span>
+                </li>
+                <li value="2" dir="ltr">
+                  <span data-lexical-text="true">two</span>
+                </li>
+                <li value="3" dir="ltr">
+                  <span data-lexical-text="true">three</span>
+                </li>
+                <li value="4"><br /></li>
+              </ul>
+            </div>
+          `,
         );
       });
 
@@ -965,8 +1165,27 @@ describe('LexicalListItemNode tests', () => {
           listItemNode3.insertNewAfter();
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" dir="ltr"><span data-lexical-text="true">two</span></li><li value="3" dir="ltr"><span data-lexical-text="true">three</span></li><li value="4"><br></li></ul></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">one</span>
+                </li>
+                <li value="2" dir="ltr">
+                  <span data-lexical-text="true">two</span>
+                </li>
+                <li value="3" dir="ltr">
+                  <span data-lexical-text="true">three</span>
+                </li>
+                <li value="4"><br /></li>
+              </ul>
+            </div>
+          `,
         );
       });
 
@@ -978,16 +1197,41 @@ describe('LexicalListItemNode tests', () => {
           listItemNode3.remove();
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li></ul></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">one</span>
+                </li>
+              </ul>
+            </div>
+          `,
         );
 
         await editor.update(() => {
           listItemNode1.insertNewAfter();
         });
 
-        expect(testEnv.outerHTML).toBe(
-          '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2"><br></li></ul></div>',
+        expectHtmlToBeEqual(
+          testEnv.outerHTML,
+          html`
+            <div
+              contenteditable="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word;"
+              data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">one</span>
+                </li>
+                <li value="2"><br /></li>
+              </ul>
+            </div>
+          `,
         );
       });
     });
@@ -1048,8 +1292,30 @@ describe('LexicalListItemNode tests', () => {
           expect(listItemNode1.getIndent()).toBe(3);
         });
 
-        expect(editor.getRootElement().innerHTML).toBe(
-          '<ul><li value="1"><ul><li value="1"><ul><li value="1"><ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li></ul></li></ul></li></ul></li><li value="1" dir="ltr"><span data-lexical-text="true">two</span></li></ul>',
+        expectHtmlToBeEqual(
+          editor.getRootElement().innerHTML,
+          html`
+            <ul>
+              <li value="1">
+                <ul>
+                  <li value="1">
+                    <ul>
+                      <li value="1">
+                        <ul>
+                          <li value="1" dir="ltr">
+                            <span data-lexical-text="true">one</span>
+                          </li>
+                        </ul>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+              <li value="1" dir="ltr">
+                <span data-lexical-text="true">two</span>
+              </li>
+            </ul>
+          `,
         );
 
         await editor.update(() => {
@@ -1060,8 +1326,18 @@ describe('LexicalListItemNode tests', () => {
           expect(listItemNode1.getIndent()).toBe(0);
         });
 
-        expect(editor.getRootElement().innerHTML).toBe(
-          '<ul><li value="1" dir="ltr"><span data-lexical-text="true">one</span></li><li value="2" dir="ltr"><span data-lexical-text="true">two</span></li></ul>',
+        expectHtmlToBeEqual(
+          editor.getRootElement().innerHTML,
+          html`
+            <ul>
+              <li value="1" dir="ltr">
+                <span data-lexical-text="true">one</span>
+              </li>
+              <li value="2" dir="ltr">
+                <span data-lexical-text="true">two</span>
+              </li>
+            </ul>
+          `,
         );
       });
     });

--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
@@ -28,6 +28,10 @@ const editorConfig = Object.freeze({
   },
 });
 
+function stripLineBreaks(str: string): string {
+  return str.replace(/\n\s+/g, '');
+}
+
 describe('LexicalListItemNode tests', () => {
   initializeUnitTest((testEnv) => {
     test('ListItemNode.constructor', async () => {
@@ -233,6 +237,616 @@ describe('LexicalListItemNode tests', () => {
 
         expect(testEnv.outerHTML).toBe(
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p><br></p></div>',
+        );
+      });
+    });
+
+    describe('ListItemNode.remove()', () => {
+      // - A
+      // - x
+      // - B
+      test('siblings are not nested', async () => {
+        const {editor} = testEnv;
+        let x;
+
+        await editor.update(() => {
+          const root = $getRoot();
+          const parent = new ListNode('bullet', 1);
+
+          const A_listItem = new ListItemNode();
+          A_listItem.append(new TextNode('A'));
+
+          x = new ListItemNode();
+          x.append(new TextNode('x'));
+
+          const B_listItem = new ListItemNode();
+          B_listItem.append(new TextNode('B'));
+
+          parent.append(A_listItem, x, B_listItem);
+          root.append(parent);
+        });
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">A</span>
+                </li>
+                <li value="2" dir="ltr">
+                  <span data-lexical-text="true">x</span>
+                </li>
+                <li value="3" dir="ltr">
+                  <span data-lexical-text="true">B</span>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+
+        await editor.update(() => x.remove());
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">A</span>
+                </li>
+                <li value="2" dir="ltr">
+                  <span data-lexical-text="true">B</span>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+      });
+
+      //   - A
+      // - x
+      // - B
+      test('the previous sibling is nested', async () => {
+        const {editor} = testEnv;
+        let x;
+
+        await editor.update(() => {
+          const root = $getRoot();
+          const parent = new ListNode('bullet', 1);
+
+          const A_listItem = new ListItemNode();
+          const A_nestedList = new ListNode('bullet', 1);
+          const A_nestedListItem = new ListItemNode();
+          A_listItem.append(A_nestedList);
+          A_nestedList.append(A_nestedListItem);
+          A_nestedListItem.append(new TextNode('A'));
+
+          x = new ListItemNode();
+          x.append(new TextNode('x'));
+
+          const B_listItem = new ListItemNode();
+          B_listItem.append(new TextNode('B'));
+
+          parent.append(A_listItem, x, B_listItem);
+          root.append(parent);
+        });
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">A</span>
+                    </li>
+                  </ul>
+                </li>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">x</span>
+                </li>
+                <li value="2" dir="ltr">
+                  <span data-lexical-text="true">B</span>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+
+        await editor.update(() => x.remove());
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">A</span>
+                    </li>
+                  </ul>
+                </li>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">B</span>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+      });
+
+      // - A
+      // - x
+      //   - B
+      test('the next sibling is nested', async () => {
+        const {editor} = testEnv;
+        let x;
+
+        await editor.update(() => {
+          const root = $getRoot();
+          const parent = new ListNode('bullet', 1);
+
+          const A_listItem = new ListItemNode();
+          A_listItem.append(new TextNode('A'));
+
+          x = new ListItemNode();
+          x.append(new TextNode('x'));
+
+          const B_listItem = new ListItemNode();
+          const B_nestedList = new ListNode('bullet', 1);
+          const B_nestedListItem = new ListItemNode();
+          B_listItem.append(B_nestedList);
+          B_nestedList.append(B_nestedListItem);
+          B_nestedListItem.append(new TextNode('B'));
+
+          parent.append(A_listItem, x, B_listItem);
+          root.append(parent);
+        });
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">A</span>
+                </li>
+                <li value="2" dir="ltr">
+                  <span data-lexical-text="true">x</span>
+                </li>
+                <li value="3">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">B</span>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+
+        await editor.update(() => x.remove());
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">A</span>
+                </li>
+                <li value="2">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">B</span>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+      });
+
+      //   - A
+      // - x
+      //   - B
+      test('both siblings are nested', async () => {
+        const {editor} = testEnv;
+        let x;
+
+        await editor.update(() => {
+          const root = $getRoot();
+          const parent = new ListNode('bullet', 1);
+
+          const A_listItem = new ListItemNode();
+          const A_nestedList = new ListNode('bullet', 1);
+          const A_nestedListItem = new ListItemNode();
+          A_listItem.append(A_nestedList);
+          A_nestedList.append(A_nestedListItem);
+          A_nestedListItem.append(new TextNode('A'));
+
+          x = new ListItemNode();
+          x.append(new TextNode('x'));
+
+          const B_listItem = new ListItemNode();
+          const B_nestedList = new ListNode('bullet', 1);
+          const B_nestedListItem = new ListItemNode();
+          B_listItem.append(B_nestedList);
+          B_nestedList.append(B_nestedListItem);
+          B_nestedListItem.append(new TextNode('B'));
+
+          parent.append(A_listItem, x, B_listItem);
+          root.append(parent);
+        });
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">A</span>
+                    </li>
+                  </ul>
+                </li>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">x</span>
+                </li>
+                <li value="2">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">B</span>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+
+        await editor.update(() => x.remove());
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">A</span>
+                    </li>
+                    <li value="2" dir="ltr">
+                      <span data-lexical-text="true">B</span>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+      });
+
+      //  - A1
+      //     - A2
+      // - x
+      //   - B
+      test('the previous sibling is nested deeper than the next sibling', async () => {
+        const {editor} = testEnv;
+        let x;
+
+        await editor.update(() => {
+          const root = $getRoot();
+          const parent = new ListNode('bullet', 1);
+
+          const A_listItem = new ListItemNode();
+          const A_nestedList = new ListNode('bullet', 1);
+          const A_nestedListItem1 = new ListItemNode();
+          const A_nestedListItem2 = new ListItemNode();
+          const A_deeplyNestedList = new ListNode('bullet', 1);
+          const A_deeplyNestedListItem = new ListItemNode();
+          A_listItem.append(A_nestedList);
+          A_nestedList.append(A_nestedListItem1);
+          A_nestedList.append(A_nestedListItem2);
+          A_nestedListItem1.append(new TextNode('A1'));
+          A_nestedListItem2.append(A_deeplyNestedList);
+          A_deeplyNestedList.append(A_deeplyNestedListItem);
+          A_deeplyNestedListItem.append(new TextNode('A2'));
+
+          x = new ListItemNode();
+          x.append(new TextNode('x'));
+
+          const B_listItem = new ListItemNode();
+          const B_nestedList = new ListNode('bullet', 1);
+          const B_nestedlistItem = new ListItemNode();
+          B_listItem.append(B_nestedList);
+          B_nestedList.append(B_nestedlistItem);
+          B_nestedlistItem.append(new TextNode('B'));
+
+          parent.append(A_listItem, x, B_listItem);
+          root.append(parent);
+        });
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">A1</span>
+                    </li>
+                    <li value="2">
+                      <ul>
+                        <li value="1" dir="ltr">
+                          <span data-lexical-text="true">A2</span>
+                        </li>
+                      </ul>
+                    </li>
+                  </ul>
+                </li>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">x</span>
+                </li>
+                <li value="2">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">B</span>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+
+        await editor.update(() => x.remove());
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">A1</span>
+                    </li>
+                    <li value="2">
+                      <ul>
+                        <li value="1" dir="ltr">
+                          <span data-lexical-text="true">A2</span>
+                        </li>
+                      </ul>
+                    </li>
+                    <li value="2" dir="ltr">
+                      <span data-lexical-text="true">B</span>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+      });
+
+      //   - A
+      // - x
+      //     - B1
+      //   - B2
+      test('the next sibling is nested deeper than the previous sibling', async () => {
+        const {editor} = testEnv;
+        let x;
+
+        await editor.update(() => {
+          const root = $getRoot();
+          const parent = new ListNode('bullet', 1);
+
+          const A_listItem = new ListItemNode();
+          const A_nestedList = new ListNode('bullet', 1);
+          const A_nestedListItem = new ListItemNode();
+          A_listItem.append(A_nestedList);
+          A_nestedList.append(A_nestedListItem);
+          A_nestedListItem.append(new TextNode('A'));
+
+          x = new ListItemNode();
+          x.append(new TextNode('x'));
+
+          const B_listItem = new ListItemNode();
+          const B_nestedList = new ListNode('bullet', 1);
+          const B_nestedListItem1 = new ListItemNode();
+          const B_nestedListItem2 = new ListItemNode();
+          const B_deeplyNestedList = new ListNode('bullet', 1);
+          const B_deeplyNestedListItem = new ListItemNode();
+          B_listItem.append(B_nestedList);
+          B_nestedList.append(B_nestedListItem1);
+          B_nestedList.append(B_nestedListItem2);
+          B_nestedListItem1.append(B_deeplyNestedList);
+          B_nestedListItem2.append(new TextNode('B2'));
+          B_deeplyNestedList.append(B_deeplyNestedListItem);
+          B_deeplyNestedListItem.append(new TextNode('B1'));
+
+          parent.append(A_listItem, x, B_listItem);
+          root.append(parent);
+        });
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">A</span>
+                    </li>
+                  </ul>
+                </li>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">x</span>
+                </li>
+                <li value="2">
+                  <ul>
+                    <li value="1">
+                      <ul>
+                        <li value="1" dir="ltr">
+                          <span data-lexical-text="true">B1</span>
+                        </li>
+                      </ul>
+                    </li>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">B2</span>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+
+        await editor.update(() => x.remove());
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">A</span>
+                    </li>
+                    <li value="2">
+                      <ul>
+                        <li value="1" dir="ltr">
+                          <span data-lexical-text="true">B1</span>
+                        </li>
+                      </ul>
+                    </li>
+                    <li value="2" dir="ltr">
+                      <span data-lexical-text="true">B2</span>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+      });
+
+      //   - A1
+      //     - A2
+      // - x
+      //     - B1
+      //   - B2
+      test('both siblings are deeply nested', async () => {
+        const {editor} = testEnv;
+        let x;
+
+        await editor.update(() => {
+          const root = $getRoot();
+          const parent = new ListNode('bullet', 1);
+
+          const A_listItem = new ListItemNode();
+          const A_nestedList = new ListNode('bullet', 1);
+          const A_nestedListItem1 = new ListItemNode();
+          const A_nestedListItem2 = new ListItemNode();
+          const A_deeplyNestedList = new ListNode('bullet', 1);
+          const A_deeplyNestedListItem = new ListItemNode();
+          A_listItem.append(A_nestedList);
+          A_nestedList.append(A_nestedListItem1);
+          A_nestedList.append(A_nestedListItem2);
+          A_nestedListItem1.append(new TextNode('A1'));
+          A_nestedListItem2.append(A_deeplyNestedList);
+          A_deeplyNestedList.append(A_deeplyNestedListItem);
+          A_deeplyNestedListItem.append(new TextNode('A2'));
+
+          x = new ListItemNode();
+          x.append(new TextNode('x'));
+
+          const B_listItem = new ListItemNode();
+          const B_nestedList = new ListNode('bullet', 1);
+          const B_nestedListItem1 = new ListItemNode();
+          const B_nestedListItem2 = new ListItemNode();
+          const B_deeplyNestedList = new ListNode('bullet', 1);
+          const B_deeplyNestedListItem = new ListItemNode();
+          B_listItem.append(B_nestedList);
+          B_nestedList.append(B_nestedListItem1);
+          B_nestedList.append(B_nestedListItem2);
+          B_nestedListItem1.append(B_deeplyNestedList);
+          B_nestedListItem2.append(new TextNode('B2'));
+          B_deeplyNestedList.append(B_deeplyNestedListItem);
+          B_deeplyNestedListItem.append(new TextNode('B1'));
+
+          parent.append(A_listItem, x, B_listItem);
+          root.append(parent);
+        });
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">A1</span>
+                    </li>
+                    <li value="2">
+                      <ul>
+                        <li value="1" dir="ltr">
+                          <span data-lexical-text="true">A2</span>
+                        </li>
+                      </ul>
+                    </li>
+                  </ul>
+                </li>
+                <li value="1" dir="ltr">
+                  <span data-lexical-text="true">x</span>
+                </li>
+                <li value="2">
+                  <ul>
+                    <li value="1">
+                      <ul>
+                        <li value="1" dir="ltr">
+                          <span data-lexical-text="true">B1</span>
+                        </li>
+                      </ul>
+                    </li>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">B2</span>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          `),
+        );
+
+        await editor.update(() => x.remove());
+
+        expect(testEnv.outerHTML).toBe(
+          stripLineBreaks(`
+            <div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true">
+              <ul>
+                <li value="1">
+                  <ul>
+                    <li value="1" dir="ltr">
+                      <span data-lexical-text="true">A1</span>
+                    </li>
+                    <li value="2">
+                      <ul>
+                        <li value="1" dir="ltr">
+                          <span data-lexical-text="true">A2</span>
+                        </li>
+                        <li value="2" dir="ltr">
+                          <span data-lexical-text="true">B1</span>
+                        </li>
+                      </ul>
+                    </li>
+                    <li value="2" dir="ltr">
+                      <span data-lexical-text="true">B2</span>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          `),
         );
       });
     });

--- a/packages/lexical-list/src/__tests__/utils.ts
+++ b/packages/lexical-list/src/__tests__/utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {expect} from '@playwright/test';
+import prettier from 'prettier';
+
+// This tag function is just used to trigger prettier auto-formatting.
+// (https://prettier.io/blog/2020/08/24/2.1.0.html#api)
+export function html(partials: TemplateStringsArray, ...params: string[]) {
+  let output = '';
+  for (let i = 0; i < partials.length; i++) {
+    output += partials[i];
+    if (i < partials.length - 1) {
+      output += params[i];
+    }
+  }
+  return output;
+}
+
+export function expectHtmlToBeEqual(expected: string, actual: string): void {
+  expect(prettifyHtml(expected)).toBe(prettifyHtml(actual));
+}
+
+function prettifyHtml(s: string) {
+  return prettier.format(s.replace(/\n/g, ''), {parser: 'html'});
+}

--- a/packages/lexical-list/src/__tests__/utils.ts
+++ b/packages/lexical-list/src/__tests__/utils.ts
@@ -10,7 +10,10 @@ import prettier from 'prettier';
 
 // This tag function is just used to trigger prettier auto-formatting.
 // (https://prettier.io/blog/2020/08/24/2.1.0.html#api)
-export function html(partials: TemplateStringsArray, ...params: string[]) {
+export function html(
+  partials: TemplateStringsArray,
+  ...params: string[]
+): string {
   let output = '';
   for (let i = 0; i < partials.length; i++) {
     output += partials[i];
@@ -25,6 +28,6 @@ export function expectHtmlToBeEqual(expected: string, actual: string): void {
   expect(prettifyHtml(expected)).toBe(prettifyHtml(actual));
 }
 
-function prettifyHtml(s: string) {
+function prettifyHtml(s: string): string {
   return prettier.format(s.replace(/\n/g, ''), {parser: 'html'});
 }

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -207,6 +207,29 @@ function createListOrMerge(node: ElementNode, listType: ListType): ListNode {
   }
 }
 
+export function mergeLists(list1: ListNode, list2: ListNode): void {
+  const listItem1 = list1.getLastChild();
+  const listItem2 = list2.getFirstChild();
+
+  if (
+    listItem1 &&
+    listItem2 &&
+    isNestedListNode(listItem1) &&
+    isNestedListNode(listItem2)
+  ) {
+    mergeLists(listItem1.getFirstChild(), listItem2.getFirstChild());
+    listItem2.remove();
+  }
+
+  const toMerge = list2.getChildren();
+  if (toMerge.length > 0) {
+    list1.append(...toMerge);
+    updateChildrenListItemValue(list1);
+  }
+
+  list2.remove();
+}
+
 export function removeList(editor: LexicalEditor): void {
   editor.update(() => {
     const selection = $getSelection();


### PR DESCRIPTION
Properly handles siblings that contain nested lists.

# Before:

https://user-images.githubusercontent.com/3211874/223054925-c7a752bd-275e-4864-b29b-0be509729d33.mov


# After:

https://user-images.githubusercontent.com/3211874/223054952-5bb5f620-489a-46bf-8959-2e996c780fd8.mov

