### PR TITLE
Allow to pass all possible attributes to a content editable div

### DIFF
--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -45,6 +45,7 @@ export function ContentEditable({
   style,
   tabIndex,
   'data-testid': testid,
+  ...rest
 }: Props): JSX.Element {
   const [editor] = useLexicalComposerContext();
   const [isEditable, setEditable] = useState(false);
@@ -65,6 +66,7 @@ export function ContentEditable({
 
   return (
     <div
+      {...rest}
       aria-activedescendant={!isEditable ? undefined : ariaActiveDescendant}
       aria-autocomplete={!isEditable ? 'none' : ariaAutoComplete}
       aria-controls={!isEditable ? undefined : ariaControls}


### PR DESCRIPTION
The issue
----------
Currently the `ContentEditable` component is misleading because the interface for its props makes a union with all possible HTML attributes like so `} & React.AllHTMLAttributes<HTMLDivElement>` but at the same time doesn't pass them to the actual div its creating.

Essentially if you write a code: `<ContentEditable autoCorrect="off" />` typescript won't complain because it's within the interface. However the attribute itself isn't passed down into a `div` so that's where the issue at.

Solution
--------
I assume that it's totally fine to just pass the rest of the attributes for the lack of better context