### PR TITLE
Create fragment attached to the doc

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -100,7 +100,7 @@ function $appendNodesToHTML(
     return false;
   }
 
-  const fragment = new DocumentFragment();
+  const fragment = document.createDocumentFragment();
 
   for (let i = 0; i < children.length; i++) {
     const childNode = children[i];


### PR DESCRIPTION
Our JSDom implementation does not handle DocumentFragment constuctor as it's not attached to specific doc so we can't run headless html conversion for tests. 

document.createDocumentFragment works fine