### PR TITLE
Clear selection format when backspace on empty

### DIFF
--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -852,6 +852,12 @@ export function registerRichText(editor: LexicalEditor): () => void {
           if (element.getIndent() > 0) {
             return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
           }
+          if (
+            $isRootNode(anchorNode.getParent()) &&
+            !anchorNode.getPreviousSibling()
+          ) {
+            selection.format = 0;
+          }
         }
         return editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
       },


### PR DESCRIPTION
## Context

Now when pressing backspace on empty content, the rich text format isn't cleared.

**Current behavior:**

https://github.com/facebook/lexical/assets/23469706/40944976-03a1-4154-812e-16d40f03e49b

## Change

This diff clears the rich text format for the selection when backspace on empty content, which is more intuitive.

- Set selection format to 0 (`packages/lexical-rich-text/src/index.ts`)

## Screen recording after change

https://github.com/facebook/lexical/assets/23469706/e8236604-bb01-4131-8793-fba4968292af



