### PR TITLE
Fix uuid bug in `AutocompleteNode.clone()`

### DIFF
--- a/packages/lexical-playground/src/nodes/AutocompleteNode.tsx
+++ b/packages/lexical-playground/src/nodes/AutocompleteNode.tsx
@@ -39,7 +39,7 @@ export class AutocompleteNode extends DecoratorNode<JSX.Element | null> {
   __uuid: string;
 
   static clone(node: AutocompleteNode): AutocompleteNode {
-    return new AutocompleteNode(node.__key);
+    return new AutocompleteNode(node.__uuid, node.__key);
   }
 
   static getType(): 'autocomplete' {


### PR DESCRIPTION
UUID and key should be stable when the node is cloned, but currently, the old key becomes the new UUID and a new key is regenerated. 

This feels like a simple typo that arose in the v2 rewrite a few months ago.

Fixes  #4589