### PR TITLE
Fix cursor changing to default when resizing image (#4317)

### DIFF
--- a/packages/lexical-playground/src/ui/ImageResizer.tsx
+++ b/packages/lexical-playground/src/ui/ImageResizer.tsx
@@ -122,7 +122,7 @@ export default function ImageResizer({
 
   const setEndCursor = () => {
     if (editorRootElement !== null) {
-      editorRootElement.style.setProperty('cursor', 'default');
+      editorRootElement.style.setProperty('cursor', 'text');
     }
     if (document.body !== null) {
       document.body.style.setProperty('cursor', 'default');


### PR DESCRIPTION
This commit fixes the issue of the cursor changing to default when resizing an image. The change was made in the `setEndCursor()` function, where the `cursor` property of the `editorRootElement` is set to `text`. This ensures that the cursor changes to the expected text cursor when hovering over the text.

No other changes were made in this commit.