### PR TITLE
Add HTML deserialization recipe to docs

### DIFF
--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -380,11 +380,9 @@ function patchStyleConversion(
 
     const backgroundColor = node.style.backgroundColor;
     const color = node.style.color;
-    const fontStyle = node.style.fontStyle;
+    const fontFamily = node.style.fontFamily;
     const fontWeight = node.style.fontWeight;
     const textDecoration = node.style.textDecoration;
-    const textDecorationLine = node.style.textDecorationLine;
-    const textAlign = node.style.textAlign;
 
     return {
       ...originalOutput,
@@ -393,13 +391,11 @@ function patchStyleConversion(
         const result = originalForChild(lexicalNode, parent);
         if ($isTextNode(result)) {
           const style = [
-            backgroundColor ? `background-color: ${backgroundColor}` : null, // background color
-            color ? `color: ${color}` : null, // color
-            fontStyle ? `font-style: ${fontStyle}` : null, // italic
-            fontWeight ? `font-weight: ${fontWeight}` : null, // bold
-            textDecoration ? `text-decoration: ${textDecoration}` : null, // underline
-            textDecorationLine ? `text-decoration-line: ${textDecorationLine}` : null, // strikethrough
-            textAlign ? `text-align: ${textAlign}` : null, // alignment
+            backgroundColor ? `background-color: ${backgroundColor}` : null,
+            color ? `color: ${color}` : null,
+            fontFamily ? `font-family: ${fontFamily}` : null,
+            fontWeight ? `font-weight: ${fontWeight}` : null,
+            textDecoration ? `text-decoration: ${textDecoration}` : null,
           ]
             .filter((value) => value != null)
             .join('; ');

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -356,14 +356,6 @@ export class ExtendedTextNode extends TextNode {
         conversion: patchStyleConversion(importers?.em),
         priority: 1
       }),
-      i: () => ({
-        conversion: patchStyleConversion(importers?.i),
-        priority: 1
-      }),
-      s: () => ({
-        conversion: patchStyleConversion(importers?.s),
-        priority: 1
-      }),
       span: () => ({
         conversion: patchStyleConversion(importers?.span),
         priority: 1
@@ -378,10 +370,6 @@ export class ExtendedTextNode extends TextNode {
       }),
       sup: () => ({
         conversion: patchStyleConversion(importers?.sup),
-        priority: 1
-      }),
-      u: () => ({
-        conversion: patchStyleConversion(importers?.u),
         priority: 1
       }),
     };
@@ -410,6 +398,7 @@ function patchStyleConversion(
     const color = node.style.color;
     const fontFamily = node.style.fontFamily;
     const fontWeight = node.style.fontWeight;
+    const fontSize = node.style.fontSize;
     const textDecoration = node.style.textDecoration;
 
     return {
@@ -423,6 +412,7 @@ function patchStyleConversion(
             color ? `color: ${color}` : null,
             fontFamily ? `font-family: ${fontFamily}` : null,
             fontWeight ? `font-weight: ${fontWeight}` : null,
+            fontSize ? `font-size: ${fontSize}` : null,
             textDecoration ? `text-decoration: ${textDecoration}` : null,
           ]
             .filter((value) => value != null)

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -310,8 +310,8 @@ const initialConfig: InitialConfigType = {
     theme: editorThemeClasses,
     onError: (error: any) => console.log(error),
     nodes: [
-      ExtentedTextNode,
-      { replace: TextNode, with: (node: TextNode) => new ExtentedTextNode(node.__text, node.__key) },
+      ExtendedTextNode,
+      { replace: TextNode, with: (node: TextNode) => new ExtendedTextNode(node.__text, node.__key) },
       ListNode,
       ListItemNode,   
     ]
@@ -331,7 +331,7 @@ import {
   SerializedTextNode
 } from 'lexical';
 
-export class ExtentedTextNode extends TextNode {
+export class ExtendedTextNode extends TextNode {
   constructor(text: string, key?: NodeKey) {
     super(text, key);
   }
@@ -340,8 +340,8 @@ export class ExtentedTextNode extends TextNode {
     return 'extended-text';
   }
 
-  static clone(node: ExtentedTextNode): ExtentedTextNode {
-    return new ExtentedTextNode(node.__text, node.__key);
+  static clone(node: ExtendedTextNode): ExtendedTextNode {
+    return new ExtendedTextNode(node.__text, node.__key);
   }
 
   static importDOM(): DOMConversionMap | null {

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -384,6 +384,7 @@ function patchStyleConversion(
     const fontWeight = node.style.fontWeight;
     const textDecoration = node.style.textDecoration;
     const textDecorationLine = node.style.textDecorationLine;
+    const textAlign = node.style.textAlign;
 
     return {
       ...originalOutput,
@@ -398,6 +399,7 @@ function patchStyleConversion(
             fontWeight ? `font-weight: ${fontWeight}` : null, // bold
             textDecoration ? `text-decoration: ${textDecoration}` : null, // underline
             textDecorationLine ? `text-decoration-line: ${textDecorationLine}` : null, // strikethrough
+            textAlign ? `text-align: ${textAlign}` : null, // alignment
           ]
             .filter((value) => value != null)
             .join('; ');

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -348,19 +348,47 @@ export class ExtendedTextNode extends TextNode {
     const importers = TextNode.importDOM();
     return {
       ...importers,
+      code: () => ({
+        conversion: patchStyleConversion(importers?.code),
+        priority: 1
+      }),
+      em: () => ({
+        conversion: patchStyleConversion(importers?.em),
+        priority: 1
+      }),
+      i: () => ({
+        conversion: patchStyleConversion(importers?.i),
+        priority: 1
+      }),
+      s: () => ({
+        conversion: patchStyleConversion(importers?.s),
+        priority: 1
+      }),
       span: () => ({
         conversion: patchStyleConversion(importers?.span),
         priority: 1
-      })
+      }),
+      strong: () => ({
+        conversion: patchStyleConversion(importers?.strong),
+        priority: 1
+      }),
+      sub: () => ({
+        conversion: patchStyleConversion(importers?.sub),
+        priority: 1
+      }),
+      sup: () => ({
+        conversion: patchStyleConversion(importers?.sup),
+        priority: 1
+      }),
+      u: () => ({
+        conversion: patchStyleConversion(importers?.u),
+        priority: 1
+      }),
     };
   }
 
   static importJSON(serializedNode: SerializedTextNode): TextNode {
     return TextNode.importJSON(serializedNode);
-  }
-
-  exportJSON(): SerializedTextNode {
-    return super.exportJSON();
   }
 }
 


### PR DESCRIPTION
I've used the most approved code snippet from the following issue: https://github.com/facebook/lexical/issues/2452 as a base to address the case for full style serialization/deserialization of HTML styles to preserve the HTML<>JSON fidelity.

Please comment on what to modify, add, remove. I'd like to make this snippet as canonical as possible, since most people will copy-paste without any modifications. I'd like to treat it as a piece of code in the library, we just can't add to the core. Should help solve a lot of the Discord questions by providing a link.