### PR TITLE
Fix TypeaheadMenuPlugin scrollIntoView to not rely on external class

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -79,10 +79,7 @@ export type MenuRenderFn<TOption extends TypeaheadOption> = (
 ) => ReactPortal | JSX.Element | null;
 
 const scrollIntoViewIfNeeded = (target: HTMLElement) => {
-  const container = document.getElementById('typeahead-menu');
-  if (!container) return;
-
-  const typeaheadContainerNode = container.querySelector('.typeahead-popover');
+  const typeaheadContainerNode = document.getElementById('typeahead-menu');
   if (!typeaheadContainerNode) return;
 
   const typeaheadRect = typeaheadContainerNode.getBoundingClientRect();


### PR DESCRIPTION
In this PR:
- https://github.com/facebook/lexical/pull/3826

The logic for `scrollIntoViewIfNeeded` was changed to rely on a class that is required to be provided to the ReactDOM.createPortal element.

```
...l-playground/src/plugins/AutoEmbedPlugin/index.tsx |  200:20 |     <div className="typeahead-popover">
...l-playground/src/plugins/AutoEmbedPlugin/index.tsx |  328:29 |                   className="typeahead-popover auto-embed-menu"
...al-playground/src/plugins/MentionsPlugin/index.tsx |  696:30 |               <div className="typeahead-popover mentions-menu">
...playground/src/plugins/EmojiPickerPlugin/index.tsx |  174:30 |               <div className="typeahead-popover emoji-menu">
...ground/src/plugins/ComponentPickerPlugin/index.tsx |  383:32 |                 <div className="typeahead-popover component-picker-menu">
```

This change did not work in our project. A simple solution for lexical users would be to add `className="typeahead-popover"` but maybe using the first child of the menu is a better approach.

When the portal does not have `"typeahead-popover"`:
Before:

https://user-images.githubusercontent.com/16056918/228559136-9e48f702-9857-4e88-862f-2c758b70bfe7.mov

After:

https://user-images.githubusercontent.com/16056918/228559180-43a723ad-32a2-4c13-9bf0-233bf48f5004.mov



