### PR TITLE
Fix Bulleting a Node Selection

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -215,7 +215,9 @@ function BlockFormatDropDown({
   const formatParagraph = () => {
     editor.update(() => {
       const selection = $getSelection();
-      $setBlocksType(selection, () => $createParagraphNode());
+      if ($isRangeSelection(selection)) {
+        $setBlocksType(selection, () => $createParagraphNode());
+      }
     });
   };
 


### PR DESCRIPTION
Partial fix for: #5698

When selection is NodeSelection, not a range one nodes like Image, Poll, etc. are not bulleted correctly.
 
Unbulleting doesn't work, but as the full proper fix will be quite involved - introducing a proper REMOVE_LIST_ITEM_COMMAND that unbulleting any node, just doing this part for the first half.

Review with hiding the whitespace, it's only 3-4 lines changes, but deindenting, makes it look as larger change.