### PR TITLE
fix : Add column shortcut gets hidden when mouse leave the table #4857

### DIFF
--- a/packages/lexical-playground/src/nodes/TableComponent.tsx
+++ b/packages/lexical-playground/src/nodes/TableComponent.tsx
@@ -1717,10 +1717,10 @@ export default function TableComponent({
 
   return (
     <div
-    style={{
-      position: 'relative',
-      width: (tableRef.current?.clientWidth || 0) + 'px',
-    }}>
+      style={{
+        position: 'relative',
+        width: (tableRef.current?.offsetWidth || 0) + 'px',
+      }}>
       <table
         className={`${theme.table} ${isSelected ? theme.tableSelected : ''}`}
         ref={tableRef}

--- a/packages/lexical-playground/src/nodes/TableComponent.tsx
+++ b/packages/lexical-playground/src/nodes/TableComponent.tsx
@@ -1716,7 +1716,11 @@ export default function TableComponent({
   }
 
   return (
-    <div style={{position: 'relative'}}>
+    <div
+    style={{
+      position: 'relative',
+      width: (tableRef.current?.clientWidth || 0) + 'px',
+    }}>
       <table
         className={`${theme.table} ${isSelected ? theme.tableSelected : ''}`}
         ref={tableRef}

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -187,7 +187,7 @@
   width: 20px;
   background-color: #eee;
   height: 100%;
-  right: 0;
+  right: -25px;
   animation: table-controls 0.2s ease;
   border: 0;
   cursor: pointer;


### PR DESCRIPTION
Though the feature is experimental, incase if you need a fix for this, kindly check out the PR. Please close them if its not necessary. 

 https://github.com/facebook/lexical/issues/4857#issuecomment-1664242477
 
Before Fix:

https://github.com/facebook/lexical/assets/21175404/54834861-7d0f-4dec-8e06-bca5ff25db64


After Fix:

https://github.com/facebook/lexical/assets/21175404/d53c9548-12b6-4078-910b-8e8929b07975

