### PR TITLE
Color picker - fixes #4127

### DIFF
--- a/packages/lexical-playground/src/ui/ColorPicker.tsx
+++ b/packages/lexical-playground/src/ui/ColorPicker.tsx
@@ -23,6 +23,7 @@ interface ColorPickerProps {
   color: string;
   children?: ReactNode;
   onChange?: (color: string) => void;
+  stopCloseOnClickSelf?: boolean;
   title?: string;
 }
 
@@ -52,6 +53,7 @@ export default function ColorPicker({
   children,
   onChange,
   disabled = false,
+  stopCloseOnClickSelf = true,
   ...rest
 }: Readonly<ColorPickerProps>): JSX.Element {
   const [selfColor, setSelfColor] = useState(transformColor('hex', color));
@@ -116,7 +118,10 @@ export default function ColorPicker({
   }, [color]);
 
   return (
-    <DropDown {...rest} disabled={disabled}>
+    <DropDown
+      {...rest}
+      disabled={disabled}
+      stopCloseOnClickSelf={stopCloseOnClickSelf}>
       <div
         className="color-picker-wrapper"
         style={{width: WIDTH}}


### PR DESCRIPTION
This PR technically fixes #4127 the color picker closing immediately on color selection, including typing in the TextInput field, but there are a couple more issues here that could use fixing, I'm just not sure how to go about all of them.

1. It'd be nice if you could make the ::selection background clear so that you can see the color as it changes, but only while the color picker is open. I suppose I could do that with a useEffect hook and check if the picker isOpen or not, but I'm not exactly sure how to change the raw CSS for that. 
2. If you type in the hex code and accidentally type again, either hitting enter or something, it will replace the current selection with the key stroke. I'm not sure what the best way is to prevent that, but my first thought is don't allow the TextInput to autocomplete, instead require an enter keystroke or for the TextInput to lose focus in order to acknowledge the color change. 
I feel like that may be a big ask though.