### PR TITLE
Keeping local comments and sharedCommentsArray orders in sync

### DIFF
--- a/packages/lexical-playground/src/commenting/index.ts
+++ b/packages/lexical-playground/src/commenting/index.ts
@@ -351,50 +351,53 @@ export class CommentStore {
 
               if (Array.isArray(insert)) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                insert.forEach((map: YMap<any>) => {
-                  const id = map.get('id');
-                  const type = map.get('type');
+                insert
+                  .slice()
+                  .reverse()
+                  .forEach((map: YMap<any>) => {
+                    const id = map.get('id');
+                    const type = map.get('type');
 
-                  const commentOrThread =
-                    type === 'thread'
-                      ? createThread(
-                          map.get('quote'),
-                          map
-                            .get('comments')
-                            .toArray()
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            .map(
-                              (
-                                innerComment: Map<
-                                  string,
-                                  string | number | boolean
-                                >,
-                              ) =>
-                                createComment(
-                                  innerComment.get('content') as string,
-                                  innerComment.get('author') as string,
-                                  innerComment.get('id') as string,
-                                  innerComment.get('timeStamp') as number,
-                                  innerComment.get('deleted') as boolean,
-                                ),
-                            ),
-                          id,
-                        )
-                      : createComment(
-                          map.get('content'),
-                          map.get('author'),
-                          id,
-                          map.get('timeStamp'),
-                          map.get('deleted'),
-                        );
-                  this._withLocalTransaction(() => {
-                    this.addComment(
-                      commentOrThread,
-                      parentThread as Thread,
-                      offset,
-                    );
+                    const commentOrThread =
+                      type === 'thread'
+                        ? createThread(
+                            map.get('quote'),
+                            map
+                              .get('comments')
+                              .toArray()
+                              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                              .map(
+                                (
+                                  innerComment: Map<
+                                    string,
+                                    string | number | boolean
+                                  >,
+                                ) =>
+                                  createComment(
+                                    innerComment.get('content') as string,
+                                    innerComment.get('author') as string,
+                                    innerComment.get('id') as string,
+                                    innerComment.get('timeStamp') as number,
+                                    innerComment.get('deleted') as boolean,
+                                  ),
+                              ),
+                            id,
+                          )
+                        : createComment(
+                            map.get('content'),
+                            map.get('author'),
+                            id,
+                            map.get('timeStamp'),
+                            map.get('deleted'),
+                          );
+                    this._withLocalTransaction(() => {
+                      this.addComment(
+                        commentOrThread,
+                        parentThread as Thread,
+                        offset,
+                      );
+                    });
                   });
-                });
               } else if (typeof retain === 'number') {
                 offset += retain;
               } else if (typeof del === 'number') {


### PR DESCRIPTION
The order of [CommentStore local comments](https://github.com/facebook/lexical/blob/1ce51a8b6e4bec14601829f5503022015dc05403/packages/lexical-playground/src/commenting/index.ts#L106C3-L106C12) and the [shared comments array](https://github.com/facebook/lexical/blob/1ce51a8b6e4bec14601829f5503022015dc05403/packages/lexical-playground/src/commenting/index.ts#L250) must be exactly the same. Otherwise, the order of comments may be different for different users, and most importantly the [delete operation](https://github.com/facebook/lexical/blob/1ce51a8b6e4bec14601829f5503022015dc05403/packages/lexical-playground/src/commenting/index.ts#L187C11-L187C24) depends on it.

If the delta contains more than one insert (happens during the initial load of comments) the order of the comments is reversed. This PR fixes this issue by applying the inserts to the local comments in the reverse order.

This is a one line change. Turn on the ignore-whitespaces feature to review.

![commentsWrongOrder](https://github.com/facebook/lexical/assets/7505359/6e86dbeb-2180-447a-b997-1f92aae9b79b)
