### PR TITLE
Markdown Import options

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -24,9 +24,13 @@ import {
 
 import {transformersByType} from './utils';
 
+export type ExportOptions = Readonly<{
+  node?: ElementNode;
+}>;
+
 export function createMarkdownExport(
   transformers: Array<Transformer>,
-): (node?: ElementNode) => string {
+): (exportOptions?: ExportOptions) => string {
   const byType = transformersByType(transformers);
 
   // Export only uses text formats that are responsible for single format
@@ -35,7 +39,8 @@ export function createMarkdownExport(
     (transformer) => transformer.format.length === 1,
   );
 
-  return (node) => {
+  return (exportOptions) => {
+    const {node} = exportOptions || {};
     const output = [];
     const children = (node || $getRoot()).getChildren();
 

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -41,15 +41,21 @@ type TextFormatTransformersIndex = Readonly<{
   transformersByTag: Readonly<Record<string, TextFormatTransformer>>;
 }>;
 
+export type ImportOptions = Readonly<{
+  node?: ElementNode;
+  stripEmptyLines?: boolean;
+}>;
+
 export function createMarkdownImport(
   transformers: Array<Transformer>,
-): (markdownString: string, node?: ElementNode) => void {
+): (markdownString: string, importOptions?: ImportOptions) => void {
   const byType = transformersByType(transformers);
   const textFormatTransformersIndex = createTextFormatTransformersIndex(
     byType.textFormat,
   );
 
-  return (markdownString, node) => {
+  return (markdownString, importOptions) => {
+    const {node, stripEmptyLines} = importOptions || {};
     const lines = markdownString.split('\n');
     const linesLength = lines.length;
     const root = node || $getRoot();
@@ -77,12 +83,14 @@ export function createMarkdownImport(
       );
     }
 
-    // Removing empty paragraphs as md does not really
-    // allow empty lines and uses them as dilimiter
-    const children = root.getChildren();
-    for (const child of children) {
-      if (isEmptyParagraph(child)) {
-        child.remove();
+    // Removing empty paragraphs if desired, this is the default
+    // as md does not really allow empty lines and uses them as dilimiter
+    if (stripEmptyLines === undefined || stripEmptyLines) {
+      const children = root.getChildren();
+      for (const child of children) {
+        if (isEmptyParagraph(child)) {
+          child.remove();
+        }
       }
     }
 

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -276,6 +276,24 @@ export const ORDERED_LIST: ElementTransformer = {
   type: 'element',
 };
 
+/*
+// Removing empty paragraphs as md does not really
+// allow empty lines and uses them as dilimiter
+export const EMPTY_LINE: ElementTransformer = {
+  dependencies: [ParagraphNode],
+  export: () => null,
+  regExp: /^\s{0,3}$/,
+  replace: (node) => {
+    if (!$isParagraphNode(node)) {
+      return null;
+    }
+
+    node.remove();
+  },
+  type: 'element',
+};
+*/
+
 export const INLINE_CODE: TextFormatTransformer = {
   format: ['code'],
   tag: '`',

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -7,13 +7,14 @@
  *
  */
 
+import type {ExportOptions} from './MarkdownExport';
+import type {ImportOptions} from './MarkdownImport';
 import type {
   ElementTransformer,
   TextFormatTransformer,
   TextMatchTransformer,
   Transformer,
 } from './MarkdownTransformers';
-import type {ElementNode} from 'lexical';
 
 import {createMarkdownExport} from './MarkdownExport';
 import {createMarkdownImport} from './MarkdownImport';
@@ -72,18 +73,18 @@ const TRANSFORMERS: Array<Transformer> = [
 function $convertFromMarkdownString(
   markdown: string,
   transformers: Array<Transformer> = TRANSFORMERS,
-  node?: ElementNode,
+  importOptions?: ImportOptions,
 ): void {
   const importMarkdown = createMarkdownImport(transformers);
-  return importMarkdown(markdown, node);
+  return importMarkdown(markdown, importOptions);
 }
 
 function $convertToMarkdownString(
   transformers: Array<Transformer> = TRANSFORMERS,
-  node?: ElementNode,
+  exportOptions?: ExportOptions,
 ): string {
   const exportMarkdown = createMarkdownExport(transformers);
-  return exportMarkdown(node);
+  return exportMarkdown(exportOptions);
 }
 
 export {
@@ -97,8 +98,10 @@ export {
   CODE,
   ELEMENT_TRANSFORMERS,
   ElementTransformer,
+  ExportOptions,
   HEADING,
   HIGHLIGHT,
+  ImportOptions,
   INLINE_CODE,
   ITALIC_STAR,
   ITALIC_UNDERSCORE,


### PR DESCRIPTION
Made import options for markdown helper of that name. To standardise the interface I did it for exports to.

The added import options allows configuring of the empty lines behaviour on import.

I will add tests and change the documentation if the basic idea is accepted.