### PR TITLE
Fix forward line deletion

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -21,6 +21,7 @@ import {
   $isDecoratorNode,
   $isElementNode,
   $isLineBreakNode,
+  $isParagraphNode,
   $isRootNode,
   $isTextNode,
   $setSelection,
@@ -2047,7 +2048,12 @@ export class RangeSelection implements BaseSelection {
       // to delete its parent element. Otherwise text content will be deleted but empty
       // parent node will remain
       const endPoint = isBackward ? this.focus : this.anchor;
-      if (endPoint.offset === 0) {
+      const topLevel = endPoint.getNode().getTopLevelElement();
+      const next = topLevel && topLevel.getNextSibling();
+      if (
+        endPoint.offset === 0 &&
+        ($isTextNode(next) || $isParagraphNode(next))
+      ) {
         this.modify('extend', isBackward, 'character');
       }
     }


### PR DESCRIPTION
Fix for: https://github.com/facebook/lexical/issues/5330
Before video inside the Issue.

After:
https://github.com/facebook/lexical/assets/7893468/41a46b60-5c5f-4531-8a2e-af3af767958b

It does delete line by line, low FPS in the recording shows as if it deletes 2 at once.
I'm fairly sure, I'm not solving this correctly. Because after the line deletion, the cursor should be at the start of the next line. Which is currently not the behaviour.

@zurfyx @fantactuka @acywatson I need your help here for a proper fix, since it's in the core.