### PR TITLE
Fix insertNodes after selection swap

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -15,6 +15,7 @@ import {
 import {
   $createLineBreakNode,
   $createParagraphNode,
+  $createRangeSelection,
   $createTextNode,
   $getNodeByKey,
   $getRoot,
@@ -22,6 +23,7 @@ import {
   $insertNodes,
   $isNodeSelection,
   $isRangeSelection,
+  $setSelection,
   RangeSelection,
   TextNode,
 } from 'lexical';
@@ -30,6 +32,7 @@ import {
   $createTestElementNode,
   $createTestShadowRootNode,
   createTestEditor,
+  createTestHeadlessEditor,
   TestDecoratorNode,
 } from 'lexical/src/__tests__/utils';
 
@@ -2668,6 +2671,35 @@ describe('insertNodes', () => {
         '<span data-lexical-decorator="true" contenteditable="false"></span>' +
         '<p dir="ltr"><span data-lexical-text="true">Text after</span></p>',
     );
+  });
+
+  it('can insert when previous selection was null', async () => {
+    const editor = createTestHeadlessEditor();
+    await editor.update(() => {
+      const selection = $createRangeSelection();
+      selection.anchor.set('root', 0, 'element');
+      selection.focus.set('root', 0, 'element');
+
+      selection.insertNodes([
+        $createParagraphNode().append($createTextNode('Text')),
+      ]);
+
+      expect($getRoot().getTextContent()).toBe('Text');
+
+      $setSelection(null);
+    });
+    await editor.update(() => {
+      const selection = $createRangeSelection();
+      const text = $getRoot().getLastDescendant();
+      selection.anchor.set(text.getKey(), 0, 'text');
+      selection.focus.set(text.getKey(), 0, 'text');
+
+      selection.insertNodes([
+        $createParagraphNode().append($createTextNode('Before ')),
+      ]);
+
+      expect($getRoot().getTextContent()).toBe('Before Text');
+    });
   });
 });
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1522,12 +1522,18 @@ export class RangeSelection implements BaseSelection {
    *
    * @param nodes - the nodes to insert
    */
-  insertNodes(nodes: Array<LexicalNode>) {
+  insertNodes(nodes: Array<LexicalNode>): void {
     if (nodes.length === 0) {
       return;
     }
     if (this.anchor.key === 'root') {
       this.insertParagraph();
+      const selection = $getSelection();
+      invariant(
+        $isRangeSelection(selection),
+        'Expected RangeSelection after insertParagraph',
+      );
+      return selection.insertNodes(nodes);
     }
     const firstBlock = $getAncestor(this.anchor.getNode(), INTERNAL_$isBlock)!;
 

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -8,6 +8,7 @@
 
 import {CodeHighlightNode, CodeNode} from '@lexical/code';
 import {HashtagNode} from '@lexical/hashtag';
+import {createHeadlessEditor} from '@lexical/headless';
 import {AutoLinkNode, LinkNode} from '@lexical/link';
 import {ListItemNode, ListNode} from '@lexical/list';
 import {OverflowNode} from '@lexical/overflow';
@@ -502,6 +503,15 @@ export function createTestEditor(
     nodes: DEFAULT_NODES.concat(customNodes),
   });
   return editor;
+}
+
+export function createTestHeadlessEditor(): LexicalEditor {
+  return createHeadlessEditor({
+    namespace: '',
+    onError: (error) => {
+      throw error;
+    },
+  });
 }
 
 export function $assertRangeSelection(selection): RangeSelection {


### PR DESCRIPTION
Functions like `insertParagraph` can generate a brand new selection. Hence, `insertNodes` needs to be restarted as the `this` no longer points to the valid selection.

I think this is only the case when this happens, I'm surprised there wasn't a test for this.