### PR TITLE
Fix comment plugin selection rect top position

### DIFF
--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.css
@@ -51,7 +51,7 @@ i.add-comment {
 
 .CommentPlugin_CommentInputBox {
   display: block;
-  position: fixed;
+  position: absolute;
   width: 250px;
   min-height: 80px;
   background-color: #fff;

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -265,7 +265,7 @@ function CommentInputBox({
               container.appendChild(elem);
             }
             const color = '255, 212, 0';
-            const style = `position:absolute;top:${selectionRect.top}px;left:${selectionRect.left}px;height:${selectionRect.height}px;width:${selectionRect.width}px;background-color:rgba(${color}, 0.3);pointer-events:none;z-index:5;`;
+            const style = `position:absolute;top:${selectionRect.top + (window.pageYOffset || document.documentElement.scrollTop)}px;left:${selectionRect.left}px;height:${selectionRect.height}px;width:${selectionRect.width}px;background-color:rgba(${color}, 0.3);pointer-events:none;z-index:5;`;
             elem.style.cssText = style;
           }
           for (let i = elementsLength - 1; i >= selectionRectsLength; i--) {

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -250,7 +250,7 @@ function CommentInputBox({
             correctedLeft = 10;
           }
           boxElem.style.left = `${correctedLeft}px`;
-          boxElem.style.top = `${bottom + 20}px`;
+          boxElem.style.top = `${bottom + 20 + (window.pageYOffset || document.documentElement.scrollTop)}px`;
           const selectionRectsLength = selectionRects.length;
           const {container} = selectionState;
           const elements: Array<HTMLSpanElement> = selectionState.elements;


### PR DESCRIPTION
Reproduction steps:
1. Open the lexical playground
2. Add more content so you can scroll down the page
3. Select some text after scrolling
4. Press the comment icon

Result:
Selection rect is not positioned correctly

Fix:
Take the scroll offset into account