### PR TITLE
Bug: The selection changes unexpectedly when changing font family (or anything using inline style)

### DIFF
--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -440,6 +440,8 @@ export function $patchStyleText(
       if (endOffset !== 0 || endType === 'element') {
         $patchStyle(lastNode as TextNode, patch);
       }
+
+      focus.set(lastNode.getKey(), endOffset, 'text');
     }
 
     // style all the text nodes in between

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -414,8 +414,9 @@ export function $patchStyleText(
         // the entire first node isn't selected, so split it
         firstNode = firstNode.splitText(startOffset)[1];
         startOffset = 0;
-        anchor.set(firstNode.getKey(), startOffset, 'text');
       }
+
+      anchor.set(firstNode.getKey(), startOffset, 'text');
 
       $patchStyle(firstNode as TextNode, patch);
     }


### PR DESCRIPTION
This Pull Request is related to #5632

Solution:
Handle set focus for the last node