### PR TITLE
Fix tables Webkit e2e

### DIFF
--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -762,7 +762,7 @@ export async function selectCellsFromTableCords(
   await firstRowFirstColumnCell.click(
     // This is a test runner quirk. Chrome seems to need two clicks to focus on the
     // content editable cell before dragging, but Firefox treats it as a double click event.
-    E2E_BROWSER !== 'firefox' ? {clickCount: 2} : {},
+    E2E_BROWSER === 'chromium' ? {clickCount: 2} : {},
   );
 
   await dragMouse(


### PR DESCRIPTION
Turns out the E2E setup was wrong; it didn't break before #4162 because the logic was not correct