### PR TITLE
Show excalidraw edit button

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1002,6 +1002,27 @@ i.prettier-error {
   background-color: rgba(60, 132, 244, 0.5);
 }
 
+.editor-shell .editor-image .image-edit-button {
+  border: 1px solid rgba(0, 0, 0, 0.3);
+  border-radius: 5px;
+  background-image: url(/src/images/icons/pencil-fill.svg);
+  background-size: 16px;
+  background-position: center;
+  background-repeat: no-repeat;
+  width: 35px;
+  height: 35px;
+  vertical-align: -0.25em;
+  position: absolute;
+  right: 4px;
+  top: 4px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.editor-shell .editor-image .image-edit-button:hover {
+  background-color: rgba(60, 132, 244, 0.1);
+}
+
 .editor-shell .editor-image .image-resizer {
   display: block;
   width: 7px;

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -161,6 +161,10 @@ export default function ExcalidrawComponent({
     }, 200);
   };
 
+  const openModal = useCallback(() => {
+    setModalOpen(true);
+  }, []);
+
   const {
     elements = [],
     files = {},
@@ -194,6 +198,15 @@ export default function ExcalidrawComponent({
             files={files}
             appState={appState}
           />
+          {isSelected && (
+            <div
+              className="image-edit-button"
+              role="button"
+              tabIndex={0}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={openModal}
+            />
+          )}
           {(isSelected || isResizing) && (
             <ImageResizer
               buttonRef={captionButtonRef}


### PR DESCRIPTION
The current way to edit the Excalidraw node is to double click the image which is not super accessible.
This pull request adds a button to open the modal if the node is selected.