### PR TITLE
Update Node version in Publish Workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -22,7 +22,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: |
           git config user.name "Lexical GitHub Actions Bot"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,12 +15,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.SSH_KEY }}
           fetch-depth: 0
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
To remove the warning for using deprecated Node version inside the publishing workflow in GitHub