### PR TITLE
URL sanitization ClickableLinkPlugin

### DIFF
--- a/packages/lexical-react/src/LexicalClickableLinkPlugin.tsx
+++ b/packages/lexical-react/src/LexicalClickableLinkPlugin.tsx
@@ -61,7 +61,7 @@ export default function LexicalClickableLinkPlugin({
             $isElementNode,
           );
           if ($isLinkNode(maybeLinkNode)) {
-            url = maybeLinkNode.getURL();
+            url = maybeLinkNode.sanitizeUrl(maybeLinkNode.getURL());
             urlTarget = maybeLinkNode.getTarget();
           } else {
             const a = findMatchingDOM(target, isHTMLAnchorElement);


### PR DESCRIPTION
Even though URLs undergo sanitization when the Link Node generates the DOM, when someone clicks a link using the ClickableLinkPlugin, the link isn't sanitized.

This pull request resolves the issue by sanitizing the URL within the event handler.