### PR TITLE
Add key to portal to avoid decorator component remounting

### DIFF
--- a/packages/lexical-react/src/shared/useDecorators.tsx
+++ b/packages/lexical-react/src/shared/useDecorators.tsx
@@ -61,7 +61,7 @@ export function useDecorators(
       const element = editor.getElementByKey(nodeKey);
 
       if (element !== null) {
-        decoratedPortals.push(createPortal(reactDecorator, element));
+        decoratedPortals.push(createPortal(reactDecorator, element, nodeKey));
       }
     }
 


### PR DESCRIPTION
createPortal missed key, so when we reconciled decorators and order/amount of decorators changed it caused full rerendering

https://github.com/facebook/lexical/assets/132642/f3470ea8-ed23-4694-ad54-c6a42dec052f

