### PR TITLE
Bugfix: Floating tool bar not responsive in tables

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -145,7 +145,6 @@ export function applyTableHandlers(
     if (event.button !== 0) {
       return;
     }
-
     editor.update(() => {
       const selection = $getSelection();
       const target = event.target;
@@ -176,7 +175,7 @@ export function applyTableHandlers(
   );
 
   const mouseUpCallback = (event: MouseEvent) => {
-    if (isMouseDown) {
+    if (isMouseDown && !doesTargetContainText(event.target as Node)) {
       event.preventDefault();
       event.stopPropagation();
     }
@@ -1022,6 +1021,19 @@ export function getCellFromTarget(node: Node): Cell | null {
   }
 
   return null;
+}
+
+export function doesTargetContainText(node: Node): boolean {
+  const currentNode: ParentNode | Node | null = node;
+
+  if (currentNode !== null) {
+    const nodeName = currentNode.nodeName;
+
+    if (nodeName === 'SPAN') {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function getTableGrid(tableElement: HTMLElement): Grid {

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -145,6 +145,7 @@ export function applyTableHandlers(
     if (event.button !== 0) {
       return;
     }
+
     editor.update(() => {
       const selection = $getSelection();
       const target = event.target;


### PR DESCRIPTION
Solves the issue raised here: https://github.com/facebook/lexical/issues/4223

- The event in `mouseUpCallback` doesn't bubble up to floating tool bar event handler, so the `.pointerEvent` style is never changed from 'none' to 'auto' meaning the toolbar is not interactive when text is selected within a table cell. 
- When text is selected in table cells, it's treated as a span dom node. We can use this information to check whether we want to propagate the event up to the floating tool bar event handler. 
- If text is not selected in the table cell, but the table cell is clicked on, the event should not bubble up. This is handled in the if statement. 
