### PR TITLE
ESM build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,13 @@ module.exports = {
       },
     },
     {
+      // These aren't compiled, but they're written in module JS
+      files: ['packages/lexical-playground/esm/*.js'],
+      parserOptions: {
+        sourceType: 'module',
+      },
+    },
+    {
       files: [
         'packages/**/src/__tests__/**',
         'packages/lexical-playground/**',

--- a/jest.config.js
+++ b/jest.config.js
@@ -71,6 +71,7 @@ module.exports = {
           '<rootDir>/packages/lexical-react/src/LexicalTabIndentationPlugin.tsx',
         '^@lexical/react/LexicalTablePlugin$':
           '<rootDir>/packages/lexical-react/src/LexicalTablePlugin.ts',
+        '^@lexical/react/src/(.*)$': '<rootDir>/packages/lexical-react/src/$1',
         '^@lexical/react/useLexicalCanShowPlaceholder$':
           '<rootDir>/packages/lexical-react/src/useLexicalCanShowPlaceholder.ts',
         '^@lexical/react/useLexicalDecorators$':

--- a/package-lock.json
+++ b/package-lock.json
@@ -4447,6 +4447,25 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -4594,6 +4613,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "17.0.45",
@@ -18905,6 +18930,82 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-copy": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.5.0.tgz",
+      "integrity": "sha512-wI8D5dvYovRMx/YYKtUNt3Yxaw4ORC9xo6Gt9t22kveWz1enG9QrhVlagzwrxSC455xD1dHMKhIJkbsQ7d48BA==",
+      "dev": true,
+      "dependencies": {
+        "@types/fs-extra": "^8.0.1",
+        "colorette": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "10.0.1",
+        "is-plain-object": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.3"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/globby": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+      "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/is-plain-object": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
@@ -23158,6 +23259,7 @@
       "devDependencies": {
         "@types/lodash-es": "^4.14.182",
         "@vitejs/plugin-react": "^1.0.7",
+        "rollup-plugin-copy": "^3.5.0",
         "vite": "^2.9.16",
         "vite-plugin-replace": "0.1.1"
       }
@@ -28213,6 +28315,25 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/fs-extra": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -28353,6 +28474,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
+    "@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
     },
     "@types/node": {
       "version": "17.0.45",
@@ -35756,6 +35883,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^3.1.4",
+        "rollup-plugin-copy": "^3.5.0",
         "vite": "^2.9.16",
         "vite-plugin-replace": "0.1.1",
         "y-websocket": ">=1.3.x",
@@ -38654,6 +38782,69 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-copy": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.5.0.tgz",
+      "integrity": "sha512-wI8D5dvYovRMx/YYKtUNt3Yxaw4ORC9xo6Gt9t22kveWz1enG9QrhVlagzwrxSC455xD1dHMKhIJkbsQ7d48BA==",
+      "dev": true,
+      "requires": {
+        "@types/fs-extra": "^8.0.1",
+        "colorette": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "10.0.1",
+        "is-plain-object": "^3.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "globby": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+          "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+          "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        }
       }
     },
     "rrweb-cssom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@rollup/plugin-json": "^5.0.2",
         "@rollup/plugin-node-resolve": "^13.0.2",
         "@rollup/plugin-replace": "^3.0.0",
+        "@rollup/plugin-terser": "^0.4.4",
         "@size-limit/preset-big-lib": "^8.1.0",
         "@types/jest": "^29.4.0",
         "@types/jsdom": "^21.1.6",
@@ -3793,6 +3794,28 @@
       },
       "peerDependencies": {
         "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "dev": true,
+      "dependencies": {
+        "serialize-javascript": "^6.0.1",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -19529,6 +19552,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/smob": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.4.1.tgz",
+      "integrity": "sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ==",
+      "dev": true
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -27728,6 +27757,17 @@
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
         "magic-string": "^0.25.7"
+      }
+    },
+    "@rollup/plugin-terser": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "dev": true,
+      "requires": {
+        "serialize-javascript": "^6.0.1",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
       }
     },
     "@rollup/pluginutils": {
@@ -39129,6 +39169,12 @@
           "dev": true
         }
       }
+    },
+    "smob": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.4.1.tgz",
+      "integrity": "sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ==",
+      "dev": true
     },
     "sockjs": {
       "version": "0.3.24",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@rollup/plugin-json": "^5.0.2",
     "@rollup/plugin-node-resolve": "^13.0.2",
     "@rollup/plugin-replace": "^3.0.0",
+    "@rollup/plugin-terser": "^0.4.4",
     "@size-limit/preset-big-lib": "^8.1.0",
     "@types/jest": "^29.4.0",
     "@types/jsdom": "^21.1.6",

--- a/packages/lexical-clipboard/package.json
+++ b/packages/lexical-clipboard/package.json
@@ -24,5 +24,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-clipboard"
-  }
+  },
+  "module": "LexicalClipboard.esm.js"
 }

--- a/packages/lexical-clipboard/package.json
+++ b/packages/lexical-clipboard/package.json
@@ -25,5 +25,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-clipboard"
   },
-  "module": "LexicalClipboard.esm.js"
+  "module": "LexicalClipboard.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-code/package.json
+++ b/packages/lexical-code/package.json
@@ -24,5 +24,6 @@
   },
   "devDependencies": {
     "@types/prismjs": "^1.26.0"
-  }
+  },
+  "module": "LexicalCode.esm.js"
 }

--- a/packages/lexical-code/package.json
+++ b/packages/lexical-code/package.json
@@ -25,5 +25,6 @@
   "devDependencies": {
     "@types/prismjs": "^1.26.0"
   },
-  "module": "LexicalCode.esm.js"
+  "module": "LexicalCode.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-dragon/package.json
+++ b/packages/lexical-dragon/package.json
@@ -19,5 +19,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-dragon"
   },
-  "module": "LexicalDragon.esm.js"
+  "module": "LexicalDragon.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-dragon/package.json
+++ b/packages/lexical-dragon/package.json
@@ -18,5 +18,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-dragon"
-  }
+  },
+  "module": "LexicalDragon.esm.js"
 }

--- a/packages/lexical-file/package.json
+++ b/packages/lexical-file/package.json
@@ -20,5 +20,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-file"
   },
-  "module": "LexicalFile.esm.js"
+  "module": "LexicalFile.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-file/package.json
+++ b/packages/lexical-file/package.json
@@ -19,5 +19,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-file"
-  }
+  },
+  "module": "LexicalFile.esm.js"
 }

--- a/packages/lexical-hashtag/package.json
+++ b/packages/lexical-hashtag/package.json
@@ -20,5 +20,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-hashtag"
-  }
+  },
+  "module": "LexicalHashtag.esm.js"
 }

--- a/packages/lexical-hashtag/package.json
+++ b/packages/lexical-hashtag/package.json
@@ -21,5 +21,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-hashtag"
   },
-  "module": "LexicalHashtag.esm.js"
+  "module": "LexicalHashtag.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-headless/package.json
+++ b/packages/lexical-headless/package.json
@@ -18,5 +18,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-headless"
   },
-  "module": "LexicalHeadless.esm.js"
+  "module": "LexicalHeadless.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-headless/package.json
+++ b/packages/lexical-headless/package.json
@@ -17,5 +17,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-headless"
-  }
+  },
+  "module": "LexicalHeadless.esm.js"
 }

--- a/packages/lexical-history/package.json
+++ b/packages/lexical-history/package.json
@@ -20,5 +20,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-history"
-  }
+  },
+  "module": "LexicalHistory.esm.js"
 }

--- a/packages/lexical-history/package.json
+++ b/packages/lexical-history/package.json
@@ -21,5 +21,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-history"
   },
-  "module": "LexicalHistory.esm.js"
+  "module": "LexicalHistory.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-html/package.json
+++ b/packages/lexical-html/package.json
@@ -22,5 +22,6 @@
     "@lexical/selection": "0.13.1",
     "@lexical/utils": "0.13.1"
   },
-  "module": "LexicalHtml.esm.js"
+  "module": "LexicalHtml.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-html/package.json
+++ b/packages/lexical-html/package.json
@@ -21,5 +21,6 @@
   "dependencies": {
     "@lexical/selection": "0.13.1",
     "@lexical/utils": "0.13.1"
-  }
+  },
+  "module": "LexicalHtml.esm.js"
 }

--- a/packages/lexical-link/package.json
+++ b/packages/lexical-link/package.json
@@ -21,5 +21,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-link"
   },
-  "module": "LexicalLink.esm.js"
+  "module": "LexicalLink.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-link/package.json
+++ b/packages/lexical-link/package.json
@@ -20,5 +20,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-link"
-  }
+  },
+  "module": "LexicalLink.esm.js"
 }

--- a/packages/lexical-list/package.json
+++ b/packages/lexical-list/package.json
@@ -20,5 +20,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-list"
-  }
+  },
+  "module": "LexicalList.esm.js"
 }

--- a/packages/lexical-list/package.json
+++ b/packages/lexical-list/package.json
@@ -21,5 +21,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-list"
   },
-  "module": "LexicalList.esm.js"
+  "module": "LexicalList.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-mark/package.json
+++ b/packages/lexical-mark/package.json
@@ -20,5 +20,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-mark"
-  }
+  },
+  "module": "LexicalMark.esm.js"
 }

--- a/packages/lexical-mark/package.json
+++ b/packages/lexical-mark/package.json
@@ -21,5 +21,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-mark"
   },
