### PR TITLE
Fix GC memory leak

### DIFF
--- a/packages/lexical/src/LexicalGC.ts
+++ b/packages/lexical/src/LexicalGC.ts
@@ -49,7 +49,7 @@ function $garbageCollectDetachedDeepChildNodes(
   while (child !== null) {
     const nextChild = child.getNextSibling();
     const childKey = child.__key;
-    if (child !== undefined && child.__parent === parentKey) {
+    if (child.__parent === parentKey) {
       if ($isElementNode(child)) {
         $garbageCollectDetachedDeepChildNodes(
           child,

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalGC.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalGC.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getNodeByKey,
+  $getRoot,
+} from 'lexical';
+
+import {
+  $createTestElementNode,
+  initializeUnitTest,
+} from '../../../__tests__/utils';
+
+describe('LexicalGC tests', () => {
+  initializeUnitTest((testEnv) => {
+    test('RootNode.clear() with a child and subchild', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('foo')),
+        );
+      });
+      expect(editor.getEditorState()._nodeMap.size).toBe(3);
+      await editor.update(() => {
+        $getRoot().clear();
+      });
+      expect(editor.getEditorState()._nodeMap.size).toBe(1);
+    });
+
+    test('RootNode.clear() with a child and three subchildren', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const text1 = $createTextNode('foo');
+        const text2 = $createTextNode('bar').toggleUnmergeable();
+        const text3 = $createTextNode('zzz').toggleUnmergeable();
+        const paragraph = $createParagraphNode();
+        paragraph.append(text1, text2, text3);
+        $getRoot().append(paragraph);
+      });
+      expect(editor.getEditorState()._nodeMap.size).toBe(5);
+      await editor.update(() => {
+        $getRoot().clear();
+      });
+      expect(editor.getEditorState()._nodeMap.size).toBe(1);
+    });
+
+    for (let i = 0; i < 3; i++) {
+      test(`RootNode.clear() with a child and three subchildren, subchild ${i} deleted first`, async () => {
+        const {editor} = testEnv;
+        await editor.update(() => {
+          const text1 = $createTextNode('foo'); // 1
+          const text2 = $createTextNode('bar').toggleUnmergeable(); // 2
+          const text3 = $createTextNode('zzz').toggleUnmergeable(); // 3
+          const paragraph = $createParagraphNode(); // 4
+          paragraph.append(text1, text2, text3);
+          $getRoot().append(paragraph);
+        });
+        expect(editor.getEditorState()._nodeMap.size).toBe(5);
+        await editor.update(() => {
+          const root = $getRoot();
+          const subchild = root.getFirstChild().getChildAtIndex(i);
+          expect(subchild.getTextContent()).toBe(['foo', 'bar', 'zzz'][i]);
+          subchild.remove();
+          root.clear();
+        });
+        expect(editor.getEditorState()._nodeMap.size).toBe(1);
+      });
+    }
+
+    for (let i = 0; i < 7; i++) {
+      /**
+       *          R
+       *          P
+       *     T   TE    T
+       *        T  T
+       */
+      test(`RootNode.clear() with a complex tree, element ${i} deleted first`, async () => {
+        const {editor} = testEnv;
+        await editor.update(() => {
+          const testElement = $createTestElementNode(); // 1
+          const testElementText1 = $createTextNode('te1').toggleUnmergeable(); // 2
+          const testElementText2 = $createTextNode('te2').toggleUnmergeable(); // 3
+          const text1 = $createTextNode('a').toggleUnmergeable(); // 4
+          const text2 = $createTextNode('b').toggleUnmergeable(); // 5
+          const paragraph = $createParagraphNode(); // 6
+          testElement.append(testElementText1, testElementText2);
+          paragraph.append(text1, testElement, text2);
+          $getRoot().append(paragraph);
+        });
+        expect(editor.getEditorState()._nodeMap.size).toBe(7);
+        await editor.update(() => {
+          const node = $getNodeByKey('1');
+          node.remove();
+          $getRoot().clear();
+        });
+        expect(editor.getEditorState()._nodeMap.size).toBe(1);
+      });
+    }
+  });
+});

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalGC.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalGC.test.tsx
@@ -81,7 +81,7 @@ describe('LexicalGC tests', () => {
        *     T   TE    T
        *        T  T
        */
-      test(`RootNode.clear() with a complex tree, element ${i} deleted first`, async () => {
+      test(`RootNode.clear() with a complex tree, element ${i} node first`, async () => {
         const {editor} = testEnv;
         await editor.update(() => {
           const testElement = $createTestElementNode(); // 1


### PR DESCRIPTION
Turns out we introduced a memory leak on the GC module when we launched doubly linked lists.

The root cause is that now order is important
1. We have to start with ElementNodes first, if a child is removed from the Map there's no way to traverse (next) children later (unless we keep a separate copy).
2. The attached assumption on children node  in `$garbageCollectDetachedDeepChildNodes` was not correct. It will  never be true because the parent is not attached in the first place.

Fixes #4509