### PR TITLE
mouseenter event typo fix

### DIFF
--- a/packages/playwright-core/lib/server/injected/packed/injectedScript.js
+++ b/packages/playwright-core/lib/server/injected/packed/injectedScript.js
@@ -5275,7 +5275,7 @@ var eventType = /* @__PURE__ */ new Map([
   ["click", "mouse"],
   ["dblclick", "mouse"],
   ["mousedown", "mouse"],
-  ["mouseeenter", "mouse"],
+  ["mouseenter", "mouse"],
   ["mouseleave", "mouse"],
   ["mousemove", "mouse"],
   ["mouseout", "mouse"],


### PR DESCRIPTION
# Descripton 
updated mouseenter event typo in injectedScript.js file