### PR TITLE
Fix insertNodes bugs

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -7,7 +7,7 @@
  */
 
 import {$createLinkNode} from '@lexical/link';
-import {$createHeadingNode,$isHeadingNode} from '@lexical/rich-text';
+import {$createHeadingNode, $isHeadingNode} from '@lexical/rich-text';
 import {
   $getSelectionStyleValueForProperty,
   $patchStyleText,

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -7,7 +7,7 @@
  */
 
 import {$createLinkNode} from '@lexical/link';
-import {$createHeadingNode} from '@lexical/rich-text';
+import {$createHeadingNode,$isHeadingNode} from '@lexical/rich-text';
 import {
   $getSelectionStyleValueForProperty,
   $patchStyleText,
@@ -21,6 +21,7 @@ import {
   $getRoot,
   $getSelection,
   $insertNodes,
+  $isParagraphNode,
   $isRangeSelection,
   $setSelection,
   RangeSelection,
@@ -2629,6 +2630,33 @@ describe('insertNodes', () => {
       selection.insertNodes([$createTextNode('foo')]);
 
       expect($getRoot().getTextContent()).toBe('footext');
+    });
+  });
+
+  it('last node is LineBreakNode', async () => {
+    const editor = createTestEditor();
+    const element = document.createElement('div');
+    editor.setRootElement(element);
+
+    await editor.update(() => {
+      // Empty text node to test empty text split
+      const paragraph = $createParagraphNode();
+      $getRoot().append(paragraph);
+      const selection = paragraph.select();
+      expect($isRangeSelection(selection)).toBeTruthy();
+
+      const newHeading = $createHeadingNode('h1').append(
+        $createTextNode('heading'),
+      );
+      selection.insertNodes([newHeading, $createLineBreakNode()]);
+    });
+    editor.getEditorState().read(() => {
+      expect(element.innerHTML).toBe(
+        '<h1 dir="ltr"><span data-lexical-text="true">heading</span></h1><p><br></p>',
+      );
+      const selectedNode = ($getSelection() as RangeSelection).anchor.getNode();
+      expect($isParagraphNode(selectedNode)).toBeTruthy();
+      expect($isHeadingNode(selectedNode.getPreviousSibling())).toBeTruthy();
     });
   });
 });

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1596,19 +1596,17 @@ export class RangeSelection implements BaseSelection {
     const notInline = (node: LexicalNode) =>
       ($isElementNode(node) || $isDecoratorNode(node)) && !node.isInline();
 
-    let nodeToSelect = $isElementNode(last)
-      ? last.getLastDescendant() || last
-      : last;
     if (!nodes.some(notInline)) {
       const index = removeTextAndSplitBlock(this);
       firstBlock.splice(index, 0, nodes);
-      nodeToSelect.selectEnd();
+      last.selectEnd();
       return;
     }
 
     // CASE 3: At least 1 element of the array is not inline
-    const blocks = $wrapInlineNodes(nodes).getChildren();
-    nodeToSelect = blocks[blocks.length - 1];
+    const blocksParent = $wrapInlineNodes(nodes);
+    const nodeToSelect = blocksParent.getLastDescendant()!;
+    const blocks = blocksParent.getChildren();
     const isLI = (node: LexicalNode) =>
       '__value' in node && '__checked' in node;
     const isMergeable = (node: LexicalNode) =>

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1596,7 +1596,7 @@ export class RangeSelection implements BaseSelection {
     const notInline = (node: LexicalNode) =>
       ($isElementNode(node) || $isDecoratorNode(node)) && !node.isInline();
 
-    const nodeToSelect = $isElementNode(last)
+    let nodeToSelect = $isElementNode(last)
       ? last.getLastDescendant() || last
       : last;
     if (!nodes.some(notInline)) {
@@ -1608,6 +1608,7 @@ export class RangeSelection implements BaseSelection {
 
     // CASE 3: At least 1 element of the array is not inline
     const blocks = $wrapInlineNodes(nodes).getChildren();
+    nodeToSelect = blocks[blocks.length - 1];
     const isLI = (node: LexicalNode) =>
       '__value' in node && '__checked' in node;
     const isMergeable = (node: LexicalNode) =>

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1631,7 +1631,7 @@ export class RangeSelection implements BaseSelection {
 
     if (
       insertedParagraph &&
-      $isElementNode(lastToInsert) &&
+      $isElementNode(lastInsertedBlock) &&
       (isLI(insertedParagraph) || INTERNAL_$isBlock(lastToInsert))
     ) {
       lastInsertedBlock.append(...insertedParagraph.getChildren());
@@ -1647,7 +1647,7 @@ export class RangeSelection implements BaseSelection {
     const lastChild = $isElementNode(firstBlock)
       ? firstBlock.getLastChild()
       : null;
-    if ($isLineBreakNode(lastChild) && lastToInsert !== firstBlock) {
+    if ($isLineBreakNode(lastChild) && lastInsertedBlock !== firstBlock) {
       lastChild.remove();
     }
   }


### PR DESCRIPTION
From Discord:

> there's 1 or 2 potential issues that we to iterate on asap or revert the commit and take a look at carefully.
> 
> This error has been reported multiple times among employees on clipboard paste before we reverted:
> 
> Cannot read properties of null (reading 'append')
> 
> Based on the trace this is pointing to:
> lastInsertedBlock.append(...insertedParagraph.getChildren());
> 
> Second and not yet sure if connected, when there's a new line at the end it crashes before the selection is lost (the line break node is removed before so we can't restore to it).

cc @zurfyx 

this replace https://github.com/facebook/lexical/pull/5324