### PR TITLE
Fixing nested collapsible section chevron

### DIFF
--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/Collapsible.css
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/Collapsible.css
@@ -41,7 +41,7 @@
   transform: translateY(-50%);
 }
 
-.Collapsible__container[open] .Collapsible__title:before {
+.Collapsible__container[open] > .Collapsible__title:before {
   border-color: transparent;
   border-width: 6px 4px 0 4px;
   border-top-color: #000;


### PR DESCRIPTION
Nested collapsible sections' chevron do not rotate when its collapsible section is collapsed/uncollapsed.

Issue:
![collapsible-chevron-issue](https://github.com/facebook/lexical/assets/7505359/b604788b-9870-4213-aaca-001fde7bd280)

Fixed:
![collapsible-chevron-issue-fixed](https://github.com/facebook/lexical/assets/7505359/f3c1bcff-f490-4e7b-9953-25c64168ae7f)
