### PR TITLE
Allow LexicalTypeaheadMenuPlugin to work when inside an iframe

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -46,7 +46,7 @@ function getTextUpToAnchor(selection: RangeSelection): string | null {
 }
 
 function tryToPositionRange(leadOffset: number, range: Range, editorWindow: Window): boolean {
-  const domSelection = _window.getSelection();
+  const domSelection = editorWindow.getSelection();
   if (domSelection === null || !domSelection.isCollapsed) {
     return false;
   }
@@ -236,8 +236,8 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
   useEffect(() => {
     const updateListener = () => {
       editor.getEditorState().read(() => {
-        const _window = editor._window ?? window;
-        const range = _window.document.createRange();
+        const editorWindow = editor._window ?? window;
+        const range = editorWindow.document.createRange();
         const selection = $getSelection();
         const text = getQueryTextForSearch(editor);
 
@@ -258,7 +258,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
           match !== null &&
           !isSelectionOnEntityBoundary(editor, match.leadOffset)
         ) {
-          const isRangePositioned = tryToPositionRange(match.leadOffset, range, _window);
+          const isRangePositioned = tryToPositionRange(match.leadOffset, range, editorWindow);
           if (isRangePositioned !== null) {
             startTransition(() =>
               openTypeahead({

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -45,7 +45,7 @@ function getTextUpToAnchor(selection: RangeSelection): string | null {
   return anchorNode.getTextContent().slice(0, anchorOffset);
 }
 
-function tryToPositionRange(leadOffset: number, range: Range, _window: Window): boolean {
+function tryToPositionRange(leadOffset: number, range: Range, editorWindow: Window): boolean {
   const domSelection = _window.getSelection();
   if (domSelection === null || !domSelection.isCollapsed) {
     return false;

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -45,8 +45,8 @@ function getTextUpToAnchor(selection: RangeSelection): string | null {
   return anchorNode.getTextContent().slice(0, anchorOffset);
 }
 
-function tryToPositionRange(leadOffset: number, range: Range): boolean {
-  const domSelection = window.getSelection();
+function tryToPositionRange(leadOffset: number, range: Range, _window: Window): boolean {
+  const domSelection = _window.getSelection();
   if (domSelection === null || !domSelection.isCollapsed) {
     return false;
   }
@@ -236,7 +236,8 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
   useEffect(() => {
     const updateListener = () => {
       editor.getEditorState().read(() => {
-        const range = document.createRange();
+        const _window = editor._window ?? window;
+        const range = _window.document.createRange();
         const selection = $getSelection();
         const text = getQueryTextForSearch(editor);
 
@@ -257,7 +258,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
           match !== null &&
           !isSelectionOnEntityBoundary(editor, match.leadOffset)
         ) {
-          const isRangePositioned = tryToPositionRange(match.leadOffset, range);
+          const isRangePositioned = tryToPositionRange(match.leadOffset, range, _window);
           if (isRangePositioned !== null) {
             startTransition(() =>
               openTypeahead({


### PR DESCRIPTION
Hi Lexical team, I'm making some changes to the `LexicalTypeaheadMenuPlugin` such that when we're using the ContentEditable in an iframe but rendering the dropdown menu of the typeahead outside (iframe's parent), we'll still calculate the position of the dropdown menu correctly.