### PR TITLE
Handle undefined rows and columns in table utils after cell merge

### DIFF
--- a/packages/lexical-playground/__tests__/regression/4872-full-row-span-cell-merge.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/4872-full-row-span-cell-merge.spec.mjs
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {
+  assertGridSelectionCoordinates,
+  click,
+  focusEditor,
+  initialize,
+  insertTable,
+  mergeTableCells,
+  selectCellsFromTableCords,
+  test,
+} from '../utils/index.mjs';
+
+test.describe('Regression test #4872', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+  test('merging two full rows does not break table selection', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await insertTable(page, 5, 5);
+
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 1},
+      {x: 4, y: 2},
+      true,
+      false,
+    );
+
+    await mergeTableCells(page);
+
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 4},
+      {x: 2, y: 4},
+      false,
+      false,
+    );
+
+    await assertGridSelectionCoordinates(page, {
+      anchor: {x: 1, y: 4},
+      focus: {x: 2, y: 4},
+    });
+  });
+});

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -135,10 +135,12 @@ export class TableNode extends DEPRECATED_GridNode {
       const row = cells[y];
 
       if (row == null) {
-        throw new Error(`Row not found at y:${y}`);
+        continue;
       }
 
-      const x = row.findIndex(({elem}) => {
+      const x = row.findIndex((cell) => {
+        if (!cell) return;
+        const {elem} = cell;
         const cellNode = $getNearestNodeFromDOMNode(elem);
         return cellNode === tableCellNode;
       });

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -49,7 +49,7 @@ export type Cell = {
   y: number;
 };
 
-export type Cells = Array<Array<Cell>>;
+export type Cells = Array<Array<Cell | undefined> | undefined>;
 
 export type Grid = {
   cells: Cells;

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -627,11 +627,12 @@ export function getTableGrid(tableElement: HTMLElement): Grid {
       // @ts-expect-error: internal field
       currentNode._cell = cell;
 
-      if (cells[y] === undefined) {
-        cells[y] = [];
+      let row = cells[y];
+      if (row === undefined) {
+        row = cells[y] = [];
       }
 
-      cells[y][x] = cell;
+      row[x] = cell;
     } else {
       const child = currentNode.firstChild;
 
@@ -707,9 +708,15 @@ export function $forEachGridCell(
 
   for (let y = 0; y < cells.length; y++) {
     const row = cells[y];
+    if (!row) {
+      continue;
+    }
 
     for (let x = 0; x < row.length; x++) {
       const cell = row[x];
+      if (!cell) {
+        continue;
+      }
       const lexicalNode = $getNearestNodeFromDOMNode(cell.elem);
 
       if (lexicalNode !== null) {


### PR DESCRIPTION
Fixes issue: #4872

Changes typing to expect undefined rows and cells and handles this where necessary.

The alternative is to always make sure that row indices are not deleted from grids during i.e. cell merge. That seems like a more fragile solution than just accepting that rows might be deleted. Currently, rows are being deleted leading to an array structure like this:
![image](https://github.com/facebook/lexical/assets/23295934/da0736e3-e6ac-4f40-9aa6-56ad790f81ad)
I don't know where the indices are deleted, but it seems like it is possible to do so without getting caught by the type checking.
That is why I have modified the types to accept that this might happen (and is happening today), which seems more maintainable.

Now the editor does not crash after merging cells spanning multiple full rows, and according to the type checks, it should also be ok in most other cases.

The only downside I can see of using this typing is that it might be more difficult to code some places, as can be seen in LexicalTableSelectionHelpers:630:
```ts
if (cells[y] === undefined) {
    cells[y] = [];
}
cells[y][x] = cell;
```
has to be changed to
```ts
let row = cells[y];
if (row === undefined) {
    row = cells[y] = [];
}
row[x] = cell;
```
because typescript is not able to infer that cells[y] is defined due to the assignment.

Here is a recording of the working example shown in issue #4872:

https://github.com/facebook/lexical/assets/23295934/44666ed8-1733-45f0-a6b8-24111978b195
