### PR TITLE
Fix hashtag regex blocking transform to heading

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
@@ -302,4 +302,46 @@ test.describe('Hashtags', () => {
       `,
     );
   });
+
+  test('Should break when additional # added in front of it', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('#hello');
+
+    await waitForSelector(page, '.PlaygroundEditorTheme__hashtag');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #hello
+          </span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 6,
+      anchorPath: [0, 0, 0],
+      focusOffset: 6,
+      focusPath: [0, 0, 0],
+    });
+
+    await moveToEditorBeginning(page);
+    await page.keyboard.type('#');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">##hello</span>
+        </p>
+      `,
+    );
+  });
 });

--- a/packages/lexical-playground/__tests__/e2e/Headings/HeadingsTransformToHeadings.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Headings/HeadingsTransformToHeadings.spec.mjs
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {moveToEditorBeginning} from '../../keyboardShortcuts/index.mjs';
+import {
+  assertHTML,
+  focusEditor,
+  html,
+  initialize,
+  test,
+} from '../../utils/index.mjs';
+
+test('Headings - can transform to Headings when it has text', async ({
+  page,
+  isPlainText,
+  isCollab,
+}) => {
+  test.skip(isPlainText);
+  await initialize({isCollab, page});
+  await focusEditor(page);
+
+  await page.keyboard.type('Welcome to the playground');
+
+  await assertHTML(
+    page,
+    html`
+      <p
+        class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+        dir="ltr">
+        <span data-lexical-text="true">Welcome to the playground</span>
+      </p>
+    `,
+  );
+
+  await moveToEditorBeginning(page);
+
+  for (const level of [1, 2, 3, 4, 5, 6, 1]) {
+    await page.keyboard.type(`${'#'.repeat(level)} `);
+
+    await assertHTML(
+      page,
+      html`
+        <h${level}
+          class="PlaygroundEditorTheme__h${level} PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Welcome to the playground</span>
+        </h${level}>
+      `,
+    );
+  }
+});

--- a/packages/lexical-react/src/LexicalHashtagPlugin.ts
+++ b/packages/lexical-react/src/LexicalHashtagPlugin.ts
@@ -226,7 +226,7 @@ function getHashtagRegexString(): string {
 
   const hashtagAlpha = '[' + alpha + ']';
   const hashtagAlphanumeric = '[' + alphanumeric + ']';
-  const hashtagBoundary = '^|$|[^&/' + alphanumeric + ']';
+  const hashtagBoundary = '^|$|[^&/' + alphanumeric + hashChars + ']';
   const hashCharList = '[' + hashChars + ']';
 
   // A hashtag contains characters, numbers and underscores,


### PR DESCRIPTION
Fixes #5366

This prevents multiple hash chars on hashtag, which blocks transformation to heading.

before:

https://github.com/facebook/lexical/issues/5366#:~:text=The%20current%20behavior-,before,-%2Dheading%2D01.mov

after:

https://github.com/facebook/lexical/assets/40269597/d7804367-57fe-4188-b21c-8ea906f21921


