### PR TITLE
fix: Text format getting lost when using suggestion/autocorrect on iOS

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -124,6 +124,7 @@ export function $insertDataTransferForRichText(
   dataTransfer: DataTransfer,
   selection: BaseSelection,
   editor: LexicalEditor,
+  event?: InputEvent,
 ): void {
   const lexicalString = dataTransfer.getData('application/x-lexical-editor');
 
@@ -142,15 +143,22 @@ export function $insertDataTransferForRichText(
     }
   }
 
-  const htmlString = dataTransfer.getData('text/html');
-  if (htmlString) {
-    try {
-      const parser = new DOMParser();
-      const dom = parser.parseFromString(htmlString, 'text/html');
-      const nodes = $generateNodesFromDOM(editor, dom);
-      return $insertGeneratedNodes(editor, nodes, selection);
-    } catch {
-      // Fail silently.
+  const shouldIgnoreHTML =
+    event &&
+    event.inputType === 'insertReplacementText' &&
+    dataTransfer.types.includes('text/plain');
+
+  if (!shouldIgnoreHTML) {
+    const htmlString = dataTransfer.getData('text/html');
+    if (htmlString) {
+      try {
+        const parser = new DOMParser();
+        const dom = parser.parseFromString(htmlString, 'text/html');
+        const nodes = $generateNodesFromDOM(editor, dom);
+        return $insertGeneratedNodes(editor, nodes, selection);
+      } catch {
+        // Fail silently.
+      }
     }
   }
 

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -592,7 +592,12 @@ export function registerRichText(editor: LexicalEditor): () => void {
 
           const dataTransfer = eventOrText.dataTransfer;
           if (dataTransfer != null) {
-            $insertDataTransferForRichText(dataTransfer, selection, editor);
+            $insertDataTransferForRichText(
+              dataTransfer,
+              selection,
+              editor,
+              eventOrText,
+            );
           } else if ($isRangeSelection(selection)) {
             const data = eventOrText.data;
             if (data) {


### PR DESCRIPTION
fixes #4801 

Auto-correct/suggestions on iOS (and macOS?) trigger the `insertReplacementText` input type event, and inserting the nodes generated from the `text/html` data cause the formatting to be lost.
That isn't an issue if only the `text/plain` data is used to insert the text. With the `insertReplacementText` there's probably no need to be using the HTML data anyways.