### PR TITLE
Updated Toolbar Plugin to Add keyboard shortcut for adding hyperlinks

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -59,10 +59,12 @@ import {
   CAN_REDO_COMMAND,
   CAN_UNDO_COMMAND,
   COMMAND_PRIORITY_CRITICAL,
+  COMMAND_PRIORITY_NORMAL,
   DEPRECATED_$isGridSelection,
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
   INDENT_CONTENT_COMMAND,
+  KEY_MODIFIER_COMMAND,
   OUTDENT_CONTENT_COMMAND,
   REDO_COMMAND,
   SELECTION_CHANGE_COMMAND,
@@ -515,16 +517,6 @@ export default function ToolbarPlugin(): JSX.Element {
       editor.registerEditableListener((editable) => {
         setIsEditable(editable);
       }),
-      activeEditor.registerRootListener((rootElement) => {
-        if (rootElement) {
-          rootElement.addEventListener('keydown', (event) => {
-            const {code, ctrlKey, metaKey, altKey} = event;
-            if (code === 'KeyK' && !altKey && (metaKey || ctrlKey)) {
-              insertLink();
-            }
-          });
-        }
-      }),
       activeEditor.registerUpdateListener(({editorState}) => {
         editorState.read(() => {
           $updateToolbar();
@@ -548,6 +540,26 @@ export default function ToolbarPlugin(): JSX.Element {
       ),
     );
   }, [$updateToolbar, activeEditor, editor]);
+
+  useEffect(() => {
+    return activeEditor.registerCommand(
+      KEY_MODIFIER_COMMAND,
+      (payload) => {
+        const event: KeyboardEvent = payload;
+        const {code, ctrlKey, metaKey} = event;
+
+        if (code === 'KeyK' && (ctrlKey || metaKey)) {
+          event.preventDefault();
+          return activeEditor.dispatchCommand(
+            TOGGLE_LINK_COMMAND,
+            sanitizeUrl('https://'),
+          );
+        }
+        return false;
+      },
+      COMMAND_PRIORITY_NORMAL,
+    );
+  }, [activeEditor, isLink]);
 
   const applyStyleText = useCallback(
     (styles: Record<string, string>) => {

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -515,6 +515,16 @@ export default function ToolbarPlugin(): JSX.Element {
       editor.registerEditableListener((editable) => {
         setIsEditable(editable);
       }),
+      activeEditor.registerRootListener((rootElement) => {
+        if (rootElement) {
+          rootElement.addEventListener('keydown', (event) => {
+            const {code, ctrlKey, metaKey, altKey} = event;
+            if (code === 'KeyK' && !altKey && (metaKey || ctrlKey)) {
+              insertLink();
+            }
+          });
+        }
+      }),
       activeEditor.registerUpdateListener(({editorState}) => {
         editorState.read(() => {
           $updateToolbar();


### PR DESCRIPTION
Fix for Issue #4347

Registered new event listener in Toolbar plugin to insert link using TOGGLE_LINK_COMMAND when we press Cmd/Ctrl + K

This is my first contribution in the repo so not sure if I did it the right way. 