### PR TITLE
Fix insertNodes insert position at start of inline ElementNode

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -13,6 +13,7 @@ import {
   $patchStyleText,
 } from '@lexical/selection';
 import {
+  $createLineBreakNode,
   $createParagraphNode,
   $createTextNode,
   $getNodeByKey,
@@ -2371,6 +2372,30 @@ describe('LexicalSelectionHelpers tests', () => {
           '<p dir="ltr"><a href="https://" dir="ltr"><span data-lexical-text="true">link</span></a><span data-lexical-text="true">foo</span></p>',
         );
       });
+    });
+
+    test('can insert a linebreak node before an inline element node', async () => {
+      const editor = createTestEditor();
+      const element = document.createElement('div');
+      editor.setRootElement(element);
+
+      await editor.update(() => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
+        const link = $createLinkNode('https://lexical.dev/');
+        paragraph.append(link);
+        const text = $createTextNode('Lexical');
+        link.append(text);
+        text.select(0, 0);
+
+        $insertNodes([$createLineBreakNode()]);
+      });
+
+      // TODO #5109 ElementNode should have a way to control when other nodes can be inserted inside
+      expect(element.innerHTML).toBe(
+        '<p><a href="https://lexical.dev/" dir="ltr"><br><span data-lexical-text="true">Lexical</span></a></p>',
+      );
     });
   });
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1731,7 +1731,7 @@ export class RangeSelection implements BaseSelection {
         );
       }
       didReplaceOrMerge = false;
-      if ($isElementNode(target) && !target.isInline()) {
+      if ($isElementNode(target) && (i === 0 || !target.isInline())) {
         lastNode = node;
         if ($isDecoratorNode(node) && !node.isInline()) {
           if (nodes.length === 1 && target.canBeEmpty() && target.isEmpty()) {


### PR DESCRIPTION
`insertNodes` does too much... 

`insertNodes` is a function that's able to insert N amount of nodes and fixed the hierarchy *accordingly*.

In https://github.com/facebook/lexical/pull/1996/ we determined that insertNodes `[x, y, z]` where `y` is an ElementNode should never be merged into `z`. That makes sense, from a user PoV these are 3 separate nodes (an array) and you'd want them one next to the other.

However, when you `insertNodes` from a paste PoV, if your target is non-empty ElementNode you'd want to `insertBefore` the Element. For example, `insertNodes[$createLineBreakNode()]` with the aforementioned target should prepend it on the list of nodes.  

Where do we draw the line? ~~We don't, we reduce `insertNodes` responsibilities.~~ We can assume that the first node's target can be treated as merge with the current hierarchy, whereas `target`s for subsequent node's should always be appended.

https://github.com/facebook/lexical/assets/193447/87ca9a48-817b-43cc-99df-ab2764449416

Closes https://github.com/facebook/lexical/issues/4172