### PR TITLE
Setting initial state of isSmallWidthViewport

### DIFF
--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -126,7 +126,7 @@ export default function Editor(): JSX.Element {
         setIsSmallWidthViewport(isNextSmallWidthViewport);
       }
     };
-
+    updateViewPortWidth();
     window.addEventListener('resize', updateViewPortWidth);
 
     return () => {


### PR DESCRIPTION
isSmallWidthViewport state is not set correctly when the editor is rendered in a small window. That's why DraggableBlockPlugin is enabled initially when in a small window.

![DraggableBlockPlugin-bug](https://user-images.githubusercontent.com/7505359/233984584-394ba2ad-6eb8-4c1a-ae16-d6deaf8c9a94.png)
