### PR TITLE
Fix code block export

### DIFF
--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -129,7 +129,7 @@ export class CodeNode extends ElementNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement('code');
+    const element = document.createElement('pre');
     element.setAttribute('spellcheck', 'false');
     const language = this.getLanguage();
     if (language) {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -140,16 +140,12 @@ describe('Markdown', () => {
       skipExport: true,
     },
     {
-      // Import only: export will have extra <pre> wrapper
-      html: '<code spellcheck="false"><span>Code</span></code>',
+      html: '<pre spellcheck="false"><span>Code</span></pre>',
       md: '```\nCode\n```',
-      skipExport: true,
     },
     {
-      // Export only: due to extra <pre> wrapper
-      html: '<code spellcheck="false"><pre><span>Code</span></pre></code>',
+      html: '<pre spellcheck="false"><span>Code</span></pre>',
       md: '```\nCode\n```',
-      skipImport: true,
     },
     {
       // Import only: extra empty lines will be removed for export

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/HTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/HTMLCopyAndPaste.spec.mjs
@@ -159,7 +159,6 @@ test.describe('HTML CopyAndPaste', () => {
             {
           </span>
           <br />
-          <span data-lexical-text="true"></span>
           <span
             class="PlaygroundEditorTheme__tokenAttr"
             data-lexical-text="true">

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -1128,7 +1128,6 @@ const preParentCache = new WeakMap<Node, null | Node>();
 function isNodePre(node: Node): boolean {
   return (
     node.nodeName === 'PRE' ||
-    node.nodeName === 'CODE' ||
     (node.nodeType === DOM_ELEMENT_TYPE &&
       (node as HTMLElement).style.whiteSpace.startsWith('pre'))
   );


### PR DESCRIPTION
We should export multi-line code as pre, same as other editors do

Fixes #4677

