### PR TITLE
Fix theme mutation with separate cache

### DIFF
--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -9,6 +9,7 @@
 import type {
   EditorConfig,
   EditorThemeClasses,
+  LexicalEditor,
   LexicalNode,
   LineBreakNode,
   NodeKey,
@@ -136,8 +137,8 @@ export class CodeHighlightNode extends TextNode {
     return self.__highlightType;
   }
 
-  createDOM(config: EditorConfig): HTMLElement {
-    const element = super.createDOM(config);
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
+    const element = super.createDOM(config, editor);
     const className = getHighlightThemeClass(
       config.theme,
       this.__highlightType,
@@ -150,8 +151,9 @@ export class CodeHighlightNode extends TextNode {
     prevNode: CodeHighlightNode,
     dom: HTMLElement,
     config: EditorConfig,
+    editor: LexicalEditor,
   ): boolean {
-    const update = super.updateDOM(prevNode, dom, config);
+    const update = super.updateDOM(prevNode, dom, config, editor);
     const prevClassName = getHighlightThemeClass(
       config.theme,
       prevNode.__highlightType,

--- a/packages/lexical-hashtag/src/LexicalHashtagNode.ts
+++ b/packages/lexical-hashtag/src/LexicalHashtagNode.ts
@@ -8,6 +8,7 @@
 
 import type {
   EditorConfig,
+  LexicalEditor,
   LexicalNode,
   NodeKey,
   SerializedTextNode,
@@ -30,8 +31,8 @@ export class HashtagNode extends TextNode {
     super(text, key);
   }
 
-  createDOM(config: EditorConfig): HTMLElement {
-    const element = super.createDOM(config);
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
+    const element = super.createDOM(config, editor);
     addClassNamesToElement(element, config.theme.hashtag);
     return element;
   }

--- a/packages/lexical-playground/src/nodes/EmojiNode.tsx
+++ b/packages/lexical-playground/src/nodes/EmojiNode.tsx
@@ -8,6 +8,7 @@
 
 import type {
   EditorConfig,
+  LexicalEditor,
   LexicalNode,
   NodeKey,
   SerializedTextNode,
@@ -39,9 +40,9 @@ export class EmojiNode extends TextNode {
     this.__className = className;
   }
 
-  createDOM(config: EditorConfig): HTMLElement {
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     const dom = document.createElement('span');
-    const inner = super.createDOM(config);
+    const inner = super.createDOM(config, editor);
     dom.className = this.__className;
     inner.className = 'emoji-inner';
     dom.appendChild(inner);
@@ -52,12 +53,13 @@ export class EmojiNode extends TextNode {
     prevNode: TextNode,
     dom: HTMLElement,
     config: EditorConfig,
+    editor: LexicalEditor,
   ): boolean {
     const inner = dom.firstChild;
     if (inner === null) {
       return true;
     }
-    super.updateDOM(prevNode, inner as HTMLElement, config);
+    super.updateDOM(prevNode, inner as HTMLElement, config, editor);
     return false;
   }
 

--- a/packages/lexical-playground/src/nodes/KeywordNode.ts
+++ b/packages/lexical-playground/src/nodes/KeywordNode.ts
@@ -6,7 +6,12 @@
  *
  */
 
-import type {EditorConfig, LexicalNode, SerializedTextNode} from 'lexical';
+import type {
+  EditorConfig,
+  LexicalEditor,
+  LexicalNode,
+  SerializedTextNode,
+} from 'lexical';
 
 import {TextNode} from 'lexical';
 
@@ -38,8 +43,8 @@ export class KeywordNode extends TextNode {
     };
   }
 
-  createDOM(config: EditorConfig): HTMLElement {
-    const dom = super.createDOM(config);
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
+    const dom = super.createDOM(config, editor);
     dom.style.cursor = 'default';
     dom.className = 'keyword';
     return dom;

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -13,6 +13,7 @@ import {
   type DOMConversionOutput,
   type DOMExportOutput,
   type EditorConfig,
+  type LexicalEditor,
   type LexicalNode,
   type NodeKey,
   type SerializedTextNode,
@@ -77,8 +78,8 @@ export class MentionNode extends TextNode {
     };
   }
 
-  createDOM(config: EditorConfig): HTMLElement {
-    const dom = super.createDOM(config);
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
+    const dom = super.createDOM(config, editor);
     dom.style.cssText = mentionStyle;
     dom.className = 'mention';
     return dom;

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -548,6 +548,8 @@ export class LexicalEditor {
   _editable: boolean;
   /** @internal */
   _blockCursorElement: null | HTMLDivElement;
+  /** @internal */
+  _classNameCache: Map<string, Array<string>>;
 
   /** @internal */
   constructor(
@@ -609,6 +611,7 @@ export class LexicalEditor {
     this._headless = parentEditor !== null && parentEditor._headless;
     this._window = null;
     this._blockCursorElement = null;
+    this._classNameCache = new Map<string, Array<string>>();
   }
 
   /**
@@ -913,7 +916,11 @@ export class LexicalEditor {
     const prevRootElement = this._rootElement;
 
     if (nextRootElement !== prevRootElement) {
-      const classNames = getCachedClassNameArray(this._config.theme, 'root');
+      const classNames = getCachedClassNameArray(
+        this._config.theme,
+        'root',
+        this,
+      );
       const pendingEditorState = this._pendingEditorState || this._editorState;
       this._rootElement = nextRootElement;
       resetEditor(this, prevRootElement, nextRootElement, pendingEditorState);

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -758,6 +758,7 @@ export class LexicalNode {
     _prevNode: unknown,
     _dom: HTMLElement,
     _config: EditorConfig,
+    _editor: LexicalEditor,
   ): boolean {
     invariant(false, 'updateDOM: base method not extended');
   }

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -582,7 +582,7 @@ function reconcileNode(
   }
 
   // Update node. If it returns true, we need to unmount and re-create the node
-  if (nextNode.updateDOM(prevNode, dom, activeEditorConfig)) {
+  if (nextNode.updateDOM(prevNode, dom, activeEditorConfig, activeEditor)) {
     const replacementDOM = createNode(key, null, null);
 
     if (parentDOM === null) {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1010,14 +1010,13 @@ export function isSelectAll(
   return keyCode === 65 && controlOrMeta(metaKey, ctrlKey);
 }
 
-const classNameCache = new Map<string, Array<string>>();
-
 export function getCachedClassNameArray(
   classNamesTheme: EditorThemeClasses,
   classNameThemeType: string,
+  editor: LexicalEditor,
 ): Array<string> {
-  if (classNameCache.has(classNameThemeType)) {
-    return classNameCache.get(classNameThemeType) as Array<string>;
+  if (editor._classNameCache.has(classNameThemeType)) {
+    return editor._classNameCache.get(classNameThemeType) as Array<string>;
   }
   const classNames = classNamesTheme[classNameThemeType];
   // As we're using classList, we need
@@ -1027,7 +1026,7 @@ export function getCachedClassNameArray(
   // applied to classList.add()/remove().
   if (typeof classNames === 'string') {
     const classNamesArr = classNames.split(' ');
-    classNameCache.set(classNameThemeType, classNamesArr);
+    editor._classNameCache.set(classNameThemeType, classNamesArr);
     return classNamesArr;
   }
   return classNames;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1010,10 +1010,15 @@ export function isSelectAll(
   return keyCode === 65 && controlOrMeta(metaKey, ctrlKey);
 }
 
+const classNameCache = new Map<string, Array<string>>();
+
 export function getCachedClassNameArray(
   classNamesTheme: EditorThemeClasses,
   classNameThemeType: string,
 ): Array<string> {
+  if (classNameCache.has(classNameThemeType)) {
+    return classNameCache.get(classNameThemeType) as Array<string>;
+  }
   const classNames = classNamesTheme[classNameThemeType];
   // As we're using classList, we need
   // to handle className tokens that have spaces.
@@ -1022,7 +1027,7 @@ export function getCachedClassNameArray(
   // applied to classList.add()/remove().
   if (typeof classNames === 'string') {
     const classNamesArr = classNames.split(' ');
-    classNamesTheme[classNameThemeType] = classNamesArr;
+    classNameCache.set(classNameThemeType, classNamesArr);
     return classNamesArr;
   }
   return classNames;

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -37,9 +37,13 @@ export class ParagraphNode extends ElementNode {
 
   // View
 
-  createDOM(config: EditorConfig): HTMLElement {
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     const dom = document.createElement('p');
-    const classNames = getCachedClassNameArray(config.theme, 'paragraph');
+    const classNames = getCachedClassNameArray(
+      config.theme,
+      'paragraph',
+      editor,
+    );
     if (classNames !== undefined) {
       const domClassList = dom.classList;
       domClassList.add(...classNames);

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -130,10 +130,11 @@ function setTextThemeClassNames(
   nextFormat: number,
   dom: HTMLElement,
   textClassNames: TextNodeThemeClasses,
+  editor: LexicalEditor,
 ): void {
   const domClassList = dom.classList;
   // Firstly we handle the base theme.
-  let classNames = getCachedClassNameArray(textClassNames, 'base');
+  let classNames = getCachedClassNameArray(textClassNames, 'base', editor);
   if (classNames !== undefined) {
     domClassList.add(...classNames);
   }
@@ -145,6 +146,7 @@ function setTextThemeClassNames(
   classNames = getCachedClassNameArray(
     textClassNames,
     'underlineStrikethrough',
+    editor,
   );
   let hasUnderlineStrikethrough = false;
   const prevUnderlineStrikethrough =
@@ -166,7 +168,7 @@ function setTextThemeClassNames(
   for (const key in TEXT_TYPE_TO_FORMAT) {
     const format = key;
     const flag = TEXT_TYPE_TO_FORMAT[format];
-    classNames = getCachedClassNameArray(textClassNames, key);
+    classNames = getCachedClassNameArray(textClassNames, key, editor);
     if (classNames !== undefined) {
       if (nextFormat & flag) {
         if (
@@ -255,6 +257,7 @@ function createTextInnerDOM(
   format: number,
   text: string,
   config: EditorConfig,
+  editor: LexicalEditor,
 ): void {
   setTextContent(text, innerDOM, node);
   const theme = config.theme;
@@ -262,7 +265,14 @@ function createTextInnerDOM(
   const textClassNames = theme.text;
 
   if (textClassNames !== undefined) {
-    setTextThemeClassNames(innerTag, 0, format, innerDOM, textClassNames);
+    setTextThemeClassNames(
+      innerTag,
+      0,
+      format,
+      innerDOM,
+      textClassNames,
+      editor,
+    );
   }
 }
 
@@ -367,7 +377,7 @@ export class TextNode extends LexicalNode {
 
   // View
 
-  createDOM(config: EditorConfig): HTMLElement {
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     const format = this.__format;
     const outerTag = getElementOuterTag(this, format);
     const innerTag = getElementInnerTag(this, format);
@@ -379,7 +389,7 @@ export class TextNode extends LexicalNode {
       dom.appendChild(innerDOM);
     }
     const text = this.__text;
-    createTextInnerDOM(innerDOM, this, innerTag, format, text, config);
+    createTextInnerDOM(innerDOM, this, innerTag, format, text, config, editor);
     const style = this.__style;
     if (style !== '') {
       dom.style.cssText = style;
@@ -391,6 +401,7 @@ export class TextNode extends LexicalNode {
     prevNode: TextNode,
     dom: HTMLElement,
     config: EditorConfig,
+    editor: LexicalEditor,
   ): boolean {
     const nextText = this.__text;
     const prevFormat = prevNode.__format;
@@ -419,6 +430,7 @@ export class TextNode extends LexicalNode {
         nextFormat,
         nextText,
         config,
+        editor,
       );
       dom.replaceChild(nextInnerDOM, prevInnerDOM);
       return false;
@@ -444,6 +456,7 @@ export class TextNode extends LexicalNode {
         nextFormat,
         innerDOM,
         textClassNames,
+        editor,
       );
     }
     const prevStyle = prevNode.__style;

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalParagraphNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalParagraphNode.test.ts
@@ -63,14 +63,17 @@ describe('LexicalParagraphNode tests', () => {
       await editor.update(() => {
         const paragraphNode = new ParagraphNode();
 
-        expect(paragraphNode.createDOM(editorConfig).outerHTML).toBe(
+        expect(paragraphNode.createDOM(editorConfig, editor).outerHTML).toBe(
           '<p class="my-paragraph-class"></p>',
         );
         expect(
-          paragraphNode.createDOM({
-            namespace: '',
-            theme: {},
-          }).outerHTML,
+          paragraphNode.createDOM(
+            {
+              namespace: '',
+              theme: {},
+            },
+            editor,
+          ).outerHTML,
         ).toBe('<p></p>');
       });
     });
@@ -80,7 +83,7 @@ describe('LexicalParagraphNode tests', () => {
 
       await editor.update(() => {
         const paragraphNode = new ParagraphNode();
-        const domElement = paragraphNode.createDOM(editorConfig);
+        const domElement = paragraphNode.createDOM(editorConfig, editor);
 
         expect(domElement.outerHTML).toBe('<p class="my-paragraph-class"></p>');
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -641,7 +641,7 @@ describe('LexicalTextNode tests', () => {
       await update(() => {
         const textNode = $createTextNode(contents);
         textNode.setFormat(format);
-        const element = textNode.createDOM(editorConfig);
+        const element = textNode.createDOM(editorConfig, editor);
 
         expect(element.outerHTML).toBe(expectedHTML);
       });
@@ -659,7 +659,7 @@ describe('LexicalTextNode tests', () => {
             const textNode = $createTextNode(contents);
             textNode.setFormat(format);
             paragraphNode.append(textNode);
-            const element = textNode.createDOM(editorConfig);
+            const element = textNode.createDOM(editorConfig, editor);
 
             expect(element.outerHTML).toBe(expectedHTML);
           });
@@ -751,14 +751,14 @@ describe('LexicalTextNode tests', () => {
           const prevTextNode = $createTextNode(prevText);
           prevTextNode.setMode(prevMode as TextModeType);
           prevTextNode.setFormat(prevFormat);
-          const element = prevTextNode.createDOM(editorConfig);
+          const element = prevTextNode.createDOM(editorConfig, editor);
           const textNode = $createTextNode(nextText);
           textNode.setMode(nextMode as TextModeType);
           textNode.setFormat(nextFormat);
 
-          expect(textNode.updateDOM(prevTextNode, element, editorConfig)).toBe(
-            result,
-          );
+          expect(
+            textNode.updateDOM(prevTextNode, element, editorConfig, editor),
+          ).toBe(result);
           // Only need to bother about DOM element contents if updateDOM()
           // returns false.
           if (!result) {


### PR DESCRIPTION
The "cache" for getCachedClassNameArray is the theme itself. We mutate the theme object provided in the initial config, which is problematic because it can cause runtime type errors when we're looking for a string when accessing the theme properties directly, but instead we get an array. It looks like this is possible because we have an explicit *any* in the EditorTheme class types in TS, which we also probably need to fix.