### PR TITLE
Extract "select all" behavior to new `SELECT_ALL_COMMAND`

### DIFF
--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -21,6 +21,7 @@ import {mergeRegister} from '@lexical/utils';
 import {
   $getSelection,
   $isRangeSelection,
+  $selectAll,
   COMMAND_PRIORITY_EDITOR,
   CONTROLLED_TEXT_INSERTION_COMMAND,
   COPY_COMMAND,
@@ -39,6 +40,7 @@ import {
   KEY_ENTER_COMMAND,
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
+  SELECT_ALL_COMMAND,
 } from 'lexical';
 import {
   CAN_USE_BEFORE_INPUT,
@@ -319,6 +321,15 @@ export function registerPlainText(editor: LexicalEditor): () => void {
         }
 
         return editor.dispatchCommand(INSERT_LINE_BREAK_COMMAND, false);
+      },
+      COMMAND_PRIORITY_EDITOR,
+    ),
+    editor.registerCommand(
+      SELECT_ALL_COMMAND,
+      () => {
+        $selectAll();
+
+        return true;
       },
       COMMAND_PRIORITY_EDITOR,
     ),

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -58,6 +58,7 @@ import {
   $isRootNode,
   $isTextNode,
   $normalizeSelection__EXPERIMENTAL,
+  $selectAll,
   $setSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_EDITOR,
@@ -91,6 +92,7 @@ import {
   OUTDENT_CONTENT_COMMAND,
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
+  SELECT_ALL_COMMAND,
 } from 'lexical';
 import caretFromPoint from 'shared/caretFromPoint';
 import {
@@ -986,6 +988,15 @@ export function registerRichText(editor: LexicalEditor): () => void {
             event.preventDefault();
           }
         }
+        return true;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    ),
+    editor.registerCommand(
+      SELECT_ALL_COMMAND,
+      () => {
+        $selectAll();
+
         return true;
       },
       COMMAND_PRIORITY_EDITOR,

--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -95,6 +95,8 @@ export const COPY_COMMAND: LexicalCommand<
 export const CUT_COMMAND: LexicalCommand<
   ClipboardEvent | KeyboardEvent | null
 > = createCommand('CUT_COMMAND');
+export const SELECT_ALL_COMMAND: LexicalCommand<KeyboardEvent> =
+  createCommand('SELECT_ALL_COMMAND');
 export const CLEAR_EDITOR_COMMAND: LexicalCommand<void> = createCommand(
   'CLEAR_EDITOR_COMMAND',
 );

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -64,7 +64,7 @@ import {
   SELECTION_CHANGE_COMMAND,
   UNDO_COMMAND,
 } from '.';
-import {KEY_MODIFIER_COMMAND} from './LexicalCommands';
+import {KEY_MODIFIER_COMMAND, SELECT_ALL_COMMAND} from './LexicalCommands';
 import {
   COMPOSITION_START_CHAR,
   DOM_ELEMENT_TYPE,
@@ -79,7 +79,6 @@ import {
   $getNodeByKey,
   $isSelectionCapturedInDecorator,
   $isTokenOrSegmented,
-  $selectAll,
   $setSelection,
   $shouldInsertTextAfterOrBeforeTextNode,
   $updateSelectedTextFromDOM,
@@ -1018,16 +1017,12 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
         dispatchCommand(editor, CUT_COMMAND, event);
       } else if (isSelectAll(keyCode, metaKey, ctrlKey)) {
         event.preventDefault();
-        editor.update(() => {
-          $selectAll();
-        });
+        dispatchCommand(editor, SELECT_ALL_COMMAND, event);
       }
       // FF does it well (no need to override behavior)
     } else if (!IS_FIREFOX && isSelectAll(keyCode, metaKey, ctrlKey)) {
       event.preventDefault();
-      editor.update(() => {
-        $selectAll();
-      });
+      dispatchCommand(editor, SELECT_ALL_COMMAND, event);
     }
   }
 

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -105,6 +105,7 @@ export {
   PASTE_COMMAND,
   REDO_COMMAND,
   REMOVE_TEXT_COMMAND,
+  SELECT_ALL_COMMAND,
   SELECTION_CHANGE_COMMAND,
   UNDO_COMMAND,
 } from './LexicalCommands';
@@ -149,6 +150,7 @@ export {
   $isLeafNode,
   $isRootOrShadowRoot,
   $nodesOfType,
+  $selectAll,
   $setCompositionKey,
   $setSelection,
   $splitNode,


### PR DESCRIPTION
Move the "select all" behavior from `LexicalEvents` into a new `SELECT_ALL_COMMAND`. This will make overriding the default behavior easier for developers and matches the way that commands like copy, paste, arrow up, etc are handled.

Overriding "select all" is not common, but several applications have introduced context-aware versions of the behavior that are difficult to change with lexical's current implementation. For example, an editor may choose to have the first invocation of `⌘ + a` select the current paragraph and a subsequent `⌘ + a` select the entire document.