### PR TITLE
Mutations to respect canInsertBeforeAfter

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Composition.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Composition.spec.mjs
@@ -547,6 +547,42 @@ test.describe('Composition', () => {
       });
     });
 
+    test('Typing after mention with IME should not break it', async ({
+      page,
+      browserName,
+      isPlainText,
+    }) => {
+      await focusEditor(page);
+
+      await page.keyboard.type('Luke');
+      await waitForSelector(page, '#typeahead-menu ul li');
+      await page.keyboard.press('Enter');
+
+      await page.keyboard.imeSetComposition('ｓ', 1, 1);
+      await page.keyboard.imeSetComposition('す', 1, 1);
+      await page.keyboard.imeSetComposition('すｓ', 2, 2);
+      await page.keyboard.imeSetComposition('すｓｈ', 3, 3);
+      await page.keyboard.imeSetComposition('すし', 2, 2);
+      await page.keyboard.insertText('すし');
+
+      await assertHTML(
+        page,
+        html`
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span
+              class="mention"
+              style="background-color: rgba(24, 119, 232, 0.2)"
+              data-lexical-text="true">
+              Luke Skywalker
+            </span>
+            <span data-lexical-text="true">すし</span>
+          </p>
+        `,
+      );
+    });
+
     test('Can type Hiragana via IME with hashtags', async ({
       page,
       browserName,
@@ -718,42 +754,6 @@ test.describe('Composition', () => {
       });
 
       expect(isFloatingToolbarDisplayed).toEqual(true);
-    });
-
-    test('Typing after mention with IME should not break it', async ({
-      page,
-      browserName,
-      isPlainText,
-    }) => {
-      await focusEditor(page);
-
-      await page.keyboard.type('Luke');
-      await waitForSelector(page, '#typeahead-menu ul li');
-      await page.keyboard.press('Enter');
-
-      await page.pause();
-      await page.keyboard.imeSetComposition('ｓ', 0, 1);
-      await page.keyboard.imeSetComposition('す', 0, 1);
-      await page.keyboard.imeSetComposition('すｓ', 0, 2);
-      await page.keyboard.imeSetComposition('すｓｈ', 0, 3);
-      await page.keyboard.imeSetComposition('すｓｈ', 0, 4);
-
-      await assertHTML(
-        page,
-        html`
-          <p
-            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-            dir="ltr">
-            <span
-              class="mention"
-              style="background-color: rgba(24, 119, 232, 0.2)"
-              data-lexical-text="true">
-              Luke Skywalker
-            </span>
-            <span data-lexical-text="true">すｓｈ​</span>
-          </p>
-        `,
-      );
     });
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/Composition.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Composition.spec.mjs
@@ -552,7 +552,11 @@ test.describe('Composition', () => {
       browserName,
       isPlainText,
     }) => {
+      // We don't yet support FF.
+      test.skip(browserName === 'firefox');
+
       await focusEditor(page);
+      await enableCompositionKeyEvents(page);
 
       await page.keyboard.type('Luke');
       await waitForSelector(page, '#typeahead-menu ul li');

--- a/packages/lexical-playground/__tests__/e2e/Composition.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Composition.spec.mjs
@@ -719,5 +719,41 @@ test.describe('Composition', () => {
 
       expect(isFloatingToolbarDisplayed).toEqual(true);
     });
+
+    test('Typing after mention with IME should not break it', async ({
+      page,
+      browserName,
+      isPlainText,
+    }) => {
+      await focusEditor(page);
+
+      await page.keyboard.type('Luke');
+      await waitForSelector(page, '#typeahead-menu ul li');
+      await page.keyboard.press('Enter');
+
+      await page.pause();
+      await page.keyboard.imeSetComposition('ｓ', 0, 1);
+      await page.keyboard.imeSetComposition('す', 0, 1);
+      await page.keyboard.imeSetComposition('すｓ', 0, 2);
+      await page.keyboard.imeSetComposition('すｓｈ', 0, 3);
+      await page.keyboard.imeSetComposition('すｓｈ', 0, 4);
+
+      await assertHTML(
+        page,
+        html`
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span
+              class="mention"
+              style="background-color: rgba(24, 119, 232, 0.2)"
+              data-lexical-text="true">
+              Luke Skywalker
+            </span>
+            <span data-lexical-text="true">すｓｈ​</span>
+          </p>
+        `,
+      );
+    });
   });
 });

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -108,6 +108,14 @@ export class MentionNode extends TextNode {
   isTextEntity(): true {
     return true;
   }
+
+  canInsertTextBefore(): boolean {
+    return false;
+  }
+
+  canInsertTextAfter(): boolean {
+    return false;
+  }
 }
 
 export function $createMentionNode(mentionName: string): MentionNode {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -635,6 +635,7 @@ export function $updateTextNodeFromDOMContent(
       }
       const parent = node.getParent();
       const prevSelection = $getPreviousSelection();
+      const prevTextContentSize = node.getTextContentSize();
       const compositionKey = $getCompositionKey();
       const nodeKey = node.getKey();
 
@@ -646,10 +647,16 @@ export function $updateTextNodeFromDOMContent(
         // Check if character was added at the start, and we need
         // to clear this input from occurring as that action wasn't
         // permitted.
-        (parent !== null &&
-          $isRangeSelection(prevSelection) &&
-          !parent.canInsertTextBefore() &&
-          prevSelection.anchor.offset === 0)
+        ($isRangeSelection(prevSelection) &&
+          ((parent !== null &&
+            !parent.canInsertTextBefore() &&
+            prevSelection.anchor.offset === 0) ||
+            (prevSelection.anchor.key === textNode.__key &&
+              prevSelection.anchor.offset === 0 &&
+              !node.canInsertTextBefore()) ||
+            (prevSelection.focus.key === textNode.__key &&
+              prevSelection.focus.offset === prevTextContentSize &&
+              !node.canInsertTextAfter())))
       ) {
         node.markDirty();
         return;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -644,9 +644,8 @@ export function $updateTextNodeFromDOMContent(
         (compositionKey !== null &&
           nodeKey === compositionKey &&
           !isComposing) ||
-        // Check if character was added at the start, and we need
-        // to clear this input from occurring as that action wasn't
-        // permitted.
+        // Check if character was added at the start or boundaries when not insertable, and we need
+        // to clear this input from occurring as that action wasn't permitted.
         ($isRangeSelection(prevSelection) &&
           ((parent !== null &&
             !parent.canInsertTextBefore() &&


### PR DESCRIPTION
We're usually very lenient when it comes to composition (as it can break easily) and we don't touch it unless it's imprescindible.

However, Mutations as they're now are breaking the `canInsert{Before/After}` rules which directly impacts things like Mentions or TabNode. This PR forbids Mutations that violate this rule and will instead fallback to `input`.

The other question is whether TabNode has to implement `canInsert{Before/After}` or we can do something smarter with it.

This PR also adjusts the behavior for MentionNode, which also makes me think whether this `canInsert` rule should be automatically applied when there's segmentation as I can't think why it would make sense to allow characters at the end when segmentation implies that the Node will be recreated as soon as you type on it.

Fixes https://github.com/facebook/lexical/issues/4547