### PR TITLE
Move isHTMLElement into core

### DIFF
--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -23,13 +23,15 @@ import {
   DEPRECATED_$isGridSelection,
   EditorState,
   ElementNode,
+  isHTMLAnchorElement,
+  isHTMLElement,
   Klass,
   LexicalEditor,
   LexicalNode,
 } from 'lexical';
 import invariant from 'shared/invariant';
 
-export {$splitNode};
+export {$splitNode, isHTMLAnchorElement, isHTMLElement};
 
 export type DFSNode = Readonly<{
   depth: number;
@@ -493,23 +495,6 @@ export function $wrapNodeInElement(
   node.replace(elementNode);
   elementNode.append(node);
   return elementNode;
-}
-
-/**
- * @param x - The element being tested
- * @returns Returns true if x is an HTML anchor tag, false otherwise
- */
-export function isHTMLAnchorElement(x: Node): x is HTMLAnchorElement {
-  return isHTMLElement(x) && x.tagName === 'A';
-}
-
-/**
- * @param x - The element being testing
- * @returns Returns true if x is an HTML element, false otherwise.
- */
-export function isHTMLElement(x: Node | EventTarget): x is HTMLElement {
-  // @ts-ignore-next-line - strict check on nodeType here should filter out non-Element EventTarget implementors
-  return x.nodeType === 1;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1573,3 +1573,20 @@ export function $getChildrenRecursively(node: LexicalNode): Array<LexicalNode> {
   }
   return nodes;
 }
+
+/**
+ * @param x - The element being tested
+ * @returns Returns true if x is an HTML anchor tag, false otherwise
+ */
+export function isHTMLAnchorElement(x: Node): x is HTMLAnchorElement {
+  return isHTMLElement(x) && x.tagName === 'A';
+}
+
+/**
+ * @param x - The element being testing
+ * @returns Returns true if x is an HTML element, false otherwise.
+ */
+export function isHTMLElement(x: Node | EventTarget): x is HTMLElement {
+  // @ts-ignore-next-line - strict check on nodeType here should filter out non-Element EventTarget implementors
+  return x.nodeType === 1;
+}

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -155,6 +155,8 @@ export {
   $setSelection,
   $splitNode,
   getNearestEditorFromDOMNode,
+  isHTMLAnchorElement,
+  isHTMLElement,
   isSelectionCapturedInDecoratorInput,
   isSelectionWithinEditor,
 } from './LexicalUtils';

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -19,9 +19,11 @@ import type {
 } from './LexicalElementNode';
 import type {RangeSelection} from 'lexical';
 
-import {isHTMLElement} from '@lexical/utils';
-
-import {$applyNodeReplacement, getCachedClassNameArray} from '../LexicalUtils';
+import {
+  $applyNodeReplacement,
+  getCachedClassNameArray,
+  isHTMLElement,
+} from '../LexicalUtils';
 import {ElementNode} from './LexicalElementNode';
 import {$isTextNode} from './LexicalTextNode';
 

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -25,7 +25,6 @@ import type {
   RangeSelection,
 } from '../LexicalSelection';
 
-import {isHTMLElement} from '@lexical/utils';
 import {IS_FIREFOX} from 'shared/environment';
 import invariant from 'shared/invariant';
 
@@ -65,6 +64,7 @@ import {
   $setCompositionKey,
   getCachedClassNameArray,
   internalMarkSiblingsAsDirty,
+  isHTMLElement,
   toggleTextFormatType,
 } from '../LexicalUtils';
 import {$createLineBreakNode} from './LexicalLineBreakNode';


### PR DESCRIPTION
Adding this dependency onto core adds another 6.9K to core unnecessarily. Since it's just a couple very lightweight functions I'm moving them into core for now while retaining the export onto @lexical/utils for backward compatibility.