### PR TITLE
Context Menu Options Added

### DIFF
--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -52,19 +52,21 @@ function onCopyForPlainText(
   editor: LexicalEditor,
 ): void {
   editor.update(() => {
-    const clipboardData =
-      event instanceof KeyboardEvent ? null : event.clipboardData;
-    const selection = $getSelection();
+    if (event !== null) {
+      const clipboardData =
+        event instanceof KeyboardEvent ? null : event.clipboardData;
+      const selection = $getSelection();
 
-    if (selection !== null && clipboardData != null) {
-      event.preventDefault();
-      const htmlString = $getHtmlContent(editor);
+      if (selection !== null && clipboardData != null) {
+        event.preventDefault();
+        const htmlString = $getHtmlContent(editor);
 
-      if (htmlString !== null) {
-        clipboardData.setData('text/html', htmlString);
+        if (htmlString !== null) {
+          clipboardData.setData('text/html', htmlString);
+        }
+
+        clipboardData.setData('text/plain', selection.getTextContent());
       }
-
-      clipboardData.setData('text/plain', selection.getTextContent());
     }
   });
 }

--- a/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
@@ -11,7 +11,6 @@ import {
   LexicalContextMenuPlugin,
   MenuOption,
 } from '@lexical/react/LexicalContextMenuPlugin';
-import {$findMatchingParent} from '@lexical/utils';
 import {
   type LexicalNode,
   $getSelection,
@@ -175,11 +174,11 @@ export default function ContextMenuPlugin(): JSX.Element {
           const selection = $getSelection();
           if ($isRangeSelection(selection)) {
             const currentNode = selection.anchor.getNode();
+            const ancestorNodeWithRootAsParent = currentNode
+              .getParents()
+              .at(-2);
 
-            const parentNode = $findMatchingParent(currentNode, (node) => {
-              return node.__parent === 'root';
-            });
-            parentNode?.remove();
+            ancestorNodeWithRootAsParent?.remove();
           }
         },
       }),

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -524,7 +524,7 @@ export function objectKlassEquals<T>(
   object: unknown,
   objectClass: ObjectKlass<T>,
 ): boolean {
-  return object
+  return typeof object === 'object'
     ? Object.getPrototypeOf(object).constructor.name === objectClass.name
     : false;
 }

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -524,5 +524,7 @@ export function objectKlassEquals<T>(
   object: unknown,
   objectClass: ObjectKlass<T>,
 ): boolean {
-  return Object.getPrototypeOf(object).constructor.name === objectClass.name;
+  return object
+    ? Object.getPrototypeOf(object).constructor.name === objectClass.name
+    : false;
 }

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -524,7 +524,7 @@ export function objectKlassEquals<T>(
   object: unknown,
   objectClass: ObjectKlass<T>,
 ): boolean {
-  return typeof object === 'object'
+  return object !== null
     ? Object.getPrototypeOf(object).constructor.name === objectClass.name
     : false;
 }

--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -90,10 +90,12 @@ export const DRAGOVER_COMMAND: LexicalCommand<DragEvent> =
   createCommand('DRAGOVER_COMMAND');
 export const DRAGEND_COMMAND: LexicalCommand<DragEvent> =
   createCommand('DRAGEND_COMMAND');
-export const COPY_COMMAND: LexicalCommand<ClipboardEvent | KeyboardEvent> =
-  createCommand('COPY_COMMAND');
-export const CUT_COMMAND: LexicalCommand<ClipboardEvent | KeyboardEvent> =
-  createCommand('CUT_COMMAND');
+export const COPY_COMMAND: LexicalCommand<
+  ClipboardEvent | KeyboardEvent | null
+> = createCommand('COPY_COMMAND');
+export const CUT_COMMAND: LexicalCommand<
+  ClipboardEvent | KeyboardEvent | null
+> = createCommand('CUT_COMMAND');
 export const CLEAR_EDITOR_COMMAND: LexicalCommand<void> = createCommand(
   'CLEAR_EDITOR_COMMAND',
 );


### PR DESCRIPTION
This PR adds cut, copy, paste, paste as plain text and delete node options to the context menu.

Demo:
![context-menu](https://github.com/facebook/lexical/assets/33776279/88a27737-6d58-4d42-98ec-ce3720fded23)
