### PR TITLE
Fix floating link editor on inline image caption

### DIFF
--- a/packages/lexical-playground/src/nodes/InlineImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/InlineImageComponent.tsx
@@ -35,7 +35,6 @@ import * as React from 'react';
 import {Suspense, useCallback, useEffect, useRef, useState} from 'react';
 
 import useModal from '../hooks/useModal';
-import FloatingLinkEditorPlugin from '../plugins/FloatingLinkEditorPlugin/index';
 import FloatingTextFormatToolbarPlugin from '../plugins/FloatingTextFormatToolbarPlugin/index';
 import LinkPlugin from '../plugins/LinkPlugin';
 import Button from '../ui/Button';
@@ -387,10 +386,6 @@ export default function InlineImageComponent({
             <LexicalNestedComposer initialEditor={caption}>
               <AutoFocusPlugin />
               <LinkPlugin />
-              <FloatingLinkEditorPlugin
-                isLinkEditMode={false}
-                setIsLinkEditMode={() => {}}
-              />
               <FloatingTextFormatToolbarPlugin />
               <RichTextPlugin
                 contentEditable={


### PR DESCRIPTION
`InlineImageComponent` makes two of floating link editor toolbar element and it's triggering some bugs.

before:

https://github.com/facebook/lexical/assets/40269597/f71da3f7-3d69-4eb8-99bb-81296ffc9587

after:

https://github.com/facebook/lexical/assets/40269597/2f5487bd-3a18-472f-8a36-6f6ded32478d
