### PR TITLE
bug: add a fix for collapseAtStart never run for nested element node

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1754,9 +1754,10 @@ export class RangeSelection extends INTERNAL_PointSelection {
       }
     }
     this.removeText();
+
     if (
       isBackward &&
-      !wasCollapsed &&
+      wasCollapsed &&
       this.isCollapsed() &&
       this.anchor.type === 'element' &&
       this.anchor.offset === 0
@@ -1764,10 +1765,14 @@ export class RangeSelection extends INTERNAL_PointSelection {
       const anchorNode = this.anchor.getNode();
       if (
         anchorNode.isEmpty() &&
-        $isRootNode(anchorNode.getParent()) &&
-        anchorNode.getIndexWithinParent() === 0
+        anchorNode.__prev == null &&
+        anchorNode.__next == null
       ) {
-        anchorNode.collapseAtStart(this);
+        const parentNode = anchorNode.getParent();
+
+        if (parentNode) {
+          parentNode.collapseAtStart(this);
+        }
       }
     }
   }


### PR DESCRIPTION
Run collapseAtStart function of parent node  if:
- child element is only child.
- child element is empty (does not contain any node)


