### PR TITLE
Restore MD selection

### DIFF
--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -24,6 +24,7 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  $getSelection,
   $isParagraphNode,
   $isTextNode,
   ElementNode,
@@ -83,6 +84,10 @@ export function createMarkdownImport(
       if (isEmptyParagraph(child)) {
         child.remove();
       }
+    }
+
+    if ($getSelection() !== null) {
+      root.selectEnd();
     }
   };
 }


### PR DESCRIPTION
My understanding is that `root.selectEnd` was dropped in https://github.com/facebook/lexical/pull/3886 because it was incorrectly restoring however. However, when selection is present we still want to restore it, otherwise we risk facing the lost selection invariant.

> updateEditor: selection has been lost because the previously selected nodes have been removed and selection wasn't moved to another node. Ensure selection changes after removing/replacing a selected node.