### PR TITLE
Prevent file:/// img conversion

### DIFF
--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -38,12 +38,13 @@ export interface ImagePayload {
 }
 
 function convertImageElement(domNode: Node): null | DOMConversionOutput {
-  if (domNode instanceof HTMLImageElement) {
-    const {alt: altText, src, width, height} = domNode;
-    const node = $createImageNode({altText, height, src, width});
-    return {node};
+  const img = domNode as HTMLImageElement;
+  if (img.src.startsWith('file:///')) {
+    return null;
   }
-  return null;
+  const {alt: altText, src, width, height} = img;
+  const node = $createImageNode({altText, height, src, width});
+  return {node};
 }
 
 export type SerializedImageNode = Spread<


### PR DESCRIPTION
I don't think we ever want to import a `file:///` as we will have no system permission.

On top of that, we should implement some UI that shows when an image can't be loaded (i.e. network connection, page down, etc.) https://github.com/facebook/lexical/issues/5564

Closes https://github.com/facebook/lexical/issues/5316 (thanks @mok419 for the research!)