### PR TITLE
Allow exporting a document fragment from the exportDOM function

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -130,14 +130,20 @@ function $appendNodesToHTML(
   }
 
   if (shouldInclude && !shouldExclude) {
-    if (isHTMLElement(element)) {
+    if (isHTMLElement(element) || element instanceof DocumentFragment) {
       element.append(fragment);
     }
     parentElement.append(element);
 
     if (after) {
       const newElement = after.call(target, element);
-      if (newElement) element.replaceWith(newElement);
+      if (newElement) {
+        if (element instanceof DocumentFragment) {
+          element.replaceChildren(newElement);
+        } else {
+          element.replaceWith(newElement);
+        }
+      }
     }
   } else {
     parentElement.append(fragment);

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -342,8 +342,8 @@ export type DOMConversionOutput = {
   node: null | LexicalNode | Array<LexicalNode>,
 };
 export type DOMExportOutput = {
-  after?: (generatedElement: ?HTMLElement) => ?HTMLElement,
-  element?: HTMLElement | null,
+  after?: (generatedElement: ?HTMLElement) => ?HTMLElement | DocumentFragment,
+  element?: HTMLElement | DocumentFragment | null,
 };
 export type NodeKey = string;
 declare export class LexicalNode {

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -151,9 +151,9 @@ export type DOMConversionOutput = {
 
 export type DOMExportOutput = {
   after?: (
-    generatedElement: HTMLElement | Text | null | undefined,
-  ) => HTMLElement | Text | null | undefined;
-  element: HTMLElement | Text | null;
+    generatedElement: HTMLElement | DocumentFragment | Text | null | undefined,
+  ) => HTMLElement | DocumentFragment | Text | null | undefined;
+  element: HTMLElement | DocumentFragment | Text | null;
 };
 
 export type NodeKey = string;


### PR DESCRIPTION
Closes #5238 

This PR allows a node's `exportDOM` function to return a [`DocumentFragment`](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment) in addition to a HTMLElement or TextNode, which allows exporting a collection of elements with no wrapping element from that node.

See the linked issue for more details, but my basic use case is being able to remove a wrapping anchor tag from the HTML output if the `href` property is invalid, but keep any formatting (such as <em> tags) within that anchor tag.