### PR TITLE
use selection from state in insertNodeToNearestRoot

### DIFF
--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -10,6 +10,7 @@
 import {$cloneWithProperties} from '@lexical/selection';
 import {
   $createParagraphNode,
+  $getPreviousSelection,
   $getRoot,
   $getSelection,
   $isElementNode,
@@ -430,7 +431,8 @@ export function $restoreEditorState(
  * @returns The node after its insertion
  */
 export function $insertNodeToNearestRoot<T extends LexicalNode>(node: T): T {
-  const selection = $getSelection();
+  const selection = $getSelection() || $getPreviousSelection();
+
   if ($isRangeSelection(selection)) {
     const {focus} = selection;
     const focusNode = focus.getNode();

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -3117,7 +3117,8 @@ export function $insertNodes(
   nodes: Array<LexicalNode>,
   selectStart?: boolean,
 ): boolean {
-  let selection = $getSelection();
+  let selection = $getSelection() || $getPreviousSelection();
+
   if (selection === null) {
     selection = $getRoot().selectEnd();
   }


### PR DESCRIPTION
PR to follow up #4497. 

It loads selection from state if there is no selection from active editor (It could happen when an async insert happen when user focusing on element)