### PR TITLE
Make Excalidraw Modal render interacting user specific

### DIFF
--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -29,6 +29,7 @@ import {CAN_USE_DOM} from 'shared/canUseDOM';
 import {createWebsocketProvider} from './collaboration';
 import {useSettings} from './context/SettingsContext';
 import {useSharedHistoryContext} from './context/SharedHistoryContext';
+import {ExcalidrawNode} from './nodes/ExcalidrawNode';
 import TableCellNodes from './nodes/TableCellNodes';
 import ActionsPlugin from './plugins/ActionsPlugin';
 import AutocompletePlugin from './plugins/AutocompletePlugin';
@@ -74,6 +75,12 @@ import Placeholder from './ui/Placeholder';
 const skipCollaborationInit =
   // @ts-ignore
   window.parent != null && window.parent.frames.right === window;
+
+const excludedCollaborationProps = new Map();
+excludedCollaborationProps.set(
+  ExcalidrawNode,
+  new Set<string>(['__showModal']),
+);
 
 export default function Editor(): JSX.Element {
   const {historyState} = useSharedHistoryContext();
@@ -167,6 +174,7 @@ export default function Editor(): JSX.Element {
                 id="main"
                 providerFactory={createWebsocketProvider}
                 shouldBootstrap={!skipCollaborationInit}
+                excludedProperties={excludedCollaborationProps}
               />
             ) : (
               <HistoryPlugin externalHistoryState={historyState} />

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -33,20 +33,32 @@ import ExcalidrawModal from './ExcalidrawModal';
 export default function ExcalidrawComponent({
   nodeKey,
   data,
+  isModalOpen,
+  renderModal,
 }: {
   data: string;
   nodeKey: NodeKey;
+  isModalOpen: boolean;
+  renderModal: (visibility: boolean) => void;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
-  const [isModalOpen, setModalOpen] = useState<boolean>(
-    data === '[]' && editor.isEditable(),
-  );
   const imageContainerRef = useRef<HTMLImageElement | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const captionButtonRef = useRef<HTMLButtonElement | null>(null);
   const [isSelected, setSelected, clearSelection] =
     useLexicalNodeSelection(nodeKey);
   const [isResizing, setIsResizing] = useState<boolean>(false);
+
+  const setModalOpen = useCallback(
+    (show: boolean) => {
+      editor.update(() => {
+        if (editor.isEditable()) {
+          renderModal(show);
+        }
+      });
+    },
+    [editor, renderModal],
+  );
 
   const onDelete = useCallback(
     (event: KeyboardEvent) => {

--- a/packages/lexical-playground/src/plugins/ExcalidrawPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/ExcalidrawPlugin/index.ts
@@ -38,7 +38,7 @@ export default function ExcalidrawPlugin(): null {
     return editor.registerCommand(
       INSERT_EXCALIDRAW_COMMAND,
       () => {
-        const excalidrawNode = $createExcalidrawNode();
+        const excalidrawNode = $createExcalidrawNode('[]', true);
 
         $insertNodes([excalidrawNode]);
         if ($isRootOrShadowRoot(excalidrawNode.getParentOrThrow())) {


### PR DESCRIPTION
Fixes #1788 

Before when an Excalidraw node is added, the popup will show up for all collaborators, not just the creating user. Which would lead to a number of other issues, as shown in the Before video. Skipping the syncing for a showModal property on the ExcalidrawNode, allows for independent editing.

Before:

https://github.com/facebook/lexical/assets/7893468/817b2e48-c4ec-41ce-982d-44b60d3bb997

After:

https://github.com/facebook/lexical/assets/7893468/1bc7e901-26e7-4bc3-a601-eec8f15d2df3
