### PR TITLE
Floating link editor for AutoLinkNode and conversion to LinkNode once modified.

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -291,19 +291,19 @@ function useFloatingLinkEditorToolbar(
   const [activeEditor, setActiveEditor] = useState(editor);
   const [isLink, setIsLink] = useState(false);
 
-  const updateToolbar = useCallback(() => {
-    const selection = $getSelection();
-    if ($isRangeSelection(selection)) {
-      const node = getSelectedNode(selection);
-      const linkParent = $findMatchingParent(node, $isLinkNode);
-      const autoLinkParent = $findMatchingParent(node, $isAutoLinkNode);
-
-      // We don't want this menu to open for auto links.
-      if (linkParent != null || autoLinkParent != null) {
-        setIsLink(true);
-      } else {
-        setIsLink(false);
-
+  useEffect(() => {
+    function updateToolbar() {
+      const selection = $getSelection();
+      if ($isRangeSelection(selection)) {
+        const node = getSelectedNode(selection);
+        const linkParent = $findMatchingParent(node, $isLinkNode);
+        const autoLinkParent = $findMatchingParent(node, $isAutoLinkNode);
+        // We don't want this menu to open for auto links.
+        if (linkParent !== null && autoLinkParent === null) {
+          setIsLink(true);
+        } else {
+          setIsLink(false);
+        }
       }
     }
     return mergeRegister(

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -7,10 +7,16 @@
  */
 import './index.css';
 
-import {$isAutoLinkNode, $isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
+import {
+  $createLinkNode,
+  $isAutoLinkNode,
+  $isLinkNode,
+  TOGGLE_LINK_COMMAND,
+} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
+  $createTextNode,
   $getSelection,
   $isRangeSelection,
   BaseSelection,
@@ -188,6 +194,21 @@ function FloatingLinkEditor({
     if (lastSelection !== null) {
       if (linkUrl !== '') {
         editor.dispatchCommand(TOGGLE_LINK_COMMAND, sanitizeUrl(editedLinkUrl));
+        editor.update(() => {
+          const selection = $getSelection();
+          if ($isRangeSelection(selection)) {
+            const parent = getSelectedNode(selection).getParent();
+            if ($isAutoLinkNode(parent)) {
+              const linkNode = $createLinkNode(parent.getURL(), {
+                rel: parent.__rel,
+                target: parent.__target,
+                title: parent.__title,
+              }).append($createTextNode(parent.getURL()));
+              parent.getParent()?.append(linkNode);
+              parent.remove();
+            }
+          }
+        });
       }
       setEditedLinkUrl('https://');
       setIsLinkEditMode(false);

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -203,7 +203,6 @@ function FloatingLinkEditor({
                 target: parent.__target,
                 title: parent.__title,
               });
-              parent.select();
               parent.replace(linkNode, true);
             }
           }

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -298,8 +298,7 @@ function useFloatingLinkEditorToolbar(
         const node = getSelectedNode(selection);
         const linkParent = $findMatchingParent(node, $isLinkNode);
         const autoLinkParent = $findMatchingParent(node, $isAutoLinkNode);
-        // We don't want this menu to open for auto links.
-        if (linkParent !== null && autoLinkParent === null) {
+        if (linkParent !== null || autoLinkParent !== null) {
           setIsLink(true);
         } else {
           setIsLink(false);

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -16,7 +16,6 @@ import {
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
-  $createTextNode,
   $getSelection,
   $isRangeSelection,
   BaseSelection,
@@ -203,9 +202,9 @@ function FloatingLinkEditor({
                 rel: parent.__rel,
                 target: parent.__target,
                 title: parent.__title,
-              }).append($createTextNode(parent.getURL()));
-              parent.getParent()?.append(linkNode);
-              parent.remove();
+              });
+              parent.select();
+              parent.replace(linkNode, true);
             }
           }
         });


### PR DESCRIPTION
This PR fixes #4202 as well as satisfies @zurfyx request in #4203 to have the AutoLinkNode be converted to a LinkNode once modified in the floating link editor toolbar.
I saw multiple closed PR's for this and it looked like it was still an issue no one was currently working on. 
Please let me know if there's anything I need to change, I know the conversion logic is kind of ugly. 