### PR TITLE
[0.14] Remove unused canExtractContents

### DIFF
--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -111,11 +111,6 @@ export class TableNode extends ElementNode {
     };
   }
 
-  // TODO 0.10 deprecate
-  canExtractContents(): false {
-    return false;
-  }
-
   canBeEmpty(): false {
     return false;
   }

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -734,7 +734,6 @@ declare export class ElementNode extends LexicalNode {
   canIndent(): boolean;
   collapseAtStart(selection: RangeSelection): boolean;
   excludeFromCopy(destination: 'clone' | 'html'): boolean;
-  canExtractContents(): boolean;
   canReplaceWith(replacement: LexicalNode): boolean;
   canInsertAfter(node: LexicalNode): boolean;
   extractWithChild(

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -531,10 +531,6 @@ export class ElementNode extends LexicalNode {
   excludeFromCopy(destination?: 'clone' | 'html'): boolean {
     return false;
   }
-  // TODO 0.10 deprecate
-  canExtractContents(): boolean {
-    return true;
-  }
   canReplaceWith(replacement: LexicalNode): boolean {
     return true;
   }


### PR DESCRIPTION
Was meant to be since 0.10, the method was defined only on TableNode and unused anywhere else. Should be safe to remove, since nobody should be relying on this externally.