### PR TITLE
List node export dom direction

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -10,9 +10,11 @@ import type {ListNode} from './';
 import type {
   DOMConversionMap,
   DOMConversionOutput,
+  DOMExportOutput,
   EditorConfig,
   EditorThemeClasses,
   GridSelection,
+  LexicalEditor,
   LexicalNode,
   NodeKey,
   NodeSelection,
@@ -100,6 +102,19 @@ export class ListItemNode extends ElementNode {
     $setListItemThemeClassNames(dom, config.theme, this);
 
     return false;
+  }
+
+  exportDOM(editor: LexicalEditor): DOMExportOutput {
+    const {element} = super.exportDOM(editor);
+    if (element && isHTMLElement(element)) {
+      const direction = this.getDirection();
+      if (direction) {
+        element.dir = direction;
+      }
+    }
+    return {
+      element,
+    };
   }
 
   static transform(): (node: LexicalNode) => void {

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -150,6 +150,10 @@ export class ListNode extends ElementNode {
       if (this.__listType === 'check') {
         element.setAttribute('__lexicalListType', 'check');
       }
+      const direction = this.getDirection();
+      if (direction) {
+        element.dir = direction;
+      }
     }
     return {
       element,


### PR DESCRIPTION
The list node exported dom is missing `dir` attribute, this PR adds it.