### PR TITLE
Remove style attributes for text/html before paste

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -158,6 +158,19 @@ export function $insertDataTransferForRichText(
     try {
       const parser = new DOMParser();
       const dom = parser.parseFromString(htmlString, 'text/html');
+
+      // strip any style attributes from pasted text/html content
+      const removeStyleAttributes = (element: HTMLElement) => {
+        element.removeAttribute('style');
+        for(const child of el.childNodes) {
+          if (child instanceof HTMLElement) {
+            removeStyles(child as HTMLElement)
+          }
+        }
+      }  
+      const body = dom.querySelector('body')
+      if (body) { removeStyles(body) }
+      
       const nodes = $generateNodesFromDOM(editor, dom);
       return $insertGeneratedNodes(editor, nodes, selection);
     } catch {


### PR DESCRIPTION
Update $insertDataTransferForRichText to remove style attributes for text/html before paste

Situation: When using the RichTextPlugin, common use cases involve controlling the styles with which the content is rendered to ensure a consistent experience. 

Problem: When pasting content from external sources (Example VS Code) the style attributes are inserted as well, creating an uncontrolled experience of how pasted content is rendered. 

Proposed Solution: Automatically remove all style attributes before pasting "text/html" content.