### PR TITLE
Select original cell if empty

### DIFF
--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -590,8 +590,11 @@ export function $deleteTableColumn__EXPERIMENTAL(): void {
 
 function $moveSelectionToCell(cell: DEPRECATED_GridCellNode): void {
   const firstDescendant = cell.getFirstDescendant();
-  invariant(firstDescendant !== null, 'Unexpected empty cell');
-  firstDescendant.getParentOrThrow().selectStart();
+  if (firstDescendant == null) {
+    cell.selectStart();
+  } else {
+    firstDescendant.getParentOrThrow().selectStart();
+  }
 }
 
 function $insertFirst(parent: ElementNode, node: LexicalNode): void {


### PR DESCRIPTION
## Why
In #4377 we have an issue when user cannot delete row if previous row is empty.

## What
Simple fix in addressing issue - select cell of no descendant selected. I find it a bit weird why we couldn't do that in a first place, but leaving original logic in place to not break whole Lexical ;) 

https://github.com/facebook/lexical/assets/5208565/bfaf26f9-bbdf-4e80-b53b-ab1a89d53030

