### PR TITLE
Fix: Pressing enter now doesnot delete ImageNode from the ListItemNode

### DIFF
--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -506,7 +506,7 @@ export function $handleListInsertParagraph(): boolean {
   // Only run this code on empty list items
   const anchor = selection.anchor.getNode();
 
-  if (!$isListItemNode(anchor) || anchor.getTextContent() !== '') {
+  if (!$isListItemNode(anchor) || anchor.getChildrenSize() !== 0) {
     return false;
   }
   const topListNode = $getTopListNode(anchor);


### PR DESCRIPTION
Earlier pressing enter unexpectedly deletes the ImageNode from the child of ListItemNode. Now it is fixed.

https://github.com/facebook/lexical/issues/4236


https://github.com/facebook/lexical/assets/63761544/d2403a7b-94cb-4441-8892-d89197264ab9

