### PR TITLE
Fix check for menu cannot fit on top

### DIFF
--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -516,7 +516,7 @@ export function useMenuAnchorRef(
         if (
           (top + menuHeight > window.innerHeight ||
             top + menuHeight > rootElementRect.bottom) &&
-          top - rootElementRect.top > menuHeight
+          top - rootElementRect.top > menuHeight + height
         ) {
           containerDiv.style.top = `${
             top - menuHeight + window.pageYOffset - height


### PR DESCRIPTION
issue https://github.com/facebook/lexical/issues/5740 

Originally, the check doesn't consider the resolution height, but the resolution height is being used below to determine the style.top. This causes the element to overlap with the parent box, and in turn causes the menu to close onScroll, because of the check [here](https://github.com/facebook/lexical/blob/6e4f072ea194e7d3e631e488ad1ca1be79add50e/packages/lexical-react/src/shared/LexicalMenu.ts#L225).

<img width="391" alt="Screenshot 2024-03-20 at 3 14 23 AM" src="https://github.com/facebook/lexical/assets/30300487/384b643f-f4ba-4b2c-aa39-79429b5a2c18">
<img width="318" alt="Screenshot 2024-03-20 at 3 31 46 AM" src="https://github.com/facebook/lexical/assets/30300487/71eb58c9-d7d4-42c1-b56d-ef1c6ac48607">

Add the height check to the RHS of the > , so the menu won't be placed on the top if it cannot fit.

Taking a step back, I'm not sure why when the menu is placed on top of the cursor, it's `height` length away from the cursor, whereas when the menu is placed below the cursor, it's 0 length away from the cursor. In other words, we could have removed both `+ height` on line 519 and `- height` on line 522, but I didn't implement that to preserve the original style.

## Results

Before:
<img width="946" alt="Screenshot 2024-03-20 at 4 33 28 AM" src="https://github.com/facebook/lexical/assets/30300487/01827f94-e66e-41d1-b73b-00edd836ee64">

After:
<img width="1016" alt="Screenshot 2024-03-20 at 4 33 46 AM" src="https://github.com/facebook/lexical/assets/30300487/3bae6cad-a582-486b-88ed-ebd8d626ad46">

