### PR TITLE
Loosen node and version types

### DIFF
--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -49,8 +49,6 @@ export const DEFAULT_CODE_LANGUAGE = 'javascript';
 type SerializedCodeHighlightNode = Spread<
   {
     highlightType: string | null | undefined;
-    type: 'code-highlight';
-    version: 1;
   },
   SerializedTextNode
 >;

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -53,8 +53,6 @@ import * as Prism from 'prismjs';
 export type SerializedCodeNode = Spread<
   {
     language: string | null | undefined;
-    type: 'code';
-    version: 1;
   },
   SerializedElementNode
 >;

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -39,9 +39,7 @@ export type LinkAttributes = {
 
 export type SerializedLinkNode = Spread<
   {
-    type: 'link';
     url: string;
-    version: 1;
   },
   Spread<LinkAttributes, SerializedElementNode>
 >;
@@ -299,13 +297,7 @@ export function $isLinkNode(
   return node instanceof LinkNode;
 }
 
-export type SerializedAutoLinkNode = Spread<
-  {
-    type: 'autolink';
-    version: 1;
-  },
-  SerializedLinkNode
->;
+export type SerializedAutoLinkNode = SerializedLinkNode;
 
 // Custom node type to override `canInsertTextAfter` that will
 // allow typing within the link

--- a/packages/lexical-list/flow/LexicalList.js.flow
+++ b/packages/lexical-list/flow/LexicalList.js.flow
@@ -78,8 +78,6 @@ export type SerializedListItemNode = {
   ...SerializedElementNode,
   checked: boolean | void,
   value: number,
-  type: 'listitem',
-  version: 1,
   ...
 };
 
@@ -88,7 +86,5 @@ export type SerializedListNode = {
   listType: ListType,
   start: number,
   tag: ListNodeTagType,
-  type: 'list',
-  version: 1,
   ...
 };

--- a/packages/lexical-list/flow/LexicalList.js.flow
+++ b/packages/lexical-list/flow/LexicalList.js.flow
@@ -74,17 +74,13 @@ declare export var INSERT_ORDERED_LIST_COMMAND: LexicalCommand<void>;
 declare export var INSERT_CHECK_LIST_COMMAND: LexicalCommand<void>;
 declare export var REMOVE_LIST_COMMAND: LexicalCommand<void>;
 
-export type SerializedListItemNode = {
-  ...SerializedElementNode,
+export type SerializedListItemNode = SerializedElementNode & {
   checked: boolean | void,
   value: number,
-  ...
 };
 
-export type SerializedListNode = {
-  ...SerializedElementNode,
+export type SerializedListNode = SerializedElementNode & {
   listType: ListType,
   start: number,
   tag: ListNodeTagType,
-  ...
 };

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -49,9 +49,7 @@ import {isNestedListNode} from './utils';
 export type SerializedListItemNode = Spread<
   {
     checked: boolean | undefined;
-    type: 'listitem';
     value: number;
-    version: 1;
   },
   SerializedElementNode
 >;

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -37,8 +37,6 @@ export type SerializedListNode = Spread<
     listType: ListType;
     start: number;
     tag: ListNodeTagType;
-    type: 'list';
-    version: 1;
   },
   SerializedElementNode
 >;

--- a/packages/lexical-mark/flow/LexicalMark.js.flow
+++ b/packages/lexical-mark/flow/LexicalMark.js.flow
@@ -18,8 +18,6 @@ import {ElementNode, LexicalNode} from 'lexical';
 export type SerializedMarkNode = {
   ...SerializedElementNode,
   ids: Array<string>,
-  type: 'mark',
-  version: 1,
   ...
 };
 

--- a/packages/lexical-mark/flow/LexicalMark.js.flow
+++ b/packages/lexical-mark/flow/LexicalMark.js.flow
@@ -15,10 +15,8 @@ import type {
 } from 'lexical';
 import {ElementNode, LexicalNode} from 'lexical';
 
-export type SerializedMarkNode = {
-  ...SerializedElementNode,
+export type SerializedMarkNode = SerializedElementNode & {
   ids: Array<string>,
-  ...
 };
 
 declare export class MarkNode extends ElementNode {

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -31,8 +31,6 @@ import {
 export type SerializedMarkNode = Spread<
   {
     ids: Array<string>;
-    type: 'mark';
-    version: 1;
   },
   SerializedElementNode
 >;

--- a/packages/lexical-overflow/flow/LexicalOverflow.js.flow
+++ b/packages/lexical-overflow/flow/LexicalOverflow.js.flow
@@ -29,7 +29,4 @@ declare export function $isOverflowNode(
   node: ?LexicalNode,
 ): boolean %checks(node instanceof OverflowNode);
 
-export type SerializedOverflowNode = {
-  ...SerializedElementNode,
-  ...
-};
+export type SerializedOverflowNode = SerializedElementNode;

--- a/packages/lexical-overflow/flow/LexicalOverflow.js.flow
+++ b/packages/lexical-overflow/flow/LexicalOverflow.js.flow
@@ -31,7 +31,5 @@ declare export function $isOverflowNode(
 
 export type SerializedOverflowNode = {
   ...SerializedElementNode,
-  type: 'overflow',
-  version: 1,
   ...
 };

--- a/packages/lexical-overflow/src/index.ts
+++ b/packages/lexical-overflow/src/index.ts
@@ -13,18 +13,11 @@ import type {
   NodeKey,
   RangeSelection,
   SerializedElementNode,
-  Spread,
 } from 'lexical';
 
 import {$applyNodeReplacement, ElementNode} from 'lexical';
 
-export type SerializedOverflowNode = Spread<
-  {
-    type: 'overflow';
-    version: 1;
-  },
-  SerializedElementNode
->;
+export type SerializedOverflowNode = SerializedElementNode;
 
 /** @noInheritDoc */
 export class OverflowNode extends ElementNode {

--- a/packages/lexical-playground/src/nodes/AutocompleteNode.tsx
+++ b/packages/lexical-playground/src/nodes/AutocompleteNode.tsx
@@ -29,8 +29,6 @@ declare global {
 
 export type SerializedAutocompleteNode = Spread<
   {
-    type: 'autocomplete';
-    version: 1;
     uuid: string;
   },
   SerializedLexicalNode

--- a/packages/lexical-playground/src/nodes/EmojiNode.tsx
+++ b/packages/lexical-playground/src/nodes/EmojiNode.tsx
@@ -19,7 +19,6 @@ import {$applyNodeReplacement, TextNode} from 'lexical';
 export type SerializedEmojiNode = Spread<
   {
     className: string;
-    type: 'emoji';
   },
   SerializedTextNode
 >;

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -28,7 +28,6 @@ const EquationComponent = React.lazy(
 
 export type SerializedEquationNode = Spread<
   {
-    type: 'equation';
     equation: string;
     inline: boolean;
   },

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -30,8 +30,6 @@ const ExcalidrawComponent = React.lazy(
 export type SerializedExcalidrawNode = Spread<
   {
     data: string;
-    type: 'excalidraw';
-    version: 1;
   },
   SerializedLexicalNode
 >;

--- a/packages/lexical-playground/src/nodes/FigmaNode.tsx
+++ b/packages/lexical-playground/src/nodes/FigmaNode.tsx
@@ -57,8 +57,6 @@ function FigmaComponent({
 export type SerializedFigmaNode = Spread<
   {
     documentID: string;
-    type: 'figma';
-    version: 1;
   },
   SerializedDecoratorBlockNode
 >;

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -58,8 +58,6 @@ export type SerializedImageNode = Spread<
     showCaption: boolean;
     src: string;
     width?: number;
-    type: 'image';
-    version: 1;
   },
   SerializedLexicalNode
 >;

--- a/packages/lexical-playground/src/nodes/KeywordNode.ts
+++ b/packages/lexical-playground/src/nodes/KeywordNode.ts
@@ -6,22 +6,11 @@
  *
  */
 
-import type {
-  EditorConfig,
-  LexicalNode,
-  SerializedTextNode,
-  Spread,
-} from 'lexical';
+import type {EditorConfig, LexicalNode, SerializedTextNode} from 'lexical';
 
 import {TextNode} from 'lexical';
 
-export type SerializedKeywordNode = Spread<
-  {
-    type: 'keyword';
-    version: 1;
-  },
-  SerializedTextNode
->;
+export type SerializedKeywordNode = SerializedTextNode;
 
 export class KeywordNode extends TextNode {
   static getType(): string {

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -23,8 +23,6 @@ import {
 export type SerializedMentionNode = Spread<
   {
     mentionName: string;
-    type: 'mention';
-    version: 1;
   },
   SerializedTextNode
 >;

--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -63,8 +63,6 @@ export type SerializedPollNode = Spread<
   {
     question: string;
     options: Options;
-    type: 'poll';
-    version: 1;
   },
   SerializedLexicalNode
 >;

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -34,8 +34,6 @@ export type SerializedStickyNode = Spread<
     yOffset: number;
     color: StickyNoteColor;
     caption: SerializedEditor;
-    type: 'sticky';
-    version: 1;
   },
   SerializedLexicalNode
 >;

--- a/packages/lexical-playground/src/nodes/TableNode.tsx
+++ b/packages/lexical-playground/src/nodes/TableNode.tsx
@@ -82,8 +82,6 @@ export function createRow(): Row {
 export type SerializedTableNode = Spread<
   {
     rows: Rows;
-    type: 'tablesheet';
-    version: 1;
   },
   SerializedLexicalNode
 >;

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -126,8 +126,6 @@ function TweetComponent({
 export type SerializedTweetNode = Spread<
   {
     id: string;
-    type: 'tweet';
-    version: 1;
   },
   SerializedDecoratorBlockNode
 >;

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -62,8 +62,6 @@ function YouTubeComponent({
 export type SerializedYouTubeNode = Spread<
   {
     videoID: string;
-    type: 'youtube';
-    version: 1;
   },
   SerializedDecoratorBlockNode
 >;

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -22,8 +22,6 @@ import {
 type SerializedCollapsibleContainerNode = Spread<
   {
     open: boolean;
-    type: 'collapsible-container';
-    version: 1;
   },
   SerializedElementNode
 >;

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
@@ -14,16 +14,9 @@ import {
   ElementNode,
   LexicalNode,
   SerializedElementNode,
-  Spread,
 } from 'lexical';
 
-type SerializedCollapsibleContentNode = Spread<
-  {
-    type: 'collapsible-content';
-    version: 1;
-  },
-  SerializedElementNode
->;
+type SerializedCollapsibleContentNode = SerializedElementNode;
 
 export function convertCollapsibleContentElement(
   domNode: HTMLElement,

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
@@ -18,19 +18,12 @@ import {
   LexicalNode,
   RangeSelection,
   SerializedElementNode,
-  Spread,
 } from 'lexical';
 
 import {$isCollapsibleContainerNode} from './CollapsibleContainerNode';
 import {$isCollapsibleContentNode} from './CollapsibleContentNode';
 
-type SerializedCollapsibleTitleNode = Spread<
-  {
-    type: 'collapsible-title';
-    version: 1;
-  },
-  SerializedElementNode
->;
+type SerializedCollapsibleTitleNode = SerializedElementNode;
 
 export function convertSummaryElement(
   domNode: HTMLElement,

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -34,10 +34,7 @@ import {
 import * as React from 'react';
 import {useCallback, useEffect} from 'react';
 
-export type SerializedHorizontalRuleNode = SerializedLexicalNode & {
-  type: 'horizontalrule';
-  version: 1;
-};
+export type SerializedHorizontalRuleNode = SerializedLexicalNode;
 
 export const INSERT_HORIZONTAL_RULE_COMMAND: LexicalCommand<void> =
   createCommand('INSERT_HORIZONTAL_RULE_COMMAND');

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -97,8 +97,6 @@ import {
 export type SerializedHeadingNode = Spread<
   {
     tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-    type: 'heading';
-    version: 1;
   },
   SerializedElementNode
 >;
@@ -107,13 +105,7 @@ export const DRAG_DROP_PASTE: LexicalCommand<Array<File>> = createCommand(
   'DRAG_DROP_PASTE_FILE',
 );
 
-export type SerializedQuoteNode = Spread<
-  {
-    type: 'quote';
-    version: 1;
-  },
-  SerializedElementNode
->;
+export type SerializedQuoteNode = SerializedElementNode;
 
 /** @noInheritDoc */
 export class QuoteNode extends ElementNode {

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -40,7 +40,6 @@ export type TableCellHeaderState =
 export type SerializedTableCellNode = Spread<
   {
     headerState: TableCellHeaderState;
-    type: string;
     width?: number;
   },
   SerializedGridCellNode

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -17,7 +17,6 @@ import type {
   LexicalNode,
   NodeKey,
   SerializedElementNode,
-  Spread,
 } from 'lexical';
 
 import {addClassNamesToElement} from '@lexical/utils';
@@ -31,13 +30,7 @@ import {$isTableCellNode} from './LexicalTableCellNode';
 import {$isTableRowNode, TableRowNode} from './LexicalTableRowNode';
 import {getTableGrid} from './LexicalTableSelectionHelpers';
 
-export type SerializedTableNode = Spread<
-  {
-    type: 'table';
-    version: 1;
-  },
-  SerializedElementNode
->;
+export type SerializedTableNode = SerializedElementNode;
 
 /** @noInheritDoc */
 export class TableNode extends DEPRECATED_GridNode {

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -23,7 +23,6 @@ import {
 export type SerializedTableRowNode = Spread<
   {
     height: number;
-    type: string;
   },
   SerializedElementNode
 >;

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -24,7 +24,6 @@ export type SerializedTableRowNode = Spread<
   {
     height: number;
     type: string;
-    version: 1;
   },
   SerializedElementNode
 >;

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -205,8 +205,6 @@ Here's an example of `exportJSON` for the `HeadingNode`:
 export type SerializedHeadingNode = Spread<
   {
     tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-    type: 'heading';
-    version: 1;
   },
   SerializedElementNode
 >;
@@ -279,7 +277,6 @@ export type SerializedTextNodeV1 = Spread<
     mode: TextModeType;
     style: string;
     text: string;
-    version: 1,
   },
   SerializedLexicalNode
 >;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -905,19 +905,16 @@ export type SerializedElementNode = {
 
 export type SerializedParagraphNode = {
   ...SerializedElementNode,
-  type: 'paragraph',
   ...
 };
 
 export type SerializedLineBreakNode = {
   ...SerializedLexicalNode,
-  type: 'linebreak',
   ...
 };
 
 export type SerializedRootNode = {
   ...SerializedElementNode,
-  type: 'root',
   ...
 };
 

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -881,47 +881,31 @@ declare export function $applyNodeReplacement<N: LexicalNode>(
 export type SerializedLexicalNode = {
   type: string,
   version: number,
-  ...
 };
 
-export type SerializedTextNode = {
-  ...SerializedLexicalNode,
+export type SerializedTextNode = SerializedLexicalNode & {
   detail: number,
   format: number,
   mode: TextModeType,
   style: string,
   text: string,
-  ...
 };
 
-export type SerializedElementNode = {
-  ...SerializedLexicalNode,
+export type SerializedElementNode = SerializedLexicalNode & {
   children: Array<SerializedLexicalNode>,
   direction: 'ltr' | 'rtl' | null,
   format: ElementFormatType,
   indent: number,
-  ...
 };
 
-export type SerializedParagraphNode = {
-  ...SerializedElementNode,
-  ...
-};
+export type SerializedParagraphNode = SerializedElementNode;
 
-export type SerializedLineBreakNode = {
-  ...SerializedLexicalNode,
-  ...
-};
+export type SerializedLineBreakNode = SerializedLexicalNode;
 
-export type SerializedRootNode = {
-  ...SerializedElementNode,
-  ...
-};
+export type SerializedRootNode = SerializedElementNode;
 
-export type SerializedGridCellNode = {
-  ...SerializedElementNode,
+export type SerializedGridCellNode = SerializedElementNode & {
   colSpan: number,
-  ...
 };
 
 export interface SerializedEditorState {

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -881,31 +881,52 @@ declare export function $applyNodeReplacement<N: LexicalNode>(
 export type SerializedLexicalNode = {
   type: string,
   version: number,
+  ...
 };
 
-export type SerializedTextNode = SerializedLexicalNode & {
+export type SerializedTextNode = {
+  ...SerializedLexicalNode,
   detail: number,
   format: number,
   mode: TextModeType,
   style: string,
   text: string,
+  ...
 };
 
-export type SerializedElementNode = SerializedLexicalNode & {
+export type SerializedElementNode = {
+  ...SerializedLexicalNode,
   children: Array<SerializedLexicalNode>,
   direction: 'ltr' | 'rtl' | null,
   format: ElementFormatType,
   indent: number,
+  ...
 };
 
-export type SerializedParagraphNode = SerializedElementNode;
+export type SerializedParagraphNode = {
+  ...SerializedElementNode,
+  ...
+};
 
-export type SerializedLineBreakNode = SerializedLexicalNode;
+export type SerializedLineBreakNode = {
+  ...SerializedLexicalNode,
+  ...
+};
 
-export type SerializedRootNode = SerializedElementNode;
+export type SerializedDecoratorNode = {
+  ...SerializedLexicalNode,
+  ...
+};
 
-export type SerializedGridCellNode = SerializedElementNode & {
+export type SerializedRootNode = {
+  ...SerializedElementNode,
+  ...
+};
+
+export type SerializedGridCellNode = {
+  ...SerializedElementNode,
   colSpan: number,
+  ...
 };
 
 export interface SerializedEditorState {

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -16,7 +16,6 @@ import type {
   SerializedElementNode,
   SerializedLexicalNode,
   SerializedTextNode,
-  Spread,
 } from 'lexical';
 
 import {CodeHighlightNode, CodeNode} from '@lexical/code';
@@ -107,13 +106,7 @@ export function initializeClipboard() {
   });
 }
 
-export type SerializedTestElementNode = Spread<
-  {
-    type: 'test_block';
-    version: 1;
-  },
-  SerializedElementNode
->;
+export type SerializedTestElementNode = SerializedElementNode;
 
 export class TestElementNode extends ElementNode {
   static getType(): string {
@@ -155,10 +148,8 @@ export function $createTestElementNode(): TestElementNode {
   return new TestElementNode();
 }
 
-type SerializedTestTextNode = Spread<
-  {type: 'test_text'; version: 1},
-  SerializedTextNode
->;
+type SerializedTestTextNode = SerializedTextNode;
+
 export class TestTextNode extends TextNode {
   static getType() {
     return 'test_text';
@@ -183,13 +174,7 @@ export class TestTextNode extends TextNode {
   }
 }
 
-export type SerializedTestInlineElementNode = Spread<
-  {
-    type: 'test_inline_block';
-    version: 1;
-  },
-  SerializedElementNode
->;
+export type SerializedTestInlineElementNode = SerializedElementNode;
 
 export class TestInlineElementNode extends ElementNode {
   static getType(): string {
@@ -235,13 +220,7 @@ export function $createTestInlineElementNode(): TestInlineElementNode {
   return new TestInlineElementNode();
 }
 
-export type SerializedTestShadowRootNode = Spread<
-  {
-    type: 'test_block';
-    version: 1;
-  },
-  SerializedElementNode
->;
+export type SerializedTestShadowRootNode = SerializedElementNode;
 
 export class TestShadowRootNode extends ElementNode {
   static getType(): string {
@@ -287,13 +266,7 @@ export function $createTestShadowRootNode(): TestShadowRootNode {
   return new TestShadowRootNode();
 }
 
-export type SerializedTestSegmentedNode = Spread<
-  {
-    type: 'test_segmented';
-    version: 1;
-  },
-  SerializedTextNode
->;
+export type SerializedTestSegmentedNode = SerializedTextNode;
 
 export class TestSegmentedNode extends TextNode {
   static getType(): string {
@@ -328,13 +301,7 @@ export function $createTestSegmentedNode(text): TestSegmentedNode {
   return new TestSegmentedNode(text).setMode('segmented');
 }
 
-export type SerializedTestExcludeFromCopyElementNode = Spread<
-  {
-    type: 'test_exclude_from_copy_block';
-    version: 1;
-  },
-  SerializedElementNode
->;
+export type SerializedTestExcludeFromCopyElementNode = SerializedElementNode;
 
 export class TestExcludeFromCopyElementNode extends ElementNode {
   static getType(): string {
@@ -380,13 +347,7 @@ export function $createTestExcludeFromCopyElementNode(): TestExcludeFromCopyElem
   return new TestExcludeFromCopyElementNode();
 }
 
-export type SerializedTestDecoratorNode = Spread<
-  {
-    type: 'test_decorator';
-    version: 1;
-  },
-  SerializedLexicalNode
->;
+export type SerializedTestDecoratorNode = SerializedLexicalNode;
 
 export class TestDecoratorNode extends DecoratorNode<JSX.Element> {
   static getType(): string {

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -12,17 +12,11 @@ import type {
   NodeKey,
   SerializedLexicalNode,
 } from '../LexicalNode';
-import type {Spread} from 'lexical';
 
 import {LexicalNode} from '../LexicalNode';
 import {$applyNodeReplacement} from '../LexicalUtils';
 
-export type SerializedLineBreakNode = Spread<
-  {
-    type: 'linebreak';
-  },
-  SerializedLexicalNode
->;
+export type SerializedLineBreakNode = SerializedLexicalNode;
 
 /** @noInheritDoc */
 export class LineBreakNode extends LexicalNode {

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -17,19 +17,13 @@ import type {
   ElementFormatType,
   SerializedElementNode,
 } from './LexicalElementNode';
-import type {RangeSelection, Spread} from 'lexical';
+import type {RangeSelection} from 'lexical';
 
 import {$applyNodeReplacement, getCachedClassNameArray} from '../LexicalUtils';
 import {ElementNode} from './LexicalElementNode';
 import {$isTextNode} from './LexicalTextNode';
 
-export type SerializedParagraphNode = Spread<
-  {
-    type: 'paragraph';
-    version: 1;
-  },
-  SerializedElementNode
->;
+export type SerializedParagraphNode = SerializedElementNode;
 
 /** @noInheritDoc */
 export class ParagraphNode extends ElementNode {


### PR DESCRIPTION
Despite using the `Spread` utility function we still get type errors when we try to override string literal types, as evidenced in #4142. 

A simple solution is just to change the `type` of a node to only use `string` and instead rely on runtime checks if a node type is incorrect or unknown.