### PR TITLE
Add lexical menu command priority prop

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -18,6 +18,8 @@ import {
   $getSelection,
   $isRangeSelection,
   $isTextNode,
+  COMMAND_PRIORITY_LOW,
+  CommandListenerPriority,
   createCommand,
   LexicalCommand,
   LexicalEditor,
@@ -258,6 +260,7 @@ export type TypeaheadMenuPluginProps<TOption extends MenuOption> = {
   onOpen?: (resolution: MenuResolution) => void;
   onClose?: () => void;
   anchorClassName?: string;
+  keyboardPriority?: CommandListenerPriority;
 };
 
 export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
@@ -269,6 +272,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
   menuRenderFn,
   triggerFn,
   anchorClassName,
+  keyboardPriority = COMMAND_PRIORITY_LOW,
 }: TypeaheadMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
@@ -358,6 +362,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
       menuRenderFn={menuRenderFn}
       shouldSplitNodeWithQuery={true}
       onSelectOption={onSelectOption}
+      keyboardPriority={keyboardPriority}
     />
   );
 }

--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -12,6 +12,7 @@ import {
   $getSelection,
   $isRangeSelection,
   COMMAND_PRIORITY_LOW,
+  CommandListenerPriority,
   createCommand,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_UP_COMMAND,
@@ -260,6 +261,7 @@ export function LexicalMenu<TOption extends MenuOption>({
   menuRenderFn,
   onSelectOption,
   shouldSplitNodeWithQuery = false,
+  keyboardPriority = COMMAND_PRIORITY_LOW,
 }: {
   close: () => void;
   editor: LexicalEditor;
@@ -267,6 +269,7 @@ export function LexicalMenu<TOption extends MenuOption>({
   resolution: MenuResolution;
   options: Array<TOption>;
   shouldSplitNodeWithQuery?: boolean;
+  keyboardPriority?: CommandListenerPriority;
   menuRenderFn: MenuRenderFn<TOption>;
   onSelectOption: (
     option: TOption,
@@ -375,7 +378,7 @@ export function LexicalMenu<TOption extends MenuOption>({
           }
           return true;
         },
-        COMMAND_PRIORITY_LOW,
+        keyboardPriority,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_ARROW_UP_COMMAND,
@@ -394,7 +397,7 @@ export function LexicalMenu<TOption extends MenuOption>({
           }
           return true;
         },
-        COMMAND_PRIORITY_LOW,
+        keyboardPriority,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_ESCAPE_COMMAND,
@@ -405,7 +408,7 @@ export function LexicalMenu<TOption extends MenuOption>({
           close();
           return true;
         },
-        COMMAND_PRIORITY_LOW,
+        keyboardPriority,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_TAB_COMMAND,
@@ -423,7 +426,7 @@ export function LexicalMenu<TOption extends MenuOption>({
           selectOptionAndCleanUp(options[selectedIndex]);
           return true;
         },
-        COMMAND_PRIORITY_LOW,
+        keyboardPriority,
       ),
       editor.registerCommand(
         KEY_ENTER_COMMAND,
@@ -442,7 +445,7 @@ export function LexicalMenu<TOption extends MenuOption>({
           selectOptionAndCleanUp(options[selectedIndex]);
           return true;
         },
-        COMMAND_PRIORITY_LOW,
+        keyboardPriority,
       ),
     );
   }, [


### PR DESCRIPTION
keyboardPriority prop added to LexicalMenu and LexicalTypeaheadMenuPlugin so you can, for example, use KEY_ENTER_COMMAND overriding creation of new line, but not when selecting item in menu