### PR TITLE
Table insert row w/ span support

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -8,6 +8,7 @@
 
 import {
   moveDown,
+  moveLeft,
   moveRight,
   moveToEditorBeginning,
   pressBackspace,
@@ -24,6 +25,7 @@ import {
   insertHorizontalRule,
   insertSampleImage,
   insertTable,
+  insertTableRowBelow,
   IS_COLLAB,
   mergeTableCells,
   pasteFromClipboard,
@@ -934,7 +936,7 @@ test.describe('Tables', () => {
       page,
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-        <table class="PlaygroundEditorTheme__table disable-selection">
+        <table class="PlaygroundEditorTheme__table">
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -1099,6 +1101,62 @@ test.describe('Tables', () => {
             <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test('Insert row above (with conflicting merged cell)', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await insertTable(page, 2, 2);
+
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await moveDown(page, 1);
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
+    await mergeTableCells(page);
+
+    await moveLeft(page, 1);
+    await page.pause();
+    await insertTableRowBelow(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              rowspan="3">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell"><br /></td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
           </tr>
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -772,9 +772,19 @@ export async function selectCellsFromTableCords(
   );
 }
 
+export async function insertTableRowAbove(page) {
+  await click(page, '.table-cell-action-button-container');
+  await click(page, '.item[data-test-id="table-insert-row-above"]');
+}
+
+export async function insertTableRowBelow(page) {
+  await click(page, '.table-cell-action-button-container');
+  await click(page, '.item[data-test-id="table-insert-row-below"]');
+}
+
 export async function mergeTableCells(page) {
   await click(page, '.table-cell-action-button-container');
-  await click(page, '.item:text("Merge cells")');
+  await click(page, '.item[data-test-id="table-merge-cells"]');
 }
 
 export async function enableCompositionKeyEvents(page) {

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -49,6 +49,7 @@ import {
   $getTableRowNodeFromTableCellNodeOrThrow,
   $insertTableColumn,
   $insertTableRow,
+  $insertTableRow__EXPERIMENTAL,
   $removeTableRowAtIndex,
 } from './LexicalTableUtils';
 
@@ -66,6 +67,7 @@ export {
   $getTableRowNodeFromTableCellNodeOrThrow,
   $insertTableColumn,
   $insertTableRow,
+  $insertTableRow__EXPERIMENTAL,
   $isTableCellNode,
   $isTableNode,
   $isTableRowNode,

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2216,6 +2216,8 @@ function moveNativeSelection(
   direction: 'backward' | 'forward' | 'left' | 'right',
   granularity: 'character' | 'word' | 'lineboundary',
 ): void {
+  // @ts-expect-error Selection.modify() method applies a change to the current selection or cursor position,
+  // but is still non-standard in some browsers.
   domSelection.modify(alter, direction, granularity);
 }
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -466,8 +466,6 @@ export class GridSelection implements BaseSelection {
     return selection.insertNodes(nodes, selectStart);
   }
 
-  // getShape2(): {co};
-
   // TODO Deprecate this method. It's confusing when used with colspan|rowspan
   getShape(): GridSelectionShape {
     const anchorCellNode = $getNodeByKey(this.anchor.key);

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -40,6 +40,8 @@ export type {
 export type {
   BaseSelection,
   ElementPointType as ElementPoint,
+  GridMapType,
+  GridMapValueType,
   GridSelection,
   GridSelectionShape,
   NodeSelection,
@@ -124,7 +126,9 @@ export {
   $insertNodes,
   $isNodeSelection,
   $isRangeSelection,
+  DEPRECATED_$computeGridMap,
   DEPRECATED_$createGridSelection,
+  DEPRECATED_$getNodeTriplet,
   DEPRECATED_$isGridSelection,
 } from './LexicalSelection';
 export {$parseSerializedNode} from './LexicalUpdates';


### PR DESCRIPTION
Rewriting insert row so that it supports merged cells

https://user-images.githubusercontent.com/193447/223866807-9a5fc9a2-493e-47d2-8319-17727e1a974a.mov

~~(disregard the fact that the header is not kept, headers are not logically compatible with merged cells, we'll kill them and replace them for background colors)~~

Update: will iterate on this on another PR. They can't really work with merged cells themselves but we can still forbid merged cells on the headers and work on them as usual