-  "module": "LexicalMark.esm.js"
+  "module": "LexicalMark.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-markdown/package.json
+++ b/packages/lexical-markdown/package.json
@@ -25,5 +25,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-markdown"
-  }
+  },
+  "module": "LexicalMarkdown.esm.js"
 }

--- a/packages/lexical-markdown/package.json
+++ b/packages/lexical-markdown/package.json
@@ -26,5 +26,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-markdown"
   },
-  "module": "LexicalMarkdown.esm.js"
+  "module": "LexicalMarkdown.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-offset/package.json
+++ b/packages/lexical-offset/package.json
@@ -18,5 +18,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-offset"
   },
-  "module": "LexicalOffset.esm.js"
+  "module": "LexicalOffset.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-offset/package.json
+++ b/packages/lexical-offset/package.json
@@ -17,5 +17,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-offset"
-  }
+  },
+  "module": "LexicalOffset.esm.js"
 }

--- a/packages/lexical-overflow/package.json
+++ b/packages/lexical-overflow/package.json
@@ -17,5 +17,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-overflow"
-  }
+  },
+  "module": "LexicalOverflow.esm.js"
 }

--- a/packages/lexical-overflow/package.json
+++ b/packages/lexical-overflow/package.json
@@ -18,5 +18,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-overflow"
   },
-  "module": "LexicalOverflow.esm.js"
+  "module": "LexicalOverflow.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-plain-text/package.json
+++ b/packages/lexical-plain-text/package.json
@@ -20,5 +20,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-plain-text"
   },
-  "module": "LexicalPlainText.esm.js"
+  "module": "LexicalPlainText.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-plain-text/package.json
+++ b/packages/lexical-plain-text/package.json
@@ -19,5 +19,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-plain-text"
-  }
+  },
+  "module": "LexicalPlainText.esm.js"
 }

--- a/packages/lexical-playground/esm/index.esm.js
+++ b/packages/lexical-playground/esm/index.esm.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {registerDragonSupport} from '@lexical/dragon';
+import {createEmptyHistoryState, registerHistory} from '@lexical/history';
+import {HeadingNode, QuoteNode, registerRichText} from '@lexical/rich-text';
+import {mergeRegister} from '@lexical/utils';
+import {createEditor} from 'lexical';
+
+import prepopulatedRichText from './prepopulatedRichText.esm.js';
+
+const editorRef = document.getElementById('lexical-editor');
+const stateRef = document.getElementById('lexical-state');
+
+const initialConfig = {
+  namespace: 'Vanilla JS Demo',
+  // Register nodes specific for @lexical/rich-text
+  nodes: [HeadingNode, QuoteNode],
+  onError: (error) => {
+    throw error;
+  },
+  theme: {
+    // Adding styling to Quote node, see styles.css
+    quote: 'PlaygroundEditorTheme__quote',
+  },
+};
+const editor = createEditor(initialConfig);
+editor.setRootElement(editorRef);
+
+// Registering Plugins
+mergeRegister(
+  registerRichText(editor),
+  registerDragonSupport(editor),
+  registerHistory(editor, createEmptyHistoryState(), 300),
+);
+
+editor.update(prepopulatedRichText, {tag: 'history-merge'});
+
+editor.registerUpdateListener(({editorState}) => {
+  stateRef.value = JSON.stringify(editorState.toJSON(), undefined, 2);
+});

--- a/packages/lexical-playground/esm/index.html
+++ b/packages/lexical-playground/esm/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Lexical Basic - Vanilla JS with ESM" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="stylesheet" href="./styles.css" />
+    <title>Lexical Basic - Vanilla JS with ESM</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <h1>Lexical Basic - Vanilla JS with ESM</h1>
+    <div class="editor-wrapper">
+      <div id="lexical-editor" contenteditable></div>
+    </div>
+    <h4>Editor state:</h4>
+    <textarea id="lexical-state"></textarea>
+    <script type="importmap">
+      {
+        "imports": {
+          "lexical": "./dist/Lexical.esm.js",
+          "@lexical/clipboard": "./dist/LexicalClipboard.esm.js",
+          "@lexical/dragon": "./dist/LexicalDragon.esm.js",
+          "@lexical/history": "./dist/LexicalHistory.esm.js",
+          "@lexical/html": "./dist/LexicalHtml.esm.js",
+          "@lexical/rich-text": "./dist/LexicalRichText.esm.js",
+          "@lexical/selection": "./dist/LexicalSelection.esm.js",
+          "@lexical/utils": "./dist/LexicalUtils.esm.js"
+        }
+      }
+    </script>
+    <script type="module" src="./index.esm.js"></script>
+  </body>
+</html>

--- a/packages/lexical-playground/esm/prepopulatedRichText.esm.js
+++ b/packages/lexical-playground/esm/prepopulatedRichText.esm.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {$createHeadingNode, $createQuoteNode} from '@lexical/rich-text';
+import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+
+export default function prepopulatedRichText() {
+  const root = $getRoot();
+  if (root.getFirstChild() !== null) {
+    return;
+  }
+
+  const heading = $createHeadingNode('h1');
+  heading.append($createTextNode('Welcome to the Vanilla JS Lexical Demo!'));
+  root.append(heading);
+  const quote = $createQuoteNode();
+  quote.append(
+    $createTextNode(
+      `In case you were wondering what the text area at the bottom is – it's the debug view, showing the current state of the editor. `,
+    ),
+  );
+  root.append(quote);
+  const paragraph = $createParagraphNode();
+  paragraph.append(
+    $createTextNode('This is a demo environment built with '),
+    $createTextNode('lexical').toggleFormat('code'),
+    $createTextNode('.'),
+    $createTextNode(' Try typing in '),
+    $createTextNode('some text').toggleFormat('bold'),
+    $createTextNode(' with '),
+    $createTextNode('different').toggleFormat('italic'),
+    $createTextNode(' formats.'),
+  );
+  root.append(paragraph);
+}

--- a/packages/lexical-playground/esm/styles.css
+++ b/packages/lexical-playground/esm/styles.css
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+.editor-wrapper {
+  border: 2px solid gray;
+}
+#lexical-state {
+  width: 100%;
+  height: 300px;
+}
+
+.PlaygroundEditorTheme__quote {
+  margin: 0;
+  margin-left: 20px;
+  margin-bottom: 10px;
+  font-size: 15px;
+  color: rgb(101, 103, 107);
+  border-left-color: rgb(206, 208, 212);
+  border-left-width: 4px;
+  border-left-style: solid;
+  padding-left: 16px;
+}

--- a/packages/lexical-playground/package.json
+++ b/packages/lexical-playground/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@types/lodash-es": "^4.14.182",
     "@vitejs/plugin-react": "^1.0.7",
+    "rollup-plugin-copy": "^3.5.0",
     "vite": "^2.9.16",
     "vite-plugin-replace": "0.1.1"
   }

--- a/packages/lexical-playground/package.json
+++ b/packages/lexical-playground/package.json
@@ -41,5 +41,6 @@
     "rollup-plugin-copy": "^3.5.0",
     "vite": "^2.9.16",
     "vite-plugin-replace": "0.1.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/lexical-playground/vite.prod.config.js
+++ b/packages/lexical-playground/vite.prod.config.js
@@ -13,6 +13,7 @@ import path from 'path';
 import fs from 'fs';
 import {replaceCodePlugin} from 'vite-plugin-replace';
 import babel from '@rollup/plugin-babel';
+import copy from 'rollup-plugin-copy';
 
 const moduleResolution = [
   {
@@ -182,6 +183,24 @@ export default defineConfig({
       presets: ['@babel/preset-react'],
     }),
     react(),
+    copy({
+      hook: 'writeBundle',
+      verbose: true,
+      targets: [
+        {src: './esm/*', dest: './build/esm/'},
+        {src: ['./*.png', './*.ico'], dest: './build/'},
+        ...((() => {
+          const m = /<script type="importmap">([\s\S]+?)<\/script>/g.exec(fs.readFileSync('./esm/index.html', 'utf8'));
+          if (!m) {
+            throw new Error('Could not parse importmap from esm/index.html');
+          }
+          return Object.entries(JSON.parse(m[1]).imports).map(([k, v]) => ({
+            src: path.join(`../${k.replace(/^@/, '').replace(/\//g, '-')}`, v),
+            dest: './build/esm/dist/',
+          }));
+        })()),
+      ],
+    }),
   ],
   resolve: {
     alias: moduleResolution,

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -44,7 +44,15 @@
       "import": "./LexicalAutoEmbedPlugin.esm.js",
       "require": "./LexicalAutoEmbedPlugin.js"
     },
+    "./LexicalAutoEmbedPlugin.js": {
+      "import": "./LexicalAutoEmbedPlugin.esm.js",
+      "require": "./LexicalAutoEmbedPlugin.js"
+    },
     "./LexicalAutoFocusPlugin": {
+      "import": "./LexicalAutoFocusPlugin.esm.js",
+      "require": "./LexicalAutoFocusPlugin.js"
+    },
+    "./LexicalAutoFocusPlugin.js": {
       "import": "./LexicalAutoFocusPlugin.esm.js",
       "require": "./LexicalAutoFocusPlugin.js"
     },
@@ -52,7 +60,15 @@
       "import": "./LexicalAutoLinkPlugin.esm.js",
       "require": "./LexicalAutoLinkPlugin.js"
     },
