### PR TITLE
Use broader return types in `HorizontalRuleNode`

### DIFF
--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -144,15 +144,15 @@ export class HorizontalRuleNode extends DecoratorNode<JSX.Element> {
     return document.createElement('hr');
   }
 
-  getTextContent(): '\n' {
+  getTextContent(): string {
     return '\n';
   }
 
-  isInline(): false {
+  isInline(): boolean {
     return false;
   }
 
-  updateDOM(): false {
+  updateDOM(): boolean {
     return false;
   }
 

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -148,7 +148,7 @@ export class HorizontalRuleNode extends DecoratorNode<JSX.Element> {
     return '\n';
   }
 
-  isInline(): boolean {
+  isInline(): false {
     return false;
   }
 


### PR DESCRIPTION
Use broader return types inside `HorizontalRuleNode` to make extending the node easier. Currently, subclasses cannot override these methods with anything other than what's specified by `HorizontalRuleNode`.