### PR TITLE
Revert Fix $transferStartingElementPointToTextPoint() #4756 

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -244,17 +244,6 @@ function $transferStartingElementPointToTextPoint(
     element.append(target);
   } else {
     placementNode.insertBefore(target);
-    // Fix the end point offset if it refers to the same element as start,
-    // as we've now inserted another element before it. Note that we only
-    // do it if selection is not collapsed as otherwise it'll transfer
-    // both focus and anchor to the text node below
-    if (
-      end.type === 'element' &&
-      end.key === start.key &&
-      end.offset !== start.offset
-    ) {
-      end.set(end.key, end.offset + 1, 'element');
-    }
   }
   // Transfer the element point to a text point.
   if (start.is(end)) {

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -9,14 +9,13 @@
 import {$createLinkNode} from '@lexical/link';
 import {
   $createParagraphNode,
-  $createRangeSelection,
   $createTextNode,
   $getRoot,
   LexicalEditor,
   RangeSelection,
 } from 'lexical';
 
-import {$createTestDecoratorNode, initializeUnitTest} from '../utils';
+import {initializeUnitTest} from '../utils';
 
 describe('LexicalSelection tests', () => {
   initializeUnitTest((testEnv) => {
@@ -322,51 +321,6 @@ describe('LexicalSelection tests', () => {
 
           //   await insertText({container, editor, method: 'insertNodes'});
           // });
-        });
-
-        describe('transferStartingElementPointToTextPoint', () => {
-          test('transferStartingElementPointToTextPoint', async () => {
-            const {container, editor} = testEnv;
-
-            if (!container) {
-              throw new Error('Expected container to be truthy');
-            }
-
-            await editor.update(() => {
-              const root = $getRoot();
-              if (root.getFirstChild() !== null) {
-                throw new Error('Expected root to be childless');
-              }
-
-              const paragraph = $createParagraphNode();
-              const text = $createTextNode('Text');
-              const image = $createTestDecoratorNode();
-              paragraph.append(text, image);
-
-              root.append(paragraph);
-
-              expect(root.getTextContent()).toEqual('TextHello world');
-
-              const decoratorIndexInParent = image.getIndexWithinParent();
-              const paragraphKey = paragraph.getKey();
-
-              const selection = $createRangeSelection();
-              selection.anchor.set(
-                paragraphKey,
-                decoratorIndexInParent,
-                'element',
-              );
-              selection.focus.set(
-                paragraphKey,
-                decoratorIndexInParent + 1,
-                'element',
-              );
-
-              selection.insertText('A');
-
-              expect(root.getTextContent()).toEqual('TextA');
-            });
-          });
         });
       });
     });


### PR DESCRIPTION
This is causing issues in the `PlainTextPlugin` prevent users from deleting line breaks within paragraph nodes. When the cursor is collapsed and on a `LineBreakNode` the selection is of type `element` which causes the condition to trigger, incrementing the offset even during a deletion. 

I think we can the original PR as it seems more like a browser bug if the base Selection offset isn't being increment for an empty node (e.g. a decorator node).


Before: 

https://github.com/facebook/lexical/assets/7748470/97778bdd-4445-4ff9-ba59-5d5de5c5bc30

After: 

https://github.com/facebook/lexical/assets/7748470/6a983d57-6bcb-4e6b-a9df-3eec6580c758
