### PR TITLE
Add missing ExportDOM to CodeNode

### DIFF
--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -10,6 +10,7 @@
 import type {
   DOMConversionMap,
   DOMConversionOutput,
+  DOMExportOutput,
   EditorConfig,
   LexicalNode,
   NodeKey,
@@ -125,6 +126,16 @@ export class CodeNode extends ElementNode {
       dom.removeAttribute(LANGUAGE_DATA_ATTRIBUTE);
     }
     return false;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement('code');
+    element.setAttribute('spellcheck', 'false');
+    const language = this.getLanguage();
+    if (language) {
+      element.setAttribute(LANGUAGE_DATA_ATTRIBUTE, language);
+    }
+    return {element};
   }
 
   static importDOM(): DOMConversionMap | null {


### PR DESCRIPTION
CodeNode didn't have ExportDOM defined, breaking the import/export HTML workflow.