### PR TITLE
Allow more granular priorities

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -256,12 +256,12 @@ export type EditorConfig = {
   namespace: string,
   disableEvents?: boolean,
 };
-export type CommandListenerPriority = 0 | 1 | 2 | 3 | 4;
+export type CommandListenerPriority = number;
 export const COMMAND_PRIORITY_EDITOR = 0;
-export const COMMAND_PRIORITY_LOW = 1;
-export const COMMAND_PRIORITY_NORMAL = 2;
-export const COMMAND_PRIORITY_HIGH = 3;
-export const COMMAND_PRIORITY_CRITICAL = 4;
+export const COMMAND_PRIORITY_LOW = 100;
+export const COMMAND_PRIORITY_NORMAL = 200;
+export const COMMAND_PRIORITY_HIGH = 300;
+export const COMMAND_PRIORITY_CRITICAL = 400;
 
 declare export function createEditor(editorConfig?: {
   editorState?: EditorState,

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -256,12 +256,56 @@ export type EditorConfig = {
   namespace: string,
   disableEvents?: boolean,
 };
-export type CommandListenerPriority = number;
-export const COMMAND_PRIORITY_EDITOR = 0;
-export const COMMAND_PRIORITY_LOW = 100;
-export const COMMAND_PRIORITY_NORMAL = 200;
-export const COMMAND_PRIORITY_HIGH = 300;
-export const COMMAND_PRIORITY_CRITICAL = 400;
+export type CommandListenerPriority =
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 13
+  | 14
+  | 15
+  | 16
+  | 17
+  | 18
+  | 19
+  | 20;
+
+export const COMMAND_PRIORITY_0 = 0;
+export const COMMAND_PRIORITY_1 = 1;
+export const COMMAND_PRIORITY_2 = 2;
+export const COMMAND_PRIORITY_3 = 3;
+export const COMMAND_PRIORITY_4 = 4;
+export const COMMAND_PRIORITY_5 = 5;
+export const COMMAND_PRIORITY_6 = 6;
+export const COMMAND_PRIORITY_7 = 7;
+export const COMMAND_PRIORITY_8 = 8;
+export const COMMAND_PRIORITY_9 = 9;
+export const COMMAND_PRIORITY_10 = 10;
+export const COMMAND_PRIORITY_11 = 11;
+export const COMMAND_PRIORITY_12 = 12;
+export const COMMAND_PRIORITY_13 = 13;
+export const COMMAND_PRIORITY_14 = 14;
+export const COMMAND_PRIORITY_15 = 15;
+export const COMMAND_PRIORITY_16 = 16;
+export const COMMAND_PRIORITY_17 = 17;
+export const COMMAND_PRIORITY_18 = 18;
+export const COMMAND_PRIORITY_19 = 19;
+export const COMMAND_PRIORITY_20 = 20;
+
+export const COMMAND_PRIORITY_EDITOR = COMMAND_PRIORITY_0;
+export const COMMAND_PRIORITY_LOW = COMMAND_PRIORITY_5;
+export const COMMAND_PRIORITY_NORMAL = COMMAND_PRIORITY_10;
+export const COMMAND_PRIORITY_HIGH = COMMAND_PRIORITY_15;
+export const COMMAND_PRIORITY_CRITICAL = COMMAND_PRIORITY_20;
 
 declare export function createEditor(editorConfig?: {
   editorState?: EditorState,

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -212,13 +212,56 @@ export type CommandListener<P> = (payload: P, editor: LexicalEditor) => boolean;
 
 export type EditableListener = (editable: boolean) => void;
 
-export type CommandListenerPriority = number;
+export type CommandListenerPriority =
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 13
+  | 14
+  | 15
+  | 16
+  | 17
+  | 18
+  | 19
+  | 20;
 
-export const COMMAND_PRIORITY_EDITOR = 0;
-export const COMMAND_PRIORITY_LOW = 100;
-export const COMMAND_PRIORITY_NORMAL = 200;
-export const COMMAND_PRIORITY_HIGH = 300;
-export const COMMAND_PRIORITY_CRITICAL = 400;
+export const COMMAND_PRIORITY_0 = 0;
+export const COMMAND_PRIORITY_1 = 1;
+export const COMMAND_PRIORITY_2 = 2;
+export const COMMAND_PRIORITY_3 = 3;
+export const COMMAND_PRIORITY_4 = 4;
+export const COMMAND_PRIORITY_5 = 5;
+export const COMMAND_PRIORITY_6 = 6;
+export const COMMAND_PRIORITY_7 = 7;
+export const COMMAND_PRIORITY_8 = 8;
+export const COMMAND_PRIORITY_9 = 9;
+export const COMMAND_PRIORITY_10 = 10;
+export const COMMAND_PRIORITY_11 = 11;
+export const COMMAND_PRIORITY_12 = 12;
+export const COMMAND_PRIORITY_13 = 13;
+export const COMMAND_PRIORITY_14 = 14;
+export const COMMAND_PRIORITY_15 = 15;
+export const COMMAND_PRIORITY_16 = 16;
+export const COMMAND_PRIORITY_17 = 17;
+export const COMMAND_PRIORITY_18 = 18;
+export const COMMAND_PRIORITY_19 = 19;
+export const COMMAND_PRIORITY_20 = 20;
+
+export const COMMAND_PRIORITY_EDITOR = COMMAND_PRIORITY_0;
+export const COMMAND_PRIORITY_LOW = COMMAND_PRIORITY_5;
+export const COMMAND_PRIORITY_NORMAL = COMMAND_PRIORITY_10;
+export const COMMAND_PRIORITY_HIGH = COMMAND_PRIORITY_15;
+export const COMMAND_PRIORITY_CRITICAL = COMMAND_PRIORITY_20;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type LexicalCommand<TPayload> = {
@@ -250,7 +293,7 @@ export type CommandPayloadType<TCommand extends LexicalCommand<unknown>> =
 
 type Commands = Map<
   LexicalCommand<unknown>,
-  Array<Set<CommandListener<unknown>>>
+  Map<number, Set<CommandListener<unknown>>>
 >;
 type Listeners = {
   decorator: Set<DecoratorListener>;
@@ -724,13 +767,16 @@ export class LexicalEditor {
     const commandsMap = this._commands;
 
     if (!commandsMap.has(command)) {
-      commandsMap.set(command, [
-        new Set(),
-        new Set(),
-        new Set(),
-        new Set(),
-        new Set(),
-      ]);
+      commandsMap.set(
+        command,
+        new Map([
+          [0, new Set()],
+          [5, new Set()],
+          [10, new Set()],
+          [15, new Set()],
+          [20, new Set()],
+        ]),
+      );
     }
 
     const listenersInPriorityOrder = commandsMap.get(command);
@@ -743,13 +789,18 @@ export class LexicalEditor {
       );
     }
 
-    const listeners = listenersInPriorityOrder[priority];
+    if (!listenersInPriorityOrder.has(priority)) {
+      listenersInPriorityOrder.set(priority, new Set());
+    }
+    const listeners = listenersInPriorityOrder.get(priority) as Set<
+      CommandListener<unknown>
+    >;
     listeners.add(listener as CommandListener<unknown>);
     return () => {
       listeners.delete(listener as CommandListener<unknown>);
 
       if (
-        listenersInPriorityOrder.every(
+        Array.from(listenersInPriorityOrder.values()).every(
           (listenersSet) => listenersSet.size === 0,
         )
       ) {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -212,13 +212,13 @@ export type CommandListener<P> = (payload: P, editor: LexicalEditor) => boolean;
 
 export type EditableListener = (editable: boolean) => void;
 
-export type CommandListenerPriority = 0 | 1 | 2 | 3 | 4;
+export type CommandListenerPriority = number;
 
 export const COMMAND_PRIORITY_EDITOR = 0;
-export const COMMAND_PRIORITY_LOW = 1;
-export const COMMAND_PRIORITY_NORMAL = 2;
-export const COMMAND_PRIORITY_HIGH = 3;
-export const COMMAND_PRIORITY_CRITICAL = 4;
+export const COMMAND_PRIORITY_LOW = 100;
+export const COMMAND_PRIORITY_NORMAL = 200;
+export const COMMAND_PRIORITY_HIGH = 300;
+export const COMMAND_PRIORITY_CRITICAL = 400;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type LexicalCommand<TPayload> = {

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -703,14 +703,14 @@ export function triggerCommandListeners<
 
   const editors = getEditorsToPropagate(editor);
 
-  for (let i = 4; i >= 0; i--) {
+  for (let i = 20; i >= 0; i--) {
     for (let e = 0; e < editors.length; e++) {
       const currentEditor = editors[e];
       const commandListeners = currentEditor._commands;
       const listenerInPriorityOrder = commandListeners.get(type);
 
       if (listenerInPriorityOrder !== undefined) {
-        const listenersSet = listenerInPriorityOrder[i];
+        const listenersSet = listenerInPriorityOrder.get(i);
 
         if (listenersSet !== undefined) {
           const listeners = Array.from(listenersSet);

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1572,13 +1572,13 @@ describe('LexicalEditor tests', () => {
       new Map([
         [
           command,
-          [
-            new Set([commandListener, commandListenerTwo]),
-            new Set(),
-            new Set(),
-            new Set(),
-            new Set(),
-          ],
+          new Map([
+            [0, new Set([commandListener, commandListenerTwo])],
+            [5, new Set()],
+            [10, new Set()],
+            [15, new Set()],
+            [20, new Set()],
+          ]),
         ],
       ]),
     );
@@ -1589,13 +1589,13 @@ describe('LexicalEditor tests', () => {
       new Map([
         [
           command,
-          [
-            new Set([commandListenerTwo]),
-            new Set(),
-            new Set(),
-            new Set(),
-            new Set(),
-          ],
+          new Map([
+            [0, new Set([commandListenerTwo])],
+            [5, new Set()],
+            [10, new Set()],
+            [15, new Set()],
+            [20, new Set()],
+          ]),
         ],
       ]),
     );


### PR DESCRIPTION
This provides more flexibility in the command priority system by providing more granularity in the priority values. This is useful for cases where core functionality uses a low command priority, but you need that core functionality to run first and only then delegate to your handler. 

A concrete example is the core typeahead plugin, which intercepts Enter events at LOW priority and selects the option if the menu is open. In a case where you also want Enter to submit the form if the menu is NOT open, the only option is to use EDITOR priority, which is reserved for the editor and may cause other collisions. 

I think the most robust solution here is to introduce more granularity. I made the ranges large because we only want to do this one time - if we do it again, we'd risk breaking people who are relying on numbers that fall between the values represented by the constants.

Another option might be to make 10 or 20 constants, instead of 5, and we can do it that way if that's preferred.