### PR TITLE
Improve rect deduplication

### DIFF
--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -140,6 +140,8 @@ export function createRectsFromDOMRange(
   //sort rects from top left to bottom right.
   selectionRects.sort((a, b) => {
     const top = a.top - b.top;
+    // Some rects match position closely, but not perfectly,
+    // so we give a 3px tolerance.
     if (Math.abs(top) <= 3) {
       return a.left - b.left;
     }

--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -150,7 +150,7 @@ export function createRectsFromDOMRange(
   let prevRect;
   for (let i = 0; i < selectionRectsLength; i++) {
     const selectionRect = selectionRects[i];
-    // Exclude a rects that overlap preceding Rects in the sorted list.
+    // Exclude rects that overlap preceding Rects in the sorted list.
     const isOverlappingRect =
       prevRect &&
       prevRect.top <= selectionRect.top &&

--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -137,26 +137,27 @@ export function createRectsFromDOMRange(
     parseFloat(computedStyle.paddingRight);
   const selectionRects = Array.from(range.getClientRects());
   let selectionRectsLength = selectionRects.length;
+  //sort rects from top left to bottom right.
+  selectionRects.sort((a, b) => {
+    const top = a.top - b.top;
+    if (Math.abs(top) <= 3) {
+      return a.left - b.left;
+    }
+    return top;
+  });
   let prevRect;
-
   for (let i = 0; i < selectionRectsLength; i++) {
     const selectionRect = selectionRects[i];
-    // Exclude a rect that is the exact same as the last rect. getClientRects() can return
-    // the same rect twice for some elements. A more sophisticated thing to do here is to
-    // merge all the rects together into a set of rects that don't overlap, so we don't
-    // generate backgrounds that are too dark.
-    const isDuplicateRect =
+    // Exclude a rects that overlap preceding Rects in the sorted list.
+    const isOverlappingRect =
       prevRect &&
-      prevRect.top === selectionRect.top &&
-      prevRect.left === selectionRect.left &&
-      prevRect.width === selectionRect.width &&
-      prevRect.height === selectionRect.height;
-
+      prevRect.top <= selectionRect.top &&
+      prevRect.top + prevRect.height > selectionRect.top &&
+      prevRect.left + prevRect.width > selectionRect.left;
     // Exclude selections that span the entire element
     const selectionSpansElement =
       selectionRect.width + rootPadding === rootRect.width;
-
-    if (isDuplicateRect || selectionSpansElement) {
+    if (isOverlappingRect || selectionSpansElement) {
       selectionRects.splice(i--, 1);
       selectionRectsLength--;
       continue;


### PR DESCRIPTION
This function helps creates a "fake" selection by getting all the rects for a given range, then creating a span tag for each that we layer over the rect position. For reasons that are not completely clear to me, the browser sometimes gives us what amount to "duplicate" rects for our purposes - Rects that completely or partially overlap and cause visual issues like a darker colored selection.

This PR is an effort to improve our deduplication logic to better detect these overlaps, which don't always have exactly matching top, left, width, and height properties. The approach here is instead to try to figure out of the top left corner of a given rect is inside of the previous rect when traversing the rects in order from top-left to bottom-right.


Before:
![Screenshot 2023-05-08 at 3 48 56 PM](https://user-images.githubusercontent.com/14864325/236944471-47eb961f-1acb-4cbf-b3b5-80c24e8abb2f.png)

After:

![Screenshot 2023-05-08 at 3 49 16 PM](https://user-images.githubusercontent.com/14864325/236944530-40395bda-74ff-4cf6-acb9-b88d8fd43b0b.png)
