### PR TITLE
chore: prevent action from running on forks

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -5,6 +5,8 @@ on:
     - cron: '30 2 * * 1-5'
 jobs:
   release:
+    # prevents this action from running on forks
+    if: github.repository_owner == 'facebook'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   integrity:
+    if: github.repository_owner == 'facebook'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -46,6 +47,7 @@ jobs:
       - run: npm run build-www
 
   unit:
+    if: github.repository_owner == 'facebook'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -72,6 +74,7 @@ jobs:
       - run: npm run test-unit
 
   e2e-mac:
+    if: github.repository_owner == 'facebook'
     runs-on: macos-latest
     strategy:
       matrix:
@@ -113,6 +116,7 @@ jobs:
           retention-days: 7
 
   e2e-linux:
+    if: github.repository_owner == 'facebook'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -158,6 +162,7 @@ jobs:
           retention-days: 7
 
   e2e-windows:
+    if: github.repository_owner == 'facebook'
     runs-on: windows-latest
     strategy:
       matrix:
@@ -198,6 +203,7 @@ jobs:
           retention-days: 7
 
   e2e-collab-mac:
+    if: github.repository_owner == 'facebook'
     runs-on: macos-latest
     strategy:
       matrix:
@@ -235,6 +241,7 @@ jobs:
           retention-days: 7
 
   e2e-collab-linux:
+    if: github.repository_owner == 'facebook'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -276,6 +283,7 @@ jobs:
           retention-days: 7
 
   e2e-collab-windows:
+    if: github.repository_owner == 'facebook'
     runs-on: windows-latest
     strategy:
       matrix:
@@ -312,6 +320,7 @@ jobs:
           retention-days: 7
 
   e2e-prod:
+    if: github.repository_owner == 'facebook'
     runs-on: macos-latest
     strategy:
       matrix:
@@ -353,6 +362,7 @@ jobs:
           retention-days: 7
 
   e2e-collab-prod:
+    if: github.repository_owner == 'facebook'
     runs-on: macos-latest
     strategy:
       matrix:


### PR DESCRIPTION
### Description
In our forked repositories, the execution of actions looks like should be disabled, especially the "Nightly Release Branch - main" task, as it is scheduled to run regularly and is certain to fail, resulting in a large number of failure notifications via email.