### PR TITLE
keep selection style when clicking empty editor

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -11,6 +11,7 @@ import type {NodeKey} from './LexicalNode';
 import type {ElementNode} from './nodes/LexicalElementNode';
 import type {TextNode} from './nodes/LexicalTextNode';
 
+import {$isRootTextContentEmpty} from '@lexical/text';
 import {
   CAN_USE_BEFORE_INPUT,
   IS_ANDROID,
@@ -334,7 +335,10 @@ function onSelectionChange(
           if (anchor.type === 'text') {
             selection.format = anchorNode.getFormat();
             selection.style = anchorNode.getStyle();
-          } else if (anchor.type === 'element') {
+          } else if (
+            anchor.type === 'element' &&
+            !$isRootTextContentEmpty(editor.isComposing(), false)
+          ) {
             selection.format = 0;
             selection.style = '';
           }

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -11,7 +11,6 @@ import type {NodeKey} from './LexicalNode';
 import type {ElementNode} from './nodes/LexicalElementNode';
 import type {TextNode} from './nodes/LexicalTextNode';
 
-import {$isRootTextContentEmpty} from '@lexical/text';
 import {
   CAN_USE_BEFORE_INPUT,
   IS_ANDROID,
@@ -324,6 +323,10 @@ function onSelectionChange(
         const [lastFormat, lastStyle, lastOffset, lastKey, timeStamp] =
           collapsedSelectionFormat;
 
+        const root = $getRoot();
+        const isRootTextContentEmpty =
+          editor.isComposing() === false && root.getTextContent() === '';
+
         if (
           currentTimeStamp < timeStamp + 200 &&
           anchor.offset === lastOffset &&
@@ -335,10 +338,7 @@ function onSelectionChange(
           if (anchor.type === 'text') {
             selection.format = anchorNode.getFormat();
             selection.style = anchorNode.getStyle();
-          } else if (
-            anchor.type === 'element' &&
-            !$isRootTextContentEmpty(editor.isComposing(), false)
-          ) {
+          } else if (anchor.type === 'element' && !isRootTextContentEmpty) {
             selection.format = 0;
             selection.style = '';
           }


### PR DESCRIPTION
resolve #5202 

change code to keep selection style when clicking editor which has empty content.

`before`

https://github.com/facebook/lexical/assets/78121870/c2198c28-e190-4efe-886c-03ed20e4be80

`after`

https://github.com/facebook/lexical/assets/78121870/01f0deb7-5b65-4e01-b77a-cdaf16a85bc1

