### PR TITLE
Fix: Resolve "Cannot read properties of undefined (reading 'trim')" issue in $getSelectionStyleValueForProperty

### DIFF
--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -181,7 +181,9 @@ export function getStyleObjectFromRawCSS(css: string): Record<string, string> {
   for (const style of styles) {
     if (style !== '') {
       const [key, value] = style.split(/:([^]+)/); // split on first colon
-      styleObject[key.trim()] = value.trim();
+      if(key && value) {
+        styleObject[key.trim()] = value.trim();
+      }
     }
   }
 

--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -181,7 +181,7 @@ export function getStyleObjectFromRawCSS(css: string): Record<string, string> {
   for (const style of styles) {
     if (style !== '') {
       const [key, value] = style.split(/:([^]+)/); // split on first colon
-      if(key && value) {
+      if (key && value) {
         styleObject[key.trim()] = value.trim();
       }
     }


### PR DESCRIPTION
Addresses #5270


Changes Made:

* Modified `getStyleObjectFromRawCSS` to validated key and value before calling `trim`
