### PR TITLE
Fix shift+arrow down selection for tables in sequence.

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -471,10 +471,12 @@ export function applyTableHandlers(
           // as in that case we'll leave selection resolving to that table
           const anchorCellNode = $findCellNode(anchorNode);
           const focusCellNode = $findCellNode(focusNode);
-          const isAnchorInside =
-            anchorCellNode && tableNode.is($findTableNode(anchorCellNode));
-          const isFocusInside =
-            focusCellNode && tableNode.is($findTableNode(focusCellNode));
+          const isAnchorInside = !!(
+            anchorCellNode && tableNode.is($findTableNode(anchorCellNode))
+          );
+          const isFocusInside = !!(
+            focusCellNode && tableNode.is($findTableNode(focusCellNode))
+          );
           const isPartialyWithinTable = isAnchorInside !== isFocusInside;
           const isWithinTable = isAnchorInside && isFocusInside;
           const isBackward = selection.isBackward();


### PR DESCRIPTION
Before:

[table-sequence-selection-before.webm](https://github.com/facebook/lexical/assets/88986106/09853d27-ab1d-4e54-bc36-1ae5d6ab1d28)

After: 

[table-sequence-selection-after.webm](https://github.com/facebook/lexical/assets/88986106/f2b6c445-87ba-4142-b92f-85d0ec0c2ab8)

Fixes #5616.