### PR TITLE
Update anchor selection if split by patching style

### DIFF
--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -422,6 +422,7 @@ export function $patchStyleText(
         // the entire first node isn't selected, so split it
         firstNode = firstNode.splitText(startOffset)[1];
         startOffset = 0;
+        anchor.set(firstNode.getKey(), startOffset, 'text');
       }
 
       $patchStyle(firstNode as TextNode, patch);


### PR DESCRIPTION
## Problem

Setting styles using `$patchStyleText` does not update the selection when the anchor node is split. This causes the selection to contain a node that is not part of the selection. As a result, the toolbar/`$getSelectionStyleValueForProperty` is not able to determine the correct selection style.

https://github.com/facebook/lexical/assets/1575198/e438e605-4d4d-4c78-9967-e3176ed531f8

## Solution

Update the selection anchor with the new text node after splitting.

https://github.com/facebook/lexical/assets/1575198/22c177ae-fd17-4b30-bb68-2adab21a9b78


