### PR TITLE
Fix insertNodes when inserting into inline elements

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/LinksHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/LinksHTMLCopyAndPaste.spec.mjs
@@ -9,6 +9,7 @@
 import {
   extendToNextWord,
   moveLeft,
+  moveRight,
   moveToEditorBeginning,
   moveToEditorEnd,
   moveToLineBeginning,
@@ -255,6 +256,182 @@ test.describe('HTML Links CopyAndPaste', () => {
             <span data-lexical-text="true">Lexical</span>
           </a>
           <span data-lexical-text="true">in the wild</span>
+        </p>
+      `,
+    );
+  });
+
+  test('Paste text into a link', async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+
+    await page.keyboard.type('Link text');
+    await selectAll(page);
+    await click(page, '.link');
+    await moveRight(page, 1);
+    await moveLeft(page, 4);
+
+    await pasteFromClipboard(page, {
+      'text/html': 'normal text',
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">Link</span>
+          </a>
+          <span data-lexical-text="true">normal text</span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">text</span>
+          </a>
+        </p>
+      `,
+    );
+  });
+
+  test('Paste formatted text into a link', async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+
+    await page.keyboard.type('Link text');
+    await selectAll(page);
+    await click(page, '.link');
+    await moveRight(page, 1);
+    await moveLeft(page, 4);
+
+    await pasteFromClipboard(page, {
+      'text/html': '<b>bold</b> text',
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">Link</span>
+          </a>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            bold
+          </strong>
+          <span data-lexical-text="true">text</span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">text</span>
+          </a>
+        </p>
+      `,
+    );
+  });
+
+  test('Paste a link into a link', async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+
+    await page.keyboard.type('Link text');
+    await selectAll(page);
+    await click(page, '.link');
+    await moveRight(page, 1);
+    await moveLeft(page, 4);
+
+    await pasteFromClipboard(page, {
+      'text/html': 'text with <a href="https://lexical.dev">link</b>',
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">Link</span>
+          </a>
+          <span data-lexical-text="true">text with</span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://lexical.dev">
+            <span data-lexical-text="true">link</span>
+          </a>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">text</span>
+          </a>
+        </p>
+      `,
+    );
+  });
+
+  test('Paste multiple blocks into a link', async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+
+    await page.keyboard.type('Link text');
+    await selectAll(page);
+    await click(page, '.link');
+    await moveRight(page, 1);
+    await moveLeft(page, 4);
+
+    await pasteFromClipboard(page, {
+      'text/html': '<p>para 1</p><p>para 2</p>',
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">Link</span>
+          </a>
+          <span data-lexical-text="true">para 1</span>
+        </p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">para 2</span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">text</span>
+          </a>
         </p>
       `,
     );

--- a/packages/lexical-playground/__tests__/regression/5251-paste-into-inline-element.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/5251-paste-into-inline-element.spec.mjs
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  moveToLineBeginning,
+  moveToNextWord,
+  moveToPrevWord,
+  selectCharacters,
+} from '../keyboardShortcuts/index.mjs';
+import {
+  assertHTML,
+  click,
+  copyToClipboard,
+  focusEditor,
+  html,
+  initialize,
+  IS_WINDOWS,
+  pasteFromClipboard,
+  pressToggleBold,
+  test,
+} from '../utils/index.mjs';
+
+test.describe('Regression test #5251', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+  test('Correctly pastes rich content inside an inline element', async ({
+    isPlainText,
+    page,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+
+    // Root
+    //   |- Paragraph
+    //      |- Text "Hello "
+    //      |- Text "bold" { format: bold }
+    //      |- Text " "
+    //      |- Link
+    //         |- Text "World"
+    await page.keyboard.type('Hello ');
+    await pressToggleBold(page);
+    await page.keyboard.type('bold');
+    await pressToggleBold(page);
+    await page.keyboard.type(' World');
+    await moveToPrevWord(page);
+    await selectCharacters(page, 'right', 'World'.length);
+    await click(page, '.link');
+
+    // Copy "Hello bold"
+    await moveToLineBeginning(page);
+    await selectCharacters(page, 'right', 'Hello bold'.length);
+    const clipboard = await copyToClipboard(page);
+
+    // Drop "bold"
+    await page.keyboard.press('ArrowLeft');
+    await moveToNextWord(page);
+    await selectCharacters(page, 'right', 'bold '.length);
+    await page.keyboard.press('Delete');
+
+    // Check our current state
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello</span>
+          <a
+            href="https://"
+            rel="noreferrer"
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">World</span>
+          </a>
+        </p>
+      `,
+    );
+
+    // Replace "Wor" with the contents of the clipboard
+    if (!IS_WINDOWS) {
+      await page.keyboard.press('ArrowRight');
+    }
+    await selectCharacters(page, 'right', 'Wor'.length);
+    await pasteFromClipboard(page, clipboard);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello Hello</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            bold
+          </strong>
+          <a
+            href="https://"
+            rel="noreferrer"
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">ld</span>
+          </a>
+        </p>
+      `,
+    );
+  });
+});


### PR DESCRIPTION
This restores the behavior that changed in #5002 particularly when
pasting into links and other inline elements.

Fixes facebook#5251.
