### PR TITLE
DecoratorNode not disabling placeholder at root

### DIFF
--- a/packages/lexical-text/src/index.ts
+++ b/packages/lexical-text/src/index.ts
@@ -12,6 +12,7 @@ import type {Klass, LexicalEditor, LexicalNode, RootNode} from 'lexical';
 import {
   $createTextNode,
   $getRoot,
+  $isDecoratorNode,
   $isElementNode,
   $isParagraphNode,
   $isTextNode,
@@ -114,7 +115,7 @@ export function $canShowPlaceholder(isComposing: boolean): boolean {
   for (let i = 0; i < childrenLength; i++) {
     const topBlock = children[i];
 
-    if ($isElementNode(topBlock)) {
+    if ($isElementNode(topBlock) || $isDecoratorNode(topBlock)) {
       if (!$isParagraphNode(topBlock)) {
         return false;
       }


### PR DESCRIPTION
This PR fixes #4145 . TBH I'm not completely sure what the expected behavior of a DecoratorNode is supposed to be, or whether this PR might break something. I ran the unit tests and they passed, but I couldn't get the e2e tests to work even for the unchanged main.