### PR TITLE
Fix: Pasting position is wrong if a line ends with DecoratorNode

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1542,7 +1542,6 @@ export class RangeSelection implements BaseSelection {
       const node = nodes[i];
       if (
         !$isRootOrShadowRoot(target) &&
-        !$isDecoratorNode(target) &&
         $isElementNode(node) &&
         !node.isInline()
       ) {


### PR DESCRIPTION
#4668
Removed the line checking for target should not be decoratorNode. DecoratorNode is inline so adding textNode or another decoratorNode should not be a problem.
### Current Behavior
https://github.com/facebook/lexical/assets/43951027/214b0b8f-b554-4182-bf24-357692c5a06f
### With Updated code
https://github.com/facebook/lexical/assets/43951027/ada6337d-256b-4c85-a321-4ea319184dda

Current code code changes fixes the bug. I can understand that line could be for some cases, I would like to know the same.
Thank you.

