### PR TITLE
Table unmerge

### DIFF
--- a/packages/lexical-playground/__tests__/regression/4876-unmerge-cell.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/4876-unmerge-cell.spec.mjs
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {
+  click,
+  expect,
+  focusEditor,
+  initialize,
+  insertTable,
+  mergeTableCells,
+  selectCellsFromTableCords,
+  test,
+  unmergeTableCell,
+} from '../utils/index.mjs';
+
+test.describe('Regression test #4876', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+  test('unmerging cells should add cells to correct rows', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await insertTable(page, 4, 4);
+
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 1},
+      {x: 1, y: 3},
+      true,
+      false,
+    );
+
+    await mergeTableCells(page);
+
+    await unmergeTableCell(page);
+
+    const tableRow = await page.locator('tr');
+    expect(await tableRow.count()).toBe(4);
+    for (let i = 0; i < 4; i++) {
+      const tableCells = tableRow.nth(i).locator('th, td');
+      expect(await tableCells.count()).toBe(4);
+    }
+  });
+});

--- a/packages/lexical-playground/__tests__/regression/4876-unmerge-cell.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/4876-unmerge-cell.spec.mjs
@@ -11,6 +11,7 @@ import {
   focusEditor,
   initialize,
   insertTable,
+  locate,
   mergeTableCells,
   selectCellsFromTableCords,
   test,
@@ -43,7 +44,7 @@ test.describe('Regression test #4876', () => {
 
     await unmergeTableCell(page);
 
-    const tableRow = await page.locator('tr');
+    const tableRow = await locate(page, 'tr');
     expect(await tableRow.count()).toBe(4);
     for (let i = 0; i < 4; i++) {
       const tableCells = tableRow.nth(i).locator('th, td');

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -519,6 +519,14 @@ export async function waitForSelector(page, selector, options) {
   }
 }
 
+export async function locate(page, selector) {
+  let leftFrame = page;
+  if (IS_COLLAB) {
+    leftFrame = await page.frame('left');
+  }
+  return await leftFrame.locator(selector);
+}
+
 export async function selectorBoundingBox(page, selector) {
   let leftFrame = page;
   if (IS_COLLAB) {

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -621,7 +621,7 @@ export function $unmergeCell(): void {
     for (let i = 1; i < rowSpan; i++) {
       const currentRow = startRow + i;
       const currentRowMap = map[currentRow];
-      currentRowNode = row.getNextSibling();
+      currentRowNode = (currentRowNode ?? row).getNextSibling();
       invariant(
         DEPRECATED_$isGridRowNode(currentRowNode),
         'Expected row next sibling to be a row',

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -621,7 +621,7 @@ export function $unmergeCell(): void {
     for (let i = 1; i < rowSpan; i++) {
       const currentRow = startRow + i;
       const currentRowMap = map[currentRow];
-      currentRowNode = (currentRowNode ?? row).getNextSibling();
+      currentRowNode = (currentRowNode || row).getNextSibling();
       invariant(
         DEPRECATED_$isGridRowNode(currentRowNode),
         'Expected row next sibling to be a row',


### PR DESCRIPTION
Fixes #4876

When adding cells to rows when unmerging cells, $unmergeCell used `row.getNextSibling()` with the same row an all iterations  of the row span except the first to get current row node. This resulted in the same row node being used on all iterations.

https://github.com/facebook/lexical/assets/23295934/5f23b3ed-c467-4b55-b595-67bfb3ab2a12

