### PR TITLE
Update CharacterLimitPlugin to support custom renderer

### DIFF
--- a/packages/lexical-react/src/LexicalCharacterLimitPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCharacterLimitPlugin.tsx
@@ -39,12 +39,29 @@ function utf8Length(text: string) {
   return currentTextEncoder.encode(text).length;
 }
 
+function DefaultRenderer({remainingCharacters}: {remainingCharacters: number}) {
+  return (
+    <span
+      className={`characters-limit ${
+        remainingCharacters < 0 ? 'characters-limit-exceeded' : ''
+      }`}>
+      {remainingCharacters}
+    </span>
+  );
+}
+
 export function CharacterLimitPlugin({
   charset = 'UTF-16',
   maxLength = CHARACTER_LIMIT,
+  renderer = DefaultRenderer,
 }: {
   charset: 'UTF-8' | 'UTF-16';
   maxLength: number;
+  renderer?: ({
+    remainingCharacters,
+  }: {
+    remainingCharacters: number;
+  }) => JSX.Element;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
 
@@ -68,12 +85,5 @@ export function CharacterLimitPlugin({
 
   useCharacterLimit(editor, maxLength, characterLimitProps);
 
-  return (
-    <span
-      className={`characters-limit ${
-        remainingCharacters < 0 ? 'characters-limit-exceeded' : ''
-      }`}>
-      {remainingCharacters}
-    </span>
-  );
+  return renderer({remainingCharacters});
 }


### PR DESCRIPTION
Currently the UI for CharacterLimitPlugin is not customizable. And mimicking this plugin our own is not easy since `useCharacterLimit` is not exported. Is this my misunderstanding ? in any case, I believe this is still useful change.

Allowing to pass custom renderer, we can easily render own UI or do some state or effect manipulation depending remainingCharacters. (i.e. deactivating some actions ... )

For compatibility, I made existing JSX as DefaultRenderer.

The easiest and common use case with this:

<img width="601" alt="스크린샷 2024-03-15 오전 12 48 23" src="https://github.com/facebook/lexical/assets/40269597/4374e08c-6d3c-4152-9caa-5aeef12709b3">

https://github.com/facebook/lexical/assets/40269597/bd46c404-8724-47bf-9d9f-219088bc2b04



Edit: OR we just can convert `useCharacterLimit` to public API (as `useLexicalCharacterLimit` ?) to give some more flexibility what do you think ?
