### PR TITLE
fix: removed window.pageXOffset and window.pageYOffset from TableActionMenu position calculation

### DIFF
--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -236,16 +236,22 @@ function TableActionMenu({
       ) {
         const position =
           menuButtonRect.left - dropDownElementRect.width - margin;
-        leftPosition = (position < 0 ? margin : position) + window.pageXOffset;
+        // leftPosition = (position < 0 ? margin : position) + window.pageXOffset
+        leftPosition = position < 0 ? margin : position;
       }
-      dropDownElement.style.left = `${leftPosition + window.pageXOffset}px`;
+      // TODO: Revisit - this almost seems too easy as a fix for correct x / y position
+      // dropDownElement.style.left = `${leftPosition + window.pageXOffset}px`
+      dropDownElement.style.left = `${leftPosition}px`;
 
       let topPosition = menuButtonRect.top;
       if (topPosition + dropDownElementRect.height > window.innerHeight) {
         const position = menuButtonRect.bottom - dropDownElementRect.height;
-        topPosition = (position < 0 ? margin : position) + window.pageYOffset;
+        // topPosition = (position < 0 ? margin : position) + window.pageYOffset
+        topPosition = position < 0 ? margin : position;
       }
-      dropDownElement.style.top = `${topPosition + +window.pageYOffset}px`;
+      // TODO: Revisit - this almost seems too easy as a fix for correct x / y position
+      // dropDownElement.style.top = `${topPosition + +window.pageYOffset}px`
+      dropDownElement.style.top = `${topPosition}px`;
     }
   }, [contextRef, dropDownRef, editor]);
 


### PR DESCRIPTION
Apologies for the YOLO PR, however, based on a recent discord discussion here  https://discord.com/channels/953974421008293909/953974421486436393/1219603905198161920 - it appears we are not the only ones having a problem with the TableActionMenu plugin dropdown position when there are multiple editors on the page, or when the editor position requires scrolling down (i.e. the editor appears lower down on the page or 'below the fold'). In these cases, the dropdown menu does not appear over the cell that requested it (it may not even appear in the browser viewport).

This PR contains the fix we applied (and re-apply if we ever take an update from the Playground).

It works for us without any problem on all editor instances, irrespective of how many editors there are or whether you have to 'scroll down' to use the editor. See the screenshot below.

However, I have NOT tested this in the Playground demo site yet, and there may be an 'adjustment' like 'position: relative' required in the editor container there (honestly not sure).

See the comments in the commit as well.

Hope at least that this is of some help.

<img width="700" alt="image" src="https://github.com/facebook/lexical/assets/405612/078fb592-93b7-4089-8945-110a467543fe">
