### PR TITLE
fix: Double input of text including composing, such as Japanese, at TextNode Boundaries with in a MarkNode #5761

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -713,13 +713,15 @@ export function $shouldInsertTextAfterOrBeforeTextNode(
   if (offset === 0) {
     return (
       !node.canInsertTextBefore() ||
-      !parent.canInsertTextBefore() ||
+      (!parent.canInsertTextBefore() && !node.isComposing()) ||
       isToken ||
       $previousSiblingDoesNotAcceptText(node)
     );
   } else if (offset === node.getTextContentSize()) {
     return (
-      !node.canInsertTextAfter() || !parent.canInsertTextAfter() || isToken
+      !node.canInsertTextAfter() ||
+      (!parent.canInsertTextAfter() && !node.isComposing()) ||
+      isToken
     );
   } else {
     return false;


### PR DESCRIPTION
fixed #5761

## After
https://github.com/facebook/lexical/assets/111737064/4d6f94da-a90a-4810-b79f-7e463e8101cb


## Bug
This happens inside an ElementNode, like MarkNode or LinkNode, where `canInsertTextAfter` or `canInsertTextBefore` is set to false. If a part of the internal TextNode is formatted to split it, and text that includes composing is inputted at the boundary, the composition is released, and the text is inputted twice.

## Cause of the bug
The bug arise when the `CONTROLLED_TEXT_INSERTION_COMMAND` is unnecessarily triggered, even when `isComposition` is true at the node boundary.
Despite the fact that text insertion into the Node is already being behind elsewhere during composing, the `selection.insertText` function called by the command cause a repeated input.
This leads to the text being doubly entered.

## Solution
To resolve this, I modified the behavior so that `CONTROLLED_TEXT_INSERTION_COMMAND` does not get triggered while composing at the boundary.
`$shouldInsertTextAfterOrBeforeTextNode` function now returns false during composing because it was previously causing the command to dispatch at boundary inputs.

Since text input during composing is a provisional state, the default behavior is sufficient.
The strategy now ensure that the behavior at the boundary is confirmed only after composing has concluded.