### PR TITLE
Fix: add class to elements exported from CodeNode

### DIFF
--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -12,6 +12,7 @@ import type {
   DOMConversionOutput,
   DOMExportOutput,
   EditorConfig,
+  LexicalEditor,
   LexicalNode,
   NodeKey,
   ParagraphNode,
@@ -129,8 +130,9 @@ export class CodeNode extends ElementNode {
     return false;
   }
 
-  exportDOM(): DOMExportOutput {
+  exportDOM(editor: LexicalEditor): DOMExportOutput {
     const element = document.createElement('pre');
+    addClassNamesToElement(element, editor._config.theme.code);
     element.setAttribute('spellcheck', 'false');
     const language = this.getLanguage();
     if (language) {


### PR DESCRIPTION
On exporting, `CodeHighlightNode` and other many `ElementNode` have same class as on created. However, `CodeNode` skips to add class to it, so on the page that uses exported HTML, the CSS for theming `code` should be duplicated for `pre`. So I'm utilizing `htmlConfig` as a workaround for now. 
before:
<img width="1070" alt="image" src="https://github.com/facebook/lexical/assets/40269597/90a06617-8033-4068-8c5a-cec7a7cb450f">

I'm aware of `exportDOM` and `createDOM` of `CodeNode` return different semantic but still they could have same class.