### PR TITLE
fix: freeze get style object in DEV env to avoid mutations

### DIFF
--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -199,6 +199,12 @@ export function getStyleObjectFromCSS(css: string): Record<string, string> {
     value = getStyleObjectFromRawCSS(css);
     CSS_TO_STYLES.set(css, value);
   }
+
+  if (__DEV__) {
+    // Freeze the value in DEV to prevent accidental mutations
+    Object.freeze(value);
+  }
+
   return value;
 }
 


### PR DESCRIPTION
closes #3946

Currently, the `getStyleObjectFromCSS` returns the object which is directly mutable. So, added logic to freeze the object before returning to avoid accidental mutations in __DEV__.