+    "./LexicalAutoLinkPlugin.js": {
+      "import": "./LexicalAutoLinkPlugin.esm.js",
+      "require": "./LexicalAutoLinkPlugin.js"
+    },
     "./LexicalBlockWithAlignableContents": {
+      "import": "./LexicalBlockWithAlignableContents.esm.js",
+      "require": "./LexicalBlockWithAlignableContents.js"
+    },
+    "./LexicalBlockWithAlignableContents.js": {
       "import": "./LexicalBlockWithAlignableContents.esm.js",
       "require": "./LexicalBlockWithAlignableContents.js"
     },
@@ -60,7 +76,15 @@
       "import": "./LexicalCharacterLimitPlugin.esm.js",
       "require": "./LexicalCharacterLimitPlugin.js"
     },
+    "./LexicalCharacterLimitPlugin.js": {
+      "import": "./LexicalCharacterLimitPlugin.esm.js",
+      "require": "./LexicalCharacterLimitPlugin.js"
+    },
     "./LexicalCheckListPlugin": {
+      "import": "./LexicalCheckListPlugin.esm.js",
+      "require": "./LexicalCheckListPlugin.js"
+    },
+    "./LexicalCheckListPlugin.js": {
       "import": "./LexicalCheckListPlugin.esm.js",
       "require": "./LexicalCheckListPlugin.js"
     },
@@ -68,7 +92,15 @@
       "import": "./LexicalClearEditorPlugin.esm.js",
       "require": "./LexicalClearEditorPlugin.js"
     },
+    "./LexicalClearEditorPlugin.js": {
+      "import": "./LexicalClearEditorPlugin.esm.js",
+      "require": "./LexicalClearEditorPlugin.js"
+    },
     "./LexicalClickableLinkPlugin": {
+      "import": "./LexicalClickableLinkPlugin.esm.js",
+      "require": "./LexicalClickableLinkPlugin.js"
+    },
+    "./LexicalClickableLinkPlugin.js": {
       "import": "./LexicalClickableLinkPlugin.esm.js",
       "require": "./LexicalClickableLinkPlugin.js"
     },
@@ -76,7 +108,15 @@
       "import": "./LexicalCollaborationContext.esm.js",
       "require": "./LexicalCollaborationContext.js"
     },
+    "./LexicalCollaborationContext.js": {
+      "import": "./LexicalCollaborationContext.esm.js",
+      "require": "./LexicalCollaborationContext.js"
+    },
     "./LexicalCollaborationPlugin": {
+      "import": "./LexicalCollaborationPlugin.esm.js",
+      "require": "./LexicalCollaborationPlugin.js"
+    },
+    "./LexicalCollaborationPlugin.js": {
       "import": "./LexicalCollaborationPlugin.esm.js",
       "require": "./LexicalCollaborationPlugin.js"
     },
@@ -84,7 +124,15 @@
       "import": "./LexicalComposer.esm.js",
       "require": "./LexicalComposer.js"
     },
+    "./LexicalComposer.js": {
+      "import": "./LexicalComposer.esm.js",
+      "require": "./LexicalComposer.js"
+    },
     "./LexicalComposerContext": {
+      "import": "./LexicalComposerContext.esm.js",
+      "require": "./LexicalComposerContext.js"
+    },
+    "./LexicalComposerContext.js": {
       "import": "./LexicalComposerContext.esm.js",
       "require": "./LexicalComposerContext.js"
     },
@@ -92,7 +140,15 @@
       "import": "./LexicalContentEditable.esm.js",
       "require": "./LexicalContentEditable.js"
     },
+    "./LexicalContentEditable.js": {
+      "import": "./LexicalContentEditable.esm.js",
+      "require": "./LexicalContentEditable.js"
+    },
     "./LexicalContextMenuPlugin": {
+      "import": "./LexicalContextMenuPlugin.esm.js",
+      "require": "./LexicalContextMenuPlugin.js"
+    },
+    "./LexicalContextMenuPlugin.js": {
       "import": "./LexicalContextMenuPlugin.esm.js",
       "require": "./LexicalContextMenuPlugin.js"
     },
@@ -100,7 +156,15 @@
       "import": "./LexicalDecoratorBlockNode.esm.js",
       "require": "./LexicalDecoratorBlockNode.js"
     },
+    "./LexicalDecoratorBlockNode.js": {
+      "import": "./LexicalDecoratorBlockNode.esm.js",
+      "require": "./LexicalDecoratorBlockNode.js"
+    },
     "./LexicalEditorRefPlugin": {
+      "import": "./LexicalEditorRefPlugin.esm.js",
+      "require": "./LexicalEditorRefPlugin.js"
+    },
+    "./LexicalEditorRefPlugin.js": {
       "import": "./LexicalEditorRefPlugin.esm.js",
       "require": "./LexicalEditorRefPlugin.js"
     },
@@ -108,7 +172,15 @@
       "import": "./LexicalErrorBoundary.esm.js",
       "require": "./LexicalErrorBoundary.js"
     },
+    "./LexicalErrorBoundary.js": {
+      "import": "./LexicalErrorBoundary.esm.js",
+      "require": "./LexicalErrorBoundary.js"
+    },
     "./LexicalHashtagPlugin": {
+      "import": "./LexicalHashtagPlugin.esm.js",
+      "require": "./LexicalHashtagPlugin.js"
+    },
+    "./LexicalHashtagPlugin.js": {
       "import": "./LexicalHashtagPlugin.esm.js",
       "require": "./LexicalHashtagPlugin.js"
     },
@@ -116,7 +188,15 @@
       "import": "./LexicalHistoryPlugin.esm.js",
       "require": "./LexicalHistoryPlugin.js"
     },
+    "./LexicalHistoryPlugin.js": {
+      "import": "./LexicalHistoryPlugin.esm.js",
+      "require": "./LexicalHistoryPlugin.js"
+    },
     "./LexicalHorizontalRuleNode": {
+      "import": "./LexicalHorizontalRuleNode.esm.js",
+      "require": "./LexicalHorizontalRuleNode.js"
+    },
+    "./LexicalHorizontalRuleNode.js": {
       "import": "./LexicalHorizontalRuleNode.esm.js",
       "require": "./LexicalHorizontalRuleNode.js"
     },
@@ -124,7 +204,15 @@
       "import": "./LexicalHorizontalRulePlugin.esm.js",
       "require": "./LexicalHorizontalRulePlugin.js"
     },
+    "./LexicalHorizontalRulePlugin.js": {
+      "import": "./LexicalHorizontalRulePlugin.esm.js",
+      "require": "./LexicalHorizontalRulePlugin.js"
+    },
     "./LexicalLinkPlugin": {
+      "import": "./LexicalLinkPlugin.esm.js",
+      "require": "./LexicalLinkPlugin.js"
+    },
+    "./LexicalLinkPlugin.js": {
       "import": "./LexicalLinkPlugin.esm.js",
       "require": "./LexicalLinkPlugin.js"
     },
@@ -132,7 +220,15 @@
       "import": "./LexicalListPlugin.esm.js",
       "require": "./LexicalListPlugin.js"
     },
+    "./LexicalListPlugin.js": {
+      "import": "./LexicalListPlugin.esm.js",
+      "require": "./LexicalListPlugin.js"
+    },
     "./LexicalMarkdownShortcutPlugin": {
+      "import": "./LexicalMarkdownShortcutPlugin.esm.js",
+      "require": "./LexicalMarkdownShortcutPlugin.js"
+    },
+    "./LexicalMarkdownShortcutPlugin.js": {
       "import": "./LexicalMarkdownShortcutPlugin.esm.js",
       "require": "./LexicalMarkdownShortcutPlugin.js"
     },
@@ -140,7 +236,15 @@
       "import": "./LexicalNestedComposer.esm.js",
       "require": "./LexicalNestedComposer.js"
     },
+    "./LexicalNestedComposer.js": {
+      "import": "./LexicalNestedComposer.esm.js",
+      "require": "./LexicalNestedComposer.js"
+    },
     "./LexicalNodeEventPlugin": {
+      "import": "./LexicalNodeEventPlugin.esm.js",
+      "require": "./LexicalNodeEventPlugin.js"
+    },
+    "./LexicalNodeEventPlugin.js": {
       "import": "./LexicalNodeEventPlugin.esm.js",
       "require": "./LexicalNodeEventPlugin.js"
     },
@@ -148,7 +252,15 @@
       "import": "./LexicalNodeMenuPlugin.esm.js",
       "require": "./LexicalNodeMenuPlugin.js"
     },
+    "./LexicalNodeMenuPlugin.js": {
+      "import": "./LexicalNodeMenuPlugin.esm.js",
+      "require": "./LexicalNodeMenuPlugin.js"
+    },
     "./LexicalOnChangePlugin": {
+      "import": "./LexicalOnChangePlugin.esm.js",
+      "require": "./LexicalOnChangePlugin.js"
+    },
+    "./LexicalOnChangePlugin.js": {
       "import": "./LexicalOnChangePlugin.esm.js",
       "require": "./LexicalOnChangePlugin.js"
     },
@@ -156,7 +268,15 @@
       "import": "./LexicalPlainTextPlugin.esm.js",
       "require": "./LexicalPlainTextPlugin.js"
     },
+    "./LexicalPlainTextPlugin.js": {
+      "import": "./LexicalPlainTextPlugin.esm.js",
+      "require": "./LexicalPlainTextPlugin.js"
+    },
     "./LexicalRichTextPlugin": {
+      "import": "./LexicalRichTextPlugin.esm.js",
+      "require": "./LexicalRichTextPlugin.js"
+    },
+    "./LexicalRichTextPlugin.js": {
       "import": "./LexicalRichTextPlugin.esm.js",
       "require": "./LexicalRichTextPlugin.js"
     },
