### PR TITLE
Add playwright-report to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ npm
 .docusaurus
 e2e-screenshots
 test-results
+playwright-report
 
 npm-debug.log*
 


### PR DESCRIPTION
I frequently use --reporter=html to debug. Playwright puts the necessary files there and you have to remove them from stage.