### PR TITLE
Fix toolbars that shouldn't appear in certain cases

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -924,7 +924,7 @@ test.describe('TextFormatting', () => {
     await page.keyboard.type('A');
     await page.keyboard.press('Enter');
     await page.keyboard.type('B');
-    await selectCharacters(page, 'left', 2);
+    await selectCharacters(page, 'left', 3);
     await toggleBold(page);
     await toggleItalic(page);
 

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -924,7 +924,7 @@ test.describe('TextFormatting', () => {
     await page.keyboard.type('A');
     await page.keyboard.press('Enter');
     await page.keyboard.type('B');
-    await selectCharacters(page, 'left', 3);
+    await selectCharacters(page, 'left', 2);
     await toggleBold(page);
     await toggleItalic(page);
 

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -76,7 +76,6 @@ header h1 {
 .editor-scroller {
   min-height: 150px;
   border: 0;
-  resize: none;
   cursor: text;
   display: flex;
   position: relative;
@@ -1377,6 +1376,9 @@ button.action-button:disabled {
   vertical-align: middle;
   overflow: auto;
   height: 36px;
+  position: sticky;
+  top: 0;
+  z-index: 2;
 }
 
 .toolbar button.toolbar-item {

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -58,7 +58,6 @@ header h1 {
 .editor-shell .editor-container {
   background: #fff;
   position: relative;
-  cursor: text;
   display: block;
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
@@ -76,7 +75,6 @@ header h1 {
 .editor-scroller {
   min-height: 150px;
   border: 0;
-  cursor: text;
   display: flex;
   position: relative;
   outline: 0;
@@ -88,6 +86,8 @@ header h1 {
 .editor {
   flex: auto;
   position: relative;
+  resize: vertical;
+  z-index: -1;
 }
 
 .test-recorder-output {

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -307,18 +307,10 @@ function useFloatingTextFormatToolbar(
         setIsText(false);
       }
 
-      if ($isRangeSelection(selection) && !selection.isCollapsed()) {
-        const anchorOffset = selection.anchor.offset;
-        const focusOffset = selection.focus.offset;
-        if (
-          selection.anchor.key !== selection.focus.key &&
-          selection.dirty &&
-          focusOffset === 0 &&
-          anchorOffset > 0
-        ) {
-          setIsText(false);
-          return;
-        }
+      const rawTextContent = selection.getTextContent().replace(/\n/g, '');
+      if (!selection.isCollapsed() && rawTextContent === '') {
+        setIsText(false);
+        return;
       }
     });
   }, [editor]);

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -317,8 +317,7 @@ function useFloatingTextFormatToolbar(
           anchorOffset > 0
         ) {
           setIsText(false);
-        } else {
-          setIsText(true);
+          return;
         }
       }
     });

--- a/packages/lexical-playground/src/plugins/TablePlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TablePlugin.tsx
@@ -98,8 +98,19 @@ export function InsertTableDialog({
   activeEditor: LexicalEditor;
   onClose: () => void;
 }): JSX.Element {
-  const [rows, setRows] = useState('5');
-  const [columns, setColumns] = useState('5');
+  const [rows, setRows] = useState('');
+  const [columns, setColumns] = useState('');
+  const [isDisabled, setIsDisabled] = useState(true);
+
+  useEffect(() => {
+    const row = Number(rows);
+    const column = Number(columns);
+    if (row && row > 0 && row <= 500 && column && column > 0 && column <= 50) {
+      setIsDisabled(false);
+    } else {
+      setIsDisabled(true);
+    }
+  }, [rows, columns]);
 
   const onClick = () => {
     activeEditor.dispatchCommand(INSERT_TABLE_COMMAND, {
@@ -113,19 +124,23 @@ export function InsertTableDialog({
   return (
     <>
       <TextInput
-        label="No of rows"
+        placeholder={'# of rows (1-500)'}
+        label="Rows"
         onChange={setRows}
         value={rows}
         data-test-id="table-modal-rows"
       />
       <TextInput
-        label="No of columns"
+        placeholder={'# of columns (1-50)'}
+        label="Columns"
         onChange={setColumns}
         value={columns}
         data-test-id="table-modal-columns"
       />
       <DialogActions data-test-id="table-model-confirm-insert">
-        <Button onClick={onClick}>Confirm</Button>
+        <Button disabled={isDisabled} onClick={onClick}>
+          Confirm
+        </Button>
       </DialogActions>
     </>
   );
@@ -138,8 +153,19 @@ export function InsertNewTableDialog({
   activeEditor: LexicalEditor;
   onClose: () => void;
 }): JSX.Element {
-  const [rows, setRows] = useState('5');
-  const [columns, setColumns] = useState('5');
+  const [rows, setRows] = useState('');
+  const [columns, setColumns] = useState('');
+  const [isDisabled, setIsDisabled] = useState(true);
+
+  useEffect(() => {
+    const row = Number(rows);
+    const column = Number(columns);
+    if (row && row > 0 && row <= 500 && column && column > 0 && column <= 50) {
+      setIsDisabled(false);
+    } else {
+      setIsDisabled(true);
+    }
+  }, [rows, columns]);
 
   const onClick = () => {
     activeEditor.dispatchCommand(INSERT_NEW_TABLE_COMMAND, {columns, rows});
@@ -149,19 +175,23 @@ export function InsertNewTableDialog({
   return (
     <>
       <TextInput
-        label="No of rows"
+        placeholder={'# of rows (1-500)'}
+        label="Rows"
         onChange={setRows}
         value={rows}
         data-test-id="table-modal-rows"
       />
       <TextInput
-        label="No of columns"
+        placeholder={'# of columns (1-50)'}
+        label="Columns"
         onChange={setColumns}
         value={columns}
         data-test-id="table-modal-columns"
       />
-      <DialogActions data-test-id="table-modal-confirm-insert">
-        <Button onClick={onClick}>Confirm</Button>
+      <DialogActions data-test-id="table-model-confirm-insert">
+        <Button disabled={isDisabled} onClick={onClick}>
+          Confirm
+        </Button>
       </DialogActions>
     </>
   );

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -145,6 +145,7 @@ export {
   $setCompositionKey,
   $setSelection,
   $splitNode,
+  getNearestEditorFromDOMNode,
   isSelectionWithinEditor,
 } from './LexicalUtils';
 export {$isDecoratorNode, DecoratorNode} from './nodes/LexicalDecoratorNode';


### PR DESCRIPTION
For example,
when the number of lines in the editor is more than 2,
gently double-click the end of the line, a toolbar will appear, and this toolbar will not process any text content.
In this case, it is obviously unnecessary to display the toolbar.


https://user-images.githubusercontent.com/48719861/224102364-2faa88a9-0fb7-4fed-9666-cc6240717a49.mov


![image](https://user-images.githubusercontent.com/48719861/224092845-c65333cc-3eda-41b3-b6cb-de5259a91ee2.png)
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/48719861/224093018-6706c63a-039b-4e32-a2ee-8bdcdc573010.png">




