### PR TITLE
fix get text selectRect error

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -3084,8 +3084,10 @@ export function updateDOMSelection(
         : domSelection.rangeCount > 0
         ? domSelection.getRangeAt(0)
         : null;
-    if (selectionTarget instanceof HTMLElement) {
-      // @ts-ignore Text nodes do have getBoundingClientRect
+    if (selectionTarget instanceof Text) {
+      const range = document.createRange();
+      range.select(selectionTarget);
+      selectionRect = range.getBoundingClientRect();
       const selectionRect = selectionTarget.getBoundingClientRect();
       scrollIntoViewIfNeeded(editor, selectionRect, rootElement);
     }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -3084,7 +3084,7 @@ export function updateDOMSelection(
         : domSelection.rangeCount > 0
         ? domSelection.getRangeAt(0)
         : null;
-    if (selectionTarget !== null) {
+    if (selectionTarget instanceof HTMLElement) {
       // @ts-ignore Text nodes do have getBoundingClientRect
       const selectionRect = selectionTarget.getBoundingClientRect();
       scrollIntoViewIfNeeded(editor, selectionRect, rootElement);

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -3084,11 +3084,15 @@ export function updateDOMSelection(
         : domSelection.rangeCount > 0
         ? domSelection.getRangeAt(0)
         : null;
-    if (selectionTarget instanceof Text) {
-      const range = document.createRange();
-      range.select(selectionTarget);
-      selectionRect = range.getBoundingClientRect();
-      const selectionRect = selectionTarget.getBoundingClientRect();
+    if (selectionTarget !== null) {
+      let selectionRect: DOMRect;
+      if (selectionTarget instanceof Text) {
+        const range = document.createRange();
+        range.selectNode(selectionTarget);
+        selectionRect = range.getBoundingClientRect();
+      } else {
+        selectionRect = selectionTarget.getBoundingClientRect();
+      }
       scrollIntoViewIfNeeded(editor, selectionRect, rootElement);
     }
   }


### PR DESCRIPTION
`getBoundingClientRect`is not a function when`selectionTarget` is of type`Text`, So just by judging `selectionTarget! == null` will not avoid this error

<img width="756" alt="image" src="https://user-images.githubusercontent.com/39440537/229711504-be772c4f-365c-4f30-aaee-fe39c5e0da8a.png">
