### PR TITLE
Add text/uri-list support in clipboard.

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -130,22 +130,35 @@ export function $insertDataTransferForRichText(
   // instead of single paragraph with linebreaks.
   const text = dataTransfer.getData('text/plain');
   if (text != null) {
-    if ($isRangeSelection(selection)) {
-      const parts = text.split(/(\r?\n|\t)/);
-      const partsLength = parts.length;
-      for (let i = 0; i < partsLength; i++) {
-        const part = parts[i];
-        if (part === '\n' || part === '\r\n') {
-          selection.insertParagraph();
-        } else if (part === '\t') {
-          selection.insertNodes([$createTabNode()]);
-        } else {
-          selection.insertText(part);
-        }
+    $pasteMultilineText(selection, text);
+  }
+
+  // Webkit-specific: Supports read 'text/uri-list' in clipboard.
+  const uriListString = dataTransfer.getData('text/uri-list');
+  if (uriListString != null) {
+    $pasteMultilineText(selection, uriListString);
+  }
+}
+
+function $pasteMultilineText(
+  selection: RangeSelection | GridSelection,
+  text: string,
+) {
+  if ($isRangeSelection(selection)) {
+    const parts = text.split(/(\r?\n|\t)/);
+    const partsLength = parts.length;
+    for (let i = 0; i < partsLength; i++) {
+      const part = parts[i];
+      if (part === '\n' || part === '\r\n') {
+        selection.insertParagraph();
+      } else if (part === '\t') {
+        selection.insertNodes([$createTabNode()]);
+      } else {
+        selection.insertText(part);
       }
-    } else {
-      selection.insertRawText(text);
     }
+  } else {
+    selection.insertRawText(text);
   }
 }
 

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -86,7 +86,8 @@ export function $insertDataTransferForPlainText(
   dataTransfer: DataTransfer,
   selection: RangeSelection | GridSelection,
 ): void {
-  const text = dataTransfer.getData('text/plain');
+  const text =
+    dataTransfer.getData('text/plain') || dataTransfer.getData('text/uri-list');
 
   if (text != null) {
     selection.insertRawText(text);
@@ -128,37 +129,26 @@ export function $insertDataTransferForRichText(
 
   // Multi-line plain text in rich text mode pasted as separate paragraphs
   // instead of single paragraph with linebreaks.
-  const text = dataTransfer.getData('text/plain');
-  if (text != null) {
-    $pasteMultilineText(selection, text);
-  }
-
   // Webkit-specific: Supports read 'text/uri-list' in clipboard.
-  const uriListString = dataTransfer.getData('text/uri-list');
-  if (uriListString != null) {
-    $pasteMultilineText(selection, uriListString);
-  }
-}
-
-function $pasteMultilineText(
-  selection: RangeSelection | GridSelection,
-  text: string,
-) {
-  if ($isRangeSelection(selection)) {
-    const parts = text.split(/(\r?\n|\t)/);
-    const partsLength = parts.length;
-    for (let i = 0; i < partsLength; i++) {
-      const part = parts[i];
-      if (part === '\n' || part === '\r\n') {
-        selection.insertParagraph();
-      } else if (part === '\t') {
-        selection.insertNodes([$createTabNode()]);
-      } else {
-        selection.insertText(part);
+  const text =
+    dataTransfer.getData('text/plain') || dataTransfer.getData('text/uri-list');
+  if (text != null) {
+    if ($isRangeSelection(selection)) {
+      const parts = text.split(/(\r?\n|\t)/);
+      const partsLength = parts.length;
+      for (let i = 0; i < partsLength; i++) {
+        const part = parts[i];
+        if (part === '\n' || part === '\r\n') {
+          selection.insertParagraph();
+        } else if (part === '\t') {
+          selection.insertNodes([$createTabNode()]);
+        } else {
+          selection.insertText(part);
+        }
       }
+    } else {
+      selection.insertRawText(text);
     }
-  } else {
-    selection.insertRawText(text);
   }
 }
 


### PR DESCRIPTION
## Background
Issue #4409 highlights a problem where users are unable to paste text/uri-list type content. This PR aims to address and resolve this issue.

## Cause of the Problem
The problem is due to discrepancies in the valid MIME types for read/write operations in the clipboard between Chromium and WebKit. 

Chromium supports the read/write operations for the following MIME types [(Chromium)](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/clipboard/clipboard_writer.cc;drc=e882b8e4a8272f65cb14c608d3d2bc4f0512aa20;l=304):
- `text/plain`
- `text/html`
- `image/png`

On the other hand, WebKit supports all the above types as well as `text/uri-list` [(WebKit)](https://webkit.org/blog/10855/async-clipboard-api/).

This inconsistency causes an issue when, for example, a user opens a webpage in Safari on iOS, copies content via the share menu, and tries to paste it elsewhere. In this case, the MIME type of the content in the clipboard is `text/uri-list`.

However, based on the current logic in `$insertDataTransferForRichText` in [`clipboard.ts`](https://github.com/facebook/lexical/blob/main/packages/lexical-clipboard/src/clipboard.ts), only `text/plain`, `text/html`, `image/png`, and `'application/x-lexical-editor'` are accepted for pasting. Hence, when a user attempts to paste text of type `text/uri-list`, no content is pasted.

## Proposed Changes
This PR proposes a modification to the `$insertDataTransferForRichText` function in [`clipboard.ts`](https://github.com/facebook/lexical/blob/main/packages/lexical-clipboard/src/clipboard.ts) to support pasting of `text/uri-list` MIME type.

## Impact of Changes
This change will allow pasting of `text/uri-list` type content in Safari. However, given Chrome's current lack of support for reading/writing `text/uri-list` in the clipboard, the behaviour of pasting this MIME type in Chrome remains unchanged.

Fixes #4409 
