### PR TITLE
Added new line options on import and export markdown

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -26,7 +26,7 @@ import {transformersByType} from './utils';
 
 export function createMarkdownExport(
   transformers: Array<Transformer>,
-): (node?: ElementNode) => string {
+): (node?: ElementNode, shouldUseDoubleLineDelimiter?: boolean) => string {
   const byType = transformersByType(transformers);
 
   // Export only uses text formats that are responsible for single format
@@ -35,7 +35,7 @@ export function createMarkdownExport(
     (transformer) => transformer.format.length === 1,
   );
 
-  return (node) => {
+  return (node, shouldUseDoubleLineDelimiter = true) => {
     const output = [];
     const children = (node || $getRoot()).getChildren();
 
@@ -52,7 +52,7 @@ export function createMarkdownExport(
       }
     }
 
-    return output.join('\n\n');
+    return output.join(shouldUseDoubleLineDelimiter ? '\n\n' : '\n');
   };
 }
 

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -43,13 +43,17 @@ type TextFormatTransformersIndex = Readonly<{
 
 export function createMarkdownImport(
   transformers: Array<Transformer>,
-): (markdownString: string, node?: ElementNode) => void {
+): (
+  markdownString: string,
+  node?: ElementNode,
+  shouldRemoveEmptyLines?: boolean,
+) => void {
   const byType = transformersByType(transformers);
   const textFormatTransformersIndex = createTextFormatTransformersIndex(
     byType.textFormat,
   );
 
-  return (markdownString, node) => {
+  return (markdownString, node, shouldRemoveEmptyLines = true) => {
     const lines = markdownString.split('\n');
     const linesLength = lines.length;
     const root = node || $getRoot();
@@ -78,11 +82,14 @@ export function createMarkdownImport(
     }
 
     // Removing empty paragraphs as md does not really
-    // allow empty lines and uses them as dilimiter
-    const children = root.getChildren();
-    for (const child of children) {
-      if (isEmptyParagraph(child)) {
-        child.remove();
+    // allow empty lines and uses them as delimiter
+    // but providing an option to keep them
+    if (shouldRemoveEmptyLines) {
+      const children = root.getChildren();
+      for (const child of children) {
+        if (isEmptyParagraph(child)) {
+          child.remove();
+        }
       }
     }
 

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -73,17 +73,19 @@ function $convertFromMarkdownString(
   markdown: string,
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
+  shouldRemoveEmptyLines?: boolean,
 ): void {
   const importMarkdown = createMarkdownImport(transformers);
-  return importMarkdown(markdown, node);
+  return importMarkdown(markdown, node, shouldRemoveEmptyLines);
 }
 
 function $convertToMarkdownString(
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
+  shouldUseDoubleLineDelimiter?: boolean,
 ): string {
   const exportMarkdown = createMarkdownExport(transformers);
-  return exportMarkdown(node);
+  return exportMarkdown(node, shouldUseDoubleLineDelimiter);
 }
 
 export {


### PR DESCRIPTION
With these updates, users can choose to keep extra empty lines they see on editor updates.
Default params ensure existing usages are not affected.