### PR TITLE
Fix inf loop block cursor

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -933,14 +933,10 @@ function beginUpdate(
     editor._updating = previouslyUpdating;
     infiniteTransformCount = 0;
   }
-  const windowObj = editor._window;
-  const windowEvent = windowObj !== null ? window.event : null;
-  const eventType = windowEvent != null ? windowEvent.type : null;
 
   const shouldUpdate =
     editor._dirtyType !== NO_DIRTY_NODES ||
-    editorStateHasDirtySelection(pendingEditorState, editor) ||
-    (editor._blockCursorElement !== null && eventType === 'blur');
+    editorStateHasDirtySelection(pendingEditorState, editor);
 
   if (shouldUpdate) {
     if (pendingEditorState._flushSync) {


### PR DESCRIPTION
Introduced in #3434 as part of the block cursor implementation. This PR is debatable as I'm not sure how this conflicts with the correct behavior of block emulated nodes. My understanding that this logic is the responsible for hiding the block cursor when moving away from the editor but this doesn't work in the current version either so the whole thing needs revisiting.

As for the problem, it comes to down to block emulated nodes plus the frown upon _listener + update_ pattern. The fact that block emulated nodes bypass the typical dirty behavior means that they trigger updates regardless and the _listener + update_ pattern will continue feeding new updates. Hence, causing a loop.

It's worth noting that while frown upon, the _listener + update_ pattern is still valid and supported.

Closes https://github.com/facebook/lexical/issues/4048