### PR TITLE
Persist files and scene state in Excalidraw plugin

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -9,6 +9,7 @@
 import type {ExcalidrawElementFragment} from './ExcalidrawModal';
 import type {NodeKey} from 'lexical';
 
+import {AppState, BinaryFiles} from '@excalidraw/excalidraw/types/types';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {mergeRegister} from '@lexical/utils';
@@ -123,15 +124,25 @@ export default function ExcalidrawComponent({
     });
   }, [editor, nodeKey]);
 
-  const setData = (newData: ReadonlyArray<ExcalidrawElementFragment>) => {
+  const setData = (
+    els: ReadonlyArray<ExcalidrawElementFragment>,
+    aps: Partial<AppState>,
+    fls: BinaryFiles,
+  ) => {
     if (!editor.isEditable()) {
       return;
     }
     return editor.update(() => {
       const node = $getNodeByKey(nodeKey);
       if ($isExcalidrawNode(node)) {
-        if (newData.length > 0) {
-          node.setData(JSON.stringify(newData));
+        if (els.length > 0 || Object.keys(fls).length > 0) {
+          node.setData(
+            JSON.stringify({
+              appState: aps,
+              elements: els,
+              files: fls,
+            }),
+          );
         } else {
           node.remove();
         }
@@ -150,17 +161,24 @@ export default function ExcalidrawComponent({
     }, 200);
   };
 
-  const elements = useMemo(() => JSON.parse(data), [data]);
+  const {
+    elements = [],
+    files = {},
+    appState = {},
+  } = useMemo(() => JSON.parse(data), [data]);
+
   return (
     <>
       <ExcalidrawModal
         initialElements={elements}
+        initialFiles={files}
+        initialAppState={appState}
         isShown={isModalOpen}
         onDelete={deleteNode}
         onClose={() => setModalOpen(false)}
-        onSave={(newData) => {
+        onSave={(els, aps, fls) => {
           editor.setEditable(true);
-          setData(newData);
+          setData(els, aps, fls);
           setModalOpen(false);
         }}
         closeOnClickOutside={false}
@@ -173,6 +191,8 @@ export default function ExcalidrawComponent({
             imageContainerRef={imageContainerRef}
             className="image"
             elements={elements}
+            files={files}
+            appState={appState}
           />
           {(isSelected || isResizing) && (
             <ImageResizer

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
@@ -11,7 +11,7 @@ import {
   ExcalidrawElement,
   NonDeleted,
 } from '@excalidraw/excalidraw/types/element/types';
-import {AppState} from '@excalidraw/excalidraw/types/types';
+import {AppState, BinaryFiles} from '@excalidraw/excalidraw/types/types';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 
@@ -21,7 +21,7 @@ type Props = {
   /**
    * Configures the export setting for SVG/Canvas
    */
-  appState?: Partial<Omit<AppState, 'offsetTop' | 'offsetLeft'>> | null;
+  appState: AppState;
   /**
    * The css class applied to image to be rendered
    */
@@ -30,6 +30,10 @@ type Props = {
    * The Excalidraw elements to be rendered as an image
    */
   elements: NonDeleted<ExcalidrawElement>[];
+  /**
+   * The Excalidraw elements to be rendered as an image
+   */
+  files: BinaryFiles;
   /**
    * The height of the image to be rendered
    */
@@ -77,8 +81,9 @@ const removeStyleFromSvg_HACK = (svg: SVGElement) => {
  */
 export default function ExcalidrawImage({
   elements,
+  files,
   imageContainerRef,
-  appState = null,
+  appState,
   rootClassName = null,
 }: Props): JSX.Element {
   const [Svg, setSvg] = useState<SVGElement | null>(null);
@@ -86,8 +91,9 @@ export default function ExcalidrawImage({
   useEffect(() => {
     const setContent = async () => {
       const svg: SVGElement = await exportToSvg({
+        appState,
         elements,
-        files: null,
+        files,
       });
       removeStyleFromSvg_HACK(svg);
 
@@ -98,7 +104,7 @@ export default function ExcalidrawImage({
       setSvg(svg);
     };
     setContent();
-  }, [elements, appState]);
+  }, [elements, files, appState]);
 
   return (
     <div

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
@@ -144,7 +144,7 @@ export default function ExcalidrawModal({
       const partialState: Partial<AppState> = {
         exportBackground: appState.exportBackground,
         exportScale: appState.exportScale,
-        exportWithDarkMode: appState.appState,
+        exportWithDarkMode: appState.theme === 'dark',
         isBindingEnabled: appState.isBindingEnabled,
         isLoading: appState.isLoading,
         name: appState.name,

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
@@ -9,6 +9,11 @@
 import './ExcalidrawModal.css';
 
 import {Excalidraw} from '@excalidraw/excalidraw';
+import {
+  AppState,
+  BinaryFiles,
+  ExcalidrawImperativeAPI,
+} from '@excalidraw/excalidraw/types/types';
 import * as React from 'react';
 import {ReactPortal, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
@@ -27,6 +32,14 @@ type Props = {
    */
   initialElements: ReadonlyArray<ExcalidrawElementFragment>;
   /**
+   * The initial set of elements to draw into the scene
+   */
+  initialAppState: AppState;
+  /**
+   * The initial set of elements to draw into the scene
+   */
+  initialFiles: BinaryFiles;
+  /**
    * Controls the visibility of the modal
    */
   isShown?: boolean;
@@ -41,7 +54,11 @@ type Props = {
   /**
    * Callback when the save button is clicked
    */
-  onSave: (elements: ReadonlyArray<ExcalidrawElementFragment>) => void;
+  onSave: (
+    elements: ReadonlyArray<ExcalidrawElementFragment>,
+    appState: Partial<AppState>,
+    files: BinaryFiles,
+  ) => void;
 };
 
 /**
@@ -53,15 +70,18 @@ export default function ExcalidrawModal({
   closeOnClickOutside = false,
   onSave,
   initialElements,
+  initialAppState,
+  initialFiles,
   isShown = false,
   onDelete,
   onClose,
 }: Props): ReactPortal | null {
   const excaliDrawModelRef = useRef<HTMLDivElement | null>(null);
-
+  const excaliDrawSceneRef = useRef<ExcalidrawImperativeAPI>(null);
   const [discardModalOpen, setDiscardModalOpen] = useState(false);
   const [elements, setElements] =
     useState<ReadonlyArray<ExcalidrawElementFragment>>(initialElements);
+  const [files, setFiles] = useState<BinaryFiles>(initialFiles);
 
   useEffect(() => {
     if (excaliDrawModelRef.current !== null) {
@@ -115,11 +135,26 @@ export default function ExcalidrawModal({
         currentModalRef.removeEventListener('keydown', onKeyDown);
       }
     };
-  }, [elements, onDelete]);
+  }, [elements, files, onDelete]);
 
   const save = () => {
     if (elements.filter((el) => !el.isDeleted).length > 0) {
-      onSave(elements);
+      const appState = excaliDrawSceneRef?.current?.getAppState();
+      // We only need a subset of the state
+      const partialState: Partial<AppState> = {
+        exportBackground: appState.exportBackground,
+        exportScale: appState.exportScale,
+        exportWithDarkMode: appState.appState,
+        isBindingEnabled: appState.isBindingEnabled,
+        isLoading: appState.isLoading,
+        name: appState.name,
+        theme: appState.theme,
+        viewBackgroundColor: appState.viewBackgroundColor,
+        viewModeEnabled: appState.viewModeEnabled,
+        zenModeEnabled: appState.zenModeEnabled,
+        zoom: appState.zoom,
+      };
+      onSave(elements, partialState, files);
     } else {
       // delete node if the scene is clear
       onDelete();
@@ -168,8 +203,13 @@ export default function ExcalidrawModal({
     return null;
   }
 
-  const onChange = (els: ReadonlyArray<ExcalidrawElementFragment>) => {
+  const onChange = (
+    els: ReadonlyArray<ExcalidrawElementFragment>,
+    _: AppState,
+    fls: BinaryFiles,
+  ) => {
     setElements(els);
+    setFiles(fls);
   };
 
   // This is a hacky work-around for Excalidraw + Vite.
@@ -188,9 +228,11 @@ export default function ExcalidrawModal({
           {discardModalOpen && <ShowDiscardDialog />}
           <_Excalidraw
             onChange={onChange}
+            ref={excaliDrawSceneRef}
             initialData={{
-              appState: {isLoading: false},
+              appState: initialAppState || {isLoading: false},
               elements: initialElements,
+              files: initialFiles,
             }}
           />
           <div className="ExcalidrawModal__actions">


### PR DESCRIPTION
- When adding images to the Excalidraw scene, the files were not persisted
- When exporting the scene, it was losing some of the scene data, like background color.

Before:

https://user-images.githubusercontent.com/7893468/231016887-7a68c03b-341b-4156-b78c-414b828893b3.mp4

After:

https://user-images.githubusercontent.com/7893468/231016948-61eae2ab-d813-4de5-b588-e5bd7732fbdd.mp4