### PR TITLE
Fix: Use $createListItemNode within importJSON to override on deserialization

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -124,9 +124,7 @@ export class ListItemNode extends ElementNode {
   }
 
   static importJSON(serializedNode: SerializedListItemNode): ListItemNode {
-    const node = $applyNodeReplacement<ListItemNode>(
-      new ListItemNode(serializedNode.value, serializedNode.checked),
-    );
+    const node = new ListItemNode(serializedNode.value, serializedNode.checked);
     node.setFormat(serializedNode.format);
     node.setDirection(serializedNode.direction);
     return node;

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -124,7 +124,9 @@ export class ListItemNode extends ElementNode {
   }
 
   static importJSON(serializedNode: SerializedListItemNode): ListItemNode {
-    const node = new ListItemNode(serializedNode.value, serializedNode.checked);
+    const node = $createListItemNode();
+    node.setChecked(serializedNode.checked);
+    node.setValue(serializedNode.value);
     node.setFormat(serializedNode.format);
     node.setDirection(serializedNode.direction);
     return node;

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -124,7 +124,9 @@ export class ListItemNode extends ElementNode {
   }
 
   static importJSON(serializedNode: SerializedListItemNode): ListItemNode {
-    const node = new ListItemNode(serializedNode.value, serializedNode.checked);
+    const node = $applyNodeReplacement<ListItemNode>(
+      new ListItemNode(serializedNode.value, serializedNode.checked),
+    );
     node.setFormat(serializedNode.format);
     node.setDirection(serializedNode.direction);
     return node;


### PR DESCRIPTION
This PR fixes an issue with node deserialization. Currently, when importing from JSON, the `importJSON` method directly returns an instance of ListItemNode instead of an overridden one. I believe that just like other nodes, ListItemNode should also go through `$applyNodeReplacement`.