### PR TITLE
Rework generateNodesFromDOM API

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -121,10 +121,27 @@ export type DOMConversion<T extends HTMLElement = HTMLElement> = {
   priority: 0 | 1 | 2 | 3 | 4;
 };
 
+export type DOMConversionOptions = {
+  textStyles?: true;
+  elementFormats?: true;
+  preformatted?: boolean;
+};
+
+export type DOMConversionContext = {
+  editor: LexicalEditor;
+  textStyles?: true;
+  elementFormats?: true;
+  parent?: Node;
+  preformatted?: boolean;
+};
+
 export type DOMConversionFn<T extends HTMLElement = HTMLElement> = (
   element: T,
+  /** @deprecated use context.parent */
   parent?: Node,
+  /** @deprecated use context.preformatted */
   preformatted?: boolean,
+  context?: DOMConversionContext,
 ) => DOMConversionOutput | null;
 
 export type DOMChildConversion = (

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -26,6 +26,7 @@ import type {
   PointType,
   RangeSelection,
 } from './LexicalSelection';
+import type {ElementFormatType} from './nodes/LexicalElementNode';
 import type {RootNode} from './nodes/LexicalRootNode';
 import type {TextFormatType, TextNode} from './nodes/LexicalTextNode';
 
@@ -1590,4 +1591,21 @@ export function $getChildrenRecursively(node: LexicalNode): Array<LexicalNode> {
     }
   }
   return nodes;
+}
+
+export function convertDOMElementLexicalData(
+  element: HTMLElement,
+  lexicalNode: ElementNode,
+): ElementNode {
+  const lexicalDataFormatAlign = element.getAttribute(
+    'lexical-data-format-align',
+  );
+  const lexicalDataIndent = element.getAttribute('lexical-data-indent');
+  if (lexicalDataFormatAlign !== null) {
+    lexicalNode.setFormat(lexicalDataFormatAlign as ElementFormatType);
+  }
+  if (lexicalDataIndent != null) {
+    lexicalNode.setIndent(parseInt(lexicalDataIndent, 10));
+  }
+  return lexicalNode;
 }

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -28,8 +28,10 @@ export type {EditorState, SerializedEditorState} from './LexicalEditorState';
 export type {
   DOMChildConversion,
   DOMConversion,
+  DOMConversionContext,
   DOMConversionFn,
   DOMConversionMap,
+  DOMConversionOptions,
   DOMConversionOutput,
   DOMExportOutput,
   LexicalNode,
@@ -150,6 +152,7 @@ export {
   $setCompositionKey,
   $setSelection,
   $splitNode,
+  convertDOMElementLexicalData,
   getNearestEditorFromDOMNode,
   isSelectionWithinEditor,
 } from './LexicalUtils';

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -6,7 +6,11 @@
  *
  */
 
-import type {NodeKey, SerializedLexicalNode} from '../LexicalNode';
+import type {
+  DOMExportOutput,
+  NodeKey,
+  SerializedLexicalNode,
+} from '../LexicalNode';
 import type {
   GridSelection,
   NodeSelection,
@@ -23,6 +27,7 @@ import {
   ELEMENT_FORMAT_TO_TYPE,
   ELEMENT_TYPE_TO_FORMAT,
 } from '../LexicalConstants';
+import {LexicalEditor} from '../LexicalEditor';
 import {LexicalNode} from '../LexicalNode';
 import {
   $getSelection,
@@ -524,7 +529,25 @@ export class ElementNode extends LexicalNode {
       version: 1,
     };
   }
-  // These are intended to be extends for specific element heuristics.
+
+  exportDOM(editor: LexicalEditor): DOMExportOutput {
+    const {element} = super.exportDOM(editor);
+    if (element !== null) {
+      const formatType = this.getFormatType();
+      if (formatType !== '') {
+        element.setAttribute('lexical-data-format-align', formatType);
+      }
+      const indent = this.getIndent();
+      if (indent > 0) {
+        element.setAttribute('lexical-data-format-indent', `${indent}`);
+      }
+    }
+    return {
+      element,
+    };
+  }
+
+  // These are intended to be extended for specific element heuristics.
   insertNewAfter(
     selection: RangeSelection,
     restoreSelection?: boolean,

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -13,6 +13,7 @@ import type {
   TextNodeThemeClasses,
 } from '../LexicalEditor';
 import type {
+  DOMConversionContext,
   DOMConversionMap,
   DOMConversionOutput,
   DOMExportOutput,
@@ -535,6 +536,7 @@ export class TextNode extends LexicalNode {
       if (this.hasFormat('underline')) {
         element = wrapElementWith(element, 'u');
       }
+      element.setAttribute('lexical-data-style', element.style.cssText);
     }
 
     return {
@@ -881,7 +883,12 @@ export class TextNode extends LexicalNode {
   }
 }
 
-function convertSpanElement(domNode: Node): DOMConversionOutput {
+function convertSpanElement(
+  domNode: Node,
+  _parent?: Node,
+  _preformatted?: boolean,
+  context?: DOMConversionContext,
+): DOMConversionOutput {
   // domNode is a <span> since we matched it by nodeName
   const span = domNode as HTMLSpanElement;
   // Google Docs uses span tags + font-weight for bold text
@@ -895,6 +902,7 @@ function convertSpanElement(domNode: Node): DOMConversionOutput {
   const hasUnderlineTextDecoration = span.style.textDecoration === 'underline';
   // Google Docs uses span tags + vertical-align to specify subscript and superscript
   const verticalAlign = span.style.verticalAlign;
+  const lexicalStyleData = span.getAttribute('lexical-data-style');
 
   return {
     forChild: (lexicalNode) => {
@@ -919,7 +927,9 @@ function convertSpanElement(domNode: Node): DOMConversionOutput {
       if (verticalAlign === 'super') {
         lexicalNode.toggleFormat('superscript');
       }
-
+      if (context && context.textStyles && lexicalStyleData !== null) {
+        lexicalNode.setStyle(lexicalStyleData);
+      }
       return lexicalNode;
     },
     node: null,


### PR DESCRIPTION
I will try to get around to writing up a more extensive explanation later. The main purposes of this are twofold:

1) Improve the out-of-the-box experience for HTML serialization and deserialization in the storage format use-case (as opposed to the transfer/copy-paste use case).

One of the big issues here is that we can't support interpretation of html attributes like background-color or text-align in the core without creating a poor user experience during HTML copy+paste. The idea here is to transfer those semantics via custom attributes on HTML, so we can support HTML-as-a-storage-format (deserializing into an editor with the same configuration) at a higher fidelity while preserving control during copy/paste.

2) Amend the public API to be less cluttered and provide a path for additional options

Ultimately, I'd like to experiment with bringing more of this logic out of the core library and into the editor configuration, possible with some defaults in the rich-text or utils modules. import/exportDOM makes sense on the nodes, but it is honestly pretty clunky to have to do that for just a simple use case like supporting a text style.