### PR TITLE
Fall back to url if parser fails

### DIFF
--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -169,8 +169,8 @@ export class LinkNode extends ElementNode {
       if (!SUPPORTED_URL_PROTOCOLS.has(parsedUrl.protocol)) {
         return 'about:blank';
       }
-    } catch (e) {
-      return 'https://';
+    } catch {
+      return url;
     }
     return url;
   }


### PR DESCRIPTION
#4342 Will break some links that don't use the full protocol and therefore can't be pasted correctly by the URL lib.

This fixes that by falling back to the url in the event of a failure to parse the string passed into theURL constructor.