### PR TITLE
Remove depecated usage of `%checks` from Flow types

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,4 +1,4 @@
 module.exports = {
-  '*.(js|mjs|jsx|css|html|d.ts|js.flow|ts|tsx)': 'prettier --write',
+  '*.(js|mjs|jsx|css|html|d.ts|ts|tsx)': 'prettier --write',
   '*.(js|mjs|jsx|ts|tsx)': ['eslint --fix'],
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@ packages/playwright-core
 packages/**/vite.config.js
 packages/**/vite.prod.config.js
 **/*.md
+**/*.js.flow
 **/node_modules
 flow-typed
 .github/CODEOWNERS

--- a/packages/lexical-code/flow/LexicalCode.js.flow
+++ b/packages/lexical-code/flow/LexicalCode.js.flow
@@ -65,7 +65,7 @@ declare export function $createCodeHighlightNode(
 
 declare export function $isCodeHighlightNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof CodeHighlightNode);
+): node is CodeHighlightNode;
 
 declare export var CODE_LANGUAGE_FRIENDLY_NAME_MAP: {[string]: string};
 declare export var CODE_LANGUAGE_MAP: {[string]: string};
@@ -117,7 +117,7 @@ declare export function $createCodeNode(language: ?string): CodeNode;
 
 declare export function $isCodeNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof CodeNode);
+): node is CodeNode;
 
 declare export class CodeNode extends ElementNode {
   __language: string | null | void;

--- a/packages/lexical-hashtag/flow/LexicalHashtag.js.flow
+++ b/packages/lexical-hashtag/flow/LexicalHashtag.js.flow
@@ -30,4 +30,4 @@ declare export class HashtagNode extends TextNode {
 declare export function $createHashtagNode(text?: string): HashtagNode;
 declare export function $isHashtagNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof HashtagNode);
+): node is HashtagNode;

--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -59,7 +59,7 @@ declare export function $createLinkNode(
 ): LinkNode;
 declare export function $isLinkNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof LinkNode);
+): node is LinkNode;
 declare export class AutoLinkNode extends LinkNode {
   static getType(): string;
   // $FlowFixMe clone method inheritance
@@ -75,7 +75,7 @@ declare export function $createAutoLinkNode(
 ): AutoLinkNode;
 declare export function $isAutoLinkNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof AutoLinkNode);
+): node is AutoLinkNode;
 
 declare export var TOGGLE_LINK_COMMAND: LexicalCommand<
   string | {url: string, ...LinkAttributes} | null,

--- a/packages/lexical-list/flow/LexicalList.js.flow
+++ b/packages/lexical-list/flow/LexicalList.js.flow
@@ -30,10 +30,10 @@ declare export function $getListDepth(listNode: ListNode): number;
 declare export function $handleListInsertParagraph(): boolean;
 declare export function $isListItemNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof ListItemNode);
+): node is ListItemNode;
 declare export function $isListNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof ListNode);
+): node is ListNode;
 declare export function indentList(): void;
 declare export function insertList(
   editor: LexicalEditor,

--- a/packages/lexical-mark/flow/LexicalMark.js.flow
+++ b/packages/lexical-mark/flow/LexicalMark.js.flow
@@ -36,7 +36,7 @@ declare export class MarkNode extends ElementNode {
 
 declare export function $isMarkNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof MarkNode);
+): node is MarkNode;
 
 declare export function $createMarkNode(ids: Array<string>): MarkNode;
 

--- a/packages/lexical-overflow/flow/LexicalOverflow.js.flow
+++ b/packages/lexical-overflow/flow/LexicalOverflow.js.flow
@@ -27,6 +27,6 @@ declare export class OverflowNode extends ElementNode {
 declare export function $createOverflowNode(): OverflowNode;
 declare export function $isOverflowNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof OverflowNode);
+): node is OverflowNode;
 
 export type SerializedOverflowNode = SerializedElementNode;

--- a/packages/lexical-react/flow/LexicalDecoratorBlockNode.js.flow
+++ b/packages/lexical-react/flow/LexicalDecoratorBlockNode.js.flow
@@ -25,4 +25,4 @@ declare export class DecoratorBlockNode<T> extends DecoratorNode<T> {
 
 declare export function $isDecoratorBlockNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof DecoratorBlockNode);
