### PR TITLE
Fix missing token type

### DIFF
--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -353,7 +353,7 @@ function getHighlightNodes(
       if (typeof content === 'string') {
         nodes.push(...getHighlightNodes([content], token.type));
       } else if (Array.isArray(content)) {
-        nodes.push(...getHighlightNodes(content));
+        nodes.push(...getHighlightNodes(content, token.type));
       }
     }
   }


### PR DESCRIPTION
Before

<img width="225" alt="Screenshot 2023-07-06 at 11 56 11 AM" src="https://github.com/facebook/lexical/assets/132642/b21526ca-f1eb-43a1-9bdf-cf3425b6f36e">

After

<img width="207" alt="Screenshot 2023-07-06 at 11 56 16 AM" src="https://github.com/facebook/lexical/assets/132642/499ad0d2-739a-4ce2-a7ff-663809ce4616">
