### PR TITLE
Fix GC memory leak (2)

### DIFF
--- a/packages/lexical/src/LexicalGC.ts
+++ b/packages/lexical/src/LexicalGC.ts
@@ -42,6 +42,7 @@ function $garbageCollectDetachedDeepChildNodes(
   parentKey: NodeKey,
   prevNodeMap: NodeMap,
   nodeMap: NodeMap,
+  nodeMapDelete: Array<NodeKey>,
   dirtyNodes: Map<NodeKey, IntentionallyMarkedAsDirtyElement>,
 ): void {
   let child = node.getFirstChild();
@@ -49,6 +50,7 @@ function $garbageCollectDetachedDeepChildNodes(
   while (child !== null) {
     const nextChild = child.getNextSibling();
     const childKey = child.__key;
+    // TODO Revise condition below, redundant? LexicalNode already cleans up children when moving Nodes
     if (child.__parent === parentKey) {
       if ($isElementNode(child)) {
         $garbageCollectDetachedDeepChildNodes(
@@ -56,6 +58,7 @@ function $garbageCollectDetachedDeepChildNodes(
           childKey,
           prevNodeMap,
           nodeMap,
+          nodeMapDelete,
           dirtyNodes,
         );
       }
@@ -65,7 +68,7 @@ function $garbageCollectDetachedDeepChildNodes(
       if (!prevNodeMap.has(childKey)) {
         dirtyNodes.delete(childKey);
       }
-      nodeMap.delete(childKey);
+      nodeMapDelete.push(childKey);
     }
     child = nextChild;
   }
@@ -79,6 +82,9 @@ export function $garbageCollectDetachedNodes(
 ): void {
   const prevNodeMap = prevEditorState._nodeMap;
   const nodeMap = editorState._nodeMap;
+  // Store dirtyElements in a queue for later deletion; deleting dirty subtrees too early will
+  // hinder accessing .__next on child nodes
+  const nodeMapDelete: Array<NodeKey> = [];
 
   for (const [nodeKey] of dirtyElements) {
     const node = nodeMap.get(nodeKey);
@@ -91,6 +97,7 @@ export function $garbageCollectDetachedNodes(
             nodeKey,
             prevNodeMap,
             nodeMap,
+            nodeMapDelete,
             dirtyElements,
           );
         }
@@ -99,9 +106,13 @@ export function $garbageCollectDetachedNodes(
         if (!prevNodeMap.has(nodeKey)) {
           dirtyElements.delete(nodeKey);
         }
-        nodeMap.delete(nodeKey);
+        nodeMapDelete.push(nodeKey);
       }
     }
+  }
+  const nodeMapDeleteLength = nodeMapDelete.length;
+  for (let i = 0; i < nodeMapDeleteLength; i++) {
+    nodeMap.delete(nodeMapDelete[i]);
   }
 
   for (const nodeKey of dirtyLeaves) {

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -639,3 +639,33 @@ export function shiftTabKeyboardEvent() {
   keyboardEvent.shiftKey = true;
   return keyboardEvent;
 }
+
+export function generatePermutations<T>(
+  values: T[],
+  maxLength = values.length,
+): T[][] {
+  if (maxLength > values.length) {
+    throw new Error('maxLength over values.length');
+  }
+  const result: T[][] = [];
+  const current: T[] = [];
+  const seen = new Set();
+  (function permutationsImpl() {
+    if (current.length > maxLength) {
+      return;
+    }
+    result.push(current.slice());
+    for (let i = 0; i < values.length; i++) {
+      const key = values[i];
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      current.push(key);
+      permutationsImpl();
+      seen.delete(key);
+      current.pop();
+    }
+  })();
+  return result;
+}

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalGC.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalGC.test.tsx
@@ -15,6 +15,7 @@ import {
 
 import {
   $createTestElementNode,
+  generatePermutations,
   initializeUnitTest,
 } from '../../../__tests__/utils';
 
@@ -52,7 +53,7 @@ describe('LexicalGC tests', () => {
     });
 
     for (let i = 0; i < 3; i++) {
-      test(`RootNode.clear() with a child and three subchildren, subchild ${i} deleted first`, async () => {
+      test(`RootNode.clear() with a child and three subchildren, subchild ${i} removed first`, async () => {
         const {editor} = testEnv;
         await editor.update(() => {
           const text1 = $createTextNode('foo'); // 1
@@ -70,18 +71,23 @@ describe('LexicalGC tests', () => {
           subchild.remove();
           root.clear();
         });
-        expect(editor.getEditorState()._nodeMap.size).toBe(1);
+        expect(editor.getEditorState()._nodeMap.size).toEqual(1);
       });
     }
 
-    for (let i = 0; i < 7; i++) {
+    const permutations2 = generatePermutations<string>(
+      ['1', '2', '3', '4', '5', '6'],
+      2,
+    );
+    for (let i = 0; i < permutations2.length; i++) {
+      const removeKeys = permutations2[i];
       /**
        *          R
        *          P
        *     T   TE    T
        *        T  T
        */
-      test(`RootNode.clear() with a complex tree, element ${i} node first`, async () => {
+      test(`RootNode.clear() with a complex tree, nodes ${removeKeys.toString()} removed first`, async () => {
         const {editor} = testEnv;
         await editor.update(() => {
           const testElement = $createTestElementNode(); // 1
@@ -96,11 +102,13 @@ describe('LexicalGC tests', () => {
         });
         expect(editor.getEditorState()._nodeMap.size).toBe(7);
         await editor.update(() => {
-          const node = $getNodeByKey('1');
-          node.remove();
+          for (const key of removeKeys) {
+            const node = $getNodeByKey(String(key));
+            node.remove();
+          }
           $getRoot().clear();
         });
-        expect(editor.getEditorState()._nodeMap.size).toBe(1);
+        expect(editor.getEditorState()._nodeMap.size).toEqual(1);
       });
     }
   });


### PR DESCRIPTION
The hardcoded condition on the test (`const node = $getNodeByKey('1');`) was hiding that the fix in #4510 was actually not good enough.

Subtrees fail. For example, if a subtree is deleted and we visit the parent later, their children might not have deleted (previously deleted)

This PR stores the dirtyElements keys to delete and does the deletion later, without interfering with the loop itself.