### PR TITLE
UX: Floating link editor: better positioning

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.css
@@ -9,7 +9,7 @@
   opacity: 0;
   background-color: #fff;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.3);
-  border-radius: 8px;
+  border-radius: 0 0 8px 8px;
   transition: opacity 0.5s;
   will-change: transform;
 }

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -28,7 +28,7 @@ import * as React from 'react';
 import {createPortal} from 'react-dom';
 
 import {getSelectedNode} from '../../utils/getSelectedNode';
-import {setFloatingElemPosition} from '../../utils/setFloatingElemPosition';
+import {setFloatingElemPositionForLinkEditor} from '../../utils/setFloatingElemPositionForLinkEditor';
 import {sanitizeUrl} from '../../utils/url';
 
 function FloatingLinkEditor({
@@ -81,23 +81,16 @@ function FloatingLinkEditor({
       rootElement.contains(nativeSelection.anchorNode) &&
       editor.isEditable()
     ) {
-      const domRange = nativeSelection.getRangeAt(0);
-      let rect;
-      if (nativeSelection.anchorNode === rootElement) {
-        let inner = rootElement;
-        while (inner.firstElementChild != null) {
-          inner = inner.firstElementChild as HTMLElement;
-        }
-        rect = inner.getBoundingClientRect();
-      } else {
-        rect = domRange.getBoundingClientRect();
+      const domRect: DOMRect | undefined =
+        nativeSelection.focusNode?.parentElement?.getBoundingClientRect();
+      if (domRect) {
+        domRect.y += 40;
+        setFloatingElemPositionForLinkEditor(domRect, editorElem, anchorElem);
       }
-
-      setFloatingElemPosition(rect, editorElem, anchorElem);
       setLastSelection(selection);
     } else if (!activeElement || activeElement.className !== 'link-input') {
       if (rootElement !== null) {
-        setFloatingElemPosition(null, editorElem, anchorElem);
+        setFloatingElemPositionForLinkEditor(null, editorElem, anchorElem);
       }
       setLastSelection(null);
       setEditMode(false);

--- a/packages/lexical-playground/src/utils/setFloatingElemPositionForLinkEditor.ts
+++ b/packages/lexical-playground/src/utils/setFloatingElemPositionForLinkEditor.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+const VERTICAL_GAP = 10;
+const HORIZONTAL_OFFSET = 5;
+
+export function setFloatingElemPositionForLinkEditor(
+  targetRect: ClientRect | null,
+  floatingElem: HTMLElement,
+  anchorElem: HTMLElement,
+  verticalGap: number = VERTICAL_GAP,
+  horizontalOffset: number = HORIZONTAL_OFFSET,
+): void {
+  const scrollerElem = anchorElem.parentElement;
+
+  if (targetRect === null || !scrollerElem) {
+    floatingElem.style.opacity = '0';
+    floatingElem.style.transform = 'translate(-10000px, -10000px)';
+    return;
+  }
+
+  const floatingElemRect = floatingElem.getBoundingClientRect();
+  const anchorElementRect = anchorElem.getBoundingClientRect();
+  const editorScrollerRect = scrollerElem.getBoundingClientRect();
+
+  let top = targetRect.top - verticalGap;
+  let left = targetRect.left - horizontalOffset;
+
+  if (top < editorScrollerRect.top) {
+    top += floatingElemRect.height + targetRect.height + verticalGap * 2;
+  }
+
+  if (left + floatingElemRect.width > editorScrollerRect.right) {
+    left = editorScrollerRect.right - floatingElemRect.width - horizontalOffset;
+  }
+
+  top -= anchorElementRect.top;
+  left -= anchorElementRect.left;
+
+  floatingElem.style.opacity = '1';
+  floatingElem.style.transform = `translate(${left}px, ${top}px)`;
+}


### PR DESCRIPTION
## Old:

https://user-images.githubusercontent.com/70709113/226237755-c9176cc2-8527-4a09-878d-5620e8d6c11f.mp4

## New:

https://user-images.githubusercontent.com/70709113/226237880-9a732cfa-171a-4e2f-ab5f-f4ddd4323b3a.mp4

The new floating link editor has the following benefits:
- Less distractions when writing, as it moves around in a more predictable way - always under the link. It doesn't move around when clicking on different positions in the link as seen in the old one. I found that to be pretty annoying and distracting
- The old one sometimes overlaps the link & positions itself incorrectly - as seen in the video. Very annoying! This does not happen with the new one anymore
- Even for longer selections, the floating link editor now positions itself correctly, directly under the link
- Simpler code & logic => better performance

This code also changes

`  let top = targetRect.top - floatingElemRect.height - verticalGap;`

to

`  let top = targetRect.top - verticalGap;`

in the setFloatingElemPosition.ts as that extra minus caused incorrect and non-predictable positioning. Instead of overriding  the file, I created a new one, to avoid breaking anything which uses that.

I think the reason this was glitchy is that floatingElemRect.height  does not have a height for the first click, but it does have a height for consecutive clicks, resulting in positioning inconsistency.

Having two almost identical setFloatingElemPosition files might be weird architecturally, so feel free to change this around if you have a better solution!