### PR TITLE
docs: fix typo in decorators.md

### DIFF
--- a/examples/decorators.md
+++ b/examples/decorators.md
@@ -71,7 +71,7 @@ function VideoPlugin(): ReactNode {
     // Similar with command listener, which returns unlisten callback
     const removeListener = editor.registerCommand(
       INSERT_VIDEO_COMMAND,
-      (payload) => {
+      (url) => {
         // Adding custom command that will be handled by this plugin
         editor.update(() => {
           $insertNodes([$createVideoNode(url)]);


### PR DESCRIPTION
> because it's docs only I hope it's fine I just open a PR against main 😬 

alternative is to name both payload I guess