### PR TITLE
Feature/excalidraw resize

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -802,6 +802,10 @@ i.page-break,
     display: none !important;
   }
 
+  .dialog-dropdown > .dropdown-button-text {
+    display: flex !important;
+  }
+
   .font-size .dropdown-button-text {
     display: flex !important;
   }

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -153,11 +153,23 @@ export default function ExcalidrawComponent({
     setIsResizing(true);
   };
 
-  const onResizeEnd = () => {
+  const onResizeEnd = (
+    nextWidth: 'inherit' | number,
+    nextHeight: 'inherit' | number,
+  ) => {
     // Delay hiding the resize bars for click case
     setTimeout(() => {
       setIsResizing(false);
     }, 200);
+
+    editor.update(() => {
+      const node = $getNodeByKey(nodeKey);
+
+      if ($isExcalidrawNode(node)) {
+        node.setWidth(nextWidth);
+        node.setHeight(nextHeight);
+      }
+    });
   };
 
   const openModal = useCallback(() => {

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -30,6 +30,8 @@ const ExcalidrawComponent = React.lazy(
 export type SerializedExcalidrawNode = Spread<
   {
     data: string;
+    width: number | 'inherit';
+    height: number | 'inherit';
   },
   SerializedLexicalNode
 >;
@@ -50,6 +52,8 @@ function convertExcalidrawElement(
 
 export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
   __data: string;
+  __width: number | 'inherit';
+  __height: number | 'inherit';
 
   static getType(): string {
     return 'excalidraw';
@@ -66,14 +70,18 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
   exportJSON(): SerializedExcalidrawNode {
     return {
       data: this.__data,
+      height: this.__height,
       type: 'excalidraw',
       version: 1,
+      width: this.__width,
     };
   }
 
   constructor(data = '[]', key?: NodeKey) {
     super(key);
     this.__data = data;
+    this.__width = 'inherit';
+    this.__height = 'inherit';
   }
 
   // View
@@ -81,6 +89,12 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
     const span = document.createElement('span');
     const theme = config.theme;
     const className = theme.image;
+
+    span.style.width =
+      this.__width === 'inherit' ? 'inherit' : `${this.__width}px`;
+    span.style.height =
+      this.__height === 'inherit' ? 'inherit' : `${this.__height}px`;
+
     if (className !== undefined) {
       span.className = className;
     }
@@ -107,6 +121,9 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
     const element = document.createElement('span');
+
+    element.style.display = 'inline-block';
+
     const content = editor.getElementByKey(this.getKey());
     if (content !== null) {
       const svg = content.querySelector('svg');
@@ -114,6 +131,12 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
         element.innerHTML = svg.outerHTML;
       }
     }
+
+    element.style.width =
+      this.__width === 'inherit' ? 'inherit' : `${this.__width}px`;
+    element.style.height =
+      this.__height === 'inherit' ? 'inherit' : `${this.__height}px`;
+
     element.setAttribute('data-lexical-excalidraw-json', this.__data);
     return {element};
   }
@@ -121,6 +144,16 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
   setData(data: string): void {
     const self = this.getWritable();
     self.__data = data;
+  }
+
+  setWidth(width: number | 'inherit'): void {
+    const self = this.getWritable();
+    self.__width = width;
+  }
+
+  setHeight(height: number | 'inherit'): void {
+    const self = this.getWritable();
+    self.__height = height;
   }
 
   decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {


### PR DESCRIPTION
Resizing excalidraw figures was already exist. But width and height hasn't saved to anywhere.
So I store the width and height in Excalidraw node then apply style to span element and make the span element, **inline-block** so it can change size while still being span element.