### PR TITLE
Add documentation for TabIndentationPlugin

### DIFF
--- a/packages/lexical-website/docs/react/plugins.md
+++ b/packages/lexical-website/docs/react/plugins.md
@@ -115,6 +115,14 @@ React wrapper for `@lexical/table` that adds support for tables
 <TablePlugin />
 ```
 
+### `LexicalTabIndentationPlugin`
+
+Plugin that allows tab indentation in combination with `@lexical/rich-text`.
+
+```jsx
+<TabIndentationPlugin />
+```
+
 ### `LexicalAutoLinkPlugin`
 
 Plugin will convert text into links based on passed matchers list. In example below whenever user types url-like string it will automaticaly convert it into a link node


### PR DESCRIPTION
Simple addition to the documentation for plugins regarding the TabIndentationPlugin, which corresponds to the functionality that was removed on this PR #2855.