@@ -164,7 +284,15 @@
       "import": "./LexicalTabIndentationPlugin.esm.js",
       "require": "./LexicalTabIndentationPlugin.js"
     },
+    "./LexicalTabIndentationPlugin.js": {
+      "import": "./LexicalTabIndentationPlugin.esm.js",
+      "require": "./LexicalTabIndentationPlugin.js"
+    },
     "./LexicalTableOfContents": {
+      "import": "./LexicalTableOfContents.esm.js",
+      "require": "./LexicalTableOfContents.js"
+    },
+    "./LexicalTableOfContents.js": {
       "import": "./LexicalTableOfContents.esm.js",
       "require": "./LexicalTableOfContents.js"
     },
@@ -172,7 +300,15 @@
       "import": "./LexicalTablePlugin.esm.js",
       "require": "./LexicalTablePlugin.js"
     },
+    "./LexicalTablePlugin.js": {
+      "import": "./LexicalTablePlugin.esm.js",
+      "require": "./LexicalTablePlugin.js"
+    },
     "./LexicalTreeView": {
+      "import": "./LexicalTreeView.esm.js",
+      "require": "./LexicalTreeView.js"
+    },
+    "./LexicalTreeView.js": {
       "import": "./LexicalTreeView.esm.js",
       "require": "./LexicalTreeView.js"
     },
@@ -180,7 +316,15 @@
       "import": "./LexicalTypeaheadMenuPlugin.esm.js",
       "require": "./LexicalTypeaheadMenuPlugin.js"
     },
+    "./LexicalTypeaheadMenuPlugin.js": {
+      "import": "./LexicalTypeaheadMenuPlugin.esm.js",
+      "require": "./LexicalTypeaheadMenuPlugin.js"
+    },
     "./useLexicalEditable": {
+      "import": "./useLexicalEditable.esm.js",
+      "require": "./useLexicalEditable.js"
+    },
+    "./useLexicalEditable.js": {
       "import": "./useLexicalEditable.esm.js",
       "require": "./useLexicalEditable.js"
     },
@@ -188,7 +332,15 @@
       "import": "./useLexicalIsTextContentEmpty.esm.js",
       "require": "./useLexicalIsTextContentEmpty.js"
     },
+    "./useLexicalIsTextContentEmpty.js": {
+      "import": "./useLexicalIsTextContentEmpty.esm.js",
+      "require": "./useLexicalIsTextContentEmpty.js"
+    },
     "./useLexicalNodeSelection": {
+      "import": "./useLexicalNodeSelection.esm.js",
+      "require": "./useLexicalNodeSelection.js"
+    },
+    "./useLexicalNodeSelection.js": {
       "import": "./useLexicalNodeSelection.esm.js",
       "require": "./useLexicalNodeSelection.js"
     },
@@ -196,7 +348,15 @@
       "import": "./useLexicalSubscription.esm.js",
       "require": "./useLexicalSubscription.js"
     },
