### PR TITLE
fix: Return LexicalEditorRefPlugin as valid JSX

### DIFF
--- a/packages/lexical-react/src/LexicalEditorRefPlugin.tsx
+++ b/packages/lexical-react/src/LexicalEditorRefPlugin.tsx
@@ -22,7 +22,7 @@ export function EditorRefPlugin({
   editorRef,
 }: {
   editorRef: React.RefCallback<LexicalEditor> | MutableRefObject<LexicalEditor>;
-}): JSX.Element {
+}): null {
   const [editor] = useLexicalComposerContext();
   if (typeof editorRef === 'function') {
     editorRef(editor);

--- a/packages/lexical-react/src/LexicalEditorRefPlugin.tsx
+++ b/packages/lexical-react/src/LexicalEditorRefPlugin.tsx
@@ -22,14 +22,12 @@ export function EditorRefPlugin({
   editorRef,
 }: {
   editorRef: React.RefCallback<LexicalEditor> | MutableRefObject<LexicalEditor>;
-}) {
+}): JSX.Element {
   const [editor] = useLexicalComposerContext();
   if (typeof editorRef === 'function') {
     editorRef(editor);
-    return;
-  }
-  if (typeof editorRef === 'object') {
+  } else if (typeof editorRef === 'object') {
     editorRef.current = editor;
-    return;
   }
+  return null;
 }


### PR DESCRIPTION
Small fix to avoid the `Its return type void is not a valid JSX element`  when using Typescript.