### PR TITLE
Allow passing in a custom Set of tags to ignore in $generateNodesFromDOM

### DIFF
--- a/packages/lexical-html/flow/LexicalHtml.js.flow
+++ b/packages/lexical-html/flow/LexicalHtml.js.flow
@@ -25,5 +25,7 @@ declare export function $generateHtmlFromNodes(
 declare export function $generateNodesFromDOM(
   editor: LexicalEditor,
   dom: Document,
-  ignoreTags?: Set<string>,
+  options?: {
+    ignoreTags: Set<string>,
+  },
 ): Array<LexicalNode>;

--- a/packages/lexical-html/flow/LexicalHtml.js.flow
+++ b/packages/lexical-html/flow/LexicalHtml.js.flow
@@ -25,4 +25,5 @@ declare export function $generateHtmlFromNodes(
 declare export function $generateNodesFromDOM(
   editor: LexicalEditor,
   dom: Document,
+  ignoreTags?: Set<string>,
 ): Array<LexicalNode>;

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -32,6 +32,7 @@ import {$getRoot, $isElementNode, $isTextNode} from 'lexical';
 export function $generateNodesFromDOM(
   editor: LexicalEditor,
   dom: Document,
+  ignoreTags = IGNORE_TAGS,
 ): Array<LexicalNode> {
   let lexicalNodes: Array<LexicalNode> = [];
   const elements = dom.body ? dom.body.childNodes : [];
@@ -39,8 +40,8 @@ export function $generateNodesFromDOM(
   for (let i = 0; i < elements.length; i++) {
     const element = elements[i];
 
-    if (!IGNORE_TAGS.has(element.nodeName)) {
-      const lexicalNode = $createNodesFromDOM(element, editor);
+    if (!ignoreTags.has(element.nodeName)) {
+      const lexicalNode = $createNodesFromDOM(element, editor, ignoreTags);
 
       if (lexicalNode !== null) {
         lexicalNodes = lexicalNodes.concat(lexicalNode);
@@ -167,13 +168,14 @@ const IGNORE_TAGS = new Set(['STYLE']);
 function $createNodesFromDOM(
   node: Node,
   editor: LexicalEditor,
+  ignoreTags = IGNORE_TAGS,
   forChildMap: Map<string, DOMChildConversion> = new Map(),
   parentLexicalNode?: LexicalNode | null | undefined,
   preformatted = false,
 ): Array<LexicalNode> {
   let lexicalNodes: Array<LexicalNode> = [];
 
-  if (IGNORE_TAGS.has(node.nodeName)) {
+  if (ignoreTags.has(node.nodeName)) {
     return lexicalNodes;
   }
 
@@ -220,6 +222,7 @@ function $createNodesFromDOM(
       ...$createNodesFromDOM(
         children[i],
         editor,
+        ignoreTags,
         new Map(forChildMap),
         currentLexicalNode,
         preformatted ||

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -32,7 +32,7 @@ import {$getRoot, $isElementNode, $isTextNode} from 'lexical';
 export function $generateNodesFromDOM(
   editor: LexicalEditor,
   dom: Document,
-  ignoreTags = IGNORE_TAGS,
+  {ignoreTags = IGNORE_TAGS}: {ignoreTags?: Set<string>} = {},
 ): Array<LexicalNode> {
   let lexicalNodes: Array<LexicalNode> = [];
   const elements = dom.body ? dom.body.childNodes : [];
@@ -41,7 +41,7 @@ export function $generateNodesFromDOM(
     const element = elements[i];
 
     if (!ignoreTags.has(element.nodeName)) {
-      const lexicalNode = $createNodesFromDOM(element, editor, ignoreTags);
+      const lexicalNode = $createNodesFromDOM(element, editor, {ignoreTags});
 
       if (lexicalNode !== null) {
         lexicalNodes = lexicalNodes.concat(lexicalNode);
@@ -168,10 +168,17 @@ const IGNORE_TAGS = new Set(['STYLE']);
 function $createNodesFromDOM(
   node: Node,
   editor: LexicalEditor,
-  ignoreTags = IGNORE_TAGS,
-  forChildMap: Map<string, DOMChildConversion> = new Map(),
-  parentLexicalNode?: LexicalNode | null | undefined,
-  preformatted = false,
+  {
+    ignoreTags = IGNORE_TAGS,
+    forChildMap = new Map(),
+    parentLexicalNode,
+    preformatted = false,
+  }: {
+    ignoreTags?: Set<string>;
+    forChildMap?: Map<string, DOMChildConversion>;
+    parentLexicalNode?: LexicalNode | null | undefined;
+    preformatted?: boolean;
+  },
 ): Array<LexicalNode> {
   let lexicalNodes: Array<LexicalNode> = [];
 
@@ -219,15 +226,14 @@ function $createNodesFromDOM(
 
   for (let i = 0; i < children.length; i++) {
     childLexicalNodes.push(
-      ...$createNodesFromDOM(
-        children[i],
-        editor,
+      ...$createNodesFromDOM(children[i], editor, {
+        forChildMap: new Map(forChildMap),
         ignoreTags,
-        new Map(forChildMap),
-        currentLexicalNode,
-        preformatted ||
+        parentLexicalNode: currentLexicalNode,
+        preformatted:
+          preformatted ||
           (transformOutput && transformOutput.preformatted) === true,
-      ),
+      }),
     );
   }
 


### PR DESCRIPTION
Currently there is no way of modifying the HTML tags that the `$generateNodesFromDOM` function ignores without maintaining a copy of both the `$generateNodesFromDOM` and `$createNodesFromDOM` functions in our own codebase. This PR adds a way to pass in a custom `Set` of HTML tags that get ignored when generating nodes from DOM.