### PR TITLE
Pass tags to onChange for LexicalOnChangePlugin

### DIFF
--- a/packages/lexical-react/src/LexicalOnChangePlugin.ts
+++ b/packages/lexical-react/src/LexicalOnChangePlugin.ts
@@ -18,7 +18,11 @@ export function OnChangePlugin({
 }: {
   ignoreHistoryMergeTagChange?: boolean;
   ignoreSelectionChange?: boolean;
-  onChange: (editorState: EditorState, editor: LexicalEditor) => void;
+  onChange: (
+    editorState: EditorState,
+    editor: LexicalEditor,
+    tags: Set<string>,
+  ) => void;
 }): null {
   const [editor] = useLexicalComposerContext();
 
@@ -36,7 +40,7 @@ export function OnChangePlugin({
             return;
           }
 
-          onChange(editorState, editor);
+          onChange(editorState, editor, tags);
         },
       );
     }


### PR DESCRIPTION
We are using LexicalOnChangePlugin to save the state in DB.

We also have a plugin for reactive updates:

```js
type Props = {
  serializedEditorState: SerializedEditorState | undefined;
  debounceTime?: number;
};

export const REACTIVE_UPDATE_TAG = 'reactive-update';

/**
 * Plugin to update the editor when the incoming serializedEditorState changes
 * (in cases when several users are editing at the same time)
 */
export const ReactiveUpdatePlugin = ({ serializedEditorState, debounceTime = 0 }: Props) => {
  const [editor] = useLexicalComposerContext();

  const checkDiff = useMemo(
    () =>
      debounce((current: SerializedEditorState, incoming: SerializedEditorState, update: () => void) => {
        if (JSON.stringify(current) === JSON.stringify(incoming)) {
          return;
        }

        update();
      }, debounceTime),
    [debounceTime]
  );

  useEffect(() => {
    if (!serializedEditorState) {
      return;
    }

    checkDiff(editor.getEditorState().toJSON(), serializedEditorState, () => {
      const newSerializedState = editor.parseEditorState(serializedEditorState);
      editor.setEditorState(newSerializedState, { tag: REACTIVE_UPDATE_TAG });
    });
  }, [editor, serializedEditorState, checkDiff]);

  return null;
};
```

We can identify that an update comes from this plugin by tag.

```js
function onChange(editorState: EditorState, editor: LexicalEditor, tags: Set<string>) {
  if (tags.has(REACTIVE_UPDATE_TAG)) {
    return;
  }

  // do the DB update.
}

...


<OnChangePlugin onChange={onChange} />
```

We actually create our own OnChangePlugin but thought that other users may also benefit from tags passed to onChange
