### PR TITLE
fix: adding missing argument for $sliceSelectedTextContent

### DIFF
--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -96,7 +96,7 @@ export function $sliceSelectedTextNodeContent(
   textNode: TextNode,
 ): LexicalNode {
   if (
-    textNode.isSelected() &&
+    textNode.isSelected(selection) &&
     !textNode.isSegmented() &&
     !textNode.isToken() &&
     $INTERNAL_isPointSelection(selection)


### PR DESCRIPTION
Code was using default of the current selection when it should be using the selection that is passed through