+    "./useLexicalSubscription.js": {
+      "import": "./useLexicalSubscription.esm.js",
+      "require": "./useLexicalSubscription.js"
+    },
     "./useLexicalTextEntity": {
+      "import": "./useLexicalTextEntity.esm.js",
+      "require": "./useLexicalTextEntity.js"
+    },
+    "./useLexicalTextEntity.js": {
       "import": "./useLexicalTextEntity.esm.js",
       "require": "./useLexicalTextEntity.js"
     }

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -600,5 +600,6 @@
       },
       "require": "./useLexicalTextEntity.js"
     }
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -41,323 +41,563 @@
   },
   "exports": {
     "./LexicalAutoEmbedPlugin": {
-      "import": "./LexicalAutoEmbedPlugin.esm.js",
+      "import": {
+        "default": "./LexicalAutoEmbedPlugin.esm.js",
+        "types": "./LexicalAutoEmbedPlugin.d.ts"
+      },
       "require": "./LexicalAutoEmbedPlugin.js"
     },
     "./LexicalAutoEmbedPlugin.js": {
-      "import": "./LexicalAutoEmbedPlugin.esm.js",
+      "import": {
+        "default": "./LexicalAutoEmbedPlugin.esm.js",
+        "types": "./LexicalAutoEmbedPlugin.d.ts"
+      },
       "require": "./LexicalAutoEmbedPlugin.js"
     },
     "./LexicalAutoFocusPlugin": {
-      "import": "./LexicalAutoFocusPlugin.esm.js",
+      "import": {
+        "default": "./LexicalAutoFocusPlugin.esm.js",
+        "types": "./LexicalAutoFocusPlugin.d.ts"
+      },
       "require": "./LexicalAutoFocusPlugin.js"
     },
     "./LexicalAutoFocusPlugin.js": {
-      "import": "./LexicalAutoFocusPlugin.esm.js",
+      "import": {
+        "default": "./LexicalAutoFocusPlugin.esm.js",
+        "types": "./LexicalAutoFocusPlugin.d.ts"
+      },
       "require": "./LexicalAutoFocusPlugin.js"
     },
     "./LexicalAutoLinkPlugin": {
-      "import": "./LexicalAutoLinkPlugin.esm.js",
+      "import": {
+        "default": "./LexicalAutoLinkPlugin.esm.js",
+        "types": "./LexicalAutoLinkPlugin.d.ts"
+      },
       "require": "./LexicalAutoLinkPlugin.js"
     },
     "./LexicalAutoLinkPlugin.js": {
-      "import": "./LexicalAutoLinkPlugin.esm.js",
+      "import": {
+        "default": "./LexicalAutoLinkPlugin.esm.js",
+        "types": "./LexicalAutoLinkPlugin.d.ts"
+      },
       "require": "./LexicalAutoLinkPlugin.js"
     },
     "./LexicalBlockWithAlignableContents": {
-      "import": "./LexicalBlockWithAlignableContents.esm.js",
+      "import": {
+        "default": "./LexicalBlockWithAlignableContents.esm.js",
+        "types": "./LexicalBlockWithAlignableContents.d.ts"
+      },
       "require": "./LexicalBlockWithAlignableContents.js"
     },
     "./LexicalBlockWithAlignableContents.js": {
-      "import": "./LexicalBlockWithAlignableContents.esm.js",
+      "import": {
+        "default": "./LexicalBlockWithAlignableContents.esm.js",
+        "types": "./LexicalBlockWithAlignableContents.d.ts"
+      },
       "require": "./LexicalBlockWithAlignableContents.js"
     },
     "./LexicalCharacterLimitPlugin": {
-      "import": "./LexicalCharacterLimitPlugin.esm.js",
+      "import": {
+        "default": "./LexicalCharacterLimitPlugin.esm.js",
+        "types": "./LexicalCharacterLimitPlugin.d.ts"
+      },
       "require": "./LexicalCharacterLimitPlugin.js"
     },
     "./LexicalCharacterLimitPlugin.js": {
-      "import": "./LexicalCharacterLimitPlugin.esm.js",
+      "import": {
+        "default": "./LexicalCharacterLimitPlugin.esm.js",
+        "types": "./LexicalCharacterLimitPlugin.d.ts"
+      },
       "require": "./LexicalCharacterLimitPlugin.js"
     },
     "./LexicalCheckListPlugin": {
-      "import": "./LexicalCheckListPlugin.esm.js",
+      "import": {
+        "default": "./LexicalCheckListPlugin.esm.js",
+        "types": "./LexicalCheckListPlugin.d.ts"
+      },
       "require": "./LexicalCheckListPlugin.js"
     },
     "./LexicalCheckListPlugin.js": {
-      "import": "./LexicalCheckListPlugin.esm.js",
+      "import": {
+        "default": "./LexicalCheckListPlugin.esm.js",
+        "types": "./LexicalCheckListPlugin.d.ts"
+      },
       "require": "./LexicalCheckListPlugin.js"
     },
     "./LexicalClearEditorPlugin": {
-      "import": "./LexicalClearEditorPlugin.esm.js",
+      "import": {
+        "default": "./LexicalClearEditorPlugin.esm.js",
+        "types": "./LexicalClearEditorPlugin.d.ts"
+      },
       "require": "./LexicalClearEditorPlugin.js"
     },
     "./LexicalClearEditorPlugin.js": {
-      "import": "./LexicalClearEditorPlugin.esm.js",
+      "import": {
+        "default": "./LexicalClearEditorPlugin.esm.js",
+        "types": "./LexicalClearEditorPlugin.d.ts"
+      },
       "require": "./LexicalClearEditorPlugin.js"
     },
     "./LexicalClickableLinkPlugin": {
-      "import": "./LexicalClickableLinkPlugin.esm.js",
+      "import": {
+        "default": "./LexicalClickableLinkPlugin.esm.js",
+        "types": "./LexicalClickableLinkPlugin.d.ts"
+      },
       "require": "./LexicalClickableLinkPlugin.js"
     },
     "./LexicalClickableLinkPlugin.js": {
-      "import": "./LexicalClickableLinkPlugin.esm.js",
+      "import": {
+        "default": "./LexicalClickableLinkPlugin.esm.js",
+        "types": "./LexicalClickableLinkPlugin.d.ts"
+      },
       "require": "./LexicalClickableLinkPlugin.js"
     },
     "./LexicalCollaborationContext": {
-      "import": "./LexicalCollaborationContext.esm.js",
+      "import": {
+        "default": "./LexicalCollaborationContext.esm.js",
+        "types": "./LexicalCollaborationContext.d.ts"
+      },
       "require": "./LexicalCollaborationContext.js"
     },
     "./LexicalCollaborationContext.js": {
-      "import": "./LexicalCollaborationContext.esm.js",
+      "import": {
+        "default": "./LexicalCollaborationContext.esm.js",
+        "types": "./LexicalCollaborationContext.d.ts"
+      },
       "require": "./LexicalCollaborationContext.js"
     },
     "./LexicalCollaborationPlugin": {
-      "import": "./LexicalCollaborationPlugin.esm.js",
+      "import": {
+        "default": "./LexicalCollaborationPlugin.esm.js",
+        "types": "./LexicalCollaborationPlugin.d.ts"
+      },
       "require": "./LexicalCollaborationPlugin.js"
     },
     "./LexicalCollaborationPlugin.js": {
-      "import": "./LexicalCollaborationPlugin.esm.js",
+      "import": {
+        "default": "./LexicalCollaborationPlugin.esm.js",
+        "types": "./LexicalCollaborationPlugin.d.ts"
+      },
       "require": "./LexicalCollaborationPlugin.js"
     },
     "./LexicalComposer": {
-      "import": "./LexicalComposer.esm.js",
+      "import": {
+        "default": "./LexicalComposer.esm.js",
+        "types": "./LexicalComposer.d.ts"
+      },
       "require": "./LexicalComposer.js"
     },
     "./LexicalComposer.js": {
-      "import": "./LexicalComposer.esm.js",
+      "import": {
+        "default": "./LexicalComposer.esm.js",
+        "types": "./LexicalComposer.d.ts"
+      },
       "require": "./LexicalComposer.js"
     },
     "./LexicalComposerContext": {
-      "import": "./LexicalComposerContext.esm.js",
+      "import": {
+        "default": "./LexicalComposerContext.esm.js",
+        "types": "./LexicalComposerContext.d.ts"
+      },
       "require": "./LexicalComposerContext.js"
     },
     "./LexicalComposerContext.js": {
-      "import": "./LexicalComposerContext.esm.js",
+      "import": {
+        "default": "./LexicalComposerContext.esm.js",
+        "types": "./LexicalComposerContext.d.ts"
+      },
       "require": "./LexicalComposerContext.js"
     },
     "./LexicalContentEditable": {
-      "import": "./LexicalContentEditable.esm.js",
+      "import": {
+        "default": "./LexicalContentEditable.esm.js",
+        "types": "./LexicalContentEditable.d.ts"
+      },
       "require": "./LexicalContentEditable.js"
     },
     "./LexicalContentEditable.js": {
-      "import": "./LexicalContentEditable.esm.js",
+      "import": {
+        "default": "./LexicalContentEditable.esm.js",
+        "types": "./LexicalContentEditable.d.ts"
+      },
       "require": "./LexicalContentEditable.js"
     },
     "./LexicalContextMenuPlugin": {
-      "import": "./LexicalContextMenuPlugin.esm.js",
+      "import": {
+        "default": "./LexicalContextMenuPlugin.esm.js",
+        "types": "./LexicalContextMenuPlugin.d.ts"
+      },
       "require": "./LexicalContextMenuPlugin.js"
     },
     "./LexicalContextMenuPlugin.js": {
-      "import": "./LexicalContextMenuPlugin.esm.js",
+      "import": {
+        "default": "./LexicalContextMenuPlugin.esm.js",
+        "types": "./LexicalContextMenuPlugin.d.ts"
+      },
       "require": "./LexicalContextMenuPlugin.js"
     },
     "./LexicalDecoratorBlockNode": {
-      "import": "./LexicalDecoratorBlockNode.esm.js",
+      "import": {
+        "default": "./LexicalDecoratorBlockNode.esm.js",
+        "types": "./LexicalDecoratorBlockNode.d.ts"
+      },
       "require": "./LexicalDecoratorBlockNode.js"
     },
     "./LexicalDecoratorBlockNode.js": {
-      "import": "./LexicalDecoratorBlockNode.esm.js",
+      "import": {
+        "default": "./LexicalDecoratorBlockNode.esm.js",
+        "types": "./LexicalDecoratorBlockNode.d.ts"
+      },
       "require": "./LexicalDecoratorBlockNode.js"
     },
     "./LexicalEditorRefPlugin": {
-      "import": "./LexicalEditorRefPlugin.esm.js",
+      "import": {
+        "default": "./LexicalEditorRefPlugin.esm.js",
+        "types": "./LexicalEditorRefPlugin.d.ts"
+      },
       "require": "./LexicalEditorRefPlugin.js"
     },
     "./LexicalEditorRefPlugin.js": {
-      "import": "./LexicalEditorRefPlugin.esm.js",
+      "import": {
+        "default": "./LexicalEditorRefPlugin.esm.js",
+        "types": "./LexicalEditorRefPlugin.d.ts"
+      },
       "require": "./LexicalEditorRefPlugin.js"
     },
     "./LexicalErrorBoundary": {
-      "import": "./LexicalErrorBoundary.esm.js",
+      "import": {
+        "default": "./LexicalErrorBoundary.esm.js",
+        "types": "./LexicalErrorBoundary.d.ts"
+      },
       "require": "./LexicalErrorBoundary.js"
     },
     "./LexicalErrorBoundary.js": {
-      "import": "./LexicalErrorBoundary.esm.js",
+      "import": {
+        "default": "./LexicalErrorBoundary.esm.js",
+        "types": "./LexicalErrorBoundary.d.ts"
+      },
       "require": "./LexicalErrorBoundary.js"
     },
     "./LexicalHashtagPlugin": {
-      "import": "./LexicalHashtagPlugin.esm.js",
+      "import": {
+        "default": "./LexicalHashtagPlugin.esm.js",
+        "types": "./LexicalHashtagPlugin.d.ts"
+      },
       "require": "./LexicalHashtagPlugin.js"
     },
     "./LexicalHashtagPlugin.js": {
-      "import": "./LexicalHashtagPlugin.esm.js",
+      "import": {
+        "default": "./LexicalHashtagPlugin.esm.js",
+        "types": "./LexicalHashtagPlugin.d.ts"
+      },
       "require": "./LexicalHashtagPlugin.js"
     },
     "./LexicalHistoryPlugin": {
-      "import": "./LexicalHistoryPlugin.esm.js",
+      "import": {
+        "default": "./LexicalHistoryPlugin.esm.js",
+        "types": "./LexicalHistoryPlugin.d.ts"
+      },
       "require": "./LexicalHistoryPlugin.js"
     },
     "./LexicalHistoryPlugin.js": {
-      "import": "./LexicalHistoryPlugin.esm.js",
+      "import": {
+        "default": "./LexicalHistoryPlugin.esm.js",
+        "types": "./LexicalHistoryPlugin.d.ts"
+      },
       "require": "./LexicalHistoryPlugin.js"
     },
     "./LexicalHorizontalRuleNode": {
-      "import": "./LexicalHorizontalRuleNode.esm.js",
+      "import": {
+        "default": "./LexicalHorizontalRuleNode.esm.js",
+        "types": "./LexicalHorizontalRuleNode.d.ts"
+      },
       "require": "./LexicalHorizontalRuleNode.js"
     },
     "./LexicalHorizontalRuleNode.js": {
-      "import": "./LexicalHorizontalRuleNode.esm.js",
+      "import": {
+        "default": "./LexicalHorizontalRuleNode.esm.js",
+        "types": "./LexicalHorizontalRuleNode.d.ts"
+      },
       "require": "./LexicalHorizontalRuleNode.js"
     },
     "./LexicalHorizontalRulePlugin": {
-      "import": "./LexicalHorizontalRulePlugin.esm.js",
+      "import": {
+        "default": "./LexicalHorizontalRulePlugin.esm.js",
+        "types": "./LexicalHorizontalRulePlugin.d.ts"
+      },
       "require": "./LexicalHorizontalRulePlugin.js"
     },
     "./LexicalHorizontalRulePlugin.js": {
-      "import": "./LexicalHorizontalRulePlugin.esm.js",
+      "import": {
+        "default": "./LexicalHorizontalRulePlugin.esm.js",
+        "types": "./LexicalHorizontalRulePlugin.d.ts"
+      },
       "require": "./LexicalHorizontalRulePlugin.js"
     },
     "./LexicalLinkPlugin": {
-      "import": "./LexicalLinkPlugin.esm.js",
+      "import": {
+        "default": "./LexicalLinkPlugin.esm.js",
+        "types": "./LexicalLinkPlugin.d.ts"
+      },
       "require": "./LexicalLinkPlugin.js"
     },
     "./LexicalLinkPlugin.js": {
-      "import": "./LexicalLinkPlugin.esm.js",
+      "import": {
+        "default": "./LexicalLinkPlugin.esm.js",
+        "types": "./LexicalLinkPlugin.d.ts"
+      },
       "require": "./LexicalLinkPlugin.js"
     },
     "./LexicalListPlugin": {
-      "import": "./LexicalListPlugin.esm.js",
+      "import": {
+        "default": "./LexicalListPlugin.esm.js",
+        "types": "./LexicalListPlugin.d.ts"
+      },
       "require": "./LexicalListPlugin.js"
     },
     "./LexicalListPlugin.js": {
-      "import": "./LexicalListPlugin.esm.js",
+      "import": {
+        "default": "./LexicalListPlugin.esm.js",
+        "types": "./LexicalListPlugin.d.ts"
+      },
       "require": "./LexicalListPlugin.js"
     },
     "./LexicalMarkdownShortcutPlugin": {
-      "import": "./LexicalMarkdownShortcutPlugin.esm.js",
+      "import": {
+        "default": "./LexicalMarkdownShortcutPlugin.esm.js",
+        "types": "./LexicalMarkdownShortcutPlugin.d.ts"
+      },
       "require": "./LexicalMarkdownShortcutPlugin.js"
     },
     "./LexicalMarkdownShortcutPlugin.js": {
-      "import": "./LexicalMarkdownShortcutPlugin.esm.js",
+      "import": {
+        "default": "./LexicalMarkdownShortcutPlugin.esm.js",
+        "types": "./LexicalMarkdownShortcutPlugin.d.ts"
+      },
       "require": "./LexicalMarkdownShortcutPlugin.js"
     },
     "./LexicalNestedComposer": {
-      "import": "./LexicalNestedComposer.esm.js",
+      "import": {
+        "default": "./LexicalNestedComposer.esm.js",
+        "types": "./LexicalNestedComposer.d.ts"
+      },
       "require": "./LexicalNestedComposer.js"
     },
     "./LexicalNestedComposer.js": {
-      "import": "./LexicalNestedComposer.esm.js",
+      "import": {
+        "default": "./LexicalNestedComposer.esm.js",
+        "types": "./LexicalNestedComposer.d.ts"
+      },
       "require": "./LexicalNestedComposer.js"
     },
     "./LexicalNodeEventPlugin": {
-      "import": "./LexicalNodeEventPlugin.esm.js",
+      "import": {
+        "default": "./LexicalNodeEventPlugin.esm.js",
+        "types": "./LexicalNodeEventPlugin.d.ts"
+      },
       "require": "./LexicalNodeEventPlugin.js"
     },
     "./LexicalNodeEventPlugin.js": {
-      "import": "./LexicalNodeEventPlugin.esm.js",
+      "import": {
+        "default": "./LexicalNodeEventPlugin.esm.js",
+        "types": "./LexicalNodeEventPlugin.d.ts"
+      },
       "require": "./LexicalNodeEventPlugin.js"
     },
     "./LexicalNodeMenuPlugin": {
-      "import": "./LexicalNodeMenuPlugin.esm.js",
+      "import": {
+        "default": "./LexicalNodeMenuPlugin.esm.js",
+        "types": "./LexicalNodeMenuPlugin.d.ts"
+      },
       "require": "./LexicalNodeMenuPlugin.js"
     },
     "./LexicalNodeMenuPlugin.js": {
-      "import": "./LexicalNodeMenuPlugin.esm.js",
+      "import": {
+        "default": "./LexicalNodeMenuPlugin.esm.js",
+        "types": "./LexicalNodeMenuPlugin.d.ts"
+      },
       "require": "./LexicalNodeMenuPlugin.js"
     },
     "./LexicalOnChangePlugin": {
-      "import": "./LexicalOnChangePlugin.esm.js",
+      "import": {
+        "default": "./LexicalOnChangePlugin.esm.js",
+        "types": "./LexicalOnChangePlugin.d.ts"
+      },
       "require": "./LexicalOnChangePlugin.js"
     },
     "./LexicalOnChangePlugin.js": {
-      "import": "./LexicalOnChangePlugin.esm.js",
+      "import": {
+        "default": "./LexicalOnChangePlugin.esm.js",
+        "types": "./LexicalOnChangePlugin.d.ts"
+      },
       "require": "./LexicalOnChangePlugin.js"
     },
     "./LexicalPlainTextPlugin": {
-      "import": "./LexicalPlainTextPlugin.esm.js",
+      "import": {
+        "default": "./LexicalPlainTextPlugin.esm.js",
+        "types": "./LexicalPlainTextPlugin.d.ts"
+      },
       "require": "./LexicalPlainTextPlugin.js"
     },
     "./LexicalPlainTextPlugin.js": {
-      "import": "./LexicalPlainTextPlugin.esm.js",
+      "import": {
+        "default": "./LexicalPlainTextPlugin.esm.js",
+        "types": "./LexicalPlainTextPlugin.d.ts"
+      },
       "require": "./LexicalPlainTextPlugin.js"
     },
     "./LexicalRichTextPlugin": {
-      "import": "./LexicalRichTextPlugin.esm.js",
+      "import": {
+        "default": "./LexicalRichTextPlugin.esm.js",
+        "types": "./LexicalRichTextPlugin.d.ts"
+      },
       "require": "./LexicalRichTextPlugin.js"
     },
     "./LexicalRichTextPlugin.js": {
-      "import": "./LexicalRichTextPlugin.esm.js",
+      "import": {
+        "default": "./LexicalRichTextPlugin.esm.js",
+        "types": "./LexicalRichTextPlugin.d.ts"
+      },
       "require": "./LexicalRichTextPlugin.js"
     },
     "./LexicalTabIndentationPlugin": {
-      "import": "./LexicalTabIndentationPlugin.esm.js",
+      "import": {
+        "default": "./LexicalTabIndentationPlugin.esm.js",
+        "types": "./LexicalTabIndentationPlugin.d.ts"
+      },
       "require": "./LexicalTabIndentationPlugin.js"
     },
     "./LexicalTabIndentationPlugin.js": {
-      "import": "./LexicalTabIndentationPlugin.esm.js",
+      "import": {
+        "default": "./LexicalTabIndentationPlugin.esm.js",
+        "types": "./LexicalTabIndentationPlugin.d.ts"
+      },
       "require": "./LexicalTabIndentationPlugin.js"
     },
     "./LexicalTableOfContents": {
-      "import": "./LexicalTableOfContents.esm.js",
+      "import": {
+        "default": "./LexicalTableOfContents.esm.js",
+        "types": "./LexicalTableOfContents.d.ts"
+      },
       "require": "./LexicalTableOfContents.js"
     },
     "./LexicalTableOfContents.js": {
-      "import": "./LexicalTableOfContents.esm.js",
+      "import": {
+        "default": "./LexicalTableOfContents.esm.js",
+        "types": "./LexicalTableOfContents.d.ts"
+      },
       "require": "./LexicalTableOfContents.js"
     },
     "./LexicalTablePlugin": {
-      "import": "./LexicalTablePlugin.esm.js",
+      "import": {
+        "default": "./LexicalTablePlugin.esm.js",
+        "types": "./LexicalTablePlugin.d.ts"
+      },
       "require": "./LexicalTablePlugin.js"
     },
     "./LexicalTablePlugin.js": {
-      "import": "./LexicalTablePlugin.esm.js",
+      "import": {
+        "default": "./LexicalTablePlugin.esm.js",
+        "types": "./LexicalTablePlugin.d.ts"
+      },
       "require": "./LexicalTablePlugin.js"
     },
     "./LexicalTreeView": {
-      "import": "./LexicalTreeView.esm.js",
+      "import": {
+        "default": "./LexicalTreeView.esm.js",
+        "types": "./LexicalTreeView.d.ts"
+      },
       "require": "./LexicalTreeView.js"
     },
     "./LexicalTreeView.js": {
-      "import": "./LexicalTreeView.esm.js",
+      "import": {
+        "default": "./LexicalTreeView.esm.js",
+        "types": "./LexicalTreeView.d.ts"
+      },
       "require": "./LexicalTreeView.js"
     },
     "./LexicalTypeaheadMenuPlugin": {
-      "import": "./LexicalTypeaheadMenuPlugin.esm.js",
+      "import": {
+        "default": "./LexicalTypeaheadMenuPlugin.esm.js",
+        "types": "./LexicalTypeaheadMenuPlugin.d.ts"
+      },
       "require": "./LexicalTypeaheadMenuPlugin.js"
     },
     "./LexicalTypeaheadMenuPlugin.js": {
-      "import": "./LexicalTypeaheadMenuPlugin.esm.js",
+      "import": {
+        "default": "./LexicalTypeaheadMenuPlugin.esm.js",
+        "types": "./LexicalTypeaheadMenuPlugin.d.ts"
+      },
       "require": "./LexicalTypeaheadMenuPlugin.js"
     },
     "./useLexicalEditable": {
-      "import": "./useLexicalEditable.esm.js",
+      "import": {
+        "default": "./useLexicalEditable.esm.js",
+        "types": "./useLexicalEditable.d.ts"
+      },
       "require": "./useLexicalEditable.js"
     },
     "./useLexicalEditable.js": {
-      "import": "./useLexicalEditable.esm.js",
+      "import": {
+        "default": "./useLexicalEditable.esm.js",
+        "types": "./useLexicalEditable.d.ts"
+      },
       "require": "./useLexicalEditable.js"
     },
     "./useLexicalIsTextContentEmpty": {
-      "import": "./useLexicalIsTextContentEmpty.esm.js",
+      "import": {
+        "default": "./useLexicalIsTextContentEmpty.esm.js",
+        "types": "./useLexicalIsTextContentEmpty.d.ts"
+      },
       "require": "./useLexicalIsTextContentEmpty.js"
     },
     "./useLexicalIsTextContentEmpty.js": {
-      "import": "./useLexicalIsTextContentEmpty.esm.js",
+      "import": {
+        "default": "./useLexicalIsTextContentEmpty.esm.js",
+        "types": "./useLexicalIsTextContentEmpty.d.ts"
+      },
       "require": "./useLexicalIsTextContentEmpty.js"
     },
     "./useLexicalNodeSelection": {
-      "import": "./useLexicalNodeSelection.esm.js",
+      "import": {
+        "default": "./useLexicalNodeSelection.esm.js",
+        "types": "./useLexicalNodeSelection.d.ts"
+      },
       "require": "./useLexicalNodeSelection.js"
     },
     "./useLexicalNodeSelection.js": {
-      "import": "./useLexicalNodeSelection.esm.js",
+      "import": {
+        "default": "./useLexicalNodeSelection.esm.js",
+        "types": "./useLexicalNodeSelection.d.ts"
+      },
       "require": "./useLexicalNodeSelection.js"
     },
     "./useLexicalSubscription": {
-      "import": "./useLexicalSubscription.esm.js",
+      "import": {
+        "default": "./useLexicalSubscription.esm.js",
+        "types": "./useLexicalSubscription.d.ts"
+      },
       "require": "./useLexicalSubscription.js"
     },
     "./useLexicalSubscription.js": {
-      "import": "./useLexicalSubscription.esm.js",
+      "import": {
+        "default": "./useLexicalSubscription.esm.js",
+        "types": "./useLexicalSubscription.d.ts"
+      },
       "require": "./useLexicalSubscription.js"
     },
     "./useLexicalTextEntity": {
-      "import": "./useLexicalTextEntity.esm.js",
+      "import": {
+        "default": "./useLexicalTextEntity.esm.js",
+        "types": "./useLexicalTextEntity.d.ts"
+      },
       "require": "./useLexicalTextEntity.js"
     },
     "./useLexicalTextEntity.js": {
-      "import": "./useLexicalTextEntity.esm.js",
+      "import": {
+        "default": "./useLexicalTextEntity.esm.js",
+        "types": "./useLexicalTextEntity.d.ts"
+      },
       "require": "./useLexicalTextEntity.js"
     }
   }

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -38,5 +38,167 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-react"
+  },
+  "exports": {
+    "./LexicalAutoEmbedPlugin": {
+      "import": "./LexicalAutoEmbedPlugin.esm.js",
+      "require": "./LexicalAutoEmbedPlugin.js"
+    },
+    "./LexicalAutoFocusPlugin": {
+      "import": "./LexicalAutoFocusPlugin.esm.js",
+      "require": "./LexicalAutoFocusPlugin.js"
+    },
+    "./LexicalAutoLinkPlugin": {
+      "import": "./LexicalAutoLinkPlugin.esm.js",
+      "require": "./LexicalAutoLinkPlugin.js"
+    },
+    "./LexicalBlockWithAlignableContents": {
+      "import": "./LexicalBlockWithAlignableContents.esm.js",
+      "require": "./LexicalBlockWithAlignableContents.js"
+    },
+    "./LexicalCharacterLimitPlugin": {
+      "import": "./LexicalCharacterLimitPlugin.esm.js",
+      "require": "./LexicalCharacterLimitPlugin.js"
+    },
+    "./LexicalCheckListPlugin": {
+      "import": "./LexicalCheckListPlugin.esm.js",
+      "require": "./LexicalCheckListPlugin.js"
+    },
+    "./LexicalClearEditorPlugin": {
+      "import": "./LexicalClearEditorPlugin.esm.js",
+      "require": "./LexicalClearEditorPlugin.js"
+    },
+    "./LexicalClickableLinkPlugin": {
+      "import": "./LexicalClickableLinkPlugin.esm.js",
+      "require": "./LexicalClickableLinkPlugin.js"
+    },
+    "./LexicalCollaborationContext": {
+      "import": "./LexicalCollaborationContext.esm.js",
+      "require": "./LexicalCollaborationContext.js"
+    },
+    "./LexicalCollaborationPlugin": {
+      "import": "./LexicalCollaborationPlugin.esm.js",
+      "require": "./LexicalCollaborationPlugin.js"
+    },
+    "./LexicalComposer": {
+      "import": "./LexicalComposer.esm.js",
+      "require": "./LexicalComposer.js"
+    },
+    "./LexicalComposerContext": {
+      "import": "./LexicalComposerContext.esm.js",
+      "require": "./LexicalComposerContext.js"
+    },
+    "./LexicalContentEditable": {
+      "import": "./LexicalContentEditable.esm.js",
+      "require": "./LexicalContentEditable.js"
+    },
+    "./LexicalContextMenuPlugin": {
+      "import": "./LexicalContextMenuPlugin.esm.js",
+      "require": "./LexicalContextMenuPlugin.js"
+    },
+    "./LexicalDecoratorBlockNode": {
+      "import": "./LexicalDecoratorBlockNode.esm.js",
+      "require": "./LexicalDecoratorBlockNode.js"
+    },
+    "./LexicalEditorRefPlugin": {
+      "import": "./LexicalEditorRefPlugin.esm.js",
+      "require": "./LexicalEditorRefPlugin.js"
+    },
+    "./LexicalErrorBoundary": {
+      "import": "./LexicalErrorBoundary.esm.js",
+      "require": "./LexicalErrorBoundary.js"
+    },
+    "./LexicalHashtagPlugin": {
+      "import": "./LexicalHashtagPlugin.esm.js",
+      "require": "./LexicalHashtagPlugin.js"
+    },
+    "./LexicalHistoryPlugin": {
+      "import": "./LexicalHistoryPlugin.esm.js",
+      "require": "./LexicalHistoryPlugin.js"
+    },
+    "./LexicalHorizontalRuleNode": {
+      "import": "./LexicalHorizontalRuleNode.esm.js",
+      "require": "./LexicalHorizontalRuleNode.js"
+    },
+    "./LexicalHorizontalRulePlugin": {
+      "import": "./LexicalHorizontalRulePlugin.esm.js",
+      "require": "./LexicalHorizontalRulePlugin.js"
+    },
+    "./LexicalLinkPlugin": {
+      "import": "./LexicalLinkPlugin.esm.js",
+      "require": "./LexicalLinkPlugin.js"
+    },
+    "./LexicalListPlugin": {
+      "import": "./LexicalListPlugin.esm.js",
+      "require": "./LexicalListPlugin.js"
+    },
+    "./LexicalMarkdownShortcutPlugin": {
+      "import": "./LexicalMarkdownShortcutPlugin.esm.js",
+      "require": "./LexicalMarkdownShortcutPlugin.js"
+    },
+    "./LexicalNestedComposer": {
+      "import": "./LexicalNestedComposer.esm.js",
+      "require": "./LexicalNestedComposer.js"
+    },
+    "./LexicalNodeEventPlugin": {
+      "import": "./LexicalNodeEventPlugin.esm.js",
+      "require": "./LexicalNodeEventPlugin.js"
+    },
+    "./LexicalNodeMenuPlugin": {
+      "import": "./LexicalNodeMenuPlugin.esm.js",
+      "require": "./LexicalNodeMenuPlugin.js"
+    },
+    "./LexicalOnChangePlugin": {
+      "import": "./LexicalOnChangePlugin.esm.js",
+      "require": "./LexicalOnChangePlugin.js"
+    },
+    "./LexicalPlainTextPlugin": {
+      "import": "./LexicalPlainTextPlugin.esm.js",
+      "require": "./LexicalPlainTextPlugin.js"
+    },
+    "./LexicalRichTextPlugin": {
+      "import": "./LexicalRichTextPlugin.esm.js",
+      "require": "./LexicalRichTextPlugin.js"
+    },
+    "./LexicalTabIndentationPlugin": {
+      "import": "./LexicalTabIndentationPlugin.esm.js",
+      "require": "./LexicalTabIndentationPlugin.js"
+    },
+    "./LexicalTableOfContents": {
+      "import": "./LexicalTableOfContents.esm.js",
+      "require": "./LexicalTableOfContents.js"
+    },
+    "./LexicalTablePlugin": {
+      "import": "./LexicalTablePlugin.esm.js",
+      "require": "./LexicalTablePlugin.js"
+    },
+    "./LexicalTreeView": {
+      "import": "./LexicalTreeView.esm.js",
+      "require": "./LexicalTreeView.js"
+    },
+    "./LexicalTypeaheadMenuPlugin": {
+      "import": "./LexicalTypeaheadMenuPlugin.esm.js",
+      "require": "./LexicalTypeaheadMenuPlugin.js"
+    },
+    "./useLexicalEditable": {
+      "import": "./useLexicalEditable.esm.js",
+      "require": "./useLexicalEditable.js"
+    },
+    "./useLexicalIsTextContentEmpty": {
+      "import": "./useLexicalIsTextContentEmpty.esm.js",
+      "require": "./useLexicalIsTextContentEmpty.js"
+    },
+    "./useLexicalNodeSelection": {
+      "import": "./useLexicalNodeSelection.esm.js",
+      "require": "./useLexicalNodeSelection.js"
+    },
+    "./useLexicalSubscription": {
+      "import": "./useLexicalSubscription.esm.js",
+      "require": "./useLexicalSubscription.js"
+    },
+    "./useLexicalTextEntity": {
+      "import": "./useLexicalTextEntity.esm.js",
+      "require": "./useLexicalTextEntity.js"
+    }
   }
 }

