### PR TITLE
fix: fix android backspace bug

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -515,6 +515,12 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
 
       if ($isRangeSelection(selection)) {
         // Used for handling backspace in Android.
+        const isAndroidDevice = !!navigator.userAgent.match(/Android/i);
+
+        if (isAndroidDevice) {
+          $setCompositionKey(selection.anchor.key);
+        }
+
         if (
           isPossiblyAndroidKeyPress(event.timeStamp) &&
           editor.isComposing() &&

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -13,6 +13,7 @@ import type {TextNode} from './nodes/LexicalTextNode';
 
 import {
   CAN_USE_BEFORE_INPUT,
+  IS_ANDROID,
   IS_APPLE_WEBKIT,
   IS_FIREFOX,
   IS_IOS,
@@ -515,9 +516,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
 
       if ($isRangeSelection(selection)) {
         // Used for handling backspace in Android.
-        const isAndroidDevice = !!navigator.userAgent.match(/Android/i);
-
-        if (isAndroidDevice) {
+        if (IS_ANDROID) {
           $setCompositionKey(selection.anchor.key);
         }
 

--- a/packages/shared/src/environment.ts
+++ b/packages/shared/src/environment.ts
@@ -40,6 +40,9 @@ export const IS_IOS: boolean =
   /iPad|iPhone|iPod/.test(navigator.userAgent) &&
   !window.MSStream;
 
+export const IS_ANDROID: boolean =
+  CAN_USE_DOM && /Android/.test(navigator.userAgent);
+
 // Keep these in case we need to use them in the future.
 // export const IS_WINDOWS: boolean = CAN_USE_DOM && /Win/.test(navigator.platform);
 export const IS_CHROME: boolean =


### PR DESCRIPTION
**Context:**

When this [line](https://github.com/facebook/lexical/blob/main/packages/lexical/src/LexicalEvents.ts#L520) `editor.isComposing()` is evaluated, the value returned is always `false`, so the code within the `if` is not executed and continues to the `else`.

This causes deleting a character on an Android device to delete the character on the right.

I was testing a bit and giving a value to the `_compositionKey` property fixes it.

I don't know if it's the best solution, but this could help or be a guide.

**Issue:** https://github.com/facebook/lexical/issues/4340

**Evidence:** https://www.loom.com/share/24898783cffd4023bf85460966702898

