### PR TITLE
Send click event in read-only editor

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1208,7 +1208,7 @@ export function addRootElementEvents(
               return;
             }
             stopLexicalPropagation(event);
-            if (editor.isEditable()) {
+            if (editor.isEditable() || eventName === 'click') {
               onEvent(event, editor);
             }
           }


### PR DESCRIPTION
Right now only a SELECTION_CHANGE_COMMAND is passed when the editor is in read-only mode. Which makes sense, since we don't want to allow copy, paste, etc when contenteditable doesn't have true 'readonly' mode. 

However, I stumbled upon a situation where this logic disabled the 'click' event not firing the CLICK_COMMAND at all when in read-only, which is needed if you want to have any interactivity even in read-only when a non-editing user needs to interact with the widget, eg open a popup on a double click to view something for example. So passing this event through irrespective of editor editability.

Before:

https://github.com/facebook/lexical/assets/7893468/92e832d1-6b61-4a93-a91d-3e866930ceb3

After:

https://github.com/facebook/lexical/assets/7893468/fe741a9c-9ba8-4923-ba75-3a09af6d1781