--- a/packages/lexical-rich-text/package.json
+++ b/packages/lexical-rich-text/package.json
@@ -20,5 +20,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-rich-text"
   },
-  "module": "LexicalRichText.esm.js"
+  "module": "LexicalRichText.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-rich-text/package.json
+++ b/packages/lexical-rich-text/package.json
@@ -19,5 +19,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-rich-text"
-  }
+  },
+  "module": "LexicalRichText.esm.js"
 }

--- a/packages/lexical-selection/package.json
+++ b/packages/lexical-selection/package.json
@@ -18,5 +18,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-selection"
-  }
+  },
+  "module": "LexicalSelection.esm.js"
 }

--- a/packages/lexical-selection/package.json
+++ b/packages/lexical-selection/package.json
@@ -19,5 +19,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-selection"
   },
-  "module": "LexicalSelection.esm.js"
+  "module": "LexicalSelection.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-table/package.json
+++ b/packages/lexical-table/package.json
@@ -20,5 +20,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-table"
-  }
+  },
+  "module": "LexicalTable.esm.js"
 }

--- a/packages/lexical-table/package.json
+++ b/packages/lexical-table/package.json
@@ -21,5 +21,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-table"
   },
-  "module": "LexicalTable.esm.js"
+  "module": "LexicalTable.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-text/package.json
+++ b/packages/lexical-text/package.json
@@ -19,5 +19,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-text"
   },
