### PR TITLE
Fix endless renders with editorRef callback

### DIFF
--- a/packages/lexical-react/src/LexicalEditorRefPlugin.tsx
+++ b/packages/lexical-react/src/LexicalEditorRefPlugin.tsx
@@ -26,10 +26,15 @@ export function EditorRefPlugin({
     | MutableRefObject<LexicalEditor | null | undefined>;
 }): null {
   const [editor] = useLexicalComposerContext();
-  if (typeof editorRef === 'function') {
-    editorRef(editor);
-  } else if (typeof editorRef === 'object') {
-    editorRef.current = editor;
-  }
+
+  React.useEffect(() => {
+    if (typeof editorRef === 'function') {
+      editorRef(editor);
+    } else if (typeof editorRef === 'object') {
+      editorRef.current = editor;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor]);
+
   return null;
 }


### PR DESCRIPTION
fixes #5700 

Currently, passing editorRef callback containing setState() throws an warning.
And using that state triggers endless update, which throws an error.

more details in #5700