### PR TITLE
Tests for inserting text either side of an inline element

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -648,13 +648,14 @@ test.describe('Links', () => {
          */
         const setup = async (page, insertMethod) => {
           await focusEditor(page);
-          await page.keyboard.type('a');
+          await page.keyboard.type('ab');
 
           // Turn 'a' into a link
+          await moveLeft(page, 'b'.length);
           await selectCharacters(page, 'left', 1);
           await click(page, '.link');
 
-          // Paste some text at the left-hand edge of the link
+          // Insert a character directly before the link
           await moveLeft(page, 1);
           if (insertMethod === 'type') {
             await page.keyboard.type('x');
@@ -683,6 +684,7 @@ test.describe('Links', () => {
                   rel="noopener">
                   <span data-lexical-text="true">a</span>
                 </a>
+                <span data-lexical-text="true">b</span>
               </p>
             `,
           );
@@ -729,7 +731,7 @@ test.describe('Links', () => {
           await selectCharacters(page, 'left', 1);
           await click(page, '.link');
 
-          // Paste some text at the left-hand edge of the link
+          // Insert a character directly before the link
           await moveLeft(page, 1);
           if (insertMethod === 'type') {
             await page.keyboard.type('x');
@@ -796,14 +798,13 @@ test.describe('Links', () => {
          */
         const setup = async (page, insertMethod) => {
           await focusEditor(page);
-          await page.keyboard.type('a');
+          await page.keyboard.type('ab');
 
-          // Turn 'a' into a link
-          await moveLeft(page, 1);
+          // Turn 'b' into a link
           await selectCharacters(page, 'left', 1);
           await click(page, '.link');
 
-          // Paste some text at the left-hand edge of the link
+          // Insert a character directly before the link
           await moveLeft(page, 1);
           if (insertMethod === 'type') {
             await page.keyboard.type('x');
@@ -824,13 +825,13 @@ test.describe('Links', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">x</span>
+                <span data-lexical-text="true">ax</span>
                 <a
                   class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
                   dir="ltr"
                   href="https://"
                   rel="noopener">
-                  <span data-lexical-text="true">a</span>
+                  <span data-lexical-text="true">b</span>
                 </a>
               </p>
             `,
@@ -873,14 +874,14 @@ test.describe('Links', () => {
          */
         const setup = async (page, insertMethod) => {
           await focusEditor(page);
-          await page.keyboard.type('a');
+          await page.keyboard.type('ab');
 
           // Turn 'a' into a link
-          await moveLeft(page, 'a'.length);
+          await moveLeft(page, 'b'.length);
           await selectCharacters(page, 'left', 1);
           await click(page, '.link');
 
-          // Type a character at the right-hand edge of the link
+          // Insert a character directly after the link
           await moveRight(page, 1);
           if (insertMethod === 'type') {
             await page.keyboard.type('x');
@@ -908,7 +909,7 @@ test.describe('Links', () => {
                   rel="noopener">
                   <span data-lexical-text="true">a</span>
                 </a>
-                <span data-lexical-text="true">x</span>
+                <span data-lexical-text="true">xb</span>
               </p>
             `,
           );
@@ -955,7 +956,7 @@ test.describe('Links', () => {
           await selectCharacters(page, 'left', 1);
           await click(page, '.link');
 
-          // Paste some text at the right-hand edge of the link
+          // Insert a character directly after the link
           await moveRight(page, 1);
           if (insertMethod === 'type') {
             await page.keyboard.type('x');
@@ -1024,14 +1025,13 @@ test.describe('Links', () => {
          */
         const setup = async (page, insertMethod) => {
           await focusEditor(page);
-          await page.keyboard.type('a');
+          await page.keyboard.type('ab');
 
-          // Turn 'a' into a link
-          await moveLeft(page, 'a'.length);
+          // Turn 'b' into a link
           await selectCharacters(page, 'left', 1);
           await click(page, '.link');
 
-          // Type a character at the right-hand edge of the link
+          // Insert a character directly after the link
           await moveRight(page, 1);
           if (insertMethod === 'type') {
             await page.keyboard.type('x');
@@ -1052,12 +1052,13 @@ test.describe('Links', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
+                <span data-lexical-text="true">a</span>
                 <a
                   class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
                   dir="ltr"
                   href="https://"
                   rel="noopener">
-                  <span data-lexical-text="true">a</span>
+                  <span data-lexical-text="true">b</span>
                 </a>
                 <span data-lexical-text="true">x</span>
               </p>

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -27,6 +27,7 @@ import {
   IS_LINUX,
   keyDownCtrlOrMeta,
   keyUpCtrlOrMeta,
+  pasteFromClipboard,
   test,
 } from '../utils/index.mjs';
 
@@ -610,6 +611,169 @@ test.describe('Links', () => {
             <span data-lexical-text="true">a</span>
           </a>
           <span data-lexical-text="true">a</span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Can create a link then insert text after it, via typing`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('ab');
+
+    // Turn 'a' into a link
+    await moveLeft(page, 'b'.length);
+    await selectCharacters(page, 'left', 1);
+    await click(page, '.link');
+
+    // Type a character at the right-hand edge of the link
+    await moveRight(page, 1);
+    await page.keyboard.type('x');
+
+    // The character should be inserted after the link
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noopener">
+            <span data-lexical-text="true">a</span>
+          </a>
+          <span data-lexical-text="true">xb</span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Can create a link then insert text after it, via pasting plain text`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('ab');
+
+    // Turn 'a' into a link
+    await moveLeft(page, 'b'.length);
+    await selectCharacters(page, 'left', 1);
+    await click(page, '.link');
+
+    // Paste some text at the right-hand edge of the link
+    await moveRight(page, 1);
+    await pasteFromClipboard(page, {'text/plain': 'x'});
+
+    // The character should be inserted after the link
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noopener">
+            <span data-lexical-text="true">a</span>
+          </a>
+          <span data-lexical-text="true">xb</span>
+        </p>
+      `,
+    );
+  });
+
+  // Fails: https://github.com/facebook/lexical/issues/4295
+  test(`Can create a link then insert text after it, via pasting Lexical text`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('ab');
+
+    // Turn 'a' into a link
+    await moveLeft(page, 'b'.length);
+    await selectCharacters(page, 'left', 1);
+    await click(page, '.link');
+
+    // Paste some text at the right-hand edge of the link
+    await moveRight(page, 1);
+    await pasteFromClipboard(page, {
+      'application/x-lexical-editor': JSON.stringify({
+        namespace: 'Playground',
+        nodes: [
+          {
+            detail: 0,
+            format: 0,
+            mode: 'normal',
+            style: '',
+            text: 'x',
+            type: 'text',
+            version: 1,
+          },
+        ],
+      }),
+    });
+
+    // Expected: As with the equivalent 'via pasting plain text' test above, the
+    // 'x' should be inserted after the link.
+    //
+    // Observed: the whole line becomes inserted into the link.
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noopener">
+            <span data-lexical-text="true">a</span>
+          </a>
+          <span data-lexical-text="true">xb</span>
+        </p>
+      `,
+    );
+  });
+
+  // Fails: https://github.com/facebook/lexical/issues/4295
+  test(`Can create a link then insert text after it, via pasting HTML`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('ab');
+
+    // Turn 'a' into a link
+    await moveLeft(page, 'b'.length);
+    await selectCharacters(page, 'left', 1);
+    await click(page, '.link');
+
+    // Paste some text at the right-hand edge of the link
+    await moveRight(page, 1);
+    await pasteFromClipboard(page, {'text/html': 'x'});
+
+    // Expected: As with the equivalent 'via pasting plain text' test above, the
+    // 'x' should be inserted after the link.
+    //
+    // Observed: the whole line becomes inserted into the link.
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noopener">
+            <span data-lexical-text="true">a</span>
+          </a>
+          <span data-lexical-text="true">xb</span>
         </p>
       `,
     );

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -700,15 +700,15 @@ test.describe('Links', () => {
           await setup(page, 'paste:plain');
         });
 
-        // Fails: https://github.com/facebook/lexical/issues/4295
-        test(`Can insert text before a start-of-paragraph link, via pasting HTML`, async ({
+        // TODO: https://github.com/facebook/lexical/issues/4295
+        test.skip(`Can insert text before a start-of-paragraph link, via pasting HTML`, async ({
           page,
         }) => {
           await setup(page, 'paste:html');
         });
 
-        // Fails: https://github.com/facebook/lexical/issues/4295
-        test(`Can insert text before a start-of-paragraph link, via pasting Lexical text`, async ({
+        // TODO: https://github.com/facebook/lexical/issues/4295
+        test.skip(`Can insert text before a start-of-paragraph link, via pasting Lexical text`, async ({
           page,
         }) => {
           await setup(page, 'paste:lexical');
@@ -849,15 +849,15 @@ test.describe('Links', () => {
           await setup(page, 'paste:plain');
         });
 
-        // Fails: https://github.com/facebook/lexical/issues/4295
-        test(`Can insert text before an end-of-paragraph link, via pasting HTML`, async ({
+        // TODO: https://github.com/facebook/lexical/issues/4295
+        test.skip(`Can insert text before an end-of-paragraph link, via pasting HTML`, async ({
           page,
         }) => {
           await setup(page, 'paste:html');
         });
 
-        // Fails: https://github.com/facebook/lexical/issues/4295
-        test(`Can insert text before an end-of-paragraph link, via pasting Lexical text`, async ({
+        // TODO: https://github.com/facebook/lexical/issues/4295
+        test.skip(`Can insert text before an end-of-paragraph link, via pasting Lexical text`, async ({
           page,
         }) => {
           await setup(page, 'paste:lexical');
@@ -926,15 +926,15 @@ test.describe('Links', () => {
           await setup(page, 'paste:plain');
         });
 
-        // Fails: https://github.com/facebook/lexical/issues/4295
-        test(`Can insert text after a start-of-paragraph link, via pasting HTML`, async ({
+        // TODO: https://github.com/facebook/lexical/issues/4295
+        test.skip(`Can insert text after a start-of-paragraph link, via pasting HTML`, async ({
           page,
         }) => {
           await setup(page, 'paste:html');
         });
 
-        // Fails: https://github.com/facebook/lexical/issues/4295
-        test(`Can insert text after a start-of-paragraph link, via pasting Lexical text`, async ({
+        // TODO: https://github.com/facebook/lexical/issues/4295
+        test.skip(`Can insert text after a start-of-paragraph link, via pasting Lexical text`, async ({
           page,
         }) => {
           await setup(page, 'paste:lexical');
@@ -1075,15 +1075,15 @@ test.describe('Links', () => {
           await setup(page, 'paste:plain');
         });
 
-        // Fails: https://github.com/facebook/lexical/issues/4295
-        test(`Can insert text after an end-of-paragraph link, via pasting HTML`, async ({
+        // TODO: https://github.com/facebook/lexical/issues/4295
+        test.skip(`Can insert text after an end-of-paragraph link, via pasting HTML`, async ({
           page,
         }) => {
           await setup(page, 'paste:html');
         });
 
-        // Fails: https://github.com/facebook/lexical/issues/4295
-        test(`Can insert text after an end-of-paragraph link, via pasting Lexical text`, async ({
+        // TODO: https://github.com/facebook/lexical/issues/4295
+        test.skip(`Can insert text after an end-of-paragraph link, via pasting Lexical text`, async ({
           page,
         }) => {
           await setup(page, 'paste:lexical');

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -1002,13 +1002,15 @@ test.describe('Links', () => {
           await setup(page, 'paste:plain');
         });
 
-        test(`Can insert text after a mid-paragraph link, via pasting HTML`, async ({
+        // TODO: https://github.com/facebook/lexical/issues/4295
+        test.skip(`Can insert text after a mid-paragraph link, via pasting HTML`, async ({
           page,
         }) => {
           await setup(page, 'paste:html');
         });
 
-        test(`Can insert text after a mid-paragraph link, via pasting Lexical text`, async ({
+        // TODO: https://github.com/facebook/lexical/issues/4295
+        test.skip(`Can insert text after a mid-paragraph link, via pasting Lexical text`, async ({
           page,
         }) => {
           await setup(page, 'paste:lexical');

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1503,7 +1503,7 @@ export class RangeSelection implements BaseSelection {
             }
             const children = element.getChildren();
             const childrenLength = children.length;
-            if ($isElementNode(target) && target.canInsertTextAfter()) {
+            if ($isElementNode(target)) {
               let firstChild = target.getFirstChild();
               for (let s = 0; s < childrenLength; s++) {
                 const child = children[s];

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1503,7 +1503,7 @@ export class RangeSelection implements BaseSelection {
             }
             const children = element.getChildren();
             const childrenLength = children.length;
-            if ($isElementNode(target)) {
+            if ($isElementNode(target) && !target.isInline()) {
               let firstChild = target.getFirstChild();
               for (let s = 0; s < childrenLength; s++) {
                 const child = children[s];

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1503,7 +1503,7 @@ export class RangeSelection implements BaseSelection {
             }
             const children = element.getChildren();
             const childrenLength = children.length;
-            if ($isElementNode(target) && !target.isInline()) {
+            if ($isElementNode(target) && target.canInsertTextAfter()) {
               let firstChild = target.getFirstChild();
               for (let s = 0; s < childrenLength; s++) {
                 const child = children[s];

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -119,12 +119,12 @@ describe('LexicalSelection tests', () => {
             await insertText({container, editor, method: 'insertText'});
           });
 
-          // Fails: https://github.com/facebook/lexical/issues/4295
-          test('Can insert text before a start-of-paragraph inline element, using insertNodes', async () => {
-            const {container, editor} = await setup('start-of-paragraph');
+          // TODO: https://github.com/facebook/lexical/issues/4295
+          // test('Can insert text before a start-of-paragraph inline element, using insertNodes', async () => {
+          //   const {container, editor} = await setup('start-of-paragraph');
 
-            await insertText({container, editor, method: 'insertNodes'});
-          });
+          //   await insertText({container, editor, method: 'insertNodes'});
+          // });
         });
 
         describe('Mid-paragraph inline elements', () => {
@@ -236,12 +236,12 @@ describe('LexicalSelection tests', () => {
             await insertText({container, editor, method: 'insertText'});
           });
 
-          // Fails: https://github.com/facebook/lexical/issues/4295
-          test('Can insert text after a start-of-paragraph inline element, using insertNodes', async () => {
-            const {container, editor} = await setup('start-of-paragraph');
+          // TODO: https://github.com/facebook/lexical/issues/4295
+          // test('Can insert text after a start-of-paragraph inline element, using insertNodes', async () => {
+          //   const {container, editor} = await setup('start-of-paragraph');
 
-            await insertText({container, editor, method: 'insertNodes'});
-          });
+          //   await insertText({container, editor, method: 'insertNodes'});
+          // });
         });
 
         describe('Mid-paragraph inline elements', () => {
@@ -275,12 +275,12 @@ describe('LexicalSelection tests', () => {
             await insertText({container, editor, method: 'insertText'});
           });
 
-          // Fails: https://github.com/facebook/lexical/issues/4295
-          test('Can insert text after a mid-paragraph inline element, using insertNodes', async () => {
-            const {container, editor} = await setup('mid-paragraph');
+          // TODO: https://github.com/facebook/lexical/issues/4295
+          // test('Can insert text after a mid-paragraph inline element, using insertNodes', async () => {
+          //   const {container, editor} = await setup('mid-paragraph');
 
-            await insertText({container, editor, method: 'insertNodes'});
-          });
+          //   await insertText({container, editor, method: 'insertNodes'});
+          // });
         });
 
         describe('End-of-paragraph inline elements', () => {
@@ -315,12 +315,12 @@ describe('LexicalSelection tests', () => {
             await insertText({container, editor, method: 'insertText'});
           });
 
-          // Fails: https://github.com/facebook/lexical/issues/4295
-          test('Can insert text after an end-of-paragraph inline element, using insertNodes', async () => {
-            const {container, editor} = await setup('end-of-paragraph');
+          // TODO: https://github.com/facebook/lexical/issues/4295
+          // test('Can insert text after an end-of-paragraph inline element, using insertNodes', async () => {
+          //   const {container, editor} = await setup('end-of-paragraph');
 
-            await insertText({container, editor, method: 'insertNodes'});
-          });
+          //   await insertText({container, editor, method: 'insertNodes'});
+          // });
         });
       });
     });

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {$createLinkNode} from '@lexical/link';
+import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+
+import {initializeUnitTest} from '../utils';
+
+describe('LexicalSelection tests', () => {
+  initializeUnitTest((testEnv) => {
+    test('Can insert text after an inline element, using insertText', async () => {
+      const {editor, container} = testEnv;
+
+      if (!container) {
+        throw new Error('Expected container to be truthy');
+      }
+
+      await editor.update(() => {
+        const root = $getRoot();
+        if (root.getFirstChild() !== null) {
+          throw new Error('Expected root to be childless');
+        }
+
+        // Set up a paragraph holding a link side-by-side with a text node
+        root.append(
+          $createParagraphNode().append(
+            $createLinkNode('https://', {}).append($createTextNode('a')),
+            $createTextNode('b'),
+          ),
+        );
+      });
+
+      expect(container.innerHTML).toBe(
+        '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="ltr"><a href="https://" dir="ltr"><span data-lexical-text="true">a</span></a><span data-lexical-text="true">b</span></p></div>',
+      );
+
+      await editor.update(() => {
+        const paragraph = $getRoot().getFirstChildOrThrow();
+        const textNode = paragraph.getLastChildOrThrow();
+
+        // Place the cursor between the link and the text node by selecting the
+        // start of the text node
+        const selection = textNode.select(0, 0);
+
+        // Insert text (mirroring what LexicalClipboard does when pasting inline
+        // plain text)
+        selection.insertText('x');
+      });
+
+      expect(container.innerHTML).toBe(
+        '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="ltr"><a href="https://" dir="ltr"><span data-lexical-text="true">a</span></a><span data-lexical-text="true">xb</span></p></div>',
+      );
+    });
+
+    // Fails: https://github.com/facebook/lexical/issues/4295
+    test('Can insert text after an inline element, using insertNodes', async () => {
+      const {editor, container} = testEnv;
+
+      if (!container) {
+        throw new Error('Expected container to be truthy');
+      }
+
+      await editor.update(() => {
+        const root = $getRoot();
+        if (root.getFirstChild() !== null) {
+          throw new Error('Expected root to be childless');
+        }
+
+        // Set up a paragraph holding a link side-by-side with a text node
+        root.append(
+          $createParagraphNode().append(
+            $createLinkNode('https://', {}).append($createTextNode('a')),
+            $createTextNode('b'),
+          ),
+        );
+      });
+
+      expect(container.innerHTML).toBe(
+        '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="ltr"><a href="https://" dir="ltr"><span data-lexical-text="true">a</span></a><span data-lexical-text="true">b</span></p></div>',
+      );
+
+      await editor.update(() => {
+        const paragraph = $getRoot().getFirstChildOrThrow();
+        const textNode = paragraph.getLastChildOrThrow();
+
+        // Place the cursor between the link and the text node by selecting the
+        // start of the text node
+        const selection = textNode.select(0, 0);
+
+        // Insert a paragraph bearing a single text node (mirroring what
+        // LexicalClipboard does when pasting inline rich text)
+        selection.insertNodes([
+          $createParagraphNode().append($createTextNode('x')),
+        ]);
+      });
+
+      // Expected: As with the equivalent 'using insertText' test above, the 'x'
+      // should be inserted after the link.
+      //
+      // Observed: the whole line becomes inserted into the link.
+      expect(container.innerHTML).toBe(
+        '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="ltr"><a href="https://" dir="ltr"><span data-lexical-text="true">a</span></a><span data-lexical-text="true">xb</span></p></div>',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes: #4295 

(Well, it's a strawman implementation.)

CLA signing currently pending response from `cla@meta.com`.