### PR TITLE
fix Heading.insertNewAfter

### DIFF
--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -361,7 +361,9 @@ export class HeadingNode extends ElementNode {
     newElement.setDirection(direction);
     this.insertAfter(newElement, restoreSelection);
     if (anchorOffet === 0 && !this.isEmpty() && selection) {
-      this.replace($createParagraphNode(), restoreSelection);
+      const paragraph = $createParagraphNode();
+      paragraph.select();
+      this.replace(paragraph, true);
     }
     return newElement;
   }


### PR DESCRIPTION
- The second parameter of `replace` had to be true, not `restoreSelection` which has nothing to do with it.
- I had to add a select, because otherwise when trying to paste a heading at the beginning of a heading an error would appear. This shouldn't be like this, maybe it's a bug in `replace`.
- Inserting a heading at the beginning of a heading does not combine them as part of the same block. I don't think it's the best behavior. I tried to fix it but `insertNodes` is still tremendously complex despite recent improvements.