### PR TITLE
Bump Excalidraw to v0.14.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2367,18 +2367,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@excalidraw/excalidraw": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.11.0.tgz",
-      "integrity": "sha512-wY0UdnN9JAcBKLzkGlVXiPSKgTO06YeeBhoIy/ezIiMJtfFtWBPjRjJROkdIGqnUmBz5L16MkuXE7b8j1b1ouw==",
-      "dependencies": {
-        "dotenv": "10.0.0"
-      },
-      "peerDependencies": {
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
-      }
-    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -8099,14 +8087,6 @@
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/duplexer": {
@@ -22195,7 +22175,7 @@
     "packages/lexical-playground": {
       "version": "0.9.0",
       "dependencies": {
-        "@excalidraw/excalidraw": "0.11.0",
+        "@excalidraw/excalidraw": "0.14.2",
         "@lexical/clipboard": "0.9.0",
         "@lexical/code": "0.9.0",
         "@lexical/file": "0.9.0",
@@ -22225,6 +22205,15 @@
         "@vitejs/plugin-react": "^1.0.7",
         "vite": "^2.8.0",
         "vite-plugin-replace": "0.1.1"
+      }
+    },
+    "packages/lexical-playground/node_modules/@excalidraw/excalidraw": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.14.2.tgz",
+      "integrity": "sha512-8LdjpTBWEK5waDWB7Bt/G9YBI4j0OxkstUhvaDGz7dwQGfzF6FW5CXBoYHNEoX0qmb+Fg/NPOlZ7FrKsrSVCqg==",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.2.0",
+        "react-dom": "^17.0.2 || ^18.2.0"
       }
     },
     "packages/lexical-react": {
@@ -25027,14 +25016,6 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
-      }
-    },
-    "@excalidraw/excalidraw": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.11.0.tgz",
-      "integrity": "sha512-wY0UdnN9JAcBKLzkGlVXiPSKgTO06YeeBhoIy/ezIiMJtfFtWBPjRjJROkdIGqnUmBz5L16MkuXE7b8j1b1ouw==",
-      "requires": {
-        "dotenv": "10.0.0"
       }
     },
     "@hapi/hoek": {
@@ -30110,11 +30091,6 @@
         }
       }
     },
-    "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
-    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -34604,7 +34580,7 @@
     "lexical-playground": {
       "version": "file:packages/lexical-playground",
       "requires": {
-        "@excalidraw/excalidraw": "0.11.0",
+        "@excalidraw/excalidraw": "0.14.2",
         "@lexical/clipboard": "0.9.0",
         "@lexical/code": "0.9.0",
         "@lexical/file": "0.9.0",
@@ -34632,6 +34608,13 @@
         "vite-plugin-replace": "0.1.1",
         "y-websocket": ">=1.3.x",
         "yjs": ">=13.5.42"
+      },
+      "dependencies": {
+        "@excalidraw/excalidraw": {
+          "version": "0.14.2",
+          "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.14.2.tgz",
+          "integrity": "sha512-8LdjpTBWEK5waDWB7Bt/G9YBI4j0OxkstUhvaDGz7dwQGfzF6FW5CXBoYHNEoX0qmb+Fg/NPOlZ7FrKsrSVCqg=="
+        }
       }
     },
     "lib0": {

--- a/packages/lexical-playground/package.json
+++ b/packages/lexical-playground/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@excalidraw/excalidraw": "0.11.0",
+    "@excalidraw/excalidraw": "0.14.2",
     "@lexical/clipboard": "0.9.0",
     "@lexical/code": "0.9.0",
     "@lexical/file": "0.9.0",

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
@@ -8,7 +8,7 @@
 
 import './ExcalidrawModal.css';
 
-import Excalidraw from '@excalidraw/excalidraw';
+import {Excalidraw} from '@excalidraw/excalidraw';
 import * as React from 'react';
 import {ReactPortal, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';


### PR DESCRIPTION
- The used Excalidraw was over 1 year old (v0.11) and wanted to pick up a number of fixes, including better integration with Vite. The changelog is available here: https://github.com/excalidraw/excalidraw/releases

- Also includes the new Excalidraw UI

Before:
![Excalidraw_before_0 11](https://user-images.githubusercontent.com/7893468/226215102-67df95a3-2edc-4fb4-b647-e4da4667b042.png)

After:
![Excalidraw_after_0 14 2](https://user-images.githubusercontent.com/7893468/226215124-433747c5-6536-4171-8fa8-d2227238beff.png)
