### PR TITLE
feat: open a link in a new tab with ctrl+click/command+click

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -20,6 +20,7 @@ import {
   assertHTML,
   assertSelection,
   click,
+  expect,
   focus,
   focusEditor,
   html,
@@ -2033,6 +2034,52 @@ test.describe('Links', () => {
       undefined,
       {ignoreClasses: true},
     );
+  });
+
+  test('Can open a link in new tab with Ctrl+Click or Command+Click', async ({
+    context,
+    page,
+  }) => {
+    const linkText = 'facebook.com';
+    await focusEditor(page);
+    await page.keyboard.type('Hello');
+    await selectAll(page);
+
+    // Link
+    await click(page, '.link');
+
+    await selectAll(page);
+    await setURL(page, linkText);
+
+    const link = await page.getByRole('link', {name: `https://${linkText}`});
+
+    // Verify link behavior without Ctrl+Click
+    const [newPageOpened] = await Promise.all([
+      context.waitForEvent('page', {timeout: 2000}).catch((error) => null),
+      link.click(),
+    ]);
+    expect(newPageOpened).toBeFalsy();
+
+    // Verify link behavior with Shift+Click
+    const [newPageOpenedShiftClick] = await Promise.all([
+      context.waitForEvent('page', {timeout: 2000}).catch((error) => null),
+      link.click({modifiers: ['Shift']}),
+    ]);
+    expect(newPageOpenedShiftClick).toBeFalsy();
+
+    // Verify link behavior with Ctrl+Click
+    const [newPageOpenedCtrlClick] = await Promise.all([
+      context.waitForEvent('page'),
+      link.click({modifiers: ['Control']}),
+    ]);
+    expect(newPageOpenedCtrlClick).toBeTruthy();
+
+    // Verify link behavior with Command+Click
+    const [newPageOpenedCommandClick] = await Promise.all([
+      context.waitForEvent('page'),
+      link.click({modifiers: ['Meta']}),
+    ]);
+    expect(newPageOpenedCommandClick).toBeTruthy();
   });
 });
 

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -187,6 +187,12 @@ function FloatingLinkEditor({
     }
   };
 
+  const handleLinkClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!(event.ctrlKey || event.metaKey)) {
+      event.preventDefault();
+    }
+  };
+
   return (
     <div ref={editorRef} className="link-editor">
       {!isLink ? null : isEditMode ? (
@@ -227,6 +233,7 @@ function FloatingLinkEditor({
           <a
             href={sanitizeUrl(linkUrl)}
             target="_blank"
+            onClick={handleLinkClick}
             rel="noopener noreferrer">
             {linkUrl}
           </a>


### PR DESCRIPTION
## Description of your changes
The issue description is not much. What I have learned from that is, right now when we click on a link in editing mode it opens in a new tab. 

Changes have been made so one can only open a link in a new tab with `ctrl+click`. And for Mac users, it will be `command+click`. I have written an e2e test to check this. 
### How to verify this change
An e2e test for this new feature has been written to verify the changes.

### Related issue
 #4565 
