### PR TITLE
docs: added exportJSON function to the ExtendedTextNode plugin code

### DIFF
--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -385,6 +385,14 @@ export class ExtendedTextNode extends TextNode {
       this.__mode === 0
     );
   }
+
+  exportJSON(): SerializedTextNode {
+    return {
+      ...super.exportJSON(),
+      type: 'extended-text',
+      version: 1,
+    }
+  }
 }
 
 function patchStyleConversion(


### PR DESCRIPTION
Added the exportJSON function to solve the problem of errors when calling the `editor.getEditorState().toJSON()` method when using official documents.