### PR TITLE
Remove instanceof checks in onPasteForPlainText

### DIFF
--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -79,11 +79,7 @@ function onPasteForPlainText(
   editor.update(
     () => {
       const selection = $getSelection();
-      const clipboardData =
-        event instanceof InputEvent || event instanceof KeyboardEvent
-          ? null
-          : event.clipboardData;
-
+      const {clipboardData} = event as ClipboardEvent;
       if (clipboardData != null && $isRangeSelection(selection)) {
         $insertDataTransferForPlainText(clipboardData, selection);
       }


### PR DESCRIPTION
Android Chrome < 60 doesn't have the InputEvent constructor, so it throws on check. We don't technically support Android Chrome before 72, but I think this is a relatively unintrusive fix.