### PR TITLE
Auto embed fix #4530

### DIFF
--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -129,7 +129,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
         if (
           mutation === 'created' &&
           updateTags.has('paste') &&
-          dirtyLeaves.size === 1
+          dirtyLeaves.size <= 3
         ) {
           checkIfLinkNodeIsEmbeddable(key);
         } else if (key === nodeKey) {


### PR DESCRIPTION
Pasting enbeddable url can trigger mutation listener with up to 3 dirty leaves: new node itself and (optional) siblings on both sides of the node:

Before:
See #4530

After:

https://github.com/facebook/lexical/assets/132642/301629c3-9367-4723-95d8-ba3c9fd150f7
