### PR TITLE
Table - cell merging

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
       "source.fixAll.eslint",
       "source.fixAll.format"
     ]
+  },
+  "[xml]": {
+    "editor.defaultFormatter": "redhat.vscode-xml"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,8 +8,5 @@
       "source.fixAll.eslint",
       "source.fixAll.format"
     ]
-  },
-  "[xml]": {
-    "editor.defaultFormatter": "redhat.vscode-xml"
   }
 }

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste.spec.mjs
@@ -2066,7 +2066,13 @@ test.describe('CopyAndPaste', () => {
       'text/html': `<meta charset='utf-8'><table class="PlaygroundEditorTheme__table"><colgroup><col><col><col><col><col></colgroup><tbody><tr><th class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader" style="border: 1px solid black; width: 140px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p class="PlaygroundEditorTheme__paragraph"><span>a</span></p></th><th class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader" style="border: 1px solid black; width: 140px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p class="PlaygroundEditorTheme__paragraph"><span>b</span></p></th></tr><tr><th class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader" style="border: 1px solid black; width: 140px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);"><p class="PlaygroundEditorTheme__paragraph"><span>c</span></p></th><td class="PlaygroundEditorTheme__tableCell" style="border: 1px solid black; width: 140px; vertical-align: top; text-align: start;"><p class="PlaygroundEditorTheme__paragraph"><span>d</span></p></td></tr></tbody></table>`,
     };
 
-    await selectCellsFromTableCords(page, {x: 0, y: 0}, {x: 3, y: 3});
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 3, y: 3},
+      true,
+      false,
+    );
 
     await pasteFromClipboard(page, clipboard);
 

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -2487,6 +2487,27 @@ test.describe('Tables', () => {
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
       `,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              colspan="2">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">first</span>
+              </p>
+            </th>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
     );
   });
 
@@ -2560,6 +2581,44 @@ test.describe('Tables', () => {
             <td
               class="PlaygroundEditorTheme__tableCell"
               style="background-color: rgb(172, 206, 247); caret-color: transparent">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              rowspan="2">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              colspan="2">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>
           </tr>

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -7,6 +7,7 @@
  */
 
 import {
+  moveDown,
   moveRight,
   pressBackspace,
   selectAll,
@@ -2482,6 +2483,97 @@ test.describe('Tables', () => {
                 <span data-lexical-text="true">first</span>
               </p>
             </th>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test('Select multiple merged cells (selection expands to a rectangle)', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await insertTable(page, 3, 3);
+
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await moveDown(page, 1);
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 0, y: 1},
+      true,
+      true,
+    );
+    await mergeTableCells(page);
+    await page.pause();
+
+    await moveRight(page, 1);
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 0},
+      {x: 2, y: 0},
+      true,
+      true,
+    );
+    await mergeTableCells(page);
+    await page.pause();
+
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 0},
+      true,
+      true,
+    );
+    await page.pause();
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table disable-selection">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              rowspan="2"
+              style="background-color: rgb(172, 206, 247); caret-color: transparent">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              colspan="2"
+              style="background-color: rgb(172, 206, 247); caret-color: transparent">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              style="background-color: rgb(172, 206, 247); caret-color: transparent">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              style="background-color: rgb(172, 206, 247); caret-color: transparent">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
           </tr>
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -23,6 +23,7 @@ import {
   insertSampleImage,
   insertTable,
   IS_COLLAB,
+  mergeTableCells,
   pasteFromClipboard,
   SAMPLE_IMAGE_URL,
   selectCellsFromTableCords,
@@ -396,7 +397,13 @@ test.describe('Tables', () => {
     await insertTable(page);
 
     await fillTablePartiallyWithText(page);
-    await selectCellsFromTableCords(page, {x: 0, y: 0}, {x: 1, y: 1});
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
 
     await assertHTML(
       page,
@@ -1047,7 +1054,13 @@ test.describe('Tables', () => {
     await insertTable(page);
 
     await fillTablePartiallyWithText(page);
-    await selectCellsFromTableCords(page, {x: 0, y: 0}, {x: 1, y: 1});
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
 
     await clickSelectors(page, ['.bold', '.italic', '.underline']);
 
@@ -1268,7 +1281,13 @@ test.describe('Tables', () => {
     await insertTable(page);
 
     await fillTablePartiallyWithText(page);
-    await selectCellsFromTableCords(page, {x: 0, y: 0}, {x: 1, y: 1});
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
 
     const clipboard = await copyToClipboard(page);
 
@@ -1454,7 +1473,13 @@ test.describe('Tables', () => {
     await insertTable(page);
 
     await fillTablePartiallyWithText(page);
-    await selectCellsFromTableCords(page, {x: 0, y: 0}, {x: 1, y: 1});
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
 
     await page.keyboard.press('Backspace');
 
@@ -2410,6 +2435,53 @@ test.describe('Tables', () => {
             <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test('Merge cells', async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await insertTable(page, 1, 3);
+
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await moveRight(page, 1);
+    await page.keyboard.type('first');
+    await page.keyboard.press('Tab');
+    await page.keyboard.type('second');
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 0},
+      {x: 2, y: 0},
+      true,
+      true,
+    );
+    await mergeTableCells(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table disable-selection">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              colspan="2">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">first</span>
+              </p>
+            </th>
           </tr>
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>

--- a/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
+++ b/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
@@ -179,6 +179,15 @@ export async function moveRight(page, numCharacters = 1, delayMs) {
   }
 }
 
+export async function moveDown(page, numCharacters = 1, delayMs) {
+  for (let i = 0; i < numCharacters; i++) {
+    if (delayMs !== undefined) {
+      await sleep(delayMs);
+    }
+    await page.keyboard.press('ArrowDown');
+  }
+}
+
 export async function pressBackspace(page, numCharacters = 1, delayMs) {
   for (let i = 0; i < numCharacters; i++) {
     if (delayMs !== undefined) {

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -713,14 +713,18 @@ export async function selectFromAlignDropdown(page, selector) {
 }
 
 export async function insertTable(page, rows = null, columns = null) {
+  let leftFrame = page;
+  if (IS_COLLAB) {
+    leftFrame = await page.frame('left');
+  }
   await selectFromInsertDropdown(page, '.item .table');
   if (rows !== null) {
-    await page
+    await leftFrame
       .locator('input[data-test-id="table-modal-rows"]')
       .fill(String(rows));
   }
   if (columns !== null) {
-    await page
+    await leftFrame
       .locator('input[data-test-id="table-modal-columns"]')
       .fill(String(columns));
   }

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -712,15 +712,31 @@ export async function selectFromAlignDropdown(page, selector) {
   await click(page, '.dropdown ' + selector);
 }
 
-export async function insertTable(page) {
+export async function insertTable(page, rows = null, columns = null) {
   await selectFromInsertDropdown(page, '.item .table');
+  if (rows !== null) {
+    await page
+      .locator('input[data-test-id="table-modal-rows"]')
+      .fill(String(rows));
+  }
+  if (columns !== null) {
+    await page
+      .locator('input[data-test-id="table-modal-columns"]')
+      .fill(String(columns));
+  }
   await click(
     page,
     'div[data-test-id="table-model-confirm-insert"] > .Button__root',
   );
 }
 
-export async function selectCellsFromTableCords(page, firstCords, secondCords) {
+export async function selectCellsFromTableCords(
+  page,
+  firstCords,
+  secondCords,
+  isFirstHeader = false,
+  isSecondHeader = false,
+) {
   let leftFrame = page;
   if (IS_COLLAB) {
     await focusEditor(page);
@@ -728,14 +744,14 @@ export async function selectCellsFromTableCords(page, firstCords, secondCords) {
   }
 
   const firstRowFirstColumnCell = await leftFrame.locator(
-    `table:first-of-type > tr:nth-child(${firstCords.y + 1}) > th:nth-child(${
-      firstCords.x + 1
-    })`,
+    `table:first-of-type > tr:nth-child(${firstCords.y + 1}) > ${
+      isFirstHeader ? 'th' : 'td'
+    }:nth-child(${firstCords.x + 1})`,
   );
   const secondRowSecondCell = await leftFrame.locator(
-    `table:first-of-type > tr:nth-child(${secondCords.y + 1}) > td:nth-child(${
-      secondCords.x + 1
-    })`,
+    `table:first-of-type > tr:nth-child(${secondCords.y + 1}) > ${
+      isSecondHeader ? 'th' : 'td'
+    }:nth-child(${secondCords.x + 1})`,
   );
 
   // Focus on inside the iFrame or the boundingBox() below returns null.
@@ -750,6 +766,11 @@ export async function selectCellsFromTableCords(page, firstCords, secondCords) {
     await firstRowFirstColumnCell.boundingBox(),
     await secondRowSecondCell.boundingBox(),
   );
+}
+
+export async function mergeTableCells(page) {
+  await click(page, '.table-cell-action-button-container');
+  await click(page, '.item:text("Merge cells")');
 }
 
 export async function enableCompositionKeyEvents(page) {

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -216,7 +216,10 @@ export default function Editor(): JSX.Element {
                 <DraggableBlockPlugin anchorElem={floatingAnchorElem} />
                 <CodeActionMenuPlugin anchorElem={floatingAnchorElem} />
                 <FloatingLinkEditorPlugin anchorElem={floatingAnchorElem} />
-                <TableCellActionMenuPlugin anchorElem={floatingAnchorElem} />
+                <TableCellActionMenuPlugin
+                  anchorElem={floatingAnchorElem}
+                  cellMerge__EXPERIMENTAL={true}
+                />
                 <FloatingTextFormatToolbarPlugin
                   anchorElem={floatingAnchorElem}
                 />

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -218,7 +218,7 @@ export default function Editor(): JSX.Element {
                 <FloatingLinkEditorPlugin anchorElem={floatingAnchorElem} />
                 <TableCellActionMenuPlugin
                   anchorElem={floatingAnchorElem}
-                  cellMerge__EXPERIMENTAL={true}
+                  cellMerge={true}
                 />
                 <FloatingTextFormatToolbarPlugin
                   anchorElem={floatingAnchorElem}

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -29,17 +29,74 @@ import {
   $getRoot,
   $getSelection,
   $isRangeSelection,
+  DEPRECATED_$isGridCellNode,
   DEPRECATED_$isGridSelection,
+  GridSelection,
 } from 'lexical';
 import * as React from 'react';
 import {ReactPortal, useCallback, useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
+import invariant from 'shared/invariant';
+
+function computeSelectionCount(selection: GridSelection): {
+  columns: number;
+  rows: number;
+} {
+  const selectionShape = selection.getShape();
+  return {
+    columns: selectionShape.toX - selectionShape.fromX + 1,
+    rows: selectionShape.toY - selectionShape.fromY + 1,
+  };
+}
+
+// This is important when merging cells as there is no good way to re-merge weird shapes (a result
+// of selecting merged cells and non-merged)
+function isGridSelectionRectangular(selection: GridSelection): boolean {
+  const nodes = selection.getNodes();
+  const currentRows: Array<number> = [];
+  let currentRow = null;
+  let expectedColumns = null;
+  let currentColumns = 0;
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    if ($isTableCellNode(node)) {
+      const row = node.getParentOrThrow();
+      invariant(
+        $isTableRowNode(row),
+        'Expected CellNode to have a RowNode parent',
+      );
+      if (currentRow !== row) {
+        if (expectedColumns !== null && currentColumns !== expectedColumns) {
+          return false;
+        }
+        if (currentRow !== null) {
+          expectedColumns = currentColumns;
+        }
+        currentRow = row;
+        currentColumns = 0;
+      }
+      const colSpan = node.__colSpan;
+      for (let j = 0; j < colSpan; j++) {
+        if (currentRows[currentColumns + j] === undefined) {
+          currentRows[currentColumns + j] = 0;
+        }
+        currentRows[currentColumns + j] += node.__rowSpan;
+      }
+      currentColumns += colSpan;
+    }
+  }
+  return (
+    (expectedColumns === null || currentColumns === expectedColumns) &&
+    currentRows.every((v) => v === currentRows[0])
+  );
+}
 
 type TableCellActionMenuProps = Readonly<{
   contextRef: {current: null | HTMLElement};
   onClose: () => void;
   setIsMenuOpen: (isOpen: boolean) => void;
   tableCellNode: TableCellNode;
+  cellMerge__EXPERIMENTAL: boolean;
 }>;
 
 function TableActionMenu({
@@ -47,6 +104,7 @@ function TableActionMenu({
   tableCellNode: _tableCellNode,
   setIsMenuOpen,
   contextRef,
+  cellMerge__EXPERIMENTAL,
 }: TableCellActionMenuProps) {
   const [editor] = useLexicalComposerContext();
   const dropDownRef = useRef<HTMLDivElement | null>(null);
@@ -55,6 +113,7 @@ function TableActionMenu({
     columns: 1,
     rows: 1,
   });
+  const [canMergeCells, setCanMergeCells] = useState(false);
 
   useEffect(() => {
     return editor.registerMutationListener(TableCellNode, (nodeMutations) => {
@@ -72,14 +131,9 @@ function TableActionMenu({
   useEffect(() => {
     editor.getEditorState().read(() => {
       const selection = $getSelection();
-
       if (DEPRECATED_$isGridSelection(selection)) {
-        const selectionShape = selection.getShape();
-
-        updateSelectionCounts({
-          columns: selectionShape.toX - selectionShape.fromX + 1,
-          rows: selectionShape.toY - selectionShape.fromY + 1,
-        });
+        updateSelectionCounts(computeSelectionCount(selection));
+        setCanMergeCells(isGridSelectionRectangular(selection));
       }
     });
   }, [editor]);
@@ -150,13 +204,23 @@ function TableActionMenu({
     editor.update(() => {
       const selection = $getSelection();
       if (DEPRECATED_$isGridSelection(selection)) {
-        const anchor = selection.anchor.getNode();
-        const focus = selection.focus.getNode();
-        if ($isTableCellNode(anchor)) {
-          anchor.getWritable().__rowSpan = 2;
-          focus.remove();
-          anchor.select();
+        const {columns, rows} = computeSelectionCount(selection);
+        const nodes = selection.getNodes();
+        let isFirstCell = true;
+        for (let i = 0; i < nodes.length; i++) {
+          const node = nodes[i];
+          if (DEPRECATED_$isGridCellNode(node)) {
+            if (isFirstCell) {
+              node.setColSpan(columns).setRowSpan(rows);
+              selection.anchor.set(node.getKey(), 0, 'element');
+              selection.focus.set(node.getKey(), 0, 'element');
+              isFirstCell = false;
+            } else {
+              nodes[i].remove();
+            }
+          }
         }
+        onClose();
       }
     });
   };
@@ -351,10 +415,18 @@ function TableActionMenu({
       onClick={(e) => {
         e.stopPropagation();
       }}>
-      <button className="item" onClick={() => mergeTableColumnsAtSelection()}>
-        Merge cells
-      </button>
-      <hr />
+      {cellMerge__EXPERIMENTAL &&
+        (selectionCounts.columns > 1 || selectionCounts.rows > 1) &&
+        canMergeCells && (
+          <>
+            <button
+              className="item"
+              onClick={() => mergeTableColumnsAtSelection()}>
+              Merge cells
+            </button>
+            <hr />
+          </>
+        )}
       <button className="item" onClick={() => insertTableRowAtSelection(false)}>
         <span className="text">
           Insert{' '}
@@ -428,8 +500,10 @@ function TableActionMenu({
 
 function TableCellActionMenuContainer({
   anchorElem,
+  cellMerge__EXPERIMENTAL,
 }: {
   anchorElem: HTMLElement;
+  cellMerge__EXPERIMENTAL: boolean;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
 
@@ -545,6 +619,7 @@ function TableCellActionMenuContainer({
               setIsMenuOpen={setIsMenuOpen}
               onClose={() => setIsMenuOpen(false)}
               tableCellNode={tableCellNode}
+              cellMerge__EXPERIMENTAL={cellMerge__EXPERIMENTAL}
             />
           )}
         </>
@@ -555,13 +630,18 @@ function TableCellActionMenuContainer({
 
 export default function TableActionMenuPlugin({
   anchorElem = document.body,
+  cellMerge__EXPERIMENTAL = false,
 }: {
   anchorElem?: HTMLElement;
+  cellMerge__EXPERIMENTAL?: boolean;
 }): null | ReactPortal {
   const isEditable = useLexicalEditable();
   return createPortal(
     isEditable ? (
-      <TableCellActionMenuContainer anchorElem={anchorElem} />
+      <TableCellActionMenuContainer
+        anchorElem={anchorElem}
+        cellMerge__EXPERIMENTAL={cellMerge__EXPERIMENTAL}
+      />
     ) : null,
     anchorElem,
   );

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -146,6 +146,21 @@ function TableActionMenu({
     });
   }, [editor, tableCellNode]);
 
+  const mergeTableColumnsAtSelection = () => {
+    editor.update(() => {
+      const selection = $getSelection();
+      if (DEPRECATED_$isGridSelection(selection)) {
+        const anchor = selection.anchor.getNode();
+        const focus = selection.focus.getNode();
+        if ($isTableCellNode(anchor)) {
+          anchor.getWritable().__rowSpan = 2;
+          focus.remove();
+          anchor.select();
+        }
+      }
+    });
+  };
+
   const insertTableRowAtSelection = useCallback(
     (shouldInsertAfter: boolean) => {
       editor.update(() => {
@@ -336,6 +351,10 @@ function TableActionMenu({
       onClick={(e) => {
         e.stopPropagation();
       }}>
+      <button className="item" onClick={() => mergeTableColumnsAtSelection()}>
+        Merge cells
+      </button>
+      <hr />
       <button className="item" onClick={() => insertTableRowAtSelection(false)}>
         <span className="text">
           Insert{' '}

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -96,7 +96,7 @@ type TableCellActionMenuProps = Readonly<{
   onClose: () => void;
   setIsMenuOpen: (isOpen: boolean) => void;
   tableCellNode: TableCellNode;
-  cellMerge__EXPERIMENTAL: boolean;
+  cellMerge: boolean;
 }>;
 
 function TableActionMenu({
@@ -104,7 +104,7 @@ function TableActionMenu({
   tableCellNode: _tableCellNode,
   setIsMenuOpen,
   contextRef,
-  cellMerge__EXPERIMENTAL,
+  cellMerge,
 }: TableCellActionMenuProps) {
   const [editor] = useLexicalComposerContext();
   const dropDownRef = useRef<HTMLDivElement | null>(null);
@@ -415,7 +415,7 @@ function TableActionMenu({
       onClick={(e) => {
         e.stopPropagation();
       }}>
-      {cellMerge__EXPERIMENTAL &&
+      {cellMerge &&
         (selectionCounts.columns > 1 || selectionCounts.rows > 1) &&
         canMergeCells && (
           <>
@@ -500,10 +500,10 @@ function TableActionMenu({
 
 function TableCellActionMenuContainer({
   anchorElem,
-  cellMerge__EXPERIMENTAL,
+  cellMerge,
 }: {
   anchorElem: HTMLElement;
-  cellMerge__EXPERIMENTAL: boolean;
+  cellMerge: boolean;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
 
@@ -619,7 +619,7 @@ function TableCellActionMenuContainer({
               setIsMenuOpen={setIsMenuOpen}
               onClose={() => setIsMenuOpen(false)}
               tableCellNode={tableCellNode}
-              cellMerge__EXPERIMENTAL={cellMerge__EXPERIMENTAL}
+              cellMerge={cellMerge}
             />
           )}
         </>
@@ -630,17 +630,17 @@ function TableCellActionMenuContainer({
 
 export default function TableActionMenuPlugin({
   anchorElem = document.body,
-  cellMerge__EXPERIMENTAL = false,
+  cellMerge = false,
 }: {
   anchorElem?: HTMLElement;
-  cellMerge__EXPERIMENTAL?: boolean;
+  cellMerge?: boolean;
 }): null | ReactPortal {
   const isEditable = useLexicalEditable();
   return createPortal(
     isEditable ? (
       <TableCellActionMenuContainer
         anchorElem={anchorElem}
-        cellMerge__EXPERIMENTAL={cellMerge__EXPERIMENTAL}
+        cellMerge={cellMerge}
       />
     ) : null,
     anchorElem,

--- a/packages/lexical-playground/src/plugins/TablePlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TablePlugin.tsx
@@ -112,8 +112,18 @@ export function InsertTableDialog({
 
   return (
     <>
-      <TextInput label="No of rows" onChange={setRows} value={rows} />
-      <TextInput label="No of columns" onChange={setColumns} value={columns} />
+      <TextInput
+        label="No of rows"
+        onChange={setRows}
+        value={rows}
+        data-test-id="table-modal-rows"
+      />
+      <TextInput
+        label="No of columns"
+        onChange={setColumns}
+        value={columns}
+        data-test-id="table-modal-columns"
+      />
       <DialogActions data-test-id="table-model-confirm-insert">
         <Button onClick={onClick}>Confirm</Button>
       </DialogActions>
@@ -138,9 +148,19 @@ export function InsertNewTableDialog({
 
   return (
     <>
-      <TextInput label="No of rows" onChange={setRows} value={rows} />
-      <TextInput label="No of columns" onChange={setColumns} value={columns} />
-      <DialogActions data-test-id="table-model-confirm-insert">
+      <TextInput
+        label="No of rows"
+        onChange={setRows}
+        value={rows}
+        data-test-id="table-modal-rows"
+      />
+      <TextInput
+        label="No of columns"
+        onChange={setColumns}
+        value={columns}
+        data-test-id="table-modal-columns"
+      />
+      <DialogActions data-test-id="table-modal-confirm-insert">
         <Button onClick={onClick}>Confirm</Button>
       </DialogActions>
     </>

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -99,10 +99,18 @@ export class TableCellNode extends DEPRECATED_GridCellNode {
   }
 
   createDOM(config: EditorConfig): HTMLElement {
-    const element = document.createElement(this.getTag());
+    const element = document.createElement(
+      this.getTag(),
+    ) as HTMLTableCellElement;
 
     if (this.__width) {
       element.style.width = `${this.__width}px`;
+    }
+    if (this.__colSpan !== 1) {
+      element.colSpan = this.__colSpan;
+    }
+    if (this.__rowSpan !== 1) {
+      element.rowSpan = this.__rowSpan;
     }
 
     addClassNamesToElement(
@@ -118,18 +126,25 @@ export class TableCellNode extends DEPRECATED_GridCellNode {
     const {element} = super.exportDOM(editor);
 
     if (element) {
+      const element_ = element as HTMLTableCellElement;
       const maxWidth = 700;
       const colCount = this.getParentOrThrow().getChildrenSize();
-      element.style.border = '1px solid black';
-      element.style.width = `${
+      element_.style.border = '1px solid black';
+      if (this.__colSpan !== 1) {
+        element_.colSpan = this.__colSpan;
+      }
+      if (this.__rowSpan !== 1) {
+        element_.rowSpan = this.__rowSpan;
+      }
+      element_.style.width = `${
         this.getWidth() || Math.max(90, maxWidth / colCount)
       }px`;
 
-      element.style.verticalAlign = 'top';
-      element.style.textAlign = 'start';
+      element_.style.verticalAlign = 'top';
+      element_.style.textAlign = 'start';
 
       if (this.hasHeader()) {
-        element.style.backgroundColor = '#f2f3f5';
+        element_.style.backgroundColor = '#f2f3f5';
       }
     }
 
@@ -195,7 +210,9 @@ export class TableCellNode extends DEPRECATED_GridCellNode {
   updateDOM(prevNode: TableCellNode): boolean {
     return (
       prevNode.__headerState !== this.__headerState ||
-      prevNode.__width !== this.__width
+      prevNode.__width !== this.__width ||
+      prevNode.__colSpan !== this.__colSpan ||
+      prevNode.__rowSpan !== this.__rowSpan
     );
   }
 

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -416,6 +416,9 @@ export class LexicalNode {
   }
 
   isBefore(targetNode: LexicalNode): boolean {
+    if (this === targetNode) {
+      return false;
+    }
     if (targetNode.isParentOf(this)) {
       return true;
     }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1547,3 +1547,39 @@ export function $splitNode(
 
   return [leftTree, rightTree];
 }
+
+export function $findMatchingParent(
+  startingNode: LexicalNode,
+  findFn: (node: LexicalNode) => boolean,
+): LexicalNode | null {
+  let curr: ElementNode | LexicalNode | null = startingNode;
+
+  while (curr !== $getRoot() && curr != null) {
+    if (findFn(curr)) {
+      return curr;
+    }
+
+    curr = curr.getParent();
+  }
+
+  return null;
+}
+
+export function $getChildrenRecursively(node: LexicalNode): Array<LexicalNode> {
+  const nodes = [];
+  const stack = [node];
+  while (stack.length > 0) {
+    const currentNode = stack.pop();
+    invariant(
+      currentNode !== undefined,
+      "Stack.length > 0; can't be undefined",
+    );
+    if ($isElementNode(currentNode)) {
+      stack.unshift(...currentNode.getChildren());
+    }
+    if (currentNode !== node) {
+      nodes.push(currentNode);
+    }
+  }
+  return nodes;
+}

--- a/packages/lexical/src/nodes/LexicalGridCellNode.ts
+++ b/packages/lexical/src/nodes/LexicalGridCellNode.ts
@@ -40,6 +40,16 @@ export class DEPRECATED_GridCellNode extends ElementNode {
       colSpan: this.__colSpan,
     };
   }
+
+  setColSpan(colSpan: number): this {
+    this.getWritable().__colSpan = colSpan;
+    return this;
+  }
+
+  setRowSpan(rowSpan: number): this {
+    this.getWritable().__rowSpan = rowSpan;
+    return this;
+  }
 }
 
 export function DEPRECATED_$isGridCellNode(

--- a/packages/lexical/src/nodes/LexicalGridCellNode.ts
+++ b/packages/lexical/src/nodes/LexicalGridCellNode.ts
@@ -26,10 +26,12 @@ export type SerializedGridCellNode = Spread<
 export class DEPRECATED_GridCellNode extends ElementNode {
   /** @internal */
   __colSpan: number;
+  __rowSpan: number;
 
   constructor(colSpan: number, key?: NodeKey) {
     super(key);
     this.__colSpan = colSpan;
+    this.__rowSpan = 1;
   }
 
   exportJSON(): SerializedGridCellNode {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -101,5 +101,16 @@
   "99": "Only element or decorator nodes can be inserted in to the root node",
   "100": "splice: sibling not found",
   "101": "createChildrenArray: node does not exist in nodeMap",
-  "102": "Can not call $splitNode() on root element"
+  "102": "Can not call $splitNode() on root element",
+  "103": "Expected GridSelection anchor to be (or a child of) GridCellNode",
+  "104": "Expected GridSelection focus to be (or a child of) GridCellNode",
+  "105": "Expected anchorCell to have a parent GridRowNode",
+  "106": "Expected tableNode to have a parent GridNode",
+  "107": "Expected GridCellNode parent to be a GridRowNode",
+  "108": "Expected GridNode children to be GridRowNode",
+  "109": "Expected GridRowNode children to be GridCellNode",
+  "110": "Anchor not found in Grid",
+  "111": "Focus not found in Grid",
+  "112": "Stack.length > 0; can't be undefined",
+  "113": "Lexical node does not exist in active editor state. Avoid using the same node references between nested closures from editorState.read/editor.update."
 }


### PR DESCRIPTION
This PR adds support for cell merging on the stable tables implementation. We store this with a simple `__colSpan` and `__rowSpan` property on the GridCellNode.

There are many follow ups from this PR, including the fact that only basic cases work for now:
- Doesn't copy merged content onto the merged cell
- Rewrite `getShape()` - indexes fail when merged cells are present
- Fix paste (it's already crashing in the current version for some reason)
- Kill GridSelection - performance and budget issues (adds cost the Lexical Core plain text users that don't use tables)

Cell merging

https://user-images.githubusercontent.com/193447/223561223-16d84087-a07b-4fd3-afa6-f9ba2029e7df.mov

_(yes, the menu visibility needs a fix but we're considering dropping it for a better a11y alternative)_

Selection is guaranteed to be rectangular

https://user-images.githubusercontent.com/193447/223561217-3f1dc72d-1404-433f-bca3-5ff348ed98e3.mov

More complicated selection

https://user-images.githubusercontent.com/193447/223561222-a33aae54-14b5-4518-ac0c-8b73d2de834a.mov


