### PR TITLE
Remove duplicated test codes

### DIFF
--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -162,10 +162,6 @@ describe('Markdown', () => {
       md: '```\nCode\n```',
     },
     {
-      html: '<pre spellcheck="false"><span style="white-space: pre-wrap;">Code</span></pre>',
-      md: '```\nCode\n```',
-    },
-    {
       // Import only: extra empty lines will be removed for export
       html: '<p><span style="white-space: pre-wrap;">Hello</span></p><p><span style="white-space: pre-wrap;">world</span></p>',
       md: ['Hello', '', '', '', 'world'].join('\n'),


### PR DESCRIPTION
There are same test codes here:
https://github.com/facebook/lexical/blob/9d247acc42998b4de3ed079069584ebde701640b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts#L160-L167

