### PR TITLE
Fix exportTextFormat to keep dollar sign

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -165,9 +165,7 @@ function exportTextFormat(
   }
 
   // Replace trimmed version of textContent ensuring surrounding whitespace is not modified
-  return textContent.replace(frozenString, function () {
-    return output;
-  });
+  return textContent.replace(frozenString, () => output);
 }
 
 // Get next or previous text sibling a text node, including cases

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -165,7 +165,9 @@ function exportTextFormat(
   }
 
   // Replace trimmed version of textContent ensuring surrounding whitespace is not modified
-  return textContent.replace(frozenString, output);
+  return textContent.replace(frozenString, function () {
+    return output;
+  });
 }
 
 // Get next or previous text sibling a text node, including cases

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -183,6 +183,12 @@ describe('Markdown', () => {
       md: `Hello [world](${URL})! Hello $world$! [Hello](${URL}) world! Hello $world$!`,
       skipExport: true,
     },
+    {
+      // Export only: import will use $...$ to transform <span /> to <mark /> due to HIGHLIGHT_TEXT_MATCH_IMPORT
+      html: "<p><span style='white-space: pre-wrap;'>$$H$&e$`l$'lo</span></p>",
+      md: "$$H$&e$`l$'lo",
+      skipImport: true,
+    },
   ];
 
   const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -118,6 +118,10 @@ describe('Markdown', () => {
       md: '`hello$`',
     },
     {
+      html: '<p><code spellcheck="false" style="white-space: pre-wrap;"><span>$$hello</span></code></p>',
+      md: '`$$hello`',
+    },
+    {
       html: '<p><a href="https://lexical.dev"><span style="white-space: pre-wrap;">Hello</span></a><span style="white-space: pre-wrap;"> world</span></p>',
       md: '[Hello](https://lexical.dev) world',
     },

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -114,6 +114,10 @@ describe('Markdown', () => {
       md: '~~Hello~~ world',
     },
     {
+      html: '<p><code spellcheck="false" style="white-space: pre-wrap;"><span>hello$</span></code></p>',
+      md: '`hello$`',
+    },
+    {
       html: '<p><a href="https://lexical.dev"><span style="white-space: pre-wrap;">Hello</span></a><span style="white-space: pre-wrap;"> world</span></p>',
       md: '[Hello](https://lexical.dev) world',
     },
@@ -185,8 +189,8 @@ describe('Markdown', () => {
     },
     {
       // Export only: import will use $...$ to transform <span /> to <mark /> due to HIGHLIGHT_TEXT_MATCH_IMPORT
-      html: "<p><span style='white-space: pre-wrap;'>$$H$&e$`l$'lo</span></p>",
-      md: "$$H$&e$`l$'lo",
+      html: "<p><span style='white-space: pre-wrap;'>$$H$&e$`l$'l$o$</span></p>",
+      md: "$$H$&e$`l$'l$o$",
       skipImport: true,
     },
   ];


### PR DESCRIPTION
Fixes #5319 
Fixes #4931

Currently we uses `replace` in `exportTextFormat`:
```ts
function exportTextFormat(...) {
// ...
  return textContent.replace(frozenString, output);
}
```
The issue happens when `output` has `$&`, `$$`, .... 
It is because there are [special replacement sequences](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement) beginning with `$`: 
<img width="631" alt="image" src="https://github.com/facebook/lexical/assets/40269597/0ce07456-59f3-4143-9d09-76baa68a7d9e">

A workaround for this: https://stackoverflow.com/questions/9423722/string-replace-weird-behavior-when-using-dollar-sign-as-replacement


before:

https://github.com/facebook/lexical/assets/40269597/698381e9-08b0-4f6f-ae00-ac7a94124b96

after:

https://github.com/facebook/lexical/assets/40269597/e4f2f79e-ae20-447a-b9c6-82af6499863f


