### PR TITLE
Fix deletion issues when using Chromium Android

### DIFF
--- a/packages/shared/src/environment.ts
+++ b/packages/shared/src/environment.ts
@@ -49,5 +49,8 @@ export const IS_CHROME: boolean =
   CAN_USE_DOM && /^(?=.*Chrome).*/i.test(navigator.userAgent);
 // export const canUseTextInputEvent: boolean = CAN_USE_DOM && 'TextEvent' in window && !documentMode;
 
+export const IS_ANDROID_CHROME: boolean =
+  CAN_USE_DOM && IS_ANDROID && IS_CHROME;
+
 export const IS_APPLE_WEBKIT =
   CAN_USE_DOM && /AppleWebKit\/[\d.]+/.test(navigator.userAgent) && !IS_CHROME;


### PR DESCRIPTION
Because `preventDefault` doesn't actually do anything on the `beforeinput` event on Chromium Android, `deleteContentBackward` will actually delete things twice, once by Lexical and once by the browser. This is the cause of issues like #4941 and #5538.

The issue with backspace deleting two characters at once was patched in #5077 by pretending to be in composition mode so that the else statement with the `DELETE_CHARACTER_COMMAND` line wouldn't be triggered. This patched the issue but in turn caused issues #5274 and #5259.

#5274 was fixed in #5282 by adding new logic to actually trigger the `DELETE_CHARACTER_COMMAND` if the current node had the length `<= 1`. #5259 was fixed in #5389 by resetting the compositionKey if the keys of the anchor and focus nodes is different.

The changes in this PR were originally made to fix #5538, but I realized that it also fixes the other Chromium Android deletion issues. Doing it this way, we don't have to pretend to be in composition mode and the code is also more clear about why that logic is required.