### PR TITLE
Link title is correctly applied through the command

### DIFF
--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -6,7 +6,20 @@
  *
  */
 
-import {$createLinkNode, $isLinkNode, LinkNode} from '@lexical/link';
+import {
+  $createLinkNode,
+  $isLinkNode,
+  LinkNode,
+  SerializedLinkNode,
+  toggleLink,
+} from '@lexical/link';
+import {
+  $getRoot,
+  $selectAll,
+  ParagraphNode,
+  SerializedParagraphNode,
+  TextNode,
+} from 'lexical/src';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 
 const editorConfig = Object.freeze({
@@ -376,6 +389,25 @@ describe('LexicalLinkNode tests', () => {
 
         expect($isLinkNode(linkNode)).toBe(true);
       });
+    });
+
+    test('toggleLink applies the title attribute when creating', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const p = new ParagraphNode();
+        p.append(new TextNode('Some text'));
+        $getRoot().append(p);
+      });
+
+      await editor.update(() => {
+        $selectAll();
+        toggleLink('https://lexical.dev/', {title: 'Lexical Website'});
+      });
+
+      const paragraph = editor!.getEditorState().toJSON().root
+        .children[0] as SerializedParagraphNode;
+      const link = paragraph.children[0] as SerializedLinkNode;
+      expect(link.title).toBe('Lexical Website');
     });
   });
 });

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -494,7 +494,7 @@ export function toggleLink(
 
       if (!parent.is(prevParent)) {
         prevParent = parent;
-        linkNode = $createLinkNode(url, {rel, target});
+        linkNode = $createLinkNode(url, {rel, target, title});
 
         if ($isLinkNode(parent)) {
           if (node.getPreviousSibling() === null) {


### PR DESCRIPTION
ATM, the TOGGLE_LINK_COMMAND ignores the title in the payload. It's a one liner fix, but I wanted to ensure that it works as expected so an illustrative test is included. 

Thanks!