-  "module": "LexicalText.esm.js"
+  "module": "LexicalText.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-text/package.json
+++ b/packages/lexical-text/package.json
@@ -18,5 +18,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-text"
-  }
+  },
+  "module": "LexicalText.esm.js"
 }

--- a/packages/lexical-utils/package.json
+++ b/packages/lexical-utils/package.json
@@ -23,5 +23,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-utils"
   },
-  "module": "LexicalUtils.esm.js"
+  "module": "LexicalUtils.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical-utils/package.json
+++ b/packages/lexical-utils/package.json
@@ -22,5 +22,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-utils"
-  }
+  },
+  "module": "LexicalUtils.esm.js"
 }

--- a/packages/lexical-yjs/package.json
+++ b/packages/lexical-yjs/package.json
@@ -24,5 +24,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-yjs"
-  }
+  },
+  "module": "LexicalYjs.esm.js"
 }

--- a/packages/lexical-yjs/package.json
+++ b/packages/lexical-yjs/package.json
@@ -25,5 +25,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-yjs"
   },
-  "module": "LexicalYjs.esm.js"
+  "module": "LexicalYjs.esm.js",
+  "sideEffects": false
 }

--- a/packages/lexical/package.json
+++ b/packages/lexical/package.json
@@ -15,5 +15,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical"
-  }
+  },
+  "module": "Lexical.esm.js"
 }

