### PR TITLE
[RFC] Add prev editor state for mutation listener

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -88,7 +88,11 @@ type TextContentListener = (text: string) => void;
 type ErrorHandler = (error: Error) => void;
 export type MutationListener = (
   nodes: Map<NodeKey, NodeMutation>,
-  {updateTags: Set<string>, dirtyLeaves: Set<string>},
+  {
+    updateTags: Set<string>,
+    dirtyLeaves: Set<string>,
+    prevEditorState: EditorState,
+  },
 ) => void;
 export type EditableListener = (editable: boolean) => void;
 type Listeners = {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -205,7 +205,11 @@ export type TextContentListener = (text: string) => void;
 
 export type MutationListener = (
   nodes: Map<NodeKey, NodeMutation>,
-  payload: {updateTags: Set<string>; dirtyLeaves: Set<string>},
+  payload: {
+    updateTags: Set<string>;
+    dirtyLeaves: Set<string>;
+    prevEditorState: EditorState;
+  },
 ) => void;
 
 export type CommandListener<P> = (payload: P, editor: LexicalEditor) => boolean;

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -594,7 +594,13 @@ export function commitPendingUpdates(
   }
 
   if (mutatedNodes !== null) {
-    triggerMutationListeners(editor, mutatedNodes, tags, dirtyLeaves);
+    triggerMutationListeners(
+      editor,
+      mutatedNodes,
+      tags,
+      dirtyLeaves,
+      currentEditorState,
+    );
   }
   if (
     !$isRangeSelection(pendingSelection) &&
@@ -653,6 +659,7 @@ function triggerMutationListeners(
   mutatedNodes: MutatedNodes,
   updateTags: Set<string>,
   dirtyLeaves: Set<string>,
+  prevEditorState: EditorState,
 ): void {
   const listeners = Array.from(editor._listeners.mutation);
   const listenersLength = listeners.length;
@@ -663,6 +670,7 @@ function triggerMutationListeners(
     if (mutatedNodesByType !== undefined) {
       listener(mutatedNodesByType, {
         dirtyLeaves,
+        prevEditorState,
         updateTags,
       });
     }


### PR DESCRIPTION
This one should allow access for deleted nodes state using prev editor state:

```js
editor.registerMutationListener(
  SomeNode,
  (mutations, {prevEditorState}) => {
    for (const [key, type] of mutations.entries()) {
      if (type === 'destroyed') {
      	const destroyedNode = prevEditorState.read(() => $getNodeByKey<LexicalNode>(key));
		...
      }
    }
  },
)
```

