### PR TITLE
Allow an empty paragraph child on converting from markdown

### DIFF
--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -77,21 +77,13 @@ export function createMarkdownImport(
       );
     }
 
-    const wasRootNotEmpty = root.isEmpty() === false;
-
     // Removing empty paragraphs as md does not really
     // allow empty lines and uses them as delimiter
     const children = root.getChildren();
     for (const child of children) {
-      if (isEmptyParagraph(child)) {
+      if (isEmptyParagraph(child) && root.getChildrenSize() > 1) {
         child.remove();
       }
-    }
-
-    // When removing empty paragraphs makes the nodes empty that
-    // can not be empty, an empty paragraph should be appended.
-    if (wasRootNotEmpty && root.isEmpty() && !root.canBeEmpty()) {
-      root.append($createParagraphNode());
     }
 
     if ($getSelection() !== null) {

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -79,7 +79,7 @@ export function createMarkdownImport(
 
     // Removing empty paragraphs as md does not really
     // allow empty lines and uses them as delimiter
-    // this should be done only for the node whose parent can be empty
+    // this should be done only for the node that can be empty
     if (root.canBeEmpty()) {
       const children = root.getChildren();
       for (const child of children) {

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -18,6 +18,7 @@ import type {LexicalNode, TextNode} from 'lexical';
 import {$createCodeNode} from '@lexical/code';
 import {$isListItemNode, $isListNode, ListItemNode} from '@lexical/list';
 import {$isQuoteNode} from '@lexical/rich-text';
+import {$isTableCellNode} from '@lexical/table';
 import {$findMatchingParent} from '@lexical/utils';
 import {
   $createLineBreakNode,
@@ -78,11 +79,14 @@ export function createMarkdownImport(
     }
 
     // Removing empty paragraphs as md does not really
-    // allow empty lines and uses them as dilimiter
+    // allow empty lines and uses them as delimiter
     const children = root.getChildren();
-    for (const child of children) {
-      if (isEmptyParagraph(child)) {
-        child.remove();
+    // TableCellNodes should keep an empty paragraph child
+    if (!$isTableCellNode(root)) {
+      for (const child of children) {
+        if (isEmptyParagraph(child)) {
+          child.remove();
+        }
       }
     }
 

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -18,7 +18,6 @@ import type {LexicalNode, TextNode} from 'lexical';
 import {$createCodeNode} from '@lexical/code';
 import {$isListItemNode, $isListNode, ListItemNode} from '@lexical/list';
 import {$isQuoteNode} from '@lexical/rich-text';
-import {$isTableCellNode} from '@lexical/table';
 import {$findMatchingParent} from '@lexical/utils';
 import {
   $createLineBreakNode,
@@ -82,7 +81,7 @@ export function createMarkdownImport(
     // allow empty lines and uses them as delimiter
     const children = root.getChildren();
     // TableCellNodes should keep an empty paragraph child
-    if (!$isTableCellNode(root)) {
+    if (root.canBeEmpty()) {
       for (const child of children) {
         if (isEmptyParagraph(child)) {
           child.remove();

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -77,6 +77,8 @@ export function createMarkdownImport(
       );
     }
 
+    const wasRootNotEmpty = root.isEmpty() === false;
+
     // Removing empty paragraphs as md does not really
     // allow empty lines and uses them as delimiter
     const children = root.getChildren();
@@ -88,7 +90,7 @@ export function createMarkdownImport(
 
     // When removing empty paragraphs makes the nodes empty that
     // can not be empty, an empty paragraph should be appended.
-    if (root.isEmpty() && !root.canBeEmpty()) {
+    if (wasRootNotEmpty && root.isEmpty() && !root.canBeEmpty()) {
       root.append($createParagraphNode());
     }
 

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -79,9 +79,9 @@ export function createMarkdownImport(
 
     // Removing empty paragraphs as md does not really
     // allow empty lines and uses them as delimiter
-    const children = root.getChildren();
-    // TableCellNodes should keep an empty paragraph child
+    // this should be done only for the node whose parent can be empty
     if (root.canBeEmpty()) {
+      const children = root.getChildren();
       for (const child of children) {
         if (isEmptyParagraph(child)) {
           child.remove();

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -79,14 +79,17 @@ export function createMarkdownImport(
 
     // Removing empty paragraphs as md does not really
     // allow empty lines and uses them as delimiter
-    // this should be done only for the nodes that can be empty
-    if (root.canBeEmpty()) {
-      const children = root.getChildren();
-      for (const child of children) {
-        if (isEmptyParagraph(child)) {
-          child.remove();
-        }
+    const children = root.getChildren();
+    for (const child of children) {
+      if (isEmptyParagraph(child)) {
+        child.remove();
       }
+    }
+
+    // When removing empty paragraphs makes the nodes empty that
+    // can not be empty, an empty paragraph should be appended.
+    if (root.isEmpty() && !root.canBeEmpty()) {
+      root.append($createParagraphNode());
     }
 
     if ($getSelection() !== null) {

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -79,7 +79,7 @@ export function createMarkdownImport(
 
     // Removing empty paragraphs as md does not really
     // allow empty lines and uses them as delimiter
-    // this should be done only for the node that can be empty
+    // this should be done only for the nodes that can be empty
     if (root.canBeEmpty()) {
       const children = root.getChildren();
       for (const child of children) {


### PR DESCRIPTION
fixes #5516

after:


https://github.com/facebook/lexical/assets/40269597/0e1e970f-f91f-499a-a33c-9ebb6a81979b

