### PR TITLE
Bug: The first letter took different format when typing after selecting 2 different style text

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1373,6 +1373,8 @@ export class RangeSelection implements BaseSelection {
           text,
           true,
         );
+        firstNode.setFormat(format);
+        firstNode.setStyle(style);
         if (firstNode.getTextContent() === '') {
           firstNode.remove();
         } else if (firstNode.isComposing() && this.anchor.type === 'text') {


### PR DESCRIPTION
This Pull Request is related to #5105

Update selection insertText function:

- Update inserted text format to selection format
- Update inserted text style to selection style

It was a bit confusing to me for the first time to decide to keep the style/format of the inserted text the same as the first node or set it to selection style/format. However, after diving into insertText function, i decided to set it to selection style/format as the other case inside insertText function does the same. Otherwise, the toolbar displays the status of selection style/format so I think the inserted text should folow it