### PR TITLE
Fix path alias typo

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,7 +64,7 @@
         "./packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx"
       ],
       "@lexical/react/useLexicalIsTextContentEmpty": [
-        "./packages/lexical-reactsrc//useLexicalIsTextContentEmpty.ts"
+        "./packages/lexical-react/src/useLexicalIsTextContentEmpty.ts"
       ],
       "@lexical/react/useLexicalNodeSelection": [
         "./packages/lexical-react/src/useLexicalNodeSelection.ts"


### PR DESCRIPTION
While trying to use `useLexicalIsTextContentEmpty`, I ran into a complaint from `ts`.
There was a typo in the path alias for it !