### PR TITLE
Word count plugin

### DIFF
--- a/packages/lexical-react/src/LexicalWordCountPlugin.ts
+++ b/packages/lexical-react/src/LexicalWordCountPlugin.ts
@@ -185,6 +185,22 @@ export default function WordCountPlugin(): [
                 );
                 currentWordCount += wordCountOfTextNode;
               }
+            } else if (mutation === 'updated') {
+              const textNode = $getNodeByKey(nodeKey);
+              if (textNode !== null) {
+                const textContent = textNode.getTextContent();
+                const oldWordCountOfTextNode =
+                  currentTextNodeKeyToTextNodeWordCountMap.get(nodeKey);
+                const updatedWordCountOfTextNode =
+                  getWordCountOfTextNode(textContent);
+                currentTextNodeKeyToTextNodeWordCountMap.set(
+                  nodeKey,
+                  updatedWordCountOfTextNode,
+                );
+                if (oldWordCountOfTextNode !== undefined)
+                  currentWordCount -= oldWordCountOfTextNode;
+                currentWordCount += updatedWordCountOfTextNode;
+              }
             }
           }
           setTextNodeKeyToTextNodeWordCountMap(

--- a/packages/lexical-react/src/LexicalWordCountPlugin.ts
+++ b/packages/lexical-react/src/LexicalWordCountPlugin.ts
@@ -118,17 +118,26 @@ function getWordCountOfTextNode(text: string): number {
   return wordCountOfTextNode;
 }
 
-export default function WordCountPlugin(): [string[], number] {
+type textNodeKeyToTextNodeCount = Map<NodeKey, number>;
+
+export default function WordCountPlugin(): [
+  textNodeKeyToTextNodeCount,
+  number,
+] {
   const [editor] = useLexicalComposerContext();
   const [wordCount, setWordCount] = useState(0);
-  const [textNodesKeys, setTextNodesKeys] = useState<NodeKey[]>([]);
+  const [
+    textNodeKeyToTextNodeWordCountMap,
+    setTextNodeKeyToTextNodeWordCountMap,
+  ] = useState<textNodeKeyToTextNodeCount>(new Map());
 
   useEffect(() => {
     // Set the intital wordCount state when the plugin is loaded for the first time
     editor.getEditorState().read(() => {
       const root = $getRoot();
       const children = root.getChildren();
-      const initialTextNodesKeys: NodeKey[] = [];
+      const initialTextNodeKeyToTextNodeWordCountMap: textNodeKeyToTextNodeCount =
+        new Map();
       let initialWordCount = 0;
       for (const child of children) {
         if ($isParagraphNode(child)) {
@@ -137,14 +146,19 @@ export default function WordCountPlugin(): [string[], number] {
             const text = textNode.getTextContent();
             const wordCountOfTextNode = getWordCountOfTextNode(text);
             initialWordCount += wordCountOfTextNode;
-            initialTextNodesKeys.push(textNode.getKey());
+            initialTextNodeKeyToTextNodeWordCountMap.set(
+              textNode.getKey(),
+              wordCountOfTextNode,
+            );
           }
         }
       }
-      setTextNodesKeys(initialTextNodesKeys);
+      setTextNodeKeyToTextNodeWordCountMap(
+        initialTextNodeKeyToTextNodeWordCountMap,
+      );
       setWordCount(initialWordCount);
     });
   }, [editor]);
 
-  return [textNodesKeys, wordCount];
+  return [textNodeKeyToTextNodeWordCountMap, wordCount];
 }

--- a/packages/lexical-react/src/LexicalWordCountPlugin.ts
+++ b/packages/lexical-react/src/LexicalWordCountPlugin.ts
@@ -99,23 +99,23 @@ function getWordCountOfTextNode(text: string): number {
 
   // eslint-disable-next-line no-misleading-character-class
   const regex = new RegExp(common + '[' + cjk + jp + kr + ']', 'g');
-  let finalTextWords: string[] = [];
+  let wordCountOfTextNode = 0;
   words.forEach((word: string) => {
-    // Stores the matached charecters so we can treat them as seperate words (as per the grammer of these langaues)
-    const charecterWords = [];
+    // Stores the count of matached charecters so we can treat them as seperate words (as per the grammer of these langaues)
+    let singleCharecterWordsCount = 0;
     let matched;
     do {
       matched = regex.exec(word);
-      if (matched) charecterWords.push(matched[0]);
+      if (matched) singleCharecterWordsCount++;
     } while (matched);
-    if (charecterWords.length === 0) {
-      finalTextWords.push(word);
+    if (singleCharecterWordsCount === 0) {
+      wordCountOfTextNode++;
     } else {
-      finalTextWords = finalTextWords.concat(charecterWords);
+      wordCountOfTextNode += singleCharecterWordsCount;
     }
   });
 
-  return finalTextWords.length;
+  return wordCountOfTextNode;
 }
 
 export default function WordCountPlugin(): [string[], number] {

--- a/packages/lexical-react/src/LexicalWordCountPlugin.ts
+++ b/packages/lexical-react/src/LexicalWordCountPlugin.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$getRoot, $isParagraphNode, NodeKey, TextNode} from 'lexical';
+import {useEffect, useState} from 'react';
+
+const PUNCTUATION = [
+  ',',
+  '，',
+  '.',
+  '。',
+  ':',
+  '：',
+  ';',
+  '；',
+  '[',
+  ']',
+  '【',
+  ']',
+  '】',
+  '{',
+  '｛',
+  '}',
+  '｝',
+  '(',
+  '（',
+  ')',
+  '）',
+  '<',
+  '《',
+  '>',
+  '》',
+  '$',
+  '￥',
+  '!',
+  '！',
+  '?',
+  '？',
+  '~',
+  '～',
+  "'",
+  '’',
+  '"',
+  '“',
+  '”',
+  '*',
+  '/',
+  '\\',
+  '&',
+  '%',
+  '@',
+  '#',
+  '^',
+  '、',
+  '、',
+  '、',
+  '、',
+];
+
+// Got from https://github.com/byn9826/words-count/blob/master/src/globalWordsCount.js
+function getWordCountOfTextNode(text: string): number {
+  if (text.length === 0 || text.trim() === '') return 0;
+
+  // Change punctuation to empty space
+  const punctuationRegex = new RegExp('\\' + PUNCTUATION.join(' '), 'g');
+  text = text.replace(punctuationRegex, ' ');
+
+  // Remove all kind of symbols
+  text = text.replace(/[\uFF00-\uFFEF\u2000-\u206F]/g, '');
+
+  // Format white space character
+  text = text.replace(/\s+/, ' ');
+
+  // Split text by white space (For European languages)
+  let words = text.split(' ');
+
+  words = words.filter((word: string) => word.trim());
+
+  // Match latin, cyrillic, Malayalam letters and numbers
+  const common =
+    '(\\d+)|[a-zA-Z\u00C0-\u00FF\u0100-\u017F\u0180-\u024F\u0250-\u02AF\u1E00-\u1EFF\u0400-\u04FF\u0500-\u052F\u0D00-\u0D7F]+|';
+
+  // Match Chinese Hànzì, the Japanese Kanji and the Korean Hanja
+  const cjk =
+    '\u2E80-\u2EFF\u2F00-\u2FDF\u3000-\u303F\u31C0-\u31EF\u3200-\u32FF\u3300-\u33FF\u3400-\u3FFF\u4000-\u4DBF\u4E00-\u4FFF\u5000-\u5FFF\u6000-\u6FFF\u7000-\u7FFF\u8000-\u8FFF\u9000-\u9FFF\uF900-\uFAFF';
+
+  // Match Japanese Hiragana, Katakana, Rōmaji
+  const jp = '\u3040-\u309F\u30A0-\u30FF\u31F0-\u31FF\u3190-\u319F';
+
+  // Match Korean Hangul
+  const kr =
+    '\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uAC00-\uAFFF\uB000-\uBFFF\uC000-\uCFFF\uD000-\uD7AF\uD7B0-\uD7FF';
+
+  // eslint-disable-next-line no-misleading-character-class
+  const regex = new RegExp(common + '[' + cjk + jp + kr + ']', 'g');
+  let finalTextWords: string[] = [];
+  words.forEach((word: string) => {
+    // Stores the matached charecters so we can treat them as seperate words (as per the grammer of these langaues)
+    const charecterWords = [];
+    let matched;
+    do {
+      matched = regex.exec(word);
+      if (matched) charecterWords.push(matched[0]);
+    } while (matched);
+    if (charecterWords.length === 0) {
+      finalTextWords.push(word);
+    } else {
+      finalTextWords = finalTextWords.concat(charecterWords);
+    }
+  });
+
+  return finalTextWords.length;
+}
+
+export default function WordCountPlugin(): [string[], number] {
+  const [editor] = useLexicalComposerContext();
+  const [wordCount, setWordCount] = useState(0);
+  const [textNodesKeys, setTextNodesKeys] = useState<NodeKey[]>([]);
+
+  useEffect(() => {
+    // Set the intital wordCount state when the plugin is loaded for the first time
+    editor.getEditorState().read(() => {
+      const root = $getRoot();
+      const children = root.getChildren();
+      const initialTextNodesKeys: NodeKey[] = [];
+      let initialWordCount = 0;
+      for (const child of children) {
+        if ($isParagraphNode(child)) {
+          const textNodes: TextNode[] = child.getAllTextNodes();
+          for (const textNode of textNodes) {
+            const text = textNode.getTextContent();
+            const wordCountOfTextNode = getWordCountOfTextNode(text);
+            initialWordCount += wordCountOfTextNode;
+            initialTextNodesKeys.push(textNode.getKey());
+          }
+        }
+      }
+      setTextNodesKeys(initialTextNodesKeys);
+      setWordCount(initialWordCount);
+    });
+  }, [editor]);
+
+  return [textNodesKeys, wordCount];
+}

--- a/packages/lexical-react/src/LexicalWordCountPlugin.ts
+++ b/packages/lexical-react/src/LexicalWordCountPlugin.ts
@@ -201,6 +201,12 @@ export default function WordCountPlugin(): [
                   currentWordCount -= oldWordCountOfTextNode;
                 currentWordCount += updatedWordCountOfTextNode;
               }
+            } else if (mutation === 'destroyed') {
+              const wordCountOfTextNode =
+                currentTextNodeKeyToTextNodeWordCountMap.get(nodeKey);
+              if (wordCountOfTextNode !== undefined)
+                currentWordCount -= wordCountOfTextNode;
+              currentTextNodeKeyToTextNodeWordCountMap.delete(nodeKey);
             }
           }
           setTextNodeKeyToTextNodeWordCountMap(


### PR DESCRIPTION
This is the core part of the WordCountPlugin decoupled from any UI implementations. It returns the number of words in the document (updated in real-time) by actively listening to changes in TextNodes.