### PR TITLE
Disable CI cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,13 +32,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g npm@8
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            node_modules
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      # - uses: actions/cache@v3
+      #   id: cache
+      #   with:
+      #     path: |
+      #       node_modules
+      #       ~/.cache/ms-playwright
+      #     key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -61,13 +61,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g npm@8
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            node_modules
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      # - uses: actions/cache@v3
+      #   id: cache
+      #   with:
+      #     path: |
+      #       node_modules
+      #       ~/.cache/ms-playwright
+      #     key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -93,14 +93,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g npm@8
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            node_modules
-            packages/playwright-core/node_modules
-            ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      # - uses: actions/cache@v3
+      #   id: cache
+      #   with:
+      #     path: |
+      #       node_modules
+      #       packages/playwright-core/node_modules
+      #       ~/Library/Caches/ms-playwright
+      #     key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -139,14 +139,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install xvfb
       - run: npm i -g npm@8
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            node_modules
-            packages/playwright-core/node_modules
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      # - uses: actions/cache@v3
+      #   id: cache
+      #   with:
+      #     path: |
+      #       node_modules
+      #       packages/playwright-core/node_modules
+      #       ~/.cache/ms-playwright
+      #     key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -218,14 +218,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g npm@8
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            node_modules
-            packages/playwright-core/node_modules
-            ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      # - uses: actions/cache@v3
+      #   id: cache
+      #   with:
+      #     path: |
+      #       node_modules
+      #       packages/playwright-core/node_modules
+      #       ~/Library/Caches/ms-playwright
+      #     key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -260,14 +260,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install xvfb
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            node_modules
-            packages/playwright-core/node_modules
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      # - uses: actions/cache@v3
+      #   id: cache
+      #   with:
+      #     path: |
+      #       node_modules
+      #       packages/playwright-core/node_modules
+      #       ~/.cache/ms-playwright
+      #     key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -298,13 +298,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g npm@8
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            node_modules
-            C:\Users\runneradmin\AppData\Local\ms-playwright
-          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      # - uses: actions/cache@v3
+      #   id: cache
+      #   with:
+      #     path: |
+      #       node_modules
+      #       C:\Users\runneradmin\AppData\Local\ms-playwright
+      #     key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         #   if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -339,14 +339,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g npm@8
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            node_modules
-            packages/playwright-core/node_modules
-            ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      # - uses: actions/cache@v3
+      #   id: cache
+      #   with:
+      #     path: |
+      #       node_modules
+      #       packages/playwright-core/node_modules
+      #       ~/Library/Caches/ms-playwright
+      #     key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -381,14 +381,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g npm@8
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            node_modules
-            packages/playwright-core/node_modules
-            ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      # - uses: actions/cache@v3
+      #   id: cache
+      #   with:
+      #     path: |
+      #       node_modules
+      #       packages/playwright-core/node_modules
+      #       ~/Library/Caches/ms-playwright
+      #     key: ${{ runner.os }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci


### PR DESCRIPTION
Should we disable the cache for now while we investigate the recurrent Excalidraw dependency issue?

```
Error: packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx(9,***7): error TS***307: Cannot find module '@excalidraw/excalidraw' or its corresponding type declarations.
```