### PR TITLE
Handle a = null in LexicalClickableLinkPlugin

### DIFF
--- a/packages/lexical-react/src/LexicalClickableLinkPlugin.tsx
+++ b/packages/lexical-react/src/LexicalClickableLinkPlugin.tsx
@@ -69,13 +69,14 @@ export default function LexicalClickableLinkPlugin({
                 ? target
                 : domGetParent(target, isHTMLAnchorElement)
             ) as HTMLAnchorElement;
-            url = a.href;
-            urlTarget = a.target;
+            // domGetParent can return null
+            url = a?.href;
+            urlTarget = a?.target;
           }
         }
       });
 
-      if (url === null || url === '') {
+      if (!url) {
         return;
       }
 


### PR DESCRIPTION
I fixed the bug: `TypeError: Cannot read property 'href' of null`.
This bug may be caused by `a` variable that can be `null`. (`domGetParent ` function can return `null`)
That's why `a` variable has no attribute `href`.

I modified `a?.href` and `a?.target` using `?` operator instead of `a.href` and `a.target`.
When the optional `?` operator is used, `a` variable can be `undefined`. So, I modified next condition with `!url` instead of  `url === null || url === ''`.