### PR TITLE
Fix Double Deletion on Backspace

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -56,6 +56,7 @@ export default function ExcalidrawComponent({
           const node = $getNodeByKey(nodeKey);
           if ($isExcalidrawNode(node)) {
             node.remove();
+            return true;
           }
         });
       }

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -151,6 +151,7 @@ export default function ImageComponent({
         const node = $getNodeByKey(nodeKey);
         if ($isImageNode(node)) {
           node.remove();
+          return true;
         }
       }
       return false;

--- a/packages/lexical-playground/src/nodes/InlineImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/InlineImageComponent.tsx
@@ -211,6 +211,7 @@ export default function InlineImageComponent({
         const node = $getNodeByKey(nodeKey);
         if ($isInlineImageNode(node)) {
           node.remove();
+          return true;
         }
       }
       return false;

--- a/packages/lexical-playground/src/nodes/PollComponent.tsx
+++ b/packages/lexical-playground/src/nodes/PollComponent.tsx
@@ -152,6 +152,7 @@ export default function PollComponent({
         const node = $getNodeByKey(nodeKey);
         if ($isPollNode(node)) {
           node.remove();
+          return true;
         }
       }
       return false;

--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -59,6 +59,7 @@ export function BlockWithAlignableContents({
         const node = $getNodeByKey(nodeKey);
         if ($isDecoratorNode(node)) {
           node.remove();
+          return true;
         }
       }
 

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -51,6 +51,7 @@ function HorizontalRuleComponent({nodeKey}: {nodeKey: NodeKey}) {
         const node = $getNodeByKey(nodeKey);
         if ($isHorizontalRuleNode(node)) {
           node.remove();
+          return true;
         }
       }
       return false;


### PR DESCRIPTION
A couple of nodes didn't `return true` on backspace deletion, leading to deleting an extra node before them. I guess someone forgot the `return true` for one `onDelete` implementation in a node and then by virtue of copy-pasting the bug made its way to multiple nodes, most notably the 'Image', 'Horizontal Line' and 'Block With Alignable Contents'.

Fixes: [#5249](https://github.com/facebook/lexical/issues/5249) and I believe #3707 was referring to this behaviour as well