### PR TITLE
Fix "touple" typo to make it correctly "tuple"

### DIFF
--- a/packages/lexical-text/src/index.ts
+++ b/packages/lexical-text/src/index.ts
@@ -187,7 +187,7 @@ export function $canShowPlaceholderCurry(
 export type EntityMatch = {end: number; start: number};
 
 /**
- * Returns a touple that can be rested (...) into mergeRegister to clean up
+ * Returns a tuple that can be rested (...) into mergeRegister to clean up
  * node transforms listeners that transforms text into another node, eg. a HashtagNode.
  * @example
  * ```ts


### PR DESCRIPTION
The typo "touple" has been changed to the correct spelling, "tuple"