### PR TITLE
Fix empty editor focus

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1072,12 +1072,10 @@ export class LexicalEditor {
           if (selection !== null) {
             // Marking the selection dirty will force the selection back to it
             selection.dirty = true;
-          } else if (root.getChildrenSize() !== 0) {
-            if (options.defaultSelection === 'rootStart') {
-              root.selectStart();
-            } else {
-              root.selectEnd();
-            }
+          } else if (options.defaultSelection === 'rootStart') {
+            root.selectStart();
+          } else {
+            root.selectEnd();
           }
         },
         {


### PR DESCRIPTION
Currently editor.focus did not work on empty editors.
To use AutofocusPlugin it was necessary to initialize the editor with even one paragraph.
Correct me if I'm wrong, but it looks like a bug, right?