### PR TITLE
fix: disable markdown shortcuts for collaboration

### DIFF
--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -385,8 +385,8 @@ export function registerMarkdownShortcuts(
 
   return editor.registerUpdateListener(
     ({tags, dirtyLeaves, editorState, prevEditorState}) => {
-      // Ignore updates from undo/redo (as changes already calculated)
-      if (tags.has('historic')) {
+      // Ignore updates from collaboration and undo/redo (as changes already calculated)
+      if (tags.has('collaboration') || tags.has('historic')) {
         return;
       }
 


### PR DESCRIPTION
This PR fixes an issue where Markdown transformations could be triggered simultaneously in collaborative editors, leading to duplicated nodes.

### Before:

https://github.com/facebook/lexical/assets/59686138/19c14981-27f5-4e72-b826-8cc72d27f12c

### After:

https://github.com/facebook/lexical/assets/59686138/8425d148-052b-47d0-844d-e688c426d51d

