### PR TITLE
Remove codeowners to prevent unnecessary pings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @zurfyx @fantactuka @acywatson @tylerjbainbridge @thegreatercurve
+* @zurfyx @fantactuka @acywatson


### PR DESCRIPTION
I'm still reviewing PRs, but I want to prevent myself from constant GitHub pings. 