### PR TITLE
Fix: Dispatch SELECT_ALL_COMMAND from Firefox as well

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1024,8 +1024,7 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
         event.preventDefault();
         dispatchCommand(editor, SELECT_ALL_COMMAND, event);
       }
-      // FF does it well (no need to override behavior)
-    } else if (!IS_FIREFOX && isSelectAll(keyCode, metaKey, ctrlKey)) {
+    } else if (isSelectAll(keyCode, metaKey, ctrlKey)) {
       event.preventDefault();
       dispatchCommand(editor, SELECT_ALL_COMMAND, event);
     }


### PR DESCRIPTION
Modification of PR #4818

## Bug
https://github.com/facebook/lexical/assets/77579276/765a3f2f-95da-4e90-9699-db85d298554f
- `cmd`+`a` not working properly in **Firefox**(Chrome doesn't seem to have this problem)
  - Selection is moved to the beginning of the document
  - Subsequent deletion or insertions only happen in the beginning of the document
- Is not reproducible
  - Happens sometimes during text operations, but happens quite often.
## Fix
- Made `SELECT_ALL_COMMAND` dispatch from Firefox as well.
- Not sure why, but this seems to fix the bug above.
- Also, not dispatching `SELECT_ALL_COMMAND` only in Firefox will mean that library users will have unexpected behavior if they consume the dispatched `SELECT_ALL_COMMAND, since this command won't be dispatched only in Firefox, meaning that they'll have to write different logic only for Firefox.