### PR TITLE
Import alignment for Heading and Blockquote

### DIFF
--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -383,8 +383,8 @@ function isGoogleDocsTitle(domNode: Node): boolean {
   return false;
 }
 
-function convertHeadingElement(domNode: Node): DOMConversionOutput {
-  const nodeName = domNode.nodeName.toLowerCase();
+function convertHeadingElement(element: HTMLElement): DOMConversionOutput {
+  const nodeName = element.nodeName.toLowerCase();
   let node = null;
   if (
     nodeName === 'h1' ||
@@ -395,12 +395,18 @@ function convertHeadingElement(domNode: Node): DOMConversionOutput {
     nodeName === 'h6'
   ) {
     node = $createHeadingNode(nodeName);
+    if (element.style) {
+      node.setFormat(element.style.textAlign as ElementFormatType);
+    }
   }
   return {node};
 }
 
-function convertBlockquoteElement(): DOMConversionOutput {
+function convertBlockquoteElement(element: HTMLElement): DOMConversionOutput {
   const node = $createQuoteNode();
+  if (element.style) {
+    node.setFormat(element.style.textAlign as ElementFormatType);
+  }
   return {node};
 }
 

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -395,7 +395,7 @@ function convertHeadingElement(element: HTMLElement): DOMConversionOutput {
     nodeName === 'h6'
   ) {
     node = $createHeadingNode(nodeName);
-    if (element.style) {
+    if (element.style !== null) {
       node.setFormat(element.style.textAlign as ElementFormatType);
     }
   }
@@ -404,7 +404,7 @@ function convertHeadingElement(element: HTMLElement): DOMConversionOutput {
 
 function convertBlockquoteElement(element: HTMLElement): DOMConversionOutput {
   const node = $createQuoteNode();
-  if (element.style) {
+  if (element.style !== null) {
     node.setFormat(element.style.textAlign as ElementFormatType);
   }
   return {node};


### PR DESCRIPTION
Continues the support of alignment for Heading and Blockquote nodes after we now export the property in exportDOM, we now have to import it.