### PR TITLE
Fix: don't call importDOM methods more than once

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -377,17 +377,14 @@ function initializeConversionCache(
     });
   };
   nodes.forEach((node) => {
-    const importDOM =
-      node.klass.importDOM != null
-        ? node.klass.importDOM.bind(node.klass)
-        : null;
+    const importDOM = node.klass.importDOM;
 
     if (importDOM == null || handledConversions.has(importDOM)) {
       return;
     }
 
     handledConversions.add(importDOM);
-    const map = importDOM();
+    const map = importDOM.call(node.klass);
 
     if (map !== null) {
       addConversionsToCache(map);

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2186,4 +2186,30 @@ describe('LexicalEditor tests', () => {
     expect(textListener).toBeCalledWith('Hello\n\nworld');
     expect(updateListener.mock.lastCall[0].prevEditorState).toBe(editorState);
   });
+
+  it('should call importDOM methods only once', async () => {
+    jest.spyOn(ParagraphNode, 'importDOM');
+
+    class CustomParagraphNode extends ParagraphNode {
+      static getType() {
+        return 'custom-paragraph';
+      }
+
+      static clone(node: CustomParagraphNode) {
+        return new CustomParagraphNode(node.__key);
+      }
+
+      static importJSON() {
+        return new CustomParagraphNode();
+      }
+
+      exportJSON() {
+        return {...super.exportJSON(), type: 'custom-paragraph'};
+      }
+    }
+
+    createTestEditor({nodes: [CustomParagraphNode]});
+
+    expect(ParagraphNode.importDOM).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
I didn't add this check, only fixed it.