### PR TITLE
Improve md error message

### DIFF
--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -338,11 +338,14 @@ export function registerMarkdownShortcuts(
     const type = transformer.type;
     if (type === 'element' || type === 'text-match') {
       const dependencies = transformer.dependencies;
-      if (!editor.hasNodes(dependencies)) {
-        invariant(
-          false,
-          'MarkdownShortcuts: missing dependency for transformer. Ensure node dependency is included in editor initial config.',
-        );
+      for (const node of dependencies) {
+        if (!editor.hasNode(node)) {
+          invariant(
+            false,
+            'MarkdownShortcuts: missing dependency %s for transformer. Ensure node dependency is included in editor initial config.',
+            node.getType(),
+          );
+        }
       }
     }
   }

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -862,7 +862,7 @@ export class LexicalEditor {
    * @returns True if the editor has registered all of the provided node types, false otherwise.
    */
   hasNodes<T extends Klass<LexicalNode>>(nodes: Array<T>): boolean {
-    return nodes.every(this.hasNode);
+    return nodes.every(this.hasNode.bind(this));
   }
 
   /**

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -848,21 +848,21 @@ export class LexicalEditor {
   }
 
   /**
+   * Used to assert that a certain node is registered, usually by plugins to ensure nodes that they
+   * depend on have been registered.
+   * @returns True if the editor has registered the provided node type, false otherwise.
+   */
+  hasNode<T extends Klass<LexicalNode>>(node: T): boolean {
+    return this._nodes.has(node.getType());
+  }
+
+  /**
    * Used to assert that certain nodes are registered, usually by plugins to ensure nodes that they
    * depend on have been registered.
    * @returns True if the editor has registered all of the provided node types, false otherwise.
    */
   hasNodes<T extends Klass<LexicalNode>>(nodes: Array<T>): boolean {
-    for (let i = 0; i < nodes.length; i++) {
-      const klass = nodes[i];
-      const type = klass.getType();
-
-      if (!this._nodes.has(type)) {
-        return false;
-      }
-    }
-
-    return true;
+    return nodes.every(this.hasNode);
   }
 
   /**


### PR DESCRIPTION
Also simplifies the hasNode(s) API. I don't think using Array.prototype.every should be a problem here, but willing to listen to opposing viewpoints.