### PR TITLE
fixed line number issue for code block

### DIFF
--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -256,6 +256,31 @@ function updateCodeGutter(node: CodeNode, editor: LexicalEditor): void {
       gutter += '\n' + ++count;
     }
   }
+
+  // the above logic for calculating lines of code works fine if the
+  // code container has `whitespace: nowrap`, so no need to recalculate it
+  if (codeElement.style.whiteSpace !== 'nowrap') {
+    requestAnimationFrame(() => {
+      reCalculateLineNumberForCodeBlock(codeElement, count);
+    });
+  }
+  codeElement.setAttribute('data-gutter', gutter);
+}
+
+function reCalculateLineNumberForCodeBlock(
+  codeElement: HTMLElement,
+  currentTotalLineCount: number,
+) {
+  const codeElementHeight = parseInt(getComputedStyle(codeElement).height);
+  const beforePsuedoElementHeight = parseInt(
+    getComputedStyle(codeElement, ':before').height,
+  );
+  const heightPerLine = beforePsuedoElementHeight / currentTotalLineCount;
+  const totalLineNumbers = Math.round(codeElementHeight / heightPerLine);
+  let gutter = '1';
+  for (let count = 1; count < totalLineNumbers; ) {
+    gutter += '\n' + ++count;
+  }
   codeElement.setAttribute('data-gutter', gutter);
 }
 


### PR DESCRIPTION
Fixes #4361 

The solution is a bit hacky, but I feel this is the only thing we can do for now that properly addresses the issue. I saw [another PR](https://github.com/facebook/lexical/pull/4375) that changes `white-space` to `nowrap` and it works perfectly fine, but it adds a horizontal scrollbar to the code block which affects the overall readability of the code.

Here what I have to done to fix the bug:
1. Get the `<code>` element's height. (let's call it `codeElementHeight`)
2. Get the height of the `:before` pseudo element.
3. Get the height taken by one line of code. (let's call it `heightPerLine`)
4. The total lines of code would be `codeElementHeight / heightPerLine`


https://github.com/facebook/lexical/assets/26036974/b8c1603c-b666-47db-a318-f421b52cba89

