### PR TITLE
Bug: Align list item do not change the export DOM

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -10,6 +10,7 @@ import type {ListNode} from './';
 import type {
   DOMConversionMap,
   DOMConversionOutput,
+  DOMExportOutput,
   EditorConfig,
   EditorThemeClasses,
   GridSelection,
@@ -34,6 +35,7 @@ import {
   $isParagraphNode,
   $isRangeSelection,
   ElementNode,
+  LexicalEditor,
 } from 'lexical';
 import invariant from 'shared/invariant';
 
@@ -130,6 +132,14 @@ export class ListItemNode extends ElementNode {
     node.setFormat(serializedNode.format);
     node.setDirection(serializedNode.direction);
     return node;
+  }
+
+  exportDOM(editor: LexicalEditor): DOMExportOutput {
+    const element = this.createDOM(editor._config);
+    element.style.textAlign = this.getFormatType();
+    return {
+      element,
+    };
   }
 
   exportJSON(): SerializedListItemNode {


### PR DESCRIPTION
<!--
  Please provide a clear and concise description of what the bug is. Include
  screenshots if needed. Please test using the latest version of the relevant
  Lexical packages to make sure your issue has not already been fixed.
-->
This pull request related to #5159
Lexical version:
V0.12.2
## Steps To Reproduce

1. Click Bulleted List button
![image](https://github.com/facebook/lexical/assets/48130078/d60ed991-541d-45b1-859c-32085a58422d)
2. Type something
![image](https://github.com/facebook/lexical/assets/48130078/aca8b27e-235b-43bd-8c4d-88f01c2e982b)
3. Click export DOM button, look at the DOM
![image](https://github.com/facebook/lexical/assets/48130078/480d3128-56d1-420c-861d-29f5b04d77d2)
4. Click on the text and then click Right Align button
![image](https://github.com/facebook/lexical/assets/48130078/92e94a45-211b-48a3-a688-ed32b6ff214c)
5. Look at the DOM
![image](https://github.com/facebook/lexical/assets/48130078/b4f1c5db-8d6e-48c9-8705-4aed2a55239e)

<!--
  Your bug will get fixed much faster if we can run your code and it doesn't
  have dependencies other than Lexical. Issues without reproduction steps or
  code examples may be closed as not actionable.
-->

Link to code example:
https://playground.lexical.dev/
<!--
  Please provide a CodeSandbox (https://codesandbox.io/s/new) or (https://codesandbox.io/s/lexical-plain-text-example-g932e), a link to a
  repository on GitHub, or provide a minimal code example that reproduces the
  problem. You may provide a screenshot of the application if you think it is
  relevant to your bug report. Here are some tips for providing a minimal
  example: https://stackoverflow.com/help/mcve.
-->

## The current behavior
The DOM do not change after click Right Align button
## The expected behavior
The right align style should be applied into the list item DOM