### PR TITLE
fix: respect whitelisted style css attributes on text node when importing AND exporting the DOM

### DIFF
--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -80,11 +80,11 @@ describe('Markdown', () => {
       md: '*Hello* world',
     },
     {
-      html: '<p><b><strong>Hello</strong></b><span> world</span></p>',
+      html: '<p><strong>Hello</strong><span> world</span></p>',
       md: '**Hello** world',
     },
     {
-      html: '<p><i><b><strong>Hello</strong></b></i><span> world</span></p>',
+      html: '<p><i><strong>Hello</strong></i><span> world</span></p>',
       md: '***Hello*** world',
     },
     {
@@ -108,11 +108,11 @@ describe('Markdown', () => {
       md: '[Hello](https://lexical.dev "Title with \\" escaped character") world',
     },
     {
-      html: '<p><span>Hello </span><s><i><b><strong>world</strong></b></i></s><span>!</span></p>',
+      html: '<p><span>Hello </span><s><i><strong>world</strong></i></s><span>!</span></p>',
       md: 'Hello ~~***world***~~!',
     },
     {
-      html: '<p><i><em>Hello </em></i><i><b><strong>world</strong></b></i><i><em>!</em></i></p>',
+      html: '<p><i><em>Hello </em></i><i><strong>world</strong></i><i><em>!</em></i></p>',
       md: '*Hello **world**!*',
     },
     {
@@ -123,19 +123,19 @@ describe('Markdown', () => {
     },
     {
       // Import only: export will use * instead of _ due to registered transformers order
-      html: '<p><b><strong>Hello</strong></b><span> world</span></p>',
+      html: '<p><strong>Hello</strong><span> world</span></p>',
       md: '__Hello__ world',
       skipExport: true,
     },
     {
       // Import only: export will use * instead of _ due to registered transformers order
-      html: '<p><i><b><strong>Hello</strong></b></i><span> world</span></p>',
+      html: '<p><i><strong>Hello</strong></i><span> world</span></p>',
       md: '___Hello___ world',
       skipExport: true,
     },
     {
       // Import only: export will use * instead of _ due to registered transformers order
-      html: '<p><span>Hello </span><s><i><b><strong>world</strong></b></i></s><span>!</span></p>',
+      html: '<p><span>Hello </span><s><i><strong>world</strong></i></s><span>!</span></p>',
       md: 'Hello ~~__*world*__~~!',
       skipExport: true,
     },

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -357,7 +357,7 @@ describe('LexicalEventHelpers', () => {
       const suite = [
         {
           expectedHTML:
-            '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">Get schwifty!</span></p></div>',
+            '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0);" data-lexical-text="true">Get schwifty!</span></p></div>',
           inputs: [
             pasteHTML(
               `<b style="font-weight:normal;" id="docs-internal-guid-2c706577-7fff-f54a-fe65-12f480020fac"><span style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Get schwifty!</span></b>`,
@@ -367,7 +367,7 @@ describe('LexicalEventHelpers', () => {
         },
         {
           expectedHTML:
-            '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><strong class="editor-text-bold" data-lexical-text="true">Get schwifty!</strong></p></div>',
+            '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><strong class="editor-text-bold" style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0);" data-lexical-text="true">Get schwifty!</strong></p></div>',
           inputs: [
             pasteHTML(
               `<b style="font-weight:normal;" id="docs-internal-guid-9db03964-7fff-c26c-8b1e-9484fb3b54a4"><span style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Get schwifty!</span></b>`,
@@ -377,7 +377,7 @@ describe('LexicalEventHelpers', () => {
         },
         {
           expectedHTML:
-            '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><em class="editor-text-italic" data-lexical-text="true">Get schwifty!</em></p></div>',
+            '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><em class="editor-text-italic" style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0);" data-lexical-text="true">Get schwifty!</em></p></div>',
           inputs: [
             pasteHTML(
               `<b style="font-weight:normal;" id="docs-internal-guid-9db03964-7fff-c26c-8b1e-9484fb3b54a4"><span style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:italic;font-variant:normal;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Get schwifty!</span></b>`,
@@ -387,7 +387,7 @@ describe('LexicalEventHelpers', () => {
         },
         {
           expectedHTML:
-            '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span class="editor-text-strikethrough" data-lexical-text="true">Get schwifty!</span></p></div>',
+            '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p class="editor-paragraph" dir="ltr"><span class="editor-text-strikethrough" style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0);" data-lexical-text="true">Get schwifty!</span></p></div>',
           inputs: [
             pasteHTML(
               `<b style="font-weight:normal;" id="docs-internal-guid-9db03964-7fff-c26c-8b1e-9484fb3b54a4"><span style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:line-through;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Get schwifty!</span></b>`,

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
@@ -106,7 +106,7 @@ describe('LexicalTabNode tests', () => {
         $insertDataTransferForRichText(dataTransfer, selection, editor);
       });
       expect(testEnv.innerHTML).toBe(
-        '<p dir="ltr"><span data-lexical-text="true">Hello</span><span data-lexical-text="true">\t</span><span data-lexical-text="true">world</span></p><p dir="ltr"><span data-lexical-text="true">Hello</span><span data-lexical-text="true">\t</span><span data-lexical-text="true">world</span></p>',
+        '<p dir="ltr"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0);" data-lexical-text="true">Hello</span><span data-lexical-text="true">        </span><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0);" data-lexical-text="true">world</span></p><p dir="ltr"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0);" data-lexical-text="true">Hello</span><span data-lexical-text="true">   </span><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0);" data-lexical-text="true">world</span></p>',
       );
     });
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import {$generateHtmlFromNodes,$generateNodesFromDOM} from '@lexical/html';
 import {
   $createParagraphNode,
   $createTextNode,
@@ -797,5 +798,23 @@ describe('LexicalTextNode tests', () => {
     });
 
     expect(getEditorStateTextContent(editor.getEditorState())).toBe('123');
+  });
+
+  test('importDOM()', async () => {
+    const html = `<p><strong style="font-family: Arial;">Hello</strong><span style="color: blue;">World</span></p>`;
+    let generated = '';
+    await update(() => {
+      const nodes = $generateNodesFromDOM(
+        editor,
+        new DOMParser().parseFromString(html, 'text/html'),
+      );
+      $getRoot().clear();
+      $getRoot().append(...nodes);
+      generated = $generateHtmlFromNodes(editor);
+    });
+
+    expect(generated).toBe(
+      `<p><strong class="my-bold-class" style="font-family: Arial;">Hello</strong><span style="color: blue;">World</span></p>`,
+    );
   });
 });


### PR DESCRIPTION
We noticed strange behaviour with `TextNode` that's not easy to pick up on the Lexical playground, because Lexical playground doesn't demonstrate exporting to HTML and then importing that HTML again.

TextNode correctly sets **bold**, _italic_, and other style attributes when it *exports* the DOM, but this is lost if you export/import this HTML

This PR defines a small set of "allowed" CSS style attributes (font-family, color, and float) that should be imported, and exported again, when parsing html (instead of discarding these styles).

Originally we used our own node replacement for this, creating a custom `TextNode` that extended LexicalTextNode, but this lead to strange problems with `@lexical/clipboard`, where (for reasons I haven't been able to figure out) text could not be copied without copying the entire nodes, even if `$isTextNode` returned true for our custom nodes. 

We've applied this same patch on the prototype of the builtin Lexical TextNode to solve our issues, and this PR seeks to get that upstream :)  