### PR TITLE
Change `MarkNode::clone` `node` arg type to `this`

### DIFF
--- a/packages/lexical-mark/flow/LexicalMark.js.flow
+++ b/packages/lexical-mark/flow/LexicalMark.js.flow
@@ -22,7 +22,7 @@ export type SerializedMarkNode = SerializedElementNode & {
 declare export class MarkNode extends ElementNode {
   __ids: Array<string>;
 
-  static clone(node: MarkNode): MarkNode;
+  static clone(node: this): MarkNode;
   constructor(ids: Array<string>, key?: NodeKey): void;
 
   hasID(id: string): boolean;


### PR DESCRIPTION
Subclasses of `MarkNode` can't override `clone` without adding a Flow type error ignore annotation without this change.