### PR TITLE
Add `commandPriority` option to `LexicalMenu` and dependent components

### DIFF
--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import type {LexicalNode, MutationListener} from 'lexical';
+import type {
+  CommandListenerPriority,
+  LexicalNode,
+  MutationListener,
+} from 'lexical';
 
 import {$isLinkNode, AutoLinkNode, LinkNode} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -19,6 +23,7 @@ import {
   $getNodeByKey,
   $getSelection,
   COMMAND_PRIORITY_EDITOR,
+  COMMAND_PRIORITY_LOW,
   createCommand,
   LexicalCommand,
   LexicalEditor,
@@ -78,6 +83,7 @@ type LexicalAutoEmbedPluginProps<TEmbedConfig extends EmbedConfig> = {
     dismissFn: () => void,
   ) => Array<AutoEmbedOption>;
   menuRenderFn: MenuRenderFn<AutoEmbedOption>;
+  menuCommandPriority?: CommandListenerPriority;
 };
 
 export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
@@ -85,6 +91,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
   onOpenEmbedModalForConfig,
   getMenuOptions,
   menuRenderFn,
+  menuCommandPriority = COMMAND_PRIORITY_LOW,
 }: LexicalAutoEmbedPluginProps<TEmbedConfig>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
 
@@ -223,6 +230,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
       onSelectOption={onSelectOption}
       options={options}
       menuRenderFn={menuRenderFn}
+      commandPriority={menuCommandPriority}
     />
   ) : null;
 }

--- a/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
@@ -8,7 +8,11 @@
 import type {MenuRenderFn, MenuResolution} from './shared/LexicalMenu';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {LexicalNode} from 'lexical';
+import {
+  COMMAND_PRIORITY_LOW,
+  CommandListenerPriority,
+  LexicalNode,
+} from 'lexical';
 import {
   MutableRefObject,
   ReactPortal,
@@ -45,6 +49,7 @@ export type LexicalContextMenuPluginProps<TOption extends MenuOption> = {
   onOpen?: (resolution: MenuResolution) => void;
   menuRenderFn: ContextMenuRenderFn<TOption>;
   anchorClassName?: string;
+  commandPriority?: CommandListenerPriority;
 };
 
 const PRE_PORTAL_DIV_SIZE = 1;
@@ -56,6 +61,7 @@ export function LexicalContextMenuPlugin<TOption extends MenuOption>({
   onSelectOption,
   menuRenderFn: contextMenuRenderFn,
   anchorClassName,
+  commandPriority = COMMAND_PRIORITY_LOW,
 }: LexicalContextMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
@@ -143,6 +149,7 @@ export function LexicalContextMenuPlugin<TOption extends MenuOption>({
         })
       }
       onSelectOption={onSelectOption}
+      commandPriority={commandPriority}
     />
   );
 }

--- a/packages/lexical-react/src/LexicalNodeMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeMenuPlugin.tsx
@@ -9,7 +9,13 @@
 import type {MenuRenderFn, MenuResolution} from './shared/LexicalMenu';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$getNodeByKey, NodeKey, TextNode} from 'lexical';
+import {
+  $getNodeByKey,
+  COMMAND_PRIORITY_LOW,
+  CommandListenerPriority,
+  NodeKey,
+  TextNode,
+} from 'lexical';
 import {useCallback, useEffect, useState} from 'react';
 import * as React from 'react';
 
@@ -36,6 +42,7 @@ export type NodeMenuPluginProps<TOption extends MenuOption> = {
   onOpen?: (resolution: MenuResolution) => void;
   menuRenderFn: MenuRenderFn<TOption>;
   anchorClassName?: string;
+  commandPriority?: CommandListenerPriority;
 };
 
 export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
@@ -46,6 +53,7 @@ export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
   onSelectOption,
   menuRenderFn,
   anchorClassName,
+  commandPriority = COMMAND_PRIORITY_LOW,
 }: NodeMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
@@ -115,6 +123,7 @@ export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
       options={options}
       menuRenderFn={menuRenderFn}
       onSelectOption={onSelectOption}
+      commandPriority={commandPriority}
     />
   );
 }

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -18,6 +18,8 @@ import {
   $getSelection,
   $isRangeSelection,
   $isTextNode,
+  COMMAND_PRIORITY_LOW,
+  CommandListenerPriority,
   createCommand,
   LexicalCommand,
   LexicalEditor,
@@ -200,6 +202,7 @@ export type TypeaheadMenuPluginProps<TOption extends MenuOption> = {
   onOpen?: (resolution: MenuResolution) => void;
   onClose?: () => void;
   anchorClassName?: string;
+  commandPriority?: CommandListenerPriority;
 };
 
 export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
@@ -211,6 +214,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
   menuRenderFn,
   triggerFn,
   anchorClassName,
+  commandPriority = COMMAND_PRIORITY_LOW,
 }: TypeaheadMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
