### PR TITLE
Reset editor state when setting null root

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -951,6 +951,10 @@ export class LexicalEditor {
           nextRootElement.classList.add(...classNames);
         }
       } else {
+        // If content editable is unmounted we'll reset editor state back to original
+        // (or pending) editor state since there will be no reconciliation
+        this._editorState = pendingEditorState;
+        this._pendingEditorState = null;
         this._window = null;
       }
 

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -15,7 +15,6 @@ import {
   LexicalEditor,
   RangeSelection,
 } from 'lexical';
-import {$createRangeSelection} from 'lexical/src';
 
 import {$createTestDecoratorNode, initializeUnitTest} from '../utils';
 

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -15,6 +15,7 @@ import {
   LexicalEditor,
   RangeSelection,
 } from 'lexical';
+import {$createRangeSelection} from 'lexical/src';
 
 import {$createTestDecoratorNode, initializeUnitTest} from '../utils';
 


### PR DESCRIPTION
We missed resetting editor state back to its original (or pending value) when unset root element (by either unmounting contenteditable or directly calling `setRootElement(null)`). Which caused editor with unset root element to always return empty editor state