### PR TITLE
Move to new Excalidraw APIs for 0.17 update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2399,15 +2399,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@excalidraw/excalidraw": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.15.3.tgz",
-      "integrity": "sha512-/gpY7fgMO/AEaFLWnPqzbY8H7ly+/zocFf7D0Is5sWNMD2mhult5tana12lXKLSJ6EAz7ubo1A7LajXzvJXJDA==",
-      "peerDependencies": {
-        "react": "^17.0.2 || ^18.2.0",
-        "react-dom": "^17.0.2 || ^18.2.0"
-      }
-    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -22894,7 +22885,7 @@
     "packages/lexical-playground": {
       "version": "0.12.4",
       "dependencies": {
-        "@excalidraw/excalidraw": "^0.15.3",
+        "@excalidraw/excalidraw": "^0.17.0",
         "@lexical/clipboard": "0.12.4",
         "@lexical/code": "0.12.4",
         "@lexical/file": "0.12.4",
@@ -22924,6 +22915,15 @@
         "@vitejs/plugin-react": "^1.0.7",
         "vite": "^2.9.16",
         "vite-plugin-replace": "0.1.1"
+      }
+    },
+    "packages/lexical-playground/node_modules/@excalidraw/excalidraw": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.17.0.tgz",
+      "integrity": "sha512-NzP22v5xMqxYW27ZtTHhiGFe7kE8NeBk45aoeM/mDSkXiOXPDH+PcvwzHRN/Ei+Vj/0sTPHxejn8bZyRWKGjXg==",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.2.0",
+        "react-dom": "^17.0.2 || ^18.2.0"
       }
     },
     "packages/lexical-react": {
@@ -25673,11 +25673,6 @@
           "dev": true
         }
       }
-    },
-    "@excalidraw/excalidraw": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.15.3.tgz",
-      "integrity": "sha512-/gpY7fgMO/AEaFLWnPqzbY8H7ly+/zocFf7D0Is5sWNMD2mhult5tana12lXKLSJ6EAz7ubo1A7LajXzvJXJDA=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",
@@ -35352,7 +35347,7 @@
     "lexical-playground": {
       "version": "file:packages/lexical-playground",
       "requires": {
-        "@excalidraw/excalidraw": "^0.15.3",
+        "@excalidraw/excalidraw": "^0.17.0",
         "@lexical/clipboard": "0.12.4",
         "@lexical/code": "0.12.4",
         "@lexical/file": "0.12.4",
@@ -35380,6 +35375,13 @@
         "vite-plugin-replace": "0.1.1",
         "y-websocket": ">=1.3.x",
         "yjs": ">=13.5.42"
+      },
+      "dependencies": {
+        "@excalidraw/excalidraw": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.17.0.tgz",
+          "integrity": "sha512-NzP22v5xMqxYW27ZtTHhiGFe7kE8NeBk45aoeM/mDSkXiOXPDH+PcvwzHRN/Ei+Vj/0sTPHxejn8bZyRWKGjXg=="
+        }
       }
     },
     "lib0": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25677,7 +25677,7 @@
     "@excalidraw/excalidraw": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.17.0.tgz",
-      "integrity": "sha512-NzP22v5xMqxYW27ZtTHhiGFe7kE8NeBk45aoeM/mDSkXiOXPDH+PcvwzHRN/Ei+Vj/0sTPHxejn8bZyRWKGjXg==",
+      "integrity": "sha512-NzP22v5xMqxYW27ZtTHhiGFe7kE8NeBk45aoeM/mDSkXiOXPDH+PcvwzHRN/Ei+Vj/0sTPHxejn8bZyRWKGjXg=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35380,13 +35380,6 @@
         "vite-plugin-replace": "0.1.1",
         "y-websocket": ">=1.3.x",
         "yjs": ">=13.5.42"
-      },
-      "dependencies": {
-        "@excalidraw/excalidraw": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.17.0.tgz",
-          "integrity": "sha512-NzP22v5xMqxYW27ZtTHhiGFe7kE8NeBk45aoeM/mDSkXiOXPDH+PcvwzHRN/Ei+Vj/0sTPHxejn8bZyRWKGjXg=="
-        }
       }
     },
     "lib0": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2399,6 +2399,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@excalidraw/excalidraw": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.17.0.tgz",
+      "integrity": "sha512-NzP22v5xMqxYW27ZtTHhiGFe7kE8NeBk45aoeM/mDSkXiOXPDH+PcvwzHRN/Ei+Vj/0sTPHxejn8bZyRWKGjXg==",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.2.0",
+        "react-dom": "^17.0.2 || ^18.2.0"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -22917,15 +22926,6 @@
         "vite-plugin-replace": "0.1.1"
       }
     },
-    "packages/lexical-playground/node_modules/@excalidraw/excalidraw": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.17.0.tgz",
-      "integrity": "sha512-NzP22v5xMqxYW27ZtTHhiGFe7kE8NeBk45aoeM/mDSkXiOXPDH+PcvwzHRN/Ei+Vj/0sTPHxejn8bZyRWKGjXg==",
-      "peerDependencies": {
-        "react": "^17.0.2 || ^18.2.0",
-        "react-dom": "^17.0.2 || ^18.2.0"
-      }
-    },
     "packages/lexical-react": {
       "name": "@lexical/react",
       "version": "0.12.4",
@@ -25673,6 +25673,11 @@
           "dev": true
         }
       }
