### PR TITLE
Fix clipboard if content editable is in an iframe.

### DIFF
--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -39,6 +39,7 @@ import {
   $getNearestBlockElementAncestorOrThrow,
   addClassNamesToElement,
   mergeRegister,
+  objectKlassEquals,
 } from '@lexical/utils';
 import {
   $applyNodeReplacement,
@@ -449,7 +450,10 @@ async function onCutForRichText(
   event: CommandPayloadType<typeof CUT_COMMAND>,
   editor: LexicalEditor,
 ): Promise<void> {
-  await copyToClipboard(editor, event instanceof ClipboardEvent ? event : null);
+  await copyToClipboard(
+    editor,
+    objectKlassEquals(event, ClipboardEvent) ? (event as ClipboardEvent) : null,
+  );
   editor.update(() => {
     const selection = $getSelection();
     if ($isRangeSelection(selection)) {
@@ -989,7 +993,12 @@ export function registerRichText(editor: LexicalEditor): () => void {
     editor.registerCommand(
       COPY_COMMAND,
       (event) => {
-        copyToClipboard(editor, event instanceof ClipboardEvent ? event : null);
+        copyToClipboard(
+          editor,
+          objectKlassEquals(event, ClipboardEvent)
+            ? (event as ClipboardEvent)
+            : null,
+        );
         return true;
       },
       COMMAND_PRIORITY_EDITOR,

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsKlassEqual.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsKlassEqual.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {objectKlassEquals} from '@lexical/utils';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+
+class MyEvent extends Event {}
+
+class MyEvent2 extends Event {}
+
+let MyEventShadow: typeof Event = MyEvent;
+
+{
+  // eslint-disable-next-line no-shadow
+  class MyEvent extends Event {}
+  MyEventShadow = MyEvent;
+}
+
+describe('LexicalUtilsKlassEqual tests', () => {
+  initializeUnitTest((testEnv) => {
+    it('objectKlassEquals', async () => {
+      const eventInstance = new MyEvent('');
+      expect(eventInstance instanceof MyEvent).toBeTruthy();
+      expect(objectKlassEquals(eventInstance, MyEvent)).toBeTruthy();
+      expect(eventInstance instanceof MyEvent2).toBeFalsy();
+      expect(objectKlassEquals(eventInstance, MyEvent2)).toBeFalsy();
+      expect(eventInstance instanceof MyEventShadow).toBeFalsy();
+      expect(objectKlassEquals(eventInstance, MyEventShadow)).toBeTruthy();
+    });
+  });
+});

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -511,3 +511,18 @@ export function isHTMLElement(x: Node | EventTarget): x is HTMLElement {
   // @ts-ignore-next-line - strict check on nodeType here should filter out non-Element EventTarget implementors
   return x.nodeType === 1;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ObjectKlass<T> = new (...args: any[]) => T;
+
+/**
+ * @param object = The instance of the type
+ * @param objectClass = The class of the type
+ * @returns Whether the object is has the same Klass of the objectClass, ignoring the difference across window (e.g. different iframs)
+ */
+export function objectKlassEquals<T>(
+  object: unknown,
+  objectClass: ObjectKlass<T>,
+): boolean {
+  return Object.getPrototypeOf(object).constructor.name === objectClass.name;
+}


### PR DESCRIPTION
This is also my first contribution attempt to the project. Sorry in advance if something doesn't make sense!

In #2108  we support for iframe (use React.Portal to render the content editable area in an iframe). It works well.

Recently I notice that some of the clipboard logic doesn't work in iframe. More specifically, I found that `DecoratorNode` won't be exported on copy.

After digging into it, I found that is caused by global class variables having different instances in different window. There is more detail about this behaviour [in MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms).

In this diff, the issue I personally encounter has been fixed. But there are wider usage of `instanceof` in the codebase.

Overall, I want to hear from maintainers about

- Whether it's okay to directly use internal field `_window` from `LexicalEditor`
- Should I add another example / another mode of `<Editor />` for usage with iframe
