### PR TITLE
Check for specific excluded props

### DIFF
--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -79,7 +79,7 @@ function isExcludedProperty(
 
   const nodeKlass = node.constructor as Klass<LexicalNode>;
   const excludedProperties = binding.excludedProperties.get(nodeKlass);
-  return excludedProperties == null || !excludedProperties.has(name);
+  return excludedProperties != null && excludedProperties.has(name);
 }
 
 export function getIndexOfYjsNode(

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -47,15 +47,12 @@ const baseExcludedProperties = new Set<string>([
   '__next',
   '__prev',
 ]);
-
 const elementExcludedProperties = new Set<string>([
   '__first',
   '__last',
   '__size',
 ]);
-
 const rootExcludedProperties = new Set<string>(['__cachedText']);
-
 const textExcludedProperties = new Set<string>(['__text']);
 
 function isExcludedProperty(
@@ -71,12 +68,11 @@ function isExcludedProperty(
     if (textExcludedProperties.has(name)) {
       return true;
     }
-  } else if ($isRootNode(node)) {
-    if (rootExcludedProperties.has(name)) {
-      return true;
-    }
   } else if ($isElementNode(node)) {
-    if (elementExcludedProperties.has(name)) {
+    if (
+      elementExcludedProperties.has(name) ||
+      ($isRootNode(node) && rootExcludedProperties.has(name))
+    ) {
       return true;
     }
   }


### PR DESCRIPTION
`excludedProperties` is a global list of properties that are not synced in collab mode, which includes node-specific props like `__size`, `__first`, `__last` (that should be filtered for elements only), or `__text` which is relevant for text nodes. That introduces possible issue where a decorator node (let's say Emoji) can have perfectly valid `__size` property, but it won't be sync'd over collab because it's filtered out for all nodes.

This PR checks if property should be excluded based on node type (element, text, root) and any extra excluded props from plugin to avoid it

Ref #3670