### PR TITLE
Fix insertNodes when anchor point is blank TextNode

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -2701,6 +2701,24 @@ describe('insertNodes', () => {
       expect($getRoot().getTextContent()).toBe('Before Text');
     });
   });
+
+  it('can insert when before empty text node', async () => {
+    const editor = createTestEditor();
+    const element = document.createElement('div');
+    editor.setRootElement(element);
+
+    await editor.update(() => {
+      // Empty text node to test empty text split
+      const emptyTextNode = $createTextNode('');
+      $getRoot().append(
+        $createParagraphNode().append(emptyTextNode, $createTextNode('text')),
+      );
+      emptyTextNode.select(0, 0);
+      $getSelection().insertNodes([$createTextNode('foo')]);
+
+      expect($getRoot().getTextContent()).toBe('footext');
+    });
+  });
 });
 
 describe('$patchStyleText', () => {

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -3097,6 +3097,9 @@ function removeTextAndSplitBlock(selection: RangeSelection): number {
   }
 
   const split = pointNode.splitText(point.offset);
+  if (split.length === 0) {
+    return 0;
+  }
   const x = point.offset === 0 ? 0 : 1;
   const index = split[0].getIndexWithinParent() + x;
 


### PR DESCRIPTION
TextNodes are usually not empty but they can be as a result of non-reconciled updates (& plugin logic) or custom TextNodes (that won't be consolidated). Either of these are valid states.