### PR TITLE
docs: correct react plugin name

### DIFF
--- a/packages/lexical-website/docs/react/plugins.md
+++ b/packages/lexical-website/docs/react/plugins.md
@@ -183,5 +183,5 @@ Allows you to get a ref to the underlying editor instance outside of LexicalComp
 from a separate part of your application.
 ```jsx
   const editorRef = useRef(null);
-  <LexicalEditorRefPlugin editorRef={ref}>
+  <EditorRefPlugin editorRef={ref}>
 ```


### PR DESCRIPTION
Fix a wrong component name in docs.