### PR TITLE
Updated link markdown regex

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -359,7 +359,7 @@ export const LINK: TextMatchTransformer = {
   importRegExp:
     /(?<!!)(?:\[([^[]+)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))/,
   regExp:
-    /(?<!!)(?:\[([^[]+)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))/,
+    /(?<!!)(?:\[([^[]+)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))$/,
   replace: (textNode, match) => {
     const [, linkText, linkUrl, linkTitle] = match;
     const linkNode = $createLinkNode(linkUrl, {title: linkTitle});

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -357,9 +357,9 @@ export const LINK: TextMatchTransformer = {
     }
   },
   importRegExp:
-    /(?:\[([^[]+)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))/,
+    /(?<!!)(?:\[([^[]+)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))/,
   regExp:
-    /(?:\[([^[]+)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))$/,
+    /(?<!!)(?:\[([^[]+)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))/,
   replace: (textNode, match) => {
     const [, linkText, linkUrl, linkTitle] = match;
     const linkNode = $createLinkNode(linkUrl, {title: linkTitle});

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -169,6 +169,11 @@ describe('Markdown', () => {
       md: `Hello [world](${URL})! Hello $world$! [Hello](${URL}) world! Hello $world$!`,
       skipExport: true,
     },
+    // We should not render non-link markdown as a link
+    {
+      html: '<p><span>![alt text](https://lexical.dev/image.jpeg)</span></p>',
+      md: '![alt text](https://lexical.dev/image.jpeg)',
+    },
   ];
 
   const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {


### PR DESCRIPTION
No issue

The current `regExp` is causing non-link Markdown syntax to be parsed as a link.

Example, the markdown syntax for an image would be `![alt text](https://example.com/example.jpeg` would be detected as link markdown and render it as a link, eg `!<a href"">alt text</a>`.
It completely overrides my custom transformers that wants to parse markdown to a custom image node.

This fix updates the regex to not render a link if `!` is in front of the link markdown syntax, allowing the custom transformer to initiate if available.