### PR TITLE
Update "Spread" to work better with overrided nodes

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -37,7 +37,7 @@ import {LineBreakNode} from './nodes/LexicalLineBreakNode';
 import {ParagraphNode} from './nodes/LexicalParagraphNode';
 import {RootNode} from './nodes/LexicalRootNode';
 
-export type Spread<T1, T2> = Omit<T2, keyof T1> & T1;
+export type Spread<T1, T2> = {[K in Exclude<keyof T1, keyof T2>]: T1[K]} & T2;
 
 export type Klass<T extends LexicalNode> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Update the `Spread` helper to make overriding nodes easier.

Consider this example where `CustomListNode` extends `ListNode`:
```js
type SerializedCustomListNode = Spread<{
  type: "custom-list";
  version: 1;
}, SerializedListNode>

class CustomListNode extends ListNode {
  exportJSON(): SerializedCustomListNode {
    return {
      ...super.exportJSON(),
      type: "custom-list",
      version: 1,
    };
  }
}
```

Previously, the line `type: 'custom-list'` would throw the type error:
```
Type '"list_module"' is not assignable to type '"list"'
```

That made it difficult to override nodes as you'd need to either disable the type warning or else return `type: "list"` as expected by `SerializedListNode`.