### PR TITLE
fix: remove revert to previos styles on empty editor click

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -334,7 +334,7 @@ function onSelectionChange(
             selection.format = anchorNode.getFormat();
             selection.style = anchorNode.getStyle();
           } else if (anchor.type === 'element') {
-            selection.format = lastFormat;
+            selection.format = anchorNode.getFormat();
             selection.style = lastStyle;
           }
         }

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -334,7 +334,7 @@ function onSelectionChange(
             selection.format = anchorNode.getFormat();
             selection.style = anchorNode.getStyle();
           } else if (anchor.type === 'element') {
-            selection.format = anchorNode.getFormat();
+            selection.format = lastFormat;
             selection.style = lastStyle;
           }
         }

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -334,8 +334,8 @@ function onSelectionChange(
             selection.format = anchorNode.getFormat();
             selection.style = anchorNode.getStyle();
           } else if (anchor.type === 'element') {
-            selection.format = 0;
-            selection.style = '';
+            selection.format = lastFormat;
+            selection.style = lastStyle;
           }
         }
       } else {

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -323,9 +323,10 @@ function onSelectionChange(
           collapsedSelectionFormat;
 
         if (
-          currentTimeStamp < timeStamp + 200 &&
-          anchor.offset === lastOffset &&
-          anchor.key === lastKey
+          (currentTimeStamp < timeStamp + 200 &&
+            anchor.offset === lastOffset &&
+            anchor.key === lastKey) ||
+          anchor.type === 'element'
         ) {
           selection.format = lastFormat;
           selection.style = lastStyle;
@@ -333,9 +334,6 @@ function onSelectionChange(
           if (anchor.type === 'text') {
             selection.format = anchorNode.getFormat();
             selection.style = anchorNode.getStyle();
-          } else if (anchor.type === 'element') {
-            selection.format = lastFormat;
-            selection.style = lastStyle;
           }
         }
       } else {


### PR DESCRIPTION
Fixes the problem where the styles get reverted when you click on a collapsed selection.

Fix for Issue: [#4908](https://github.com/facebook/lexical/issues/4908)

## The current behavior
![behavior_now](https://github.com/facebook/lexical/assets/59730495/a1c0dfb7-6a90-4bdb-92a1-0fff5113b26b)

## The new expected behavior
![behavior_wanted](https://github.com/facebook/lexical/assets/59730495/4e044ecc-0826-4d4f-838c-9740a1b38079)