### PR TITLE
refactor: Implement CollabTextNode as a single yjs map

### DIFF
--- a/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
@@ -82,9 +82,6 @@ describe('Collaboration', () => {
       '<p dir="ltr"><span data-lexical-text="true">Hello metaverse</span></p>',
     );
     expect(client1.getHTML()).toEqual(client2.getHTML());
-    expect(client1.getDocJSON()).toEqual({
-      root: '[object Object]Hello metaverse',
-    });
     expect(client1.getDocJSON()).toEqual(client2.getDocJSON());
 
     client1.stop();
@@ -146,9 +143,6 @@ describe('Collaboration', () => {
       '<p dir="ltr"><span data-lexical-text="true">Hello worldHello world</span></p>',
     );
     expect(client1.getHTML()).toEqual(client2.getHTML());
-    expect(client1.getDocJSON()).toEqual({
-      root: '[object Object]Hello worldHello world',
-    });
     expect(client1.getDocJSON()).toEqual(client2.getDocJSON());
 
     client2.disconnect();
@@ -190,9 +184,6 @@ describe('Collaboration', () => {
       '<p dir="ltr"><span data-lexical-text="true">Hello world!</span></p>',
     );
     expect(client1.getHTML()).toEqual(client2.getHTML());
-    expect(client1.getDocJSON()).toEqual({
-      root: '[object Object]Hello world!',
-    });
     expect(client1.getDocJSON()).toEqual(client2.getDocJSON());
 
     client1.stop();
@@ -223,9 +214,6 @@ describe('Collaboration', () => {
       '<p dir="ltr"><span data-lexical-text="true">Hello world</span></p>',
     );
     expect(client1.getHTML()).toEqual(client2.getHTML());
-    expect(client1.getDocJSON()).toEqual({
-      root: '[object Object]Hello world',
-    });
     expect(client1.getDocJSON()).toEqual(client2.getDocJSON());
 
     client1.disconnect();

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -134,7 +134,7 @@ export function useYjsCollaboration(
     provider.on('sync', onSync);
     awareness.on('update', onAwarenessUpdate);
     // This updates the local editor state when we recieve updates from other clients
-    root.getSharedType().observeDeep(onYjsTreeChanges);
+    root._xmlText.observeDeep(onYjsTreeChanges);
     const removeListener = editor.registerUpdateListener(
       ({
         prevEditorState,
@@ -169,7 +169,7 @@ export function useYjsCollaboration(
       provider.off('status', onStatus);
       provider.off('reload', onProviderDocReload);
       awareness.off('update', onAwarenessUpdate);
-      root.getSharedType().unobserveDeep(onYjsTreeChanges);
+      root._xmlText.unobserveDeep(onYjsTreeChanges);
       docMap.delete(id);
       removeListener();
     };
@@ -259,7 +259,7 @@ export function useYjsHistory(
   binding: Binding,
 ): () => void {
   const undoManager = useMemo(
-    () => createUndoManager(binding, binding.root.getSharedType()),
+    () => createUndoManager(binding, binding.root._xmlText),
     [binding],
   );
 

--- a/packages/lexical-yjs/src/CollabDecoratorNode.ts
+++ b/packages/lexical-yjs/src/CollabDecoratorNode.ts
@@ -43,8 +43,8 @@ export class CollabDecoratorNode {
     return $isDecoratorNode(node) ? node : null;
   }
 
-  getSharedType(): XmlElement {
-    return this._xmlElem;
+  getCursorYjsType(): never {
+    invariant(false, 'getCursorYjsType: not a valid cursor type');
   }
 
   getType(): string {
@@ -53,10 +53,6 @@ export class CollabDecoratorNode {
 
   getKey(): NodeKey {
     return this._key;
-  }
-
-  getSize(): number {
-    return 1;
   }
 
   getOffset(): number {

--- a/packages/lexical-yjs/src/CollabLineBreakNode.ts
+++ b/packages/lexical-yjs/src/CollabLineBreakNode.ts
@@ -12,6 +12,7 @@ import type {LineBreakNode, NodeKey} from 'lexical';
 import type {Map as YMap} from 'yjs';
 
 import {$getNodeByKey, $isLineBreakNode} from 'lexical';
+import invariant from 'shared/invariant';
 
 export class CollabLineBreakNode {
   _map: YMap<unknown>;
@@ -35,16 +36,12 @@ export class CollabLineBreakNode {
     return this._key;
   }
 
-  getSharedType(): YMap<unknown> {
-    return this._map;
+  getCursorYjsType(): never {
+    invariant(false, 'getCursorYjsType: not a valid cursor type');
   }
 
   getType(): string {
     return this._type;
-  }
-
-  getSize(): number {
-    return 1;
   }
 
   getOffset(): number {

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -54,15 +54,16 @@ function syncEvent(binding: Binding, event: any): void {
       collabNode.applyChildrenYjsDelta(binding, delta);
       collabNode.syncChildrenFromYjs(binding);
     }
-  } else if (
-    collabNode instanceof CollabTextNode &&
-    event instanceof YMapEvent
-  ) {
-    const {keysChanged} = event;
+  } else if (collabNode instanceof CollabTextNode) {
+    if (event instanceof YMapEvent) {
+      const {keysChanged} = event;
 
-    // Update
-    if (keysChanged.size > 0) {
-      collabNode.syncPropertiesAndTextFromYjs(binding, keysChanged);
+      // Update
+      if (keysChanged.size > 0) {
+        collabNode.syncPropertiesAndTextFromYjs(binding, keysChanged);
+      }
+    } else {
+      collabNode.syncTextFromYjs();
     }
   } else if (
     collabNode instanceof CollabDecoratorNode &&
@@ -204,7 +205,6 @@ function handleNormalizationMergeConflicts(
         }
 
         const parent = collabNode._parent;
-        collabNode._normalized = true;
 
         parent._xmlText.delete(offset, 1);
 
@@ -219,7 +219,9 @@ function handleNormalizationMergeConflicts(
   for (let i = 0; i < mergedNodes.length; i++) {
     const [collabNode, text] = mergedNodes[i];
     if (collabNode instanceof CollabTextNode && typeof text === 'string') {
-      collabNode._text = text;
+      const yText = collabNode._text;
+      yText.delete(0, yText.length);
+      yText.insert(0, text);
     }
   }
 }

--- a/packages/lexical-yjs/types.ts
+++ b/packages/lexical-yjs/types.ts
@@ -24,6 +24,11 @@ declare module 'yjs' {
 declare module 'yjs/dist/src/internals' {
   // @ts-ignore
   interface YMap {
-    _collabNode: CollabLineBreakNode | CollabTextNode;
+    _collabNode: CollabTextNode | CollabLineBreakNode;
+  }
+
+  interface YText {
+    // YXmlText extends YText, so CollabElementNode should be added here.
+    _collabNode: CollabTextNode | CollabElementNode;
   }
 }


### PR DESCRIPTION
## Original bug
Self-host lexical playground, enable collaboration, enable split view.
Type some characters ("abc" in the example)
Disconnect one of the view.
Add some characters before "abc" in one view ("123" in the example)
In another view, delete "abc", then add some new characters ("456" in the example)
Reconnect the view again, now two views are not consistent.

https://github.com/facebook/lexical/assets/36890796/73bf6dc4-9769-4e87-844f-be5184098e7c

Expected behavior:
Two views in sync.

## Root cause analysis
In original implementation, a "LexicalTextNode" is encoded to as two parts, a yjs map and a piece of string.

For example, the character sequence "abc", is encoded as [Y.map, "a", "b", "c"].
The map at the beginning indicates the format of the character sequence , then followed by the LexicalTextNode's content. Therefore, if different format texts are concatenating together, then each of them would start with a Y.map, followed by their content respectively.

**This implementation violates CRDT's rule.**

In the example above, at the beginning, the sequence is like:
`[Y.map, a, b, c]`
Then, when the "123" is added, the diff is encoded as
`Insert at position 1, character 1, 2, 3`
Then, when the "abc" is deleted, the diff is encoded as
`Delete sequence from position 0, length 4, then insert at position 0 [Y.map, 4, 5, 6]`
When the two views are connected again, those two diffs are getting merged.

For the view on the left (current [Y.map, 1, 2, 3, a, b, c]), the new diff becomes:
`Delete 1, retain 3, delete 3, add [Y.map, 4, 5, 6]`
Then it becomes `[1, 2, 3, Y.map, 4, 5, 6]`, which is already broken since the leading Y.map is removed. It is shown as "23456".

For the view on the right(current [Y.map, 4, 5, 6]), the new diff becomes:
`insert [1, 2, 3]`
Then it becomes `[1, 2, 3, Y.map, 4, 5, 6]`, not sure why it is converted to `12456`. Possibly due to some inconsistence when converting delta to LexicalTextNode.

Similar cases can be created when disconnecting and then remove styled texts in a multi-format text sequence and added some new texts.

## Refactor
To refactor, a new entry `_text` is added to `CollabTextNode`'s map, that is a `Y.Text` class, so all the character changes are no longer handled by the `CollabElementNode`, and we do not encode the text as a leading prefix with characters.
Now, each `CollabTextNode` is exactly one Y.map in the element node's XmlText class (with length 1), so all the intricate size computation can be removed.

Going back to the original bug, the correct behavior should be:
Original: "abc"
Left: "123abc"
Right: "456"
After merge: "456"
Although it is not intuitive at the first glance, that is the correct behavior. Suppose this is not a text node, this is a list item. The first user adds some texts, the second user remove the item, then adds a new item with some texts, when they are merged, only the new item and new texts are kept, since the second user directly removes the container (the original list item).

