### PR TITLE
Quote can be entered in multiple lines

### DIFF
--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
@@ -7,7 +7,7 @@
  */
 
 import {$createQuoteNode} from '@lexical/rich-text';
-import {$getRoot, ParagraphNode} from 'lexical';
+import {$getRoot} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 
 const editorConfig = Object.freeze({
@@ -72,14 +72,6 @@ describe('LexicalQuoteNode tests', () => {
       });
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><blockquote><br></blockquote></div>',
-      );
-      await editor.update(() => {
-        const result = quoteNode.insertNewAfter();
-        expect(result).toBeInstanceOf(ParagraphNode);
-        expect(result.getDirection()).toEqual(quoteNode.getDirection());
-      });
-      expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><blockquote><br></blockquote><p><br></p></div>',
       );
     });
 

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
@@ -7,7 +7,7 @@
  */
 
 import {$createQuoteNode} from '@lexical/rich-text';
-import {$getRoot, ParagraphNode} from 'lexical';
+import {$getRoot} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 
 const editorConfig = Object.freeze({
@@ -65,6 +65,7 @@ describe('LexicalQuoteNode tests', () => {
     test('QuoteNode.insertNewAfter()', async () => {
       const {editor} = testEnv;
       let quoteNode;
+
       await editor.update(() => {
         const root = $getRoot();
         quoteNode = $createQuoteNode();
@@ -72,14 +73,6 @@ describe('LexicalQuoteNode tests', () => {
       });
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><blockquote><br></blockquote></div>',
-      );
-      await editor.update(() => {
-        const result = quoteNode.insertNewAfter();
-        expect(result).toBeInstanceOf(ParagraphNode);
-        expect(result.getDirection()).toEqual(quoteNode.getDirection());
-      });
-      expect(testEnv.outerHTML).toBe(
-        '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><blockquote><br></blockquote><p><br></p></div>',
       );
     });
 

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
@@ -7,7 +7,7 @@
  */
 
 import {$createQuoteNode} from '@lexical/rich-text';
-import {$getRoot} from 'lexical';
+import {$getRoot, ParagraphNode} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 
 const editorConfig = Object.freeze({
@@ -65,7 +65,6 @@ describe('LexicalQuoteNode tests', () => {
     test('QuoteNode.insertNewAfter()', async () => {
       const {editor} = testEnv;
       let quoteNode;
-
       await editor.update(() => {
         const root = $getRoot();
         quoteNode = $createQuoteNode();
@@ -73,6 +72,14 @@ describe('LexicalQuoteNode tests', () => {
       });
       expect(testEnv.outerHTML).toBe(
         '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><blockquote><br></blockquote></div>',
+      );
+      await editor.update(() => {
+        const result = quoteNode.insertNewAfter();
+        expect(result).toBeInstanceOf(ParagraphNode);
+        expect(result.getDirection()).toEqual(quoteNode.getDirection());
+      });
+      expect(testEnv.outerHTML).toBe(
+        '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><blockquote><br></blockquote><p><br></p></div>',
       );
     });
 

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -185,12 +185,29 @@ export class QuoteNode extends ElementNode {
 
   // Mutation
 
-  insertNewAfter(_: RangeSelection, restoreSelection?: boolean): ParagraphNode {
-    const newBlock = $createParagraphNode();
-    const direction = this.getDirection();
-    newBlock.setDirection(direction);
-    this.insertAfter(newBlock, restoreSelection);
-    return newBlock;
+  insertNewAfter(
+    _: RangeSelection,
+    restoreSelection?: boolean,
+  ): null | ParagraphNode {
+    const children = this.getChildren();
+    const childrenLength = children.length;
+
+    if (
+      childrenLength >= 2 &&
+      children[childrenLength - 1].getTextContent() === '\n' &&
+      children[childrenLength - 2].getTextContent() === '\n' &&
+      _.isCollapsed() &&
+      _.anchor.key === this.__key &&
+      _.anchor.offset === childrenLength
+    ) {
+      children[childrenLength - 1].remove();
+      children[childrenLength - 2].remove();
+      const newBlock = $createParagraphNode();
+      this.insertAfter(newBlock, restoreSelection);
+      return newBlock;
+    }
+
+    return null;
   }
 
   collapseAtStart(): true {

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -185,29 +185,12 @@ export class QuoteNode extends ElementNode {
 
   // Mutation
 
-  insertNewAfter(
-    _: RangeSelection,
-    restoreSelection?: boolean,
-  ): null | ParagraphNode {
-    const children = this.getChildren();
-    const childrenLength = children.length;
-
-    if (
-      childrenLength >= 2 &&
-      children[childrenLength - 1].getTextContent() === '\n' &&
-      children[childrenLength - 2].getTextContent() === '\n' &&
-      _.isCollapsed() &&
-      _.anchor.key === this.__key &&
-      _.anchor.offset === childrenLength
-    ) {
-      children[childrenLength - 1].remove();
-      children[childrenLength - 2].remove();
-      const newBlock = $createParagraphNode();
-      this.insertAfter(newBlock, restoreSelection);
-      return newBlock;
-    }
-
-    return null;
+  insertNewAfter(_: RangeSelection, restoreSelection?: boolean): ParagraphNode {
+    const newBlock = $createParagraphNode();
+    const direction = this.getDirection();
+    newBlock.setDirection(direction);
+    this.insertAfter(newBlock, restoreSelection);
+    return newBlock;
   }
 
   collapseAtStart(): true {


### PR DESCRIPTION
## What is the Issue?

### In the quote, click enter to exit the quote, and the quote text cannot be entered in multiple lines

![quote-only-input-one-line](https://github.com/facebook/lexical/assets/135085401/dfe188ba-bd01-45dc-924f-1d14216f5af9)

## Implementing Line Break in Quote Node

![quote-line-break](https://github.com/facebook/lexical/assets/135085401/d88fa2cd-0161-40e0-91b2-a6d98087a15b)

## Additional Information

- In the quote, click enter, and the number of quote lines will increase by one.
- Press two consecutive enters and there are two lines of empty text to exit quote，same as code exit mechanism.