### PR TITLE
Add error formating params

### DIFF
--- a/packages/lexical-website/src/pages/docs/error/index.js
+++ b/packages/lexical-website/src/pages/docs/error/index.js
@@ -55,9 +55,9 @@ function ErrorFinder() {
     if (adj !== null) {
       description = description.replace('%s', adj);
     }
-    const noon = params.get('n');
-    if (noon !== null) {
-      description = description.replace('%s', noon);
+    const noun = params.get('n');
+    if (noun !== null) {
+      description = description.replace('%s', noun);
     }
     return {code, description};
   }, []);

--- a/packages/lexical-website/src/pages/docs/error/index.js
+++ b/packages/lexical-website/src/pages/docs/error/index.js
@@ -42,13 +42,22 @@ export default function ErrorCodePage() {
 
 function ErrorFinder() {
   const error = useMemo(() => {
-    const code = new URLSearchParams(window.location.search).get('code');
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
     if (code === null) {
       return null;
     }
-    const description = codes[code];
+    let description = codes[code];
     if (description === undefined) {
       return null;
+    }
+    const adj = params.get('a');
+    if (adj !== null) {
+      description = description.replace('%s', adj);
+    }
+    const noon = params.get('n');
+    if (noon !== null) {
+      description = description.replace('%s', noon);
     }
     return {code, description};
   }, []);

--- a/scripts/error-codes/formatProdErrorMessage.js
+++ b/scripts/error-codes/formatProdErrorMessage.js
@@ -12,9 +12,16 @@
 // template literal strings. The messages will be replaced with error codes
 // during build.
 
-function formatProdErrorMessage(code) {
+function formatProdErrorMessage(code, adj, noon) {
+  let url = `https://lexical.dev/docs/error?code=${code}`;
+  if (adj != null) {
+    url += `&a=${decodeURIComponent(adj)}`;
+  }
+  if (noon != null) {
+    url += `&n=${decodeURIComponent(noon)}`;
+  }
   throw Error(
-    `Minified Lexical error #${code}; visit https://lexical.dev/docs/error?code=${code} for the full message or ` +
+    `Minified Lexical error #${code}; visit ${url} for the full message or ` +
       'use the non-minified dev environment for full errors and additional ' +
       'helpful warnings.',
   );

--- a/scripts/error-codes/formatProdErrorMessage.js
+++ b/scripts/error-codes/formatProdErrorMessage.js
@@ -13,15 +13,16 @@
 // during build.
 
 function formatProdErrorMessage(code, adj, noon) {
-  let url = `https://lexical.dev/docs/error?code=${code}`;
+  const params = URLSearchParams();
+  params.append('code', code);
   if (adj != null) {
-    url += `&a=${decodeURIComponent(adj)}`;
+    params.append('a', adj);
   }
   if (noon != null) {
-    url += `&n=${decodeURIComponent(noon)}`;
+    params.append('n', noon);
   }
   throw Error(
-    `Minified Lexical error #${code}; visit ${url} for the full message or ` +
+    `Minified Lexical error #${code}; visit https://lexical.dev/docs/error?${params} for the full message or ` +
       'use the non-minified dev environment for full errors and additional ' +
       'helpful warnings.',
   );

--- a/scripts/error-codes/formatProdErrorMessage.js
+++ b/scripts/error-codes/formatProdErrorMessage.js
@@ -12,14 +12,14 @@
 // template literal strings. The messages will be replaced with error codes
 // during build.
 
-function formatProdErrorMessage(code, adj, noon) {
+function formatProdErrorMessage(code, adj, noun) {
   const params = new URLSearchParams();
   params.append('code', code);
   if (adj != null) {
     params.append('a', adj);
   }
-  if (noon != null) {
-    params.append('n', noon);
+  if (noun != null) {
+    params.append('n', noun);
   }
   throw Error(
     `Minified Lexical error #${code}; visit https://lexical.dev/docs/error?${params} for the full message or ` +

--- a/scripts/error-codes/formatProdErrorMessage.js
+++ b/scripts/error-codes/formatProdErrorMessage.js
@@ -13,7 +13,7 @@
 // during build.
 
 function formatProdErrorMessage(code, adj, noon) {
-  const params = URLSearchParams();
+  const params = new URLSearchParams();
   params.append('code', code);
   if (adj != null) {
     params.append('a', adj);


### PR DESCRIPTION
Add adj/noon params into error url to support error formatting:

1. Trigger error by registrering mutation on non-existing node
<img width="1048" alt="Screenshot 2023-06-09 at 10 20 04 AM" src="https://github.com/facebook/lexical/assets/132642/3c55a18d-c215-423e-8772-0f9dfb988cac">


2. Use website preview to get formatted error

https://lexical-czmewj31g-fbopensource.vercel.app/docs/error?code=37&a=MentionNode
<img width="699" alt="Screenshot 2023-06-09 at 10 21 43 AM" src="https://github.com/facebook/lexical/assets/132642/d67915c9-9e52-4e28-b650-18b2ec520cbf">

Fixes #4624