### PR TITLE
Fix: Selection issue in registerLexicalTextEntity

### DIFF
--- a/packages/lexical-text/src/index.ts
+++ b/packages/lexical-text/src/index.ts
@@ -251,8 +251,8 @@ export function registerLexicalTextEntity<T extends TextNode>(
           if (diff > 0) {
             const concatText = text.slice(0, diff);
             const newTextContent = previousText + concatText;
-            prevSibling.select();
             prevSibling.setTextContent(newTextContent);
+            prevSibling.select();
 
             if (diff === text.length) {
               node.remove();


### PR DESCRIPTION
Issue in registerLexicalTextEntity used for Hashtag component, or similar. 
Selection was happening before the new text was set, resulting in incorrect cursor position.

**Before:**

https://github.com/facebook/lexical/assets/10382614/9173ff64-3ca4-4304-9fab-e3c2d55fcbf9

**After swapping the order of set and select:**

https://github.com/facebook/lexical/assets/10382614/afda1a65-d1be-456f-9017-8af0a2ecfc8f
