### PR TITLE
Support select all for node selection

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -11,6 +11,7 @@ import {
   moveToLineBeginning,
   moveToPrevWord,
   pressShiftEnter,
+  selectAll,
 } from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
@@ -261,6 +262,22 @@ test.describe('Selection', () => {
           dir="ltr">
           <span data-lexical-text="true">aaa</span>
         </p>
+      `,
+    );
+  });
+
+  test('Can select all with node selection', async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    await page.keyboard.type('Text before');
+    await insertSampleImage(page);
+    await page.keyboard.type('Text after');
+    await selectAll(page);
+    await page.keyboard.press('Delete');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
       `,
     );
   });

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -116,6 +116,7 @@ import {
   isOpenLineBreak,
   isParagraph,
   isRedo,
+  isSelectAll,
   isSelectionWithinEditor,
   isSpace,
   isTab,
@@ -180,6 +181,7 @@ let collapsedSelectionFormat: [number, string, number, NodeKey, number] = [
 // work as intended between different browsers and across word, line and character
 // boundary/formats. It also is important for text replacement, node schemas and
 // composition mechanics.
+
 function $shouldPreventDefaultAndInsertText(
   selection: RangeSelection,
   domTargetRange: null | StaticRange,
@@ -977,6 +979,12 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
       } else if (isCut(keyCode, shiftKey, metaKey, ctrlKey)) {
         event.preventDefault();
         dispatchCommand(editor, CUT_COMMAND, event);
+      } else if (isSelectAll(keyCode, metaKey, ctrlKey)) {
+        event.preventDefault();
+        editor.update(() => {
+          const root = $getRoot();
+          root.select(0, root.getChildrenSize());
+        });
       }
     }
   }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1031,6 +1031,14 @@ export function isDelete(keyCode: number): boolean {
   return keyCode === 46;
 }
 
+export function isSelectAll(
+  keyCode: number,
+  metaKey: boolean,
+  ctrlKey: boolean,
+): boolean {
+  return keyCode === 65 && controlOrMeta(metaKey, ctrlKey);
+}
+
 export function getCachedClassNameArray(
   classNamesTheme: EditorThemeClasses,
   classNameThemeType: string,


### PR DESCRIPTION
Fixes #4215

We usually dispatch command (e.g., would be SELECT_ALL_COMMAND), and later handle it in RichTextPlugin/PlainTextPlugin, but this one is slightly different, since it's specifically for node selection as range selection is handled by contenteditable. So to avoid discrepancy, when node selection would trigger command and range selection would not, handling it right in core