### PR TITLE
Fix a11y for ContentEditable

### DIFF
--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -82,6 +82,7 @@ export function ContentEditable({
       aria-labelledby={ariaLabelledBy}
       aria-multiline={ariaMultiline}
       aria-owns={!isEditable ? undefined : ariaOwns}
+      aria-readonly={!isEditable ? true : undefined}
       aria-required={ariaRequired}
       autoCapitalize={autoCapitalize}
       className={className}
@@ -89,7 +90,7 @@ export function ContentEditable({
       data-testid={testid}
       id={id}
       ref={ref}
-      role={!isEditable ? undefined : role}
+      role={role}
       spellCheck={spellCheck}
       style={style}
       tabIndex={tabIndex}


### PR DESCRIPTION
This PR fix accessibility of ContentEditable in the non editable mode.

When Lexical editor is not editable, there is no `role` attribute, but `aria-autocomplete` has the value 'none'. That breaks our pipeline during a11y check with the critical warning:
![image](https://github.com/facebook/lexical/assets/1593015/6c23cb76-b814-49a4-b78f-c1599c46ccd3)

As I understand the issue, we can not have aria attributes without a valid role. So I keep the role 'textbox' for non-editable case, but at the same time set `aria-readonly="true"` as suggested in [doc](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role)