### PR TITLE
fix: use mjs as file extension

### DIFF
--- a/packages/lexical-clipboard/package.json
+++ b/packages/lexical-clipboard/package.json
@@ -25,6 +25,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-clipboard"
   },
-  "module": "LexicalClipboard.esm.js",
+  "module": "LexicalClipboard.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-code/package.json
+++ b/packages/lexical-code/package.json
@@ -25,6 +25,6 @@
   "devDependencies": {
     "@types/prismjs": "^1.26.0"
   },
-  "module": "LexicalCode.esm.js",
+  "module": "LexicalCode.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-dragon/package.json
+++ b/packages/lexical-dragon/package.json
@@ -19,6 +19,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-dragon"
   },
-  "module": "LexicalDragon.esm.js",
+  "module": "LexicalDragon.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-file/package.json
+++ b/packages/lexical-file/package.json
@@ -20,6 +20,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-file"
   },
-  "module": "LexicalFile.esm.js",
+  "module": "LexicalFile.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-hashtag/package.json
+++ b/packages/lexical-hashtag/package.json
@@ -21,6 +21,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-hashtag"
   },
-  "module": "LexicalHashtag.esm.js",
+  "module": "LexicalHashtag.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-headless/package.json
+++ b/packages/lexical-headless/package.json
@@ -18,6 +18,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-headless"
   },
-  "module": "LexicalHeadless.esm.js",
+  "module": "LexicalHeadless.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-history/package.json
+++ b/packages/lexical-history/package.json
@@ -21,6 +21,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-history"
   },
-  "module": "LexicalHistory.esm.js",
+  "module": "LexicalHistory.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-html/package.json
+++ b/packages/lexical-html/package.json
@@ -22,6 +22,6 @@
     "@lexical/selection": "0.14.2",
     "@lexical/utils": "0.14.2"
   },
-  "module": "LexicalHtml.esm.js",
+  "module": "LexicalHtml.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-link/package.json
+++ b/packages/lexical-link/package.json
@@ -21,6 +21,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-link"
   },
-  "module": "LexicalLink.esm.js",
+  "module": "LexicalLink.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-list/package.json
+++ b/packages/lexical-list/package.json
@@ -21,6 +21,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-list"
   },
-  "module": "LexicalList.esm.js",
+  "module": "LexicalList.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-mark/package.json
+++ b/packages/lexical-mark/package.json
@@ -21,6 +21,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-mark"
   },
-  "module": "LexicalMark.esm.js",
+  "module": "LexicalMark.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-markdown/package.json
+++ b/packages/lexical-markdown/package.json
@@ -26,6 +26,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-markdown"
   },
-  "module": "LexicalMarkdown.esm.js",
+  "module": "LexicalMarkdown.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-offset/package.json
+++ b/packages/lexical-offset/package.json
@@ -18,6 +18,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-offset"
   },
-  "module": "LexicalOffset.esm.js",
+  "module": "LexicalOffset.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-overflow/package.json
+++ b/packages/lexical-overflow/package.json
@@ -18,6 +18,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-overflow"
   },
-  "module": "LexicalOverflow.esm.js",
+  "module": "LexicalOverflow.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-plain-text/package.json
+++ b/packages/lexical-plain-text/package.json
@@ -20,6 +20,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-plain-text"
   },
