### PR TITLE
Fix escape down for collapsible section when collapsed

### DIFF
--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts
@@ -112,11 +112,17 @@ export default function CollapsiblePlugin(): null {
             parent !== null &&
             parent.getLastChild<LexicalNode>() === container
           ) {
-            const lastDescendant = container.getLastDescendant<LexicalNode>();
+            const titleParagraph = container.getFirstDescendant<LexicalNode>();
+            const contentParagraph = container.getLastDescendant<LexicalNode>();
+
             if (
-              lastDescendant !== null &&
-              selection.anchor.key === lastDescendant.getKey() &&
-              selection.anchor.offset === lastDescendant.getTextContentSize()
+              (contentParagraph !== null &&
+                selection.anchor.key === contentParagraph.getKey() &&
+                selection.anchor.offset ===
+                  contentParagraph.getTextContentSize()) ||
+              (titleParagraph !== null &&
+                selection.anchor.key === titleParagraph.getKey() &&
+                selection.anchor.offset === titleParagraph.getTextContentSize())
             ) {
               container.insertAfter($createParagraphNode());
             }


### PR DESCRIPTION
At the moment there's a logic that when the collapsible section is the very last node, pressing ArrowDown will append a paragraph below to escape the section. This only worked when the section is expanded, since the logic only applied on exiting the content node of the container, but when the section was collapsed, you exit from the title node, so the logic didn't kick in. 
Extending the logic to check for either fixes the issue.

This was only an issue for the "Escape down", since "Escape up" is always going from the title, irrespective if expanded or collapsed.