### PR TITLE
Add test for multiple leading "#" characters in a hashtag

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
@@ -302,4 +302,47 @@ test.describe('Hashtags', () => {
       `,
     );
   });
+
+  test('Should not break with multiple leading "#" #5636', async ({page}) => {
+    await focusEditor(page);
+    await page.keyboard.type('#hello');
+
+    await waitForSelector(page, '.PlaygroundEditorTheme__hashtag');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #hello
+          </span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 6,
+      anchorPath: [0, 0, 0],
+      focusOffset: 6,
+      focusPath: [0, 0, 0],
+    });
+
+    await moveToEditorBeginning(page);
+    await page.keyboard.type('#');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">#</span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #hello
+          </span>
+        </p>
+      `,
+    );
+  });
 });


### PR DESCRIPTION
Let's add a test for #5636 
