### PR TITLE
Fix forward word deletion destructing element nodes

### DIFF
--- a/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
+++ b/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
@@ -65,6 +65,10 @@ export class LayoutContainerNode extends ElementNode {
     return $createLayoutContainerNode(json.templateColumns);
   }
 
+  isShadowRoot(): boolean {
+    return true;
+  }
+
   canBeEmpty(): boolean {
     return false;
   }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1582,7 +1582,9 @@ export class RangeSelection implements BaseSelection {
     if (this.isCollapsed()) {
       const anchor = this.anchor;
       let anchorNode: TextNode | ElementNode | null = anchor.getNode();
-      if (this.forwardDeletion(anchor, anchorNode, isBackward)) return;
+      if (this.forwardDeletion(anchor, anchorNode, isBackward)) {
+        return;
+      }
 
       // Handle the deletion around decorators.
       const focus = this.focus;

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1537,6 +1537,39 @@ export class RangeSelection implements BaseSelection {
       }
     }
   }
+  /**
+   * Helper for handling forward character and word deletion that prevents element nodes
+   * like a table, columns layout being destroyed
+   *
+   * @param anchor the anchor
+   * @param anchorNode the anchor node in the selection
+   * @param isBackward whether or not selection is backwards
+   */
+  forwardDeletion(
+    anchor: PointType,
+    anchorNode: TextNode | ElementNode,
+    isBackward: boolean,
+  ): boolean {
+    if (
+      !isBackward &&
+      // Delete forward handle case
+      ((anchor.type === 'element' &&
+        $isElementNode(anchorNode) &&
+        anchor.offset === anchorNode.getChildrenSize()) ||
+        (anchor.type === 'text' &&
+          anchor.offset === anchorNode.getTextContentSize()))
+    ) {
+      const parent = anchorNode.getParent();
+      const nextSibling =
+        anchorNode.getNextSibling() ||
+        (parent === null ? null : parent.getNextSibling());
+
+      if ($isElementNode(nextSibling) && nextSibling.isShadowRoot()) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   /**
    * Performs one logical character deletion operation on the EditorState based on the current Selection.
@@ -1548,27 +1581,11 @@ export class RangeSelection implements BaseSelection {
     const wasCollapsed = this.isCollapsed();
     if (this.isCollapsed()) {
       const anchor = this.anchor;
-      const focus = this.focus;
       let anchorNode: TextNode | ElementNode | null = anchor.getNode();
-      if (
-        !isBackward &&
-        // Delete forward handle case
-        ((anchor.type === 'element' &&
-          $isElementNode(anchorNode) &&
-          anchor.offset === anchorNode.getChildrenSize()) ||
-          (anchor.type === 'text' &&
-            anchor.offset === anchorNode.getTextContentSize()))
-      ) {
-        const parent = anchorNode.getParent();
-        const nextSibling =
-          anchorNode.getNextSibling() ||
-          (parent === null ? null : parent.getNextSibling());
+      if (this.forwardDeletion(anchor, anchorNode, isBackward)) return;
 
-        if ($isElementNode(nextSibling) && nextSibling.isShadowRoot()) {
-          return;
-        }
-      }
       // Handle the deletion around decorators.
+      const focus = this.focus;
       const possibleNode = $getAdjacentNode(focus, isBackward);
       if ($isDecoratorNode(possibleNode) && !possibleNode.isIsolated()) {
         // Make it possible to move selection from range selection to
@@ -1689,6 +1706,9 @@ export class RangeSelection implements BaseSelection {
    */
   deleteWord(isBackward: boolean): void {
     if (this.isCollapsed()) {
+      const anchor = this.anchor;
+      const anchorNode: TextNode | ElementNode | null = anchor.getNode();
+      if (this.forwardDeletion(anchor, anchorNode, isBackward)) return;
       this.modify('extend', isBackward, 'word');
     }
     this.removeText();


### PR DESCRIPTION
Forward word deletion (Ctrl + Del on Windows) would destroy composite element nodes (tables, columns layout).
The logic to handle this was already implement inside Delete Character, so extracted it to helper and reused it inside Delete Word as well.

Before: 

https://github.com/facebook/lexical/assets/7893468/2419b44b-2b76-4256-b185-581c739dc8e3

https://github.com/facebook/lexical/assets/7893468/ebdace55-1fb3-447c-8c4b-cd8c5c488909

After:

https://github.com/facebook/lexical/assets/7893468/1e8ebefb-49ed-4e70-99c3-4e1454bf234c

https://github.com/facebook/lexical/assets/7893468/d9cf00f3-ec10-490d-97bb-2f5503968855



