### PR TITLE
Add columns next to selection

### DIFF
--- a/packages/lexical-playground/__tests__/regression/4661-insert-column-selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/4661-insert-column-selection.spec.mjs
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  assertHTML,
+  click,
+  focusEditor,
+  html,
+  initialize,
+  insertTable,
+  insertTableColumnAfter,
+  insertTableColumnBefore,
+  selectCellsFromTableCords,
+  test,
+} from '../utils/index.mjs';
+
+test.describe('Regression test #4661', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+  test('inserting 2 columns before inserts before selection', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await insertTable(page, 2, 2);
+
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 0},
+      true,
+      true,
+    );
+
+    await insertTableColumnBefore(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+  test('inserting 2 columns after inserts after selection', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await insertTable(page, 2, 2);
+
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 0},
+      {x: 0, y: 0},
+      true,
+      true,
+    );
+
+    // await moveDown(page, 1);
+    // await moveRight(page, 1);
+    await insertTableColumnAfter(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+});

--- a/packages/lexical-playground/__tests__/regression/4661-insert-column-selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/4661-insert-column-selection.spec.mjs
@@ -104,8 +104,6 @@ test.describe('Regression test #4661', () => {
       true,
     );
 
-    // await moveDown(page, 1);
-    // await moveRight(page, 1);
     await insertTableColumnAfter(page);
 
     await assertHTML(

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -360,11 +360,13 @@ function TableActionMenu({
   const insertTableColumnAtSelection = useCallback(
     (shouldInsertAfter: boolean) => {
       editor.update(() => {
-        $insertTableColumn__EXPERIMENTAL(shouldInsertAfter);
+        for (let i = 0; i < selectionCounts.columns; i++) {
+          $insertTableColumn__EXPERIMENTAL(shouldInsertAfter);
+        }
         onClose();
       });
     },
-    [editor, onClose],
+    [editor, onClose, selectionCounts.columns],
   );
 
   const deleteTableRowAtSelection = useCallback(() => {

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -341,18 +341,22 @@ export function $insertTableColumn__EXPERIMENTAL(insertAfter = true): void {
     $isRangeSelection(selection) || DEPRECATED_$isGridSelection(selection),
     'Expected a RangeSelection or GridSelection',
   );
+  const anchor = selection.anchor.getNode();
   const focus = selection.focus.getNode();
+  const [anchorCell] = DEPRECATED_$getNodeTriplet(anchor);
   const [focusCell, , grid] = DEPRECATED_$getNodeTriplet(focus);
-  const [gridMap, focusCellMap] = DEPRECATED_$computeGridMap(
+  const [gridMap, focusCellMap, anchorCellMap] = DEPRECATED_$computeGridMap(
     grid,
     focusCell,
-    focusCell,
+    anchorCell,
   );
   const rowCount = gridMap.length;
-  const {startColumn: focusStartColumn} = focusCellMap;
+  const startColumn = insertAfter
+    ? Math.max(focusCellMap.startColumn, anchorCellMap.startColumn)
+    : Math.min(focusCellMap.startColumn, anchorCellMap.startColumn);
   const insertAfterColumn = insertAfter
-    ? focusStartColumn + focusCell.__colSpan - 1
-    : focusStartColumn - 1;
+    ? startColumn + focusCell.__colSpan - 1
+    : startColumn - 1;
   const gridFirstChild = grid.getFirstChild();
   invariant(
     DEPRECATED_$isGridRowNode(gridFirstChild),


### PR DESCRIPTION
Retrieves selection anchor node in addition to focus node in order to find the start or end of table selection when inserting columns.

Fixes issue https://github.com/facebook/lexical/issues/4661

The start of selection is used as target for inserting columns if we want to insert columns before.
The end of selection is used as target if we want to insert after.

Before:

https://github.com/facebook/lexical/assets/23295934/6848a138-e92c-412e-8939-131a1b2c34e1

After:

https://github.com/facebook/lexical/assets/23295934/91ddd789-dc8c-4375-9bcb-fd4ed1a60d76