### PR TITLE
Fix incorrect placement of Auto Embed

### DIFF
--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+// eslint-disable-next-line simple-import-sort/imports
 import type {LexicalNode, MutationListener} from 'lexical';
 
 import {$isLinkNode, AutoLinkNode, LinkNode} from '@lexical/link';
@@ -17,6 +18,7 @@ import {
 import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
+  $getSelection,
   COMMAND_PRIORITY_EDITOR,
   createCommand,
   LexicalCommand,
@@ -176,6 +178,9 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
         );
         if (result != null) {
           editor.update(() => {
+            if (!$getSelection()) {
+              linkNode.selectEnd();
+            }
             activeEmbedConfig.insertNode(editor, result);
             if (linkNode.isAttached()) {
               linkNode.remove();


### PR DESCRIPTION
### Problem

If there is text behind the current cursor position, Auto Embed Element will be inserted at the end of the editor when the following conditions are met: 

1. EmbedConfig#parseUrl takes some time (such as 1 second)
2. Trigger embedding by clicking on the “Embed xxx” option instead of pressing the enter key

### How to reproduce

1. Modify the code of [YoutubeEmbedConfig#parseUrl](https://github.com/facebook/lexical/blob/bd65af5487657d8e42cb5063732e3e58cf14e674/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx#L62) to simulate longer execution time.
    ```ts
    export const YoutubeEmbedConfig: PlaygroundEmbedConfig = {
      ...
      parseUrl: async (url: string) => {
        await new Promise(resolve => setTimeout(resolve, 1000));
        ...
      ...
    };
    ```
2. Type some text in editor and then try to embed a YouTube video before it


https://user-images.githubusercontent.com/24994263/227627537-786d251a-95c4-4e29-89b0-964f2dc2eb60.mov


