### PR TITLE
Fix issue with syncing yjs changes to Lexical

### DIFF
--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -87,6 +87,14 @@ export function syncYjsChangesToLexical(
 ): void {
   const editor = binding.editor;
   const currentEditorState = editor._editorState;
+
+  // This line precompute the delta before editor update. The reason is
+  // delta is computed when it is accessed. Note that this can only be
+  // safely computed during the event call. If it is accessed after event
+  // call it might result in unexpected behavior.
+  // https://github.com/yjs/yjs/blob/00ef472d68545cb260abd35c2de4b3b78719c9e4/src/utils/YEvent.js#L132
+  events.forEach((event) => event.delta);
+
   editor.update(
     () => {
       const pendingEditorState: EditorState | null = editor._pendingEditorState;


### PR DESCRIPTION
Issue explanation:

Lexical uses the delta in the events coming from yjs document to sync the state of the editor with the latest changes. According to yjs delta is a computed property, meaning that it is computed when it is accessed for the first time. yjs also says :  

> Note that this can only be safely computed during the event call. Computing this property after other changes happened might result in unexpected behavior.

[Link to yjs repo where it's explained.](https://github.com/yjs/yjs/blob/00ef472d68545cb260abd35c2de4b3b78719c9e4/src/utils/YEvent.js#L132)

Lexical accesses delta in a callback function passed to `editor.update` and this function can be scheduled to run in a separate event call. That means delta can be computed unsafely in a different event call. This affects the changes coming from undo manager particularly.


