### PR TITLE
[FIX] dropdown misplacement after scrolling

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -720,7 +720,7 @@ i.page-break,
 .dropdown {
   z-index: 100;
   display: block;
-  position: fixed;
+  position: absolute;
   box-shadow: 0 12px 28px 0 rgba(0, 0, 0, 0.2), 0 2px 4px 0 rgba(0, 0, 0, 0.1),
     inset 0 0 0 1px rgba(255, 255, 255, 0.5);
   border-radius: 8px;

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -248,7 +248,7 @@ function TableActionMenu({
       let topPosition = menuButtonRect.top;
       if (topPosition + dropDownElementRect.height > window.innerHeight) {
         const position = menuButtonRect.bottom - dropDownElementRect.height;
-        topPosition = (position < 0 ? margin : position) + window.pageYOffset;
+        topPosition = position < 0 ? margin : position;
       }
       dropDownElement.style.top = `${topPosition + +window.pageYOffset}px`;
     }


### PR DESCRIPTION
This PR is an extension of https://github.com/facebook/lexical/pull/5290 and is related to the [issue](https://github.com/facebook/lexical/issues/5289) 

## Before
- After adding extensive content to the editor, I inserted a table. However, the dropdown for Table Action doesn't appear at all. Upon inspecting the console, it was evident that the dropdown, located at the bottom of the page, fails to display.
https://github.com/facebook/lexical/assets/70982342/4e2168c8-a862-451b-a7ce-8ef478f05390

## After
- Modifying the dropdown CSS and adjusting the top position of the TableActionMenuPlugin dropdown resolved the issue.
https://github.com/facebook/lexical/assets/70982342/64a1134d-db77-44b1-b62f-4c1a57b78537

