### PR TITLE
Allow preventing text drag

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -20,7 +20,7 @@ declare export var INSERT_LINE_BREAK_COMMAND: LexicalCommand<boolean>;
 declare export var INSERT_PARAGRAPH_COMMAND: LexicalCommand<void>;
 declare export var CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<string>;
 declare export var PASTE_COMMAND: LexicalCommand<ClipboardEvent>;
-declare export var REMOVE_TEXT_COMMAND: LexicalCommand<void>;
+declare export var REMOVE_TEXT_COMMAND: LexicalCommand<InputEvent | null>;
 declare export var DELETE_WORD_COMMAND: LexicalCommand<boolean>;
 declare export var DELETE_LINE_COMMAND: LexicalCommand<boolean>;
 declare export var FORMAT_TEXT_COMMAND: LexicalCommand<TextFormatType>;

--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -33,9 +33,8 @@ export const CONTROLLED_TEXT_INSERTION_COMMAND: LexicalCommand<
 > = createCommand('CONTROLLED_TEXT_INSERTION_COMMAND');
 export const PASTE_COMMAND: LexicalCommand<PasteCommandType> =
   createCommand('PASTE_COMMAND');
-export const REMOVE_TEXT_COMMAND: LexicalCommand<void> = createCommand(
-  'REMOVE_TEXT_COMMAND',
-);
+export const REMOVE_TEXT_COMMAND: LexicalCommand<InputEvent | null> =
+  createCommand('REMOVE_TEXT_COMMAND');
 export const DELETE_WORD_COMMAND: LexicalCommand<boolean> = createCommand(
   'DELETE_WORD_COMMAND',
 );

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -660,7 +660,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
 
       case 'deleteByComposition': {
         if ($canRemoveText(anchorNode, focusNode)) {
-          dispatchCommand(editor, REMOVE_TEXT_COMMAND, undefined);
+          dispatchCommand(editor, REMOVE_TEXT_COMMAND, event);
         }
 
         break;
@@ -668,7 +668,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
 
       case 'deleteByDrag':
       case 'deleteByCut': {
-        dispatchCommand(editor, REMOVE_TEXT_COMMAND, undefined);
+        dispatchCommand(editor, REMOVE_TEXT_COMMAND, event);
         break;
       }
 


### PR DESCRIPTION
This PR adds input event to REMOVE_TEXT_COMMAND to allow preventing text drag by simple plugin:

```js
useEffect(() => {
  const preventInputEvent = (inputType: string) => (event: unknown) => {
    if (event instanceof InputEvent && event.inputType === inputType) {
      event.preventDefault();
      return true;
    }
    return false;
  };

  return mergeRegister(
    editor.registerCommand(
      CONTROLLED_TEXT_INSERTION_COMMAND,
      preventInputEvent('insertFromDrop'),
      COMMAND_PRIORITY_HIGH,
    ),

    editor.registerCommand(
      REMOVE_TEXT_COMMAND,
      preventInputEvent('deleteByDrag'),
      COMMAND_PRIORITY_HIGH,
    ),
  );
}, [editor]);
```


https://github.com/facebook/lexical/assets/132642/6fcfe20a-21dd-4786-aba7-5466e449b06a





Fix #4744