### PR TITLE
Fix reconciler recovery listeners

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -433,7 +433,10 @@ function handleDEVOnlyPendingUpdateGuarantees(
   };
 }
 
-export function commitPendingUpdates(editor: LexicalEditor): void {
+export function commitPendingUpdates(
+  editor: LexicalEditor,
+  recoveryEditorState?: EditorState,
+): void {
   const pendingEditorState = editor._pendingEditorState;
   const rootElement = editor._rootElement;
   const shouldSkipDOM = editor._headless || rootElement === null;
@@ -491,7 +494,7 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
         initMutationObserver(editor);
         editor._dirtyType = FULL_RECONCILE;
         isAttemptingToRecoverFromReconcilerError = true;
-        commitPendingUpdates(editor);
+        commitPendingUpdates(editor, currentEditorState);
         isAttemptingToRecoverFromReconcilerError = false;
       } else {
         // To avoid a possible situation of infinite loops, lets throw
@@ -591,14 +594,7 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
   }
 
   if (mutatedNodes !== null) {
-    triggerMutationListeners(
-      editor,
-      currentEditorState,
-      pendingEditorState,
-      mutatedNodes,
-      tags,
-      dirtyLeaves,
-    );
+    triggerMutationListeners(editor, mutatedNodes, tags, dirtyLeaves);
   }
   if (
     !$isRangeSelection(pendingSelection) &&
@@ -617,13 +613,22 @@ export function commitPendingUpdates(editor: LexicalEditor): void {
     triggerListeners('decorator', editor, true, pendingDecorators);
   }
 
-  triggerTextContentListeners(editor, currentEditorState, pendingEditorState);
+  // If reconciler fails, we reset whole editor (so current editor state becomes empty)
+  // and attempt to re-render pendingEditorState. If that goes through we trigger
+  // listeners, but instead use recoverEditorState which is current editor state before reset
+  // This specifically important for collab that relies on prevEditorState from update
+  // listener to calculate delta of changed nodes/properties
+  triggerTextContentListeners(
+    editor,
+    recoveryEditorState || currentEditorState,
+    pendingEditorState,
+  );
   triggerListeners('update', editor, true, {
     dirtyElements,
     dirtyLeaves,
     editorState: pendingEditorState,
     normalizedNodes,
-    prevEditorState: currentEditorState,
+    prevEditorState: recoveryEditorState || currentEditorState,
     tags,
   });
   triggerDeferredUpdateCallbacks(editor, deferred);
@@ -645,8 +650,6 @@ function triggerTextContentListeners(
 
 function triggerMutationListeners(
   editor: LexicalEditor,
-  currentEditorState: EditorState,
-  pendingEditorState: EditorState,
   mutatedNodes: MutatedNodes,
   updateTags: Set<string>,
   dirtyLeaves: Set<string>,


### PR DESCRIPTION
When reconciler fails we try to recover editor by reseting it to empty state and then doing full reconciliation for `pendingEditorState`. If that goes through, we trigger listeners but the problem is that since we reset editor during recovery `prevEditorState` will be empty, while it's expected to be whatever state was before changes that caused reconciler failre. This PR adjusts `commitPendingUpdates` to ensure it uses proper prevEditorState for those listeners.

This issue affecting collab in its worst way since collab heavily relies on `prevEditorState` from update listener to calculate require Yjs updates for mutated nodes. And since in reconciler recovery scenario prev state is empty, collab assumes that all mutated nodes didn't exist before and re-inserts them causing content duplication. Here's an example of MentionNode that has error thrown inside `updateDOM` method:

https://github.com/facebook/lexical/assets/132642/f1a39631-5526-49c7-b330-00071f7618ee
