### PR TITLE
Preserve bullet item indent on newline

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -282,36 +282,36 @@
 .PlaygroundEditorTheme__ol1 {
   padding: 0;
   margin: 0;
-  list-style-position: inside;
+  list-style-position: outside;
 }
 .PlaygroundEditorTheme__ol2 {
   padding: 0;
   margin: 0;
   list-style-type: upper-alpha;
-  list-style-position: inside;
+  list-style-position: outside;
 }
 .PlaygroundEditorTheme__ol3 {
   padding: 0;
   margin: 0;
   list-style-type: lower-alpha;
-  list-style-position: inside;
+  list-style-position: outside;
 }
 .PlaygroundEditorTheme__ol4 {
   padding: 0;
   margin: 0;
   list-style-type: upper-roman;
-  list-style-position: inside;
+  list-style-position: outside;
 }
 .PlaygroundEditorTheme__ol5 {
   padding: 0;
   margin: 0;
   list-style-type: lower-roman;
-  list-style-position: inside;
+  list-style-position: outside;
 }
 .PlaygroundEditorTheme__ul {
   padding: 0;
   margin: 0;
-  list-style-position: inside;
+  list-style-position: outside;
 }
 .PlaygroundEditorTheme__listItem {
   margin: 0 32px;


### PR DESCRIPTION
Before:

https://github.com/facebook/lexical/assets/7893468/6f3a3463-dbef-4109-9ccf-ddf84f51ff9b

After:

https://github.com/facebook/lexical/assets/7893468/c1b852bf-5877-447e-b73a-9c63c6e8fb74

This is a fix for https://github.com/facebook/lexical/issues/3999 technically.

Applying this on 'ul' level, I verified it behaves correctly in Safari as well.