### PR TITLE
fix editor ref types and use EditorRefPlugin in the playground

### DIFF
--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -31,6 +31,7 @@ import {ClearEditorPlugin} from '@lexical/react/LexicalClearEditorPlugin';
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {LexicalComposer} from '@lexical/react/LexicalComposer';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {EditorRefPlugin} from '@lexical/react/LexicalEditorRefPlugin';
 import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
@@ -117,23 +118,6 @@ function AddCommentBox({
       </button>
     </div>
   );
-}
-
-function EditorRefPlugin({
-  editorRef,
-}: {
-  editorRef: {current: null | LexicalEditor};
-}): null {
-  const [editor] = useLexicalComposerContext();
-
-  useLayoutEffect(() => {
-    editorRef.current = editor;
-    return () => {
-      editorRef.current = null;
-    };
-  }, [editor, editorRef]);
-
-  return null;
 }
 
 function EscapeHandlerPlugin({

--- a/packages/lexical-react/src/LexicalEditorRefPlugin.tsx
+++ b/packages/lexical-react/src/LexicalEditorRefPlugin.tsx
@@ -21,7 +21,9 @@ import * as React from 'react';
 export function EditorRefPlugin({
   editorRef,
 }: {
-  editorRef: React.RefCallback<LexicalEditor> | MutableRefObject<LexicalEditor>;
+  editorRef:
+    | React.RefCallback<LexicalEditor>
+    | MutableRefObject<LexicalEditor | null | undefined>;
 }): null {
   const [editor] = useLexicalComposerContext();
   if (typeof editorRef === 'function') {


### PR DESCRIPTION
Fixes: https://github.com/facebook/lexical/issues/4849
- fix editor ref types
- use EditorRefPlugin in the playground