### PR TITLE
Styling tweaks to better accommodate long urls

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -587,6 +587,12 @@ i.prettier-error {
   font-family: inherit;
 }
 
+.link-editor .link-view a {
+  display: block;
+  word-break: break-word;
+  width: calc(100% - 33px);
+}
+
 .link-editor div.link-edit {
   background-image: url(images/icons/pencil-fill.svg);
   background-size: 16px;


### PR DESCRIPTION
Quick fix for an issue I noticed after the link editor ui tweaks.

**Before:**
<img width="707" alt="Screenshot 2023-03-06 at 1 27 39 PM" src="https://user-images.githubusercontent.com/29527680/223223058-bb0d94cb-b352-419d-8a86-9190d7ef5d6a.png">

**After:**

<img width="523" alt="Screenshot 2023-03-06 at 1 31 01 PM" src="https://user-images.githubusercontent.com/29527680/223223758-0e33c687-d2fc-4ec3-a2b1-aa032551fe00.png">
