### PR TITLE
Update editor payload type

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -878,7 +878,7 @@ export class LexicalEditor {
    */
   dispatchCommand<TCommand extends LexicalCommand<unknown>>(
     type: TCommand,
-    payload: CommandPayloadType<TCommand>,
+    payload?: CommandPayloadType<TCommand>,
   ): boolean {
     return dispatchCommand(this, type, payload);
   }

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -702,7 +702,7 @@ export function triggerCommandListeners<
 >(
   editor: LexicalEditor,
   type: TCommand,
-  payload: CommandPayloadType<TCommand>,
+  payload?: CommandPayloadType<TCommand>,
 ): boolean {
   if (editor._updating === false || activeEditor !== editor) {
     let returnVal = false;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1156,7 +1156,7 @@ export function isFirefoxClipboardEvents(editor: LexicalEditor): boolean {
 export function dispatchCommand<TCommand extends LexicalCommand<unknown>>(
   editor: LexicalEditor,
   command: TCommand,
-  payload: CommandPayloadType<TCommand>,
+  payload?: CommandPayloadType<TCommand>,
 ): boolean {
   return triggerCommandListeners(editor, command, payload);
 }


### PR DESCRIPTION
Hello,
Thank you for developing such an excellent framework.

I have a question regarding the use of "dispatchCommand".

I often find myself passing undefined when using dispatchCommand payload.

In fact, the actual playground examples are set up that way too. However, this seems like a cumbersome step every time.

If it's not mandatory to always include undefined, it would be nice if the type could be updated accordingly.

example
```ts
const formatBulletList = () => {
    if (blockType !== "ul") {
      editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
    } else {
      editor.dispatchCommand(REMOVE_LIST_COMMAND, undefined);
    }
    setShowBlockOptionsDropDown(false);
};
```