### PR TITLE
Fix getting style via $getSelectionStyleValueForProperty when selection is collapsed

### DIFF
--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -538,7 +538,7 @@ export function $getSelectionStyleValueForProperty(
   const endOffset = isBackward ? focus.offset : anchor.offset;
   const endNode = isBackward ? focus.getNode() : anchor.getNode();
 
-  if (selection.style !== '') {
+  if (selection.isCollapsed() && selection.style !== '') {
     const css = selection.style;
     const styleObject = getStyleObjectFromCSS(css);
 


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/4491

**Note:** This PR focuses on a fix inside `$getSelectionStyleValueForProperty` and **not** on the RangeSelection style property (which I believe should be a long-term fix).

## Context:

`style` property on the RangeSelection was implemented in https://github.com/facebook/lexical/pull/3863

however, it was not implemented for the case when selection is **not** collapsed

https://github.com/facebook/lexical/blob/c09ab7314fba32f0246a24df35c5d64061541978/packages/lexical/src/LexicalEvents.ts#L306-L350

Since `$getSelectionStyleValueForProperty` relies on this property, it does not return the correct value in cases when the selection is not collapsed.

### Problem
This method is often used for reflecting current values on toolbars, but it does not work in half (range selection) cases.
