### PR TITLE
Revert "chore: prevent action from running on forks"

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -5,8 +5,6 @@ on:
     - cron: '30 2 * * 1-5'
 jobs:
   release:
-    # prevents this action from running on forks
-    if: github.repository_owner == 'facebook'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ concurrency:
 
 jobs:
   integrity:
-    if: github.repository_owner == 'facebook'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -47,7 +46,6 @@ jobs:
       - run: npm run build-www
 
   unit:
-    if: github.repository_owner == 'facebook'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -74,7 +72,6 @@ jobs:
       - run: npm run test-unit
 
   e2e-mac:
-    if: github.repository_owner == 'facebook'
     runs-on: macos-latest
     strategy:
       matrix:
@@ -116,7 +113,6 @@ jobs:
           retention-days: 7
 
   e2e-linux:
-    if: github.repository_owner == 'facebook'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -162,7 +158,6 @@ jobs:
           retention-days: 7
 
   e2e-windows:
-    if: github.repository_owner == 'facebook'
     runs-on: windows-latest
     strategy:
       matrix:
@@ -203,7 +198,6 @@ jobs:
           retention-days: 7
 
   e2e-collab-mac:
-    if: github.repository_owner == 'facebook'
     runs-on: macos-latest
     strategy:
       matrix:
@@ -241,7 +235,6 @@ jobs:
           retention-days: 7
 
   e2e-collab-linux:
-    if: github.repository_owner == 'facebook'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -283,7 +276,6 @@ jobs:
           retention-days: 7
 
   e2e-collab-windows:
-    if: github.repository_owner == 'facebook'
     runs-on: windows-latest
     strategy:
       matrix:
@@ -320,7 +312,6 @@ jobs:
           retention-days: 7
 
   e2e-prod:
-    if: github.repository_owner == 'facebook'
     runs-on: macos-latest
     strategy:
       matrix:
@@ -362,7 +353,6 @@ jobs:
           retention-days: 7
 
   e2e-collab-prod:
-    if: github.repository_owner == 'facebook'
     runs-on: macos-latest
     strategy:
       matrix:


### PR DESCRIPTION
Realized we should revert this before doing the 0.9.0 release. Reverts facebook/lexical#4068