### PR TITLE
refactor(playground): dry settings

### DIFF
--- a/packages/lexical-playground/src/appSettings.ts
+++ b/packages/lexical-playground/src/appSettings.ts
@@ -6,31 +6,12 @@
  *
  */
 
-export type SettingName =
-  | 'disableBeforeInput'
-  | 'measureTypingPerf'
-  | 'isRichText'
-  | 'isCollab'
-  | 'isCharLimit'
-  | 'isMaxLength'
-  | 'isCharLimitUtf8'
-  | 'isAutocomplete'
-  | 'shouldUseLexicalContextMenu'
-  | 'showTreeView'
-  | 'showNestedEditorTreeView'
-  | 'emptyEditor'
-  | 'showTableOfContents'
-  | 'tableCellMerge'
-  | 'tableCellBackgroundColor';
-
-export type Settings = Record<SettingName, boolean>;
-
 const hostName = window.location.hostname;
 export const isDevPlayground: boolean =
   hostName !== 'playground.lexical.dev' &&
   hostName !== 'lexical-playground.vercel.app';
 
-export const DEFAULT_SETTINGS: Settings = {
+export const DEFAULT_SETTINGS = {
   disableBeforeInput: false,
   emptyEditor: isDevPlayground,
   isAutocomplete: false,
@@ -47,3 +28,7 @@ export const DEFAULT_SETTINGS: Settings = {
   tableCellBackgroundColor: true,
   tableCellMerge: true,
 };
+
+export type SettingName = keyof typeof DEFAULT_SETTINGS;
+
+export type Settings = typeof DEFAULT_SETTINGS;


### PR DESCRIPTION
Small refactor to dry up some code. The `DEFAULT_SETTINGS` object implies the list of settings. There's no need to repeat the keys between the type definition and the defaults.