### PR TITLE
Table/TableRow should not be a shadow root

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1518,7 +1518,7 @@ test.describe('Tables', () => {
 
     await focusEditor(page);
 
-    await insertTable(page, 2, 1);
+    await insertTable(page, 2, 2);
 
     await click(page, '.PlaygroundEditorTheme__tableCell');
     await selectCellsFromTableCords(
@@ -1541,12 +1541,19 @@ test.describe('Tables', () => {
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>
             <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-              rowspan="2">
+              rowspan="2"
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
           </tr>
           <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -121,10 +121,6 @@ export class TableNode extends DEPRECATED_GridNode {
     return false;
   }
 
-  isShadowRoot(): boolean {
-    return true;
-  }
-
   getCordsFromCellNode(
     tableCellNode: TableCellNode,
     grid: Grid,

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -78,10 +78,6 @@ export class TableRowNode extends DEPRECATED_GridRowNode {
     return element;
   }
 
-  isShadowRoot(): boolean {
-    return true;
-  }
-
   setHeight(height: number): number | null | undefined {
     const self = this.getWritable();
     self.__height = height;


### PR DESCRIPTION
Shadow root indicates that node can be a parent for "regular" rich text content so it only makes sense for TableCellNode be a shadow root, while table and table row should be regular elements