### PR TITLE
Update build script to exclude WWW from ESM modules

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -654,6 +654,10 @@ async function buildAll() {
 
     for (const module of modules) {
       for (const format of ['cjs', 'esm']) {
+        if (isWWW && format === 'esm') {
+          break;
+        }
+
         const {sourceFileName, outputFileName} = module;
         let inputFile = path.resolve(
           path.join(`${sourcePath}${sourceFileName}`),


### PR DESCRIPTION
Haste doesn't work well with ESM modules, especially minified prod builds. 