### PR TITLE
docs(serialization): add node helpers to ExtendedTextNode example

### DIFF
--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -395,6 +395,14 @@ export class ExtendedTextNode extends TextNode {
   }
 }
 
+export function $createExtendedTextNode(text: string, className: string): ExtendedTextNode {
+	return new ExtendedTextNode(text, className);
+}
+
+export function $isExtendedTextNode(node: lexical.LexicalNode | null | undefined): node is ExtendedTextNode {
+	return node instanceof ExtendedTextNode;
+}
+
 function patchStyleConversion(
   originalDOMConverter?: (node: HTMLElement) => DOMConversion | null
 ): (node: HTMLElement) => DOMConversionOutput | null {

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -328,7 +328,8 @@ import {
   DOMConversionOutput,
   NodeKey,
   TextNode,
-  SerializedTextNode
+  SerializedTextNode,
+  LexicalNode
 } from 'lexical';
 
 export class ExtendedTextNode extends TextNode {
@@ -395,11 +396,11 @@ export class ExtendedTextNode extends TextNode {
   }
 }
 
-export function $createExtendedTextNode(text: string, className: string): ExtendedTextNode {
+export function $createExtendedTextNode(text: string): ExtendedTextNode {
 	return new ExtendedTextNode(text, className);
 }
 
-export function $isExtendedTextNode(node: lexical.LexicalNode | null | undefined): node is ExtendedTextNode {
+export function $isExtendedTextNode(node: LexicalNode | null | undefined): node is ExtendedTextNode {
 	return node instanceof ExtendedTextNode;
 }
 


### PR DESCRIPTION
I think to align it with general Node best practices, from what I understand, I added `$isExtendedTextNode` & `$createExtendedTextNode`, which I think are really useful to have and helpful to newcomers.

Please just close if if's not a fit