### PR TITLE
Replace font size dropdown with font size entry component

### DIFF
--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -136,10 +136,6 @@ export class CodeHighlightNode extends TextNode {
     return self.__highlightType;
   }
 
-  /**
-   *
-   * @returns true if the codehighlight node can be formatted, false otherwise.
-   */
   isStylable(): boolean {
     return false;
   }

--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -136,7 +136,7 @@ export class CodeHighlightNode extends TextNode {
     return self.__highlightType;
   }
 
-  isStylable(): boolean {
+  canHaveFormat(): boolean {
     return false;
   }
 

--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -136,6 +136,14 @@ export class CodeHighlightNode extends TextNode {
     return self.__highlightType;
   }
 
+  /**
+   *
+   * @returns true if the codehighlight node can be formatted, false otherwise.
+   */
+  isStylable(): boolean {
+    return false;
+  }
+
   createDOM(config: EditorConfig): HTMLElement {
     const element = super.createDOM(config);
     const className = getHighlightThemeClass(

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -427,7 +427,7 @@ test.describe('TextFormatting', () => {
     });
   });
 
-  test(`Can select text and change the font-size`, async ({
+  test(`Can select text and increase the font-size`, async ({
     page,
     isPlainText,
   }) => {
@@ -445,8 +445,7 @@ test.describe('TextFormatting', () => {
       focusPath: [0, 0, 0],
     });
 
-    await click(page, '.font-size');
-    await click(page, 'button:has-text("10px")');
+    await click(page, '.font-increment');
 
     await assertHTML(
       page,
@@ -455,7 +454,7 @@ test.describe('TextFormatting', () => {
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
           dir="ltr">
           <span data-lexical-text="true">Hello</span>
-          <span style="font-size: 10px;" data-lexical-text="true">world</span>
+          <span style="font-size: 17px;" data-lexical-text="true">world</span>
           <span data-lexical-text="true">!</span>
         </p>
       `,
@@ -467,6 +466,101 @@ test.describe('TextFormatting', () => {
       focusOffset: 5,
       focusPath: [0, 1, 0],
     });
+  });
+
+  test(`Can select text with different size and increase the font-size relatively`, async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await page.keyboard.type('Hello world!');
+    await selectCharacters(page, 'left', 6);
+    await click(page, '.font-increment');
+    await moveRight(page, 6);
+    await selectCharacters(page, 'left', 12);
+    await click(page, '.font-increment');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span style="font-size: 17px;" data-lexical-text="true">Hello</span>
+          <span style="font-size: 19px;" data-lexical-text="true">world!</span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Can select text and decrease the font-size`, async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await page.keyboard.type('Hello world!');
+    await moveLeft(page);
+    await selectCharacters(page, 'left', 5);
+
+    await assertSelection(page, {
+      anchorOffset: 11,
+      anchorPath: [0, 0, 0],
+      focusOffset: 6,
+      focusPath: [0, 0, 0],
+    });
+
+    await click(page, '.font-decrement');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello</span>
+          <span style="font-size: 13px;" data-lexical-text="true">world</span>
+          <span data-lexical-text="true">!</span>
+        </p>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0, 1, 0],
+      focusOffset: 5,
+      focusPath: [0, 1, 0],
+    });
+  });
+
+  test(`Can select text with different size and decrease the font-size relatively`, async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await page.keyboard.type('Hello world!');
+    await selectCharacters(page, 'left', 6);
+    await click(page, '.font-decrement');
+    await moveRight(page, 6);
+    await selectCharacters(page, 'left', 12);
+    await click(page, '.font-decrement');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span style="font-size: 13px;" data-lexical-text="true">Hello</span>
+          <span style="font-size: 12px;" data-lexical-text="true">world!</span>
+        </p>
+      `,
+    );
   });
 
   test(`Can select text and change the font-size and font-family`, async ({
@@ -488,8 +582,7 @@ test.describe('TextFormatting', () => {
       focusPath: [0, 0, 0],
     });
 
-    await click(page, '.font-size');
-    await click(page, 'button:has-text("10px")');
+    await click(page, '.font-increment');
 
     await assertHTML(
       page,
@@ -498,7 +591,7 @@ test.describe('TextFormatting', () => {
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
           dir="ltr">
           <span data-lexical-text="true">Hello</span>
-          <span style="font-size: 10px;" data-lexical-text="true">world</span>
+          <span style="font-size: 17px;" data-lexical-text="true">world</span>
           <span data-lexical-text="true">!</span>
         </p>
       `,
@@ -522,7 +615,7 @@ test.describe('TextFormatting', () => {
           dir="ltr">
           <span data-lexical-text="true">Hello</span>
           <span
-            style="font-size: 10px; font-family: Georgia;"
+            style="font-size: 17px; font-family: Georgia;"
             data-lexical-text="true">
             world
           </span>
@@ -538,8 +631,7 @@ test.describe('TextFormatting', () => {
       focusPath: [0, 1, 0],
     });
 
-    await click(page, '.font-size');
-    await click(page, 'button:has-text("20px")');
+    await click(page, '.font-decrement');
 
     await assertHTML(
       page,
@@ -549,7 +641,7 @@ test.describe('TextFormatting', () => {
           dir="ltr">
           <span data-lexical-text="true">Hello</span>
           <span
-            style="font-size: 20px; font-family: Georgia;"
+            style="font-size: 15px; font-family: Georgia;"
             data-lexical-text="true">
             world
           </span>
@@ -564,6 +656,77 @@ test.describe('TextFormatting', () => {
       focusOffset: 5,
       focusPath: [0, 1, 0],
     });
+  });
+
+  test(`Can select text and update font size by entering the value`, async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await page.keyboard.type('Hello world!');
+    await moveLeft(page);
+    await selectCharacters(page, 'left', 5);
+
+    await assertSelection(page, {
+      anchorOffset: 11,
+      anchorPath: [0, 0, 0],
+      focusOffset: 6,
+      focusPath: [0, 0, 0],
+    });
+
+    await page.locator('.font-size-input').fill('20');
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello</span>
+          <span style="font-size: 20px;" data-lexical-text="true">world</span>
+          <span data-lexical-text="true">!</span>
+        </p>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0, 1, 0],
+      focusOffset: 5,
+      focusPath: [0, 1, 0],
+    });
+  });
+
+  test(`Can select text with different size and update font size by entering the value`, async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await page.keyboard.type('Hello world!');
+    await selectCharacters(page, 'left', 6);
+    await click(page, '.font-decrement');
+    await moveRight(page, 6);
+    await selectCharacters(page, 'left', 12);
+    await page.locator('.font-size-input').fill('20');
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span style="font-size: 20px;" data-lexical-text="true">
+            Hello world!
+          </span>
+        </p>
+      `,
+    );
   });
 
   test(`Can select multiple text parts and format them with shortcuts`, async ({

--- a/packages/lexical-playground/src/images/icons/add-sign.svg
+++ b/packages/lexical-playground/src/images/icons/add-sign.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 17">
+    <path fill="" d="M10 7H6V3H4v4H0v2h4v4h2V9h4z"/>
+</svg>

--- a/packages/lexical-playground/src/images/icons/minus-sign.svg
+++ b/packages/lexical-playground/src/images/icons/minus-sign.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" version="1.2" baseProfile="tiny" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 17">
+    <path d="M0 7h8v2H0z"/>
+</svg>

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
@@ -21,17 +21,20 @@ input[type='number']::-webkit-inner-spin-button {
   background-image: url(../../images/icons/add-sign.svg);
   background-repeat: no-repeat;
   background-position: center;
-  margin-left: 5px;
 }
 
 .minus-icon {
   background-image: url(../../images/icons/minus-sign.svg);
   background-repeat: no-repeat;
   background-position: center;
-  margin-right: 5px;
 }
 
-button.font-decrement,
+button.font-decrement {
+  padding: 0px;
+  margin-right: 3px;
+}
+
 button.font-increment {
   padding: 0px;
+  margin-left: 3px;
 }

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
@@ -8,9 +8,7 @@
   margin-top: 5px;
   padding: 2px 4px;
   text-align: center;
-  vertical-align: middle;
   width: 20px;
-  align-items: center;
 }
 
 input[type='number']::-webkit-outer-spin-button,
@@ -33,6 +31,7 @@ input[type='number']::-webkit-inner-spin-button {
   margin-right: 5px;
 }
 
-#font-size-btn {
+button.font-decrement,
+button.font-increment {
   padding: 0px;
 }

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
@@ -1,0 +1,38 @@
+.font-size-input {
+  font-weight: bold;
+  font-size: 14px;
+  color: #777;
+  border-radius: 5px;
+  border-color: grey;
+  height: 21px;
+  margin-top: 5px;
+  padding: 2px 4px;
+  text-align: center;
+  vertical-align: middle;
+  width: 20px;
+  align-items: center;
+}
+
+input[type='number']::-webkit-outer-spin-button,
+input[type='number']::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.add-icon {
+  background-image: url(../../images/icons/add-sign.svg);
+  background-repeat: no-repeat;
+  background-position: center;
+  margin-left: 5px;
+}
+
+.minus-icon {
+  background-image: url(../../images/icons/minus-sign.svg);
+  background-repeat: no-repeat;
+  background-position: center;
+  margin-right: 5px;
+}
+
+#font-size-btn {
+  padding: 0px;
+}

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -158,7 +158,7 @@ export default function FontSize({
   };
 
   const handleButtonClick = (updateType: updateFontSizeType) => {
-    if (selectionFontSize !== '') {
+    if (inputValue !== '') {
       const nextFontSize = calculateNextFontSize(
         Number(inputValue),
         updateType,

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import './fontSize.css';
+
+import {$patchStyleText} from '@lexical/selection';
+import {
+  $getSelection,
+  $INTERNAL_isPointSelection,
+  LexicalEditor,
+} from 'lexical';
+import * as React from 'react';
+
+const MIN_ALLOWED_FONT_SIZE = 8;
+const MAX_ALLOWED_FONT_SIZE = 72;
+const DEFAULT_FONT_SIZE = 15;
+
+// eslint-disable-next-line no-shadow
+enum updateFontSizeType {
+  increment = 1,
+  decrement,
+}
+
+export default function FontSize({
+  selectionFontSize,
+  disabled,
+  editor,
+}: {
+  selectionFontSize: string;
+  disabled: boolean;
+  editor: LexicalEditor;
+}) {
+  const [inputValue, setInputValue] = React.useState<string>(selectionFontSize);
+
+  const calculateNextFontSize = (
+    currentFontSize: number,
+    updateType: updateFontSizeType | null,
+  ) => {
+    if (!updateType) {
+      return currentFontSize;
+    }
+
+    let updatedFontSize: number = currentFontSize;
+    switch (updateType) {
+      case updateFontSizeType.decrement:
+        switch (true) {
+          case currentFontSize > MAX_ALLOWED_FONT_SIZE:
+            updatedFontSize = MAX_ALLOWED_FONT_SIZE;
+            break;
+          case currentFontSize >= 48:
+            updatedFontSize -= 12;
+            break;
+          case currentFontSize >= 24:
+            updatedFontSize -= 4;
+            break;
+          case currentFontSize >= 14:
+            updatedFontSize -= 2;
+            break;
+          case currentFontSize >= 9:
+            updatedFontSize -= 1;
+            break;
+          default:
+            updatedFontSize = MIN_ALLOWED_FONT_SIZE;
+            break;
+        }
+        break;
+
+      case updateFontSizeType.increment:
+        switch (true) {
+          case currentFontSize < MIN_ALLOWED_FONT_SIZE:
+            updatedFontSize = MIN_ALLOWED_FONT_SIZE;
+            break;
+          case currentFontSize < 12:
+            updatedFontSize += 1;
+            break;
+          case currentFontSize < 20:
+            updatedFontSize += 2;
+            break;
+          case currentFontSize < 36:
+            updatedFontSize += 4;
+            break;
+          case currentFontSize <= 60:
+            updatedFontSize += 12;
+            break;
+          default:
+            updatedFontSize = MAX_ALLOWED_FONT_SIZE;
+            break;
+        }
+        break;
+
+      default:
+        break;
+    }
+    return updatedFontSize;
+  };
+
+  const updateFontSizeInSelection = React.useCallback(
+    (newFontSize: string | null, updateType: updateFontSizeType | null) => {
+      const getNextFontSize = (prevFontSize: string | null): string => {
+        if (!prevFontSize) {
+          prevFontSize = `${DEFAULT_FONT_SIZE}px`;
+        }
+        prevFontSize = prevFontSize.slice(0, -2);
+        const nextFontSize = calculateNextFontSize(
+          Number(prevFontSize),
+          updateType,
+        );
+        return `${nextFontSize}px`;
+      };
+
+      editor.update(() => {
+        if (editor.isEditable()) {
+          const selection = $getSelection();
+          if (selection && $INTERNAL_isPointSelection(selection)) {
+            $patchStyleText(selection, {
+              'font-size': newFontSize || getNextFontSize,
+            });
+          }
+        }
+      });
+    },
+    [editor],
+  );
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const inputValueNumber = Number(inputValue);
+
+    if (['e', 'E', '+', '-'].includes(e.key) || isNaN(inputValueNumber)) {
+      e.preventDefault();
+      setInputValue('');
+      return;
+    }
+
+    if (e.key === 'Enter') {
+      e.preventDefault();
+
+      let updatedFontSize = inputValueNumber;
+      if (inputValueNumber > MAX_ALLOWED_FONT_SIZE) {
+        updatedFontSize = MAX_ALLOWED_FONT_SIZE;
+      } else if (inputValueNumber < MIN_ALLOWED_FONT_SIZE) {
+        updatedFontSize = MIN_ALLOWED_FONT_SIZE;
+      }
+      setInputValue(String(updatedFontSize));
+      updateFontSizeInSelection(String(updatedFontSize) + 'px', null);
+    }
+  };
+
+  const handleButtonClick = (updateType: updateFontSizeType) => {
+    if (selectionFontSize !== '') {
+      const nextFontSize = calculateNextFontSize(
+        Number(inputValue),
+        updateType,
+      );
+      updateFontSizeInSelection(String(nextFontSize) + 'px', null);
+    } else {
+      updateFontSizeInSelection(null, updateType);
+    }
+  };
+
+  React.useEffect(() => {
+    setInputValue(selectionFontSize);
+  }, [selectionFontSize]);
+
+  return (
+    <>
+      <button
+        type="button"
+        disabled={
+          disabled ||
+          (selectionFontSize !== '' &&
+            Number(inputValue) <= MIN_ALLOWED_FONT_SIZE)
+        }
+        onClick={() => handleButtonClick(updateFontSizeType.decrement)}
+        className="toolbar-item spaced font-decrement">
+        <i className="format minus-icon" />
+      </button>
+
+      <input
+        type="number"
+        value={inputValue}
+        disabled={disabled}
+        className="toolbar-item font-size-input"
+        min={MIN_ALLOWED_FONT_SIZE}
+        max={MAX_ALLOWED_FONT_SIZE}
+        onChange={(e) => setInputValue(e.target.value)}
+        onKeyDown={handleKeyPress}
+      />
+
+      <button
+        type="button"
+        disabled={
+          disabled ||
+          (selectionFontSize !== '' &&
+            Number(inputValue) >= MAX_ALLOWED_FONT_SIZE)
+        }
+        onClick={() => handleButtonClick(updateFontSizeType.increment)}
+        className="toolbar-item spaced font-increment">
+        <i className="format add-icon" />
+      </button>
+    </>
+  );
+}

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -185,7 +185,7 @@ export default function FontSize({
             Number(inputValue) <= MIN_ALLOWED_FONT_SIZE)
         }
         onClick={() => handleButtonClick(updateFontSizeType.decrement)}
-        className="toolbar-item spaced font-decrement">
+        className="toolbar-item font-decrement">
         <i className="format minus-icon" />
       </button>
 
@@ -208,7 +208,7 @@ export default function FontSize({
             Number(inputValue) >= MAX_ALLOWED_FONT_SIZE)
         }
         onClick={() => handleButtonClick(updateFontSizeType.increment)}
-        className="toolbar-item spaced font-increment">
+        className="toolbar-item font-increment">
         <i className="format add-icon" />
       </button>
     </>

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -5,13 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-/**
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- */
 
 import './fontSize.css';
 
@@ -44,6 +37,12 @@ export default function FontSize({
 }) {
   const [inputValue, setInputValue] = React.useState<string>(selectionFontSize);
 
+  /**
+   * Calculates the new font size based on the update type.
+   * @param currentFontSize - The current font size
+   * @param updateType - The type of change, either increment or decrement
+   * @returns the next font size
+   */
   const calculateNextFontSize = (
     currentFontSize: number,
     updateType: updateFontSizeType | null,
@@ -105,6 +104,9 @@ export default function FontSize({
     }
     return updatedFontSize;
   };
+  /**
+   * Patches the selection with the updated font size.
+   */
 
   const updateFontSizeInSelection = React.useCallback(
     (newFontSize: string | null, updateType: updateFontSizeType | null) => {

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -886,6 +886,7 @@ export default function ToolbarPlugin({
             value={fontFamily}
             editor={editor}
           />
+          <Divider />
           <FontSize
             selectionFontSize={fontSize.slice(0, -2)}
             editor={editor}

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -97,6 +97,7 @@ import InsertLayoutDialog from '../LayoutPlugin/InsertLayoutDialog';
 import {INSERT_PAGE_BREAK} from '../PageBreakPlugin';
 import {InsertPollDialog} from '../PollPlugin';
 import {InsertTableDialog} from '../TablePlugin';
+import FontSize from './fontSize';
 
 const blockTypeToBlockName = {
   bullet: 'Bulleted List',
@@ -885,11 +886,10 @@ export default function ToolbarPlugin({
             value={fontFamily}
             editor={editor}
           />
-          <FontDropDown
-            disabled={!isEditable}
-            style={'font-size'}
-            value={fontSize}
+          <FontSize
+            selectionFontSize={fontSize.slice(0, -2)}
             editor={editor}
+            disabled={!isEditable}
           />
           <Divider />
           <button

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -395,7 +395,7 @@ export function $patchStyleText(
 
   // This is the case where we only selected a single node
   if (selectedNodes.length === 1) {
-    if ($isTextNode(firstNode) && firstNode.isStylable()) {
+    if ($isTextNode(firstNode) && firstNode.canHaveFormat()) {
       startOffset =
         startType === 'element'
           ? 0
@@ -431,7 +431,7 @@ export function $patchStyleText(
     if (
       $isTextNode(firstNode) &&
       startOffset < firstNode.getTextContentSize() &&
-      firstNode.isStylable()
+      firstNode.canHaveFormat()
     ) {
       if (startOffset !== 0) {
         // the entire first node isn't selected, so split it
@@ -443,7 +443,7 @@ export function $patchStyleText(
       $patchStyle(firstNode as TextNode, patch);
     }
 
-    if ($isTextNode(lastNode) && lastNode.isStylable()) {
+    if ($isTextNode(lastNode) && lastNode.canHaveFormat()) {
       const lastNodeText = lastNode.getTextContent();
       const lastNodeTextLength = lastNodeText.length;
 
@@ -472,7 +472,7 @@ export function $patchStyleText(
 
       if (
         $isTextNode(selectedNode) &&
-        selectedNode.isStylable() &&
+        selectedNode.canHaveFormat() &&
         selectedNodeKey !== firstNode.getKey() &&
         selectedNodeKey !== lastNode.getKey() &&
         !selectedNode.isToken()

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -324,9 +324,8 @@ function $patchStyle(
  * Will update partially selected TextNodes by splitting the TextNode and applying
  * the styles to the appropriate one.
  * @param selection - The selected node(s) to update.
- * @param patch - The patch to apply, which can include multiple styles. { CSSProperty: value }
+ * @param patch - The patch to apply, which can include multiple styles. { CSSProperty: value }. Can also accept a function that returns the new property value.
  */
-
 export function $patchStyleText(
   selection: INTERNAL_PointSelection,
   patch: Record<
@@ -359,6 +358,7 @@ export function $patchStyleText(
     $setSelection(selection);
     return;
   }
+
   const lastIndex = selectedNodesLength - 1;
   let firstNode = selectedNodes[0];
   let lastNode = selectedNodes[lastIndex];

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {$isCodeHighlightNode} from '@lexical/code';
 import {
   $createRangeSelection,
   $createTextNode,
@@ -342,7 +341,7 @@ export function $patchStyleText(
     const cellSelectionFocus = cellSelection.focus;
     for (let i = 0; i < selectedNodesLength; i++) {
       const node = selectedNodes[i];
-      if (DEPRECATED_$isGridCellNode(node) && !$isCodeHighlightNode(node)) {
+      if (DEPRECATED_$isGridCellNode(node)) {
         cellSelectionAnchor.set(node.getKey(), 0, 'element');
         cellSelectionFocus.set(
           node.getKey(),
@@ -396,7 +395,7 @@ export function $patchStyleText(
 
   // This is the case where we only selected a single node
   if (selectedNodes.length === 1) {
-    if ($isTextNode(firstNode) && !$isCodeHighlightNode(firstNode)) {
+    if ($isTextNode(firstNode) && firstNode.isStylable()) {
       startOffset =
         startType === 'element'
           ? 0
@@ -432,7 +431,7 @@ export function $patchStyleText(
     if (
       $isTextNode(firstNode) &&
       startOffset < firstNode.getTextContentSize() &&
-      !$isCodeHighlightNode(firstNode)
+      firstNode.isStylable()
     ) {
       if (startOffset !== 0) {
         // the entire first node isn't selected, so split it
@@ -444,7 +443,7 @@ export function $patchStyleText(
       $patchStyle(firstNode as TextNode, patch);
     }
 
-    if ($isTextNode(lastNode) && !$isCodeHighlightNode(lastNode)) {
+    if ($isTextNode(lastNode) && lastNode.isStylable()) {
       const lastNodeText = lastNode.getTextContent();
       const lastNodeTextLength = lastNodeText.length;
 
@@ -473,7 +472,7 @@ export function $patchStyleText(
 
       if (
         $isTextNode(selectedNode) &&
-        !$isCodeHighlightNode(selectedNode) &&
+        selectedNode.isStylable() &&
         selectedNodeKey !== firstNode.getKey() &&
         selectedNodeKey !== lastNode.getKey() &&
         !selectedNode.isToken()

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -444,7 +444,7 @@ export class TextNode extends LexicalNode {
    *
    * @returns true if the text node supports font styling, false otherwise.
    */
-  isStylable(): boolean {
+  canHaveFormat(): boolean {
     return true;
   }
 

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -440,6 +440,14 @@ export class TextNode extends LexicalNode {
     return toggleTextFormatType(format, type, alignWithFormat);
   }
 
+  /**
+   *
+   * @returns true if the text node can be formatted, false otherwise.
+   */
+  isStylable(): boolean {
+    return true;
+  }
+
   // View
 
   createDOM(config: EditorConfig): HTMLElement {

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -442,7 +442,7 @@ export class TextNode extends LexicalNode {
 
   /**
    *
-   * @returns true if the text node can be formatted, false otherwise.
+   * @returns true if the text node supports font styling, false otherwise.
    */
   isStylable(): boolean {
     return true;


### PR DESCRIPTION
This PR replaces the font size drop down with an font size entry component.  This will allow the user to add custom font sizes ranging from `8`to `72`. There are also increment and decrement buttons, which allow font size update relative to the current size.
For font sizes:
- 8-12: Step size is 1
- 12-20: Step size is 2
- 20-36: Step size is 4
- 36-72: Step size is 12

This PR also fixes the issue where the user can format the codeblock if the selection begins outside the codeblock. The issue is illustrated below:

![code-block-isssue](https://github.com/facebook/lexical/assets/33776279/148b5f6d-f244-4d6e-a4e3-2881469a1a17)

### Font size entry component:
![font-entry](https://github.com/facebook/lexical/assets/33776279/185d78ff-e103-4869-8002-aa1a124233bf)

