### PR TITLE
Fix typechecking issues in unit tests

### DIFF
--- a/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
@@ -6,10 +6,16 @@
  *
  */
 
-import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  ParagraphNode,
+  TextNode,
+} from 'lexical';
 
 import {EditorState} from '../../LexicalEditorState';
-import {$createRootNode} from '../../nodes/LexicalRootNode';
+import {$createRootNode, RootNode} from '../../nodes/LexicalRootNode';
 import {initializeUnitTest} from '../utils';
 
 describe('LexicalEditorState tests', () => {
@@ -33,14 +39,14 @@ describe('LexicalEditorState tests', () => {
         $getRoot().append(paragraph);
       });
 
-      let root = null;
-      let paragraph = null;
-      let text = null;
+      let root!: RootNode;
+      let paragraph!: ParagraphNode;
+      let text!: TextNode;
 
       editor.getEditorState().read(() => {
         root = $getRoot();
-        paragraph = root.getFirstChild();
-        text = paragraph.getFirstChild();
+        paragraph = root.getFirstChild()!;
+        text = paragraph.getFirstChild()!;
       });
 
       expect(root).toEqual({
@@ -112,7 +118,7 @@ describe('LexicalEditorState tests', () => {
       // Remove the first node, which should cause a GC for everything
 
       await editor.update(() => {
-        $getRoot().getFirstChild().remove();
+        $getRoot().getFirstChild()!.remove();
       });
 
       expect(editor.getEditorState()._nodeMap).toEqual(

--- a/packages/lexical/src/__tests__/unit/LexicalListPlugin.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalListPlugin.test.tsx
@@ -22,7 +22,7 @@ import {
   TestComposer,
 } from 'lexical/src/__tests__/utils';
 import * as React from 'react';
-import {createRoot} from 'react-dom/client';
+import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 
 import {
@@ -31,8 +31,8 @@ import {
 } from '../../../../lexical-list/src/index';
 
 describe('@lexical/list tests', () => {
-  let container: HTMLDivElement | null = null;
-  let reactRoot;
+  let container: HTMLDivElement;
+  let reactRoot: Root;
 
   beforeEach(() => {
     container = document.createElement('div');
@@ -41,9 +41,8 @@ describe('@lexical/list tests', () => {
   });
 
   afterEach(() => {
-    if (container !== null) {
-      document.body.removeChild(container);
-    }
+    container.remove();
+    // @ts-ignore
     container = null;
 
     jest.restoreAllMocks();
@@ -88,7 +87,7 @@ describe('@lexical/list tests', () => {
     });
 
     expectHtmlToBeEqual(
-      container?.innerHTML || '',
+      container.innerHTML,
       html`
         <div
           contenteditable="true"
@@ -113,7 +112,7 @@ describe('@lexical/list tests', () => {
     });
 
     expectHtmlToBeEqual(
-      container?.innerHTML || '',
+      container.innerHTML,
       html`
         <div
           contenteditable="true"
@@ -143,7 +142,7 @@ describe('@lexical/list tests', () => {
     });
 
     expectHtmlToBeEqual(
-      container?.innerHTML || '',
+      container.innerHTML,
       html`
         <div
           contenteditable="true"
@@ -168,7 +167,7 @@ describe('@lexical/list tests', () => {
     });
 
     expectHtmlToBeEqual(
-      container?.innerHTML || '',
+      container.innerHTML,
       html`
         <div
           contenteditable="true"
@@ -195,7 +194,7 @@ describe('@lexical/list tests', () => {
     });
 
     expectHtmlToBeEqual(
-      container?.innerHTML || '',
+      container.innerHTML,
       html`
         <div
           contenteditable="true"

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -56,8 +56,8 @@ LexicalNode.getType = function () {
 describe('LexicalNode tests', () => {
   initializeUnitTest(
     (testEnv) => {
-      let paragraphNode;
-      let textNode;
+      let paragraphNode: ParagraphNode;
+      let textNode: TextNode;
 
       beforeEach(async () => {
         const {editor} = testEnv;
@@ -108,7 +108,7 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.isAttached()', async () => {
         const {editor} = testEnv;
-        let node;
+        let node: LexicalNode;
 
         await editor.update(() => {
           node = new LexicalNode('__custom_key__');
@@ -125,7 +125,7 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.isSelected()', async () => {
         const {editor} = testEnv;
-        let node;
+        let node: LexicalNode;
 
         await editor.update(() => {
           node = new LexicalNode('__custom_key__');
@@ -168,8 +168,8 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.isSelected(): selected block node range', async () => {
         const {editor} = testEnv;
-        let newParagraphNode;
-        let newTextNode;
+        let newParagraphNode: ParagraphNode;
+        let newTextNode: TextNode;
 
         await editor.update(() => {
           expect(paragraphNode.isSelected()).toBe(false);
@@ -220,8 +220,8 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.isSelected(): with custom range selection', async () => {
         const {editor} = testEnv;
-        let newParagraphNode;
-        let newTextNode;
+        let newParagraphNode: ParagraphNode;
+        let newTextNode: TextNode;
 
         await editor.update(() => {
           expect(paragraphNode.isSelected()).toBe(false);
@@ -341,7 +341,7 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.getPreviousSibling()', async () => {
         const {editor} = testEnv;
-        let barTextNode;
+        let barTextNode: TextNode;
 
         await editor.update(() => {
           barTextNode = new TextNode('bar');
@@ -365,8 +365,8 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.getPreviousSiblings()', async () => {
         const {editor} = testEnv;
-        let barTextNode;
-        let bazTextNode;
+        let barTextNode: TextNode;
+        let bazTextNode: TextNode;
 
         await editor.update(() => {
           barTextNode = new TextNode('bar');
@@ -404,7 +404,7 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.getNextSibling()', async () => {
         const {editor} = testEnv;
-        let barTextNode;
+        let barTextNode: TextNode;
 
         await editor.update(() => {
           barTextNode = new TextNode('bar');
@@ -425,8 +425,8 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.getNextSiblings()', async () => {
         const {editor} = testEnv;
-        let barTextNode;
-        let bazTextNode;
+        let barTextNode: TextNode;
+        let bazTextNode: TextNode;
 
         await editor.update(() => {
           barTextNode = new TextNode('bar');
@@ -453,11 +453,11 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.getCommonAncestor()', async () => {
         const {editor} = testEnv;
-        let quxTextNode;
-        let barParagraphNode;
-        let barTextNode;
-        let bazParagraphNode;
-        let bazTextNode;
+        let quxTextNode: TextNode;
+        let barParagraphNode: ParagraphNode;
+        let barTextNode: TextNode;
+        let bazParagraphNode: ParagraphNode;
+        let bazTextNode: TextNode;
 
         await editor.update(() => {
           const rootNode = $getRoot();
@@ -499,8 +499,8 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.isBefore()', async () => {
         const {editor} = testEnv;
-        let barTextNode;
-        let bazTextNode;
+        let barTextNode: TextNode;
+        let bazTextNode: TextNode;
 
         await editor.update(() => {
           barTextNode = new TextNode('bar');
@@ -542,10 +542,10 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.getNodesBetween()', async () => {
         const {editor} = testEnv;
-        let barTextNode;
-        let bazTextNode;
-        let newParagraphNode;
-        let quxTextNode;
+        let barTextNode: TextNode;
+        let bazTextNode: TextNode;
+        let newParagraphNode: ParagraphNode;
+        let quxTextNode: TextNode;
 
         await editor.update(() => {
           const rootNode = $getRoot();
@@ -590,7 +590,7 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.isToken()', async () => {
         const {editor} = testEnv;
-        let tokenTextNode;
+        let tokenTextNode: TextNode;
 
         await editor.update(() => {
           tokenTextNode = new TextNode('token').setMode('token');
@@ -602,7 +602,7 @@ describe('LexicalNode tests', () => {
         );
 
         await editor.getEditorState().read(() => {
-          expect(textNode.isToken(textNode)).toBe(false);
+          expect(textNode.isToken()).toBe(false);
           expect(tokenTextNode.isToken()).toBe(true);
         });
         expect(() => textNode.isToken()).toThrow();
@@ -610,7 +610,7 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.isSegmented()', async () => {
         const {editor} = testEnv;
-        let segmentedTextNode;
+        let segmentedTextNode: TextNode;
 
         await editor.update(() => {
           segmentedTextNode = new TextNode('segmented').setMode('segmented');
@@ -622,7 +622,7 @@ describe('LexicalNode tests', () => {
         );
 
         await editor.getEditorState().read(() => {
-          expect(textNode.isSegmented(textNode)).toBe(false);
+          expect(textNode.isSegmented()).toBe(false);
           expect(segmentedTextNode.isSegmented()).toBe(true);
         });
         expect(() => textNode.isSegmented()).toThrow();
@@ -630,7 +630,7 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.isDirectionless()', async () => {
         const {editor} = testEnv;
-        let directionlessTextNode;
+        let directionlessTextNode: TextNode;
 
         await editor.update(() => {
           directionlessTextNode = new TextNode(
@@ -662,9 +662,9 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.getLatest(): garbage collected node', async () => {
         const {editor} = testEnv;
-        let node;
-        let text;
-        let block;
+        let node: LexicalNode;
+        let text: TextNode;
+        let block: TestElementNode;
 
         await editor.update(() => {
           node = new LexicalNode();
@@ -762,6 +762,7 @@ describe('LexicalNode tests', () => {
         const {editor} = testEnv;
 
         await editor.getEditorState().read(() => {
+          // @ts-expect-error
           expect(() => textNode.replace()).toThrow();
         });
         expect(() => textNode.remove()).toThrow();
@@ -773,7 +774,7 @@ describe('LexicalNode tests', () => {
         expect(testEnv.outerHTML).toBe(
           '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="ltr"><span data-lexical-text="true">foo</span></p></div>',
         );
-        let barTextNode;
+        let barTextNode: TextNode;
 
         await editor.update(() => {
           const rootNode = $getRoot();
@@ -895,8 +896,10 @@ describe('LexicalNode tests', () => {
         const {editor} = testEnv;
 
         await editor.getEditorState().read(() => {
+          // @ts-expect-error
           expect(() => textNode.insertAfter()).toThrow();
         });
+        // @ts-expect-error
         expect(() => textNode.insertAfter()).toThrow();
       });
 
@@ -971,7 +974,12 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.insertAfter() move blocks around', async () => {
         const {editor} = testEnv;
-        let block1, block2, block3, text1, text2, text3;
+        let block1: ParagraphNode,
+          block2: ParagraphNode,
+          block3: ParagraphNode,
+          text1: TextNode,
+          text2: TextNode,
+          text3: TextNode;
 
         await editor.update(() => {
           const root = $getRoot();
@@ -1003,7 +1011,12 @@ describe('LexicalNode tests', () => {
 
       test('LexicalNode.insertAfter() move blocks around #2', async () => {
         const {editor} = testEnv;
-        let block1, block2, block3, text1, text2, text3;
+        let block1: ParagraphNode,
+          block2: ParagraphNode,
+          block3: ParagraphNode,
+          text1: TextNode,
+          text2: TextNode,
+          text3: TextNode;
 
         await editor.update(() => {
           const root = $getRoot();
@@ -1043,8 +1056,10 @@ describe('LexicalNode tests', () => {
         const {editor} = testEnv;
 
         await editor.getEditorState().read(() => {
+          // @ts-expect-error
           expect(() => textNode.insertBefore()).toThrow();
         });
+        // @ts-expect-error
         expect(() => textNode.insertBefore()).toThrow();
       });
 

--- a/packages/lexical/src/__tests__/unit/LexicalNormalization.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalNormalization.test.tsx
@@ -6,7 +6,12 @@
  *
  */
 
-import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  RangeSelection,
+} from 'lexical';
 
 import {$normalizeSelection} from '../../LexicalNormalization';
 import {
@@ -19,8 +24,9 @@ describe('LexicalNormalization tests', () => {
   initializeUnitTest((testEnv) => {
     describe('$normalizeSelection', () => {
       for (const reversed of [false, true]) {
-        const getAnchor = (x) => (reversed ? x.focus : x.anchor);
-        const getFocus = (x) => (reversed ? x.anchor : x.focus);
+        const getAnchor = (x: RangeSelection) =>
+          reversed ? x.focus : x.anchor;
+        const getFocus = (x: RangeSelection) => (reversed ? x.anchor : x.focus);
         const reversedStr = reversed ? ' (reversed)' : '';
 
         test(`paragraph to text nodes${reversedStr}`, async () => {

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -46,7 +46,7 @@ describe('LexicalUtils tests', () => {
 
     test('scheduleMicroTask(): promise', async () => {
       jest.resetModules();
-      // @ts-expect-error
+      // @ts-ignore
       window.queueMicrotask = undefined;
 
       let flag = false;

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -46,6 +46,7 @@ describe('LexicalUtils tests', () => {
 
     test('scheduleMicroTask(): promise', async () => {
       jest.resetModules();
+      // @ts-expect-error
       window.queueMicrotask = undefined;
 
       let flag = false;
@@ -96,7 +97,7 @@ describe('LexicalUtils tests', () => {
 
     test('isSelectionWithinEditor()', async () => {
       const {editor} = testEnv;
-      let textNode;
+      let textNode: TextNode;
 
       await editor.update(() => {
         const root = $getRoot();
@@ -107,7 +108,7 @@ describe('LexicalUtils tests', () => {
       });
 
       await editor.update(() => {
-        const domSelection = window.getSelection();
+        const domSelection = window.getSelection()!;
 
         expect(
           isSelectionWithinEditor(
@@ -121,7 +122,7 @@ describe('LexicalUtils tests', () => {
       });
 
       await editor.update(() => {
-        const domSelection = window.getSelection();
+        const domSelection = window.getSelection()!;
 
         expect(
           isSelectionWithinEditor(
@@ -183,8 +184,8 @@ describe('LexicalUtils tests', () => {
 
     test('$getNodeByKey', async () => {
       const {editor} = testEnv;
-      let paragraphNode;
-      let textNode;
+      let paragraphNode: ParagraphNode;
+      let textNode: TextNode;
 
       await editor.update(() => {
         const rootNode = $getRoot();
@@ -206,7 +207,7 @@ describe('LexicalUtils tests', () => {
 
     test('$nodesOfType', async () => {
       const {editor} = testEnv;
-      const paragraphKeys = [];
+      const paragraphKeys: string[] = [];
 
       const $paragraphKeys = () =>
         $nodesOfType(ParagraphNode).map((node) => node.getKey());

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -38,7 +38,7 @@ describe('LexicalElementNode tests', () => {
 
   afterEach(() => {
     document.body.removeChild(container);
-    // @ts-expect-error
+    // @ts-ignore
     container = null;
   });
 
@@ -48,7 +48,6 @@ describe('LexicalElementNode tests', () => {
   }
 
   function useLexicalEditor(rootElementRef: React.RefObject<HTMLDivElement>) {
-    // @ts-ignore
     const editor = React.useMemo(() => createTestEditor(), []);
 
     useEffect(() => {

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -12,6 +12,7 @@ import {
   $getSelection,
   $isRangeSelection,
   ElementNode,
+  LexicalEditor,
   LexicalNode,
   TextNode,
 } from 'lexical';
@@ -26,7 +27,7 @@ import {
 } from '../../../__tests__/utils';
 
 describe('LexicalElementNode tests', () => {
-  let container = null;
+  let container: HTMLElement;
 
   beforeEach(async () => {
     container = document.createElement('div');
@@ -37,15 +38,16 @@ describe('LexicalElementNode tests', () => {
 
   afterEach(() => {
     document.body.removeChild(container);
+    // @ts-expect-error
     container = null;
   });
 
-  async function update(fn) {
+  async function update(fn: () => void) {
     editor.update(fn);
     return Promise.resolve().then();
   }
 
-  function useLexicalEditor(rootElementRef) {
+  function useLexicalEditor(rootElementRef: React.RefObject<HTMLDivElement>) {
     // @ts-ignore
     const editor = React.useMemo(() => createTestEditor(), []);
 
@@ -57,7 +59,7 @@ describe('LexicalElementNode tests', () => {
     return editor;
   }
 
-  let editor = null;
+  let editor: LexicalEditor;
 
   async function init() {
     const ref = createRef<HTMLDivElement>();
@@ -122,7 +124,7 @@ describe('LexicalElementNode tests', () => {
 
     test('some children', async () => {
       await update(() => {
-        const children = $getRoot().getFirstChild<ElementNode>().getChildren();
+        const children = $getRoot().getFirstChild<ElementNode>()!.getChildren();
         expect(children).toHaveLength(3);
       });
     });
@@ -132,7 +134,7 @@ describe('LexicalElementNode tests', () => {
     test('basic', async () => {
       await update(() => {
         const textNodes = $getRoot()
-          .getFirstChild<ElementNode>()
+          .getFirstChild<ElementNode>()!
           .getAllTextNodes();
         expect(textNodes).toHaveLength(3);
       });
@@ -174,8 +176,8 @@ describe('LexicalElementNode tests', () => {
       await update(() => {
         expect(
           $getRoot()
-            .getFirstChild<ElementNode>()
-            .getFirstChild()
+            .getFirstChild<ElementNode>()!
+            .getFirstChild()!
             .getTextContent(),
         ).toBe('Foo');
       });
@@ -194,8 +196,8 @@ describe('LexicalElementNode tests', () => {
       await update(() => {
         expect(
           $getRoot()
-            .getFirstChild<ElementNode>()
-            .getLastChild()
+            .getFirstChild<ElementNode>()!
+            .getLastChild()!
             .getTextContent(),
         ).toBe('Baz');
       });
@@ -212,7 +214,7 @@ describe('LexicalElementNode tests', () => {
   describe('getTextContent()', () => {
     test('basic', async () => {
       await update(() => {
-        expect($getRoot().getFirstChild().getTextContent()).toBe('FooBarBaz');
+        expect($getRoot().getFirstChild()!.getTextContent()).toBe('FooBarBaz');
       });
     });
 
@@ -255,8 +257,8 @@ describe('LexicalElementNode tests', () => {
   describe('getTextContentSize()', () => {
     test('basic', async () => {
       await update(() => {
-        expect($getRoot().getFirstChild().getTextContentSize()).toBe(
-          $getRoot().getFirstChild().getTextContent().length,
+        expect($getRoot().getFirstChild()!.getTextContentSize()).toBe(
+          $getRoot().getFirstChild()!.getTextContent().length,
         );
       });
     });
@@ -274,7 +276,7 @@ describe('LexicalElementNode tests', () => {
   });
 
   describe('splice', () => {
-    let block;
+    let block: ElementNode;
 
     beforeEach(async () => {
       await update(() => {
@@ -588,7 +590,7 @@ describe('LexicalElementNode tests', () => {
 
     it('Running transforms for inserted nodes, their previous siblings and new siblings', async () => {
       const transforms = new Set();
-      const expectedTransforms = [];
+      const expectedTransforms: string[] = [];
 
       const removeTransform = editor.registerNodeTransform(TextNode, (node) => {
         transforms.add(node.__key);
@@ -610,14 +612,14 @@ describe('LexicalElementNode tests', () => {
           text1.__key,
           text2.__key,
           text3.__key,
-          block.getChildAtIndex(0).__key,
-          block.getChildAtIndex(1).__key,
+          block.getChildAtIndex(0)!.__key,
+          block.getChildAtIndex(1)!.__key,
         );
       });
 
       await update(() => {
         block.splice(1, 0, [
-          $getRoot().getLastChild<ElementNode>().getChildAtIndex(1),
+          $getRoot().getLastChild<ElementNode>()!.getChildAtIndex(1)!,
         ]);
       });
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalGC.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalGC.test.tsx
@@ -70,7 +70,7 @@ describe('LexicalGC tests', () => {
           const root = $getRoot();
           const firstChild = root.getFirstChild();
           invariant($isElementNode(firstChild));
-          const subchild = firstChild.getChildAtIndex(i);
+          const subchild = firstChild.getChildAtIndex(i)!;
           expect(subchild.getTextContent()).toBe(['foo', 'bar', 'zzz'][i]);
           subchild.remove();
           root.clear();
@@ -107,7 +107,7 @@ describe('LexicalGC tests', () => {
         expect(editor.getEditorState()._nodeMap.size).toBe(7);
         await editor.update(() => {
           for (const key of removeKeys) {
-            const node = $getNodeByKey(String(key));
+            const node = $getNodeByKey(String(key))!;
             node.remove();
           }
           $getRoot().clear();

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalParagraphNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalParagraphNode.test.ts
@@ -9,8 +9,10 @@
 import {
   $createParagraphNode,
   $getRoot,
+  $getSelection,
   $isParagraphNode,
   ParagraphNode,
+  RangeSelection,
 } from 'lexical';
 
 import {initializeUnitTest} from '../../../__tests__/utils';
@@ -98,7 +100,7 @@ describe('LexicalParagraphNode tests', () => {
 
     test('ParagraphNode.insertNewAfter()', async () => {
       const {editor} = testEnv;
-      let paragraphNode;
+      let paragraphNode: ParagraphNode;
 
       await editor.update(() => {
         const root = $getRoot();
@@ -111,7 +113,10 @@ describe('LexicalParagraphNode tests', () => {
       );
 
       await editor.update(() => {
-        const result = paragraphNode.insertNewAfter();
+        const result = paragraphNode.insertNewAfter(
+          $getSelection() as RangeSelection,
+          false,
+        );
 
         expect(result).toBeInstanceOf(ParagraphNode);
         expect(result.getDirection()).toEqual(paragraphNode.getDirection());

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
@@ -14,6 +14,7 @@ import {
   $isRangeSelection,
   $isRootNode,
   ElementNode,
+  RootNode,
   TextNode,
 } from 'lexical';
 
@@ -27,7 +28,7 @@ import {$createRootNode} from '../../LexicalRootNode';
 
 describe('LexicalRootNode tests', () => {
   initializeUnitTest((testEnv) => {
-    let rootNode;
+    let rootNode: RootNode;
 
     function expectRootTextContentToBe(text: string): void {
       const {editor} = testEnv;
@@ -85,17 +86,19 @@ describe('LexicalRootNode tests', () => {
     });
 
     test('RootNode.clone()', async () => {
-      const rootNodeClone = rootNode.constructor.clone();
+      const rootNodeClone = (rootNode.constructor as typeof RootNode).clone();
 
       expect(rootNodeClone).not.toBe(rootNode);
       expect(rootNodeClone).toStrictEqual(rootNode);
     });
 
     test('RootNode.createDOM()', async () => {
+      // @ts-expect-error
       expect(() => rootNode.createDOM()).toThrow();
     });
 
     test('RootNode.updateDOM()', async () => {
+      // @ts-expect-error
       expect(rootNode.updateDOM()).toBe(false);
     });
 
@@ -168,7 +171,7 @@ describe('LexicalRootNode tests', () => {
 
       await editor.update(() => {
         const root = $getRoot();
-        root.getFirstChild().remove();
+        root.getFirstChild()!.remove();
       });
 
       await editor.update(() => {
@@ -194,7 +197,7 @@ describe('LexicalRootNode tests', () => {
       expectRootTextContentToBe('');
 
       await editor.update(() => {
-        const firstParagraph = $getRoot().getFirstChild<ElementNode>();
+        const firstParagraph = $getRoot().getFirstChild<ElementNode>()!;
 
         firstParagraph.append($createTextNode('first line'));
       });
@@ -208,7 +211,7 @@ describe('LexicalRootNode tests', () => {
       expectRootTextContentToBe('first line\n\n');
 
       await editor.update(() => {
-        const secondParagraph = $getRoot().getLastChild<ElementNode>();
+        const secondParagraph = $getRoot().getLastChild<ElementNode>()!;
 
         secondParagraph.append($createTextNode('second line'));
       });
@@ -222,15 +225,15 @@ describe('LexicalRootNode tests', () => {
       expectRootTextContentToBe('first line\n\nsecond line\n\n');
 
       await editor.update(() => {
-        const thirdParagraph = $getRoot().getLastChild<ElementNode>();
+        const thirdParagraph = $getRoot().getLastChild<ElementNode>()!;
         thirdParagraph.append($createTextNode('third line'));
       });
 
       expectRootTextContentToBe('first line\n\nsecond line\n\nthird line');
 
       await editor.update(() => {
-        const secondParagraph = $getRoot().getChildAtIndex<ElementNode>(1);
-        const secondParagraphText = secondParagraph.getFirstChild<TextNode>();
+        const secondParagraph = $getRoot().getChildAtIndex<ElementNode>(1)!;
+        const secondParagraphText = secondParagraph.getFirstChild<TextNode>()!;
         secondParagraphText.setTextContent('second line!');
       });
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
@@ -117,7 +117,7 @@ describe('LexicalTabNode tests', () => {
       registerRichText(editor);
       registerTabIndentation(editor);
       await editor.update(() => {
-        const selection = $getSelection();
+        const selection = $getSelection()!;
         selection.insertText('foo');
         $getRoot().selectStart();
       });
@@ -168,7 +168,7 @@ describe('LexicalTabNode tests', () => {
       registerRichText(editor);
       registerTabIndentation(editor);
       await editor.update(() => {
-        $getSelection().insertText('foo');
+        $getSelection()!.insertText('foo');
       });
       await editor.dispatchCommand(
         KEY_TAB_COMMAND,
@@ -184,7 +184,7 @@ describe('LexicalTabNode tests', () => {
       registerRichText(editor);
       registerTabIndentation(editor);
       await editor.update(() => {
-        $getSelection().insertText('foo');
+        $getSelection()!.insertText('foo');
         const textNode = $getRoot().getLastDescendant();
         invariant($isTextNode(textNode));
         textNode.select(1, 1);
@@ -203,7 +203,7 @@ describe('LexicalTabNode tests', () => {
       registerRichText(editor);
       registerTabIndentation(editor);
       await editor.update(() => {
-        $getSelection().insertText('foo');
+        $getSelection()!.insertText('foo');
         const textNode = $getRoot().getLastDescendant();
         invariant($isTextNode(textNode));
         textNode.select(1, 2);
@@ -222,13 +222,13 @@ describe('LexicalTabNode tests', () => {
       registerRichText(editor);
       registerTabIndentation(editor);
       await editor.update(() => {
-        $getSelection().insertRawText('hello\tworld');
+        $getSelection()!.insertRawText('hello\tworld');
         const root = $getRoot();
         const firstTextNode = root.getFirstDescendant();
         const lastTextNode = root.getLastDescendant();
         const selection = $createRangeSelection();
-        selection.anchor.set(firstTextNode.getKey(), 'hell'.length, 'text');
-        selection.focus.set(lastTextNode.getKey(), 'wo'.length, 'text');
+        selection.anchor.set(firstTextNode!.getKey(), 'hell'.length, 'text');
+        selection.focus.set(lastTextNode!.getKey(), 'wo'.length, 'text');
         $setSelection(selection);
       });
       await editor.dispatchCommand(
@@ -247,7 +247,7 @@ describe('LexicalTabNode tests', () => {
         const tab2 = $createTabNode();
         $insertNodes([tab1, tab2]);
         tab1.select(1, 1);
-        $getSelection().insertText('f');
+        $getSelection()!.insertText('f');
       });
       expect(testEnv.innerHTML).toBe(
         '<p dir="ltr"><span data-lexical-text="true">\t</span><span data-lexical-text="true">f</span><span data-lexical-text="true">\t</span></p>',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -193,7 +193,7 @@
   },
   "include": ["./libdefs", "./packages"],
   "exclude": [
-    "**/__tests__/**",
+    "**/lexical-*/src/__tests__/**",
     "**/dist/**",
     "**/npm/**",
     "**/node_modules/**",


### PR DESCRIPTION
~~I noticed the unit tests are excluded from typechecking. Tried including them and saw multiple issues. I fixed some of them and this might already be mergeable, but it's a bit too early to enable typechecking for the tests. 1153 errors in 34 files =)~~

Okay. Fixed only the tests in the `lexical` package and enabled typechecking for them. I'm not going to fix other packages in this PR.

Also noticed:
- Prettier needs to be updated to use newer TS features like `satisfies`
- ts-jest displays warnings about the TS version. Needs to be updated too or probably replaced with a faster transform like esbuild.