### PR TITLE
Add type literal for serialized nodes types

### DIFF
--- a/packages/lexical-code/flow/LexicalCode.js.flow
+++ b/packages/lexical-code/flow/LexicalCode.js.flow
@@ -109,6 +109,7 @@ declare export function normalizeCodeLang(lang: string): string;
 
 export type SerializedCodeNode = {
   ...SerializedElementNode,
+  type: 'code',
   language: string | null | void,
   ...
 };

--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -50,6 +50,7 @@ export const DEFAULT_CODE_LANGUAGE = 'javascript';
 
 type SerializedCodeHighlightNode = Spread<
   {
+    type: 'code-highlight';
     highlightType: string | null | undefined;
   },
   SerializedTextNode

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -57,6 +57,7 @@ import * as Prism from 'prismjs';
 
 export type SerializedCodeNode = Spread<
   {
+    type: 'code';
     language: string | null | undefined;
   },
   SerializedElementNode

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -38,6 +38,7 @@ export type LinkAttributes = {
 
 export type SerializedLinkNode = Spread<
   {
+    type: 'link';
     url: string;
   },
   Spread<LinkAttributes, SerializedElementNode>
@@ -310,7 +311,10 @@ export function $isLinkNode(
   return node instanceof LinkNode;
 }
 
-export type SerializedAutoLinkNode = SerializedLinkNode;
+export type SerializedAutoLinkNode = Spread<
+  {type: 'autolink'},
+  SerializedLinkNode
+>;
 
 // Custom node type to override `canInsertTextAfter` that will
 // allow typing within the link

--- a/packages/lexical-list/flow/LexicalList.js.flow
+++ b/packages/lexical-list/flow/LexicalList.js.flow
@@ -77,11 +77,13 @@ declare export var INSERT_CHECK_LIST_COMMAND: LexicalCommand<void>;
 declare export var REMOVE_LIST_COMMAND: LexicalCommand<void>;
 
 export type SerializedListItemNode = SerializedElementNode & {
+  type: 'list-item',
   checked: boolean | void,
   value: number,
 };
 
 export type SerializedListNode = SerializedElementNode & {
+  type: 'list',
   listType: ListType,
   start: number,
   tag: ListNodeTagType,

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -49,6 +49,7 @@ import {isNestedListNode} from './utils';
 
 export type SerializedListItemNode = Spread<
   {
+    type: 'listitem';
     checked: boolean | undefined;
     value: number;
   },

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -34,6 +34,7 @@ import {$getListDepth, wrapInListItem} from './utils';
 
 export type SerializedListNode = Spread<
   {
+    type: 'list';
     listType: ListType;
     start: number;
     tag: ListNodeTagType;

--- a/packages/lexical-mark/flow/LexicalMark.js.flow
+++ b/packages/lexical-mark/flow/LexicalMark.js.flow
@@ -16,6 +16,7 @@ import type {
 import {ElementNode, LexicalNode} from 'lexical';
 
 export type SerializedMarkNode = SerializedElementNode & {
+  type: 'mark',
   ids: Array<string>,
 };
 

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -24,6 +24,7 @@ import {$applyNodeReplacement, $isRangeSelection, ElementNode} from 'lexical';
 
 export type SerializedMarkNode = Spread<
   {
+    type: 'mark';
     ids: Array<string>;
   },
   SerializedElementNode

--- a/packages/lexical-overflow/flow/LexicalOverflow.js.flow
+++ b/packages/lexical-overflow/flow/LexicalOverflow.js.flow
@@ -29,4 +29,8 @@ declare export function $isOverflowNode(
   node: ?LexicalNode,
 ): node is OverflowNode;
 
-export type SerializedOverflowNode = SerializedElementNode;
+export type SerializedOverflowNode = {
+  ...SerializedElementNode,
+  type: 'overflow',
+  ...
+};

--- a/packages/lexical-overflow/src/index.ts
+++ b/packages/lexical-overflow/src/index.ts
@@ -13,11 +13,15 @@ import type {
   NodeKey,
   RangeSelection,
   SerializedElementNode,
+  Spread,
 } from 'lexical';
 
 import {$applyNodeReplacement, ElementNode} from 'lexical';
 
-export type SerializedOverflowNode = SerializedElementNode;
+export type SerializedOverflowNode = Spread<
+  {type: 'overflow'},
+  SerializedElementNode
+>;
 
 /** @noInheritDoc */
 export class OverflowNode extends ElementNode {

--- a/packages/lexical-playground/src/nodes/AutocompleteNode.tsx
+++ b/packages/lexical-playground/src/nodes/AutocompleteNode.tsx
@@ -29,6 +29,7 @@ declare global {
 
 export type SerializedAutocompleteNode = Spread<
   {
+    type: 'autocomplete';
     uuid: string;
   },
   SerializedLexicalNode

--- a/packages/lexical-playground/src/nodes/EmojiNode.tsx
+++ b/packages/lexical-playground/src/nodes/EmojiNode.tsx
@@ -18,6 +18,7 @@ import {$applyNodeReplacement, TextNode} from 'lexical';
 
 export type SerializedEmojiNode = Spread<
   {
+    type: 'emoji';
     className: string;
   },
   SerializedTextNode
@@ -73,6 +74,7 @@ export class EmojiNode extends TextNode {
     return node;
   }
 
+  // @ts-expect-error
   exportJSON(): SerializedEmojiNode {
     return {
       ...super.exportJSON(),

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -25,6 +25,7 @@ const EquationComponent = React.lazy(() => import('./EquationComponent'));
 
 export type SerializedEquationNode = Spread<
   {
+    type: 'equation';
     equation: string;
     inline: boolean;
   },

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -26,6 +26,7 @@ const ExcalidrawComponent = React.lazy(() => import('./ExcalidrawComponent'));
 
 export type SerializedExcalidrawNode = Spread<
   {
+    type: 'excalidraw';
     data: string;
     width: number | 'inherit';
     height: number | 'inherit';

--- a/packages/lexical-playground/src/nodes/FigmaNode.tsx
+++ b/packages/lexical-playground/src/nodes/FigmaNode.tsx
@@ -56,6 +56,7 @@ function FigmaComponent({
 
 export type SerializedFigmaNode = Spread<
   {
+    type: 'figma';
     documentID: string;
   },
   SerializedDecoratorBlockNode
@@ -78,6 +79,7 @@ export class FigmaNode extends DecoratorBlockNode {
     return node;
   }
 
+  // @ts-expect-error
   exportJSON(): SerializedFigmaNode {
     return {
       ...super.exportJSON(),

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -48,6 +48,7 @@ function convertImageElement(domNode: Node): null | DOMConversionOutput {
 
 export type SerializedImageNode = Spread<
   {
+    type: 'image';
     altText: string;
     caption: SerializedEditor;
     height?: number;

--- a/packages/lexical-playground/src/nodes/InlineImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/InlineImageNode.tsx
@@ -55,6 +55,7 @@ function convertInlineImageElement(domNode: Node): null | DOMConversionOutput {
 
 export type SerializedInlineImageNode = Spread<
   {
+    type: 'inline-image';
     altText: string;
     caption: SerializedEditor;
     height?: number;

--- a/packages/lexical-playground/src/nodes/KeywordNode.ts
+++ b/packages/lexical-playground/src/nodes/KeywordNode.ts
@@ -6,11 +6,19 @@
  *
  */
 
-import type {EditorConfig, LexicalNode, SerializedTextNode} from 'lexical';
+import type {
+  EditorConfig,
+  LexicalNode,
+  SerializedTextNode,
+  Spread,
+} from 'lexical';
 
 import {TextNode} from 'lexical';
 
-export type SerializedKeywordNode = SerializedTextNode;
+export type SerializedKeywordNode = Spread<
+  {type: 'keyword'},
+  SerializedTextNode
+>;
 
 export class KeywordNode extends TextNode {
   static getType(): string {
@@ -30,6 +38,7 @@ export class KeywordNode extends TextNode {
     return node;
   }
 
+  // @ts-expect-error
   exportJSON(): SerializedKeywordNode {
     return {
       ...super.exportJSON(),

--- a/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
+++ b/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
@@ -20,6 +20,7 @@ import {ElementNode} from 'lexical';
 
 export type SerializedLayoutContainerNode = Spread<
   {
+    type: 'layout-container';
     templateColumns: string;
   },
   SerializedElementNode

--- a/packages/lexical-playground/src/nodes/LayoutItemNode.ts
+++ b/packages/lexical-playground/src/nodes/LayoutItemNode.ts
@@ -11,12 +11,16 @@ import type {
   EditorConfig,
   LexicalNode,
   SerializedElementNode,
+  Spread,
 } from 'lexical';
 
 import {addClassNamesToElement} from '@lexical/utils';
 import {ElementNode} from 'lexical';
 
-export type SerializedLayoutItemNode = SerializedElementNode;
+export type SerializedLayoutItemNode = Spread<
+  {type: 'layout-item'},
+  SerializedElementNode
+>;
 
 export class LayoutItemNode extends ElementNode {
   static getType(): string {

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -22,6 +22,7 @@ import {
 
 export type SerializedMentionNode = Spread<
   {
+    type: 'mention';
     mentionName: string;
   },
   SerializedTextNode
@@ -68,6 +69,7 @@ export class MentionNode extends TextNode {
     this.__mention = mentionName;
   }
 
+  // @ts-expect-error
   exportJSON(): SerializedMentionNode {
     return {
       ...super.exportJSON(),

--- a/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
@@ -25,11 +25,15 @@ import {
   LexicalNode,
   NodeKey,
   SerializedLexicalNode,
+  Spread,
 } from 'lexical';
 import * as React from 'react';
 import {useCallback, useEffect} from 'react';
 
-export type SerializedPageBreakNode = SerializedLexicalNode;
+export type SerializedPageBreakNode = Spread<
+  {type: 'page-break'},
+  SerializedLexicalNode
+>;
 
 function PageBreakComponent({nodeKey}: {nodeKey: NodeKey}) {
   const [editor] = useLexicalComposerContext();

--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -58,6 +58,7 @@ function cloneOption(
 
 export type SerializedPollNode = Spread<
   {
+    type: 'poll';
     question: string;
     options: Options;
   },

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -27,6 +27,7 @@ type StickyNoteColor = 'pink' | 'yellow';
 
 export type SerializedStickyNode = Spread<
   {
+    type: 'sticky';
     xOffset: number;
     yOffset: number;
     color: StickyNoteColor;

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -125,6 +125,7 @@ function TweetComponent({
 
 export type SerializedTweetNode = Spread<
   {
+    type: 'tweet';
     id: string;
   },
   SerializedDecoratorBlockNode
@@ -147,6 +148,7 @@ export class TweetNode extends DecoratorBlockNode {
     return node;
   }
 
+  // @ts-expect-error
   exportJSON(): SerializedTweetNode {
     return {
       ...super.exportJSON(),

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -61,6 +61,7 @@ function YouTubeComponent({
 
 export type SerializedYouTubeNode = Spread<
   {
+    type: 'youtube';
     videoID: string;
   },
   SerializedDecoratorBlockNode
@@ -94,6 +95,7 @@ export class YouTubeNode extends DecoratorBlockNode {
     return node;
   }
 
+  // @ts-expect-error
   exportJSON(): SerializedYouTubeNode {
     return {
       ...super.exportJSON(),

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -21,6 +21,7 @@ import {
 
 type SerializedCollapsibleContainerNode = Spread<
   {
+    type: 'collapsible-container';
     open: boolean;
   },
   SerializedElementNode

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
@@ -14,9 +14,13 @@ import {
   ElementNode,
   LexicalNode,
   SerializedElementNode,
+  Spread,
 } from 'lexical';
 
-type SerializedCollapsibleContentNode = SerializedElementNode;
+type SerializedCollapsibleContentNode = Spread<
+  {type: 'collapsible-content'},
+  SerializedElementNode
+>;
 
 export function convertCollapsibleContentElement(
   domNode: HTMLElement,

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
@@ -18,12 +18,16 @@ import {
   LexicalNode,
   RangeSelection,
   SerializedElementNode,
+  Spread,
 } from 'lexical';
 
 import {$isCollapsibleContainerNode} from './CollapsibleContainerNode';
 import {$isCollapsibleContentNode} from './CollapsibleContentNode';
 
-type SerializedCollapsibleTitleNode = SerializedElementNode;
+type SerializedCollapsibleTitleNode = Spread<
+  {type: 'collapsible-title'},
+  SerializedElementNode
+>;
 
 export function convertSummaryElement(
   domNode: HTMLElement,

--- a/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
+++ b/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
@@ -18,6 +18,7 @@ import {DecoratorNode} from 'lexical';
 
 export type SerializedDecoratorBlockNode = Spread<
   {
+    type: 'decorator-block';
     format: ElementFormatType;
   },
   SerializedLexicalNode

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -14,6 +14,7 @@ import type {
   LexicalNode,
   NodeKey,
   SerializedLexicalNode,
+  Spread,
 } from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -34,7 +35,10 @@ import {
 import * as React from 'react';
 import {useCallback, useEffect} from 'react';
 
-export type SerializedHorizontalRuleNode = SerializedLexicalNode;
+export type SerializedHorizontalRuleNode = Spread<
+  {type: 'horizontalrule'},
+  SerializedLexicalNode
+>;
 
 export const INSERT_HORIZONTAL_RULE_COMMAND: LexicalCommand<void> =
   createCommand('INSERT_HORIZONTAL_RULE_COMMAND');

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -104,6 +104,7 @@ import {
 
 export type SerializedHeadingNode = Spread<
   {
+    type: 'heading';
     tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   },
   SerializedElementNode
@@ -113,7 +114,10 @@ export const DRAG_DROP_PASTE: LexicalCommand<Array<File>> = createCommand(
   'DRAG_DROP_PASTE_FILE',
 );
 
-export type SerializedQuoteNode = SerializedElementNode;
+export type SerializedQuoteNode = Spread<
+  {type: 'quote'},
+  SerializedElementNode
+>;
 
 /** @noInheritDoc */
 export class QuoteNode extends ElementNode {

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -43,6 +43,7 @@ export type SerializedTableCellNode = Spread<
   {
     colSpan?: number;
     rowSpan?: number;
+    type: 'tablecell';
     headerState: TableCellHeaderState;
     width?: number;
     backgroundColor?: null | string;

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -16,6 +16,7 @@ import type {
   LexicalNode,
   NodeKey,
   SerializedElementNode,
+  Spread,
 } from 'lexical';
 
 import {addClassNamesToElement, isHTMLElement} from '@lexical/utils';
@@ -30,7 +31,10 @@ import {TableDOMCell, TableDOMTable} from './LexicalTableObserver';
 import {$isTableRowNode, TableRowNode} from './LexicalTableRowNode';
 import {getTable} from './LexicalTableSelectionHelpers';
 
-export type SerializedTableNode = SerializedElementNode;
+export type SerializedTableNode = Spread<
+  {type: 'table'},
+  SerializedElementNode
+>;
 
 /** @noInheritDoc */
 export class TableNode extends ElementNode {

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -24,6 +24,7 @@ import {PIXEL_VALUE_REG_EXP} from './constants';
 
 export type SerializedTableRowNode = Spread<
   {
+    type: 'tablerow';
     height: number;
   },
   SerializedElementNode

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -235,6 +235,7 @@ import type {Spread} from 'lexical';
 // over the base SerializedLexicalNode type.
 export type SerializedTextNode = Spread<
   {
+    type: 'text';
     detail: number;
     format: number;
     mode: TextModeType;
@@ -250,6 +251,7 @@ If we wanted to make changes to the above `TextNode`, we should be sure to not r
 ```js
 export type SerializedTextNodeV1 = Spread<
   {
+    type: 'text';
     detail: number;
     format: number;
     mode: TextModeType;
@@ -261,6 +263,7 @@ export type SerializedTextNodeV1 = Spread<
 
 export type SerializedTextNodeV2 = Spread<
   {
+    type: 'text';
     detail: number;
     format: number;
     mode: TextModeType;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -618,7 +618,11 @@ declare export function $isTextNode(
  * LexicalTabNode
  */
 
-export type SerializedTabNode = SerializedTextNode;
+export type SerializedTabNode = {
+  ...SerializedTextNode,
+  type: 'tab',
+  ...
+};
 
 declare export function $createTabNode(): TabNode;
 
@@ -872,6 +876,7 @@ export type SerializedLexicalNode = {
 
 export type SerializedTextNode = {
   ...SerializedLexicalNode,
+  type: 'text',
   detail: number,
   format: number,
   mode: TextModeType,
@@ -891,11 +896,13 @@ export type SerializedElementNode = {
 
 export type SerializedParagraphNode = {
   ...SerializedElementNode,
+  type: 'paragraph',
   ...
 };
 
 export type SerializedLineBreakNode = {
   ...SerializedLexicalNode,
+  type: 'linebreak',
   ...
 };
 
@@ -906,6 +913,7 @@ export type SerializedDecoratorNode = {
 
 export type SerializedRootNode = {
   ...SerializedElementNode,
+  type: 'root',
   ...
 };
 

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -47,7 +47,11 @@ import {createRef} from 'react';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 
-import {CreateEditorArgs, LexicalNodeReplacement} from '../../LexicalEditor';
+import {
+  CreateEditorArgs,
+  LexicalNodeReplacement,
+  Spread,
+} from '../../LexicalEditor';
 import {resetRandomKey} from '../../LexicalUtils';
 
 type TestEnv = {
@@ -153,7 +157,10 @@ export function initializeClipboard() {
   });
 }
 
-export type SerializedTestElementNode = SerializedElementNode;
+export type SerializedTestElementNode = Spread<
+  {type: 'test_block'},
+  SerializedElementNode
+>;
 
 export class TestElementNode extends ElementNode {
   static getType(): string {
@@ -195,7 +202,7 @@ export function $createTestElementNode(): TestElementNode {
   return new TestElementNode();
 }
 
-type SerializedTestTextNode = SerializedTextNode;
+type SerializedTestTextNode = Spread<{type: 'test_text'}, SerializedTextNode>;
 
 export class TestTextNode extends TextNode {
   static getType() {
@@ -212,6 +219,7 @@ export class TestTextNode extends TextNode {
     return new TestTextNode(serializedNode.__text);
   }
 
+  // @ts-expect-error
   exportJSON(): SerializedTestTextNode {
     return {
       ...super.exportJSON(),
@@ -221,7 +229,10 @@ export class TestTextNode extends TextNode {
   }
 }
 
-export type SerializedTestInlineElementNode = SerializedElementNode;
+export type SerializedTestInlineElementNode = Spread<
+  {type: 'test_inline_block'},
+  SerializedElementNode
+>;
 
 export class TestInlineElementNode extends ElementNode {
   static getType(): string {
@@ -267,7 +278,10 @@ export function $createTestInlineElementNode(): TestInlineElementNode {
   return new TestInlineElementNode();
 }
 
-export type SerializedTestShadowRootNode = SerializedElementNode;
+export type SerializedTestShadowRootNode = Spread<
+  {type: 'test_shadow_root'},
+  SerializedElementNode
+>;
 
 export class TestShadowRootNode extends ElementNode {
   static getType(): string {
@@ -291,7 +305,7 @@ export class TestShadowRootNode extends ElementNode {
   exportJSON(): SerializedTestShadowRootNode {
     return {
       ...super.exportJSON(),
-      type: 'test_block',
+      type: 'test_shadow_root',
       version: 1,
     };
   }
@@ -313,7 +327,10 @@ export function $createTestShadowRootNode(): TestShadowRootNode {
   return new TestShadowRootNode();
 }
 
-export type SerializedTestSegmentedNode = SerializedTextNode;
+export type SerializedTestSegmentedNode = Spread<
+  {type: 'test_segmented'},
+  SerializedTextNode
+>;
 
 export class TestSegmentedNode extends TextNode {
   static getType(): string {
@@ -335,6 +352,7 @@ export class TestSegmentedNode extends TextNode {
     return node;
   }
 
+  // @ts-expect-error
   exportJSON(): SerializedTestSegmentedNode {
     return {
       ...super.exportJSON(),
@@ -348,7 +366,10 @@ export function $createTestSegmentedNode(text: string): TestSegmentedNode {
   return new TestSegmentedNode(text).setMode('segmented');
 }
 
-export type SerializedTestExcludeFromCopyElementNode = SerializedElementNode;
+export type SerializedTestExcludeFromCopyElementNode = Spread<
+  {type: 'test_exclude_from_copy_block'},
+  SerializedElementNode
+>;
 
 export class TestExcludeFromCopyElementNode extends ElementNode {
   static getType(): string {
@@ -394,7 +415,10 @@ export function $createTestExcludeFromCopyElementNode(): TestExcludeFromCopyElem
   return new TestExcludeFromCopyElementNode();
 }
 
-export type SerializedTestDecoratorNode = SerializedLexicalNode;
+export type SerializedTestDecoratorNode = Spread<
+  {type: 'test_decorator'},
+  SerializedLexicalNode
+>;
 
 export class TestDecoratorNode extends DecoratorNode<JSX.Element> {
   static getType(): string {

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import type {KlassConstructor} from '../LexicalEditor';
+import type {KlassConstructor, Spread} from '../LexicalEditor';
 import type {
   DOMConversionMap,
   DOMConversionOutput,
@@ -18,7 +18,10 @@ import {DOM_TEXT_TYPE} from '../LexicalConstants';
 import {LexicalNode} from '../LexicalNode';
 import {$applyNodeReplacement} from '../LexicalUtils';
 
-export type SerializedLineBreakNode = SerializedLexicalNode;
+export type SerializedLineBreakNode = Spread<
+  {type: 'linebreak'},
+  SerializedLexicalNode
+>;
 
 /** @noInheritDoc */
 export class LineBreakNode extends LexicalNode {

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import type {EditorConfig, LexicalEditor} from '../LexicalEditor';
+import type {EditorConfig, LexicalEditor, Spread} from '../LexicalEditor';
 import type {
   DOMConversionMap,
   DOMConversionOutput,
@@ -27,7 +27,10 @@ import {
 import {ElementNode} from './LexicalElementNode';
 import {$isTextNode} from './LexicalTextNode';
 
-export type SerializedParagraphNode = SerializedElementNode;
+export type SerializedParagraphNode = Spread<
+  {type: 'paragraph'},
+  SerializedElementNode
+>;
 
 /** @noInheritDoc */
 export class ParagraphNode extends ElementNode {

--- a/packages/lexical/src/nodes/LexicalRootNode.ts
+++ b/packages/lexical/src/nodes/LexicalRootNode.ts
@@ -12,6 +12,7 @@ import type {SerializedElementNode} from './LexicalElementNode';
 import invariant from 'shared/invariant';
 
 import {NO_DIRTY_NODES} from '../LexicalConstants';
+import {Spread} from '../LexicalEditor';
 import {getActiveEditor, isCurrentlyReadOnlyMode} from '../LexicalUpdates';
 import {$getRoot} from '../LexicalUtils';
 import {$isDecoratorNode} from './LexicalDecoratorNode';
@@ -19,7 +20,7 @@ import {$isElementNode, ElementNode} from './LexicalElementNode';
 
 export type SerializedRootNode<
   T extends SerializedLexicalNode = SerializedLexicalNode,
-> = SerializedElementNode<T>;
+> = Spread<{type: 'root'}, SerializedElementNode<T>>;
 
 /** @noInheritDoc */
 export class RootNode extends ElementNode {

--- a/packages/lexical/src/nodes/LexicalTabNode.ts
+++ b/packages/lexical/src/nodes/LexicalTabNode.ts
@@ -11,6 +11,7 @@ import type {DOMConversionMap, NodeKey} from '../LexicalNode';
 import invariant from 'shared/invariant';
 
 import {IS_UNMERGEABLE} from '../LexicalConstants';
+import {Spread} from '../LexicalEditor';
 import {LexicalNode} from '../LexicalNode';
 import {$applyNodeReplacement} from '../LexicalUtils';
 import {
@@ -20,7 +21,7 @@ import {
   TextNode,
 } from './LexicalTextNode';
 
-export type SerializedTabNode = SerializedTextNode;
+export type SerializedTabNode = Spread<{type: 'tab'}, SerializedTextNode>;
 
 /** @noInheritDoc */
 export class TabNode extends TextNode {

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -69,6 +69,7 @@ import {$createTabNode} from './LexicalTabNode';
 
 export type SerializedTextNode = Spread<
   {
+    type: 'text';
     detail: number;
     format: number;
     mode: TextModeType;


### PR DESCRIPTION
There are use cases when you don't have the editor and operate only on the serialized state. I think it makes sense to have the ts type of `type` prop be the literal of the node.

```ts
// example.ts
export const extractCommentEditorData = (
  nodes: (SerializedLineBreakNode | SerializedAutoLinkNode | SerializedTextNode)[],
): CommentEditorData => {
  const editorData = nodes.map(element => {
    if (element.type === 'linebreak') {
      return {
        type: 'text',
        text: '\n'
      };
    }
    if (element.type === 'autolink') {
      const node = element as SerializedAutoLinkNode;
      return {
        type: 'text',
        text: node.url ?? ''
      };
    }
    return {
      type: 'text',
      text: (element as SerializedTextNode).text
    };
  }) as CommentEditorData;

  return editorData;
};
```