### PR TITLE
Fix multi-line token parsing

### DIFF
--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -328,10 +328,13 @@ function codeNodeTransform(
   );
 }
 
-function getHighlightNodes(tokens: (string | Token)[]): LexicalNode[] {
+function getHighlightNodes(
+  tokens: Array<string | Token>,
+  type?: string,
+): LexicalNode[] {
   const nodes: LexicalNode[] = [];
 
-  tokens.forEach((token) => {
+  for (const token of tokens) {
     if (typeof token === 'string') {
       const partials = token.split(/(\n|\t)/);
       const partialsLength = partials.length;
@@ -342,24 +345,18 @@ function getHighlightNodes(tokens: (string | Token)[]): LexicalNode[] {
         } else if (part === '\t') {
           nodes.push($createTabNode());
         } else if (part.length > 0) {
-          nodes.push($createCodeHighlightNode(part));
+          nodes.push($createCodeHighlightNode(part, type));
         }
       }
     } else {
       const {content} = token;
       if (typeof content === 'string') {
-        nodes.push($createCodeHighlightNode(content, token.type));
-      } else if (
-        Array.isArray(content) &&
-        content.length === 1 &&
-        typeof content[0] === 'string'
-      ) {
-        nodes.push($createCodeHighlightNode(content[0], token.type));
+        nodes.push(...getHighlightNodes([content], token.type));
       } else if (Array.isArray(content)) {
         nodes.push(...getHighlightNodes(content));
       }
     }
-  });
+  }
 
   return nodes;
 }


### PR DESCRIPTION
Noticed that we don't process multi-line code tokens (like multi-line comments) and insert raw text as is without linebreak nodes:

<img width="680" alt="Screenshot 2023-07-04 at 7 47 24 PM" src="https://github.com/facebook/lexical/assets/132642/4c99693d-edab-48cb-8933-2ab50a0ba125">

After:

<img width="897" alt="Screenshot 2023-07-04 at 7 48 25 PM" src="https://github.com/facebook/lexical/assets/132642/73e6761d-ab44-4020-b23a-0926b5c8b1c9">
