### PR TITLE
fix: Reset compositionKey when backspacing a selection on Android where anchor and focus keys are different

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -558,6 +558,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
             dispatchCommand(editor, DELETE_CHARACTER_COMMAND, true);
           }
         } else {
+          $setCompositionKey(null);
           event.preventDefault();
           dispatchCommand(editor, DELETE_CHARACTER_COMMAND, true);
         }


### PR DESCRIPTION
fixes #5259

PR #5077 added a fix for the android backspace bug where pressing backspace delete two characters at once, by setting the `compositionKey` to `selection.anchor.key` when on Android. However, in cases where the `anchor.key` and `focus.key` are different, the `compositionKey` isn't cleared causing an issue where the selection wouldn't go away as described in #5259.
