### PR TITLE
Updated cell calculation based on cellspans

### DIFF
--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -206,13 +206,29 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
             throw new Error('Expected table row');
           }
 
-          const tableCells = tableRow.getChildren();
+          const rowCells = tableRow.getChildren();
+          const rowCellsSpan = rowCells.map((cell) => cell.getColSpan());
 
-          if (tableColumnIndex >= tableCells.length || tableColumnIndex < 0) {
+          const aggregatedRowSpans = rowCellsSpan.reduce(
+            (rowSpans, cellSpan) => {
+              const previousCell = rowSpans.at(-1) ?? 0;
+              rowSpans.push(previousCell + cellSpan);
+              return rowSpans;
+            },
+            [],
+          );
+          const rowColumnIndexWithSpan = aggregatedRowSpans.findIndex(
+            (cellSpan: number) => cellSpan > tableColumnIndex,
+          );
+
+          if (
+            rowColumnIndexWithSpan >= rowCells.length ||
+            rowColumnIndexWithSpan < 0
+          ) {
             throw new Error('Expected table cell to be inside of table row.');
           }
 
-          const tableCell = tableCells[tableColumnIndex];
+          const tableCell = rowCells[rowColumnIndexWithSpan];
 
           if (!$isTableCellNode(tableCell)) {
             throw new Error('Expected table cell');


### PR DESCRIPTION
## Why
Based on this [issue](https://github.com/facebook/lexical/issues/4415) with Tables current algorithm for resizing is out of shape for cases where cells are merged. What happens is it tries to map index from given active cell and make sure that it exists on each row, if not - throwing exception.

#4415 

## What changed
I've updated TableCellResizer to acomodate that - now it claculates length of row based on children and their cell span. From this we are finding which column corresponds to given active cell, that now always should be less or equal to active cell. After this we are using this column to set width.

Test:

https://github.com/facebook/lexical/assets/5208565/b31e9159-4df7-40cb-a9bc-b7e4f2cb4344

E2E test - couldn't find a way to resize in unit/e2e test.