### PR TITLE
Use correct prop type for children in LexicalComposer

### DIFF
--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -49,10 +49,9 @@ export type InitialConfigType = Readonly<{
   html?: HTMLConfig;
 }>;
 
-type Props = {
-  children: JSX.Element | string | (JSX.Element | string)[];
+type Props = React.PropsWithChildren<{
   initialConfig: InitialConfigType;
-};
+}>;
 
 export function LexicalComposer({initialConfig, children}: Props): JSX.Element {
   const composerContext: [LexicalEditor, LexicalComposerContextType] = useMemo(


### PR DESCRIPTION
This change updates the TypeScript type of the `children` prop of the `LexicalComposer` component in `lexical-react`. This change is in line with typical React usage, and essentially widens the type of `children`, making this a non-breaking change.