### PR TITLE
Allow excluding specific properties from collab syncing via plugin

### DIFF
--- a/packages/lexical-react/src/LexicalCollaborationPlugin.ts
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.ts
@@ -11,6 +11,7 @@ import type {Doc} from 'yjs';
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {Provider} from '@lexical/yjs';
+import {addExcludedProperty} from 'packages/lexical-yjs/src/Utils';
 import {useEffect, useMemo} from 'react';
 
 import {InitialEditorStateType} from './LexicalComposer';
@@ -21,15 +22,7 @@ import {
   useYjsHistory,
 } from './shared/useYjsCollaboration';
 
-export function CollaborationPlugin({
-  id,
-  providerFactory,
-  shouldBootstrap,
-  username,
-  cursorColor,
-  cursorsContainerRef,
-  initialEditorState,
-}: {
+type Props = {
   id: string;
   providerFactory: (
     // eslint-disable-next-line no-shadow
@@ -41,12 +34,32 @@ export function CollaborationPlugin({
   cursorColor?: string;
   cursorsContainerRef?: CursorsContainerRef;
   initialEditorState?: InitialEditorStateType;
-}): JSX.Element {
+  excludedProperties?: string[];
+};
+
+export function CollaborationPlugin({
+  id,
+  providerFactory,
+  shouldBootstrap,
+  username,
+  cursorColor,
+  cursorsContainerRef,
+  initialEditorState,
+  excludedProperties,
+}: Props): JSX.Element {
   const collabContext = useCollaborationContext(username, cursorColor);
 
   const {yjsDocMap, name, color} = collabContext;
 
   const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    if (excludedProperties !== undefined) {
+      for (let i = 0; i < excludedProperties.length; i++) {
+        addExcludedProperty(excludedProperties[i]);
+      }
+    }
+  }, [excludedProperties]);
 
   useEffect(() => {
     collabContext.isCollabActive = true;

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.ts
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.ts
@@ -11,7 +11,7 @@ import type {Doc} from 'yjs';
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {Provider} from '@lexical/yjs';
-import {addExcludedProperty} from 'packages/lexical-yjs/src/Utils';
+import {ExcludedProperties} from 'packages/lexical-yjs/src/Bindings';
 import {useEffect, useMemo} from 'react';
 
 import {InitialEditorStateType} from './LexicalComposer';
@@ -34,7 +34,7 @@ type Props = {
   cursorColor?: string;
   cursorsContainerRef?: CursorsContainerRef;
   initialEditorState?: InitialEditorStateType;
-  excludedProperties?: string[];
+  excludedProperties?: ExcludedProperties;
 };
 
 export function CollaborationPlugin({
@@ -52,14 +52,6 @@ export function CollaborationPlugin({
   const {yjsDocMap, name, color} = collabContext;
 
   const [editor] = useLexicalComposerContext();
-
-  useEffect(() => {
-    if (excludedProperties !== undefined) {
-      for (let i = 0; i < excludedProperties.length; i++) {
-        addExcludedProperty(excludedProperties[i]);
-      }
-    }
-  }, [excludedProperties]);
 
   useEffect(() => {
     collabContext.isCollabActive = true;
@@ -88,6 +80,7 @@ export function CollaborationPlugin({
     shouldBootstrap,
     cursorsContainerRef,
     initialEditorState,
+    excludedProperties,
   );
 
   collabContext.clientID = binding.clientID;

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -31,6 +31,7 @@ import {
   REDO_COMMAND,
   UNDO_COMMAND,
 } from 'lexical';
+import {ExcludedProperties} from 'packages/lexical-yjs/src/Bindings';
 import * as React from 'react';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
@@ -50,13 +51,14 @@ export function useYjsCollaboration(
   shouldBootstrap: boolean,
   cursorsContainerRef?: CursorsContainerRef,
   initialEditorState?: InitialEditorStateType,
+  excludedProperties?: ExcludedProperties,
 ): [JSX.Element, Binding] {
   const isReloadingDoc = useRef(false);
   const [doc, setDoc] = useState(docMap.get(id));
 
   const binding = useMemo(
-    () => createBinding(editor, provider, id, doc, docMap),
-    [editor, provider, id, docMap, doc],
+    () => createBinding(editor, provider, id, doc, docMap, excludedProperties),
+    [editor, provider, id, docMap, doc, excludedProperties],
   );
 
   const connect = useCallback(() => {

--- a/packages/lexical-yjs/flow/LexicalYjs.js.flow
+++ b/packages/lexical-yjs/flow/LexicalYjs.js.flow
@@ -366,6 +366,8 @@ declare export function syncYjsChangesToLexical(
   events: Array<YjsEvent>,
 ): void;
 
+declare export function addExcludedProperty(property: string): void;
+
 declare export var CONNECTED_COMMAND: LexicalCommand<boolean>;
 declare export var TOGGLE_CONNECT_COMMAND: LexicalCommand<boolean>;
 

--- a/packages/lexical-yjs/flow/LexicalYjs.js.flow
+++ b/packages/lexical-yjs/flow/LexicalYjs.js.flow
@@ -366,8 +366,6 @@ declare export function syncYjsChangesToLexical(
   events: Array<YjsEvent>,
 ): void;
 
-declare export function addExcludedProperty(property: string): void;
-
 declare export var CONNECTED_COMMAND: LexicalCommand<boolean>;
 declare export var TOGGLE_CONNECT_COMMAND: LexicalCommand<boolean>;
 

--- a/packages/lexical-yjs/src/Bindings.ts
+++ b/packages/lexical-yjs/src/Bindings.ts
@@ -14,6 +14,7 @@ import type {Cursor} from './SyncCursors';
 import type {LexicalEditor, NodeKey} from 'lexical';
 import type {Doc} from 'yjs';
 
+import {Klass, LexicalNode} from 'lexical';
 import invariant from 'shared/invariant';
 import {XmlText} from 'yjs';
 
@@ -38,7 +39,9 @@ export type Binding = {
   id: string;
   nodeProperties: Map<string, Array<string>>;
   root: CollabElementNode;
+  excludedProperties: ExcludedProperties;
 };
+export type ExcludedProperties = Map<Klass<LexicalNode>, Set<string>>;
 
 export function createBinding(
   editor: LexicalEditor,
@@ -46,6 +49,7 @@ export function createBinding(
   id: string,
   doc: Doc | null | undefined,
   docMap: Map<string, Doc>,
+  excludedProperties?: ExcludedProperties,
 ): Binding {
   invariant(
     doc !== undefined && doc !== null,
@@ -66,6 +70,7 @@ export function createBinding(
     doc,
     docMap,
     editor,
+    excludedProperties: excludedProperties || new Map(),
     id,
     nodeProperties: new Map(),
     root,

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -244,15 +244,6 @@ export function syncPropertiesFromYjs(
     if (excludedProperties.has(property)) {
       continue;
     }
-    const additionalExcludedProperties = binding.excludedProperties.get(
-      lexicalNode.constructor as Klass<LexicalNode>,
-    );
-    if (
-      additionalExcludedProperties !== undefined &&
-      additionalExcludedProperties.has(property)
-    ) {
-      continue;
-    }
 
     const prevValue = lexicalNode[property];
     let nextValue =
@@ -294,10 +285,10 @@ export function syncPropertiesFromLexical(
   const type = nextLexicalNode.__type;
   const nodeProperties = binding.nodeProperties;
   let properties = nodeProperties.get(type);
-  const additionalExlcudedProperties = binding.excludedProperties.get(
-    nextLexicalNode.constructor as Klass<LexicalNode>,
-  );
   if (properties === undefined) {
+    const additionalExlcudedProperties = binding.excludedProperties.get(
+      nextLexicalNode.constructor as Klass<LexicalNode>,
+    );
     properties = Object.keys(nextLexicalNode).filter((property) => {
       return (
         !excludedProperties.has(property) ||

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -223,6 +223,10 @@ export function createLexicalNodeFromCollabNode(
   return lexicalNode;
 }
 
+export function addExcludedProperty(property: string): void {
+  excludedProperties.add(property);
+}
+
 export function syncPropertiesFromYjs(
   binding: Binding,
   sharedType: XmlText | YMap<unknown> | XmlElement,

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -244,6 +244,15 @@ export function syncPropertiesFromYjs(
     if (excludedProperties.has(property)) {
       continue;
     }
+    const additionalExcludedProperties = binding.excludedProperties.get(
+      lexicalNode.constructor as Klass<LexicalNode>,
+    );
+    if (
+      additionalExcludedProperties !== undefined &&
+      additionalExcludedProperties.has(property)
+    ) {
+      continue;
+    }
 
     const prevValue = lexicalNode[property];
     let nextValue =


### PR DESCRIPTION
Moves excluded properties to the Binding to avoid sharing them across plugin instances, allows scoping ignored properties to the node, reducing the likelihood of collisions.

Fixes #3670