### PR TITLE
Fix `DecoratorNode`s being treated as block elements

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -27,6 +27,7 @@ import {
   html,
   initialize,
   insertCollapsible,
+  insertHorizontalRule,
   insertImageCaption,
   insertSampleImage,
   insertTable,
@@ -518,6 +519,42 @@ test.describe('Selection', () => {
       page,
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test('Can use block controls on selections including decorator nodes #5371', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+
+    await page.keyboard.type('Some text');
+    await insertHorizontalRule(page);
+    await page.keyboard.type('More text');
+    await selectAll(page);
+
+    await click(page, '.block-controls');
+    await click(page, '.dropdown .icon.h1');
+
+    await assertHTML(
+      page,
+      html`
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Some text</span>
+        </h1>
+        <hr
+          class="selected"
+          contenteditable="false"
+          data-lexical-decorator="true" />
+        <h1
+          class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">More text</span>
+        </h1>
       `,
     );
   });

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -571,8 +571,8 @@ export function $getSelectionStyleValueForProperty(
 export function INTERNAL_$isBlock(
   node: LexicalNode,
 ): node is ElementNode | DecoratorNode<unknown> {
-  if ($isDecoratorNode(node) && !node.isInline()) {
-    return true;
+  if ($isDecoratorNode(node)) {
+    return false;
   }
   if (!$isElementNode(node) || $isRootOrShadowRoot(node)) {
     return false;

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -7,7 +7,6 @@
  */
 
 import type {
-  DecoratorNode,
   ElementNode,
   INTERNAL_PointSelection,
   LexicalNode,
@@ -568,9 +567,7 @@ export function $getSelectionStyleValueForProperty(
  * This function is for internal use of the library.
  * Please do not use it as it may change in the future.
  */
-export function INTERNAL_$isBlock(
-  node: LexicalNode,
-): node is ElementNode | DecoratorNode<unknown> {
+export function INTERNAL_$isBlock(node: LexicalNode): node is ElementNode {
   if ($isDecoratorNode(node)) {
     return false;
   }


### PR DESCRIPTION
closes https://github.com/facebook/lexical/issues/5369

This is a result of the larger insertNodes changes in v0.12.3+.

Causal code:
https://github.com/facebook/lexical/pull/5002/files#diff-33353db27f56a5d74e7281df0a8a2fc223eef41e9dc2efc723a412560a0148c9R561-R563

`INTERNAL_$isBlock` is treating (non-inline) `DecoratorNode`s as block elements, causing `ElementNode` methods being called on decorator nodes that result in broken functionality.

While someone could extend the decorator node class to have the indent and format properties, they are generally not elements and should not be treated as such.