### PR TITLE
Fix columns layout update command

### DIFF
--- a/packages/lexical-playground/src/plugins/LayoutPlugin/LayoutPlugin.tsx
+++ b/packages/lexical-playground/src/plugins/LayoutPlugin/LayoutPlugin.tsx
@@ -91,13 +91,11 @@ export function LayoutPlugin(): null {
                 );
               }
             } else if (itemsCount < prevItemsCount) {
-              for (let i = prevItemsCount; i < itemsCount; i++) {
+              for (let i = prevItemsCount - 1; i >= itemsCount; i--) {
                 const layoutItem = container.getChildAtIndex<LexicalNode>(i);
 
                 if ($isLayoutItemNode(layoutItem)) {
-                  for (const child of layoutItem.getChildren<LexicalNode>()) {
-                    container.insertAfter(child);
-                  }
+                  layoutItem.remove();
                 }
               }
             }


### PR DESCRIPTION
The current update command for the columns layout is broken when going to a lower column count. The current method instead of deleting, actually appends and gets the node in an invalid state. This fixes the update operation, so when going from 3 columns to 2, it will delete the last column and preserve the content as is in the first 2. 