### PR TITLE
Fix HistoryPlugin selection out of sync

### DIFF
--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -7,19 +7,10 @@
  *
  */
 
-import type {
-  EditorState,
-  GridSelection,
-  LexicalEditor,
-  LexicalNode,
-  NodeKey,
-  NodeSelection,
-  RangeSelection,
-} from 'lexical';
+import type {EditorState, LexicalEditor, LexicalNode, NodeKey} from 'lexical';
 
 import {mergeRegister} from '@lexical/utils';
 import {
-  $getSelection,
   $isRangeSelection,
   $isRootNode,
   $isTextNode,
@@ -442,9 +433,7 @@ export function registerHistory(
       if (current !== null) {
         undoStack.push({
           ...current,
-          // undoSelection: prevEditorState.read($getSelection),
         });
-        console.info(undoStack);
         editor.dispatchCommand(CAN_UNDO_COMMAND, true);
       }
     } else if (mergeAction === DISCARD_HISTORY_CANDIDATE) {

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -47,7 +47,6 @@ const DELETE_CHARACTER_AFTER_SELECTION = 4;
 export type HistoryStateEntry = {
   editor: LexicalEditor;
   editorState: EditorState;
-  undoSelection?: RangeSelection | NodeSelection | GridSelection | null;
 };
 export type HistoryState = {
   current: null | HistoryStateEntry;
@@ -374,12 +373,9 @@ function undo(editor: LexicalEditor, historyState: HistoryState): void {
     historyState.current = historyStateEntry || null;
 
     if (historyStateEntry) {
-      historyStateEntry.editor.setEditorState(
-        historyStateEntry.editorState.clone(historyStateEntry.undoSelection),
-        {
-          tag: 'historic',
-        },
-      );
+      historyStateEntry.editor.setEditorState(historyStateEntry.editorState, {
+        tag: 'historic',
+      });
     }
   }
 }
@@ -446,8 +442,9 @@ export function registerHistory(
       if (current !== null) {
         undoStack.push({
           ...current,
-          undoSelection: prevEditorState.read($getSelection),
+          // undoSelection: prevEditorState.read($getSelection),
         });
+        console.info(undoStack);
         editor.dispatchCommand(CAN_UNDO_COMMAND, true);
       }
     } else if (mergeAction === DISCARD_HISTORY_CANDIDATE) {

--- a/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
@@ -24,6 +24,7 @@ import {
   DROP_COMMAND,
   LexicalCommand,
   LexicalEditor,
+  $getRoot,
 } from 'lexical';
 import {useEffect, useRef, useState} from 'react';
 import * as React from 'react';
@@ -222,6 +223,9 @@ export default function ImagesPlugin({
         (payload) => {
           const imageNode = $createImageNode(payload);
           $insertNodes([imageNode]);
+          imageNode.__caption.update(() => {
+            $getRoot().append($createParagraphNode()).selectEnd();
+          });
           if ($isRootOrShadowRoot(imageNode.getParentOrThrow())) {
             $wrapNodeInElement(imageNode, $createParagraphNode).selectEnd();
           }

--- a/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
@@ -24,7 +24,6 @@ import {
   DROP_COMMAND,
   LexicalCommand,
   LexicalEditor,
-  $getRoot,
 } from 'lexical';
 import {useEffect, useRef, useState} from 'react';
 import * as React from 'react';
@@ -223,9 +222,6 @@ export default function ImagesPlugin({
         (payload) => {
           const imageNode = $createImageNode(payload);
           $insertNodes([imageNode]);
-          imageNode.__caption.update(() => {
-            $getRoot().append($createParagraphNode()).selectEnd();
-          });
           if ($isRootOrShadowRoot(imageNode.getParentOrThrow())) {
             $wrapNodeInElement(imageNode, $createParagraphNode).selectEnd();
           }


### PR DESCRIPTION
_Need a proper review on this one..._

When the sharedHistory is a shared across parent/nested editors, you can reach a state where the HistoryEntry contains an EditorState and a `undoSelection` that do not point to the editor. This will always cause the editor to crash as it won't be able to find the node to select.

For #4389 in particular it seems like this can ocurr when the you previously had a selection on another editor and you then create the first change onto the new editor. The first change will carry the `editor` and `editorEditor` from the previous parent iteration and the selection will be `previousSelection` of the `nestedEditor`, regardless of what the selection of the `nestedEditor` is it will never be the selection of the (parent) `editor`

What I'm suggesting in this PR is to remove any chances that it can be out-of-sync, by relying on the selection in the same EditorState. 

_But I'm not sure why `undoSelection` was created in the first place so I might be missing something important._

Fixes https://github.com/facebook/lexical/issues/4389