### PR TITLE
Fix inserting redundant paragraph on enter in MarkNode

### DIFF
--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -20,12 +20,7 @@ import {
   addClassNamesToElement,
   removeClassNamesFromElement,
 } from '@lexical/utils';
-import {
-  $applyNodeReplacement,
-  $isElementNode,
-  $isRangeSelection,
-  ElementNode,
-} from 'lexical';
+import {$applyNodeReplacement, $isRangeSelection, ElementNode} from 'lexical';
 
 export type SerializedMarkNode = Spread<
   {
@@ -151,16 +146,9 @@ export class MarkNode extends ElementNode {
     selection: RangeSelection,
     restoreSelection = true,
   ): null | ElementNode {
-    const element = this.getParentOrThrow().insertNewAfter(
-      selection,
-      restoreSelection,
-    );
-    if ($isElementNode(element)) {
-      const markNode = $createMarkNode(this.__ids);
-      element.append(markNode);
-      return markNode;
-    }
-    return null;
+    const markNode = $createMarkNode(this.__ids);
+    this.insertAfter(markNode, restoreSelection);
+    return markNode;
   }
 
   canInsertTextBefore(): false {


### PR DESCRIPTION
Related to
- f15a17564b6267531732ba5cc824b8aaf45f5b54 (these changes introduced the bug)

I am wondering if we can find a general solution, to fix the issue for any node.

Before

https://github.com/facebook/lexical/assets/16056918/da3c99d6-45b6-4a6f-9db9-390210faf879

After

https://github.com/facebook/lexical/assets/16056918/780cda16-cd1e-4e2c-b267-3ed2f220bd61

