### PR TITLE
Arrow up selection fix #4536

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/ListsHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/ListsHTMLCopyAndPaste.spec.mjs
@@ -6,7 +6,6 @@
  *
  */
 
-import {moveLeft} from '../../../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
   assertSelection,
@@ -375,7 +374,6 @@ test.describe('HTML Lists CopyAndPaste', () => {
     await page.keyboard.press('Enter');
     await page.keyboard.press('Enter');
     await page.keyboard.press('ArrowUp');
-    await moveLeft(page, 4);
     await page.keyboard.press('ArrowUp');
     await page.keyboard.press('ArrowUp');
     await pasteFromClipboard(page, {

--- a/packages/lexical-playground/src/ui/ContentEditable.css
+++ b/packages/lexical-playground/src/ui/ContentEditable.css
@@ -13,6 +13,7 @@
   position: relative;
   outline: 0;
   padding: 8px 28px 40px;
+  min-height: 150px;
 }
 @media (max-width: 1025px) {
   .ContentEditable__root {

--- a/packages/lexical-playground/src/ui/Placeholder.css
+++ b/packages/lexical-playground/src/ui/Placeholder.css
@@ -21,3 +21,8 @@
   display: inline-block;
   pointer-events: none;
 }
+@media (max-width: 1025px) {
+  .Placeholder__root {
+    left: 8px;
+  }
+}

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -50,7 +50,6 @@ import {
   $getSelection,
   $insertNodes,
   $isDecoratorNode,
-  $isElementNode,
   $isNodeSelection,
   $isRangeSelection,
   $isRootNode,
@@ -713,14 +712,6 @@ export function registerRichText(editor: LexicalEditor): () => void {
             !possibleNode.isInline()
           ) {
             possibleNode.selectPrevious();
-            event.preventDefault();
-            return true;
-          } else if (
-            $isElementNode(possibleNode) &&
-            !possibleNode.isInline() &&
-            !possibleNode.canBeEmpty()
-          ) {
-            possibleNode.select();
             event.preventDefault();
             return true;
           }


### PR DESCRIPTION
That condition looks a bit odd and is likely redundant or missing extra logic. Basically any shift + arrow-up selection will be broken if going into { canBeEmpty: false } (tables, lists). Original issue uses image as an example, but even list + paragraph case is broken:
1. Add list + paragraph, press shift + up in attempt to select
2. Note that cursor just moves to the list, without selecting anything

Before: 

https://github.com/facebook/lexical/assets/132642/80813c6d-8373-407d-a7c3-dda0aaa3802d

After:

https://github.com/facebook/lexical/assets/132642/94b8cd75-1358-4b66-8afa-88b77988a512


