### PR TITLE
Show floating link editor for autolinks

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -7,7 +7,7 @@
  */
 import './index.css';
 
-import {$isAutoLinkNode, $isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
+import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
@@ -255,9 +255,8 @@ function useFloatingLinkEditorToolbar(
     if ($isRangeSelection(selection)) {
       const node = getSelectedNode(selection);
       const linkParent = $findMatchingParent(node, $isLinkNode);
-      const autoLinkParent = $findMatchingParent(node, $isAutoLinkNode);
 
-      if (linkParent != null || autoLinkParent != null) {
+      if (linkParent != null) {
         setIsLink(true);
       } else {
         setIsLink(false);

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -257,8 +257,7 @@ function useFloatingLinkEditorToolbar(
       const linkParent = $findMatchingParent(node, $isLinkNode);
       const autoLinkParent = $findMatchingParent(node, $isAutoLinkNode);
 
-      // We don't want this menu to open for auto links.
-      if (linkParent != null && autoLinkParent == null) {
+      if (linkParent != null || autoLinkParent != null) {
         setIsLink(true);
       } else {
         setIsLink(false);


### PR DESCRIPTION
Fixes #4202 

I found it **really** confusing that the link editor menu did not show up for autolinks, to the point where I opened an issue thinking it was a bug. Apparently, this was intended, judging from the comment.

This PR makes the floating link editor show for autolinks too, as I think it's a bad UX if the link shows up as blue - looks exactly the same as normal links - but the floating link editor doesn't show up. I guess I wouldn't be the only one getting confused by this, thinking it's a bug.