### PR TITLE
docs: add a tip about discrete state update

### DIFF
--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -84,6 +84,12 @@ editor.update(() => {
 });
 ```
 
+:::tip
+
+Remember that state updates are asynchronous, so executing `editor.getEditorState()` immediately afterwards might not return the expected content. To avoid it, [pass `discrete: true` in the `editor.update` method](https://dio.la/article/lexical-state-updates#discrete-updates).
+
+:::
+
 #### `LexicalNode.importDOM()`
 You can control how an `HTMLElement` is represented in `Lexical` by adding an `importDOM()` method to your `LexicalNode`.
 


### PR DESCRIPTION
Fixes #5660 

Also, I think it might be reasonable to copy/adapt the [discrete update section of @DaniGuardiola's article](https://dio.la/article/lexical-state-updates#discrete-updates) into the docs. Applying `discrete: true` sounds like a common use case in a headless context.