### PR TITLE
Fix to count tabs as list indentation on importing markdown

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -98,9 +98,9 @@ const createBlockNode = (
 // TODO: should be an option
 const LIST_INDENT_SIZE = 4;
 
-function getIndent(match: string): number {
-  const tabs = match.match(/\t/g);
-  const spaces = match.match(/ /g);
+function getIndent(whitespaces: string): number {
+  const tabs = whitespaces.match(/\t/g);
+  const spaces = whitespaces.match(/ /g);
 
   let indent = 0;
 

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -98,6 +98,23 @@ const createBlockNode = (
 // TODO: should be an option
 const LIST_INDENT_SIZE = 4;
 
+function getIndent(match: string): number {
+  const tabs = match.match(/\t/g);
+  const spaces = match.match(/ /g);
+
+  let indent = 0;
+
+  if (tabs) {
+    indent += tabs.length;
+  }
+
+  if (spaces) {
+    indent += Math.floor(spaces.length / LIST_INDENT_SIZE);
+  }
+
+  return indent;
+}
+
 const listReplace = (listType: ListType): ElementTransformer['replace'] => {
   return (parentNode, children, match) => {
     const previousNode = parentNode.getPreviousSibling();
@@ -130,7 +147,7 @@ const listReplace = (listType: ListType): ElementTransformer['replace'] => {
     }
     listItem.append(...children);
     listItem.select(0, 0);
-    const indent = Math.floor(match[1].length / LIST_INDENT_SIZE);
+    const indent = getIndent(match[1]);
     if (indent) {
       listItem.setIndent(indent);
     }

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -79,6 +79,12 @@ describe('Markdown', () => {
       html: '<ul><li value="1"><span style="white-space: pre-wrap;">Level 1</span></li><li value="2"><ul><li value="1"><span style="white-space: pre-wrap;">Level 2</span></li><li value="2"><ul><li value="1"><span style="white-space: pre-wrap;">Level 3</span></li></ul></li></ul></li></ul><p><span style="white-space: pre-wrap;">Hello world</span></p>',
       md: '- Level 1\n    - Level 2\n        - Level 3\n\nHello world',
     },
+    // List indentation with tabs, Import only: export will use "    " only for one level of indentation
+    {
+      html: '<ul><li value="1"><span style="white-space: pre-wrap;">Level 1</span></li><li value="2"><ul><li value="1"><span style="white-space: pre-wrap;">Level 2</span></li><li value="2"><ul><li value="1"><span style="white-space: pre-wrap;">Level 3</span></li></ul></li></ul></li></ul><p><span style="white-space: pre-wrap;">Hello world</span></p>',
+      md: '- Level 1\n\t- Level 2\n  \t  - Level 3\n\nHello world',
+      skipExport: true,
+    },
     {
       // Import only: export will use "-" instead of "*"
       html: '<ul><li value="1"><span style="white-space: pre-wrap;">Level 1</span></li><li value="2"><ul><li value="1"><span style="white-space: pre-wrap;">Level 2</span></li><li value="2"><ul><li value="1"><span style="white-space: pre-wrap;">Level 3</span></li></ul></li></ul></li></ul><p><span style="white-space: pre-wrap;">Hello world</span></p>',


### PR DESCRIPTION
fixes #5704 

Currently it considers a tab (`\t`) as same as one space to count a level of indentation.
So when user inputs one tab (`\t`) expecting one indentation in markdown, it might end up feeling incorrect.

Not sure it's intentional though ...

This PR fixes to count \t and space separately.

before:

https://github.com/facebook/lexical/assets/40269597/0abb42fe-cbdd-4da6-9b10-25dc90d5d870

after:


https://github.com/facebook/lexical/assets/40269597/944eb994-e9be-432b-b5e9-39e8cd12ccb5

