### PR TITLE
Fix unresponsive resize handle in Safari

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -58,7 +58,6 @@ header h1 {
 .editor-shell .editor-container {
   background: #fff;
   position: relative;
-  cursor: text;
   display: block;
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
@@ -77,7 +76,6 @@ header h1 {
   min-height: 150px;
   border: 0;
   resize: none;
-  cursor: text;
   display: flex;
   position: relative;
   outline: 0;
@@ -89,6 +87,8 @@ header h1 {
 .editor {
   flex: auto;
   position: relative;
+  resize: vertical;
+  z-index: -1;
 }
 
 .test-recorder-output {


### PR DESCRIPTION
This bug was absurd. For whatever reason, the current setup works fine in Chromium and Firefox but is unresponsive in Safari. Using a `z-index: -1` half solves the solution but causes the resize handle to disappear and the blinking cursor to disappear.

`cursor: text` seems to interfere with the resize cursor icon regardless of the stack ordering. Eliminating `cursor: text` allows the icon to seamlessly switch and the cursor behavior throughout other areas of the app seem to be interpreted by the browser just fine.

Adding the second `resize: vertical` somehow tells Safari to bring back the blinking cursor and the resize grab handle. It's utterly bizarre... I've ran this by several experienced people and we can't make sense of it other than Safari being Safari. :D 

- This fix seems to not only fix Safari, but still works in Chromium and Firefox so we can avoid doing Safari specific behavior

**Current:**

https://user-images.githubusercontent.com/29527680/224128461-154aa6f3-991c-4594-b725-2740944dea02.mov

**Fixed:**

https://user-images.githubusercontent.com/29527680/224128629-fea548f5-9980-4f14-b1d2-ffa620069dc2.mov

