### PR TITLE
isEditable is true on first render even if editor initiated with false

### DIFF
--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -118,6 +118,7 @@ function App(): JSX.Element {
   } = useSettings();
 
   const initialConfig = {
+    editable: true,
     editorState: isCollab
       ? null
       : emptyEditor

--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -118,7 +118,6 @@ function App(): JSX.Element {
   } = useSettings();
 
   const initialConfig = {
-    editable: true,
     editorState: isCollab
       ? null
       : emptyEditor

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -81,7 +81,7 @@ export function LexicalComposer({initialConfig, children}: Props): JSX.Element {
 
       if (editor === null) {
         const newEditor = createEditor({
-          editable: initialConfig.editable ?? true,
+          editable: initialConfig.editable,
           namespace,
           nodes,
           onError: (error) => onError(error, newEditor),

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -81,7 +81,7 @@ export function LexicalComposer({initialConfig, children}: Props): JSX.Element {
 
       if (editor === null) {
         const newEditor = createEditor({
-          editable: false,
+          editable: initialConfig.editable ?? true,
           namespace,
           nodes,
           onError: (error) => onError(error, newEditor),

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -605,7 +605,7 @@ export class LexicalEditor {
     this._htmlConversions = htmlConversions;
     // We don't actually make use of the `editable` argument above.
     // Doing so, causes e2e tests around the lock to fail.
-    this._editable = true;
+    this._editable = editable;
     this._headless = parentEditor !== null && parentEditor._headless;
     this._window = null;
     this._blockCursorElement = null;

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -603,8 +603,6 @@ export class LexicalEditor {
 
     this._onError = onError;
     this._htmlConversions = htmlConversions;
-    // We don't actually make use of the `editable` argument above.
-    // Doing so, causes e2e tests around the lock to fail.
     this._editable = editable;
     this._headless = parentEditor !== null && parentEditor._headless;
     this._window = null;


### PR DESCRIPTION
Bug: isEditable is true on first render even if editor initiated with false

Ref.  #4224
