### PR TITLE
Move to native UUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,8 +81,7 @@
         "ts-jest": "^29.0.0",
         "ts-node": "^10.9.1",
         "typedoc": "^0.24.8",
-        "typescript": "5.1.6",
-        "uuid": "^8.3.2"
+        "typescript": "5.1.6"
       },
       "engines": {
         "npm": ">=8.2.3",

--- a/package.json
+++ b/package.json
@@ -165,8 +165,7 @@
     "ts-jest": "^29.0.0",
     "ts-node": "^10.9.1",
     "typedoc": "^0.24.8",
-    "typescript": "5.1.6",
-    "uuid": "^8.3.2"
+    "typescript": "5.1.6"
   },
   "dependencies": {
     "@types/katex": "^0.14.0",

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -7,9 +7,9 @@
  */
 
 import {expect, test as base} from '@playwright/test';
+import {randomUUID} from 'node:crypto';
 import prettier from 'prettier';
 import {URLSearchParams} from 'url';
-import {v4 as uuidv4} from 'uuid';
 
 import {selectAll} from '../keyboardShortcuts/index.mjs';
 
@@ -67,7 +67,7 @@ export async function initialize({
   appSettings.disableBeforeInput = LEGACY_EVENTS;
   if (isCollab) {
     appSettings.isCollab = isCollab;
-    appSettings.collabId = uuidv4();
+    appSettings.collabId = randomUUID();
   }
   if (showNestedEditorTreeView === undefined) {
     appSettings.showNestedEditorTreeView = true;


### PR DESCRIPTION
Since Node 14, 'uuid' is a NodeJS built-in from the 'crypto' package. Removing it as a direct dependency.

More here:
https://dev.to/pierre/you-should-ditch-uuid-node-has-you-covered-10i3