### PR TITLE
fix issue with dead keys (i.e. backticks) when converting markdown

### DIFF
--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -387,6 +387,11 @@ export function registerMarkdownShortcuts(
         return;
       }
 
+      // If editor is still composing (i.e. backticks) we must wait before the user confirms the key
+      if (editor.isComposing()) {
+        return;
+      }
+
       const selection = editorState.read($getSelection);
       const prevSelection = prevEditorState.read($getSelection);
 
@@ -406,7 +411,7 @@ export function registerMarkdownShortcuts(
       if (
         !$isTextNode(anchorNode) ||
         !dirtyLeaves.has(anchorKey) ||
-        (anchorOffset !== 1 && anchorOffset !== prevSelection.anchor.offset + 1)
+        (anchorOffset !== 1 && anchorOffset > prevSelection.anchor.offset + 1)
       ) {
         return;
       }


### PR DESCRIPTION
On keyboards that use [dead keys](https://en.wikipedia.org/wiki/Dead_key) for backticks the markdown converter does not work properly. The second backtick (for inline code) triggers the conversion, before the user has confirmed the key.
See here:

https://github.com/facebook/lexical/assets/32648275/f3535af7-4450-4dd8-b74a-0fe88d40ca3e

The event should be ignored, if the editor is still composing.

Further below I adjusted the offset check slightly, to allow the conversion to markdown when the user confirms the key. This is required, because the cursor will not move during these two operations.