### PR TITLE
Fix small issue with DecoratorNode type guards

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -802,9 +802,9 @@ declare export class DecoratorNode<X> extends LexicalNode {
   isInline(): boolean;
   isKeyboardSelectable(): boolean;
 }
-declare export function $isDecoratorNode(
+declare export function $isDecoratorNode<T = mixed>(
   node: ?LexicalNode,
-): node is DecoratorNode<{...}>;
+): node is DecoratorNode<T>;
 
 /**
  * LexicalParagraphNode
@@ -865,9 +865,9 @@ declare export function $getNearestNodeFromDOMNode(
 ): LexicalNode | null;
 declare export function $getNodeByKey<N: LexicalNode>(key: NodeKey): N | null;
 declare export function $getRoot(): RootNode;
-declare export function $isLeafNode(
+declare export function $isLeafNode<T = mixed>(
   node: ?LexicalNode,
-): node is TextNode | LineBreakNode |  DecoratorNode<{...}>;
+): node is TextNode | LineBreakNode |  DecoratorNode<T>;
 declare export function $setCompositionKey(
   compositionKey: null | NodeKey,
 ): void;
@@ -878,9 +878,9 @@ declare export function $getAdjacentNode(
   isBackward: boolean,
 ): null | LexicalNode;
 declare export function generateRandomKey(): string;
-declare export function $isInlineElementOrDecoratorNode(
+declare export function $isInlineElementOrDecoratorNode<T = mixed>(
   node: LexicalNode,
-): node is ElementNode|  DecoratorNode<{...}>;
+): node is ElementNode|  DecoratorNode<T>;
 declare export function $getNearestRootOrShadowRoot(
   node: LexicalNode,
 ): RootNode | ElementNode;


### PR DESCRIPTION
These shouldn't be `mixed` by default, but should accept a generic to specify the actual return type.