### PR TITLE
Fixed delete removing link node text when on linebreak

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1265,7 +1265,7 @@ export class RangeSelection implements BaseSelection {
             lastNode = textNode;
           }
           // root node selections only select whole nodes, so no text splice is necessary
-          if (!$isRootNode(endPoint.getNode())) {
+          if (!$isRootNode(endPoint.getNode()) && endPoint.type === 'text') {
             lastNode = (lastNode as TextNode).spliceText(0, endOffset, '');
           }
           markedNodeKeysForKeep.add(lastNode.__key);


### PR DESCRIPTION
closes https://github.com/facebook/lexical/issues/5144
- mutations to the end text node were too permissive
- splicing of text on removing an element (insert empty) should only impact text selections