### PR TITLE
Fix ShadowRoot + X insertNode

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -26,6 +26,8 @@ import {
 } from 'lexical';
 import {
   $createTestDecoratorNode,
+  $createTestElementNode,
+  $createTestShadowRootNode,
   createTestEditor,
   TestDecoratorNode,
 } from 'lexical/src/__tests__/utils';
@@ -2556,6 +2558,23 @@ describe('LexicalSelectionHelpers tests', () => {
       expect(element.innerHTML).toBe(
         '<p><a href="https://lexical.dev" dir="ltr"><span data-lexical-text="true">Lexical</span></a><span data-lexical-text="true">...</span></p>',
       );
+    });
+
+    test('Can insert an ElementNode after ShadowRoot', async () => {
+      const editor = createTestEditor();
+      const element = document.createElement('div');
+      editor.setRootElement(element);
+
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
+        paragraph.selectStart();
+        const element1 = $createTestShadowRootNode();
+        const element2 = $createTestElementNode();
+        $insertNodes([element1, element2]);
+      });
+      expect(element.innerHTML).toBe('<div><br></div><div><br></div>');
     });
   });
 });

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1535,6 +1535,7 @@ export class RangeSelection implements BaseSelection {
         }
       } else if (
         didReplaceOrMerge &&
+        !$isElementNode(node) &&
         !$isDecoratorNode(node) &&
         $isRootOrShadowRoot(target.getParent<ElementNode>())
       ) {

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -235,6 +235,58 @@ export function $createTestInlineElementNode(): TestInlineElementNode {
   return new TestInlineElementNode();
 }
 
+export type SerializedTestShadowRootNode = Spread<
+  {
+    type: 'test_block';
+    version: 1;
+  },
+  SerializedElementNode
+>;
+
+export class TestShadowRootNode extends ElementNode {
+  static getType(): string {
+    return 'test_shadow_root';
+  }
+
+  static clone(node: TestShadowRootNode) {
+    return new TestElementNode(node.__key);
+  }
+
+  static importJSON(
+    serializedNode: SerializedTestShadowRootNode,
+  ): TestShadowRootNode {
+    const node = $createTestShadowRootNode();
+    node.setFormat(serializedNode.format);
+    node.setIndent(serializedNode.indent);
+    node.setDirection(serializedNode.direction);
+    return node;
+  }
+
+  exportJSON(): SerializedTestShadowRootNode {
+    return {
+      ...super.exportJSON(),
+      type: 'test_block',
+      version: 1,
+    };
+  }
+
+  createDOM() {
+    return document.createElement('div');
+  }
+
+  updateDOM() {
+    return false;
+  }
+
+  isShadowRoot() {
+    return true;
+  }
+}
+
+export function $createTestShadowRootNode(): TestShadowRootNode {
+  return new TestShadowRootNode();
+}
+
 export type SerializedTestSegmentedNode = Spread<
   {
     type: 'test_segmented';
@@ -419,6 +471,7 @@ const DEFAULT_NODES = [
   TestExcludeFromCopyElementNode,
   TestDecoratorNode,
   TestInlineElementNode,
+  TestShadowRootNode,
   TestTextNode,
 ];
 


### PR DESCRIPTION
Turns out the append to ShadowRoot/RootNode condition was not correct. The reason why it's a rare crash is because usually we either don't insert multiple nodes at once or they fall under the replace/merge category (condition 1). This is not the case when you append a `ShadowRoot` followed by another (ElementNode).

Tables are ShadowRoot, and when pasting a table followed by a paragraph it falls under that condition.

Fixes #4114