### PR TITLE
Add row/column with correct header styles

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1442,9 +1442,10 @@ test.describe('Tables', () => {
             </th>
           </tr>
           <tr>
-            <td class="PlaygroundEditorTheme__tableCell">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </td>
+            </th>
           </tr>
           <tr>
             <th
@@ -1551,9 +1552,10 @@ test.describe('Tables', () => {
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
           <tr>
-            <td class="PlaygroundEditorTheme__tableCell">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </td>
+            </th>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
               rowspan="2">
@@ -1561,9 +1563,10 @@ test.describe('Tables', () => {
             </th>
           </tr>
           <tr>
-            <td class="PlaygroundEditorTheme__tableCell">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </td>
+            </th>
           </tr>
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
@@ -1603,12 +1606,14 @@ test.describe('Tables', () => {
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
           <tr>
-            <td class="PlaygroundEditorTheme__tableCell">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </td>
-            <td class="PlaygroundEditorTheme__tableCell">
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </td>
+            </th>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>

--- a/packages/lexical-playground/__tests__/regression/4661-insert-column-selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/4661-insert-column-selection.spec.mjs
@@ -49,12 +49,14 @@ test.describe('Regression test #4661', () => {
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
           <tr>
-            <td class="PlaygroundEditorTheme__tableCell">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </td>
-            <td class="PlaygroundEditorTheme__tableCell">
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </td>
+            </th>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
@@ -120,12 +122,14 @@ test.describe('Regression test #4661', () => {
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
-            <td class="PlaygroundEditorTheme__tableCell">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </td>
-            <td class="PlaygroundEditorTheme__tableCell">
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </td>
+            </th>
           </tr>
           <tr>
             <th

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -226,6 +226,19 @@ export function $insertTableRow(
   return tableNode;
 }
 
+const getHeaderState = (
+  currentState: TableCellHeaderState,
+  possibleState: TableCellHeaderState,
+): TableCellHeaderState => {
+  if (
+    currentState === TableCellHeaderStates.BOTH ||
+    currentState === possibleState
+  ) {
+    return possibleState;
+  }
+  return TableCellHeaderStates.NO_STATUS;
+};
+
 export function $insertTableRow__EXPERIMENTAL(insertAfter = true): void {
   const selection = $getSelection();
   invariant(
@@ -248,11 +261,10 @@ export function $insertTableRow__EXPERIMENTAL(insertAfter = true): void {
         const currentCell = focusEndRowMap[i].cell as TableCellNode;
         const currentCellHeaderState = currentCell.__headerState;
 
-        const headerState =
-          currentCellHeaderState === TableCellHeaderStates.COLUMN ||
-          currentCellHeaderState === TableCellHeaderStates.BOTH
-            ? TableCellHeaderStates.COLUMN
-            : TableCellHeaderStates.NO_STATUS;
+        const headerState = getHeaderState(
+          currentCellHeaderState,
+          TableCellHeaderStates.COLUMN,
+        );
 
         newRow.append(
           $createTableCellNode(headerState).append($createParagraphNode()),
@@ -277,11 +289,10 @@ export function $insertTableRow__EXPERIMENTAL(insertAfter = true): void {
         const currentCell = focusStartRowMap[i].cell as TableCellNode;
         const currentCellHeaderState = currentCell.__headerState;
 
-        const headerState =
-          currentCellHeaderState === TableCellHeaderStates.COLUMN ||
-          currentCellHeaderState === TableCellHeaderStates.BOTH
-            ? TableCellHeaderStates.COLUMN
-            : TableCellHeaderStates.NO_STATUS;
+        const headerState = getHeaderState(
+          currentCellHeaderState,
+          TableCellHeaderStates.COLUMN,
+        );
 
         newRow.append(
           $createTableCellNode(headerState).append($createParagraphNode()),
@@ -414,11 +425,10 @@ export function $insertTableColumn__EXPERIMENTAL(insertAfter = true): void {
         .cell as TableCellNode
     ).__headerState;
 
-    const headerState =
-      currentCellHeaderState === TableCellHeaderStates.ROW ||
-      currentCellHeaderState === TableCellHeaderStates.BOTH
-        ? TableCellHeaderStates.ROW
-        : TableCellHeaderStates.NO_STATUS;
+    const headerState = getHeaderState(
+      currentCellHeaderState,
+      TableCellHeaderStates.ROW,
+    );
 
     if (insertAfterColumn < 0) {
       $insertFirst(

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -253,7 +253,6 @@ export function $insertTableRow__EXPERIMENTAL(insertAfter = true): void {
   if (insertAfter) {
     const focusEndRow = focusStartRow + focusCell.__rowSpan - 1;
     const focusEndRowMap = gridMap[focusEndRow];
-    const focusEndRowNode = grid.getChildAtIndex(focusEndRow);
     const newRow = $createTableRowNode();
     for (let i = 0; i < columnCount; i++) {
       const {cell, startRow} = focusEndRowMap[i];
@@ -273,7 +272,7 @@ export function $insertTableRow__EXPERIMENTAL(insertAfter = true): void {
         cell.setRowSpan(cell.__rowSpan + 1);
       }
     }
-
+    const focusEndRowNode = grid.getChildAtIndex(focusEndRow);
     invariant(
       $isTableRowNode(focusEndRowNode),
       'focusEndRow is not a TableRowNode',
@@ -281,7 +280,6 @@ export function $insertTableRow__EXPERIMENTAL(insertAfter = true): void {
     focusEndRowNode.insertAfter(newRow);
   } else {
     const focusStartRowMap = gridMap[focusStartRow];
-    const focusStartRowNode = grid.getChildAtIndex(focusStartRow);
     const newRow = $createTableRowNode();
     for (let i = 0; i < columnCount; i++) {
       const {cell, startRow} = focusStartRowMap[i];
@@ -301,7 +299,7 @@ export function $insertTableRow__EXPERIMENTAL(insertAfter = true): void {
         cell.setRowSpan(cell.__rowSpan + 1);
       }
     }
-
+    const focusStartRowNode = grid.getChildAtIndex(focusStartRow);
     invariant(
       $isTableRowNode(focusStartRowNode),
       'focusEndRow is not a TableRowNode',


### PR DESCRIPTION
Currently, when a row/column is inserted the cells are added without the header styles. Further, removing the header style leaves the row/column with incorrect header styling. 
This PR fixes this issue by allowing row/column insertion with correct header styles.

### Before
![table-header-bug](https://github.com/facebook/lexical/assets/33776279/728a872a-af04-4076-b441-102d7df74786)


### After
![table-header-fix](https://github.com/facebook/lexical/assets/33776279/840a6746-28cb-4bf1-9650-ec587a9a9c2f)
