### PR TITLE
Iterate through the live NodeList instead of copying to an array in $generateNodesFromDOM

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -34,10 +34,9 @@ export function $generateNodesFromDOM(
   dom: Document,
 ): Array<LexicalNode> {
   let lexicalNodes: Array<LexicalNode> = [];
-  const elements: Array<Node> = dom.body ? Array.from(dom.body.childNodes) : [];
-  const elementsLength = elements.length;
+  const elements = dom.body ? dom.body.childNodes : [];
 
-  for (let i = 0; i < elementsLength; i++) {
+  for (let i = 0; i < elements.length; i++) {
     const element = elements[i];
 
     if (!IGNORE_TAGS.has(element.nodeName)) {


### PR DESCRIPTION
The HTML deserialization design is partially predicated on the user having the ability to manipulate the DOM tree in the conversion functions - this provides virtually limitless flexibility in how incoming HTML can be processed.

Previously, we copied the DOM nodes at the top level to an array, then iterated through that to initiate the HTML -> Lexical transformation. This works fine in most cases, but it can cause an issue in a couple of edge cases where you're trying to combine sibling DOM nodes into a single LexicalNode. There's no way to prevent those sibling nodes from being processed, since they have already been copied to an array, removing them from the DOM does nothing.

Alternative proposed solution was to mark the nodes as "processed" and then ignore them in the next pass, but this doesn't prevent their children from being processed. Also considered allowing the conversion to return "true" to stop further processing, but finally decided that this is just a bug.