--- a/packages/lexical/package.json
+++ b/packages/lexical/package.json
@@ -16,5 +16,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical"
   },
-  "module": "Lexical.esm.js"
+  "module": "Lexical.esm.js",
+  "sideEffects": false
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,5 +16,6 @@
     "type": "git",
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/shared"
-  }
+  },
+  "sideEffects": false
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -619,7 +619,9 @@ function buildForkModule(outputPath, outputFileName, format, exports) {
   const prodFileName = `./${outputFileName}.prod${extension}`;
   if (format === 'esm') {
     lines.push(
-      `const mod = process.env.NODE_ENV === 'development' ? await import('${devFileName}') : await import('${prodFileName}');`,
+      `import * as modDev from '${devFileName}';`,
+      `import * as modProd from '${prodFileName}';`,
+      `const mod = process.env.NODE_ENV === 'development' ? modDev : modProd;`,
     );
     for (const name of exports) {
       lines.push(

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -613,24 +613,25 @@ async function moveTSDeclarationFilesIntoDist(packageName, outputPath) {
 }
 
 function buildForkModule(outputPath, outputFileName, format, exports) {
-  const lines = [getComment(), `'use strict'`];
+  const lines = [getComment()];
   const extension = getExtension(format);
   const devFileName = `./${outputFileName}.dev${extension}`;
   const prodFileName = `./${outputFileName}.prod${extension}`;
   if (format === 'esm') {
-    lines.append(
-      `const mod = await import(process.env.NODE_ENV === 'development' ? '${devFileName}' : '${prodFileName}');`,
+    lines.push(
+      `const mod = process.env.NODE_ENV === 'development' ? await import('${devFileName}') : await import('${prodFileName}');`,
     );
     for (const name of exports) {
-      lines.append(
+      lines.push(
         name === 'default'
           ? `export default mod.default;`
           : `export const ${name} = mod.${name};`,
       );
     }
   } else {
-    lines.append(
-      `const ${outputFileName} = process.env.NODE_ENV === 'development' ? require('${devFileName}') : require('${prodFileName}')`,
+    lines.push(
+      `'use strict'`,
+      `const ${outputFileName} = process.env.NODE_ENV === 'development' ? require('${devFileName}') : require('${prodFileName}');`,
       `module.exports = ${outputFileName};`,
     );
   }

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -67,13 +67,19 @@ function updateModule(packageJSON, pkg) {
       if (/^[^.]+\.js$/.test(file)) {
         // support for import "@lexical/react/LexicalComposer"
         exports[`./${file.replace(/\.js$/, '')}`] = {
-          import: `./${withEsmExtension(file)}`,
+          import: {
+            default: `./${withEsmExtension(file)}`,
+            types: `./${file.replace(/\.js$/, '.d.ts')}`,
+          },
           require: `./${file}`,
         };
         // support for import "@lexical/react/LexicalComposer.js"
         // @mdxeditor/editor uses this at least as of 2.13.1
         exports[`./${file}`] = {
-          import: `./${withEsmExtension(file)}`,
+          import: {
+            default: `./${withEsmExtension(file)}`,
+            types: `./${file.replace(/\.js$/, '.d.ts')}`,
+          },
           require: `./${file}`,
         };
       }

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -64,8 +64,15 @@ function updateModule(packageJSON, pkg) {
   } else if (fs.existsSync(`./packages/${pkg}/dist`)) {
     const exports = {};
     for (const file of fs.readdirSync(`./packages/${pkg}/dist`)) {
-      if (file.endsWith('.js')) {
+      if (/^[^.]+\.js$/.test(file)) {
+        // support for import "@lexical/react/LexicalComposer"
         exports[`./${file.replace(/\.js$/, '')}`] = {
+          import: `./${withEsmExtension(file)}`,
+          require: `./${file}`,
+        };
+        // support for import "@lexical/react/LexicalComposer.js"
+        // @mdxeditor/editor uses this at least as of 2.13.1
+        exports[`./${file}`] = {
           import: `./${withEsmExtension(file)}`,
           require: `./${file}`,
         };

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -59,6 +59,9 @@ function withEsmExtension(fileName) {
 }
 
 function updateModule(packageJSON, pkg) {
+  if (packageJSON.sideEffects === undefined) {
+    packageJSON.sideEffects = false;
+  }
   if (packageJSON.main) {
     packageJSON.module = withEsmExtension(packageJSON.main);
   } else if (fs.existsSync(`./packages/${pkg}/dist`)) {


### PR DESCRIPTION
This adds a parallel ESM build, in addition to the current CJS build.

Code was added to `npm run update-version` to maintain the package.json metadata for each package (declaring all of the exports & setting `"sideEffect": false`).

The deepest rabbit hole was the prod build, which uses @ampproject/rollup-plugin-closure-compiler. I could not find an obvious issue about it but when it tries to optimize `LexicalClickableLinkPlugin` it ends up transforming `export default function LexicalClickableLinkPlugin(…)` to `export function default(…)` which is an error. I couldn't figure out how to fix it without also fixing the upstream package, but it seemed that terser was more popular for this use case so I gave that a shot and it compiled straight away.

The second deepest rabbit hole was figuring out how to do a fork module for the ESM build. It seems that a lot of the ecosystem is not ready for dynamic imports and top-level await, so it currently uses the pattern of importing both the dev and prod builds and exporting one of them based on `process.env.NODE_ENV`. This appears to work correctly with tree-shaking, at least with `"sideEffect": false` in the package.json files using vite/esbuild.

```typescript
import * as modDev from './Lexical.dev.esm.js';
import * as modProd from './Lexical.prod.esm.js';
const mod = process.env.NODE_ENV === 'development' ? modDev : modProd;
export const $addUpdateTag = mod.$addUpdateTag;
// …
```

Adds an [/esm/](https://lexical-playground-cf4gxxxxt-fbopensource.vercel.app/esm/) endpoint to the playground to demonstrate an ESM native build using static html with an importmap and no bundler at all. 

I did not add these to /examples/ because I have currently vendored release builds of lexical packages so they can use the esm build, but I have demonstrated that it works with SvelteKit and Astro (with some vite configuration):

* https://stackblitz.com/~/github.com/etrepum/lexical-esm-sveltekit-vanilla-js
* https://stackblitz.com/~/github.com/etrepum/lexical-esm-astro-react

The required vite configuration looks like this:

```typescript
import { sveltekit } from '@sveltejs/kit/vite';
import { defineConfig } from 'vitest/config';

export default defineConfig({
	plugins: [sveltekit()],
	test: {
		include: ['src/**/*.{test,spec}.{js,ts}']
	},
	// This ssr config is the part that is lexical-specific
	ssr: {
		noExternal: [/^(lexical|@lexical\/.*)$/]
	}
});
```

Resolves [#1707](https://github.com/facebook/lexical/issues/1707).
