### PR TITLE
bug: collapseAtStart never run for custom element node

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1754,9 +1754,10 @@ export class RangeSelection extends INTERNAL_PointSelection {
       }
     }
     this.removeText();
+
     if (
       isBackward &&
-      !wasCollapsed &&
+      wasCollapsed &&
       this.isCollapsed() &&
       this.anchor.type === 'element' &&
       this.anchor.offset === 0
@@ -1764,10 +1765,15 @@ export class RangeSelection extends INTERNAL_PointSelection {
       const anchorNode = this.anchor.getNode();
       if (
         anchorNode.isEmpty() &&
-        $isRootNode(anchorNode.getParent()) &&
-        anchorNode.getIndexWithinParent() === 0
+        anchorNode.getIndexWithinParent() === 0 &&
+        anchorNode.__prev == null &&
+        anchorNode.__next == null
       ) {
-        anchorNode.collapseAtStart(this);
+        const parentNode = anchorNode.getParent();
+
+        if (parentNode) {
+          parentNode.collapseAtStart(this);
+        }
       }
     }
   }


### PR DESCRIPTION
Its related to this issue:
https://github.com/facebook/lexical/issues/5449

To summarize, the issue is the condition inside if check is wrong lead to collapseAtStart function of custom node never run.
Its is not a big issue since i can register an event to handle it but i expect it to work out of the box.

I'm sorry to create this pull request again since i accidentally closed the old pull request.