### PR TITLE
Add debounceTime parameter to onChangePlugin

### DIFF
--- a/packages/lexical-react/src/LexicalOnChangePlugin.ts
+++ b/packages/lexical-react/src/LexicalOnChangePlugin.ts
@@ -9,15 +9,18 @@
 import type {EditorState, LexicalEditor} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {debounce} from 'lodash-es';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
 export function OnChangePlugin({
   ignoreHistoryMergeTagChange = true,
   ignoreSelectionChange = false,
+  debounceTime = 0,
   onChange,
 }: {
   ignoreHistoryMergeTagChange?: boolean;
   ignoreSelectionChange?: boolean;
+  debounceTime?: number;
   onChange: (
     editorState: EditorState,
     editor: LexicalEditor,
@@ -40,7 +43,13 @@ export function OnChangePlugin({
             return;
           }
 
-          onChange(editorState, editor, tags);
+          if (debounceTime) {
+            const debouncedOnChange = debounce(onChange, debounceTime);
+
+            debouncedOnChange(editorState, editor, tags);
+          } else {
+            onChange(editorState, editor, tags);
+          }
         },
       );
     }


### PR DESCRIPTION
Suggestion 🤓 
==========

Let's add a `debounceTime` parameter to OnChangePlugin so that nobody needs to implement it on their side?

Arguments in favour ➕
---------------------
- Lodash's `debounce` is already in dependencies
- I assume it's rare occasion when people need to process every key stroke
- I assume it's common to debounce onChange because it may lead to components been re-rendered and async requests been fired

Arguments against ➖
-------------------
- Anybody could implement it from scratch without much issues

Let me know if it makes sense and if it seems reasonable to add this 🙏 