### PR TITLE
Fix tables Collab E2E

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -916,6 +916,10 @@ test.describe('Tables', () => {
 
   test('Merge cells', async ({page, isPlainText}) => {
     test.skip(isPlainText);
+    if (IS_COLLAB) {
+      // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
+      page.setViewportSize({height: 1000, width: 3000});
+    }
 
     await focusEditor(page);
 
@@ -1116,6 +1120,10 @@ test.describe('Tables', () => {
     isPlainText,
   }) => {
     test.skip(isPlainText);
+    if (IS_COLLAB) {
+      // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
+      page.setViewportSize({height: 1000, width: 3000});
+    }
 
     await focusEditor(page);
 
@@ -1226,6 +1234,10 @@ test.describe('Tables', () => {
     isPlainText,
   }) => {
     test.skip(isPlainText);
+    if (IS_COLLAB) {
+      // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
+      page.setViewportSize({height: 1000, width: 3000});
+    }
 
     await focusEditor(page);
 
@@ -1282,6 +1294,10 @@ test.describe('Tables', () => {
     isPlainText,
   }) => {
     test.skip(isPlainText);
+    if (IS_COLLAB) {
+      // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
+      page.setViewportSize({height: 1000, width: 3000});
+    }
 
     await focusEditor(page);
 


### PR DESCRIPTION
The viewport problem seems to be flaky; but adding the same patch to the remaining tests that use the contextual menu should do the trick for now.

Eventually, we have to fix or delete the contextual menu.