### PR TITLE
Fix EquationNode issues on Android 

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1623,6 +1623,15 @@ button.action-button:disabled {
   letter-spacing: -2px;
 }
 
+.editor-equation {
+  cursor: default;
+  user-select: none;
+}
+
+.editor-equation.focused {
+  outline: 2px solid rgb(60, 132, 244);
+}
+
 button.item i {
   opacity: 0.6;
 }

--- a/packages/lexical-playground/src/nodes/EquationComponent.tsx
+++ b/packages/lexical-playground/src/nodes/EquationComponent.tsx
@@ -8,10 +8,13 @@
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
-import { $getNodeByKey,
-$getSelection, $isNodeSelection, COMMAND_PRIORITY_HIGH,
+import {
+  $getNodeByKey,
+  $getSelection,
+  $isNodeSelection,
+  COMMAND_PRIORITY_HIGH,
   KEY_ESCAPE_COMMAND,
-NodeKey,
+  NodeKey,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import * as React from 'react';

--- a/packages/lexical-playground/src/nodes/EquationComponent.tsx
+++ b/packages/lexical-playground/src/nodes/EquationComponent.tsx
@@ -6,16 +6,12 @@
  *
  */
 
-import type {NodeKey} from 'lexical';
-
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
-import {
-  $getNodeByKey,
-  $getSelection,
-  $isNodeSelection,
-  COMMAND_PRIORITY_HIGH,
+import { $getNodeByKey,
+$getSelection, $isNodeSelection, COMMAND_PRIORITY_HIGH,
   KEY_ESCAPE_COMMAND,
+NodeKey,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import * as React from 'react';
@@ -116,15 +112,13 @@ export default function EquationComponent({
           equation={equationValue}
           setEquation={setEquationValue}
           inline={inline}
-          inputRef={inputRef}
+          ref={inputRef}
         />
       ) : (
         <KatexRenderer
           equation={equationValue}
           inline={inline}
-          onClick={() => {
-            setShowEquationEditor(true);
-          }}
+          onDoubleClick={() => setShowEquationEditor(true)}
         />
       )}
     </>

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -86,7 +86,9 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
   }
 
   createDOM(_config: EditorConfig): HTMLElement {
-    return document.createElement(this.__inline ? 'span' : 'div');
+    const element = document.createElement(this.__inline ? 'span' : 'div');
+    element.className = 'editor-equation';
+    return element;
   }
 
   exportDOM(): DOMExportOutput {

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -87,6 +87,7 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
 
   createDOM(_config: EditorConfig): HTMLElement {
     const element = document.createElement(this.__inline ? 'span' : 'div');
+    // EquationNodes should implement `user-action:none` in their CSS to avoid issues with deletion on Android.
     element.className = 'editor-equation';
     return element;
   }

--- a/packages/lexical-playground/src/ui/EquationEditor.tsx
+++ b/packages/lexical-playground/src/ui/EquationEditor.tsx
@@ -6,59 +6,28 @@
  *
  */
 
+import type {Ref, RefObject} from 'react';
+
 import './EquationEditor.css';
 
 import * as React from 'react';
-import {ChangeEvent, RefObject} from 'react';
+import {ChangeEvent, forwardRef} from 'react';
 
 type BaseEquationEditorProps = {
   equation: string;
   inline: boolean;
-  inputRef: {current: null | HTMLInputElement | HTMLTextAreaElement};
   setEquation: (equation: string) => void;
 };
 
-export default function EquationEditor({
-  equation,
-  setEquation,
-  inline,
-  inputRef,
-}: BaseEquationEditorProps): JSX.Element {
+function EquationEditor(
+  {equation, setEquation, inline}: BaseEquationEditorProps,
+  forwardedRef: Ref<HTMLInputElement | HTMLTextAreaElement>,
+): JSX.Element {
   const onChange = (event: ChangeEvent) => {
     setEquation((event.target as HTMLInputElement).value);
   };
 
-  const props = {
-    equation,
-    inputRef,
-    onChange,
-  };
-
-  return inline ? (
-    <InlineEquationEditor
-      {...props}
-      inputRef={inputRef as RefObject<HTMLInputElement>}
-    />
-  ) : (
-    <BlockEquationEditor
-      {...props}
-      inputRef={inputRef as RefObject<HTMLTextAreaElement>}
-    />
-  );
-}
-
-type EquationEditorImplProps = {
-  equation: string;
-  inputRef: {current: null | HTMLInputElement};
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
-};
-
-function InlineEquationEditor({
-  equation,
-  onChange,
-  inputRef,
-}: EquationEditorImplProps): JSX.Element {
-  return (
+  return inline && forwardedRef instanceof HTMLInputElement ? (
     <span className="EquationEditor_inputBackground">
       <span className="EquationEditor_dollarSign">$</span>
       <input
@@ -66,34 +35,22 @@ function InlineEquationEditor({
         value={equation}
         onChange={onChange}
         autoFocus={true}
-        ref={inputRef}
+        ref={forwardedRef as RefObject<HTMLInputElement>}
       />
       <span className="EquationEditor_dollarSign">$</span>
     </span>
-  );
-}
-
-type BlockEquationEditorImplProps = {
-  equation: string;
-  inputRef: {current: null | HTMLTextAreaElement};
-  onChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
-};
-
-function BlockEquationEditor({
-  equation,
-  onChange,
-  inputRef,
-}: BlockEquationEditorImplProps): JSX.Element {
-  return (
+  ) : (
     <div className="EquationEditor_inputBackground">
       <span className="EquationEditor_dollarSign">{'$$\n'}</span>
       <textarea
         className="EquationEditor_blockEditor"
         value={equation}
         onChange={onChange}
-        ref={inputRef}
+        ref={forwardedRef as RefObject<HTMLTextAreaElement>}
       />
       <span className="EquationEditor_dollarSign">{'\n$$'}</span>
     </div>
   );
 }
+
+export default forwardRef(EquationEditor);

--- a/packages/lexical-playground/src/ui/KatexEquationAlterer.tsx
+++ b/packages/lexical-playground/src/ui/KatexEquationAlterer.tsx
@@ -65,7 +65,7 @@ export default function KatexEquationAlterer({
         <KatexRenderer
           equation={equation}
           inline={false}
-          onClick={() => null}
+          onDoubleClick={() => null}
         />
       </div>
       <div className="KatexEquationAlterer_dialogActions">

--- a/packages/lexical-playground/src/ui/KatexRenderer.tsx
+++ b/packages/lexical-playground/src/ui/KatexRenderer.tsx
@@ -13,11 +13,11 @@ import {useEffect, useRef} from 'react';
 export default function KatexRenderer({
   equation,
   inline,
-  onClick,
+  onDoubleClick,
 }: Readonly<{
   equation: string;
   inline: boolean;
-  onClick: () => void;
+  onDoubleClick: () => void;
 }>): JSX.Element {
   const katexElementRef = useRef(null);
 
@@ -37,18 +37,18 @@ export default function KatexRenderer({
   }, [equation, inline]);
 
   return (
-    // We use spacers either side to ensure Android doesn't try and compose from the
+    // We use an empty image tag either side to ensure Android doesn't try and compose from the
     // inner text from Katex. There didn't seem to be any other way of making this work,
     // without having a physical space.
     <>
-      <span className="spacer"> </span>
+      <img src="#" alt="" />
       <span
         role="button"
         tabIndex={-1}
-        onClick={onClick}
+        onDoubleClick={onDoubleClick}
         ref={katexElementRef}
       />
-      <span className="spacer"> </span>
+      <img src="#" alt="" />
     </>
   );
 }


### PR DESCRIPTION
This PR fixes a Android bug. 

Hitting backspace at the end of an `EquationNode` causes selection to be lost. After much experimentation, I found that the fix involves adding `user-select: none;` to the decorator node, like with the inline `ImageNodes`, and to change the wrapping spaces around the equation node into `img` tags instead. 

I made some simplifications to the equation node logic as well.

Closes #3426
Closes #1965

