### PR TITLE
Validate against infinite loop in ListItemNode.setIndent

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -128,7 +128,9 @@ export class ListItemNode extends ElementNode {
   static importJSON(serializedNode: SerializedListItemNode): ListItemNode {
     const node = new ListItemNode(serializedNode.value, serializedNode.checked);
     node.setFormat(serializedNode.format);
-    node.setIndent(serializedNode.indent);
+    //setIndent is overridden here with logic that doesn't need
+    //to run during deserialization
+    node.getWritable().__indent = serializedNode.indent;
     node.setDirection(serializedNode.direction);
     return node;
   }
@@ -367,6 +369,10 @@ export class ListItemNode extends ElementNode {
   }
 
   setIndent(indent: number): this {
+    invariant(
+      typeof indent === 'number' && indent > -1,
+      'Invalid indent value.',
+    );
     let currentIndent = this.getIndent();
     while (currentIndent !== indent) {
       if (currentIndent < indent) {


### PR DESCRIPTION
This one is a bit interesting. We had a couple of issues here.

First, we shouldn't have been using ListItemNode.setIndent in the deserialization logic for this node, as it runs a bunch of node manipulation logic that shouldn't be necessary in that code path.

Second, if you call ListItemNode.setIndent directly and you're not using a compile-time type-checker, then you can cause an infinite loop here. It's a bit of a footgun lying around.

On the other hand, you could probably cause all sorts of weird issues by passing invalid data types into node setters across the library. I'm addressing this because it seems like particularly gnarly one, but taking this to it's logic conclusion means we'd do this everywhere, which I'm not sure is practically necessary.

Fixes #4119 
