### PR TITLE
Make DecoratorBlockNode.isInline return false

### DIFF
--- a/packages/lexical-playground/src/nodes/FigmaNode.tsx
+++ b/packages/lexical-playground/src/nodes/FigmaNode.tsx
@@ -122,10 +122,6 @@ export class FigmaNode extends DecoratorBlockNode {
       />
     );
   }
-
-  isInline(): false {
-    return false;
-  }
 }
 
 export function $createFigmaNode(documentID: string): FigmaNode {

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -210,10 +210,6 @@ export class TweetNode extends DecoratorBlockNode {
       />
     );
   }
-
-  isInline(): false {
-    return false;
-  }
 }
 
 export function $createTweetNode(tweetID: string): TweetNode {

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -171,10 +171,6 @@ export class YouTubeNode extends DecoratorBlockNode {
       />
     );
   }
-
-  isInline(): false {
-    return false;
-  }
 }
 
 export function $createYouTubeNode(videoID: string): YouTubeNode {

--- a/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
+++ b/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
@@ -51,6 +51,10 @@ export class DecoratorBlockNode extends DecoratorNode<JSX.Element> {
     const self = this.getWritable();
     self.__format = format;
   }
+
+  isInline(): false {
+    return false;
+  }
 }
 
 export function $isDecoratorBlockNode(


### PR DESCRIPTION
Fix https://github.com/facebook/lexical/issues/3708

I think that thread was closed because @DaniGuardiola point was not understood, which I think was made clearer in his last comment.

To avoid confusion again, please note that this change is about the DecoratorBlockNode, not the DecoratorNode.

With this change, no one runs the risk of forgetting to override the method.