### PR TITLE
docs: remove placeholder property from exampleTheme

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -144,7 +144,6 @@ describe('LexicalSelection tests', () => {
               },
               listitem: 'editor-listitem',
               paragraph: 'editor-paragraph',
-              placeholder: 'editor-placeholder',
               quote: 'editor-quote',
               text: {
                 bold: 'editor-text-bold',

--- a/packages/lexical-website/docs/getting-started/theming.md
+++ b/packages/lexical-website/docs/getting-started/theming.md
@@ -10,7 +10,6 @@ Lexical tries to make theming straight-forward, by providing a way of passing a 
 const exampleTheme = {
   ltr: 'ltr',
   rtl: 'rtl',
-  placeholder: 'editor-placeholder',
   paragraph: 'editor-paragraph',
 };
 ```
@@ -47,14 +46,21 @@ passing it as a property of the `initialConfig` to `<LexicalComposer>`, like sho
 
 ```jsx
 import {LexicalComposer} from '@lexical/react/LexicalComposer';
+import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {exampleTheme} from './exampleTheme';
+import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 
 const initialConfig = {namespace: 'MyEditor', theme: exampleTheme};
 
 export default function Editor() {
   return (
     <LexicalComposer initialConfig={initialConfig}>
-      <div className="editor-container">...</div>
+      <PlainTextPlugin
+        contentEditable={<ContentEditable />}
+        placeholder={<div className="editor-placeholder">Enter some text...</div>}
+        ErrorBoundary={LexicalErrorBoundary}
+      />
     </LexicalComposer>
   );
 }
@@ -77,7 +83,6 @@ Many of the Lexical's core nodes also accept theming properties. Here's a more c
 const exampleTheme = {
   ltr: 'ltr',
   rtl: 'rtl',
-  placeholder: 'editor-placeholder',
   paragraph: 'editor-paragraph',
   quote: 'editor-quote',
   heading: {


### PR DESCRIPTION
It seems like `placeholder` is not a property of [`EditorThemeClasses`](https://github.com/facebook/lexical/blob/4ce3483a02f39aec5a89e9a3716d67ac27ee6365/packages/lexical/src/LexicalEditor.ts#L78) anymore.

