### PR TITLE
Fix out of order events during table selection

### DIFF
--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -678,6 +678,10 @@ export async function dragMouse(
   await page.mouse.move(fromX, fromY);
   await page.mouse.down();
 
+  // Defer dragMouse continuation past the mouse down
+  // event handler, deferred via setTimeout.
+  await sleep(0);
+
   let toX = toBoundingBox.x;
   let toY = toBoundingBox.y;
   if (positionEnd === 'middle') {


### PR DESCRIPTION
With current implementation of [applyTableHandlers](https://github.com/facebook/lexical/blob/ed8f85fb5e5106dba237e2a166e57acaa28e8fbe/packages/lexical-table/src/LexicalTableSelectionHelpers.ts#L58), when user taps a touchpad fast enough (or, presumably, clicks a mouse button), a `mouseup` event may sneak into event loop before `setTimeout` adds the actual implementation of `mousedown` handler there, so `mouseup` remains unhandled and `mousemove` is not removed until the next click. This corrupts the user experience as the table remains in "selecting" state when mouse is already up.

The issue is reproduced in lexical 0.12.2, as well as ed8f85fb5e5106dba237e2a166e57acaa28e8fbe; Chrome 118.0.5993.117 (Official Build) (arm64) 

The PR fixes this behavior by canceling `mousedown` handler upon `mouseup` if it wasn't called yet.

Before:

(logging the balance between adds and removes of `mouseup` events; the problem is reproduced when balance remains 1 after tap)


https://github.com/facebook/lexical/assets/1835333/4b9deab4-8c5b-4519-bf49-f5c4c7c049c9

After:

(few taps, then showing that selection still works for a table)

https://github.com/facebook/lexical/assets/1835333/98af19e8-9d5e-4687-b7af-aa56cbbe715e


