### PR TITLE
feat(playground): add support for drop block on empty area

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/DraggableBlock.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/DraggableBlock.spec.mjs
@@ -150,4 +150,41 @@ test.describe('DraggableBlock', () => {
       `,
     );
   });
+
+  test('Dragging the first paragraph to an empty space in the middle of the editor works correctly', async ({
+    page,
+    isPlainText,
+    browserName,
+    isCollab,
+  }) => {
+    test.skip(isCollab);
+    test.skip(isPlainText);
+    test.skip(browserName === 'firefox');
+
+    await focusEditor(page);
+    await page.keyboard.type('Paragraph 1');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Paragraph 2');
+
+    await mouseMoveToSelector(page, 'p:has-text("Paragraph 1")');
+    await page.pause();
+    await dragDraggableMenuTo(page, '.ContentEditable__root');
+
+    await assertHTML(
+      page,
+      `
+      <p
+        class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+        dir="ltr">
+        <span data-lexical-text="true">Paragraph 2</span>
+      </p>
+      <p
+        class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+        dir="ltr"
+        style="">
+        <span data-lexical-text="true">Paragraph 1</span>
+      </p>
+    `,
+    );
+  });
 });

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -59,6 +59,7 @@ function getBlockElement(
   anchorElem: HTMLElement,
   editor: LexicalEditor,
   event: MouseEvent,
+  useEdgeAsDefault = false,
 ): HTMLElement | null {
   const anchorElementRect = anchorElem.getBoundingClientRect();
   const topLevelNodeKeys = getTopLevelNodeKeys(editor);
@@ -66,6 +67,30 @@ function getBlockElement(
   let blockElem: HTMLElement | null = null;
 
   editor.getEditorState().read(() => {
+    if (useEdgeAsDefault) {
+      const [firstNode, lastNode] = [
+        editor.getElementByKey(topLevelNodeKeys[0]),
+        editor.getElementByKey(topLevelNodeKeys[topLevelNodeKeys.length - 1]),
+      ];
+
+      const [firstNodeRect, lastNodeRect] = [
+        firstNode?.getBoundingClientRect(),
+        lastNode?.getBoundingClientRect(),
+      ];
+
+      if (firstNodeRect && lastNodeRect) {
+        if (event.y < firstNodeRect.top) {
+          blockElem = firstNode;
+        } else if (event.y > lastNodeRect.bottom) {
+          blockElem = lastNode;
+        }
+
+        if (blockElem) {
+          return;
+        }
+      }
+    }
+
     let index = getCurrentIndex(topLevelNodeKeys.length);
     let direction = Indeterminate;
 
@@ -260,7 +285,7 @@ function useDraggableBlockMenu(
       if (!isHTMLElement(target)) {
         return false;
       }
-      const targetBlockElem = getBlockElement(anchorElem, editor, event);
+      const targetBlockElem = getBlockElement(anchorElem, editor, event, true);
       const targetLineElem = targetLineRef.current;
       if (targetBlockElem === null || targetLineElem === null) {
         return false;
@@ -288,7 +313,7 @@ function useDraggableBlockMenu(
       if (!isHTMLElement(target)) {
         return false;
       }
-      const targetBlockElem = getBlockElement(anchorElem, editor, event);
+      const targetBlockElem = getBlockElement(anchorElem, editor, event, true);
       if (!targetBlockElem) {
         return false;
       }


### PR DESCRIPTION
Enhances the interactivity of the Playground editor by allowing users to drop nodes into empty areas at the start or the end.

**Before**

https://github.com/facebook/lexical/assets/46543621/ad07fdc4-01cd-4b8b-8f91-4aedcc6b5b2d

**After**

https://github.com/facebook/lexical/assets/46543621/a8c72d72-f160-4c51-a4cd-9bbabfe4a1ff

