### PR TITLE
fix: Improve performance of updateChildrenListItemValue

### DIFF
--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -27,6 +27,7 @@ import {
   SerializedElementNode,
   Spread,
 } from 'lexical';
+import invariant from 'shared/invariant';
 
 import {$createListItemNode, $isListItemNode, ListItemNode} from '.';
 import {updateChildrenListItemValue} from './formatList';
@@ -120,6 +121,13 @@ export class ListNode extends ElementNode {
     return false;
   }
 
+  static transform(): (node: LexicalNode) => void {
+    return (node: LexicalNode) => {
+      invariant($isListNode(node), 'node is not a ListNode');
+      updateChildrenListItemValue(node);
+    };
+  }
+
   static importDOM(): DOMConversionMap | null {
     return {
       ol: (node: Node) => ({
@@ -195,7 +203,6 @@ export class ListNode extends ElementNode {
         super.append(listItemNode);
       }
     }
-    updateChildrenListItemValue(this);
     return this;
   }
 


### PR DESCRIPTION
The algorithm used to update `ListItemNode` values was quadratic when called in a loop as it interrogated all previous siblings. Calculating all expected values from the `ListNode` ahead of time is simpler and much more performant.

Since a transform was already in place for `ListItemNode` it seemed reasonable to implement one for `ListNode` and consolidate all of the `updateChildrenListItemValue` usage there to avoid repeating the same list traversals for each item. This also lead the way to removing code from other places that attempted to renumber lists at each mutation where that might be necessary.

RE #5589
