### PR TITLE
Fix: Cannot type composition text if anchor node is tab node

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -20,6 +20,7 @@ import {
 } from 'shared/environment';
 
 import {
+  $createTextNode,
   $getPreviousSelection,
   $getRoot,
   $getSelection,
@@ -27,6 +28,7 @@ import {
   $isNodeSelection,
   $isRangeSelection,
   $isRootNode,
+  $isTabNode,
   $isTextNode,
   $setCompositionKey,
   BLUR_COMMAND,
@@ -495,6 +497,19 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
   ) {
     return;
   } else if (inputType === 'insertCompositionText') {
+    // fix an issue where the compoisition text is not inputted
+    // when the anchor node is a tab node.
+    updateEditor(editor, () => {
+      const selection = $getSelection();
+      if ($isRangeSelection(selection)) {
+        const anchorNode = selection.anchor.getNode();
+        if ($isTabNode(anchorNode)) {
+          const textContent = anchorNode.getTextContent();
+          const textNode = $createTextNode(textContent);
+          anchorNode.replace(textNode);
+        }
+      }
+    });
     return;
   }
 


### PR DESCRIPTION
# Problem Detail

Composition text inputs are ignored when the RangeSelection's anchor node is a `TabNode`. 
This issue seems to be happened as the `TabNode` is a child of `TextNode`.

https://github.com/facebook/lexical/assets/30749436/6d910a9a-1701-44c8-962e-052e94da35e2

This also can lead us to this error:
![스크린샷 2023-08-31 오후 4 37 14](https://github.com/facebook/lexical/assets/30749436/9f5e5cc0-6295-4253-827d-c1bb3af1c932)



# Approaches to solve the issue:
1. Refactor `TabNode` to extend `LexicalNode` (or any other node than `TextNode`)
	- In this case, i don't know what sideEffect will be there, so i exclude it for now.
2. Add `$isTabNode` condition in `$updateTextNodeFromDOMContent` to convert `TabNode` into `TextNode` ([here](https://github.com/facebook/lexical/blob/1fcb3109e2389da0e61652ba24092497f5952886/packages/lexical/src/LexicalUtils.ts#L676C10-L676C10)).
	- this creates another issue where the first letter will not be in the compositional state.
3. In `onBeforeInput` event, if inputType is "insertCompositionText", change the anchor `TabNode` into `TextNode`.

I try the third one in this PR as a tricky hack because i don't fully understand the lexical composition logics.
If there is a better way, I would appreciate if you could suggest.
