### PR TITLE
[RFC] Initial stage of refactor for React Native support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,14 +86,6 @@
         "yarn": ">=1"
       }
     },
-    "eslint-plugin": {
-      "name": "eslint-plugin-lexical",
-      "version": "1.0.0",
-      "dev": true,
-      "peerDependencies": {
-        "eslint": ">=4.19.1"
-      }
-    },
     "node_modules/@algolia/autocomplete-core": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
@@ -383,10 +375,8 @@
         "@babel/generator": "^7.18.6",
         "@babel/helper-compilation-targets": "^7.18.6",
         "@babel/helper-module-transforms": "^7.18.6",
-        "@babel/helpers": "^7.18.6",
         "@babel/parser": "^7.18.6",
         "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.6",
         "@babel/types": "^7.18.6",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -9057,8 +9047,12 @@
       }
     },
     "node_modules/eslint-plugin-lexical": {
-      "resolved": "eslint-plugin",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "file:eslint-plugin",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
     },
     "node_modules/eslint-plugin-no-function-declare-after-return": {
       "version": "1.1.0",
@@ -23565,10 +23559,8 @@
         "@babel/generator": "^7.18.6",
         "@babel/helper-compilation-targets": "^7.18.6",
         "@babel/helper-module-transforms": "^7.18.6",
-        "@babel/helpers": "^7.18.6",
         "@babel/parser": "^7.18.6",
         "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.6",
         "@babel/types": "^7.18.6",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -30682,7 +30674,8 @@
       }
     },
     "eslint-plugin-lexical": {
-      "version": "file:eslint-plugin"
+      "version": "1.0.0",
+      "dev": true
     },
     "eslint-plugin-no-function-declare-after-return": {
       "version": "1.1.0",

--- a/packages/lexical-headless/src/index.ts
+++ b/packages/lexical-headless/src/index.ts
@@ -9,8 +9,7 @@
 
 import type {CreateEditorArgs, LexicalEditor} from 'lexical';
 
-import {createEditor} from 'lexical';
-import {LexicalHeadlessFrontendAdapter} from 'packages/lexical/src/LexicalHeadlessFrontendAdapter';
+import {createEditor, LexicalHeadlessFrontendAdapter} from 'lexical';
 
 export function createHeadlessEditor(
   editorConfig?: CreateEditorArgs,

--- a/packages/lexical-headless/src/index.ts
+++ b/packages/lexical-headless/src/index.ts
@@ -10,12 +10,14 @@
 import type {CreateEditorArgs, LexicalEditor} from 'lexical';
 
 import {createEditor} from 'lexical';
+import {LexicalHeadlessFrontendAdapter} from 'packages/lexical/src/LexicalHeadlessFrontendAdapter';
 
 export function createHeadlessEditor(
   editorConfig?: CreateEditorArgs,
 ): LexicalEditor {
-  const editor = createEditor(editorConfig);
-  editor._headless = true;
+  const config = editorConfig || {};
+  config.frontendAdapter = new LexicalHeadlessFrontendAdapter();
+  const editor = createEditor(config);
 
   const unsupportedMethods = [
     'registerDecoratorListener',

--- a/packages/lexical-playground/src/nodes/TableComponent.tsx
+++ b/packages/lexical-playground/src/nodes/TableComponent.tsx
@@ -202,10 +202,10 @@ function $updateCells(
     const cell = getCell(rows, id, cellCoordMap);
     if (cell !== null && cellEditor !== null) {
       const editorState = cellEditor.parseEditorState(cell.json);
-      cellEditor._headless = true;
+      cellEditor._frontendAdapter.setTemporarilyHeadless(true);
       cellEditor.setEditorState(editorState);
       cellEditor.update(fn, {discrete: true});
-      cellEditor._headless = false;
+      cellEditor._frontendAdapter.setTemporarilyHeadless(false);
       const newJSON = JSON.stringify(cellEditor.getEditorState());
       updateTableNode((tableNode) => {
         const [x, y] = cellCoordMap.get(id) as [number, number];

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
@@ -162,7 +162,8 @@ export default function CollapsiblePlugin(): JSX.Element | null {
         INSERT_PARAGRAPH_COMMAND,
         () => {
           // @ts-ignore
-          const windowEvent: KeyboardEvent | undefined = editor._window?.event;
+          const windowEvent: KeyboardEvent | undefined =
+            editor._frontendAdapter.getWindow()?.event;
 
           if (
             windowEvent &&

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -240,7 +240,9 @@ export class TableSelection {
       this.focusCell = cell;
 
       if (this.anchorCell !== null) {
-        const domSelection = getDOMSelection(this.editor._window);
+        const domSelection = getDOMSelection(
+          this.editor._frontendAdapter.getWindow(),
+        );
         // Collapse the selection
         if (domSelection) {
           domSelection.setBaseAndExtent(

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
@@ -24,7 +24,7 @@ describe('LexicalUtils#splitNode', () => {
 
   beforeEach(async () => {
     editor = createTestEditor();
-    editor._headless = true;
+    editor._frontendAdapter.setTemporarilyHeadless(true);
   });
 
   const testCases: Array<{

--- a/packages/lexical-utils/src/__tests__/unit/LexlcaiUtilsInsertNodeToNearestRoot.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexlcaiUtilsInsertNodeToNearestRoot.test.tsx
@@ -28,7 +28,7 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
 
   beforeEach(async () => {
     editor = createTestEditor();
-    editor._headless = true;
+    editor._frontendAdapter.setTemporarilyHeadless(true);
   });
 
   const testCases: Array<{

--- a/packages/lexical/src/LexicalDOMFrontendAdapter.ts
+++ b/packages/lexical/src/LexicalDOMFrontendAdapter.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import invariant from 'shared/invariant';
+
+import {FULL_RECONCILE} from './LexicalConstants';
+import {resetEditor, RootListener} from './LexicalEditor';
+import {addRootElementEvents, removeRootElementEvents} from './LexicalEvents';
+import {LexicalFrontendAdapter} from './LexicalFrontendAdapter';
+import {initMutationObserver} from './LexicalMutations';
+import {commitPendingUpdates, triggerListeners} from './LexicalUpdates';
+import {getCachedClassNameArray, getDefaultView} from './LexicalUtils';
+
+export function createDOMFrontendAdapter(): LexicalDOMFrontendAdapter {
+  return new LexicalDOMFrontendAdapter();
+}
+
+export class LexicalDOMFrontendAdapter extends LexicalFrontendAdapter {
+  constructor() {
+    super();
+    this._rootElement = null;
+    this._window = null;
+  }
+  /** @internal */
+  _rootElement: null | HTMLElement;
+  /** @internal */
+  _window: null | Window;
+
+  getWindow(): Window | null {
+    return this._window;
+  }
+  getRootElement(): HTMLElement | null {
+    return this._rootElement;
+  }
+  setRootElement(nextRootElement: HTMLElement | null): void {
+    const prevRootElement = this._rootElement;
+    const editor = this._editor;
+    if (editor === null) {
+      invariant(false, 'Should have editor here');
+      return;
+    }
+
+    if (nextRootElement !== prevRootElement) {
+      const classNames = getCachedClassNameArray(editor._config.theme, 'root');
+      const pendingEditorState =
+        editor._pendingEditorState || editor._editorState;
+      this._rootElement = nextRootElement;
+      resetEditor(editor, prevRootElement, nextRootElement, pendingEditorState);
+
+      if (prevRootElement !== null) {
+        // TODO: remove this flag once we no longer use UEv2 internally
+        if (!editor._config.disableEvents) {
+          removeRootElementEvents(prevRootElement);
+        }
+        if (classNames != null) {
+          prevRootElement.classList.remove(...classNames);
+        }
+      }
+
+      if (nextRootElement !== null) {
+        const windowObj = getDefaultView(nextRootElement);
+        const style = nextRootElement.style;
+        style.userSelect = 'text';
+        style.whiteSpace = 'pre-wrap';
+        style.wordBreak = 'break-word';
+        nextRootElement.setAttribute('data-lexical-editor', 'true');
+        this._window = windowObj;
+        editor._dirtyType = FULL_RECONCILE;
+        initMutationObserver(editor);
+
+        editor._updateTags.add('history-merge');
+
+        commitPendingUpdates(editor);
+
+        // TODO: remove this flag once we no longer use UEv2 internally
+        if (!editor._config.disableEvents) {
+          addRootElementEvents(nextRootElement, editor);
+        }
+        if (classNames != null) {
+          nextRootElement.classList.add(...classNames);
+        }
+      } else {
+        this._window = null;
+      }
+
+      triggerListeners('root', editor, false, nextRootElement, prevRootElement);
+    }
+  }
+
+  isHeadless(): boolean {
+    return this._temporarilyHeadless;
+  }
+
+  registerRootListener(listener: RootListener): () => void {
+    const editor = this._editor;
+    if (editor === null) {
+      invariant(false, 'Should have editor here');
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return () => {};
+    }
+
+    const listenerSetOrMap = editor._listeners.root;
+    listener(this._rootElement, null);
+    listenerSetOrMap.add(listener);
+    return () => {
+      listener(null, this._rootElement);
+      listenerSetOrMap.delete(listener);
+    };
+  }
+
+  _temporarilyHeadless = false;
+  setTemporarilyHeadless(headless: boolean) {
+    this._temporarilyHeadless = headless;
+  }
+}

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -191,7 +191,7 @@ function $shouldPreventDefaultAndInsertText(
   const focus = selection.focus;
   const anchorNode = anchor.getNode();
   const editor = getActiveEditor();
-  const domSelection = getDOMSelection(editor._window);
+  const domSelection = getDOMSelection(editor._frontendAdapter.getWindow());
   const domAnchorNode = domSelection !== null ? domSelection.anchorNode : null;
   const anchorKey = anchor.key;
   const backingAnchorElement = editor.getElementByKey(anchorKey);
@@ -370,7 +370,7 @@ function onSelectionChange(
 function onClick(event: MouseEvent, editor: LexicalEditor): void {
   updateEditor(editor, () => {
     const selection = $getSelection();
-    const domSelection = getDOMSelection(editor._window);
+    const domSelection = getDOMSelection(editor._frontendAdapter.getWindow());
     const lastSelection = $getPreviousSelection();
 
     if ($isRangeSelection(selection)) {
@@ -725,7 +725,7 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
       }
       const anchor = selection.anchor;
       const anchorNode = anchor.getNode();
-      const domSelection = getDOMSelection(editor._window);
+      const domSelection = getDOMSelection(editor._frontendAdapter.getWindow());
       if (domSelection === null) {
         return;
       }

--- a/packages/lexical/src/LexicalFrontendAdapter.ts
+++ b/packages/lexical/src/LexicalFrontendAdapter.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {LexicalEditor, RootListener} from './LexicalEditor';
+
+export abstract class LexicalFrontendAdapter {
+  _editor: null | LexicalEditor;
+
+  constructor() {
+    this._editor = null;
+  }
+
+  setEditor(editor: null | LexicalEditor) {
+    this._editor = editor;
+  }
+
+  // Frontend-specific methods to override
+  abstract isHeadless(): boolean;
+  abstract setTemporarilyHeadless(headless: boolean);
+
+  /**
+   * The following methods seem DOM-specific. Ideally we wouldn't expose
+   * them in the FrontendAdapter API like this. However, we are doing
+   * so during the refactor/migration, to make the refactor easier and
+   * to aid in backwards compatibility.
+   */
+  abstract getWindow(): null | Window;
+  abstract getRootElement(): null | HTMLElement;
+  abstract setRootElement(nextRootElement: null | HTMLElement): void;
+  abstract registerRootListener(listener: RootListener): () => void;
+}

--- a/packages/lexical/src/LexicalHeadlessFrontendAdapter.ts
+++ b/packages/lexical/src/LexicalHeadlessFrontendAdapter.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {RootListener} from './LexicalEditor';
+import {LexicalFrontendAdapter} from './LexicalFrontendAdapter';
+
+export class LexicalHeadlessFrontendAdapter extends LexicalFrontendAdapter {
+  isHeadless(): boolean {
+    return true;
+  }
+  registerRootListener(listener: RootListener): () => void {
+    return () => {
+      // no-op
+    };
+  }
+  getWindow(): Window | null {
+    return null;
+  }
+  getRootElement(): HTMLElement | null {
+    return null;
+  }
+  setRootElement(nextRootElement: HTMLElement | null): void {
+    // no-op
+  }
+  setTemporarilyHeadless(headless: boolean) {
+    // no-op
+  }
+}

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -82,7 +82,7 @@ function handleTextMutation(
   node: TextNode,
   editor: LexicalEditor,
 ): void {
-  const domSelection = getDOMSelection(editor._window);
+  const domSelection = getDOMSelection(editor._frontendAdapter.getWindow());
   let anchorOffset = null;
   let focusOffset = null;
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1951,13 +1951,13 @@ export class RangeSelection implements BaseSelection {
       }
     }
     const editor = getActiveEditor();
-    const domSelection = getDOMSelection(editor._window);
+    const domSelection = getDOMSelection(editor._frontendAdapter.getWindow());
 
     if (!domSelection) {
       return;
     }
     const blockCursorElement = editor._blockCursorElement;
-    const rootElement = editor._rootElement;
+    const rootElement = editor._frontendAdapter.getRootElement();
     // Remove the block cursor element if it exists. This will ensure selection
     // works as intended. If we leave it in the DOM all sorts of strange bugs
     // occur. :/
@@ -2625,7 +2625,7 @@ export function internalCreateSelection(
 ): null | RangeSelection | NodeSelection | GridSelection {
   const currentEditorState = editor.getEditorState();
   const lastSelection = currentEditorState._selection;
-  const domSelection = getDOMSelection(editor._window);
+  const domSelection = getDOMSelection(editor._frontendAdapter.getWindow());
 
   if (
     $isNodeSelection(lastSelection) ||
@@ -2642,7 +2642,7 @@ export function internalCreateRangeSelection(
   domSelection: Selection | null,
   editor: LexicalEditor,
 ): null | RangeSelection {
-  const windowObj = editor._window;
+  const windowObj = editor._frontendAdapter.getWindow();
   if (windowObj === null) {
     return null;
   }

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -431,8 +431,9 @@ function handleDEVOnlyPendingUpdateGuarantees(
 
 export function commitPendingUpdates(editor: LexicalEditor): void {
   const pendingEditorState = editor._pendingEditorState;
-  const rootElement = editor._rootElement;
-  const shouldSkipDOM = editor._headless || rootElement === null;
+  const rootElement = editor._frontendAdapter.getRootElement();
+  const shouldSkipDOM =
+    editor._frontendAdapter.isHeadless() || rootElement === null;
 
   if (pendingEditorState === null) {
     return;
@@ -537,7 +538,9 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
   // Reconciliation has finished. Now update selection and trigger listeners.
   // ======
 
-  const domSelection = shouldSkipDOM ? null : getDOMSelection(editor._window);
+  const domSelection = shouldSkipDOM
+    ? null
+    : getDOMSelection(editor._frontendAdapter.getWindow());
 
   // Attempt to update the DOM selection, including focusing of the root element,
   // and scroll into view if needed.
@@ -849,7 +852,7 @@ function beginUpdate(
 
   try {
     if (editorStateWasCloned) {
-      if (editor._headless) {
+      if (editor._frontendAdapter.isHeadless()) {
         if (currentEditorState._selection != null) {
           pendingEditorState._selection = currentEditorState._selection.clone();
         }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -563,7 +563,7 @@ export function $updateSelectedTextFromDOM(
   data?: string,
 ): void {
   // Update the text content with the latest composition text
-  const domSelection = getDOMSelection(editor._window);
+  const domSelection = getDOMSelection(editor._frontendAdapter.getWindow());
   if (domSelection === null) {
     return;
   }
@@ -1305,7 +1305,7 @@ export function getDefaultView(domElem: HTMLElement): Window | null {
 }
 
 export function getWindow(editor: LexicalEditor): Window {
-  const windowObj = editor._window;
+  const windowObj = editor._frontendAdapter.getWindow();
   if (windowObj === null) {
     invariant(false, 'window object not found');
   }

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -107,6 +107,7 @@ export {
   SELECTION_CHANGE_COMMAND,
   UNDO_COMMAND,
 } from './LexicalCommands';
+export {LexicalDOMFrontendAdapter} from './LexicalDOMFrontendAdapter';
 export {
   COMMAND_PRIORITY_CRITICAL,
   COMMAND_PRIORITY_EDITOR,
@@ -116,6 +117,8 @@ export {
   createEditor,
 } from './LexicalEditor';
 export type {EventHandler} from './LexicalEvents';
+export {LexicalFrontendAdapter} from './LexicalFrontendAdapter';
+export {LexicalHeadlessFrontendAdapter} from './LexicalHeadlessFrontendAdapter';
 export {$normalizeSelection as $normalizeSelection__EXPERIMENTAL} from './LexicalNormalization';
 export {
   $createNodeSelection,


### PR DESCRIPTION
[Disclaimer: all references to Lexical React Native should not be treated as a commitment!]

Lexical React Native will use a different reconciler to Lexical JS, as it will not have access to the DOM. In order to make Lexical Core able to work in both situations, I'm starting a refactor. I've created a thing that I call a "Frontend Adapter" (name TBC, please make suggestions if you think of something better!). Each editor possesses one `FrontendAdapter`, which can be passed in upon creation. We'll have separate Frontend Adapters for DOM, headless, and React Native (eventually).

The Frontend Adapters will (eventually) encapsulate anything that is different between the different platforms. For example, they'll be responsible for kicking off the reconciler; for storing state (e.g. the Root Element for DOM) that only applies to one platform; etc. For now, this is the very first step. Eventually, things like `window` won't be a public method on `FrontendAdapter`, because every bit of code that requires talking to the window will be encapsulated within the specific FrontendAdapter subclass, and the public methods will be at a higher abstraction level.

Questions for discussion:

* Is the name "Frontend Adapter" good? Or do you have a better idea?
* Should I be merging these PRs as I go, or should I wait a little bit? If the latter, it'll be harder for me to track the rest of the code as it is updated, of course. 