### PR TITLE
Fix lexical-link typo s/_rel/__rel/

### DIFF
--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -367,7 +367,7 @@ export class AutoLinkNode extends LinkNode {
     );
     if ($isElementNode(element)) {
       const linkNode = $createAutoLinkNode(this.__url, {
-        rel: this._rel,
+        rel: this.__rel,
         target: this.__target,
         title: this.__title,
       });


### PR DESCRIPTION
I was investigating the use of `[x: string]: any;` in LexicalNode under the assumption that it would hide bugs and I found one.