### PR TITLE
Overflow of logos of action items in Lexical Playground

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -88,6 +88,7 @@ header h1 {
   position: relative;
   resize: vertical;
   z-index: -1;
+  padding-bottom: 50px;
 }
 
 .test-recorder-output {
@@ -1152,7 +1153,7 @@ i.prettier-error {
 }
 
 .actions {
-  position: inherit;
+  position: absolute;
   text-align: right;
   margin: 10px;
   bottom: 0;

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1152,7 +1152,7 @@ i.prettier-error {
 }
 
 .actions {
-  position: absolute;
+  position: inherit;
   text-align: right;
   margin: 10px;
   bottom: 0;

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -88,7 +88,6 @@ header h1 {
   position: relative;
   resize: vertical;
   z-index: -1;
-  padding-bottom: 50px;
 }
 
 .test-recorder-output {

--- a/packages/lexical-playground/src/ui/ContentEditable.css
+++ b/packages/lexical-playground/src/ui/ContentEditable.css
@@ -14,6 +14,7 @@
   tab-size: 1;
   outline: 0;
   padding: 8px 28px;
+  padding-bottom: 45px;
   min-height: calc(100% - 16px);
 }
 @media (max-width: 1025px) {


### PR DESCRIPTION
Changed the position to inherit from absolute to fix this issue.

Fixes #4095