### PR TITLE
Fix collapseAtStart on ParagraphNode, HeadingNode

### DIFF
--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -369,9 +369,11 @@ export class HeadingNode extends ElementNode {
   }
 
   collapseAtStart(): true {
-    const newElement = !this.isEmpty()
-      ? $createHeadingNode(this.getTag())
-      : $createParagraphNode();
+    if (!this.isEmpty()) {
+      return true;
+    }
+
+    const newElement = $createParagraphNode();
     const children = this.getChildren();
     children.forEach((child) => newElement.append(child));
     this.replace(newElement);

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2048,7 +2048,7 @@ export class RangeSelection extends INTERNAL_PointSelection {
           }
         }
         $updateCaretSelectionForUnicodeCharacter(this, isBackward);
-      } else if (isBackward && anchor.offset === 0) {
+      } else if (anchor.offset === 0) {
         // Special handling around rich text nodes
         const element =
           anchor.type === 'element'

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -131,14 +131,14 @@ export class ParagraphNode extends ElementNode {
       if (nextSibling !== null) {
         this.selectNext();
         this.remove();
-        return true;
+      } else {
+        const prevSibling = this.getPreviousSibling();
+        if (prevSibling !== null) {
+          this.selectPrevious();
+          this.remove();
+        }
       }
-      const prevSibling = this.getPreviousSibling();
-      if (prevSibling !== null) {
-        this.selectPrevious();
-        this.remove();
-        return true;
-      }
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
fix #5350

### 1. ParagraphNode on empty editor, `DELETE`, `BACKSPACE`

before: 

https://github.com/facebook/lexical/assets/40269597/276b33d1-aaef-4a08-9d1c-d8b5cd46086d

after:

https://github.com/facebook/lexical/assets/40269597/3ed27818-48a2-48be-a72b-7d765c2faf0b

### 2. HeadingNode when it has text content, `BACKSPACE`

before:

https://github.com/facebook/lexical/assets/40269597/0a1b2c3c-da8d-4025-9638-b52678bfbdc3

after:

https://github.com/facebook/lexical/assets/40269597/86506853-88e2-4f7c-99ac-2e92daca8908


