### PR TITLE
Add nodes replacement support for nested composer

### DIFF
--- a/packages/lexical-react/flow/LexicalComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalComposer.js.flow
@@ -12,6 +12,7 @@ import type {
   LexicalEditor,
   LexicalNode,
   EditorState,
+  LexicalNodeReplacement,
 } from 'lexical';
 
 export type InitialEditorStateType =
@@ -24,10 +25,7 @@ export type InitialConfigType = $ReadOnly<{
   editor__DEPRECATED?: LexicalEditor | null,
   editable?: boolean,
   namespace: string,
-  nodes?: $ReadOnlyArray<
-    | Class<LexicalNode>
-    | {replace: Class<LexicalNode>, with: (node: LexicalNode) => LexicalNode},
-  >,
+  nodes?: $ReadOnlyArray<Class<LexicalNode> | LexicalNodeReplacement>,
   theme?: EditorThemeClasses,
   editorState?: InitialEditorStateType,
   onError: (error: Error, editor: LexicalEditor) => void,

--- a/packages/lexical-react/flow/LexicalNestedComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalNestedComposer.js.flow
@@ -7,11 +7,16 @@
  * @flow strict
  */
 
-import type {LexicalEditor, EditorThemeClasses, LexicalNode} from 'lexical';
+import type {
+  LexicalEditor,
+  EditorThemeClasses,
+  LexicalNode,
+  LexicalNodeReplacement,
+} from 'lexical';
 
 declare export function LexicalNestedComposer({
   children: React$Node,
   initialEditor: LexicalEditor,
   initialTheme?: EditorThemeClasses,
-  initialNodes?: $ReadOnlyArray<Class<LexicalNode>>,
+  initialNodes?: $ReadOnlyArray<Class<LexicalNode> | LexicalNodeReplacement>,
 }): React$Node;

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -22,6 +22,7 @@ import {
   Klass,
   LexicalEditor,
   LexicalNode,
+  LexicalNodeReplacement,
 } from 'lexical';
 import {useMemo} from 'react';
 import * as React from 'react';
@@ -39,16 +40,7 @@ export type InitialEditorStateType =
 export type InitialConfigType = Readonly<{
   editor__DEPRECATED?: LexicalEditor | null;
   namespace: string;
-  nodes?: ReadonlyArray<
-    | Klass<LexicalNode>
-    | {
-        replace: Klass<LexicalNode>;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        with: <T extends {new (...args: any): any}>(
-          node: InstanceType<T>,
-        ) => LexicalNode;
-      }
-  >;
+  nodes?: ReadonlyArray<Klass<LexicalNode> | LexicalNodeReplacement>;
   onError: (error: Error, editor: LexicalEditor) => void;
   editable?: boolean;
   theme?: EditorThemeClasses;

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -13,7 +13,13 @@ import {
   createLexicalComposerContext,
   LexicalComposerContext,
 } from '@lexical/react/LexicalComposerContext';
-import {EditorThemeClasses, Klass, LexicalEditor, LexicalNode} from 'lexical';
+import {
+  EditorThemeClasses,
+  Klass,
+  LexicalEditor,
+  LexicalNode,
+  LexicalNodeReplacement,
+} from 'lexical';
 import * as React from 'react';
 import {ReactNode, useContext, useEffect, useMemo, useRef} from 'react';
 import invariant from 'shared/invariant';
@@ -28,7 +34,7 @@ export function LexicalNestedComposer({
   children: ReactNode;
   initialEditor: LexicalEditor;
   initialTheme?: EditorThemeClasses;
-  initialNodes?: ReadonlyArray<Klass<LexicalNode>>;
+  initialNodes?: ReadonlyArray<Klass<LexicalNode> | LexicalNodeReplacement>;
   skipCollabChecks?: true;
 }): JSX.Element {
   const wasCollabPreviouslyReadyRef = useRef(false);
@@ -69,12 +75,21 @@ export function LexicalNestedComposer({
           });
         }
       } else {
-        for (const klass of initialNodes) {
-          const type = klass.getType();
-          initialEditor._nodes.set(type, {
+        for (let klass of initialNodes) {
+          let replace = null;
+          let replaceWithKlass = null;
+
+          if (typeof klass !== 'function') {
+            const options = klass;
+            klass = options.replace;
+            replace = options.with;
+            replaceWithKlass = options.withKlass || null;
+          }
+
+          initialEditor._nodes.set(klass.getType(), {
             klass,
-            replace: null,
-            replaceWithKlass: null,
+            replace,
+            replaceWithKlass,
             transforms: new Set(),
           });
         }

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -272,15 +272,18 @@ export const COMMAND_PRIORITY_NORMAL = 2;
 export const COMMAND_PRIORITY_HIGH = 3;
 export const COMMAND_PRIORITY_CRITICAL = 4;
 
+export type LexicalNodeReplacement = {
+  replace: Class<LexicalNode>,
+  with: (node: LexicalNode) => LexicalNode,
+  withKlass?: Class<LexicalNode>,
+};
+
 declare export function createEditor(editorConfig?: {
   editorState?: EditorState,
   namespace: string,
   theme?: EditorThemeClasses,
   parentEditor?: LexicalEditor,
-  nodes?: $ReadOnlyArray<
-    | Class<LexicalNode>
-    | {replace: Class<LexicalNode>, with: (node: LexicalNode) => LexicalNode},
-  >,
+  nodes?: $ReadOnlyArray<Class<LexicalNode> | LexicalNodeReplacement>,
   onError: (error: Error) => void,
   disableEvents?: boolean,
   editable?: boolean,

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -38,6 +38,7 @@ import {createRef} from 'react';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 
+import {LexicalNodeReplacement} from '../../LexicalEditor';
 import {resetRandomKey} from '../../LexicalUtils';
 
 type TestEnv = {
@@ -468,16 +469,7 @@ export function createTestEditor(
     editorState?: EditorState;
     theme?: EditorThemeClasses;
     parentEditor?: LexicalEditor;
-    nodes?: ReadonlyArray<
-      | Klass<LexicalNode>
-      | {
-          replace: Klass<LexicalNode>;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          with: <T extends {new (...args: any): any}>(
-            node: InstanceType<T>,
-          ) => LexicalNode;
-        }
-    >;
+    nodes?: ReadonlyArray<Klass<LexicalNode> | LexicalNodeReplacement>;
     onError?: (error: Error) => void;
     disableEvents?: boolean;
     readOnly?: boolean;

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -19,6 +19,7 @@ export type {
   Klass,
   LexicalCommand,
   LexicalEditor,
+  LexicalNodeReplacement,
   MutationListener,
   NodeMutation,
   SerializedEditor,


### PR DESCRIPTION
This should allow passing initialNodes to LexicalNestedComposer including node overrides (`replace` & `with`). It also exposes `LexicalNodeReplacement` type 