### PR TITLE
Add selection adjustments for node removal

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -57,12 +57,11 @@ export default function ExcalidrawComponent({
           if ($isExcalidrawNode(node)) {
             node.remove();
           }
-          setSelected(false);
         });
       }
       return false;
     },
-    [editor, isSelected, nodeKey, setSelected],
+    [editor, isSelected, nodeKey],
   );
 
   // Set editor to readOnly if excalidraw is open to prevent unwanted changes

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -150,11 +150,10 @@ export default function ImageComponent({
         if ($isImageNode(node)) {
           node.remove();
         }
-        setSelected(false);
       }
       return false;
     },
-    [isSelected, nodeKey, setSelected],
+    [isSelected, nodeKey],
   );
 
   const onEnter = useCallback(

--- a/packages/lexical-playground/src/nodes/InlineImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/InlineImageComponent.tsx
@@ -219,13 +219,12 @@ export default function InlineImageComponent({
         event.preventDefault();
         const node = $getNodeByKey(nodeKey);
         if ($isInlineImageNode(node)) {
-          node?.remove();
+          node.remove();
         }
-        setSelected(false);
       }
       return false;
     },
-    [isSelected, nodeKey, setSelected],
+    [isSelected, nodeKey],
   );
 
   const onEnter = useCallback(

--- a/packages/lexical-playground/src/nodes/PollComponent.tsx
+++ b/packages/lexical-playground/src/nodes/PollComponent.tsx
@@ -157,11 +157,10 @@ export default function PollComponent({
         if ($isPollNode(node)) {
           node.remove();
         }
-        setSelected(false);
       }
       return false;
     },
-    [isSelected, nodeKey, setSelected],
+    [isSelected, nodeKey],
   );
 
   useEffect(() => {

--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -21,7 +21,6 @@ import {
   $isDecoratorNode,
   $isNodeSelection,
   $isRangeSelection,
-  $setSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   FORMAT_ELEMENT_COMMAND,
@@ -57,20 +56,15 @@ export function BlockWithAlignableContents({
     (event: KeyboardEvent) => {
       if (isSelected && $isNodeSelection($getSelection())) {
         event.preventDefault();
-        editor.update(() => {
-          const node = $getNodeByKey(nodeKey);
-          if (node === null) return;
-
-          $setSelection(node.selectPrevious());
-          if ($isDecoratorNode(node)) {
-            node.remove();
-          }
-        });
+        const node = $getNodeByKey(nodeKey);
+        if ($isDecoratorNode(node)) {
+          node.remove();
+        }
       }
 
       return false;
     },
-    [editor, isSelected, nodeKey],
+    [isSelected, nodeKey],
   );
 
   useEffect(() => {

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -45,19 +45,17 @@ function HorizontalRuleComponent({nodeKey}: {nodeKey: NodeKey}) {
     useLexicalNodeSelection(nodeKey);
 
   const onDelete = useCallback(
-    (payload: KeyboardEvent) => {
+    (event: KeyboardEvent) => {
       if (isSelected && $isNodeSelection($getSelection())) {
-        const event: KeyboardEvent = payload;
         event.preventDefault();
         const node = $getNodeByKey(nodeKey);
         if ($isHorizontalRuleNode(node)) {
           node.remove();
         }
-        setSelected(false);
       }
       return false;
     },
-    [isSelected, nodeKey, setSelected],
+    [isSelected, nodeKey],
   );
 
   useEffect(() => {

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -26,6 +26,7 @@ import {
 } from '.';
 import {
   $getSelection,
+  $isNodeSelection,
   $isRangeSelection,
   $moveSelectionPointToEnd,
   $updateElementSelectionOnCreateDeleteNode,
@@ -92,6 +93,12 @@ export function removeNode(
       );
       selectionMoved = true;
     }
+  } else if (
+    $isNodeSelection(selection) &&
+    restoreSelection &&
+    nodeToRemove.isSelected()
+  ) {
+    nodeToRemove.selectPrevious();
   }
 
   if ($isRangeSelection(selection) && restoreSelection && !selectionMoved) {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1258,11 +1258,7 @@ export function $addUpdateTag(tag: string): void {
 
 export function $maybeMoveChildrenSelectionToParent(
   parentNode: LexicalNode,
-  offset = 0,
 ): RangeSelection | NodeSelection | GridSelection | null {
-  if (offset !== 0) {
-    invariant(false, 'TODO');
-  }
   const selection = $getSelection();
   if (!$isRangeSelection(selection) || !$isElementNode(parentNode)) {
     return selection;


### PR DESCRIPTION
Deleting node with NodeSelection should move selection to its sibling. Another question is whether deletion logic should remain in plugin instead of going into core.

Fixes #4738