### PR TITLE
Fix the toolbar's style activation state is incorrect in certain cases

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -347,20 +347,6 @@ function onSelectionChange(
         const nodes = selection.getNodes();
         if (
           selection.getTextContent().startsWith('\n') &&
-          selection.getTextContent().endsWith('\n') &&
-          ((anchorNode.getTextContentSize() === anchor.offset &&
-            focus.offset === 0) ||
-            (focusNode.getTextContentSize() === focus.offset &&
-              anchor.offset === 0))
-        ) {
-          if ($isTextNode(nodes[0])) {
-            nodes.shift();
-          }
-          if ($isTextNode(nodes[nodes.length - 1])) {
-            nodes.pop();
-          }
-        } else if (
-          selection.getTextContent().startsWith('\n') &&
           !selection.getTextContent().endsWith('\n') &&
           (anchorNode.getTextContentSize() === anchor.offset ||
             focusNode.getTextContentSize() === focus.offset) &&

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -347,32 +347,12 @@ function onSelectionChange(
         const nodes = selection.getNodes();
         if (
           selection.getTextContent().startsWith('\n') &&
-          selection.getTextContent().endsWith('\n') &&
-          (anchorNode.getTextContentSize() === anchor.offset ||
-            focusNode.getTextContentSize() === focus.offset)
-        ) {
-          if ($isTextNode(nodes[0])) {
-            nodes.shift();
-          }
-          if ($isTextNode(nodes[nodes.length - 1])) {
-            nodes.pop();
-          }
-        } else if (
-          selection.getTextContent().startsWith('\n') &&
           !selection.getTextContent().endsWith('\n') &&
           (anchorNode.getTextContentSize() === anchor.offset ||
             focusNode.getTextContentSize() === focus.offset) &&
           $isTextNode(nodes[0])
         ) {
           nodes.shift();
-        } else if (
-          !selection.getTextContent().startsWith('\n') &&
-          selection.getTextContent().endsWith('\n') &&
-          (anchorNode.getTextContentSize() === anchor.offset ||
-            focusNode.getTextContentSize() === focus.offset) &&
-          $isTextNode(nodes[nodes.length - 1])
-        ) {
-          nodes.pop();
         }
 
         const nodesLength = nodes.length;

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -303,6 +303,8 @@ function onSelectionChange(
     if ($isRangeSelection(selection)) {
       const anchor = selection.anchor;
       const anchorNode = anchor.getNode();
+      const focus = selection.focus;
+      const focusNode = focus.getNode();
 
       if (selection.isCollapsed()) {
         // Badly interpreted range selection when collapsed - #1482
@@ -342,23 +344,33 @@ function onSelectionChange(
       } else {
         let combinedFormat = IS_ALL_FORMATTING;
         let hasTextNodes = false;
-
         const nodes = selection.getNodes();
-
         if (
           selection.getTextContent().startsWith('\n') &&
-          selection.getTextContent().endsWith('\n')
+          selection.getTextContent().endsWith('\n') &&
+          (anchorNode.getTextContentSize() === anchor.offset ||
+            focusNode.getTextContentSize() === focus.offset)
         ) {
-          nodes.shift();
-          nodes.pop();
+          if ($isTextNode(nodes[0])) {
+            nodes.shift();
+          }
+          if ($isTextNode(nodes[nodes.length - 1])) {
+            nodes.pop();
+          }
         } else if (
           selection.getTextContent().startsWith('\n') &&
-          !selection.getTextContent().endsWith('\n')
+          !selection.getTextContent().endsWith('\n') &&
+          (anchorNode.getTextContentSize() === anchor.offset ||
+            focusNode.getTextContentSize() === focus.offset) &&
+          $isTextNode(nodes[0])
         ) {
           nodes.shift();
         } else if (
           !selection.getTextContent().startsWith('\n') &&
-          selection.getTextContent().endsWith('\n')
+          selection.getTextContent().endsWith('\n') &&
+          (anchorNode.getTextContentSize() === anchor.offset ||
+            focusNode.getTextContentSize() === focus.offset) &&
+          $isTextNode(nodes[nodes.length - 1])
         ) {
           nodes.pop();
         }

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -353,6 +353,13 @@ function onSelectionChange(
           $isTextNode(nodes[0])
         ) {
           nodes.shift();
+        } else if (
+          !selection.getTextContent().startsWith('\n') &&
+          selection.getTextContent().endsWith('\n') &&
+          (anchor.offset === 0 || focus.offset === 0) &&
+          $isTextNode(nodes[nodes.length - 1])
+        ) {
+          nodes.pop();
         }
 
         const nodesLength = nodes.length;

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -347,6 +347,20 @@ function onSelectionChange(
         const nodes = selection.getNodes();
         if (
           selection.getTextContent().startsWith('\n') &&
+          selection.getTextContent().endsWith('\n') &&
+          ((anchorNode.getTextContentSize() === anchor.offset &&
+            focus.offset === 0) ||
+            (focusNode.getTextContentSize() === focus.offset &&
+              anchor.offset === 0))
+        ) {
+          if ($isTextNode(nodes[0])) {
+            nodes.shift();
+          }
+          if ($isTextNode(nodes[nodes.length - 1])) {
+            nodes.pop();
+          }
+        } else if (
+          selection.getTextContent().startsWith('\n') &&
           !selection.getTextContent().endsWith('\n') &&
           (anchorNode.getTextContentSize() === anchor.offset ||
             focusNode.getTextContentSize() === focus.offset) &&

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -353,13 +353,6 @@ function onSelectionChange(
           $isTextNode(nodes[0])
         ) {
           nodes.shift();
-        } else if (
-          !selection.getTextContent().startsWith('\n') &&
-          selection.getTextContent().endsWith('\n') &&
-          (anchor.offset === 0 || focus.offset === 0) &&
-          $isTextNode(nodes[nodes.length - 1])
-        ) {
-          nodes.pop();
         }
 
         const nodesLength = nodes.length;

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -344,6 +344,25 @@ function onSelectionChange(
         let hasTextNodes = false;
 
         const nodes = selection.getNodes();
+
+        if (
+          selection.getTextContent().startsWith('\n') &&
+          selection.getTextContent().endsWith('\n')
+        ) {
+          nodes.shift();
+          nodes.pop();
+        } else if (
+          selection.getTextContent().startsWith('\n') &&
+          !selection.getTextContent().endsWith('\n')
+        ) {
+          nodes.shift();
+        } else if (
+          !selection.getTextContent().startsWith('\n') &&
+          selection.getTextContent().endsWith('\n')
+        ) {
+          nodes.pop();
+        }
+
         const nodesLength = nodes.length;
         for (let i = 0; i < nodesLength; i++) {
           const node = nodes[i];


### PR DESCRIPTION
Lexical version:

## Steps To Reproduce

1. Create three paragraphs.
2. Set the text style of the second and third lines to be bold and underlined, 
3. Drag from the end of the first line to the third line, the style activation state of the toolbar is incorrect.

### before:
The style activation state of the toolbar is not activated

https://github.com/facebook/lexical/assets/48719861/b5aecdc4-f8e9-4e2d-83fc-31582a6243ce


### after

The toolbar's style activation state should be bold and underlined

https://github.com/facebook/lexical/assets/48719861/862f1245-5643-4ff5-8866-07ebb9260c88

close #4785 
