### PR TITLE
Fix at() transpilation

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -173,10 +173,11 @@ export function $insertDataTransferForRichText(
   if (text != null) {
     if ($isRangeSelection(selection)) {
       const parts = text.split(/(\r?\n|\t)/);
-      if (parts.at(-1) === '') {
+      const partsLength = parts.length;
+      if (parts[partsLength - 1] === '') {
         parts.pop();
       }
-      for (let i = 0; i < parts.length; i++) {
+      for (let i = 0; i < partsLength; i++) {
         const part = parts[i];
         if (part === '\n' || part === '\r\n') {
           selection.insertParagraph();

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -173,11 +173,10 @@ export function $insertDataTransferForRichText(
   if (text != null) {
     if ($isRangeSelection(selection)) {
       const parts = text.split(/(\r?\n|\t)/);
-      const partsLength = parts.length;
-      if (parts[partsLength - 1] === '') {
+      if (parts[parts.length - 1] === '') {
         parts.pop();
       }
-      for (let i = 0; i < partsLength; i++) {
+      for (let i = 0; i < parts.length; i++) {
         const part = parts[i];
         if (part === '\n' || part === '\r\n') {
           selection.insertParagraph();

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -288,7 +288,7 @@ export class CodeNode extends ElementNode {
       const codeNode = firstSelectionNode.getParentOrThrow();
       const nodesToInsert = [$createLineBreakNode(), ...insertNodes];
       codeNode.splice(index, 0, nodesToInsert);
-      const last = insertNodes.at(-1);
+      const last = insertNodes[insertNodes.length - 1];
       if (last) {
         last.select();
       } else if (anchor.offset === 0) {

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -211,7 +211,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
 
           const aggregatedRowSpans = rowCellsSpan.reduce(
             (rowSpans, cellSpan) => {
-              const previousCell = rowSpans.at(-1) ?? 0;
+              const previousCell = rowSpans[rowSpans.length - 1] ?? 0;
               rowSpans.push(previousCell + cellSpan);
               return rowSpans;
             },

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1544,7 +1544,7 @@ export class RangeSelection implements BaseSelection {
       } else {
         const index = removeTextAndSplitBlock(this);
         firstBlock.splice(index, 0, nodes);
-        const last = nodes.at(-1)!;
+        const last = nodes[nodes.length - 1]!;
         if (last.select) {
           last.select();
         } else last.selectNext(0, 0);
@@ -1567,7 +1567,7 @@ export class RangeSelection implements BaseSelection {
     const shouldInsert = !$isElementNode(firstBlock) || !firstBlock.isEmpty();
     const insertedParagraph = shouldInsert ? this.insertParagraph() : null;
 
-    const last = nodes.at(-1)!;
+    const last = nodes[nodes.length - 1]!;
     const nodeToSelect = $isElementNode(last)
       ? last.getLastDescendant() || last
       : last;


### PR DESCRIPTION
We can't use `at` until we transpile it. This is not the case now.