### PR TITLE
Transpile optional catch binding

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,14 +14,13 @@ module.exports = {
       require('./scripts/error-codes/transform-error-messages'),
       {noMinify: true},
     ],
+    '@babel/plugin-proposal-optional-catch-binding',
   ],
   presets: [
     [
       '@babel/preset-env',
       {
-        targets: {
-          node: 'current',
-        },
+        targets: 'es2019',
       },
     ],
     '@babel/preset-react',

--- a/babel.config.js
+++ b/babel.config.js
@@ -19,7 +19,9 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        node: 'current',
+        targets: {
+          node: 'current',
+        },
       },
     ],
     '@babel/preset-react',

--- a/babel.config.js
+++ b/babel.config.js
@@ -14,13 +14,12 @@ module.exports = {
       require('./scripts/error-codes/transform-error-messages'),
       {noMinify: true},
     ],
-    '@babel/plugin-proposal-optional-catch-binding',
   ],
   presets: [
     [
       '@babel/preset-env',
       {
-        targets: 'es2019',
+        node: 'current',
       },
     ],
     '@babel/preset-react',

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
         "@babel/preset-flow": "^7.14.5",
         "@babel/preset-react": "^7.14.5",
         "@babel/preset-typescript": "^7.16.7",
@@ -999,6 +1000,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.18.6.tgz",
       "integrity": "sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
+        "@babel/plugin-transform-optional-catch-binding": "^7.22.11",
         "@babel/preset-flow": "^7.14.5",
         "@babel/preset-react": "^7.14.5",
         "@babel/preset-typescript": "^7.16.7",
@@ -663,9 +663,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1701,6 +1701,22 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/helper-replace-supers": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.22.11.tgz",
+      "integrity": "sha512-rli0WxesXUeCJnMYhzAglEjLWVDF6ahb45HuprcmQuLidBJFWjNnOzssk2kuc6e33FlLaiZhG/kUIzUMWdBKaQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -24439,9 +24455,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw=="
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg=="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.18.6",
@@ -25116,6 +25132,16 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/helper-replace-supers": "^7.18.6"
+      }
+    },
+    "@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.22.11.tgz",
+      "integrity": "sha512-rli0WxesXUeCJnMYhzAglEjLWVDF6ahb45HuprcmQuLidBJFWjNnOzssk2kuc6e33FlLaiZhG/kUIzUMWdBKaQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       }
     },
     "@babel/plugin-transform-parameters": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
+    "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
     "@babel/preset-flow": "^7.14.5",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
-    "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
+    "@babel/plugin-transform-optional-catch-binding": "^7.22.11",
     "@babel/preset-flow": "^7.14.5",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.16.7",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -204,7 +204,7 @@ async function build(name, inputFile, outputPath, outputFile, isProd) {
             require('./error-codes/transform-error-messages'),
             {noMinify: !isProd},
           ],
-          '@babel/plugin-proposal-optional-catch-binding',
+          '@babel/plugin-transform-optional-catch-binding',
         ],
         presets: [
           [

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -204,6 +204,7 @@ async function build(name, inputFile, outputPath, outputFile, isProd) {
             require('./error-codes/transform-error-messages'),
             {noMinify: !isProd},
           ],
+          '@babel/plugin-proposal-optional-catch-binding',
         ],
         presets: [
           [


### PR DESCRIPTION
My understanding is that `"target": "ES2019",` should do the trick, but it doesn't.

This additional babel config does it but unsure why I need to import separately..

Closes https://github.com/facebook/lexical/issues/5037

<img width="651" alt="Screenshot 2023-09-25 at 3 56 53 PM" src="https://github.com/facebook/lexical/assets/193447/e401016b-7c7c-471b-ac05-566adbfb0af0">

