### PR TITLE
Fix : Can't convert paragraph into a header if the first child of the paragraph is a LineBreakNode

### DIFF
--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -24,6 +24,7 @@ import {
   $isDecoratorNode,
   $isElementNode,
   $isLeafNode,
+  $isLineBreakNode,
   $isRangeSelection,
   $isRootNode,
   $isRootOrShadowRoot,
@@ -92,7 +93,10 @@ function isBlock(node: LexicalNode): boolean {
 
   const firstChild = node.getFirstChild();
   const isLeafElement =
-    firstChild === null || $isTextNode(firstChild) || firstChild.isInline();
+    firstChild === null ||
+    $isLineBreakNode(firstChild) ||
+    $isTextNode(firstChild) ||
+    firstChild.isInline();
 
   return !node.isInline() && node.canBeEmpty() !== false && isLeafElement;
 }


### PR DESCRIPTION
Fix: #4773
#### Before 

https://jam.dev/c/fea34251-b2de-4a9c-bc1a-173c4b18bf33

#### After

https://jam.dev/c/99be1b2c-10cf-40a7-ba61-53059de667f3

------------------------------------------------------------

Fix: #4696 
#### Before 

https://jam.dev/c/d05b2d2d-45c3-43cb-962d-2c276905b0a9

#### After

https://jam.dev/c/4eea839f-5817-49c9-a4ac-3941fc5f5d31