### PR TITLE
fix(markdown): escape dollar symbol when doing replacement

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -164,6 +164,9 @@ function exportTextFormat(
     }
   }
 
+  // Escape the dollar symbols to avoid being recognized as replacement patterns,
+  output = output.replaceAll('$', '$$$$');
+
   // Replace trimmed version of textContent ensuring surrounding whitespace is not modified
   return textContent.replace(frozenString, output);
 }

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -92,6 +92,10 @@ describe('Markdown', () => {
       md: '`Hello` world',
     },
     {
+      html: "<p><code><span>H$$el$'lo$</span></code><span> world</span></p>",
+      md: "`H$$el$'lo$` world",
+    },
+    {
       html: '<p><s><span>Hello</span></s><span> world</span></p>',
       md: '~~Hello~~ world',
     },


### PR DESCRIPTION
Fixes #4931 

https://github.com/facebook/lexical/assets/6022672/ed92ec13-674a-4185-932f-d371db469711

