### PR TITLE
MarkdownExport: fix export for overlapping styles

### DIFF
--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -130,8 +130,12 @@ describe('Markdown', () => {
       md: 'Hello ~~***world***~~!',
     },
     {
-      html: '<p><i><em style="white-space: pre-wrap;">Hello </em></i><i><b><strong style="white-space: pre-wrap;">world</strong></b></i><i><em style="white-space: pre-wrap;">!</em></i></p>',
-      md: '*Hello **world**!*',
+      html: '<p><i><em style="white-space: pre-wrap;">Hello</em></i><span style="white-space: pre-wrap;"> </span><i><b><strong style="white-space: pre-wrap;">world</strong></b></i><i><em style="white-space: pre-wrap;">!</em></i></p>',
+      md: '*Hello* ***world****!*',
+    },
+    {
+      html: '<p><span style="white-space: pre-wrap;">he</span><b><strong style="white-space: pre-wrap;">llo</strong></b><i><b><strong style="white-space: pre-wrap;">wor</strong></b></i><i><em style="white-space: pre-wrap;">ld</em></i><span style="white-space: pre-wrap;">!</span></p>',
+      md: 'he**llo*****wor****ld*!',
     },
     {
       // Import only: export will use * instead of _ due to registered transformers order


### PR DESCRIPTION
Previously, exporting text with "layered" formats resulted in layered
markdown. For example, this string:

     root
      └ (53) paragraph
        ├ (48) text  "he"
        ├ (49) text  "llo" { format: bold }
        ├ (50) text  "wor" { format: bold, italic }
        ├ (51) text  "ld" { format: italic }
    >   └ (52) text  "!"

Would be exported like this:

    he**llo*wor**ld*!

The export incrementally applied the italic to a portion of a bold span.
This seems to not be valid according to Commonmark, although micromark
supports it to some extent (but not fully -- it breaks on strikethroughs
for me).

This change closes and opens markdown tags every time the format
changes between text nodes. It now exports that example like this:

    he**llo*****wor****ld*!

While this uses a few more characters, it will work in more
circumstances, it fixes the specific issue I was having, and it matches
Draft.js's export behavior, anecdotally.

Fixes #4895
