### PR TITLE
Fix selection started from inside of the table

### DIFF
--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -24,7 +24,6 @@ import {
   $setSelection,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
-import {CAN_USE_DOM} from 'shared/canUseDOM';
 import invariant from 'shared/invariant';
 
 import {$isTableCellNode} from './LexicalTableCellNode';
@@ -34,7 +33,7 @@ import {
   $createTableSelection,
   $isTableSelection,
 } from './LexicalTableSelection';
-import {$updateDOMForSelection, getTable} from './LexicalTableSelectionHelpers';
+import {$findTableNode, $updateDOMForSelection, getDOMSelection,getTable} from './LexicalTableSelectionHelpers';
 
 export type TableDOMCell = {
   elem: HTMLElement;
@@ -51,9 +50,6 @@ export type TableDOMTable = {
   columns: number;
   rows: number;
 };
-
-const getDOMSelection = (targetWindow: Window | null): Selection | null =>
-  CAN_USE_DOM ? (targetWindow || window).getSelection() : null;
 
 export class TableObserver {
   focusX: number;
@@ -283,7 +279,8 @@ export class TableObserver {
         if (
           this.tableSelection != null &&
           this.anchorCellNodeKey != null &&
-          $isTableCellNode(focusTableCellNode)
+          $isTableCellNode(focusTableCellNode) &&
+          tableNode.is($findTableNode(focusTableCellNode))
         ) {
           const focusNodeKey = focusTableCellNode.getKey();
 

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -33,7 +33,12 @@ import {
   $createTableSelection,
   $isTableSelection,
 } from './LexicalTableSelection';
-import {$findTableNode, $updateDOMForSelection, getDOMSelection,getTable} from './LexicalTableSelectionHelpers';
+import {
+  $findTableNode,
+  $updateDOMForSelection,
+  getDOMSelection,
+  getTable,
+} from './LexicalTableSelectionHelpers';
 
 export type TableDOMCell = {
   elem: HTMLElement;

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -738,20 +738,30 @@ export function applyTableHandlers(
             const isFocusOutside =
               focusNode && !tableNode.is($findTableNode(focusNode));
 
-            if (isFocusOutside && domSelection.rangeCount > 0) {
+            const anchorNode = $getNearestNodeFromDOMNode(
+              domSelection.anchorNode,
+            );
+            const isAnchorInside =
+              anchorNode && tableNode.is($findTableNode(anchorNode));
+
+            if (
+              isFocusOutside &&
+              isAnchorInside &&
+              domSelection.rangeCount > 0
+            ) {
               const newSelection = $createRangeSelectionFromDom(
                 domSelection,
                 editor,
               );
-              if (isFocusOutside && newSelection) {
+              if (newSelection) {
                 newSelection.anchor.set(
                   tableNode.getKey(),
                   selection.isBackward() ? tableNode.getChildrenSize() : 0,
                   'element',
                 );
+                domSelection.removeAllRanges();
+                $setSelection(newSelection);
               }
-              domSelection.removeAllRanges();
-              $setSelection(newSelection);
             }
           }
         }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2201,6 +2201,13 @@ export function internalCreateSelection(
   return lastSelection.clone();
 }
 
+export function $createRangeSelectionFromDom(
+  domSelection: Selection | null,
+  editor: LexicalEditor,
+): null | RangeSelection {
+  return internalCreateRangeSelection(null, domSelection, editor, null);
+}
+
 export function internalCreateRangeSelection(
   lastSelection: null | BaseSelection,
   domSelection: Selection | null,

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -123,6 +123,7 @@ export {
   $createNodeSelection,
   $createPoint,
   $createRangeSelection,
+  $createRangeSelectionFromDom,
   $getCharacterOffsets,
   $getPreviousSelection,
   $getSelection,


### PR DESCRIPTION
Making it possible to select content beyond the table when starting the selection from inside of the table. In this case the whole table becomes selected similar to the case when selection starts from outside of the table and goes inside. Table selection is replaced with the Range selection
Before:
![table selection before](https://github.com/facebook/lexical/assets/29728044/e7744a2e-a994-482a-a2dd-ad8ef8685a81)
After:
![table selection after](https://github.com/facebook/lexical/assets/29728044/1eef18cf-a159-4589-a57f-ec349f4b7e7c)


Allowing to drag a selection from one table to the other without crashing
Fixes the following error:
![2 tables crash](https://github.com/facebook/lexical/assets/29728044/53c75bb4-e025-4cbe-91a6-d6932c919ea1)
