### PR TITLE
Preserve style after double line break

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -324,10 +324,6 @@ function onSelectionChange(
         const [lastFormat, lastStyle, lastOffset, lastKey, timeStamp] =
           collapsedSelectionFormat;
 
-        const root = $getRoot();
-        const isRootTextContentEmpty =
-          editor.isComposing() === false && root.getTextContent() === '';
-
         if (
           currentTimeStamp < timeStamp + 200 &&
           anchor.offset === lastOffset &&
@@ -343,9 +339,6 @@ function onSelectionChange(
             );
             selection.format = anchorNode.getFormat();
             selection.style = anchorNode.getStyle();
-          } else if (anchor.type === 'element' && !isRootTextContentEmpty) {
-            selection.format = 0;
-            selection.style = '';
           }
         }
       } else {


### PR DESCRIPTION
Fixes: #5620

The issue: When you press Enter twice, the styling gets lost in the skipped paragraph, same when you type inside a table cells.
Why change this: consistent behaviour with other text editors.

This essentially undoes the changes done in here: https://github.com/facebook/lexical/pull/5292 while still fixing the issue that PR officially addressed.

Before:

https://github.com/facebook/lexical/assets/7893468/328f5197-fa2d-457a-a4dd-7b2a4802ceb1

After:

https://github.com/facebook/lexical/assets/7893468/ae34f9f5-8146-4f0b-8580-181fe2bff74b

