### PR TITLE
Allow overriding HTML serialization behavior from the editor config.

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -92,7 +92,15 @@ function $appendNodesToHTML(
     target = clone;
   }
   const children = $isElementNode(target) ? target.getChildren() : [];
-  const {element, after} = target.exportDOM(editor);
+  const registeredNode = editor._nodes.get(target.getType());
+  let exportOutput;
+  if (registeredNode && registeredNode.exportDOM !== undefined) {
+    exportOutput = registeredNode.exportDOM(editor, target);
+  } else {
+    exportOutput = target.exportDOM(editor);
+  }
+
+  const {element, after} = exportOutput;
 
   if (!element) {
     return false;

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -94,6 +94,8 @@ function $appendNodesToHTML(
   const children = $isElementNode(target) ? target.getChildren() : [];
   const registeredNode = editor._nodes.get(target.getType());
   let exportOutput;
+
+  // Use HTMLConfig overrides, if available.
   if (registeredNode && registeredNode.exportDOM !== undefined) {
     exportOutput = registeredNode.exportDOM(editor, target);
   } else {

--- a/packages/lexical-react/flow/LexicalComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalComposer.js.flow
@@ -13,6 +13,7 @@ import type {
   LexicalNode,
   EditorState,
   LexicalNodeReplacement,
+  HTMLConfig,
 } from 'lexical';
 
 export type InitialEditorStateType =
@@ -29,6 +30,7 @@ export type InitialConfigType = $ReadOnly<{
   theme?: EditorThemeClasses,
   editorState?: InitialEditorStateType,
   onError: (error: Error, editor: LexicalEditor) => void,
+  html?: HTMLConfig,
 }>;
 
 type Props = {

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -19,6 +19,7 @@ import {
   createEditor,
   EditorState,
   EditorThemeClasses,
+  HTMLConfig,
   Klass,
   LexicalEditor,
   LexicalNode,
@@ -45,6 +46,7 @@ export type InitialConfigType = Readonly<{
   editable?: boolean;
   theme?: EditorThemeClasses;
   editorState?: InitialEditorStateType;
+  html?: HTMLConfig;
 }>;
 
 type Props = {
@@ -62,6 +64,7 @@ export function LexicalComposer({initialConfig, children}: Props): JSX.Element {
         nodes,
         onError,
         editorState: initialEditorState,
+        html,
       } = initialConfig;
 
       const context: LexicalComposerContextType = createLexicalComposerContext(
@@ -74,6 +77,7 @@ export function LexicalComposer({initialConfig, children}: Props): JSX.Element {
       if (editor === null) {
         const newEditor = createEditor({
           editable: initialConfig.editable,
+          html,
           namespace,
           nodes,
           onError: (error) => onError(error, newEditor),

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -276,6 +276,14 @@ export type LexicalNodeReplacement = {
   replace: Class<LexicalNode>,
   with: (node: LexicalNode) => LexicalNode,
   withKlass?: Class<LexicalNode>,
+}
+
+export type HTMLConfig = {
+  export?: Map<
+    Class<LexicalNode>,
+    (editor: LexicalEditor, target: LexicalNode) => DOMExportOutput,
+  >,
+  import?: DOMConversionMap,
 };
 
 declare export function createEditor(editorConfig?: {
@@ -287,6 +295,7 @@ declare export function createEditor(editorConfig?: {
   onError: (error: Error) => void,
   disableEvents?: boolean,
   editable?: boolean,
+  html?: HTMLConfig,
 }): LexicalEditor;
 
 /**

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -276,7 +276,7 @@ export type LexicalNodeReplacement = {
   replace: Class<LexicalNode>,
   with: (node: LexicalNode) => LexicalNode,
   withKlass?: Class<LexicalNode>,
-}
+};
 
 export type HTMLConfig = {
   export?: Map<

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -7,7 +7,12 @@
  */
 
 import type {EditorState, SerializedEditorState} from './LexicalEditorState';
-import type {DOMConversion, NodeKey} from './LexicalNode';
+import type {
+  DOMConversion,
+  DOMConversionMap,
+  DOMExportOutput,
+  NodeKey,
+} from './LexicalNode';
 
 import invariant from 'shared/invariant';
 
@@ -160,6 +165,10 @@ export type CreateEditorArgs = {
   parentEditor?: LexicalEditor;
   editable?: boolean;
   theme?: EditorThemeClasses;
+  html?: {
+    export?: Map<Klass<LexicalNode>, DOMExportOutput>;
+    import?: DOMConversionMap;
+  };
 };
 
 export type RegisteredNodes = Map<string, RegisteredNode>;
@@ -330,9 +339,24 @@ export function resetEditor(
   }
 }
 
-function initializeConversionCache(nodes: RegisteredNodes): DOMConversionCache {
+function initializeConversionCache(
+  nodes: RegisteredNodes,
+  additionalConversions?: DOMConversionMap,
+): DOMConversionCache {
   const conversionCache = new Map();
   const handledConversions = new Set();
+  const addConversionsToCache = (map: DOMConversionMap) => {
+    Object.keys(map).forEach((key) => {
+      let currentCache = conversionCache.get(key);
+
+      if (currentCache === undefined) {
+        currentCache = [];
+        conversionCache.set(key, currentCache);
+      }
+
+      currentCache.push(map[key]);
+    });
+  };
   nodes.forEach((node) => {
     const importDOM =
       node.klass.importDOM != null
@@ -347,18 +371,12 @@ function initializeConversionCache(nodes: RegisteredNodes): DOMConversionCache {
     const map = importDOM();
 
     if (map !== null) {
-      Object.keys(map).forEach((key) => {
-        let currentCache = conversionCache.get(key);
-
-        if (currentCache === undefined) {
-          currentCache = [];
-          conversionCache.set(key, currentCache);
-        }
-
-        currentCache.push(map[key]);
-      });
+      addConversionsToCache(map);
     }
   });
+  if (additionalConversions) {
+    addConversionsToCache(additionalConversions);
+  }
   return conversionCache;
 }
 
@@ -469,7 +487,7 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
       });
     }
   }
-
+  const {html} = config;
   const editor = new LexicalEditor(
     editorState,
     parentEditor,
@@ -480,7 +498,7 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
       theme,
     },
     onError ? onError : console.error,
-    initializeConversionCache(registeredNodes),
+    initializeConversionCache(registeredNodes, html ? html.import : undefined),
     isEditable,
   );
 

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -154,7 +154,7 @@ export type LexicalNodeReplacement = {
     node: InstanceType<T>,
   ) => LexicalNode;
   withKlass?: Klass<LexicalNode>;
-}
+};
 
 export type HTMLConfig = {
   export?: Map<

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -166,7 +166,7 @@ export type CreateEditorArgs = {
   editable?: boolean;
   theme?: EditorThemeClasses;
   html?: {
-    export?: Map<Klass<LexicalNode>, DOMExportOutput>;
+    export?: Map<Klass<LexicalNode>, () => DOMExportOutput>;
     import?: DOMConversionMap;
   };
 };
@@ -178,6 +178,10 @@ export type RegisteredNode = {
   transforms: Set<Transform<LexicalNode>>;
   replace: null | ((node: LexicalNode) => LexicalNode);
   replaceWithKlass: null | Klass<LexicalNode>;
+  exportDOM?: (
+    editor: LexicalEditor,
+    targetNode: LexicalNode,
+  ) => DOMExportOutput;
 };
 
 export type Transform<T extends LexicalNode> = (node: T) => void;

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -16,6 +16,7 @@ export type {
   EditableListener,
   EditorConfig,
   EditorThemeClasses,
+  HTMLConfig,
   Klass,
   LexicalCommand,
   LexicalEditor,


### PR DESCRIPTION
With this change, I'm adding a new path for changing or extending html serialization functionality in the editor. Currently, if you want to change HTML serialization behavior on the core nodes, you generally need to override the node, which I think is an unnecessarily confusing process, given how common the use case is.