### PR TITLE
Bug: Right Align in Toolbar for RTL direction shows Left Align Icon

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -184,7 +184,7 @@ const ELEMENT_FORMAT_OPTIONS: {
   },
   right: {
     icon: 'right-align',
-    iconRTL: 'left-align',
+    iconRTL: 'right-align',
     name: 'Right Align',
   },
   start: {


### PR DESCRIPTION
This pull request is related to #5560.

In `packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx`, `iconRTL` for `right` ELEMENT_FORMAT_OPTIONS should be `right-align`.