### PR TITLE
Fix dropdown menu position in playground when scroll

### DIFF
--- a/packages/lexical-playground/src/ui/DropDown.tsx
+++ b/packages/lexical-playground/src/ui/DropDown.tsx
@@ -246,7 +246,7 @@ export default function DropDown({
         initialPosition.current =
           button.getBoundingClientRect().top + 40 + window.scrollY;
       }
-    }, 10);
+    }, 500);
   }, [buttonRef]);
 
   return (

--- a/packages/lexical-playground/src/ui/DropDown.tsx
+++ b/packages/lexical-playground/src/ui/DropDown.tsx
@@ -211,9 +211,7 @@ export default function DropDown({
           const {top} = button.getBoundingClientRect();
           const newPosition = top + button.offsetHeight + dropDownPadding;
           if (newPosition !== dropDown.getBoundingClientRect().top) {
-            dropDown.style.top = `${
-              top + button.offsetHeight + dropDownPadding
-            }px`;
+            dropDown.style.top = `${newPosition}px`;
           }
         }
       }


### PR DESCRIPTION
## Summary

This Pull Request introduces a fix to maintain the dropdown menu's position relative to the toolbar during page scroll. Previously, the dropdown menu was using `position: fixed`, causing it to remain stationary in the viewport instead of moving along with the toolbar during scrolling.

## How to reproduce

adding content in the playground editor untill a scroll bar appear, and then open any dropdown menu in the toolbar and scroll the page.

## Details

The dropdown menu's positioning logic has been updated to become fixed or absolute based on the toolbar's position. 

## Important Note

Obtaining an accurate toolbar position is crucial for this logic. However, due to asynchronous loading of elements (like the Logo), directly extracting the toolbar's position in a `useEffect` hook can result in inaccurate values. To ensure precision, we're extracting the toolbar position asynchronously, which guarantees the correct calculation after all page elements have fully loaded. This is done by using `setTimeout` which could be consider a bad paractise, so any advice on extracting the toolbar position without using it is very appreciated.
