### PR TITLE
ExportDOM in Debug Tree View

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1368,6 +1368,21 @@ button.action-button:disabled {
   text-decoration: underline;
 }
 
+.debug-treetype-button {
+  border: 0;
+  padding: 0;
+  font-size: 12px;
+  top: 10px;
+  right: 85px;
+  position: absolute;
+  background: none;
+  color: #fff;
+}
+
+.debug-treetype-button:hover {
+  text-decoration: underline;
+}
+
 .connecting {
   font-size: 15px;
   color: #999;

--- a/packages/lexical-playground/src/plugins/TreeViewPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TreeViewPlugin/index.tsx
@@ -15,6 +15,7 @@ export default function TreeViewPlugin(): JSX.Element {
   return (
     <TreeView
       viewClassName="tree-view-output"
+      treeTypeButtonClassName="debug-treetype-button"
       timeTravelPanelClassName="debug-timetravel-panel"
       timeTravelButtonClassName="debug-timetravel-button"
       timeTravelPanelSliderClassName="debug-timetravel-panel-slider"


### PR DESCRIPTION
https://user-images.githubusercontent.com/7893468/231305891-19835d70-b54d-4833-b73b-552a8f1f5326.mp4

I've been meaning to add this for ages - the ability to toggle between node view and an exportDOM view, in order to validate if the a node's exportDOM definition is correct, since the DevTools show the createDOM output, besides manually printing exportDOM inside node methods, there is no intuitive way to check if the exportDOM properties are set correctly during development. 

Happy to hear suggestions for improvement.