### PR TITLE
Draft: Implement escape characters for text format transformers

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -161,6 +161,11 @@ function exportTextFormat(
       if (!hasFormat(nextNode, format)) {
         output += tag;
       }
+    } else if (transformer.escapeCharacters && applied.size === 0) {
+      output = output.replaceAll(
+        tag,
+        `${transformer.escapeCharacters[0]}${tag}`,
+      );
     }
   }
 

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -242,30 +242,33 @@ function importTextFormatTransformers(
   const transformer = textFormatTransformersIndex.transformersByTag[match[1]];
   let escapedChars = 0;
   for (const char of transformer.escapeCharacters ?? []) {
-    if (
-      leadingNode &&
-      leadingNode.getTextContent().indexOf(char) ===
-        leadingNode.getTextContent().length - char.length
-    ) {
-      escapedChars += char.length;
+    let found = false;
+    if (leadingNode && leadingNode.getTextContent().endsWith(char)) {
+      found = true;
       leadingNode.setTextContent(
         leadingNode
           .getTextContent()
           .substring(0, leadingNode.getTextContent().length - char.length),
       );
     }
+
+    if (match[2].endsWith(char)) {
+      found = true;
+      currentNode.setTextContent(
+        `${match[1]}${match[2].substring(0, match[2].length - char.length)}${
+          match[1]
+        }`,
+      );
+    }
+
+    if (found) escapedChars += char.length;
   }
 
   if (escapedChars > 0) {
-    currentNode.setTextContent(
-      `${match[1]}${match[2].substring(0, match[2].length - escapedChars)}${
-        match[1]
-      }`,
-    );
     return;
-  } else {
-    currentNode.setTextContent(match[2]);
   }
+
+  currentNode.setTextContent(match[2]);
 
   if (transformer) {
     for (const format of transformer.format) {

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -239,8 +239,33 @@ function importTextFormatTransformers(
     }
   }
 
-  currentNode.setTextContent(match[2]);
   const transformer = textFormatTransformersIndex.transformersByTag[match[1]];
+  let escapedChars = 0;
+  for (const char of transformer.escapeCharacters ?? []) {
+    if (
+      leadingNode &&
+      leadingNode.getTextContent().indexOf(char) ===
+        leadingNode.getTextContent().length - char.length
+    ) {
+      escapedChars += char.length;
+      leadingNode.setTextContent(
+        leadingNode
+          .getTextContent()
+          .substring(0, leadingNode.getTextContent().length - char.length),
+      );
+    }
+  }
+
+  if (escapedChars > 0) {
+    currentNode.setTextContent(
+      `${match[1]}${match[2].substring(0, match[2].length - escapedChars)}${
+        match[1]
+      }`,
+    );
+    return;
+  } else {
+    currentNode.setTextContent(match[2]);
+  }
 
   if (transformer) {
     for (const format of transformer.format) {

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -61,6 +61,7 @@ export type ElementTransformer = {
 };
 
 export type TextFormatTransformer = Readonly<{
+  escapeCharacters?: ReadonlyArray<string>;
   format: ReadonlyArray<TextFormatType>;
   tag: string;
   intraword?: boolean;
@@ -321,12 +322,14 @@ export const STRIKETHROUGH: TextFormatTransformer = {
 };
 
 export const ITALIC_STAR: TextFormatTransformer = {
+  escapeCharacters: ['\\'],
   format: ['italic'],
   tag: '*',
   type: 'text-format',
 };
 
 export const ITALIC_UNDERSCORE: TextFormatTransformer = {
+  escapeCharacters: ['\\'],
   format: ['italic'],
   intraword: false,
   tag: '_',

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -84,6 +84,42 @@ describe('Markdown', () => {
       md: '\\*Hello\\* world',
     },
     {
+      html: '<p><span>**Hello** world</span></p>',
+      md: '\\*\\*Hello\\*\\* world',
+    },
+    {
+      // Import only - import will insert both *s, so export will escape both
+      html: '<p><span>*Hello* world</span></p>',
+      md: '*Hello\\* world',
+      skipExport: true,
+    },
+    {
+      // Import only - import will insert both *s, so export will escape both
+      html: '<p><span>*Hello* world</span></p>',
+      md: '\\*Hello* world',
+      skipExport: true,
+    },
+    {
+      html: '<p><span>_Hello_ world</span></p>',
+      md: '\\_Hello\\_ world',
+    },
+    {
+      html: '<p><span>__Hello__ world</span></p>',
+      md: '\\_\\_Hello\\_\\_ world',
+    },
+    {
+      // Import only - import will insert both _s, so export will escape both
+      html: '<p><span>_Hello_ world</span></p>',
+      md: '_Hello\\_ world',
+      skipExport: true,
+    },
+    {
+      // Import only - import will insert both _s, so export will escape both
+      html: '<p><span>_Hello_ world</span></p>',
+      md: '\\_Hello_ world',
+      skipExport: true,
+    },
+    {
       html: '<p><b><strong>Hello</strong></b><span> world</span></p>',
       md: '**Hello** world',
     },

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -80,6 +80,10 @@ describe('Markdown', () => {
       md: '*Hello* world',
     },
     {
+      html: '<p><span>*Hello* world</span></p>',
+      md: '\\*Hello\\* world',
+    },
+    {
       html: '<p><b><strong>Hello</strong></b><span> world</span></p>',
       md: '**Hello** world',
     },


### PR DESCRIPTION
An attempt at allowing TextMatchTransformers to specify escape characters.

On export, will add in escape characters (if no formatting has been applied already).

On import, will strip out escape characters and not apply the transformer formatting.

I'm almost certain I've missed some behaviours here. I've added a very basic test case, but could probably do with adding more!