### PR TITLE
Add support for grid selection in text alignment.

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -36,6 +36,7 @@ import {
   SAMPLE_IMAGE_URL,
   selectCellsFromTableCords,
   selectFromAdditionalStylesDropdown,
+  selectFromAlignDropdown,
   setBackgroundColor,
   test,
   toggleColumnHeader,
@@ -2061,6 +2062,110 @@ test.describe('Tables', () => {
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
       `,
+    );
+  });
+
+  test('Can align text using Table selection', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    await initialize({isCollab, page});
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await insertTable(page, 2, 3);
+
+    await fillTablePartiallyWithText(page);
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
+
+    await selectFromAlignDropdown(page, '.center-align');
+
+    await assertHTML(
+      page,
+      html`
+        <p><br /></p>
+        <table>
+          <tr>
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent; text-align: center">
+              <p dir="ltr" style="text-align: center">
+                <span data-lexical-text="true">a</span>
+              </p>
+            </th>
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent; text-align: center">
+              <p dir="ltr" style="text-align: center">
+                <span data-lexical-text="true">bb</span>
+              </p>
+            </th>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+            </th>
+          </tr>
+          <tr>
+            <th
+              style="background-color: rgb(172, 206, 247); caret-color: transparent; text-align: center">
+              <p dir="ltr" style="text-align: center">
+                <span data-lexical-text="true">d</span>
+              </p>
+            </th>
+            <td
+              style="background-color: rgb(172, 206, 247); caret-color: transparent; text-align: center">
+              <p dir="ltr" style="text-align: center">
+                <span data-lexical-text="true">e</span>
+              </p>
+            </td>
+            <td>
+              <p dir="ltr"><span data-lexical-text="true">f</span></p>
+            </td>
+          </tr>
+        </table>
+        <p><br /></p>
+      `,
+      html`
+        <p><br /></p>
+        <table>
+          <tr>
+            <th style="text-align: center">
+              <p dir="ltr" style="text-align: center">
+                <span data-lexical-text="true">a</span>
+              </p>
+            </th>
+            <th style="text-align: center">
+              <p dir="ltr" style="text-align: center">
+                <span data-lexical-text="true">bb</span>
+              </p>
+            </th>
+            <th>
+              <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+            </th>
+          </tr>
+          <tr>
+            <th style="text-align: center">
+              <p dir="ltr" style="text-align: center">
+                <span data-lexical-text="true">d</span>
+              </p>
+            </th>
+            <td style="text-align: center">
+              <p dir="ltr" style="text-align: center">
+                <span data-lexical-text="true">e</span>
+              </p>
+            </td>
+            <td>
+              <p dir="ltr"><span data-lexical-text="true">f</span></p>
+            </td>
+          </tr>
+        </table>
+        <p><br /></p>
+      `,
+      {ignoreClasses: true},
     );
   });
 });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -632,7 +632,11 @@ export function registerRichText(editor: LexicalEditor): () => void {
       FORMAT_ELEMENT_COMMAND,
       (format) => {
         const selection = $getSelection();
-        if (!$isRangeSelection(selection) && !$isNodeSelection(selection)) {
+        const validSelection =
+          $isRangeSelection(selection) ||
+          $isNodeSelection(selection) ||
+          DEPRECATED_$isGridSelection(selection);
+        if (!validSelection) {
           return false;
         }
         const nodes = selection.getNodes();

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -34,6 +34,7 @@ import {
   $moveCharacter,
   $shouldOverrideDefaultCharacterSelection,
 } from '@lexical/selection';
+import {$isTableSelection} from '@lexical/table';
 import {
   $findMatchingParent,
   $getNearestBlockElementAncestorOrThrow,
@@ -635,7 +636,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
         const validSelection =
           $isRangeSelection(selection) ||
           $isNodeSelection(selection) ||
-          DEPRECATED_$isGridSelection(selection);
+          $isTableSelection(selection);
         if (!validSelection) {
           return false;
         }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -34,7 +34,6 @@ import {
   $moveCharacter,
   $shouldOverrideDefaultCharacterSelection,
 } from '@lexical/selection';
-import {$isTableSelection} from '@lexical/table';
 import {
   $findMatchingParent,
   $getNearestBlockElementAncestorOrThrow,
@@ -633,11 +632,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
       FORMAT_ELEMENT_COMMAND,
       (format) => {
         const selection = $getSelection();
-        const validSelection =
-          $isRangeSelection(selection) ||
-          $isNodeSelection(selection) ||
-          $isTableSelection(selection);
-        if (!validSelection) {
+        if (!$isRangeSelection(selection) && !$isNodeSelection(selection)) {
           return false;
         }
         const nodes = selection.getNodes();

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -12,6 +12,7 @@ import type {TableDOMCell, TableDOMRows} from './LexicalTableObserver';
 import type {TableSelection} from './LexicalTableSelection';
 import type {
   BaseSelection,
+  ElementFormatType,
   LexicalCommand,
   LexicalEditor,
   LexicalNode,
@@ -22,6 +23,7 @@ import type {
 import {$findMatchingParent} from '@lexical/utils';
 import {
   $createParagraphNode,
+  $createRangeSelection,
   $getNearestNodeFromDOMNode,
   $getPreviousSelection,
   $getSelection,
@@ -36,6 +38,7 @@ import {
   DELETE_LINE_COMMAND,
   DELETE_WORD_COMMAND,
   FOCUS_COMMAND,
+  FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
@@ -361,6 +364,33 @@ export function applyTableHandlers(
           }
         }
 
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    ),
+  );
+
+  tableObserver.listenersToRemove.add(
+    editor.registerCommand<ElementFormatType>(
+      FORMAT_ELEMENT_COMMAND,
+      () => {
+        const currentSelection = $getSelection();
+        if (!$isTableSelection(currentSelection)) {
+          return false;
+        }
+        const {anchor: currentAnchor, focus: currentFocus} = currentSelection;
+        const formatSelection = $createRangeSelection();
+        formatSelection.anchor.set(
+          currentAnchor.key,
+          currentAnchor.offset,
+          currentAnchor.type,
+        );
+        formatSelection.focus.set(
+          currentFocus.key,
+          currentFocus.offset,
+          currentFocus.type,
+        );
+        $setSelection(formatSelection);
         return false;
       },
       COMMAND_PRIORITY_CRITICAL,


### PR DESCRIPTION
The added support allows text alignment across multiple cells simultaneously by selecting those cells. Fixes #5638.

Before:

[before-text-alignment.webm](https://github.com/facebook/lexical/assets/88986106/74ee321e-b55e-4834-aa7d-0bc9613055c9)

After:

[after-text-alignment.webm](https://github.com/facebook/lexical/assets/88986106/629324cb-4619-4b35-af7a-bb9c6a05a6ff)
