### PR TITLE
Adding ability to mount LexicalMenus to arbitrary divs

### DIFF
--- a/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
@@ -50,6 +50,7 @@ export type LexicalContextMenuPluginProps<TOption extends MenuOption> = {
   menuRenderFn: ContextMenuRenderFn<TOption>;
   anchorClassName?: string;
   commandPriority?: CommandListenerPriority;
+  parent?: HTMLElement;
 };
 
 const PRE_PORTAL_DIV_SIZE = 1;
@@ -62,6 +63,7 @@ export function LexicalContextMenuPlugin<TOption extends MenuOption>({
   menuRenderFn: contextMenuRenderFn,
   anchorClassName,
   commandPriority = COMMAND_PRIORITY_LOW,
+  parent,
 }: LexicalContextMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
@@ -71,6 +73,7 @@ export function LexicalContextMenuPlugin<TOption extends MenuOption>({
     resolution,
     setResolution,
     anchorClassName,
+    parent,
   );
 
   const closeNodeMenu = useCallback(() => {

--- a/packages/lexical-react/src/LexicalNodeMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeMenuPlugin.tsx
@@ -43,6 +43,7 @@ export type NodeMenuPluginProps<TOption extends MenuOption> = {
   menuRenderFn: MenuRenderFn<TOption>;
   anchorClassName?: string;
   commandPriority?: CommandListenerPriority;
+  parent?: HTMLElement;
 };
 
 export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
@@ -54,6 +55,7 @@ export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
   menuRenderFn,
   anchorClassName,
   commandPriority = COMMAND_PRIORITY_LOW,
+  parent,
 }: NodeMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
@@ -61,6 +63,7 @@ export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
     resolution,
     setResolution,
     anchorClassName,
+    parent,
   );
 
   const closeNodeMenu = useCallback(() => {

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -203,6 +203,7 @@ export type TypeaheadMenuPluginProps<TOption extends MenuOption> = {
   onClose?: () => void;
   anchorClassName?: string;
   commandPriority?: CommandListenerPriority;
+  parent?: HTMLElement;
 };
 
 export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
@@ -215,6 +216,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
   triggerFn,
   anchorClassName,
   commandPriority = COMMAND_PRIORITY_LOW,
+  parent,
 }: TypeaheadMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
@@ -222,6 +224,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
     resolution,
     setResolution,
     anchorClassName,
+    parent,
   );
 
   const closeTypeahead = useCallback(() => {

--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -479,6 +479,7 @@ export function useMenuAnchorRef(
   resolution: MenuResolution | null,
   setResolution: (r: MenuResolution | null) => void,
   className?: string,
+  parent: HTMLElement = document.body,
 ): MutableRefObject<HTMLElement> {
   const [editor] = useLexicalComposerContext();
   const anchorElementRef = useRef<HTMLElement>(document.createElement('div'));
@@ -530,7 +531,7 @@ export function useMenuAnchorRef(
         containerDiv.setAttribute('role', 'listbox');
         containerDiv.style.display = 'block';
         containerDiv.style.position = 'absolute';
-        document.body.append(containerDiv);
+        parent.append(containerDiv);
       }
       anchorElementRef.current = containerDiv;
       rootElement.setAttribute('aria-controls', 'typeahead-menu');

--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -536,7 +536,7 @@ export function useMenuAnchorRef(
       anchorElementRef.current = containerDiv;
       rootElement.setAttribute('aria-controls', 'typeahead-menu');
     }
-  }, [editor, resolution, className]);
+  }, [editor, resolution, className, parent]);
 
   useEffect(() => {
     const rootElement = editor.getRootElement();


### PR DESCRIPTION
When Lexical is embedded in other web apps mounting the menus on `document.body` can be problematic. This PR allows passing a parent element on which the menus are mounted. 