### PR TITLE
TablePlugin feature: cell merge

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -62,11 +62,12 @@ async function fillTablePartiallyWithText(page) {
 }
 
 test.describe('Tables', () => {
-  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
   test(`Can a table be inserted from the toolbar`, async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
     await focusEditor(page);
 
@@ -101,7 +102,12 @@ test.describe('Tables', () => {
     );
   });
 
-  test(`Can type inside of table cell`, async ({page, isPlainText}) => {
+  test(`Can type inside of table cell`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
 
     await focusEditor(page);
@@ -138,7 +144,12 @@ test.describe('Tables', () => {
     );
   });
 
-  test(`Can navigate table with keyboard`, async ({page, isPlainText}) => {
+  test(`Can navigate table with keyboard`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
 
     await focusEditor(page);
@@ -184,7 +195,9 @@ test.describe('Tables', () => {
   test(`Can select cells using Table selection`, async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
 
     await focusEditor(page);
@@ -268,7 +281,9 @@ test.describe('Tables', () => {
   test(`Can select cells using Table selection via keyboard`, async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
 
     await focusEditor(page);
@@ -383,7 +398,12 @@ test.describe('Tables', () => {
     );
   });
 
-  test(`Can style text using Table selection`, async ({page, isPlainText}) => {
+  test(`Can style text using Table selection`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
 
     await focusEditor(page);
@@ -472,7 +492,9 @@ test.describe('Tables', () => {
   test(`Can copy + paste (internal) using Table selection`, async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
 
     await focusEditor(page);
@@ -549,7 +571,12 @@ test.describe('Tables', () => {
     );
   });
 
-  test(`Can clear text using Table selection`, async ({page, isPlainText}) => {
+  test(`Can clear text using Table selection`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
 
     await focusEditor(page);
@@ -607,6 +634,7 @@ test.describe('Tables', () => {
     isPlainText,
     isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
 
     await focusEditor(page);
@@ -658,6 +686,7 @@ test.describe('Tables', () => {
     isPlainText,
     isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
 
     await focusEditor(page);
@@ -735,7 +764,8 @@ test.describe('Tables', () => {
     );
   });
 
-  test(`Horizontal rule inside cell`, async ({page, isPlainText}) => {
+  test(`Horizontal rule inside cell`, async ({page, isPlainText, isCollab}) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
     await focusEditor(page);
 
@@ -769,7 +799,9 @@ test.describe('Tables', () => {
   test('Grid selection: can select multiple cells and insert an image', async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
 
     await focusEditor(page);
@@ -843,7 +875,9 @@ test.describe('Tables', () => {
   test('Grid selection: can backspace lines, backspacing empty cell does not destroy it #3278', async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
 
     await focusEditor(page);
@@ -916,7 +950,8 @@ test.describe('Tables', () => {
     );
   });
 
-  test('Merge/unmerge cells (1)', async ({page, isPlainText}) => {
+  test('Merge/unmerge cells (1)', async ({page, isPlainText, isCollab}) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
     if (IS_COLLAB) {
       // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
@@ -1002,7 +1037,8 @@ test.describe('Tables', () => {
     );
   });
 
-  test('Merge/unmerge cells (2)', async ({page, isPlainText}) => {
+  test('Merge/unmerge cells (2)', async ({page, isPlainText, isCollab}) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
     if (IS_COLLAB) {
       // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
@@ -1128,7 +1164,8 @@ test.describe('Tables', () => {
     );
   });
 
-  test('Merge with content', async ({page, isPlainText}) => {
+  test('Merge with content', async ({page, isPlainText, isCollab}) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
     if (IS_COLLAB) {
       // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
@@ -1221,7 +1258,9 @@ test.describe('Tables', () => {
   test('Select multiple merged cells (selection expands to a rectangle)', async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
 
     await focusEditor(page);
@@ -1347,7 +1386,9 @@ test.describe('Tables', () => {
   test('Insert row above (with conflicting merged cell)', async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
     if (IS_COLLAB) {
       // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
@@ -1405,7 +1446,9 @@ test.describe('Tables', () => {
   test('Insert column before (with conflicting merged cell)', async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
     if (IS_COLLAB) {
       // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
@@ -1463,7 +1506,9 @@ test.describe('Tables', () => {
   test('Insert column before (with selected cell with rowspan > 1)', async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
     if (IS_COLLAB) {
       // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
@@ -1515,7 +1560,9 @@ test.describe('Tables', () => {
   test('Delete rows (with conflicting merged cell)', async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
     if (IS_COLLAB) {
       // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
@@ -1574,7 +1621,9 @@ test.describe('Tables', () => {
   test('Delete columns (with conflicting merged cell)', async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
     if (IS_COLLAB) {
       // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
@@ -1633,7 +1682,9 @@ test.describe('Tables', () => {
   test('Deselect when click outside #3785 #4138', async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
+    initialize({isCollab, page});
     test.skip(isPlainText);
     if (IS_COLLAB) {
       // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
@@ -1656,5 +1707,105 @@ test.describe('Tables', () => {
       focusOffset: 3,
       focusPath: [0, 0, 0],
     });
+  });
+
+  test('Cell merge feature disabled', async ({page, isPlainText, isCollab}) => {
+    initialize({isCollab, page, tableCellMerge: false});
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await pasteFromClipboard(page, {
+      'text/html': `<div dir="ltr">
+      <table>
+         <tbody>
+            <tr>
+               <td colspan="2" rowspan="2">
+                  <p dir="ltr">Hello world</p>
+               </td>
+               <td>
+                  <p dir="ltr">a</p>
+               </td>
+            </tr>
+            <tr>
+               <td>
+                  <p dir="ltr">b</p>
+               </td>
+            </tr>
+            <tr>
+               <td>
+                  <p dir="ltr">c</p>
+               </td>
+               <td>
+                  <p dir="ltr">d</p>
+               </td>
+               <td>
+                  <p dir="ltr">e</p>
+               </td>
+            </tr>
+         </tbody>
+      </table>
+   </div>`,
+    });
+
+    await page.pause();
+
+    await assertHTML(
+      page,
+      html`
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">Hello world</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell"><br /></td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">a</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell"><br /></td>
+            <td class="PlaygroundEditorTheme__tableCell"><br /></td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">b</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">c</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">d</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">e</span>
+              </p>
+            </td>
+          </tr>
+        </table>
+      `,
+    );
   });
 });

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -42,6 +42,7 @@ export async function initialize({
   isCharLimitUtf8,
   isMaxLength,
   showNestedEditorTreeView,
+  tableCellMerge,
 }) {
   const appSettings = {};
   appSettings.isRichText = IS_RICH_TEXT;
@@ -58,6 +59,9 @@ export async function initialize({
   appSettings.isCharLimit = !!isCharLimit;
   appSettings.isCharLimitUtf8 = !!isCharLimitUtf8;
   appSettings.isMaxLength = !!isMaxLength;
+  if (tableCellMerge !== undefined) {
+    appSettings.tableCellMerge = tableCellMerge;
+  }
 
   const urlParams = appSettingsToURLParams(appSettings);
   const url = `http://localhost:${E2E_PORT}/${

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -85,6 +85,7 @@ export default function Editor(): JSX.Element {
       isRichText,
       showTreeView,
       showTableOfContents,
+      tableCellMerge,
     },
   } = useSettings();
   const text = isCollab
@@ -180,7 +181,7 @@ export default function Editor(): JSX.Element {
             <ListPlugin />
             <CheckListPlugin />
             <ListMaxIndentLevelPlugin maxDepth={7} />
-            <TablePlugin />
+            <TablePlugin hasCellMerge={tableCellMerge} />
             <TableCellResizer />
             <NewTablePlugin cellEditorConfig={cellEditorConfig}>
               <AutoFocusPlugin />

--- a/packages/lexical-playground/src/appSettings.ts
+++ b/packages/lexical-playground/src/appSettings.ts
@@ -18,7 +18,8 @@ export type SettingName =
   | 'showTreeView'
   | 'showNestedEditorTreeView'
   | 'emptyEditor'
-  | 'showTableOfContents';
+  | 'showTableOfContents'
+  | 'tableCellMerge';
 
 export type Settings = Record<SettingName, boolean>;
 
@@ -40,4 +41,5 @@ export const DEFAULT_SETTINGS: Settings = {
   showNestedEditorTreeView: false,
   showTableOfContents: false,
   showTreeView: true,
+  tableCellMerge: true,
 };

--- a/packages/lexical-react/src/LexicalTablePlugin.ts
+++ b/packages/lexical-react/src/LexicalTablePlugin.ts
@@ -11,9 +11,16 @@ import type {
   InsertTableCommandPayload,
   TableSelection,
 } from '@lexical/table';
+import type {
+  DEPRECATED_GridCellNode,
+  ElementNode,
+  LexicalNode,
+  NodeKey,
+} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
+  $createTableCellNode,
   $createTableNodeWithDimensions,
   $isTableNode,
   applyTableHandlers,
@@ -28,12 +35,28 @@ import {
   $isTextNode,
   $nodesOfType,
   COMMAND_PRIORITY_EDITOR,
-  NodeKey,
+  DEPRECATED_$computeGridMap,
+  DEPRECATED_$getNodeTriplet,
+  DEPRECATED_$isGridRowNode,
 } from 'lexical';
 import {useEffect} from 'react';
 import invariant from 'shared/invariant';
 
-export function TablePlugin(): JSX.Element | null {
+// TODO extract to utils
+function $insertFirst(parent: ElementNode, node: LexicalNode): void {
+  const firstChild = parent.getFirstChild();
+  if (firstChild !== null) {
+    firstChild.insertBefore(node);
+  } else {
+    parent.append(node);
+  }
+}
+
+export function TablePlugin({
+  hasCellMerge = true,
+}: {
+  hasCellMerge?: boolean;
+}): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
@@ -126,6 +149,59 @@ export function TablePlugin(): JSX.Element | null {
       }
     };
   }, [editor]);
+
+  // Unmerge cells when the feature isn't enabled
+  useEffect(() => {
+    if (hasCellMerge) {
+      return;
+    }
+    return editor.registerNodeTransform(TableCellNode, (node) => {
+      if (node.getColSpan() > 1 || node.getRowSpan() > 1) {
+        // When we have rowSpan we have to map the entire Table to understand where the new Cells
+        // fit best; let's analyze all Cells at once to save us from further transform iterations
+        const [, , gridNode] = DEPRECATED_$getNodeTriplet(node);
+        const [gridMap] = DEPRECATED_$computeGridMap(gridNode, node, node);
+        // TODO this function expects Tables to be normalized. Look into this once it exists
+        const rowsCount = gridMap.length;
+        const columnsCount = gridMap[0].length;
+        let row = gridNode.getFirstChild();
+        invariant(
+          DEPRECATED_$isGridRowNode(row),
+          'Expected TableNode first child to be a RowNode',
+        );
+        const unmerged = [];
+        for (let i = 0; i < rowsCount; i++) {
+          if (i !== 0) {
+            row = row.getNextSibling();
+            invariant(
+              DEPRECATED_$isGridRowNode(row),
+              'Expected TableNode first child to be a RowNode',
+            );
+          }
+          let lastRowCell: null | DEPRECATED_GridCellNode = null;
+          for (let j = 0; j < columnsCount; j++) {
+            const cellMap = gridMap[i][j];
+            const cell = cellMap.cell;
+            if (cellMap.startRow === i && cellMap.startColumn === j) {
+              lastRowCell = cell;
+              unmerged.push(cell);
+            } else if (cell.getColSpan() > 1 || cell.getRowSpan() > 1) {
+              const newCell = $createTableCellNode(cell.__headerState);
+              if (lastRowCell !== null) {
+                lastRowCell.insertAfter(newCell);
+              } else {
+                $insertFirst(row, newCell);
+              }
+            }
+          }
+        }
+        for (const cell of unmerged) {
+          cell.setColSpan(1);
+          cell.setRowSpan(1);
+        }
+      }
+    });
+  }, [editor, hasCellMerge]);
 
   return null;
 }


### PR DESCRIPTION
Initially, Nodes were simple in terms of "features", so were Tables. Few properties and 100% of the users wanted all of them. Nowadays, a few Nodes have grown, TextNode and TableNode are clear examples.

This PR doesn't address features in a generic manner (yet) but I believe this is an appropriate way to handle features without touching the Nodes, that ultimately should not be smart and should always retain the same type regardless of the feature.

Cell merge is addressed in this PR, later we'll add backgroundColor too.

https://user-images.githubusercontent.com/193447/232581073-c2738256-b93a-4d1e-a899-b0b33b130418.mov


