### PR TITLE
Remove unnecessary link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,6 @@ editor.registerUpdateListener(({editorState}) => {
 });
 ```
 
-### Creating custom Lexical nodes
-
-- [Creating custom decorator nodes](https://github.com/facebook/lexical/blob/main/examples/decorators.md)
-
 ## Contributing to Lexical
 
 1. Clone this repository


### PR DESCRIPTION
This is broadly covered by https://lexical.dev/docs/concepts/nodes#creating-custom-nodes

Original file was deleted in https://github.com/facebook/lexical/pull/5121.

Closes #5190 