+): node is DecoratorBlockNode<{...}>;

--- a/packages/lexical-react/flow/LexicalHorizontalRuleNode.js.flow
+++ b/packages/lexical-react/flow/LexicalHorizontalRuleNode.js.flow
@@ -23,6 +23,6 @@ declare export class HorizontalRuleNode extends DecoratorNode<React$Node> {
 declare export function $createHorizontalRuleNode(): HorizontalRuleNode;
 declare export function $isHorizontalRuleNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof HorizontalRuleNode);
+): node is HorizontalRuleNode;
 
 declare export var INSERT_HORIZONTAL_RULE_COMMAND: LexicalCommand<void>;

--- a/packages/lexical-rich-text/flow/LexicalRichText.js.flow
+++ b/packages/lexical-rich-text/flow/LexicalRichText.js.flow
@@ -31,7 +31,7 @@ declare export class QuoteNode extends ElementNode {
 declare export function $createQuoteNode(): QuoteNode;
 declare export function $isQuoteNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof QuoteNode);
+): node is  QuoteNode;
 export type HeadingTagType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 declare export class HeadingNode extends ElementNode {
   __tag: HeadingTagType;
@@ -50,5 +50,5 @@ declare export function $createHeadingNode(
 ): HeadingNode;
 declare export function $isHeadingNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof HeadingNode);
+): node is  HeadingNode;
 declare export function registerRichText(editor: LexicalEditor): () => void;

--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -78,7 +78,7 @@ declare export function $createTableCellNode(
 ): TableCellNode;
 declare export function $isTableCellNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof TableCellNode);
