### PR TITLE
Another approach to fixing the className cache

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1014,6 +1014,14 @@ export function getCachedClassNameArray(
   classNamesTheme: EditorThemeClasses,
   classNameThemeType: string,
 ): Array<string> {
+  if (classNamesTheme.__lexicalClassNameCache === undefined) {
+    classNamesTheme.__lexicalClassNameCache = {};
+  }
+  const classNamesCache = classNamesTheme.__lexicalClassNameCache;
+  const cachedClassNames = classNamesCache[classNameThemeType];
+  if (cachedClassNames !== undefined) {
+    return cachedClassNames;
+  }
   const classNames = classNamesTheme[classNameThemeType];
   // As we're using classList, we need
   // to handle className tokens that have spaces.
@@ -1022,7 +1030,7 @@ export function getCachedClassNameArray(
   // applied to classList.add()/remove().
   if (typeof classNames === 'string') {
     const classNamesArr = classNames.split(' ');
-    classNamesTheme[classNameThemeType] = classNamesArr;
+    classNamesCache[classNameThemeType] = classNamesArr;
     return classNamesArr;
   }
   return classNames;


### PR DESCRIPTION
The "cache" for getCachedClassNameArray is the theme itself. We mutate the theme object provided in the initial config, which is problematic because it can cause runtime type errors when we're looking for a string when accessing the theme properties directly, but instead we get an array.

This approach (vs #4581 ) has the advantage of leveraging the theme to keep the cache scoped to the Editor, disadvantage of still mutating the theme object, although collision probability seems low.