### PR TITLE
@lexical/utils -> registerNodesOfType

### DIFF
--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -11,6 +11,7 @@ import type {
   LexicalEditor,
   LexicalNode,
   ElementNode,
+  NodeKey,
 } from 'lexical';
 export type DFSNode = $ReadOnly<{
   depth: number,
@@ -83,3 +84,10 @@ declare export function $splitNode(
   node: ElementNode,
   offset: number,
 ): [ElementNode | null, ElementNode];
+
+declare export function registerNodesOfTypeListener(
+  editor: LexicalEditor,
+  klass: Class<LexicalNode>,
+  listener: (nodes: Set<NodeKey>) => void,
+  fireImmediately: ?boolean,
+): () => void;

--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodesOfTypeListener.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodesOfTypeListener.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// @ts-ignore
+import type {NodeKey} from 'lexical';
+
+import {$createParagraphNode, $getRoot, ParagraphNode} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+
+import {registerNodesOfTypeListener} from '../../index';
+
+describe('LexicalRootHelpers tests', () => {
+  initializeUnitTest((testEnv) => {
+    it('$registerNodesOfTypeListener', async () => {
+      const editor = testEnv.editor;
+
+      const paragraphKeys: Array<NodeKey> = [];
+      async function appendParagraph() {
+        await editor.update(() => {
+          const root = $getRoot();
+          const paragraph = $createParagraphNode();
+          paragraphKeys.push(paragraph.getKey());
+          root.append(paragraph);
+        });
+      }
+
+      await appendParagraph();
+      const cb = jest.fn(() => undefined);
+      registerNodesOfTypeListener(editor, ParagraphNode, cb, true);
+      await appendParagraph();
+
+      expect(cb).toHaveBeenCalledTimes(2);
+      expect(cb.mock.calls[0]).toEqual([new Set(paragraphKeys.slice(0, 1))]);
+      expect(cb.mock.calls[1]).toEqual([new Set(paragraphKeys)]);
+    });
+  });
+});

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1082,24 +1082,6 @@ export function setMutatedNode(
   }
 }
 
-export function $nodesOfType<T extends LexicalNode>(klass: Klass<T>): Array<T> {
-  const editorState = getActiveEditorState();
-  const readOnly = editorState._readOnly;
-  const klassType = klass.getType();
-  const nodes = editorState._nodeMap;
-  const nodesOfType: Array<T> = [];
-  for (const [, node] of nodes) {
-    if (
-      node instanceof klass &&
-      node.__type === klassType &&
-      (readOnly || node.isAttached())
-    ) {
-      nodesOfType.push(node as T);
-    }
-  }
-  return nodesOfType;
-}
-
 function resolveElement(
   element: ElementNode,
   isBackward: boolean,

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1082,6 +1082,24 @@ export function setMutatedNode(
   }
 }
 
+export function $nodesOfType<T extends LexicalNode>(klass: Klass<T>): Array<T> {
+  const editorState = getActiveEditorState();
+  const readOnly = editorState._readOnly;
+  const klassType = klass.getType();
+  const nodes = editorState._nodeMap;
+  const nodesOfType: Array<T> = [];
+  for (const [, node] of nodes) {
+    if (
+      node instanceof klass &&
+      node.__type === klassType &&
+      (readOnly || node.isAttached())
+    ) {
+      nodesOfType.push(node as T);
+    }
+  }
+  return nodesOfType;
+}
+
 function resolveElement(
   element: ElementNode,
   isBackward: boolean,


### PR DESCRIPTION
`$nodesOfType` is an expensive function, it iterates all the tree. It turns out that people are abusing this function as a handy shortcut (as we have no better utility) which can have performance implications on long documents.

There's two types of misuse:
1. For updates; people find it easier to use `$nodesOfType` than building more optimal tailored algorithm (via transform parent or making some hierarchy assumption).
2. For reads; `$nodesOfType` is much easier to use than `registerMutationListener` when tracking nodes as a whole as the mutation listener requires you to build your own data storage, do the first pass and handle creation and deletion.

This PR addresses the second, simplifies the whole mechanism and makes it easier to fall onto the pit of success

1. Forgetting the initial pass can cause a race condition
2. Slightly similar but this is a common race condition that has previously given us trouble with the `contenteditable` flag
```
const nodes = $nodesOfType(FooNode);
useEffect(() => {
  return editor.registerNodeMutation(..);
```
3. Tracking is verbose

Internal utilization reference https://fburl.com/diff/prwdmjw5