### PR TITLE
Fix tab replacement composition crash

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -73,7 +73,7 @@ import {
   scrollIntoViewIfNeeded,
   toggleTextFormatType,
 } from './LexicalUtils';
-import {$createTabNode} from './nodes/LexicalTabNode';
+import {$createTabNode, $isTabNode} from './nodes/LexicalTabNode';
 
 export type TextPointType = {
   _selection: RangeSelection | GridSelection;
@@ -1205,6 +1205,15 @@ export class RangeSelection implements BaseSelection {
           }
           return;
         }
+      } else if ($isTabNode(firstNode)) {
+        // We don't need to check for delCount because there is only the entire selected node case
+        // that can hit here for content size 1 and with canInsertTextBeforeAfter false
+        const textNode = $createTextNode(text);
+        textNode.setFormat(format);
+        textNode.setStyle(style);
+        textNode.select();
+        firstNode.replace(textNode);
+        return;
       }
       const delCount = endOffset - startOffset;
 

--- a/packages/lexical/src/nodes/LexicalTabNode.ts
+++ b/packages/lexical/src/nodes/LexicalTabNode.ts
@@ -65,6 +65,15 @@ export class TabNode extends TextNode {
     invariant(false, 'TabNode does not support setTextContent');
   }
 
+  spliceText(
+    _offset: number,
+    _delCount: number,
+    _newText: string,
+    _moveSelection?: boolean | undefined,
+  ): TextNode {
+    invariant(false, 'TabNode does not support spliceText');
+  }
+
   setDetail(_detail: TextDetailType | number): this {
     invariant(false, 'TabNode does not support setDetail');
   }


### PR DESCRIPTION
Composition on the entire node was hitting the "reuse" this same node part to render the new content (`firstNode.spliceText(startOffset, delCount, text, true);`). While it's a very optimal path that doesn't recreate the node and works well with composition tab node content should always strictly be `\n`. This PR forces it to recreate a new node, just like we do with token node, segmented, or other formatting edge cases.

This PR isn't ideal, the solution comes down to finding a generic solution for this issue: https://github.com/facebook/lexical/issues/5065

Chrome:
Works fairly well except that the cursor is not updated but it's a nit and doesn't affect functionality (the same functionality resembles if you select a range that includes plain text and bold)

https://github.com/facebook/lexical/assets/193447/42a688db-11de-41b7-a724-e5e90085a11f

Firefox and Safari:
Adds an additional space in the beginning, likely because of different DOM nodes and some browser magic.

https://github.com/facebook/lexical/assets/193447/6c7b5e26-43eb-42d1-8b6d-95ee3f0fe50b


