### PR TITLE
Improve responsiveness of the floating text format toolbar buttons

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -67,14 +67,30 @@ function TextFormatFloatingToolbar({
     editor.dispatchCommand(INSERT_INLINE_COMMAND, undefined);
   };
 
+  const movementThreshold = 5; // Set a threshold for minimum movement in pixels
+
+  let initialPosition = {x: 0, y: 0};
+
+  function mouseDownListener(e: MouseEvent) {
+    initialPosition = {x: e.clientX, y: e.clientY};
+  }
+
   function mouseMoveListener(e: MouseEvent) {
     if (
       popupCharStylesEditorRef?.current &&
       (e.buttons === 1 || e.buttons === 3)
     ) {
-      popupCharStylesEditorRef.current.style.pointerEvents = 'none';
+      const distanceMoved = Math.sqrt(
+        Math.pow(e.clientX - initialPosition.x, 2) +
+          Math.pow(e.clientY - initialPosition.y, 2),
+      );
+
+      if (distanceMoved > movementThreshold) {
+        popupCharStylesEditorRef.current.style.pointerEvents = 'none';
+      }
     }
   }
+
   function mouseUpListener(e: MouseEvent) {
     if (popupCharStylesEditorRef?.current) {
       popupCharStylesEditorRef.current.style.pointerEvents = 'auto';
@@ -83,10 +99,12 @@ function TextFormatFloatingToolbar({
 
   useEffect(() => {
     if (popupCharStylesEditorRef?.current) {
+      document.addEventListener('mousedown', mouseDownListener);
       document.addEventListener('mousemove', mouseMoveListener);
       document.addEventListener('mouseup', mouseUpListener);
 
       return () => {
+        document.removeEventListener('mousedown', mouseDownListener);
         document.removeEventListener('mousemove', mouseMoveListener);
         document.removeEventListener('mouseup', mouseUpListener);
       };


### PR DESCRIPTION
Introduced a movement threshold so button clicks with slight motion to them aren't filtered out. The current behavior will ignore all clicks to the toolbar with even the slightest of mouse movement, causing the toolbar to feel unresponsive.

This was broken with the fix introduced in #3959. My fix should help to improve the feel of the buttons while still mitigating the toolbar flashes on drag to highlight.

Current Behavior:

https://user-images.githubusercontent.com/29527680/231000297-d6c2cb05-dc8a-4479-b8c7-32e4c3066d45.mov

---


Fixed Behavior:

https://user-images.githubusercontent.com/29527680/231000315-ad7d6c40-2c45-4f8b-88e1-614efdafadc9.mov

