### PR TITLE
Bugfix: Comment popup closes when cursor hovers over table

### DIFF
--- a/packages/lexical-mark/src/index.ts
+++ b/packages/lexical-mark/src/index.ts
@@ -124,6 +124,13 @@ export function $wrapSelectionInMarkNode(
       lastCreatedMarkNode = undefined;
     }
   }
+  // Make selection collapsed at the end
+  if (lastCreatedMarkNode !== undefined) {
+    // eslint-disable-next-line no-unused-expressions
+    isBackward
+      ? lastCreatedMarkNode.selectStart()
+      : lastCreatedMarkNode.selectEnd();
+  }
 }
 
 export function $getMarkIDs(

--- a/packages/lexical-mark/src/index.ts
+++ b/packages/lexical-mark/src/index.ts
@@ -125,7 +125,7 @@ export function $wrapSelectionInMarkNode(
     }
   }
   // Make selection collapsed at the end
-  if (lastCreatedMarkNode !== undefined) {
+  if ($isElementNode(lastCreatedMarkNode)) {
     // eslint-disable-next-line no-unused-expressions
     isBackward
       ? lastCreatedMarkNode.selectStart()

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -12,6 +12,7 @@ import type {
   LexicalCommand,
   LexicalEditor,
   NodeKey,
+  RangeSelection,
 } from 'lexical';
 import type {Doc} from 'yjs';
 
@@ -223,6 +224,8 @@ function CommentInputBox({
   submitAddComment: (
     commentOrThread: Comment | Thread,
     isInlineComment: boolean,
+    thread?: Thread,
+    selection?: RangeSelection | null,
   ) => void;
 }) {
   const [content, setContent] = useState('');
@@ -235,6 +238,7 @@ function CommentInputBox({
     }),
     [],
   );
+  const selectionRef = useRef<RangeSelection | null>(null);
   const author = useCollabAuthorName();
 
   const updateLocation = useCallback(() => {
@@ -242,6 +246,7 @@ function CommentInputBox({
       const selection = $getSelection();
 
       if ($isRangeSelection(selection)) {
+        selectionRef.current = selection.clone();
         const anchor = selection.anchor;
         const focus = selection.focus;
         const range = createDOMRange(
@@ -318,8 +323,8 @@ function CommentInputBox({
   const submitComment = () => {
     if (canSubmit) {
       let quote = editor.getEditorState().read(() => {
-        const selection = $getSelection();
-        return selection !== null ? selection.getTextContent() : '';
+        const selection = selectionRef.current;
+        return selection ? selection.getTextContent() : '';
       });
       if (quote.length > 100) {
         quote = quote.slice(0, 99) + '…';
@@ -327,7 +332,10 @@ function CommentInputBox({
       submitAddComment(
         createThread(quote, [createComment(content, author)]),
         true,
+        undefined,
+        selectionRef.current,
       );
+      selectionRef.current = null;
     }
   };
 
@@ -774,26 +782,17 @@ export default function CommentPlugin({
       commentOrThread: Comment | Thread,
       isInlineComment: boolean,
       thread?: Thread,
+      selection?: RangeSelection | null,
     ) => {
       commentStore.addComment(commentOrThread, thread);
       if (isInlineComment) {
         editor.update(() => {
-          const selection = $getSelection();
           if ($isRangeSelection(selection)) {
-            const focus = selection.focus;
-            const anchor = selection.anchor;
             const isBackward = selection.isBackward();
             const id = commentOrThread.id;
 
             // Wrap content in a MarkNode
             $wrapSelectionInMarkNode(selection, isBackward, id);
-
-            // Make selection collapsed at the end
-            if (isBackward) {
-              focus.set(anchor.key, anchor.offset, anchor.type);
-            } else {
-              anchor.set(focus.key, focus.offset, focus.type);
-            }
           }
         });
         setShowCommentInput(false);
@@ -913,10 +912,10 @@ export default function CommentPlugin({
           if (!hasAnchorKey) {
             setActiveAnchorKey(null);
           }
+          if (!tags.has('collaboration') && $isRangeSelection(selection)) {
+            setShowCommentInput(false);
+          }
         });
-        if (!tags.has('collaboration')) {
-          setShowCommentInput(false);
-        }
       }),
       editor.registerCommand(
         INSERT_INLINE_COMMAND,


### PR DESCRIPTION
Solves the issue raised here: https://github.com/facebook/lexical/issues/4190

- The selection is now temporarily cached inside a ref, `selectionRef` when the comment button is clicked, rather then relying on the current selection using `$getSelection`
- This means changes in selection, caused by editor updates have no effect on the content being wrapped by the Mark node when the comment is being added.
- Able to hover over table with comment popup closing
- Now able to add comments to text inside of tables without the popup closing
- Collapsing selection is now done by the `.selectStart()` and `.selectEnd()` APIs, within the `$wrapSelectionInMarkNode` function
