### PR TITLE
Revert "Fixed position for lexical menu (#5602)"

### DIFF
--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -530,7 +530,7 @@ export function useMenuAnchorRef(
         containerDiv.setAttribute('id', 'typeahead-menu');
         containerDiv.setAttribute('role', 'listbox');
         containerDiv.style.display = 'block';
-        containerDiv.style.position = 'fixed';
+        containerDiv.style.position = 'absolute';
         parent.append(containerDiv);
       }
       anchorElementRef.current = containerDiv;


### PR DESCRIPTION
Reverting as the menu does not work correctly when the page is scrolled. If you scroll down the entire viewport, the menu doesn't even show.

https://github.com/facebook/lexical/assets/193447/018b9e18-5b0f-4b8b-9647-fc12e7850472

@ebads67 can you share more details on your use case and we can follow up in a separate PR?

This reverts commit 0ebb41307624af16cb2cdd48e9804ccb96edd32c.