### PR TITLE
Fix $getSelectionStyleValueForProperty does not return empty string when multiple nodes have style change

### DIFF
--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -538,12 +538,14 @@ export function $getSelectionStyleValueForProperty(
   const endOffset = isBackward ? focus.offset : anchor.offset;
   const endNode = isBackward ? focus.getNode() : anchor.getNode();
 
-  if (selection.style !== '') {
-    const css = selection.style;
-    const styleObject = getStyleObjectFromCSS(css);
+  if (nodes.length === 1) {
+    if (selection.style !== '') {
+      const css = selection.style;
+      const styleObject = getStyleObjectFromCSS(css);
 
-    if (styleObject !== null && styleProperty in styleObject) {
-      return styleObject[styleProperty];
+      if (styleObject !== null && styleProperty in styleObject) {
+        return styleObject[styleProperty];
+      }
     }
   }
 


### PR DESCRIPTION
Fixes issue where if multiple nodes in a selection all have a style change (eg all have font-size, but with different font-size values) `$getSelectionStyleValueForProperty` will return the first nodes style. I think this function should return an empty string if all TextNodes do not have the same value for a css property.

This before video shows when selecting multiple text nodes that have different font-sizes, the font size in the toolbar remains the same (first node selection) value.

https://github.com/facebook/lexical/assets/78441507/47e7e8b4-f4e0-49f8-a255-566d0a03847d

The after video shows the fix in place, where selecting multiple text nodes that have different font-sizes, an empty string is returned from $getSelectionStyleValueForProperty and now the font size in the toolbar is empty:

https://github.com/facebook/lexical/assets/78441507/c38061ff-3495-4b42-84bc-c4be5f3297c5

