### PR TITLE
Fix TableResizer when multiple editors

### DIFF
--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -161,6 +161,7 @@ export default function PlaygroundApp(): JSX.Element {
   return (
     <SettingsContext>
       <App />
+      <App />
       <a
         href="https://github.com/facebook/lexical/tree/main/packages/lexical-playground"
         className="github-corner"

--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -161,7 +161,6 @@ export default function PlaygroundApp(): JSX.Element {
   return (
     <SettingsContext>
       <App />
-      <App />
       <a
         href="https://github.com/facebook/lexical/tree/main/packages/lexical-playground"
         className="github-corner"

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -93,7 +93,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
   }, []);
 
   useEffect(() => {
-    const THROTTLE_MS = draggingDirection !== null ? 20 : 200;
+    const throttleMs = draggingDirection !== null ? 20 : 200;
     const [onMouseMove, onMouseMoveDecommission] = throttle1(
       (event: MouseEvent) => {
         const target = event.target;
@@ -152,7 +152,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
           });
         }
       },
-      THROTTLE_MS,
+      throttleMs,
     );
 
     document.addEventListener('mousemove', onMouseMove);

--- a/packages/lexical-playground/src/utils/throttle.ts
+++ b/packages/lexical-playground/src/utils/throttle.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export function throttle1<T1>(
+  fn: (arg1: T1) => void,
+  ms: number,
+): [(arg1: T1) => void, () => void] {
+  let intervalId: null | NodeJS.Timeout = null;
+  let lastArgs: null | T1 = null;
+  function handler() {
+    if (lastArgs !== null) {
+      fn(lastArgs);
+    }
+    intervalId = null;
+  }
+  return [
+    (arg1: T1) => {
+      lastArgs = arg1;
+      if (intervalId === null) {
+        intervalId = setTimeout(handler, ms);
+      }
+    },
+    () => {
+      if (intervalId !== null) {
+        clearTimeout(intervalId);
+      }
+    },
+  ];
+}

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -1001,6 +1001,7 @@ export function getTableSelectionFromTableElement(
   return tableElement[LEXICAL_ELEMENT_KEY];
 }
 
+// TODO 0.10 Deprecate
 export function getCellFromTarget(node: Node): Cell | null {
   let currentNode: ParentNode | Node | null = node;
 


### PR DESCRIPTION
The current module expect the cell to always be found. This won't be the case when there's multiple editors on the page.

Rewrote a chunk of the logic to
1. Leverage EditorState instead of HTML
2. throttle instead of setTimeout with different values depending on whether it's resizing - this should give the editor overall better performance

There's more stuff around to be fixed, the HTML `._cell` format won't work with merged cells but that's a story for another PR


https://user-images.githubusercontent.com/193447/226481598-93eb758a-30e5-40ec-86a9-591c5515983d.mov

Fixes #4157