### PR TITLE
fix: check pure text by regex (without emojis)

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -162,7 +162,15 @@ export function getNearestEditorFromDOMNode(
 }
 
 export function getTextDirection(text: string): 'ltr' | 'rtl' | null {
-  const textWithoutEmojis = text.replace(/[^\p{L}\p{N}\p{P}\p{Z}^$\n]/gu, '');
+  const stripEmojis = (str: string) =>
+    str
+      .replace(
+        /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g,
+        '',
+      )
+      .replace(/\s+/g, ' ')
+      .trim();
+  const textWithoutEmojis = stripEmojis(text);
   if (RTL_REGEX.test(textWithoutEmojis)) {
     return 'rtl';
   }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -162,10 +162,11 @@ export function getNearestEditorFromDOMNode(
 }
 
 export function getTextDirection(text: string): 'ltr' | 'rtl' | null {
-  if (RTL_REGEX.test(text)) {
+  const textWithoutEmojis = text.replace(/[^\p{L}\p{N}\p{P}\p{Z}^$\n]/gu, '');
+  if (RTL_REGEX.test(textWithoutEmojis)) {
     return 'rtl';
   }
-  if (LTR_REGEX.test(text)) {
+  if (LTR_REGEX.test(textWithoutEmojis)) {
     return 'ltr';
   }
   return null;


### PR DESCRIPTION
This pr related to this [issue](https://github.com/facebook/lexical/issues/5260). The regex was wrong and return rtl when any emoji was in the text. I added an extra regex to replace emojis with empty string then main regex check the pure text and return real direction