### PR TITLE
Return event name in Production

### DIFF
--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -17,7 +17,7 @@ import type {
 export type PasteCommandType = ClipboardEvent | InputEvent | KeyboardEvent;
 
 export function createCommand<T>(type?: string): LexicalCommand<T> {
-  return __DEV__ ? {type} : {};
+  return {type};
 }
 
 export const SELECTION_CHANGE_COMMAND: LexicalCommand<void> = createCommand(


### PR DESCRIPTION
Fix for #5344

Confirmed with @fantactuka and @zurfyx this is a good fix, since it's unlikely to remove any minification benefits.

@thegreatercurve the original conditional was introduced by you in https://github.com/facebook/lexical/pull/2942

Are you fine with this change?