### PR TITLE
Fix multiline conversion to codeblock

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1319,10 +1319,10 @@ export class RangeSelection extends INTERNAL_PointSelection {
       );
       return selection.insertNodes(nodes);
     }
-    let firstBlock = $getAncestor(this.anchor.getNode(), INTERNAL_$isBlock)!;
-    if ($isRangeSelection(this) && this.isBackward()) {
-      firstBlock = $getAncestor(this.focus.getNode(), INTERNAL_$isBlock)!;
-    }
+
+    const firstPoint = this.isBackward() ? this.focus : this.anchor;
+    const firstBlock = $getAncestor(firstPoint.getNode(), INTERNAL_$isBlock)!;
+
     const last = nodes[nodes.length - 1]!;
 
     // CASE 1: insert inside a code block

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1319,7 +1319,10 @@ export class RangeSelection extends INTERNAL_PointSelection {
       );
       return selection.insertNodes(nodes);
     }
-    const firstBlock = $getAncestor(this.anchor.getNode(), INTERNAL_$isBlock)!;
+    let firstBlock = $getAncestor(this.anchor.getNode(), INTERNAL_$isBlock)!;
+    if ($isRangeSelection(this) && this.isBackward()) {
+      firstBlock = $getAncestor(this.focus.getNode(), INTERNAL_$isBlock)!;
+    }
     const last = nodes[nodes.length - 1]!;
 
     // CASE 1: insert inside a code block


### PR DESCRIPTION
This PR fixes the issue with the lexical editor crashing when we do a multi line backward selection and try to convert it to a codeblock.

Before:

![codeblock-backward-selection](https://github.com/facebook/lexical/assets/33776279/6158596e-0c0d-4ea5-802b-cad468addc0e)


After:

![codeblock-backward-selection-fix](https://github.com/facebook/lexical/assets/33776279/e0c50090-d867-46c2-810d-09e2fe3b3f33)

