### PR TITLE
Support HTML export overrides from config for nested editors.

### DIFF
--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -68,6 +68,7 @@ export function LexicalNestedComposer({
         ));
         for (const [type, entry] of parentNodes) {
           initialEditor._nodes.set(type, {
+            exportDOM: entry.exportDOM,
             klass: entry.klass,
             replace: entry.replace,
             replaceWithKlass: entry.replaceWithKlass,
@@ -85,8 +86,9 @@ export function LexicalNestedComposer({
             replace = options.with;
             replaceWithKlass = options.withKlass || null;
           }
-
+          const registeredKlass = initialEditor._nodes.get(klass.getType());
           initialEditor._nodes.set(klass.getType(), {
+            exportDOM: registeredKlass ? registeredKlass.exportDOM : undefined,
             klass,
             replace,
             replaceWithKlass,


### PR DESCRIPTION
We were overriding the _nodes property for nested editors in LexicalNestedComposer, which meant that the HTML overrides weren't being passed through as expected.

I'm honestly not sure this conditional logic for copying over the nodes from the parent if initialNodes doesn't exist is correct - it seems like we'd want to check for any nodes already registered on the passed-in Editor instance before we just copy from the parent, but I'm not sure what other issues changing that may cause.

This adds support for copying over those overrides in either path. Note that to make this work for nested editors that specify different nodes than the parent, you need to define the initialNodes prop on LexicalNestedComposer.