### PR TITLE
Move link sanitizer into core

### DIFF
--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -412,7 +412,7 @@ export function toggleLink(
   if (url !== null) {
     let sanitizedUrl: string | null = url;
     if (sanitizeUrl !== null) {
-      const sanitize = sanitizeUrl ?? _sanitizeUrl;
+      const sanitize = sanitizeUrl ? sanitizeUrl : _sanitizeUrl;
       sanitizedUrl = sanitize(url);
       if (sanitizedUrl === null) {
         return;

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -29,7 +29,6 @@ import {createPortal} from 'react-dom';
 
 import {getSelectedNode} from '../../utils/getSelectedNode';
 import {setFloatingElemPositionForLinkEditor} from '../../utils/setFloatingElemPositionForLinkEditor';
-import {sanitizeUrl} from '../../utils/url';
 
 function FloatingLinkEditor({
   editor,
@@ -181,7 +180,7 @@ function FloatingLinkEditor({
   const handleLinkSubmission = () => {
     if (lastSelection !== null) {
       if (linkUrl !== '') {
-        editor.dispatchCommand(TOGGLE_LINK_COMMAND, sanitizeUrl(editedLinkUrl));
+        editor.dispatchCommand(TOGGLE_LINK_COMMAND, editedLinkUrl);
       }
       setEditMode(false);
     }

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -78,7 +78,6 @@ import {$createStickyNode} from '../../nodes/StickyNode';
 import ColorPicker from '../../ui/ColorPicker';
 import DropDown, {DropDownItem} from '../../ui/DropDown';
 import {getSelectedNode} from '../../utils/getSelectedNode';
-import {sanitizeUrl} from '../../utils/url';
 import {EmbedConfigs} from '../AutoEmbedPlugin';
 import {INSERT_COLLAPSIBLE_COMMAND} from '../CollapsiblePlugin';
 import {InsertEquationDialog} from '../EquationsPlugin';
@@ -607,7 +606,7 @@ export default function ToolbarPlugin(): JSX.Element {
 
   const insertLink = useCallback(() => {
     if (!isLink) {
-      editor.dispatchCommand(TOGGLE_LINK_COMMAND, sanitizeUrl('https://'));
+      editor.dispatchCommand(TOGGLE_LINK_COMMAND, 'https://');
     } else {
       editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
     }

--- a/packages/lexical-playground/src/utils/url.ts
+++ b/packages/lexical-playground/src/utils/url.ts
@@ -6,22 +6,6 @@
  *
  */
 
-export function sanitizeUrl(url: string): string {
-  /** A pattern that matches safe  URLs. */
-  const SAFE_URL_PATTERN =
-    /^(?:(?:https?|mailto|ftp|tel|file|sms):|[^&:/?#]*(?:[/?#]|$))/gi;
-
-  /** A pattern that matches safe data URLs. */
-  const DATA_URL_PATTERN =
-    /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+/]+=*$/i;
-
-  url = String(url).trim();
-
-  if (url.match(SAFE_URL_PATTERN) || url.match(DATA_URL_PATTERN)) return url;
-
-  return 'https://';
-}
-
 // Source: https://stackoverflow.com/a/8234912/2013580
 const urlRegExp = new RegExp(
   /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%/.\w-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[\w]*))?)/,


### PR DESCRIPTION
This makes the link library more secure by default by sanitizing links using default library logic. Users can provider their own sanitizer overrider or pass explicit null to disable sanitization altogether.