### PR TITLE
Select all adjustments

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -7,6 +7,7 @@
  */
 
 import {
+  deleteBackward,
   deleteForward,
   moveLeft,
   moveRight,
@@ -274,11 +275,11 @@ test.describe('Selection', () => {
   test('Can select all with node selection', async ({page, isPlainText}) => {
     test.skip(isPlainText);
     await focusEditor(page);
-    await page.keyboard.type('Text before');
+    await page.keyboard.type('# Text before');
     await insertSampleImage(page);
     await page.keyboard.type('Text after');
     await selectAll(page);
-    await page.keyboard.press('Delete');
+    await deleteBackward(page);
     await assertHTML(
       page,
       html`
@@ -350,6 +351,72 @@ test.describe('Selection', () => {
           </tr>
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test('Can delete block elements', async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    await page.keyboard.type('# A');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('b');
+    await assertHTML(
+      page,
+      html`
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">A</span>
+        </h1>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">b</span>
+        </p>
+      `,
+    );
+    await moveLeft(page, 2);
+
+    await deleteBackward(page);
+    await assertHTML(
+      page,
+      html`
+        <h1 class="PlaygroundEditorTheme__h1">
+          <br />
+        </h1>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">b</span>
+        </p>
+      `,
+    );
+
+    await deleteBackward(page);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <br />
+        </p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">b</span>
+        </p>
+      `,
+    );
+
+    await deleteBackward(page);
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph  PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">b</span>
+        </p>
       `,
     );
   });

--- a/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
+++ b/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
@@ -91,15 +91,23 @@ export async function deleteNextWord(page) {
 }
 
 export async function deleteBackward(page) {
-  await page.keyboard.down('Control');
-  await page.keyboard.press('h');
-  await page.keyboard.up('Control');
+  if (IS_MAC) {
+    await page.keyboard.down('Control');
+    await page.keyboard.press('h');
+    await page.keyboard.up('Control');
+  } else {
+    await page.keyboard.press('Backspace');
+  }
 }
 
 export async function deleteForward(page) {
-  await page.keyboard.down('Control');
-  await page.keyboard.press('d');
-  await page.keyboard.up('Control');
+  if (IS_MAC) {
+    await page.keyboard.down('Control');
+    await page.keyboard.press('d');
+    await page.keyboard.up('Control');
+  } else {
+    await page.keyboard.press('Delete');
+  }
 }
 
 export async function moveToParagraphBeginning(page) {

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2040,6 +2040,7 @@ export class RangeSelection implements BaseSelection {
   }
 
   deleteCharacter(isBackward: boolean): void {
+    const wasCollapsed = this.isCollapsed();
     if (this.isCollapsed()) {
       const anchor = this.anchor;
       const focus = this.focus;
@@ -2122,7 +2123,6 @@ export class RangeSelection implements BaseSelection {
         }
       }
     }
-    const wasCollapsed = this.isCollapsed();
     this.removeText();
     if (
       isBackward &&


### PR DESCRIPTION
Fix elements deletion which used to delete leading element node once last character within it was deleted:

Before (deleting text within first non-paragraph element converted it to paragraph right away):


https://user-images.githubusercontent.com/132642/235222095-9e8db5af-5aa7-4d82-88b0-9da46a75ae21.mov


After (deleting text keeps original element type once text deleted until press delete once again, but select all + delete cleans up element style as well, per #3840)


https://user-images.githubusercontent.com/132642/235222279-7cfa3398-1703-4f06-9744-82d4ab2acc39.mov

