### PR TITLE
[WIP] Fix internalResolveSelectionPoint resolved offset

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2379,14 +2379,23 @@ function internalResolveSelectionPoint(
           const descendant = moveSelectionToEnd
             ? child.getLastDescendant()
             : child.getFirstDescendant();
-          if (descendant === null) {
-            resolvedElement = child;
-            resolvedOffset = 0;
-          } else {
+          if (descendant !== null) {
             child = descendant;
-            resolvedElement = $isElementNode(child)
-              ? child
-              : child.getParentOrThrow();
+            if ($isElementNode(child) || $isDecoratorNode(child)) {
+              resolvedElement = child.getParentOrThrow();
+              if (moveSelectionToEnd && $isElementNode(resolvedElement)) {
+                resolvedOffset = resolvedElement.getChildrenSize();
+              } else {
+                resolvedOffset = 0;
+              }
+            } else {
+              resolvedElement = child;
+              if (moveSelectionToEnd) {
+                resolvedOffset = child.getTextContentSize();
+              } else {
+                resolvedOffset = 0;
+              }
+            }
           }
         }
         if ($isTextNode(child)) {


### PR DESCRIPTION
The resolved offset was not correct with ElementNodes. We were propagating the offset when the offset is only valid for the immediate child.

Putting this PR on hold for now because as we fix this other bad behavior around deletion arise. It seems like this bug was preventing other bigger bugs.

Fixes https://github.com/facebook/lexical/issues/4548