### PR TITLE
Add focus tag to editor.focus

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1087,6 +1087,7 @@ export class LexicalEditor {
               callbackFn();
             }
           },
+          tag: 'focus',
         },
       );
       // In the case where onUpdate doesn't fire (due to the focus update not


### PR DESCRIPTION
Issue:

`editor.focus()` triggers onChange event.

Example: https://codesandbox.io/s/lexical-focus-onchange-vot70x?file=/src/Editor.js

following 
- #4091

we could handle focus update in onChange

```js
function onChange(editorState: EditorState, editor: LexicalEditor, tags: Set<string>) {
  if (tags.has('focus')) {
    return;
  }

  // do the DB update.
}

...


<OnChangePlugin onChange={onChange} />
```