### PR TITLE
Update setFloatingElemPosition.ts

### DIFF
--- a/packages/lexical-playground/src/utils/setFloatingElemPosition.ts
+++ b/packages/lexical-playground/src/utils/setFloatingElemPosition.ts
@@ -9,7 +9,7 @@ const VERTICAL_GAP = 10;
 const HORIZONTAL_OFFSET = 5;
 
 export function setFloatingElemPosition(
-  targetRect: ClientRect | null,
+  targetRect: DOMRect | null,
   floatingElem: HTMLElement,
   anchorElem: HTMLElement,
   verticalGap: number = VERTICAL_GAP,


### PR DESCRIPTION
'ClientRect' is deprecated.ts(6385)
lib.dom.d.ts(5622, 5): The declaration was marked as deprecated here.

```
/** @deprecated */
interface ClientRect extends DOMRect {
}
```

Replaced with DOMRect