### PR TITLE
Fix breakdown in importTextMatchTransformers

### DIFF
--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -303,11 +303,11 @@ function importTextMatchTransformers(
           endIndex,
         );
       }
-      if (leftTextNode) {
-        importTextMatchTransformers(leftTextNode, textMatchTransformers);
-      }
       if (rightTextNode) {
-        textNode = rightTextNode;
+        importTextMatchTransformers(rightTextNode, textMatchTransformers);
+      }
+      if (leftTextNode) {
+        textNode = leftTextNode;
       }
       transformer.replace(replaceNode, match);
       continue mainLoop;


### PR DESCRIPTION
Fixes: #5385 

### The bug is when 
1. `importTextMatchTransformers` handles a `textNode` containing several matches
2. and the most leftward text is a match 
3. and the more rightward match happens to come first than the most leftward match.

### It occurs due to the following scenario:

1. Let's say we have `LINK`, `IMAGE` on the same line, with this order.
2. Match with `IMAGE` comes first due to transformers order. 
3. It gets split into `leftTextNode` and `replaceNode` (<-containing match  with `IMAGE`).
4. We handle `leftTextNode` first with `importTextMatchTransformers` recursively. https://github.com/facebook/lexical/blob/ee82c4f395a659eb36aa34ecd9e718894d5f094f/packages/lexical-markdown/src/MarkdownImport.ts#L306-L310
5. This will find the most leftward match (`LINK`) in `leftTextNode` and replace it,
6. which ends up removing the `parentNode` (of `replaceNode` from 3., `IMAGE`).
7. And when finally `replaceNode` (from 3., `IMAGE`) reaches `transformer.replace(replaceNode, match);` with a `null` parent, https://github.com/facebook/lexical/blob/ee82c4f395a659eb36aa34ecd9e718894d5f094f/packages/lexical-markdown/src/MarkdownImport.ts#L312
8. It fails because it is followed by `getParentOrThrow()` and throws an exception. https://github.com/facebook/lexical/blob/ee82c4f395a659eb36aa34ecd9e718894d5f094f/packages/lexical/src/LexicalNode.ts#L858

This PR makes `rightTextNode` get handled first.

before: 
https://github.com/facebook/lexical/issues/5385#:~:text=before%2D-,convertfrommarkdown,-.mov

after:

https://github.com/facebook/lexical/assets/40269597/03eeaebd-81f4-4f25-9d19-191290ceda2f



