### PR TITLE
fix(lexical-html): allow dom to be passed to generateHtmlFromNodes

### DIFF
--- a/packages/lexical-headless/src/index.ts
+++ b/packages/lexical-headless/src/index.ts
@@ -13,7 +13,7 @@ import {createEditor} from 'lexical';
 
 /**
  * Generates a headless editor that allows lexical to be used without the need for a DOM, eg in Node.js.
- * Throws an error when unsupported metehods are used.
+ * Throws an error when unsupported methods are used.
  * @param editorConfig - The optional lexical editor configuration.
  * @returns - The configured headless editor.
  */

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -52,14 +52,15 @@ export function $generateNodesFromDOM(
 export function $generateHtmlFromNodes(
   editor: LexicalEditor,
   selection?: RangeSelection | NodeSelection | GridSelection | null,
+  dom?: Document,
 ): string {
-  if (typeof document === 'undefined' || typeof window === 'undefined') {
+  if (typeof document === 'undefined' && !dom) {
     throw new Error(
-      'To use $generateHtmlFromNodes in headless mode please initialize a headless browser implementation such as JSDom before calling this function.',
+      'To use $generateHtmlFromNodes in headless mode please initialize a headless browser implementation such as JSDom and pass the document as the third argument.',
     );
   }
 
-  const container = document.createElement('div');
+  const container = (dom ?? document).createElement('div');
   const root = $getRoot();
   const topLevelChildren = root.getChildren();
 


### PR DESCRIPTION
This solves using this method in Next.js for example, that does not handle JSDOM well when on the server side. 

issue #3616 & #3097