### PR TITLE
Fix issue where H2 and H3 headings were displayed in uppercase

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -38,12 +38,10 @@
   color: rgb(101, 103, 107);
   font-weight: 700;
   margin: 0;
-  text-transform: uppercase;
 }
 .PlaygroundEditorTheme__h3 {
   font-size: 12px;
   margin: 0;
-  text-transform: uppercase;
 }
 .PlaygroundEditorTheme__indent {
   --lexical-indent-base-value: 40px;


### PR DESCRIPTION
Fix the issue where H2 and H3 headings were displayed in uppercase

This commit resolves the problem in which H2 and H3 headings were incorrectly displayed in uppercase letters. The root cause was identified, and the necessary changes were made in the CSS and/or JavaScript files to ensure that the headings are now displayed correctly. This fix improves the readability and consistency of the text editor's headings.
