### PR TITLE
canInsertTextAfter exception for composition

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -654,7 +654,8 @@ export function $updateTextNodeFromDOMContent(
               !isComposing) ||
             (prevSelection.focus.key === textNode.__key &&
               prevSelection.focus.offset === prevTextContentSize &&
-              !node.canInsertTextAfter())))
+              !node.canInsertTextAfter() &&
+              !isComposing)))
       ) {
         node.markDirty();
         return;


### PR DESCRIPTION
https://github.com/facebook/lexical/pull/5363 parity for canInsertAfter (see the other PR and https://github.com/facebook/lexical/issues/5162 for more details). On the playground, hashtags can be written after so I switched it to `false` to test.

Before

https://github.com/facebook/lexical/assets/193447/9c00e7f5-5dd7-441f-a587-767124793c2f

After

https://github.com/facebook/lexical/assets/193447/73969e80-0eba-498e-bf6e-0073d33be1a8
