### PR TITLE
Fire selection change on decorator delete

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -32,6 +32,7 @@ import {
   DEPRECATED_GridCellNode,
   DEPRECATED_GridNode,
   DEPRECATED_GridRowNode,
+  SELECTION_CHANGE_COMMAND,
   TextNode,
 } from '.';
 import {DOM_ELEMENT_TYPE, TEXT_TYPE_TO_FORMAT} from './LexicalConstants';
@@ -2080,6 +2081,8 @@ export class RangeSelection implements BaseSelection {
           $setSelection(nodeSelection);
         } else {
           possibleNode.remove();
+          const editor = getActiveEditor();
+          editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
         }
         return;
       } else if (


### PR DESCRIPTION
Fixes #4402 

For some reason, in this case,  the native selectionchange event doesn't fire. The best I can tell, it's because DOM Selection already matches what we try to set it to in the reconciler when we call setBaseAndExtent. I don't see where we're explicitly changing the native selection in this code path, so I guess it's the browser. In any case, this explicitly dispatches selection change to cover this case.