### PR TITLE
Excalidraw Component fixes

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -157,12 +157,13 @@ export default function ExcalidrawComponent({
         initialElements={elements}
         isShown={isModalOpen}
         onDelete={deleteNode}
+        onClose={() => setModalOpen(false)}
         onSave={(newData) => {
           editor.setEditable(true);
           setData(newData);
           setModalOpen(false);
         }}
-        closeOnClickOutside={true}
+        closeOnClickOutside={false}
       />
       {elements.length > 0 && (
         <button

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
@@ -31,6 +31,10 @@ type Props = {
    */
   isShown?: boolean;
   /**
+   * Callback when closing and discarding the new changes
+   */
+  onClose: () => void;
+  /**
    * Completely remove Excalidraw component
    */
   onDelete: () => void;
@@ -51,6 +55,7 @@ export default function ExcalidrawModal({
   initialElements,
   isShown = false,
   onDelete,
+  onClose,
 }: Props): ReactPortal | null {
   const excaliDrawModelRef = useRef<HTMLDivElement | null>(null);
 
@@ -138,13 +143,13 @@ export default function ExcalidrawModal({
         onClose={() => {
           setDiscardModalOpen(false);
         }}
-        closeOnClickOutside={true}>
+        closeOnClickOutside={false}>
         Are you sure you want to discard the changes?
         <div className="ExcalidrawModal__discardModal">
           <Button
             onClick={() => {
               setDiscardModalOpen(false);
-              onDelete();
+              onClose();
             }}>
             Discard
           </Button>{' '}


### PR DESCRIPTION
https://user-images.githubusercontent.com/7893468/229314462-892459ed-36d2-4b20-b119-2db9b19fb4b2.mp4


- Clicking outside of the modal was set to close the modal, this meant when you draw and finish the drawing outside of the popup it was closing the popup rather than adding the shape.
- After opening an existing Excalidraw node and drawing something new, if clicking on Discard, then Discard in the popup, it deleted the node, instead of discarding the new changes only. Now it just discards the changes since the last open.
