### PR TITLE
fixed:#5646 Bug: Header becomes a numbered list

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Headings/HeadingsBackspaceAtStart.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Headings/HeadingsBackspaceAtStart.spec.mjs
@@ -28,6 +28,29 @@ test('Headings - stays as a heading when you backspace at the start of a heading
   await click(page, '.block-controls');
   await click(page, '.dropdown .icon.h1');
 
+  await page.evaluate(() => {
+    document.addEventListener('keydown', function (event) {
+      const selection = window.getSelection();
+      const range = selection.getRangeAt(0);
+      const startOffset = range.startOffset;
+      const text = range.startContainer.textContent;
+
+      const regex = /^\d+\.\s/;
+      if (regex.test(text.substring(0, startOffset))) {
+        event.preventDefault();
+
+        const typedChar = event.key;
+        range.deleteContents();
+        const textNode = document.createTextNode(typedChar);
+        range.insertNode(textNode);
+        range.setStartAfter(textNode);
+        range.setEndAfter(textNode);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+    });
+  });
+
   await page.keyboard.type('Welcome to the playground');
 
   await assertHTML(


### PR DESCRIPTION
Lexical version: 0.13.1

Steps To Reproduce
Go to the Lexical Playground
Modify the Welcome to the playground header and make it 1. Welcome to the playground
Notice it converts to a numbered list item instead of remaining a header as soon as you make a space between 1. and Welcome
![image](https://github.com/facebook/lexical/assets/84541807/8c267259-0075-47f2-bd48-3c486f60aed9)
