### PR TITLE
Adjust selection after triple click

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -440,4 +440,39 @@ test.describe('Selection', () => {
       `,
     );
   });
+
+  test('Can adjust tripple click selection', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+
+    await page.keyboard.type('Paragraph 1');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Paragraph 2');
+    await page
+      .locator('div[contenteditable="true"] > p')
+      .first()
+      .click({clickCount: 3});
+
+    await click(page, '.block-controls');
+    await click(page, '.dropdown .item:has(.icon.h1)');
+
+    await assertHTML(
+      page,
+      html`
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Paragraph 1</span>
+        </h1>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Paragraph 2</span>
+        </p>
+      `,
+    );
+  });
 });

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -392,6 +392,20 @@ function onClick(event: PointerEvent, editor: LexicalEditor): void {
         ) {
           domSelection.removeAllRanges();
           selection.dirty = true;
+        } else if (event.detail === 3 && !selection.isCollapsed()) {
+          // Tripple click causing selection to overflow into the nearest element. In that
+          // case visually it looks like a single element content is selected, focus node
+          // is actually at the beginning of the next element (if present) and any manipulations
+          // with selection (formatting) are affecting second element as well
+          const focus = selection.focus;
+          const focusNode = focus.getNode();
+          if (anchorNode !== focusNode) {
+            if ($isElementNode(anchorNode)) {
+              anchorNode.select(0);
+            } else {
+              anchorNode.getParentOrThrow().select(0);
+            }
+          }
         }
       } else if (event.pointerType === 'touch') {
         // This is used to update the selection on touch devices when the user clicks on text after a


### PR DESCRIPTION
Triple click expands selection to cover whole element, but also moves focus node to the next element sibling. So even though visually it looks like single text block is selected, selection is also expanded to the next line. If we try to modify such selection two blocks are affected. 

Easiest way to reproduce: have two paragraphs, tripple click on first, convert into heading, then both paragraphs will be converted into headings. Another example is tripple click within table cell, and pressing delete: it selects current cell and beginning of the next one. Hitting delete will completely delete one of the cells

Before:

https://github.com/facebook/lexical/assets/132642/1bf6284c-4b72-4e5e-9d62-a8368e6e732c

After:

https://github.com/facebook/lexical/assets/132642/0c9fc3ad-911c-4bd9-a3d6-f2d0ce830699



