### PR TITLE
fix: hide Firefox's text size buttons

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
@@ -17,6 +17,10 @@ input[type='number']::-webkit-inner-spin-button {
   margin: 0;
 }
 
+input[type=number] {
+  -moz-appearance: textfield;
+}
+
 .add-icon {
   background-image: url(../../images/icons/add-sign.svg);
   background-repeat: no-repeat;

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
@@ -17,7 +17,7 @@ input[type='number']::-webkit-inner-spin-button {
   margin: 0;
 }
 
-input[type=number] {
+input[type='number'] {
   -moz-appearance: textfield;
 }
 


### PR DESCRIPTION
This is how the playground looks **in Firefox**:

![imagen](https://github.com/facebook/lexical/assets/13053829/ff370357-a9b0-4f9d-8ac2-517997998d97)

The little piece of CSS taken from [here](https://www.w3schools.com/howto/howto_css_hide_arrow_number.asp) fixes it to:

![imagen](https://github.com/facebook/lexical/assets/13053829/0a3ab2b9-4881-4626-9567-11b0dc23f349)

