### PR TITLE
chore: add typedefs for collab nodes and remove unused members

### DIFF
--- a/packages/lexical-yjs/src/CollabDecoratorNode.ts
+++ b/packages/lexical-yjs/src/CollabDecoratorNode.ts
@@ -21,14 +21,12 @@ export class CollabDecoratorNode {
   _key: NodeKey;
   _parent: CollabElementNode;
   _type: string;
-  _unobservers: Set<() => void>;
 
   constructor(xmlElem: XmlElement, parent: CollabElementNode, type: string) {
     this._key = '';
     this._xmlElem = xmlElem;
     this._parent = parent;
     this._type = type;
-    this._unobservers = new Set();
   }
 
   getPrevNode(nodeMap: null | NodeMap): null | DecoratorNode<unknown> {
@@ -98,8 +96,6 @@ export class CollabDecoratorNode {
   destroy(binding: Binding): void {
     const collabNodeMap = binding.collabNodeMap;
     collabNodeMap.delete(this._key);
-    this._unobservers.forEach((unobserver) => unobserver());
-    this._unobservers.clear();
   }
 }
 
@@ -109,7 +105,6 @@ export function $createCollabDecoratorNode(
   type: string,
 ): CollabDecoratorNode {
   const collabNode = new CollabDecoratorNode(xmlElem, parent, type);
-  // @ts-expect-error: internal field
   xmlElem._collabNode = collabNode;
   return collabNode;
 }

--- a/packages/lexical-yjs/src/CollabElementNode.ts
+++ b/packages/lexical-yjs/src/CollabElementNode.ts
@@ -662,7 +662,6 @@ export function $createCollabElementNode(
   type: string,
 ): CollabElementNode {
   const collabNode = new CollabElementNode(xmlText, parent, type);
-  // @ts-expect-error: internal field
   xmlText._collabNode = collabNode;
   return collabNode;
 }

--- a/packages/lexical-yjs/src/CollabLineBreakNode.ts
+++ b/packages/lexical-yjs/src/CollabLineBreakNode.ts
@@ -63,7 +63,6 @@ export function $createCollabLineBreakNode(
   parent: CollabElementNode,
 ): CollabLineBreakNode {
   const collabNode = new CollabLineBreakNode(map, parent);
-  // @ts-expect-error: internal field
   map._collabNode = collabNode;
   return collabNode;
 }

--- a/packages/lexical-yjs/src/CollabTextNode.ts
+++ b/packages/lexical-yjs/src/CollabTextNode.ts
@@ -173,7 +173,6 @@ export function $createCollabTextNode(
   type: string,
 ): CollabTextNode {
   const collabNode = new CollabTextNode(map, text, parent, type);
-  // @ts-expect-error: internal field
   map._collabNode = collabNode;
   return collabNode;
 }

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -180,7 +180,6 @@ export function getOrInitCollabNodeFromSharedType(
   | CollabTextNode
   | CollabLineBreakNode
   | CollabDecoratorNode {
-  // @ts-expect-error: internal field
   const collabNode = sharedType._collabNode;
 
   if (collabNode === undefined) {

--- a/packages/lexical-yjs/types.ts
+++ b/packages/lexical-yjs/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {CollabDecoratorNode} from './src/CollabDecoratorNode';
+import {CollabElementNode} from './src/CollabElementNode';
+import {CollabLineBreakNode} from './src/CollabLineBreakNode';
+import {CollabTextNode} from './src/CollabTextNode';
+
+declare module 'yjs' {
+  interface XmlElement {
+    _collabNode: CollabDecoratorNode;
+  }
+
+  interface XmlText {
+    _collabNode: CollabElementNode;
+  }
+}
+
+declare module 'yjs/dist/src/internals' {
+  // @ts-ignore
+  interface YMap {
+    _collabNode: CollabLineBreakNode | CollabTextNode;
+  }
+}


### PR DESCRIPTION
Augment typedefs for yjs (collab nodes), and removed unused `_unobservers` member from the collab decorator node