### PR TITLE
Added Link Type check and simplified floating link plugin

### DIFF
--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -567,7 +567,6 @@ export function $onlyIncludesAParentLink(
     return false;
   }
   const nodes = firstNode.getNodesBetween(lastNode);
-  let matching = false;
   let matchedParent;
   for (const node of nodes) {
     if (!$isLeafNode(node) && !$isLinkNode(node) && !$isAutoLinkNode(node)) {
@@ -576,8 +575,7 @@ export function $onlyIncludesAParentLink(
     if ($isLinkNode(node) || $isAutoLinkNode(node)) {
       if (matchedParent) {
         if (!node.is(matchedParent)) {
-          matching = false;
-          break;
+          return false;
         } else {
           continue;
         }
@@ -587,17 +585,15 @@ export function $onlyIncludesAParentLink(
       }
     }
     const parent = getParentLink(node);
-    if (parent && !matchedParent) {
-      matching = true;
+    if (!parent) {
+      return false;
+    } else if (!matchedParent) {
       matchedParent = parent;
-    } else if (parent && parent.is(matchedParent)) {
-      continue;
-    } else {
-      matching = false;
-      break;
+    } else if (!parent.is(matchedParent)) {
+      return false;
     }
   }
-  return matching;
+  return true;
 }
 
 function getParentLink(node: LexicalNode) {

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -11,13 +11,13 @@ import {
   $createLinkNode,
   $isAutoLinkNode,
   $isLinkNode,
+  $onlyIncludesAParentLink,
   TOGGLE_LINK_COMMAND,
 } from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$findMatchingParent, mergeRegister} from '@lexical/utils';
 import {
   $getSelection,
-  $isLineBreakNode,
   $isRangeSelection,
   BaseSelection,
   CLICK_COMMAND,
@@ -295,30 +295,7 @@ function useFloatingLinkEditorToolbar(
     function updateToolbar() {
       const selection = $getSelection();
       if ($isRangeSelection(selection)) {
-        const focusNode = getSelectedNode(selection);
-        const focusLinkNode = $findMatchingParent(focusNode, $isLinkNode);
-        const focusAutoLinkNode = $findMatchingParent(
-          focusNode,
-          $isAutoLinkNode,
-        );
-        if (!(focusLinkNode || focusAutoLinkNode)) {
-          setIsLink(false);
-          return;
-        }
-        const badNode = selection.getNodes().find((node) => {
-          const linkNode = $findMatchingParent(node, $isLinkNode);
-          const autoLinkNode = $findMatchingParent(node, $isAutoLinkNode);
-          if (
-            !linkNode?.is(focusLinkNode) &&
-            !autoLinkNode?.is(focusAutoLinkNode) &&
-            !linkNode &&
-            !autoLinkNode &&
-            !$isLineBreakNode(node)
-          ) {
-            return node;
-          }
-        });
-        if (!badNode) {
+        if ($onlyIncludesAParentLink(selection)) {
           setIsLink(true);
         } else {
           setIsLink(false);

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -9,9 +9,9 @@ import './index.css';
 
 import {
   $createLinkNode,
+  $getSelectedLinkNode,
   $isAutoLinkNode,
   $isLinkNode,
-  $onlyIncludesAParentLink,
   TOGGLE_LINK_COMMAND,
 } from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -63,10 +63,10 @@ function FloatingLinkEditor({
     const selection = $getSelection();
     if ($isRangeSelection(selection)) {
       const node = getSelectedNode(selection);
-      const linkParent = $findMatchingParent(node, $isLinkNode);
+      const linkNode = $getSelectedLinkNode(selection);
 
-      if (linkParent) {
-        setLinkUrl(linkParent.getURL());
+      if (linkNode) {
+        setLinkUrl(linkNode.getURL());
       } else if ($isLinkNode(node)) {
         setLinkUrl(node.getURL());
       } else {
@@ -295,7 +295,7 @@ function useFloatingLinkEditorToolbar(
     function updateToolbar() {
       const selection = $getSelection();
       if ($isRangeSelection(selection)) {
-        if ($onlyIncludesAParentLink(selection)) {
+        if ($getSelectedLinkNode(selection)) {
           setIsLink(true);
         } else {
           setIsLink(false);


### PR DESCRIPTION
Extension of #5551 
@zurfyx is this closer to what you were looking for? I certainly made it simple for the product side, but I'm not sure if there's a more optimal solution, or if this is overkill. 
Also I noticed $getAncestor and $findMatchingParent are similar but I'm not sure if there's a distinct difference I'm not seeing.