### PR TITLE
Catch failures in parseEditorState

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -371,6 +371,10 @@ export function parseEditorState(
     if (__DEV__) {
       handleDEVOnlyPendingUpdateGuarantees(editorState);
     }
+  } catch (error) {
+    if (error instanceof Error) {
+      editor._onError(error);
+    }
   } finally {
     editor._dirtyElements = previousDirtyElements;
     editor._dirtyLeaves = previousDirtyLeaves;


### PR DESCRIPTION
See this thread: 

https://discord.com/channels/953974421008293909/1075554413587996782/threads/1082425526737711115

This should allow a safer path forward cases like this.