### PR TITLE
Pass editor._updateTags to importJSON

### DIFF
--- a/packages/lexical-selection/src/__tests__/utils/index.ts
+++ b/packages/lexical-selection/src/__tests__/utils/index.ts
@@ -824,7 +824,7 @@ export async function applySelectionInputs(inputs, update, editor) {
                 {
                   clipboardData: {
                     getData: (type) => {
-                      if (type === 'application/x-lexical-nodes') {
+                      if (type === 'application/x-lexical-editor') {
                         return input.text;
                       }
 

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -248,6 +248,23 @@ static importJSON(serializedNode: SerializedHeadingNode): HeadingNode {
 }
 ```
 
+`importJSON` is called with a second parameter containing any `updateTags` on the current editor. This is useful if you need to change the behavior of the import depending on what kind of editor update is happening.
+
+Here's an example of `importJSON` checking if the user is currently in the middle of a `paste` action.
+
+```js
+static importJSON(serializedNode: SerializedCustomNode, updateTags: Set<string>): CustomNode {
+  const node = $createCustomNode();
+  if (updateTags.has('paste')) {
+    // Do something special here when pasting
+  }
+  node.setFormat(serializedNode.format);
+  node.setIndent(serializedNode.indent);
+  node.setDirection(serializedNode.direction);
+  return node;
+}
+```
+
 ### Versioning & Breaking Changes
 
 It's important to note that you should avoid making breaking changes to existing fields in your JSON object, especially if backwards compatibility is an important part of your editor. That's why we recommend using a version field to separate the different changes in your node as you add or change functionality of custom nodes. Here's the serialized type definition for Lexical's base `TextNode` class:

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -791,12 +791,15 @@ export class LexicalNode {
 
   /**
    * Controls how the this node is deserialized from JSON. This is usually boilerplate,
-   * but provides an abstraction betweent he node implementation and serialized interfaec that can
+   * but provides an abstraction between the node implementation and serialized interface that can
    * be important if you ever make breaking changes to a node schema (by adding or removing properties).
-   * See [Serialization & Deserialization](https://lexical.dev/docs/concepts/serialization#lexical---html).
+   * See [Serialization & Deserialization](https://lexical.dev/docs/concepts/serialization#lexical---json).
    *
    * */
-  static importJSON(_serializedNode: SerializedLexicalNode): LexicalNode {
+  static importJSON(
+    _serializedNode: SerializedLexicalNode,
+    _updateTags: Set<string>,
+  ): LexicalNode {
     invariant(
       false,
       'LexicalNode: Node %s does not implement .importJSON().',

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -293,6 +293,7 @@ export function $parseSerializedNode(
   return $parseSerializedNodeImpl(
     internalSerializedNode,
     getActiveEditor()._nodes,
+    getActiveEditor()._updateTags,
   );
 }
 
@@ -301,6 +302,7 @@ function $parseSerializedNodeImpl<
 >(
   serializedNode: SerializedNode,
   registeredNodes: RegisteredNodes,
+  updateTags: Set<string>,
 ): LexicalNode {
   const type = serializedNode.type;
   const registeredNode = registeredNodes.get(type);
@@ -319,7 +321,7 @@ function $parseSerializedNodeImpl<
     );
   }
 
-  const node = nodeClass.importJSON(serializedNode);
+  const node = nodeClass.importJSON(serializedNode, updateTags);
   const children = serializedNode.children;
 
   if ($isElementNode(node) && Array.isArray(children)) {
@@ -328,6 +330,7 @@ function $parseSerializedNodeImpl<
       const childNode = $parseSerializedNodeImpl(
         serializedJSONChildNode,
         registeredNodes,
+        updateTags,
       );
       node.append(childNode);
     }
@@ -360,7 +363,8 @@ export function parseEditorState(
   try {
     const registeredNodes = editor._nodes;
     const serializedNode = serializedEditorState.root;
-    $parseSerializedNodeImpl(serializedNode, registeredNodes);
+    const updateTags = editor._updateTags;
+    $parseSerializedNodeImpl(serializedNode, registeredNodes, updateTags);
     if (updateFn) {
       updateFn();
     }


### PR DESCRIPTION
Since `importJSON` is a static method on node classes, there isn't a good way to determine what is going on when `importJSON` is called - for instance are we deserializing the document initially or pasting in some lexical content from the clipboard.

It seems like `editor._updateTags` is a reasonable place to have this kind of information (as it already has `paste` when pasting) so by passing updateTags to `importJSON`, custom logic can be implemented if desired and should be extensible going forward by using additional updateTags when needed.