### PR TITLE
Set up GA4 for website

### DIFF
--- a/packages/lexical-website/docusaurus.config.js
+++ b/packages/lexical-website/docusaurus.config.js
@@ -89,6 +89,9 @@ const config = {
           remarkPlugins: [importPlugin],
           sidebarPath: require.resolve('./sidebars.js'),
         },
+        gtag: {
+          trackingID: 'G-7C6YYBYBBT',
+        },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },


### PR DESCRIPTION
Summary:
This was never set up. It's easy enough and we should have some analytics.

Test Plan:
`npm run build` & diff before & after output. The only change was adding the gtag code.