### PR TITLE
Export getNearestEditorFromDOMNode

### DIFF
--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -145,6 +145,7 @@ export {
   $setCompositionKey,
   $setSelection,
   $splitNode,
+  getNearestEditorFromDOMNode,
   isSelectionWithinEditor,
 } from './LexicalUtils';
 export {$isDecoratorNode, DecoratorNode} from './nodes/LexicalDecoratorNode';


### PR DESCRIPTION
This method can come particularly useful for plugins that work over DOMElements (i.e. DOM event listeners) and have to support NestedEditors