### PR TITLE
Cell merge backwards compatiblity

### DIFF
--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -133,10 +133,10 @@ export class TableCellNode extends DEPRECATED_GridCellNode {
       const maxWidth = 700;
       const colCount = this.getParentOrThrow().getChildrenSize();
       element_.style.border = '1px solid black';
-      if (this.__colSpan !== 1) {
+      if (this.__colSpan > 1) {
         element_.colSpan = this.__colSpan;
       }
-      if (this.__rowSpan !== 1) {
+      if (this.__rowSpan > 1) {
         element_.rowSpan = this.__rowSpan;
       }
       element_.style.width = `${


### PR DESCRIPTION
`rowSpan` and `colSpan` for old stored nodes will resolve as `undefined` and be casted as `0`, leading to bad behavior