### PR TITLE
feat: add a cleanup method to be called during garbage collection for LexicalNode 

### DIFF
--- a/packages/lexical/src/LexicalGC.ts
+++ b/packages/lexical/src/LexicalGC.ts
@@ -112,7 +112,7 @@ export function $garbageCollectDetachedNodes(
   for (const nodeKey of nodeMapDelete) {
     const node = nodeMap.get(nodeKey);
     if (node !== undefined) {
-      node[Symbol.dispose]();
+      node.cleanUp();
     }
     nodeMap.delete(nodeKey);
   }
@@ -122,7 +122,7 @@ export function $garbageCollectDetachedNodes(
     if (node !== undefined && !node.isAttached()) {
       if (!prevNodeMap.has(nodeKey)) {
         dirtyLeaves.delete(nodeKey);
-        node[Symbol.dispose]();
+        node.cleanUp();
       }
       nodeMap.delete(nodeKey);
     }

--- a/packages/lexical/src/LexicalGC.ts
+++ b/packages/lexical/src/LexicalGC.ts
@@ -110,6 +110,10 @@ export function $garbageCollectDetachedNodes(
     }
   }
   for (const nodeKey of nodeMapDelete) {
+    const node = nodeMap.get(nodeKey);
+    if (node !== undefined) {
+      node[Symbol.dispose]();
+    }
     nodeMap.delete(nodeKey);
   }
 
@@ -118,6 +122,7 @@ export function $garbageCollectDetachedNodes(
     if (node !== undefined && !node.isAttached()) {
       if (!prevNodeMap.has(nodeKey)) {
         dirtyLeaves.delete(nodeKey);
+        node[Symbol.dispose]();
       }
       nodeMap.delete(nodeKey);
     }

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -1101,7 +1101,7 @@ export class LexicalNode {
   }
 
   /**
-   * Cleanup method to release resources held by the node (event listeners, open files, etc).
+   * Cleanup method to release resources held by the node (event listeners, etc).
    * Called only when the node is being garbage collected by Lexical and detaching from the
    * EditorState.
    *

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -154,7 +154,7 @@ export type DOMExportOutput = {
 
 export type NodeKey = string;
 
-export class LexicalNode {
+export class LexicalNode implements Disposable {
   // Allow us to look up the type including static props
   ['constructor']!: KlassConstructor<typeof LexicalNode>;
   /** @internal */
@@ -1099,6 +1099,13 @@ export class LexicalNode {
   markDirty(): void {
     this.getWritable();
   }
+
+  /**
+   * Cleanup method for the node. Called when the node is garbage collected by Lexical and
+   * detached from the EditorState.
+   *
+   * */
+  [Symbol.dispose](): void {}
 }
 
 function errorOnTypeKlassMismatch(

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -154,7 +154,7 @@ export type DOMExportOutput = {
 
 export type NodeKey = string;
 
-export class LexicalNode implements Disposable {
+export class LexicalNode {
   // Allow us to look up the type including static props
   ['constructor']!: KlassConstructor<typeof LexicalNode>;
   /** @internal */
@@ -1101,11 +1101,12 @@ export class LexicalNode implements Disposable {
   }
 
   /**
-   * Cleanup method for the node. Called when the node is garbage collected by Lexical and
-   * detached from the EditorState.
+   * Cleanup method to release resources held by the node (event listeners, open files, etc).
+   * Called only when the node is being garbage collected by Lexical and detaching from the
+   * EditorState.
    *
    * */
-  [Symbol.dispose](): void {}
+  cleanUp(): void {}
 }
 
 function errorOnTypeKlassMismatch(


### PR DESCRIPTION
When a LexicalNode uses an external resource, there is no way to release the resource because the lifecycle methods of LexicalNode is incomplete. This PR adds a new method which should be called when a node is removed from the editorState.