### PR TITLE
bug: fix code block lines #4361

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -100,7 +100,7 @@
   margin-top: 8px;
   margin-bottom: 8px;
   tab-size: 2;
-  /* white-space: pre; */
+  white-space: nowrap;
   overflow-x: auto;
   position: relative;
 }


### PR DESCRIPTION
The Code block, which previously did not display line numbers until the very end, has been corrected in this pull request.

Closes #4361  Bug: code block lines

Testing instructions:
1. Install all the required packages from the package.json file.
2. Launch the Lexical Playground and evaluate the code block that now features horizontal scrolling with proper line numbering.

Additional notes:
- Please don't hesitate to bring up any additional steps needed to merge this pull request.
- Fixed ✅

![FB Lexical](https://user-images.githubusercontent.com/61039817/233623323-8107cb46-e520-413e-8234-9284de4d5d34.jpg)
