### PR TITLE
Auto release on next channel on push to main

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release:
     # prevents this action from running on forks
-    if: github.repository_owner == 'facebook'
+    if: github.repository_owner == 'facebook' && !startsWith(github.ref, 'v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -14,6 +14,7 @@ jobs:
           ssh-key: ${{ secrets.SSH_KEY }}
           fetch-depth: 0
       - uses: pozetroninc/github-action-get-latest-release@master
+        id: latest_release
         with:
           repository: facebook/lexical
       # Setup .npmrc file to publish to npm
@@ -30,7 +31,7 @@ jobs:
         id: current_version
         run: echo "current_version=$(npm pkg get version)" >> "$GITHUB_OUTPUT"
         ## increment the root package.json version
-      - run: npm run increment-version -- --i prerelease
+      - run: npm run increment-version -- --i prerelease -- base ${{ steps.latest_release.outputs.release }}
         ## increment other package versions
       - run: npm run update-version
       - name: Get New Version

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           ssh-key: ${{ secrets.SSH_KEY }}
           fetch-depth: 0
-      - uses: pozetroninc/github-action-get-latest-release@master
+      - uses: pozetroninc/github-action-get-latest-release@d1dafdb6e338bdab109e6afce581a01858680dfb
         id: latest_release
         with:
           repository: facebook/lexical

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,8 +1,8 @@
 name: Nightly Release Branch
 on:
-  schedule:
-    # Run daily at 2:30am UTC
-    - cron: '30 2 * * 1-5'
+  push:
+    branches:
+      - main
 jobs:
   release:
     # prevents this action from running on forks
@@ -13,6 +13,9 @@ jobs:
         with:
           ssh-key: ${{ secrets.SSH_KEY }}
           fetch-depth: 0
+      - uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: facebook/lexical
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
@@ -21,6 +24,26 @@ jobs:
       - run: |
           git config user.name "Lexical GitHub Actions Bot"
           git config user.email "<>"
+      -
       - run: npm install
+      - name: Get Current Version
+        id: current_version
+        run: echo "current_version=$(npm pkg get version)" >> "$GITHUB_OUTPUT"
+        ## increment the root package.json version
       - run: npm run increment-version -- --i prerelease
-      - run: git push -u git@github.com:facebook/lexical.git --follow-tags
+        ## increment other package versions
+      - run: npm run update-version
+      - name: Get New Version
+        id: new_version
+        run: echo "new_version=$(npm pkg get version)" >> "$GITHUB_OUTPUT"
+        ## tag the current commit
+      - run: git tag -a v${{ steps.new_version.outputs.new_version }} -m v${{ steps.new_version.outputs.new_version }}
+        ## push tags to the remote
+      - run: git push -u git@github.com:facebook/lexical.git --tags
+        ## prepare & release
+      - run: npm run prepare-release
+      - run: node ./scripts/npm/release.js --non-interactive --dry-run=${{ secrets.RELEASE_DRY_RUN }} --channel next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        ## create Github release
+      #- run: gh release create ${{ steps.new_version.outputs.new_version }} --verify-tag --prerelease --generate-notes --notes-start-tag ${{ steps.current_version.outputs.current_version }}

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "increment-version": "node ./scripts/npm/increment-version",
     "update-changelog": "node ./scripts/npm/update-changelog",
     "update-version": "node ./scripts/updateVersion",
-    "postversion": "git checkout -b $npm_package_version && npm install && npm run update-version && npm run update-changelog && git add -A && git commit -m v${npm_package_version} && git tag -a v${npm_package_version} -m v${npm_package_version}",
     "release": "npm run prepare-release && node ./scripts/npm/release.js",
     "size": "npm run build && size-limit"
   },

--- a/scripts/npm/increment-version.js
+++ b/scripts/npm/increment-version.js
@@ -11,19 +11,28 @@
 'use strict';
 
 const {exec} = require('child-process-promise');
+const fs = require('fs-extra');
 const argv = require('minimist')(process.argv.slice(2));
 const increment = argv.i;
+const baseVersion = argv.base;
 const validIncrements = new Set(['minor', 'patch', 'prerelease']);
 if (!validIncrements.has(increment)) {
   console.error(`Invalid value for increment: ${increment}`);
   process.exit(1);
 }
 
-async function incrementVersion(increment) {
+async function incrementVersion(increment, base) {
+  if (base !== undefined) {
+    const basePackageJSON = fs.readJsonSync(`./package.json`);
+    basePackageJSON.version = base;
+    fs.writeJsonSync(`./package.json`, basePackageJSON, {
+      spaces: 2,
+    });
+  }
   const preId = increment === 'prerelease' ? '--preid next' : '';
   const workspaces = '';
   const command = `npm --no-git-tag-version version ${increment} --include-workspace-root true ${preId} ${workspaces}`;
   await exec(command);
 }
 
-incrementVersion(increment);
+incrementVersion(increment, baseVersion);


### PR DESCRIPTION
This automates the release process end-to-end for the next channel. With each to push to main, we'll release a new version and create a GitHub release to accompany it.

If this works, I'll copy it and add some buttons to do the same for the latest channel (the primary one). This is a little more complicated because we theoretically should to commit the version bump back to main, which means we need to either have a PR or disable push protections to main, at least for admins.