### PR TITLE
Retain TextNode whitespace on export

### DIFF
--- a/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
@@ -105,7 +105,7 @@ describe('HTML', () => {
       html = $generateHtmlFromNodes(editor, selection);
     });
 
-    expect(html).toBe('<span>World</span>');
+    expect(html).toBe('<span style="white-space: pre-wrap;">World</span>');
   });
 
   test(`[Lexical -> HTML]: Default selection (undefined) should serialize entire editor state`, () => {
@@ -148,6 +148,8 @@ describe('HTML', () => {
       html = $generateHtmlFromNodes(editor);
     });
 
-    expect(html).toBe('<p><span>Hello</span></p><p><span>World</span></p>');
+    expect(html).toBe(
+      '<p><span style="white-space: pre-wrap;">Hello</span></p><p><span style="white-space: pre-wrap;">World</span></p>',
+    );
   });
 });

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -33,135 +33,153 @@ describe('Markdown', () => {
   const URL = 'https://lexical.dev';
 
   const IMPORT_AND_EXPORT: Input = [
-    {html: '<h1><span>Hello world</span></h1>', md: '# Hello world'},
-    {html: '<h2><span>Hello world</span></h2>', md: '## Hello world'},
-    {html: '<h3><span>Hello world</span></h3>', md: '### Hello world'},
-    {html: '<h4><span>Hello world</span></h4>', md: '#### Hello world'},
-    {html: '<h5><span>Hello world</span></h5>', md: '##### Hello world'},
-    {html: '<h6><span>Hello world</span></h6>', md: '###### Hello world'},
+    {
+      html: '<h1><span style="white-space: pre-wrap;">Hello world</span></h1>',
+      md: '# Hello world',
+    },
+    {
+      html: '<h2><span style="white-space: pre-wrap;">Hello world</span></h2>',
+      md: '## Hello world',
+    },
+    {
+      html: '<h3><span style="white-space: pre-wrap;">Hello world</span></h3>',
+      md: '### Hello world',
+    },
+    {
+      html: '<h4><span style="white-space: pre-wrap;">Hello world</span></h4>',
+      md: '#### Hello world',
+    },
+    {
+      html: '<h5><span style="white-space: pre-wrap;">Hello world</span></h5>',
+      md: '##### Hello world',
+    },
+    {
+      html: '<h6><span style="white-space: pre-wrap;">Hello world</span></h6>',
+      md: '###### Hello world',
+    },
     {
       // Multiline paragraphs
-      html: '<p><span>Hello</span><br><span>world</span><br><span>!</span></p>',
+      html: '<p><span style="white-space: pre-wrap;">Hello</span><br><span style="white-space: pre-wrap;">world</span><br><span style="white-space: pre-wrap;">!</span></p>',
       md: ['Hello', 'world', '!'].join('\n'),
     },
     {
-      html: '<blockquote><span>Hello</span><br><span>world!</span></blockquote>',
+      html: '<blockquote><span style="white-space: pre-wrap;">Hello</span><br><span style="white-space: pre-wrap;">world!</span></blockquote>',
       md: '> Hello\n> world!',
     },
     {
       // Miltiline list items
-      html: '<ul><li value="1"><span>Hello</span></li><li value="2"><span>world</span><br><span>!</span><br><span>!</span></li></ul>',
+      html: '<ul><li value="1"><span style="white-space: pre-wrap;">Hello</span></li><li value="2"><span style="white-space: pre-wrap;">world</span><br><span style="white-space: pre-wrap;">!</span><br><span style="white-space: pre-wrap;">!</span></li></ul>',
       md: '- Hello\n- world\n!\n!',
     },
     {
-      html: '<ul><li value="1"><span>Hello</span></li><li value="2"><span>world</span></li></ul>',
+      html: '<ul><li value="1"><span style="white-space: pre-wrap;">Hello</span></li><li value="2"><span style="white-space: pre-wrap;">world</span></li></ul>',
       md: '- Hello\n- world',
     },
     {
-      html: '<ul><li value="1"><span>Level 1</span></li><li value="2"><ul><li value="1"><span>Level 2</span></li><li value="2"><ul><li value="1"><span>Level 3</span></li></ul></li></ul></li></ul><p><span>Hello world</span></p>',
+      html: '<ul><li value="1"><span style="white-space: pre-wrap;">Level 1</span></li><li value="2"><ul><li value="1"><span style="white-space: pre-wrap;">Level 2</span></li><li value="2"><ul><li value="1"><span style="white-space: pre-wrap;">Level 3</span></li></ul></li></ul></li></ul><p><span style="white-space: pre-wrap;">Hello world</span></p>',
       md: '- Level 1\n    - Level 2\n        - Level 3\n\nHello world',
     },
     {
       // Import only: export will use "-" instead of "*"
-      html: '<ul><li value="1"><span>Level 1</span></li><li value="2"><ul><li value="1"><span>Level 2</span></li><li value="2"><ul><li value="1"><span>Level 3</span></li></ul></li></ul></li></ul><p><span>Hello world</span></p>',
+      html: '<ul><li value="1"><span style="white-space: pre-wrap;">Level 1</span></li><li value="2"><ul><li value="1"><span style="white-space: pre-wrap;">Level 2</span></li><li value="2"><ul><li value="1"><span style="white-space: pre-wrap;">Level 3</span></li></ul></li></ul></li></ul><p><span style="white-space: pre-wrap;">Hello world</span></p>',
       md: '* Level 1\n    * Level 2\n        * Level 3\n\nHello world',
       skipExport: true,
     },
     {
-      html: '<ol><li value="1"><span>Hello</span></li><li value="2"><span>world</span></li></ol>',
+      html: '<ol><li value="1"><span style="white-space: pre-wrap;">Hello</span></li><li value="2"><span style="white-space: pre-wrap;">world</span></li></ol>',
       md: '1. Hello\n2. world',
     },
     {
-      html: '<ol start="25"><li value="25"><span>Hello</span></li><li value="26"><span>world</span></li></ol>',
+      html: '<ol start="25"><li value="25"><span style="white-space: pre-wrap;">Hello</span></li><li value="26"><span style="white-space: pre-wrap;">world</span></li></ol>',
       md: '25. Hello\n26. world',
     },
     {
-      html: '<p><i><em>Hello</em></i><span> world</span></p>',
+      html: '<p><i><em style="white-space: pre-wrap;">Hello</em></i><span style="white-space: pre-wrap;"> world</span></p>',
       md: '*Hello* world',
     },
     {
-      html: '<p><b><strong>Hello</strong></b><span> world</span></p>',
+      html: '<p><b><strong style="white-space: pre-wrap;">Hello</strong></b><span style="white-space: pre-wrap;"> world</span></p>',
       md: '**Hello** world',
     },
     {
-      html: '<p><i><b><strong>Hello</strong></b></i><span> world</span></p>',
+      html: '<p><i><b><strong style="white-space: pre-wrap;">Hello</strong></b></i><span style="white-space: pre-wrap;"> world</span></p>',
       md: '***Hello*** world',
     },
     {
-      html: '<p><code spellcheck="false"><span>Hello</span></code><span> world</span></p>',
+      html: '<p><code spellcheck="false" style="white-space: pre-wrap;"><span>Hello</span></code><span style="white-space: pre-wrap;"> world</span></p>',
       md: '`Hello` world',
     },
     {
-      html: '<p><s><span>Hello</span></s><span> world</span></p>',
+      html: '<p><s><span style="white-space: pre-wrap;">Hello</span></s><span style="white-space: pre-wrap;"> world</span></p>',
       md: '~~Hello~~ world',
     },
     {
-      html: '<p><a href="https://lexical.dev"><span>Hello</span></a><span> world</span></p>',
+      html: '<p><a href="https://lexical.dev"><span style="white-space: pre-wrap;">Hello</span></a><span style="white-space: pre-wrap;"> world</span></p>',
       md: '[Hello](https://lexical.dev) world',
     },
     {
-      html: '<p><a href="https://lexical.dev" title="Hello world"><span>Hello</span></a><span> world</span></p>',
+      html: '<p><a href="https://lexical.dev" title="Hello world"><span style="white-space: pre-wrap;">Hello</span></a><span style="white-space: pre-wrap;"> world</span></p>',
       md: '[Hello](https://lexical.dev "Hello world") world',
     },
     {
-      html: '<p><a href="https://lexical.dev" title="Title with \\&quot; escaped character"><span>Hello</span></a><span> world</span></p>',
+      html: '<p><a href="https://lexical.dev" title="Title with \\&quot; escaped character"><span style="white-space: pre-wrap;">Hello</span></a><span style="white-space: pre-wrap;"> world</span></p>',
       md: '[Hello](https://lexical.dev "Title with \\" escaped character") world',
     },
     {
-      html: '<p><span>Hello </span><s><i><b><strong>world</strong></b></i></s><span>!</span></p>',
+      html: '<p><span style="white-space: pre-wrap;">Hello </span><s><i><b><strong style="white-space: pre-wrap;">world</strong></b></i></s><span style="white-space: pre-wrap;">!</span></p>',
       md: 'Hello ~~***world***~~!',
     },
     {
-      html: '<p><i><em>Hello </em></i><i><b><strong>world</strong></b></i><i><em>!</em></i></p>',
+      html: '<p><i><em style="white-space: pre-wrap;">Hello </em></i><i><b><strong style="white-space: pre-wrap;">world</strong></b></i><i><em style="white-space: pre-wrap;">!</em></i></p>',
       md: '*Hello **world**!*',
     },
     {
       // Import only: export will use * instead of _ due to registered transformers order
-      html: '<p><i><em>Hello</em></i><span> world</span></p>',
+      html: '<p><i><em style="white-space: pre-wrap;">Hello</em></i><span style="white-space: pre-wrap;"> world</span></p>',
       md: '_Hello_ world',
       skipExport: true,
     },
     {
       // Import only: export will use * instead of _ due to registered transformers order
-      html: '<p><b><strong>Hello</strong></b><span> world</span></p>',
+      html: '<p><b><strong style="white-space: pre-wrap;">Hello</strong></b><span style="white-space: pre-wrap;"> world</span></p>',
       md: '__Hello__ world',
       skipExport: true,
     },
     {
       // Import only: export will use * instead of _ due to registered transformers order
-      html: '<p><i><b><strong>Hello</strong></b></i><span> world</span></p>',
+      html: '<p><i><b><strong style="white-space: pre-wrap;">Hello</strong></b></i><span style="white-space: pre-wrap;"> world</span></p>',
       md: '___Hello___ world',
       skipExport: true,
     },
     {
       // Import only: export will use * instead of _ due to registered transformers order
-      html: '<p><span>Hello </span><s><i><b><strong>world</strong></b></i></s><span>!</span></p>',
+      html: '<p><span style="white-space: pre-wrap;">Hello </span><s><i><b><strong style="white-space: pre-wrap;">world</strong></b></i></s><span style="white-space: pre-wrap;">!</span></p>',
       md: 'Hello ~~__*world*__~~!',
       skipExport: true,
     },
     {
-      html: '<pre spellcheck="false"><span>Code</span></pre>',
+      html: '<pre spellcheck="false"><span style="white-space: pre-wrap;">Code</span></pre>',
       md: '```\nCode\n```',
     },
     {
-      html: '<pre spellcheck="false"><span>Code</span></pre>',
+      html: '<pre spellcheck="false"><span style="white-space: pre-wrap;">Code</span></pre>',
       md: '```\nCode\n```',
     },
     {
       // Import only: extra empty lines will be removed for export
-      html: '<p><span>Hello</span></p><p><span>world</span></p>',
+      html: '<p><span style="white-space: pre-wrap;">Hello</span></p><p><span style="white-space: pre-wrap;">world</span></p>',
       md: ['Hello', '', '', '', 'world'].join('\n'),
       skipExport: true,
     },
     {
       // Import only: multiline quote will be prefixed with ">" on each line during export
-      html: '<blockquote><span>Hello</span><br><span>world</span><br><span>!</span></blockquote>',
+      html: '<blockquote><span style="white-space: pre-wrap;">Hello</span><br><span style="white-space: pre-wrap;">world</span><br><span style="white-space: pre-wrap;">!</span></blockquote>',
       md: '> Hello\nworld\n!',
       skipExport: true,
     },
     {
       // Import only: ensures that left side of splitText is processed for text match transformers
-      html: '<p><span>Hello </span><a href="https://lexical.dev"><span>world</span></a><span>! Hello </span><mark><span>$world$</span></mark><span>! </span><a href="https://lexical.dev"><span>Hello</span></a><span> world! Hello </span><mark><span>$world$</span></mark><span>!</span></p>',
+      html: '<p><span style="white-space: pre-wrap;">Hello </span><a href="https://lexical.dev"><span style="white-space: pre-wrap;">world</span></a><span style="white-space: pre-wrap;">! Hello </span><mark style="white-space: pre-wrap;"><span>$world$</span></mark><span style="white-space: pre-wrap;">! </span><a href="https://lexical.dev"><span style="white-space: pre-wrap;">Hello</span></a><span style="white-space: pre-wrap;"> world! Hello </span><mark style="white-space: pre-wrap;"><span>$world$</span></mark><span style="white-space: pre-wrap;">!</span></p>',
       md: `Hello [world](${URL})! Hello $world$! [Hello](${URL}) world! Hello $world$!`,
       skipExport: true,
     },

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
@@ -37,21 +37,24 @@ describe('LexicalUtils#splitNode', () => {
   }> = [
     {
       _: 'split paragraph in between two text nodes',
-      expectedHtml: '<p><span>Hello</span></p><p><span>world</span></p>',
+      expectedHtml:
+        '<p><span style="white-space: pre-wrap;">Hello</span></p><p><span style="white-space: pre-wrap;">world</span></p>',
       initialHtml: '<p><span>Hello</span><span>world</span></p>',
       splitOffset: 1,
       splitPath: [0],
     },
     {
       _: 'split paragraph before the first text node',
-      expectedHtml: '<p><br></p><p><span>Hello</span><span>world</span></p>',
+      expectedHtml:
+        '<p><br></p><p><span style="white-space: pre-wrap;">Hello</span><span style="white-space: pre-wrap;">world</span></p>',
       initialHtml: '<p><span>Hello</span><span>world</span></p>',
       splitOffset: 0,
       splitPath: [0],
     },
     {
       _: 'split paragraph after the last text node',
-      expectedHtml: '<p><span>Hello</span><span>world</span></p><p><br></p>',
+      expectedHtml:
+        '<p><span style="white-space: pre-wrap;">Hello</span><span style="white-space: pre-wrap;">world</span></p><p><br></p>',
       initialHtml: '<p><span>Hello</span><span>world</span></p>',
       splitOffset: 2, // Any offset that is higher than children size
       splitPath: [0],
@@ -59,8 +62,8 @@ describe('LexicalUtils#splitNode', () => {
     {
       _: 'split list items between two text nodes',
       expectedHtml:
-        '<ul><li><span>Hello</span></li></ul>' +
-        '<ul><li><span>world</span></li></ul>',
+        '<ul><li><span style="white-space: pre-wrap;">Hello</span></li></ul>' +
+        '<ul><li><span style="white-space: pre-wrap;">world</span></li></ul>',
       initialHtml: '<ul><li><span>Hello</span><span>world</span></li></ul>',
       splitOffset: 1, // Any offset that is higher than children size
       splitPath: [0, 0],
@@ -69,7 +72,7 @@ describe('LexicalUtils#splitNode', () => {
       _: 'split list items before the first text node',
       expectedHtml:
         '<ul><li></li></ul>' +
-        '<ul><li><span>Hello</span><span>world</span></li></ul>',
+        '<ul><li><span style="white-space: pre-wrap;">Hello</span><span style="white-space: pre-wrap;">world</span></li></ul>',
       initialHtml: '<ul><li><span>Hello</span><span>world</span></li></ul>',
       splitOffset: 0, // Any offset that is higher than children size
       splitPath: [0, 0],
@@ -78,12 +81,12 @@ describe('LexicalUtils#splitNode', () => {
       _: 'split nested list items',
       expectedHtml:
         '<ul>' +
-        '<li><span>Before</span></li>' +
-        '<li><ul><li><span>Hello</span></li></ul></li>' +
+        '<li><span style="white-space: pre-wrap;">Before</span></li>' +
+        '<li><ul><li><span style="white-space: pre-wrap;">Hello</span></li></ul></li>' +
         '</ul>' +
         '<ul>' +
-        '<li><ul><li><span>world</span></li></ul></li>' +
-        '<li><span>After</span></li>' +
+        '<li><ul><li><span style="white-space: pre-wrap;">world</span></li></ul></li>' +
+        '<li><span style="white-space: pre-wrap;">After</span></li>' +
         '</ul>',
       initialHtml:
         '<ul>' +

--- a/packages/lexical-utils/src/__tests__/unit/LexlcaiUtilsInsertNodeToNearestRoot.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexlcaiUtilsInsertNodeToNearestRoot.test.tsx
@@ -46,7 +46,7 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
     {
       _: 'insert into paragraph in between two text nodes',
       expectedHtml:
-        '<p><span>Hello</span></p><test-decorator></test-decorator><p><span>world</span></p>',
+        '<p><span style="white-space: pre-wrap;">Hello</span></p><test-decorator></test-decorator><p><span style="white-space: pre-wrap;">world</span></p>',
       initialHtml: '<p><span>Helloworld</span></p>',
       selectionOffset: 5, // Selection on text node after "Hello" world
       selectionPath: [0, 0],
@@ -55,13 +55,13 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
       _: 'insert into nested list items',
       expectedHtml:
         '<ul>' +
-        '<li><span>Before</span></li>' +
-        '<li><ul><li><span>Hello</span></li></ul></li>' +
+        '<li><span style="white-space: pre-wrap;">Before</span></li>' +
+        '<li><ul><li><span style="white-space: pre-wrap;">Hello</span></li></ul></li>' +
         '</ul>' +
         '<test-decorator></test-decorator>' +
         '<ul>' +
-        '<li><ul><li><span>world</span></li></ul></li>' +
-        '<li><span>After</span></li>' +
+        '<li><ul><li><span style="white-space: pre-wrap;">world</span></li></ul></li>' +
+        '<li><span style="white-space: pre-wrap;">After</span></li>' +
         '</ul>',
       initialHtml:
         '<ul>' +
@@ -82,7 +82,7 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
     {
       _: 'insert in the end of paragraph',
       expectedHtml:
-        '<p><span>Hello world</span></p>' +
+        '<p><span style="white-space: pre-wrap;">Hello world</span></p>' +
         '<test-decorator></test-decorator>' +
         '<p><br></p>',
       initialHtml: '<p>Hello world</p>',
@@ -94,7 +94,7 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
       expectedHtml:
         '<p><br></p>' +
         '<test-decorator></test-decorator>' +
-        '<p><span>Hello world</span></p>',
+        '<p><span style="white-space: pre-wrap;">Hello world</span></p>',
       initialHtml: '<p>Hello world</p>',
       selectionOffset: 0, // Selection on text node after "Hello" world
       selectionPath: [0, 0],
@@ -104,8 +104,8 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
       expectedHtml:
         '<test-decorator></test-decorator>' +
         '<test-decorator></test-decorator>' +
-        '<p><span>Before</span></p>' +
-        '<p><span>After</span></p>',
+        '<p><span style="white-space: pre-wrap;">Before</span></p>' +
+        '<p><span style="white-space: pre-wrap;">After</span></p>',
       initialHtml:
         '<test-decorator></test-decorator>' +
         '<p><span>Before</span></p>' +
@@ -116,9 +116,9 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
     {
       _: 'insert with selection on root child',
       expectedHtml:
-        '<p><span>Before</span></p>' +
+        '<p><span style="white-space: pre-wrap;">Before</span></p>' +
         '<test-decorator></test-decorator>' +
-        '<p><span>After</span></p>',
+        '<p><span style="white-space: pre-wrap;">After</span></p>',
       initialHtml: '<p>Before</p><p>After</p>',
       selectionOffset: 1,
       selectionPath: [],
@@ -126,7 +126,8 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
     {
       _: 'insert with selection on root end',
       expectedHtml:
-        '<p><span>Before</span></p>' + '<test-decorator></test-decorator>',
+        '<p><span style="white-space: pre-wrap;">Before</span></p>' +
+        '<test-decorator></test-decorator>',
       initialHtml: '<p>Before</p>',
       selectionOffset: 1,
       selectionPath: [],

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -25,6 +25,7 @@ import type {
   RangeSelection,
 } from '../LexicalSelection';
 
+import {isHTMLElement} from '@lexical/utils';
 import {IS_FIREFOX} from 'shared/environment';
 import invariant from 'shared/invariant';
 
@@ -596,23 +597,25 @@ export class TextNode extends LexicalNode {
   // HTML content and not have the ability to use CSS classes.
   exportDOM(editor: LexicalEditor): DOMExportOutput {
     let {element} = super.exportDOM(editor);
-
+    invariant(
+      element !== null && isHTMLElement(element),
+      'Expected TextNode createDOM to always return a HTMLElement',
+    );
+    element.style.whiteSpace = 'pre-wrap';
     // This is the only way to properly add support for most clients,
     // even if it's semantically incorrect to have to resort to using
     // <b>, <u>, <s>, <i> elements.
-    if (element !== null) {
-      if (this.hasFormat('bold')) {
-        element = wrapElementWith(element, 'b');
-      }
-      if (this.hasFormat('italic')) {
-        element = wrapElementWith(element, 'i');
-      }
-      if (this.hasFormat('strikethrough')) {
-        element = wrapElementWith(element, 's');
-      }
-      if (this.hasFormat('underline')) {
-        element = wrapElementWith(element, 'u');
-      }
+    if (this.hasFormat('bold')) {
+      element = wrapElementWith(element, 'b');
+    }
+    if (this.hasFormat('italic')) {
+      element = wrapElementWith(element, 'i');
+    }
+    if (this.hasFormat('strikethrough')) {
+      element = wrapElementWith(element, 's');
+    }
+    if (this.hasFormat('underline')) {
+      element = wrapElementWith(element, 'u');
     }
 
     return {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -130,5 +130,6 @@
   "128": "TabNode does not support setMode",
   "129": "Expected parentElement of Text not to be null",
   "130": "LexicalNode: Node %s does not match the serialized type. Check if .exportJSON() is implemented and it is returning the correct type.",
-  "131": "Expected to find LexicalNode from Table Cell DOMNode"
+  "131": "Expected to find LexicalNode from Table Cell DOMNode",
+  "132": "Expected TextNode createDOM to always return a HTMLElement"
 }


### PR DESCRIPTION
#4467 introduced an HTML import regression for trailing spaces. The root cause is that our exported HTML is not correct, the whitespaces should never be at the end or should be marked with the white-space property. This diff does the later which is equivalent to the top-most `white-space: pre-wrap`

It also fixes export for these other surfaces that implement whitespace parsing correctly (i.e. Apple Pages):

Before

https://github.com/facebook/lexical/assets/193447/9d5bb067-18f0-419b-b458-f29e84340fa8

After

https://github.com/facebook/lexical/assets/193447/4279c985-08b2-4020-8e7f-db0d204d96f0

Closes https://github.com/facebook/lexical/issues/4919
Closes https://github.com/facebook/lexical/issues/4954