### PR TITLE
fix(markdown/export): transform text content before wrapping in a link

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -343,18 +343,22 @@ export const LINK: TextMatchTransformer = {
     if (!$isLinkNode(node)) {
       return null;
     }
-    const title = node.getTitle();
-    const linkContent = title
-      ? `[${node.getTextContent()}](${node.getURL()} "${title}")`
-      : `[${node.getTextContent()}](${node.getURL()})`;
+
     const firstChild = node.getFirstChild();
+    let textContent = node.getTextContent();
+
     // Add text styles only if link has single text node inside. If it's more
     // then one we ignore it as markdown does not support nested styles for links
     if (node.getChildrenSize() === 1 && $isTextNode(firstChild)) {
-      return exportFormat(firstChild, linkContent);
-    } else {
-      return linkContent;
+      textContent = exportFormat(firstChild, textContent);
     }
+
+    const title = node.getTitle();
+    const url = node.getURL();
+
+    return title
+      ? `[${textContent}](${url} "${title}")`
+      : `[${textContent}](${url})`;
   },
   importRegExp:
     /(?:\[([^[]+)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))/,

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -126,6 +126,11 @@ describe('Markdown', () => {
       md: '[Hello](https://lexical.dev "Title with \\" escaped character") world',
     },
     {
+      html: '<p><a href="https://lexical.dev"><code>Hello</code></a><span style="white-space: pre-wrap;"> world</span></p>',
+      md: '[`Hello`](https://lexical.dev) world',
+      skipImport: true,
+    },
+    {
       html: '<p><span style="white-space: pre-wrap;">Hello </span><s><i><b><strong style="white-space: pre-wrap;">world</strong></b></i></s><span style="white-space: pre-wrap;">!</span></p>',
       md: 'Hello ~~***world***~~!',
     },


### PR DESCRIPTION
Currently, the link transformer incorrectly applies text format transformations after wrapping the content inside a link. For example:

```markdown
<a href="https://test.com"><code>link</code></a>

// Current
=> `[link](https://test.com)`

// Expected
=> [`link`](https://test.com)
```

This PR fixes the transformation order so that we can generate a valid markdown.

I'm not sure how to handle the import transformer here since the text format transformers can't be accessed inside the `replace()` function. Any suggestions will be greatly appreciated!