### PR TITLE
skip node removal if google ime exist

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -619,7 +619,7 @@ export function $updateTextNodeFromDOMContent(
     if (compositionEnd || normalizedTextContent !== prevTextContent) {
       if (normalizedTextContent === '') {
         $setCompositionKey(null);
-        if (!IS_SAFARI && !IS_IOS && !IS_APPLE_WEBKIT) {
+        if (!IS_SAFARI && !IS_IOS && !IS_APPLE_WEBKIT && !isGoogleIMEExists()) {
           // For composition (mainly Android), we have to remove the node on a later update
           const editor = getActiveEditor();
           setTimeout(() => {
@@ -683,6 +683,10 @@ export function $updateTextNodeFromDOMContent(
     }
   }
 }
+
+// detect if the google IME extension is loaded, by checking if the floating toolbar is present
+const isGoogleIMEExists = () =>
+  CAN_USE_DOM && !!document.getElementById('GOOGLE_INPUT_CHEXT_FLAG');
 
 function $previousSiblingDoesNotAcceptText(node: TextNode): boolean {
   const previousSibling = node.getPreviousSibling();


### PR DESCRIPTION
Fix: https://github.com/facebook/lexical/issues/4572

By skipping the node.removal() if the dom has a element with id `GOOGLE_INPUT_CHEXT_FLAG` which indicate google ime is loaded.

**Questions**
1. Not sure if calling is function every-time will degrade the performance of lexical, but I don't have a good method to detect google ime

As zurfyx said in issue, maybe it is better to have a method to detect android, but I am not very familiar with that. Happy to help if it can push this fix faster. This bug is very annoying and appear in all meta product :(