-  "module": "LexicalPlainText.esm.js",
+  "module": "LexicalPlainText.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -43,560 +43,560 @@
     "./LexicalAutoEmbedPlugin": {
       "import": {
         "types": "./LexicalAutoEmbedPlugin.d.ts",
-        "default": "./LexicalAutoEmbedPlugin.esm.js"
+        "default": "./LexicalAutoEmbedPlugin.mjs"
       },
       "require": "./LexicalAutoEmbedPlugin.js"
     },
     "./LexicalAutoEmbedPlugin.js": {
       "import": {
         "types": "./LexicalAutoEmbedPlugin.d.ts",
-        "default": "./LexicalAutoEmbedPlugin.esm.js"
+        "default": "./LexicalAutoEmbedPlugin.mjs"
       },
       "require": "./LexicalAutoEmbedPlugin.js"
     },
     "./LexicalAutoFocusPlugin": {
       "import": {
         "types": "./LexicalAutoFocusPlugin.d.ts",
-        "default": "./LexicalAutoFocusPlugin.esm.js"
+        "default": "./LexicalAutoFocusPlugin.mjs"
       },
       "require": "./LexicalAutoFocusPlugin.js"
     },
     "./LexicalAutoFocusPlugin.js": {
       "import": {
         "types": "./LexicalAutoFocusPlugin.d.ts",
-        "default": "./LexicalAutoFocusPlugin.esm.js"
+        "default": "./LexicalAutoFocusPlugin.mjs"
       },
       "require": "./LexicalAutoFocusPlugin.js"
     },
     "./LexicalAutoLinkPlugin": {
       "import": {
         "types": "./LexicalAutoLinkPlugin.d.ts",
-        "default": "./LexicalAutoLinkPlugin.esm.js"
+        "default": "./LexicalAutoLinkPlugin.mjs"
       },
       "require": "./LexicalAutoLinkPlugin.js"
     },
     "./LexicalAutoLinkPlugin.js": {
       "import": {
         "types": "./LexicalAutoLinkPlugin.d.ts",
-        "default": "./LexicalAutoLinkPlugin.esm.js"
+        "default": "./LexicalAutoLinkPlugin.mjs"
       },
       "require": "./LexicalAutoLinkPlugin.js"
     },
     "./LexicalBlockWithAlignableContents": {
       "import": {
         "types": "./LexicalBlockWithAlignableContents.d.ts",
-        "default": "./LexicalBlockWithAlignableContents.esm.js"
+        "default": "./LexicalBlockWithAlignableContents.mjs"
       },
       "require": "./LexicalBlockWithAlignableContents.js"
     },
     "./LexicalBlockWithAlignableContents.js": {
       "import": {
         "types": "./LexicalBlockWithAlignableContents.d.ts",
-        "default": "./LexicalBlockWithAlignableContents.esm.js"
+        "default": "./LexicalBlockWithAlignableContents.mjs"
       },
       "require": "./LexicalBlockWithAlignableContents.js"
     },
     "./LexicalCharacterLimitPlugin": {
       "import": {
         "types": "./LexicalCharacterLimitPlugin.d.ts",
-        "default": "./LexicalCharacterLimitPlugin.esm.js"
+        "default": "./LexicalCharacterLimitPlugin.mjs"
       },
       "require": "./LexicalCharacterLimitPlugin.js"
     },
     "./LexicalCharacterLimitPlugin.js": {
       "import": {
         "types": "./LexicalCharacterLimitPlugin.d.ts",
-        "default": "./LexicalCharacterLimitPlugin.esm.js"
+        "default": "./LexicalCharacterLimitPlugin.mjs"
       },
       "require": "./LexicalCharacterLimitPlugin.js"
     },
     "./LexicalCheckListPlugin": {
       "import": {
         "types": "./LexicalCheckListPlugin.d.ts",
-        "default": "./LexicalCheckListPlugin.esm.js"
+        "default": "./LexicalCheckListPlugin.mjs"
       },
       "require": "./LexicalCheckListPlugin.js"
     },
     "./LexicalCheckListPlugin.js": {
       "import": {
         "types": "./LexicalCheckListPlugin.d.ts",
-        "default": "./LexicalCheckListPlugin.esm.js"
+        "default": "./LexicalCheckListPlugin.mjs"
       },
       "require": "./LexicalCheckListPlugin.js"
     },
     "./LexicalClearEditorPlugin": {
       "import": {
         "types": "./LexicalClearEditorPlugin.d.ts",
-        "default": "./LexicalClearEditorPlugin.esm.js"
+        "default": "./LexicalClearEditorPlugin.mjs"
       },
       "require": "./LexicalClearEditorPlugin.js"
     },
     "./LexicalClearEditorPlugin.js": {
       "import": {
         "types": "./LexicalClearEditorPlugin.d.ts",
-        "default": "./LexicalClearEditorPlugin.esm.js"
+        "default": "./LexicalClearEditorPlugin.mjs"
       },
       "require": "./LexicalClearEditorPlugin.js"
     },
     "./LexicalClickableLinkPlugin": {
       "import": {
         "types": "./LexicalClickableLinkPlugin.d.ts",
-        "default": "./LexicalClickableLinkPlugin.esm.js"
+        "default": "./LexicalClickableLinkPlugin.mjs"
       },
       "require": "./LexicalClickableLinkPlugin.js"
     },
     "./LexicalClickableLinkPlugin.js": {
       "import": {
         "types": "./LexicalClickableLinkPlugin.d.ts",
-        "default": "./LexicalClickableLinkPlugin.esm.js"
+        "default": "./LexicalClickableLinkPlugin.mjs"
       },
       "require": "./LexicalClickableLinkPlugin.js"
     },
     "./LexicalCollaborationContext": {
       "import": {
         "types": "./LexicalCollaborationContext.d.ts",
-        "default": "./LexicalCollaborationContext.esm.js"
+        "default": "./LexicalCollaborationContext.mjs"
       },
       "require": "./LexicalCollaborationContext.js"
     },
     "./LexicalCollaborationContext.js": {
       "import": {
         "types": "./LexicalCollaborationContext.d.ts",
-        "default": "./LexicalCollaborationContext.esm.js"
+        "default": "./LexicalCollaborationContext.mjs"
       },
       "require": "./LexicalCollaborationContext.js"
     },
     "./LexicalCollaborationPlugin": {
       "import": {
         "types": "./LexicalCollaborationPlugin.d.ts",
-        "default": "./LexicalCollaborationPlugin.esm.js"
+        "default": "./LexicalCollaborationPlugin.mjs"
       },
       "require": "./LexicalCollaborationPlugin.js"
     },
     "./LexicalCollaborationPlugin.js": {
       "import": {
         "types": "./LexicalCollaborationPlugin.d.ts",
-        "default": "./LexicalCollaborationPlugin.esm.js"
+        "default": "./LexicalCollaborationPlugin.mjs"
       },
       "require": "./LexicalCollaborationPlugin.js"
     },
     "./LexicalComposer": {
       "import": {
         "types": "./LexicalComposer.d.ts",
-        "default": "./LexicalComposer.esm.js"
+        "default": "./LexicalComposer.mjs"
       },
       "require": "./LexicalComposer.js"
     },
     "./LexicalComposer.js": {
       "import": {
         "types": "./LexicalComposer.d.ts",
-        "default": "./LexicalComposer.esm.js"
+        "default": "./LexicalComposer.mjs"
       },
       "require": "./LexicalComposer.js"
     },
     "./LexicalComposerContext": {
       "import": {
         "types": "./LexicalComposerContext.d.ts",
-        "default": "./LexicalComposerContext.esm.js"
+        "default": "./LexicalComposerContext.mjs"
       },
       "require": "./LexicalComposerContext.js"
     },
     "./LexicalComposerContext.js": {
       "import": {
         "types": "./LexicalComposerContext.d.ts",
-        "default": "./LexicalComposerContext.esm.js"
+        "default": "./LexicalComposerContext.mjs"
       },
       "require": "./LexicalComposerContext.js"
     },
     "./LexicalContentEditable": {
       "import": {
         "types": "./LexicalContentEditable.d.ts",
-        "default": "./LexicalContentEditable.esm.js"
+        "default": "./LexicalContentEditable.mjs"
       },
       "require": "./LexicalContentEditable.js"
     },
     "./LexicalContentEditable.js": {
       "import": {
         "types": "./LexicalContentEditable.d.ts",
-        "default": "./LexicalContentEditable.esm.js"
+        "default": "./LexicalContentEditable.mjs"
       },
       "require": "./LexicalContentEditable.js"
     },
     "./LexicalContextMenuPlugin": {
       "import": {
         "types": "./LexicalContextMenuPlugin.d.ts",
-        "default": "./LexicalContextMenuPlugin.esm.js"
+        "default": "./LexicalContextMenuPlugin.mjs"
       },
       "require": "./LexicalContextMenuPlugin.js"
     },
     "./LexicalContextMenuPlugin.js": {
       "import": {
         "types": "./LexicalContextMenuPlugin.d.ts",
-        "default": "./LexicalContextMenuPlugin.esm.js"
+        "default": "./LexicalContextMenuPlugin.mjs"
       },
       "require": "./LexicalContextMenuPlugin.js"
     },
     "./LexicalDecoratorBlockNode": {
       "import": {
         "types": "./LexicalDecoratorBlockNode.d.ts",
-        "default": "./LexicalDecoratorBlockNode.esm.js"
+        "default": "./LexicalDecoratorBlockNode.mjs"
       },
       "require": "./LexicalDecoratorBlockNode.js"
     },
     "./LexicalDecoratorBlockNode.js": {
       "import": {
         "types": "./LexicalDecoratorBlockNode.d.ts",
-        "default": "./LexicalDecoratorBlockNode.esm.js"
+        "default": "./LexicalDecoratorBlockNode.mjs"
       },
       "require": "./LexicalDecoratorBlockNode.js"
     },
     "./LexicalEditorRefPlugin": {
       "import": {
         "types": "./LexicalEditorRefPlugin.d.ts",
-        "default": "./LexicalEditorRefPlugin.esm.js"
+        "default": "./LexicalEditorRefPlugin.mjs"
       },
       "require": "./LexicalEditorRefPlugin.js"
     },
     "./LexicalEditorRefPlugin.js": {
       "import": {
         "types": "./LexicalEditorRefPlugin.d.ts",
-        "default": "./LexicalEditorRefPlugin.esm.js"
+        "default": "./LexicalEditorRefPlugin.mjs"
       },
       "require": "./LexicalEditorRefPlugin.js"
     },
     "./LexicalErrorBoundary": {
       "import": {
         "types": "./LexicalErrorBoundary.d.ts",
-        "default": "./LexicalErrorBoundary.esm.js"
+        "default": "./LexicalErrorBoundary.mjs"
       },
       "require": "./LexicalErrorBoundary.js"
     },
     "./LexicalErrorBoundary.js": {
       "import": {
         "types": "./LexicalErrorBoundary.d.ts",
-        "default": "./LexicalErrorBoundary.esm.js"
+        "default": "./LexicalErrorBoundary.mjs"
       },
       "require": "./LexicalErrorBoundary.js"
     },
     "./LexicalHashtagPlugin": {
       "import": {
         "types": "./LexicalHashtagPlugin.d.ts",
-        "default": "./LexicalHashtagPlugin.esm.js"
+        "default": "./LexicalHashtagPlugin.mjs"
       },
       "require": "./LexicalHashtagPlugin.js"
     },
     "./LexicalHashtagPlugin.js": {
       "import": {
         "types": "./LexicalHashtagPlugin.d.ts",
-        "default": "./LexicalHashtagPlugin.esm.js"
+        "default": "./LexicalHashtagPlugin.mjs"
       },
       "require": "./LexicalHashtagPlugin.js"
     },
     "./LexicalHistoryPlugin": {
       "import": {
         "types": "./LexicalHistoryPlugin.d.ts",
-        "default": "./LexicalHistoryPlugin.esm.js"
+        "default": "./LexicalHistoryPlugin.mjs"
       },
       "require": "./LexicalHistoryPlugin.js"
     },
     "./LexicalHistoryPlugin.js": {
       "import": {
         "types": "./LexicalHistoryPlugin.d.ts",
-        "default": "./LexicalHistoryPlugin.esm.js"
+        "default": "./LexicalHistoryPlugin.mjs"
       },
       "require": "./LexicalHistoryPlugin.js"
     },
     "./LexicalHorizontalRuleNode": {
       "import": {
         "types": "./LexicalHorizontalRuleNode.d.ts",
-        "default": "./LexicalHorizontalRuleNode.esm.js"
+        "default": "./LexicalHorizontalRuleNode.mjs"
       },
       "require": "./LexicalHorizontalRuleNode.js"
     },
     "./LexicalHorizontalRuleNode.js": {
       "import": {
         "types": "./LexicalHorizontalRuleNode.d.ts",
-        "default": "./LexicalHorizontalRuleNode.esm.js"
+        "default": "./LexicalHorizontalRuleNode.mjs"
       },
       "require": "./LexicalHorizontalRuleNode.js"
     },
     "./LexicalHorizontalRulePlugin": {
       "import": {
         "types": "./LexicalHorizontalRulePlugin.d.ts",
-        "default": "./LexicalHorizontalRulePlugin.esm.js"
+        "default": "./LexicalHorizontalRulePlugin.mjs"
       },
       "require": "./LexicalHorizontalRulePlugin.js"
     },
     "./LexicalHorizontalRulePlugin.js": {
       "import": {
         "types": "./LexicalHorizontalRulePlugin.d.ts",
-        "default": "./LexicalHorizontalRulePlugin.esm.js"
+        "default": "./LexicalHorizontalRulePlugin.mjs"
       },
       "require": "./LexicalHorizontalRulePlugin.js"
     },
     "./LexicalLinkPlugin": {
       "import": {
         "types": "./LexicalLinkPlugin.d.ts",
-        "default": "./LexicalLinkPlugin.esm.js"
+        "default": "./LexicalLinkPlugin.mjs"
       },
       "require": "./LexicalLinkPlugin.js"
     },
     "./LexicalLinkPlugin.js": {
       "import": {
         "types": "./LexicalLinkPlugin.d.ts",
-        "default": "./LexicalLinkPlugin.esm.js"
+        "default": "./LexicalLinkPlugin.mjs"
       },
       "require": "./LexicalLinkPlugin.js"
     },
     "./LexicalListPlugin": {
       "import": {
         "types": "./LexicalListPlugin.d.ts",
-        "default": "./LexicalListPlugin.esm.js"
+        "default": "./LexicalListPlugin.mjs"
       },
       "require": "./LexicalListPlugin.js"
     },
     "./LexicalListPlugin.js": {
       "import": {
         "types": "./LexicalListPlugin.d.ts",
-        "default": "./LexicalListPlugin.esm.js"
+        "default": "./LexicalListPlugin.mjs"
       },
       "require": "./LexicalListPlugin.js"
     },
     "./LexicalMarkdownShortcutPlugin": {
       "import": {
         "types": "./LexicalMarkdownShortcutPlugin.d.ts",
-        "default": "./LexicalMarkdownShortcutPlugin.esm.js"
+        "default": "./LexicalMarkdownShortcutPlugin.mjs"
       },
       "require": "./LexicalMarkdownShortcutPlugin.js"
     },
     "./LexicalMarkdownShortcutPlugin.js": {
       "import": {
         "types": "./LexicalMarkdownShortcutPlugin.d.ts",
-        "default": "./LexicalMarkdownShortcutPlugin.esm.js"
+        "default": "./LexicalMarkdownShortcutPlugin.mjs"
       },
       "require": "./LexicalMarkdownShortcutPlugin.js"
     },
     "./LexicalNestedComposer": {
       "import": {
         "types": "./LexicalNestedComposer.d.ts",
-        "default": "./LexicalNestedComposer.esm.js"
+        "default": "./LexicalNestedComposer.mjs"
       },
       "require": "./LexicalNestedComposer.js"
     },
     "./LexicalNestedComposer.js": {
       "import": {
         "types": "./LexicalNestedComposer.d.ts",
-        "default": "./LexicalNestedComposer.esm.js"
+        "default": "./LexicalNestedComposer.mjs"
       },
       "require": "./LexicalNestedComposer.js"
     },
     "./LexicalNodeEventPlugin": {
       "import": {
         "types": "./LexicalNodeEventPlugin.d.ts",
-        "default": "./LexicalNodeEventPlugin.esm.js"
+        "default": "./LexicalNodeEventPlugin.mjs"
       },
       "require": "./LexicalNodeEventPlugin.js"
     },
     "./LexicalNodeEventPlugin.js": {
       "import": {
         "types": "./LexicalNodeEventPlugin.d.ts",
-        "default": "./LexicalNodeEventPlugin.esm.js"
+        "default": "./LexicalNodeEventPlugin.mjs"
       },
       "require": "./LexicalNodeEventPlugin.js"
     },
     "./LexicalNodeMenuPlugin": {
       "import": {
         "types": "./LexicalNodeMenuPlugin.d.ts",
-        "default": "./LexicalNodeMenuPlugin.esm.js"
+        "default": "./LexicalNodeMenuPlugin.mjs"
       },
       "require": "./LexicalNodeMenuPlugin.js"
     },
     "./LexicalNodeMenuPlugin.js": {
       "import": {
         "types": "./LexicalNodeMenuPlugin.d.ts",
-        "default": "./LexicalNodeMenuPlugin.esm.js"
+        "default": "./LexicalNodeMenuPlugin.mjs"
       },
       "require": "./LexicalNodeMenuPlugin.js"
     },
     "./LexicalOnChangePlugin": {
       "import": {
         "types": "./LexicalOnChangePlugin.d.ts",
-        "default": "./LexicalOnChangePlugin.esm.js"
+        "default": "./LexicalOnChangePlugin.mjs"
       },
       "require": "./LexicalOnChangePlugin.js"
     },
     "./LexicalOnChangePlugin.js": {
       "import": {
         "types": "./LexicalOnChangePlugin.d.ts",
-        "default": "./LexicalOnChangePlugin.esm.js"
+        "default": "./LexicalOnChangePlugin.mjs"
       },
       "require": "./LexicalOnChangePlugin.js"
     },
     "./LexicalPlainTextPlugin": {
       "import": {
         "types": "./LexicalPlainTextPlugin.d.ts",
-        "default": "./LexicalPlainTextPlugin.esm.js"
+        "default": "./LexicalPlainTextPlugin.mjs"
       },
       "require": "./LexicalPlainTextPlugin.js"
     },
     "./LexicalPlainTextPlugin.js": {
       "import": {
         "types": "./LexicalPlainTextPlugin.d.ts",
-        "default": "./LexicalPlainTextPlugin.esm.js"
+        "default": "./LexicalPlainTextPlugin.mjs"
       },
       "require": "./LexicalPlainTextPlugin.js"
     },
     "./LexicalRichTextPlugin": {
       "import": {
         "types": "./LexicalRichTextPlugin.d.ts",
-        "default": "./LexicalRichTextPlugin.esm.js"
+        "default": "./LexicalRichTextPlugin.mjs"
       },
       "require": "./LexicalRichTextPlugin.js"
     },
     "./LexicalRichTextPlugin.js": {
       "import": {
         "types": "./LexicalRichTextPlugin.d.ts",
-        "default": "./LexicalRichTextPlugin.esm.js"
+        "default": "./LexicalRichTextPlugin.mjs"
       },
       "require": "./LexicalRichTextPlugin.js"
     },
     "./LexicalTabIndentationPlugin": {
       "import": {
         "types": "./LexicalTabIndentationPlugin.d.ts",
-        "default": "./LexicalTabIndentationPlugin.esm.js"
+        "default": "./LexicalTabIndentationPlugin.mjs"
       },
       "require": "./LexicalTabIndentationPlugin.js"
     },
     "./LexicalTabIndentationPlugin.js": {
       "import": {
         "types": "./LexicalTabIndentationPlugin.d.ts",
-        "default": "./LexicalTabIndentationPlugin.esm.js"
+        "default": "./LexicalTabIndentationPlugin.mjs"
       },
       "require": "./LexicalTabIndentationPlugin.js"
     },
     "./LexicalTableOfContents": {
       "import": {
         "types": "./LexicalTableOfContents.d.ts",
-        "default": "./LexicalTableOfContents.esm.js"
+        "default": "./LexicalTableOfContents.mjs"
       },
       "require": "./LexicalTableOfContents.js"
     },
     "./LexicalTableOfContents.js": {
       "import": {
         "types": "./LexicalTableOfContents.d.ts",
-        "default": "./LexicalTableOfContents.esm.js"
+        "default": "./LexicalTableOfContents.mjs"
       },
       "require": "./LexicalTableOfContents.js"
     },
     "./LexicalTablePlugin": {
       "import": {
         "types": "./LexicalTablePlugin.d.ts",
-        "default": "./LexicalTablePlugin.esm.js"
+        "default": "./LexicalTablePlugin.mjs"
       },
       "require": "./LexicalTablePlugin.js"
     },
     "./LexicalTablePlugin.js": {
       "import": {
         "types": "./LexicalTablePlugin.d.ts",
-        "default": "./LexicalTablePlugin.esm.js"
+        "default": "./LexicalTablePlugin.mjs"
       },
       "require": "./LexicalTablePlugin.js"
     },
     "./LexicalTreeView": {
       "import": {
         "types": "./LexicalTreeView.d.ts",
-        "default": "./LexicalTreeView.esm.js"
+        "default": "./LexicalTreeView.mjs"
       },
       "require": "./LexicalTreeView.js"
     },
     "./LexicalTreeView.js": {
       "import": {
         "types": "./LexicalTreeView.d.ts",
-        "default": "./LexicalTreeView.esm.js"
+        "default": "./LexicalTreeView.mjs"
       },
       "require": "./LexicalTreeView.js"
     },
     "./LexicalTypeaheadMenuPlugin": {
       "import": {
         "types": "./LexicalTypeaheadMenuPlugin.d.ts",
-        "default": "./LexicalTypeaheadMenuPlugin.esm.js"
+        "default": "./LexicalTypeaheadMenuPlugin.mjs"
       },
       "require": "./LexicalTypeaheadMenuPlugin.js"
     },
     "./LexicalTypeaheadMenuPlugin.js": {
       "import": {
         "types": "./LexicalTypeaheadMenuPlugin.d.ts",
-        "default": "./LexicalTypeaheadMenuPlugin.esm.js"
+        "default": "./LexicalTypeaheadMenuPlugin.mjs"
       },
       "require": "./LexicalTypeaheadMenuPlugin.js"
     },
     "./useLexicalEditable": {
       "import": {
         "types": "./useLexicalEditable.d.ts",
-        "default": "./useLexicalEditable.esm.js"
+        "default": "./useLexicalEditable.mjs"
       },
       "require": "./useLexicalEditable.js"
     },
     "./useLexicalEditable.js": {
       "import": {
         "types": "./useLexicalEditable.d.ts",
-        "default": "./useLexicalEditable.esm.js"
+        "default": "./useLexicalEditable.mjs"
       },
       "require": "./useLexicalEditable.js"
     },
     "./useLexicalIsTextContentEmpty": {
       "import": {
         "types": "./useLexicalIsTextContentEmpty.d.ts",
-        "default": "./useLexicalIsTextContentEmpty.esm.js"
+        "default": "./useLexicalIsTextContentEmpty.mjs"
       },
       "require": "./useLexicalIsTextContentEmpty.js"
     },
     "./useLexicalIsTextContentEmpty.js": {
       "import": {
         "types": "./useLexicalIsTextContentEmpty.d.ts",
-        "default": "./useLexicalIsTextContentEmpty.esm.js"
+        "default": "./useLexicalIsTextContentEmpty.mjs"
       },
       "require": "./useLexicalIsTextContentEmpty.js"
     },
     "./useLexicalNodeSelection": {
       "import": {
         "types": "./useLexicalNodeSelection.d.ts",
-        "default": "./useLexicalNodeSelection.esm.js"
+        "default": "./useLexicalNodeSelection.mjs"
       },
       "require": "./useLexicalNodeSelection.js"
     },
     "./useLexicalNodeSelection.js": {
       "import": {
         "types": "./useLexicalNodeSelection.d.ts",
-        "default": "./useLexicalNodeSelection.esm.js"
+        "default": "./useLexicalNodeSelection.mjs"
       },
       "require": "./useLexicalNodeSelection.js"
     },
     "./useLexicalSubscription": {
       "import": {
         "types": "./useLexicalSubscription.d.ts",
-        "default": "./useLexicalSubscription.esm.js"
+        "default": "./useLexicalSubscription.mjs"
       },
       "require": "./useLexicalSubscription.js"
     },
     "./useLexicalSubscription.js": {
       "import": {
         "types": "./useLexicalSubscription.d.ts",
-        "default": "./useLexicalSubscription.esm.js"
+        "default": "./useLexicalSubscription.mjs"
       },
       "require": "./useLexicalSubscription.js"
     },
     "./useLexicalTextEntity": {
       "import": {
         "types": "./useLexicalTextEntity.d.ts",
-        "default": "./useLexicalTextEntity.esm.js"
+        "default": "./useLexicalTextEntity.mjs"
       },
       "require": "./useLexicalTextEntity.js"
     },
     "./useLexicalTextEntity.js": {
       "import": {
         "types": "./useLexicalTextEntity.d.ts",
-        "default": "./useLexicalTextEntity.esm.js"
+        "default": "./useLexicalTextEntity.mjs"
       },
       "require": "./useLexicalTextEntity.js"
     }