+    },
+    "@excalidraw/excalidraw": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.17.0.tgz",
+      "integrity": "sha512-NzP22v5xMqxYW27ZtTHhiGFe7kE8NeBk45aoeM/mDSkXiOXPDH+PcvwzHRN/Ei+Vj/0sTPHxejn8bZyRWKGjXg==",
     },
     "@hapi/hoek": {
       "version": "9.3.0",

--- a/packages/lexical-playground/package.json
+++ b/packages/lexical-playground/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@excalidraw/excalidraw": "^0.15.3",
+    "@excalidraw/excalidraw": "^0.17.0",
     "@lexical/clipboard": "0.12.4",
     "@lexical/code": "0.12.4",
     "@lexical/file": "0.12.4",

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
@@ -222,12 +222,6 @@ export default function ExcalidrawModal({
     setFiles(fls);
   };
 
-  // This is a hacky work-around for Excalidraw + Vite.
-  // In DEV, Vite pulls this in fine, in prod it doesn't. It seems
-  // like a module resolution issue with ESM vs CJS?
-  // const _Excalidraw =
-  //   Excalidraw.$$typeof != null ? Excalidraw : Excalidraw.default;
-
   return createPortal(
     <div className="ExcalidrawModal__overlay" role="dialog">
       <div

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawModal.tsx
@@ -61,6 +61,16 @@ type Props = {
   ) => void;
 };
 
+export const useCallbackRefState = () => {
+  const [refValue, setRefValue] =
+    React.useState<ExcalidrawImperativeAPI | null>(null);
+  const refCallback = React.useCallback(
+    (value: ExcalidrawImperativeAPI | null) => setRefValue(value),
+    [],
+  );
+  return [refValue, refCallback] as const;
+};
+
 /**
  * @explorer-desc
  * A component which renders a modal with Excalidraw (a painting app)
@@ -77,7 +87,7 @@ export default function ExcalidrawModal({
   onClose,
 }: Props): ReactPortal | null {
   const excaliDrawModelRef = useRef<HTMLDivElement | null>(null);
-  const excaliDrawSceneRef = useRef<ExcalidrawImperativeAPI>(null);
+  const [excalidrawAPI, excalidrawAPIRefCallback] = useCallbackRefState();
   const [discardModalOpen, setDiscardModalOpen] = useState(false);
   const [elements, setElements] =
     useState<ReadonlyArray<ExcalidrawElementFragment>>(initialElements);
@@ -139,7 +149,7 @@ export default function ExcalidrawModal({
 
   const save = () => {
     if (elements.filter((el) => !el.isDeleted).length > 0) {
-      const appState = excaliDrawSceneRef?.current?.getAppState();
+      const appState = excalidrawAPI?.getAppState();
       // We only need a subset of the state
       const partialState: Partial<AppState> = {
         exportBackground: appState.exportBackground,
@@ -215,8 +225,8 @@ export default function ExcalidrawModal({
   // This is a hacky work-around for Excalidraw + Vite.
   // In DEV, Vite pulls this in fine, in prod it doesn't. It seems
   // like a module resolution issue with ESM vs CJS?
-  const _Excalidraw =
-    Excalidraw.$$typeof != null ? Excalidraw : Excalidraw.default;
+  // const _Excalidraw =
+  //   Excalidraw.$$typeof != null ? Excalidraw : Excalidraw.default;
 
   return createPortal(
     <div className="ExcalidrawModal__overlay" role="dialog">
@@ -226,9 +236,9 @@ export default function ExcalidrawModal({
         tabIndex={-1}>
         <div className="ExcalidrawModal__row">
           {discardModalOpen && <ShowDiscardDialog />}
-          <_Excalidraw
+          <Excalidraw
             onChange={onChange}
-            ref={excaliDrawSceneRef}
+            excalidrawAPI={excalidrawAPIRefCallback}
             initialData={{
               appState: initialAppState || {isLoading: false},
               elements: initialElements,

--- a/packages/lexical-playground/vite.config.js
+++ b/packages/lexical-playground/vite.config.js
@@ -169,6 +169,9 @@ const moduleResolution = [
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  define: {
+    "process.env.IS_PREACT": process.env.IS_PREACT,
+  },
   plugins: [
     replaceCodePlugin({
       replacements: [

--- a/packages/lexical-playground/vite.prod.config.js
+++ b/packages/lexical-playground/vite.prod.config.js
@@ -160,6 +160,9 @@ const moduleResolution = [
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  define: {
+    "process.env.IS_PREACT": process.env.IS_PREACT,
+  },
   plugins: [
     replaceCodePlugin({
       replacements: [


### PR DESCRIPTION
As per: https://github.com/excalidraw/excalidraw/releases/tag/v0.17.0 there are a few breaking changes in the Excalidraw API, for ViteJS and moving away from refs. Updating respectively so we can move to 0.17 and keep the dependency up to date.