### PR TITLE
dropdown text visibility problem fixed for medium and smaller screens

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -802,6 +802,10 @@ i.page-break,
     display: none !important;
   }
 
+  .dialog-dropdown > .dropdown-button-text {
+    display: flex !important;
+  }
+
   .font-size .dropdown-button-text {
     display: flex !important;
   }


### PR DESCRIPTION
When screen size gets smaller, dropdown text becomes invisible so, editor toolbar buttons stay visible.
But dropdown input element text become invincible too.

I fixed this problem by checking if it is a dropdown that isn't in editor and make it visible again.

BEFORE
![BEFORE](https://github.com/facebook/lexical/assets/43554487/2f54b0cc-39ea-4f4d-8002-dea80b8d38a0)

---

AFTER
![AFTER](https://github.com/facebook/lexical/assets/43554487/e3e75f17-4794-49a8-84d1-2f212f95c5c2)

Chrome: 119.0.6045.200 
Windows: 22H2 OS Build 19045.3758
