### PR TITLE
fix(character-limit-plugin): fix overflowNode on mount and cleanup state

### DIFF
--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -44,6 +44,34 @@ export function useCharacterLimit(
   } = optional;
 
   useEffect(() => {
+    editor.update(() => {
+      const text = editor.getEditorState().read($rootTextContent);
+      const textLength = strlen(text);
+      const textLengthAboveThreshold = textLength > maxCharacters;
+      const diff = maxCharacters - textLength;
+      remainingCharacters(diff);
+
+      if (textLengthAboveThreshold) {
+        const offset = findOffset(text, maxCharacters, strlen);
+        $wrapOverflowedNodes(offset);
+      }
+    });
+
+    return () => {
+      editor.update(() => {
+        const dfsNodes = $dfs();
+
+        for (const element of dfsNodes) {
+          const {node} = element;
+          if ($isOverflowNode(node)) {
+            $unwrapNode(node);
+          }
+        }
+      });
+    };
+  }, []);
+
+  useEffect(() => {
     if (!editor.hasNodes([OverflowNode])) {
       invariant(
         false,


### PR DESCRIPTION
# Issue
The LexicalCharacterLimitPlugin exhibits unexpected behavior when switched on (on mount) and off (during cleanup). When you enable the plugin in the playground, it displays only the initial state (with an initial character limit of 5 in the playground), without checking the current editor state. The useCharacterLimit hook updates when changes occur in the editor state only after initialization.

The same issue arises when attempting to switch the plugin off. You will still be able to see the overflowNode (highlighted with a red background in the playground) in the editor because the plugin lacks a cleanup function

https://github.com/facebook/lexical/assets/31176746/d14262a2-7c5c-457e-8758-81e0b24e3110



# Expected behavior
When the plugin is switched on, it should analyze the current characters and apply the overflowNode to text that exceeds the limit.

When the plugin is switched off, it should unwrap the overflowNode.

https://github.com/facebook/lexical/assets/31176746/4ba1d45d-cd2d-4bf5-8963-db5b5880d038


