### PR TITLE
Bug: Editing a link and changing selection shows wrong link value

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -66,6 +66,9 @@ function FloatingLinkEditor({
       } else {
         setLinkUrl('');
       }
+      if (isLinkEditMode) {
+        setEditedLinkUrl(linkUrl);
+      }
     }
     const editorElem = editorRef.current;
     const nativeSelection = window.getSelection();
@@ -101,7 +104,7 @@ function FloatingLinkEditor({
     }
 
     return true;
-  }, [anchorElem, editor, setIsLinkEditMode]);
+  }, [anchorElem, editor, setIsLinkEditMode, isLinkEditMode, linkUrl]);
 
   useEffect(() => {
     const scrollerElem = anchorElem.parentElement;


### PR DESCRIPTION
this fixes #5351

Here is a screen recording of the bug:

https://github.com/facebook/lexical/assets/2135071/bf5df3e1-d4c4-43a6-a119-4871062e84d4

Here is a screen recording after the fix:

https://github.com/facebook/lexical/assets/2135071/c2940716-468e-4827-8468-a641482dd27b

