### PR TITLE
support matcher function for markdown transformers

### DIFF
--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -119,9 +119,9 @@ function importBlocks(
   elementNode.append(textNode);
   rootNode.append(elementNode);
 
-  for (const {regExp, replace} of elementTransformers) {
-    const match = lineText.match(regExp);
-
+  for (const {matcher, regExp, replace} of elementTransformers) {
+    // use matcher function is provided
+    const match = matcher ? matcher(lineText) : lineText.match(regExp);
     if (match) {
       textNode.setTextContent(lineText.slice(match[0].length));
       replace(elementNode, [textNode], match, true);

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -50,6 +50,7 @@ export type ElementTransformer = {
     // eslint-disable-next-line no-shadow
     traverseChildren: (node: ElementNode) => string,
   ) => string | null;
+  matcher?: (textContent: string) => Array<string>;
   regExp: RegExp;
   replace: (
     parentNode: ElementNode,
@@ -77,8 +78,9 @@ export type TextMatchTransformer = Readonly<{
     exportFormat: (node: TextNode, textContent: string) => string,
   ) => string | null;
   importRegExp: RegExp;
+  matcher?: (textContent: string) => {index: number; matchText: Array<string>};
   regExp: RegExp;
-  replace: (node: TextNode, match: RegExpMatchArray) => void;
+  replace: (node: TextNode, match: Array<string>) => void;
   trigger: string;
   type: 'text-match';
 }>;

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -50,7 +50,7 @@ export type ElementTransformer = {
     // eslint-disable-next-line no-shadow
     traverseChildren: (node: ElementNode) => string,
   ) => string | null;
-  matcher?: (textContent: string) => Array<string>;
+  matcher?: (textContent: string) => Array<string> | null;
   regExp: RegExp;
   replace: (
     parentNode: ElementNode,
@@ -78,7 +78,9 @@ export type TextMatchTransformer = Readonly<{
     exportFormat: (node: TextNode, textContent: string) => string,
   ) => string | null;
   importRegExp: RegExp;
-  matcher?: (textContent: string) => {index: number; matchText: Array<string>};
+  matcher?: (
+    textContent: string,
+  ) => {index: number; matchText: Array<string>} | null;
   regExp: RegExp;
   replace: (node: TextNode, match: Array<string>) => void;
   trigger: string;


### PR DESCRIPTION
## Background
As outlined in issue #4481, the current implementation requires the use of complex regular expressions to match a transformer in Markdown. This solution can be quite convoluted and difficult to manage for more complex scenarios.

## Purpose of this PR
This Pull Request proposes the introduction of a `matcher` property to both `ElementTransformer` and `TextMatchTransformer`, aiming to offer a more flexible and intuitive method for matching patterns. This is an optional property.

### ElementTransformer
In the context of `ElementTransformer`, the `matcher` property is a function of type `(textContent: string) => Array<string> | null`. This function takes the `textContent` as input and finds all matching substrings or return null if none is found. It is an optional property of `ElementTransformer`.

When the `matcher` function is provided, the transformer will use it to find the matching patterns. If the `matcher` property is absent, the transformer will fall back to the existing `regExp` property to find matches.

### TextMatchTransformer
As for `TextMatchTransformer`, the `matcher` property takes the form of a function `(textContent: string) => {index: number; matchText: Array<string>} | null`. This function operates similarly to the `ElementTransformer`'s matcher, with the addition of an `index` property, mirroring the `index` property found in `RegExpMatchArray`. This is required by the `runTextMatchTransformers` function.

By implementing these changes, we anticipate a more versatile and user-friendly approach to finding matches within our Markdown transformers, reducing the reliance on complex regular expressions.

## Usage
an example usage of the matcher property can be 

```typescript
export const HEADING: ElementTransformer = {
  dependencies: [HeadingNode],
  export: (node, exportChildren) => {
    if (!$isHeadingNode(node)) {
      return null;
    }
    const level = Number(node.getTag().slice(1));
    return '#'.repeat(level) + ' ' + exportChildren(node);
  },
  matcher: (textContent): string[] | null => {
    const headingPrefixes: string[] = ['# ', '## ', '### ', '#### ', '##### ', '###### '];
    const matches: string[] = [];

    for (const prefix of headingPrefixes) {
      if (textContent.startsWith(prefix)) {
        matches.push(prefix, prefix.trim());
      }
    }
    return matches.length > 0 ? matches : null;
  },
  regExp: /^(#{1,6})\s/,
  replace: createBlockNode((match) => {
    const tag = ('h' + match[1].length) as HeadingTagType;
    return $createHeadingNode(tag);
  }),
  type: 'element',
};      
```
where the `matcher` will handle the pattern finding.

## Something To Note
In this PR, the type of the `replace` parameter in `TextMatchTransformer` has been updated from `(node: TextNode, match: RegExpMatchArray) => void` to `(node: TextNode, match: Array<string>) => void`. This change was made because it was determined that the additional properties provided by `RegExpMatchArray` are not necessary for the current usage of the function.

By aligning the type of the `match` parameter in `TextMatchTransformer` with the `replace` function in `ElementTransformer`, which is of type `Array<string>`, we ensure consistency and simplicity in the codebase.


Fixes #4481 

