### PR TITLE
Update clipboard.ts

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -232,8 +232,8 @@ function $basicInsertStrategy(
   selection: RangeSelection | GridSelection,
 ) {
   // Wrap text and inline nodes in paragraph nodes so we have all blocks at the top-level
-  const topLevelBlocks = [];
-  let currentBlock = null;
+  const topLevelBlocks = [] as LexicalNode[];
+  let currentBlock: LexicalNode | null = null;
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
 
@@ -545,19 +545,19 @@ export function $generateJSONFromSelectedNodes<
 export function $generateNodesFromSerializedNodes(
   serializedNodes: Array<BaseSerializedNode>,
 ): Array<LexicalNode> {
-  const nodes = [];
+  const nodes = [] as Array<LexicalNode>;
   for (let i = 0; i < serializedNodes.length; i++) {
     const serializedNode = serializedNodes[i];
     const node = $parseSerializedNode(serializedNode);
     if ($isTextNode(node)) {
       $addNodeStyle(node);
-    }
+    } // currently typescript is reading nodes as never. Adding the type assertion as Array<LexicalNode> takes care of the error.     
     nodes.push(node);
   }
   return nodes;
 }
 
-const EVENT_LATENCY = 50;
+const EVENT_LATENCY = 50;        
 let clipboardEventTimeout: null | number = null;
 
 // TODO custom selection

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -545,7 +545,7 @@ export function $generateJSONFromSelectedNodes<
 export function $generateNodesFromSerializedNodes(
   serializedNodes: Array<BaseSerializedNode>,
 ): Array<LexicalNode> {
-  const nodes = [] as Array<LexicalNode>;
+  const nodes: Array<LexicalNode> = [];
   for (let i = 0; i < serializedNodes.length; i++) {
     const serializedNode = serializedNodes[i];
     const node = $parseSerializedNode(serializedNode);

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -232,7 +232,7 @@ function $basicInsertStrategy(
   selection: RangeSelection | GridSelection,
 ) {
   // Wrap text and inline nodes in paragraph nodes so we have all blocks at the top-level
-  const topLevelBlocks = [] as LexicalNode[];
+  const topLevelBlocks: Array<LexicalNode> = [];
   let currentBlock: LexicalNode | null = null;
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];


### PR DESCRIPTION
Fixed a couple typescript errors where the types were not defined so typescript read the array as never.

> currently typescript is reading nodes as never. Adding the type assertion as Array<LexicalNode> takes care of the error.