### PR TITLE
fix(playground-text-format-toolbar): don't hide toolbar if current node is a paragraph

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -14,6 +14,7 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
 import {
   $getSelection,
+  $isParagraphNode,
   $isRangeSelection,
   $isTextNode,
   COMMAND_PRIORITY_LOW,
@@ -322,7 +323,7 @@ function useFloatingTextFormatToolbar(
         !$isCodeHighlightNode(selection.anchor.getNode()) &&
         selection.getTextContent() !== ''
       ) {
-        setIsText($isTextNode(node));
+        setIsText($isTextNode(node) || $isParagraphNode(node));
       } else {
         setIsText(false);
       }


### PR DESCRIPTION
Improve the toolbar to format text and avoid hiding it unnecessarily

**Before**

https://github.com/facebook/lexical/assets/46543621/399604a8-b6ae-4a42-bf38-e8beba6cbca3

**After**

https://github.com/facebook/lexical/assets/46543621/d1297907-ec54-4ba1-b848-c4cae92af5b0