--- a/packages/lexical-rich-text/package.json
+++ b/packages/lexical-rich-text/package.json
@@ -20,6 +20,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-rich-text"
   },
-  "module": "LexicalRichText.esm.js",
+  "module": "LexicalRichText.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-selection/package.json
+++ b/packages/lexical-selection/package.json
@@ -19,6 +19,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-selection"
   },
-  "module": "LexicalSelection.esm.js",
+  "module": "LexicalSelection.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-table/package.json
+++ b/packages/lexical-table/package.json
@@ -21,6 +21,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-table"
   },
-  "module": "LexicalTable.esm.js",
+  "module": "LexicalTable.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-text/package.json
+++ b/packages/lexical-text/package.json
@@ -19,6 +19,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-text"
   },
-  "module": "LexicalText.esm.js",
+  "module": "LexicalText.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-utils/package.json
+++ b/packages/lexical-utils/package.json
@@ -23,6 +23,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-utils"
   },
-  "module": "LexicalUtils.esm.js",
+  "module": "LexicalUtils.mjs",
   "sideEffects": false
 }

--- a/packages/lexical-yjs/package.json
+++ b/packages/lexical-yjs/package.json
@@ -25,6 +25,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical-yjs"
   },
-  "module": "LexicalYjs.esm.js",
+  "module": "LexicalYjs.mjs",
   "sideEffects": false
 }

--- a/packages/lexical/package.json
+++ b/packages/lexical/package.json
@@ -16,6 +16,6 @@
     "url": "https://github.com/facebook/lexical",
     "directory": "packages/lexical"
   },
-  "module": "Lexical.esm.js",
+  "module": "Lexical.mjs",
   "sideEffects": false
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -149,7 +149,7 @@ Object.keys(wwwMappings).forEach((mapping) => {
 });
 
 function getExtension(format) {
-  return `${format === 'esm' ? '.esm' : ''}.js`;
+  return `.${format === 'esm' ? 'm' : ''}js`;
 }
 
 async function build(name, inputFile, outputPath, outputFile, isProd, format) {


### PR DESCRIPTION
execute `NODE_OPTIONS=--experimental-vm-modules jest`

<img width="1511" alt="image" src="https://github.com/facebook/lexical/assets/47748132/0d095c64-0c53-4281-8e6b-ec410bb818f9">

only execute `jest`

<img width="1511" alt="image" src="https://github.com/facebook/lexical/assets/47748132/39c3d154-beb9-4364-b7c5-869e0ab5902b">

It seems that Node.js would treat files that don't have a .mjs extension as CommonJS.