### PR TITLE
[0.10] Ignore script nodes in HTML deserialization

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -162,7 +162,7 @@ function getConversionFunction(
   return currentConversion !== null ? currentConversion.conversion : null;
 }
 
-const IGNORE_TAGS = new Set(['STYLE']);
+const IGNORE_TAGS = new Set(['STYLE', 'SCRIPT']);
 
 function $createNodesFromDOM(
   node: Node,


### PR DESCRIPTION
Let's do this for now instead of this: https://github.com/facebook/lexical/pull/4178/files

I thought of a few problems with the API and I have some other ideas around serialization options more generally.

This is a breaking change, though., so we need to go to 0.10.