### PR TITLE
Fix bad selection shift at boundary

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -7,6 +7,7 @@
  */
 
 import {
+  moveLeft,
   moveToLineBeginning,
   moveToPrevWord,
   pressShiftEnter,
@@ -220,5 +221,47 @@ test.describe('Selection', () => {
       focusOffset: 4,
       focusPath: [0, 1, 0, 0],
     });
+  });
+
+  test('Can delete at boundary #xyz', async ({page, isPlainText}) => {
+    test.skip(!isPlainText);
+    await focusEditor(page);
+    await page.keyboard.type('aaa');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('b');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('c');
+
+    await page.keyboard.down('Shift');
+    await moveLeft(page, 3);
+    await page.keyboard.up('Shift');
+    await page.keyboard.press('Delete');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">aaa</span>
+          <br />
+          <br />
+        </p>
+      `,
+    );
+
+    await page.keyboard.down('Shift');
+    await moveLeft(page, 1);
+    await page.keyboard.up('Shift');
+    await page.keyboard.press('Delete');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">aaa</span>
+        </p>
+      `,
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -223,7 +223,7 @@ test.describe('Selection', () => {
     });
   });
 
-  test('Can delete at boundary #xyz', async ({page, isPlainText}) => {
+  test('Can delete at boundary #4221', async ({page, isPlainText}) => {
     test.skip(!isPlainText);
     await focusEditor(page);
     await page.keyboard.type('aaa');

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -1353,7 +1353,7 @@ describe('LexicalSelection tests', () => {
             expectedAnchor: text,
             expectedAnchorOffset: 0,
             expectedFocus: text,
-            expectedFocusOffset: 0,
+            expectedFocusOffset: 3,
           };
         },
         focusOffset: 1,
@@ -1440,7 +1440,7 @@ describe('LexicalSelection tests', () => {
             expectedAnchor: originalText1,
             expectedAnchorOffset: 0,
             expectedFocus: originalText1,
-            expectedFocusOffset: 0,
+            expectedFocusOffset: 3,
           };
         },
         fnBefore: (paragraph, originalText1) => {
@@ -1624,15 +1624,29 @@ describe('LexicalSelection tests', () => {
           originalText1.getNextSibling().remove();
 
           return {
-            expectedAnchor: paragraph,
-            expectedAnchorOffset: 1,
-            expectedFocus: paragraph,
-            expectedFocusOffset: 1,
+            expectedAnchor: originalText1,
+            expectedAnchorOffset: 3,
+            expectedFocus: originalText1,
+            expectedFocusOffset: 3,
           };
         },
         focusOffset: 1,
-        name: 'remove - #xyz',
-        only: true,
+        name: 'remove - Remove with collapsed selection at offset #4221',
+      },
+      {
+        anchorOffset: 0,
+        fn: (paragraph, originalText1) => {
+          originalText1.getNextSibling().remove();
+
+          return {
+            expectedAnchor: originalText1,
+            expectedAnchorOffset: 0,
+            expectedFocus: originalText1,
+            expectedFocusOffset: 3,
+          };
+        },
+        focusOffset: 1,
+        name: 'remove - Remove with non-collapsed selection at offset',
       },
     ]
       .reduce((testSuite, testCase) => {

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -1618,6 +1618,22 @@ describe('LexicalSelection tests', () => {
         focusOffset: 3,
         name: "Selection resolves to the end of text node when it's at the end (2)",
       },
+      {
+        anchorOffset: 1,
+        fn: (paragraph, originalText1) => {
+          originalText1.getNextSibling().remove();
+
+          return {
+            expectedAnchor: paragraph,
+            expectedAnchorOffset: 1,
+            expectedFocus: paragraph,
+            expectedFocusOffset: 1,
+          };
+        },
+        focusOffset: 1,
+        name: 'remove - #xyz',
+        only: true,
+      },
     ]
       .reduce((testSuite, testCase) => {
         // Test inverse selection

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2752,7 +2752,10 @@ export function $updateElementSelectionOnCreateDeleteNode(
   // Single node. We shift selection but never redimension it
   if (selection.isCollapsed()) {
     const selectionOffset = anchor.offset;
-    if (nodeOffset <= selectionOffset) {
+    if (
+      (nodeOffset <= selectionOffset && times > 0) ||
+      (nodeOffset < selectionOffset && times < 0)
+    ) {
       const newSelectionOffset = Math.max(0, selectionOffset + times);
       anchor.set(parentKey, newSelectionOffset, 'element');
       focus.set(parentKey, newSelectionOffset, 'element');
@@ -2769,7 +2772,10 @@ export function $updateElementSelectionOnCreateDeleteNode(
   const lastPointNode = lastPoint.getNode();
   if (parentNode.is(firstPointNode)) {
     const firstPointOffset = firstPoint.offset;
-    if (nodeOffset <= firstPointOffset) {
+    if (
+      (nodeOffset <= firstPointOffset && times > 0) ||
+      (nodeOffset < firstPointOffset && times < 0)
+    ) {
       firstPoint.set(
         parentKey,
         Math.max(0, firstPointOffset + times),

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2762,31 +2762,38 @@ export function $updateElementSelectionOnCreateDeleteNode(
       // The new selection might point to text nodes, try to resolve them
       $updateSelectionResolveTextNodes(selection);
     }
-    return;
-  }
-  // Multiple nodes selected. We shift or redimension selection
-  const isBackward = selection.isBackward();
-  const firstPoint = isBackward ? focus : anchor;
-  const firstPointNode = firstPoint.getNode();
-  const lastPoint = isBackward ? anchor : focus;
-  const lastPointNode = lastPoint.getNode();
-  if (parentNode.is(firstPointNode)) {
-    const firstPointOffset = firstPoint.offset;
-    if (
-      (nodeOffset <= firstPointOffset && times > 0) ||
-      (nodeOffset < firstPointOffset && times < 0)
-    ) {
-      firstPoint.set(
-        parentKey,
-        Math.max(0, firstPointOffset + times),
-        'element',
-      );
+  } else {
+    // Multiple nodes selected. We shift or redimension selection
+    const isBackward = selection.isBackward();
+    const firstPoint = isBackward ? focus : anchor;
+    const firstPointNode = firstPoint.getNode();
+    const lastPoint = isBackward ? anchor : focus;
+    const lastPointNode = lastPoint.getNode();
+    if (parentNode.is(firstPointNode)) {
+      const firstPointOffset = firstPoint.offset;
+      if (
+        (nodeOffset <= firstPointOffset && times > 0) ||
+        (nodeOffset < firstPointOffset && times < 0)
+      ) {
+        firstPoint.set(
+          parentKey,
+          Math.max(0, firstPointOffset + times),
+          'element',
+        );
+      }
     }
-  }
-  if (parentNode.is(lastPointNode)) {
-    const lastPointOffset = lastPoint.offset;
-    if (nodeOffset <= lastPointOffset) {
-      lastPoint.set(parentKey, Math.max(0, lastPointOffset + times), 'element');
+    if (parentNode.is(lastPointNode)) {
+      const lastPointOffset = lastPoint.offset;
+      if (
+        (nodeOffset <= lastPointOffset && times > 0) ||
+        (nodeOffset < lastPointOffset && times < 0)
+      ) {
+        lastPoint.set(
+          parentKey,
+          Math.max(0, lastPointOffset + times),
+          'element',
+        );
+      }
     }
   }
   // The new selection might point to text nodes, try to resolve them


### PR DESCRIPTION
It turns out that this issue can only be reproed on FF because of the way it does selection, but it's a generic issue on the underlying selection layer used across the Core.

The logic around recomputing selection for `element` selection when adding and removing nodes was not correct. Turns out that it was too generic and the removing case was badly handled. Additionally, the test case assumptions were bad too.

When the selection falls in a linebreak it turns into an `element` selection and this combined with `insertText('')` and multiple `remove()` has to be recomputed properly as the combination of multiple `remove()` with bad selection is what led to deleting more nodes than it should.

The visible result was content reappearing but the initial bug was actual linebreak being deleted when it wasn't selected in the first place.

https://user-images.githubusercontent.com/193447/228091303-70be697e-eb5c-482c-83c1-7fe65cf69601.mov


Fixes #4221 