@@ -305,6 +309,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
       menuRenderFn={menuRenderFn}
       shouldSplitNodeWithQuery={true}
       onSelectOption={onSelectOption}
+      commandPriority={commandPriority}
     />
   );
 }

--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -12,6 +12,7 @@ import {
   $getSelection,
   $isRangeSelection,
   COMMAND_PRIORITY_LOW,
+  CommandListenerPriority,
   createCommand,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_UP_COMMAND,
@@ -260,6 +261,7 @@ export function LexicalMenu<TOption extends MenuOption>({
   menuRenderFn,
   onSelectOption,
   shouldSplitNodeWithQuery = false,
+  commandPriority = COMMAND_PRIORITY_LOW,
 }: {
   close: () => void;
   editor: LexicalEditor;
@@ -274,6 +276,7 @@ export function LexicalMenu<TOption extends MenuOption>({
     closeMenu: () => void,
     matchingString: string,
   ) => void;
+  commandPriority?: CommandListenerPriority;
 }): JSX.Element | null {
   const [selectedIndex, setHighlightedIndex] = useState<null | number>(null);
 
@@ -345,10 +348,10 @@ export function LexicalMenu<TOption extends MenuOption>({
 
           return false;
         },
-        COMMAND_PRIORITY_LOW,
+        commandPriority,
       ),
     );
-  }, [editor, updateSelectedIndex]);
+  }, [editor, updateSelectedIndex, commandPriority]);
 
   useEffect(() => {
     return mergeRegister(
@@ -375,7 +378,7 @@ export function LexicalMenu<TOption extends MenuOption>({
           }
           return true;
         },
-        COMMAND_PRIORITY_LOW,
+        commandPriority,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_ARROW_UP_COMMAND,
@@ -394,7 +397,7 @@ export function LexicalMenu<TOption extends MenuOption>({
           }
           return true;
         },
-        COMMAND_PRIORITY_LOW,
+        commandPriority,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_ESCAPE_COMMAND,
@@ -405,7 +408,7 @@ export function LexicalMenu<TOption extends MenuOption>({
           close();
           return true;
         },
-        COMMAND_PRIORITY_LOW,
+        commandPriority,
       ),
       editor.registerCommand<KeyboardEvent>(
         KEY_TAB_COMMAND,
@@ -423,7 +426,7 @@ export function LexicalMenu<TOption extends MenuOption>({
           selectOptionAndCleanUp(options[selectedIndex]);
           return true;
         },
-        COMMAND_PRIORITY_LOW,
+        commandPriority,
       ),
       editor.registerCommand(
         KEY_ENTER_COMMAND,
@@ -442,7 +445,7 @@ export function LexicalMenu<TOption extends MenuOption>({
           selectOptionAndCleanUp(options[selectedIndex]);
           return true;
         },
-        COMMAND_PRIORITY_LOW,
+        commandPriority,
       ),
     );
   }, [
@@ -452,6 +455,7 @@ export function LexicalMenu<TOption extends MenuOption>({
     options,
     selectedIndex,
     updateSelectedIndex,
+    commandPriority,
   ]);
 
   const listItemProps = useMemo(


### PR DESCRIPTION
Resolves #3714, which is a long-standing issue that multiple users seem to have faced. Previously, this repo has solved it by:

1. Setting all of the commands to `COMMAND_PRIORITY_NORMAL` (#2885)
2. Setting all of the commands to `COMMAND_PRIORITY_CRITICAL` (#3106)
3. Setting all of the commands to `COMMAND_PRIORITY_LOW` (#3441)

It is pretty clear that a more generic solution is needed. This PR adds a `commandPriority` prop to `LexicalMenu` and its dependent components, including:

- `LexicalTypeaheadMenuPlugin` (most often called out)
- `LexicalNodeMenuPlugin`
- `LexicalContextMenuPlugin`
- `LexicalAutoEmbedPlugin` (under `menuCommandPriority`, because this plugin registers an insertion command that should remain at `COMMAND_PRIORITY_EDITOR`)

Future changes should address:

1. Customising priority per-command (this is hard to implement today since commands don’t have string IDs in production builds)
2. Customising priority for all components in `@lexical/react`

However, since `LexicalMenu` has been repeatedly and specifically changed, IMO this PR has a higher cost-benefit than doing those immediately (although I’d love a maintainer’s thoughts!).