### PR TITLE
Removed additional FloatingLinkEditorPlugin mouse listeners

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -113,29 +113,6 @@ function FloatingLinkEditor({
   }, [anchorElem, editor]);
 
   useEffect(() => {
-    function mouseMoveListener(e: MouseEvent) {
-      if (editorRef?.current && (e.buttons === 1 || e.buttons === 3)) {
-        editorRef.current.style.pointerEvents = 'none';
-      }
-    }
-    function mouseUpListener(e: MouseEvent) {
-      if (editorRef?.current) {
-        editorRef.current.style.pointerEvents = 'auto';
-      }
-    }
-
-    if (editorRef?.current) {
-      document.addEventListener('mousemove', mouseMoveListener);
-      document.addEventListener('mouseup', mouseUpListener);
-
-      return () => {
-        document.removeEventListener('mousemove', mouseMoveListener);
-        document.removeEventListener('mouseup', mouseUpListener);
-      };
-    }
-  }, [editorRef]);
-
-  useEffect(() => {
     const scrollerElem = anchorElem.parentElement;
 
     const update = () => {


### PR DESCRIPTION
**Issues this caused:**

- Could not highlight text in link editor with mouse
- Sometimes needed to click twice to activate link editor buttons
- If you were editing a link over / in a table it would cause a multitude of odd behavior (such as highlighting the table or the link editor bouncing around)

Pre-Fix

https://user-images.githubusercontent.com/29527680/223772108-83d04b1a-05b5-4c3e-9086-63b7d83b431e.mov

After-Fix

https://user-images.githubusercontent.com/29527680/223772135-de1b0a53-8ce3-4c53-bd10-d766a7322dee.mov

Reference: #4013 