### PR TITLE
Allow table selection when cells are already selected

### DIFF
--- a/packages/lexical-playground/__tests__/regression/4697-repeated-table-selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/4697-repeated-table-selection.spec.mjs
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  assertGridSelectionCoordinates,
+  assertIsGridSelection,
+  click,
+  focusEditor,
+  initialize,
+  insertTable,
+  selectCellsFromTableCords,
+  test,
+} from '../utils/index.mjs';
+
+test.describe('Regression test #4697', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+  test('repeated table selection results in grid selection', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await insertTable(page, 4, 4);
+
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 1},
+      {x: 2, y: 2},
+      false,
+      false,
+    );
+
+    await selectCellsFromTableCords(
+      page,
+      {x: 2, y: 1},
+      {x: 2, y: 2},
+      false,
+      false,
+    );
+
+    await assertIsGridSelection(page);
+
+    await assertGridSelectionCoordinates(page, {
+      anchor: {x: 2, y: 1},
+      focus: {x: 2, y: 2},
+    });
+  });
+});

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -202,6 +202,54 @@ async function retryAsync(page, fn, attempts) {
   }
 }
 
+export async function assertIsGridSelection(page, coordinates) {
+  const gridKey = await page.evaluate(() => {
+    const editor = window.lexicalEditor;
+    const editorState = editor.getEditorState();
+    const selection = editorState._selection;
+    return selection.gridKey;
+  });
+
+  expect(gridKey).not.toBeUndefined();
+}
+
+export async function assertGridSelectionCoordinates(page, coordinates) {
+  const {_anchor, _focus} = await page.evaluate(() => {
+    const editor = window.lexicalEditor;
+    const editorState = editor.getEditorState();
+    const selection = editorState._selection;
+    const anchorElement = editor.getElementByKey(selection.anchor.key);
+    const focusElement = editor.getElementByKey(selection.focus.key);
+    return {
+      _anchor: {
+        x: anchorElement._cell?.x,
+        y: anchorElement._cell?.y,
+      },
+      _focus: {
+        x: focusElement._cell?.x,
+        y: focusElement._cell?.y,
+      },
+    };
+  });
+
+  if (coordinates.anchor) {
+    if (coordinates.anchor.x !== undefined) {
+      expect(_anchor.x).toEqual(coordinates.anchor.x);
+    }
+    if (coordinates.anchor.y !== undefined) {
+      expect(_anchor.y).toEqual(coordinates.anchor.y);
+    }
+  }
+  if (coordinates.focus) {
+    if (coordinates.focus.x !== undefined) {
+      expect(_focus.x).toEqual(coordinates.focus.x);
+    }
+    if (coordinates.focus.y !== undefined) {
+      expect(_focus.y).toEqual(coordinates.focus.y);
+    }
+  }
+}
+
 async function assertSelectionOnPageOrFrame(page, expected) {
   // Assert the selection of the editor matches the snapshot
   const selection = await page.evaluate(() => {

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -156,7 +156,7 @@ export function applyTableHandlers(
           selection.gridKey === tableSelection.tableNodeKey &&
           rootElement.contains(target)
         ) {
-          return tableSelection.clearHighlight();
+          tableSelection.clearHighlight();
         }
         // TODO Revise this logic; the UX selection boundaries and nested editors
         const node = $getNearestNodeFromDOMNode(target);


### PR DESCRIPTION
Earlier on table selection,  previous selection was cleared before immediately returning on mousedown if table cells were already selected. By not returning, but still clearing selection, we are able to make a proper new table selection instead of ending up in bad states.

Fixes issue #4697

See issue for more details.

Before:

https://github.com/facebook/lexical/assets/23295934/d9eec6bc-6829-4dca-a4d8-023acf3ed8fa


https://github.com/facebook/lexical/assets/23295934/e101c75e-6f2c-4369-84a7-3cda2bc72817

After:

https://github.com/facebook/lexical/assets/23295934/3d1832a2-d105-422c-b005-107c3afcc4bf

https://github.com/facebook/lexical/assets/23295934/c39419ed-08d6-4cb1-97d2-04655ab0c4f8

