### PR TITLE
fix: dispatching undo & redo states for collaboration; fixing up Point.getNode not a function

### DIFF
--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -295,7 +295,6 @@ export function useYjsHistory(
     undoManager.clear();
   }, [undoManager]);
 
-
   // Exposing undo and redo states
   React.useEffect(() => {
     const updateUndoRedoStates = () => {

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -26,6 +26,8 @@ import {
   $getRoot,
   $getSelection,
   BLUR_COMMAND,
+  CAN_REDO_COMMAND,
+  CAN_UNDO_COMMAND,
   COMMAND_PRIORITY_EDITOR,
   FOCUS_COMMAND,
   REDO_COMMAND,
@@ -292,6 +294,30 @@ export function useYjsHistory(
   const clearHistory = useCallback(() => {
     undoManager.clear();
   }, [undoManager]);
+
+
+  // Exposing undo and redo states
+  React.useEffect(() => {
+    const updateUndoRedoStates = () => {
+      editor.dispatchCommand(
+        CAN_UNDO_COMMAND,
+        undoManager.undoStack.length > 0,
+      );
+      editor.dispatchCommand(
+        CAN_REDO_COMMAND,
+        undoManager.redoStack.length > 0,
+      );
+    };
+    undoManager.on('stack-item-added', updateUndoRedoStates);
+    undoManager.on('stack-item-popped', updateUndoRedoStates);
+    undoManager.on('stack-cleared', updateUndoRedoStates);
+    return () => {
+      undoManager.off('stack-item-added', updateUndoRedoStates);
+      undoManager.off('stack-item-popped', updateUndoRedoStates);
+      undoManager.off('stack-cleared', updateUndoRedoStates);
+    };
+  }, [editor, undoManager]);
+
   return clearHistory;
 }
 

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -126,11 +126,14 @@ export function syncYjsChangesToLexical(
             );
             const [start, end] =
               prevOffsetView.getOffsetsFromSelection(prevSelection);
-            const nextSelection = nextOffsetView.createSelectionFromOffsets(
-              start,
-              end,
-              prevOffsetView,
-            );
+            const nextSelection =
+              start >= 0 && end >= 0
+                ? nextOffsetView.createSelectionFromOffsets(
+                    start,
+                    end,
+                    prevOffsetView,
+                  )
+                : null;
 
             if (nextSelection !== null) {
               $setSelection(nextSelection);


### PR DESCRIPTION
Addressing issue: https://github.com/facebook/lexical/issues/4828
Addressing issue: https://github.com/facebook/lexical/issues/4832


Dispatches `CAN_UNDO_COMMAND` & `CAN_REDO_COMMAND` in collaboration mode, mimicking the behaviour from the `HistoryPlugin`

Fixes up selection checking