+): node is TableCellNode;
 
 /**
  * LexicalTableNode
@@ -107,7 +107,7 @@ declare export class TableNode extends deprecated_GridNode {
 declare export function $createTableNode(): TableNode;
 declare export function $isTableNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof TableNode);
+): node is TableNode;
 
 /**
  * LexicalTableRowNode
@@ -129,7 +129,7 @@ declare export class TableRowNode extends deprecated_GridRowNode {
 declare export function $createTableRowNode(): TableRowNode;
 declare export function $isTableRowNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof TableRowNode);
+): node is TableRowNode;
 
 /**
  * LexicalTableSelectionHelpers
@@ -299,6 +299,6 @@ declare export class GridSelection implements BaseSelection {
 
 declare export function $isGridSelection(
   x: ?mixed,
-): boolean %checks(x instanceof GridSelection);
+): x is GridSelection;
 
 declare export function $createGridSelection(): GridSelection;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -409,7 +409,7 @@ export type NodeMap = Map<NodeKey, LexicalNode>;
 
 declare export function $isBlockElementNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof ElementNode);
+): node is ElementNode;
 
 export interface BaseSelection {
   clone(): BaseSelection;
@@ -444,7 +444,7 @@ declare export class INTERNAL_PointSelection implements BaseSelection {
 
 declare export function $INTERNAL_isPointSelection(
   x: ?mixed,
-): boolean %checks(x instanceof INTERNAL_PointSelection);
+): x is INTERNAL_PointSelection;
 
 declare export class NodeSelection implements BaseSelection {
   _nodes: Set<NodeKey>;
@@ -468,7 +468,7 @@ declare export class NodeSelection implements BaseSelection {
 
 declare export function $isNodeSelection(
   x: ?mixed,
-): boolean %checks(x instanceof NodeSelection);
+): x is NodeSelection;
 
 declare export class RangeSelection extends INTERNAL_PointSelection {
   anchor: PointType;
@@ -552,7 +552,7 @@ declare export function $createRangeSelection(): RangeSelection;
 declare export function $createNodeSelection(): NodeSelection;
 declare export function $isRangeSelection(
   x: ?mixed,
-): boolean %checks(x instanceof RangeSelection);
+): x is RangeSelection;
 declare export function $getSelection(): null | BaseSelection;
 declare export function $getPreviousSelection(): null | BaseSelection;
 declare export function $insertNodes(nodes: Array<LexicalNode>): void;
@@ -644,7 +644,7 @@ declare export class TextNode extends LexicalNode {
 declare export function $createTextNode(text?: string): TextNode;
 declare export function $isTextNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof TextNode);
+): node is TextNode;
 
 /**
  * LexicalTabNode
@@ -656,7 +656,7 @@ declare export function $createTabNode(): TabNode;
 
 declare export function $isTabNode(
   node: LexicalNode | null | void,
-): boolean %checks(node instanceof TabNode);
+): node is TabNode;
 
 declare export class TabNode extends TextNode {
   static getType(): string;
@@ -686,7 +686,7 @@ declare export class LineBreakNode extends LexicalNode {
 declare export function $createLineBreakNode(): LineBreakNode;
 declare export function $isLineBreakNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof LineBreakNode);
+): node is LineBreakNode;
 
 /**
  * LexicalRootNode
@@ -709,7 +709,7 @@ declare export class RootNode extends ElementNode {
 }
 declare export function $isRootNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof RootNode);
+): node is RootNode;
 
 /**
  * LexicalElementNode
@@ -789,7 +789,7 @@ declare export class ElementNode extends LexicalNode {
 }
 declare export function $isElementNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof ElementNode);
+): node is ElementNode;
 
 /**
  * LexicalDecoratorNode
@@ -804,7 +804,7 @@ declare export class DecoratorNode<X> extends LexicalNode {
 }
 declare export function $isDecoratorNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof DecoratorNode);
+): node is DecoratorNode<{...}>;
 
 /**
  * LexicalParagraphNode
@@ -825,19 +825,19 @@ declare export class ParagraphNode extends ElementNode {
 declare export function $createParagraphNode(): ParagraphNode;
 declare export function $isParagraphNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof ParagraphNode);
+): node is ParagraphNode;
 
 declare export class deprecated_GridNode extends ElementNode {}
 
 declare export function DEPRECATED_$isGridNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof deprecated_GridNode);
+): node is deprecated_GridNode;
 
 declare export class deprecated_GridRowNode extends ElementNode {}
 
 declare export function DEPRECATED_$isGridRowNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof deprecated_GridRowNode);
+): node is deprecated_GridRowNode;
 
 declare export class deprecated_GridCellNode extends ElementNode {
   __colSpan: number;
@@ -852,7 +852,7 @@ declare export class deprecated_GridCellNode extends ElementNode {
 
 declare export function DEPRECATED_$isGridCellNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof deprecated_GridCellNode);
+): node is deprecated_GridCellNode;
 
 /**
  * LexicalUtils
@@ -867,9 +867,7 @@ declare export function $getNodeByKey<N: LexicalNode>(key: NodeKey): N | null;
 declare export function $getRoot(): RootNode;
 declare export function $isLeafNode(
   node: ?LexicalNode,
-): boolean %checks(node instanceof TextNode ||
-  node instanceof LineBreakNode ||
-  node instanceof DecoratorNode);
+): node is TextNode | LineBreakNode |  DecoratorNode<{...}>;
 declare export function $setCompositionKey(
   compositionKey: null | NodeKey,
 ): void;
@@ -882,14 +880,13 @@ declare export function $getAdjacentNode(
 declare export function generateRandomKey(): string;
 declare export function $isInlineElementOrDecoratorNode(
   node: LexicalNode,
-): boolean %checks(node instanceof ElementNode ||
-  node instanceof DecoratorNode);
+): node is ElementNode|  DecoratorNode<{...}>;
 declare export function $getNearestRootOrShadowRoot(
   node: LexicalNode,
 ): RootNode | ElementNode;
 declare export function $isRootOrShadowRoot(
   node: ?LexicalNode,
-): boolean %checks(node instanceof RootNode || node instanceof ElementNode);
+): node is RootNode | ElementNode;
 declare export function $hasAncestor(
   child: LexicalNode,
   targetNode: LexicalNode,


### PR DESCRIPTION
According to a recent Flow lint warning, `%checks` is going to be deprecated from Flow in favour of type guards: https://flow.org/en/docs/types/type-guards. 

This diff removes the use of `%checks` and migrates the Flow signatures to type guards instead. 