### PR TITLE
Override selectall on RangeSelection

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -498,7 +498,10 @@ test.describe('Selection', () => {
     );
   });
 
-  test('Select all (DecoratorNode at start)', async ({page, isPlainText}) => {
+  test('Select all (DecoratorNode at start) #4670', async ({
+    page,
+    isPlainText,
+  }) => {
     // TODO selectAll is bad for Linux #4665
     test.skip(isPlainText || IS_LINUX);
 

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -497,4 +497,25 @@ test.describe('Selection', () => {
       `,
     );
   });
+
+  test('Select all (DecoratorNode at start)', async ({page, isPlainText}) => {
+    // TODO selectAll is bad for Linux #4665
+    test.skip(isPlainText || IS_LINUX);
+
+    await insertYouTubeEmbed(page, YOUTUBE_SAMPLE_URL);
+    // Delete empty paragraph in front
+    await moveLeft(page, 2);
+    await page.keyboard.press('Backspace');
+    await moveRight(page, 2);
+    await page.keyboard.type('abcdefg');
+
+    await selectAll(page);
+    await page.keyboard.press('Backspace');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
 });

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -28,7 +28,6 @@ import {
   $isRangeSelection,
   $isRootNode,
   $isTextNode,
-  $normalizeSelection__EXPERIMENTAL,
   $setCompositionKey,
   BLUR_COMMAND,
   CLICK_COMMAND,
@@ -80,6 +79,7 @@ import {
   $getNodeByKey,
   $isSelectionCapturedInDecorator,
   $isTokenOrSegmented,
+  $selectAll,
   $setSelection,
   $shouldInsertTextAfterOrBeforeTextNode,
   $updateSelectedTextFromDOM,
@@ -1019,11 +1019,15 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
       } else if (isSelectAll(keyCode, metaKey, ctrlKey)) {
         event.preventDefault();
         editor.update(() => {
-          const root = $getRoot();
-          const selection = root.select(0, root.getChildrenSize());
-          $setSelection($normalizeSelection__EXPERIMENTAL(selection));
+          $selectAll();
         });
       }
+      // FF does it well (no need to override behavior)
+    } else if (!IS_FIREFOX && isSelectAll(keyCode, metaKey, ctrlKey)) {
+      event.preventDefault();
+      editor.update(() => {
+        $selectAll();
+      });
     }
   }
 

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -57,6 +57,7 @@ import {
 } from './LexicalConstants';
 import {LexicalEditor} from './LexicalEditor';
 import {flushRootMutations} from './LexicalMutations';
+import {$normalizeSelection} from './LexicalNormalization';
 import {
   errorOnInfiniteTransforms,
   errorOnReadOnly,
@@ -1008,6 +1009,12 @@ export function isSelectAll(
   ctrlKey: boolean,
 ): boolean {
   return keyCode === 65 && controlOrMeta(metaKey, ctrlKey);
+}
+
+export function $selectAll(): void {
+  const root = $getRoot();
+  const selection = root.select(0, root.getChildrenSize());
+  $setSelection($normalizeSelection(selection));
 }
 
 export function getCachedClassNameArray(


### PR DESCRIPTION
See issue description. Given that it works well on FF, I've decided not to overide FF's behavior for now. Safari's behavior is sometimes worse than Chrome, caret jumping around instead of selecting so Chrome + Safari are a must-do override.

I didn't narrow down to checking whether there's DecoratorNodes at its boundaries because the root cause seems to be `contenteditable=false` but it doesn't necessarily have to sit at the top

```
<div contenteditable="true"><div contenteditable="false">...</div></div>
```

^ This will not work on Chrome

Might be that the pattern is first line of descendants not contenteditable (given the correct valid Nodes that can take this properties (i.e. iframe can't take it)) but since I'm not too confident on what the pattern is and the logic might be overly complicated, I'm overriding them all.

Fixes #4670