### PR TITLE
Only allow numbers in TablePlugin row / column number input

### DIFF
--- a/packages/lexical-playground/src/plugins/TablePlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TablePlugin.tsx
@@ -129,7 +129,7 @@ export function InsertTableDialog({
         onChange={setRows}
         value={rows}
         data-test-id="table-modal-rows"
-        numberOnly={true}
+        type="number"
       />
       <TextInput
         placeholder={'# of columns (1-50)'}
@@ -137,7 +137,7 @@ export function InsertTableDialog({
         onChange={setColumns}
         value={columns}
         data-test-id="table-modal-columns"
-        numberOnly={true}
+        type="number"
       />
       <DialogActions data-test-id="table-model-confirm-insert">
         <Button disabled={isDisabled} onClick={onClick}>
@@ -182,7 +182,7 @@ export function InsertNewTableDialog({
         onChange={setRows}
         value={rows}
         data-test-id="table-modal-rows"
-        numberOnly={true}
+        type="number"
       />
       <TextInput
         placeholder={'# of columns (1-50)'}
@@ -190,7 +190,7 @@ export function InsertNewTableDialog({
         onChange={setColumns}
         value={columns}
         data-test-id="table-modal-columns"
-        numberOnly={true}
+        type="number"
       />
       <DialogActions data-test-id="table-model-confirm-insert">
         <Button disabled={isDisabled} onClick={onClick}>

--- a/packages/lexical-playground/src/plugins/TablePlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TablePlugin.tsx
@@ -129,6 +129,7 @@ export function InsertTableDialog({
         onChange={setRows}
         value={rows}
         data-test-id="table-modal-rows"
+        numberOnly={true}
       />
       <TextInput
         placeholder={'# of columns (1-50)'}
@@ -136,6 +137,7 @@ export function InsertTableDialog({
         onChange={setColumns}
         value={columns}
         data-test-id="table-modal-columns"
+        numberOnly={true}
       />
       <DialogActions data-test-id="table-model-confirm-insert">
         <Button disabled={isDisabled} onClick={onClick}>
@@ -180,6 +182,7 @@ export function InsertNewTableDialog({
         onChange={setRows}
         value={rows}
         data-test-id="table-modal-rows"
+        numberOnly={true}
       />
       <TextInput
         placeholder={'# of columns (1-50)'}
@@ -187,6 +190,7 @@ export function InsertNewTableDialog({
         onChange={setColumns}
         value={columns}
         data-test-id="table-modal-columns"
+        numberOnly={true}
       />
       <DialogActions data-test-id="table-model-confirm-insert">
         <Button disabled={isDisabled} onClick={onClick}>

--- a/packages/lexical-playground/src/ui/TextInput.tsx
+++ b/packages/lexical-playground/src/ui/TextInput.tsx
@@ -9,6 +9,7 @@
 import './Input.css';
 
 import * as React from 'react';
+import {HTMLInputTypeAttribute} from 'react';
 
 type Props = Readonly<{
   'data-test-id'?: string;
@@ -16,7 +17,7 @@ type Props = Readonly<{
   onChange: (val: string) => void;
   placeholder?: string;
   value: string;
-  numberOnly?: boolean;
+  type?: HTMLInputTypeAttribute;
 }>;
 
 export default function TextInput({
@@ -25,13 +26,13 @@ export default function TextInput({
   onChange,
   placeholder = '',
   'data-test-id': dataTestId,
-  numberOnly = false,
+  type = 'text',
 }: Props): JSX.Element {
   return (
     <div className="Input__wrapper">
       <label className="Input__label">{label}</label>
       <input
-        type={numberOnly ? 'number' : 'text'}
+        type={type}
         className="Input__input"
         placeholder={placeholder}
         value={value}

--- a/packages/lexical-playground/src/ui/TextInput.tsx
+++ b/packages/lexical-playground/src/ui/TextInput.tsx
@@ -16,6 +16,7 @@ type Props = Readonly<{
   onChange: (val: string) => void;
   placeholder?: string;
   value: string;
+  numberOnly?: boolean;
 }>;
 
 export default function TextInput({
@@ -24,12 +25,13 @@ export default function TextInput({
   onChange,
   placeholder = '',
   'data-test-id': dataTestId,
+  numberOnly = false,
 }: Props): JSX.Element {
   return (
     <div className="Input__wrapper">
       <label className="Input__label">{label}</label>
       <input
-        type="text"
+        type={numberOnly ? 'number' : 'text'}
         className="Input__input"
         placeholder={placeholder}
         value={value}


### PR DESCRIPTION
Previously, you were able to input text for the row / column number count.