### PR TITLE
Fix TextNode#createDOM types: allow editor parameter in subclasses

### DIFF
--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -442,7 +442,7 @@ export class TextNode extends LexicalNode {
 
   // View
 
-  createDOM(config: EditorConfig): HTMLElement {
+  createDOM(config: EditorConfig, editor?: LexicalEditor): HTMLElement {
     const format = this.__format;
     const outerTag = getElementOuterTag(this, format);
     const innerTag = getElementInnerTag(this, format);


### PR DESCRIPTION
Without this, using this parameter in a subclass leads to:
```
Property 'createDOM' in type 'MyTextNode' is not assignable to the same property in base type 'TextNode'.
  Type '(config: EditorConfig, editor: LexicalEditor) => HTMLElement' is not assignable to type '(config: EditorConfig) => HTMLElement'.
    Target signature provides too few arguments. Expected 2 or more, but got 1.ts(2416)
```

Or is it intentional and for some reason text nodes shouldn't use `editor` in `createDOM`?

I made it optional in order not to break existing `super.createDOM(config)` calls in subclasses.