### PR TITLE
Improve table selection and navigation

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -147,6 +147,300 @@ test.describe('Tables', () => {
     );
   });
 
+  test.describe(`Can exit tables with the horizontal arrow keys`, () => {
+    test(`Can exit the first cell of a non-nested table`, async ({
+      page,
+      isPlainText,
+      isCollab,
+    }) => {
+      await initialize({isCollab, page});
+      test.skip(isPlainText);
+
+      await focusEditor(page);
+      await insertTable(page, 2, 2);
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [1, 0, 0, 0],
+        focusOffset: 0,
+        focusPath: [1, 0, 0, 0],
+      });
+
+      await page.keyboard.press('ArrowLeft');
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0],
+        focusOffset: 0,
+        focusPath: [0],
+      });
+
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.type('ab');
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [1, 0, 0, 0, 0, 0],
+        focusOffset: 2,
+        focusPath: [1, 0, 0, 0, 0, 0],
+      });
+
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('ArrowLeft');
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0],
+        focusOffset: 0,
+        focusPath: [0],
+      });
+    });
+
+    test(`Can exit the last cell of a non-nested table`, async ({
+      page,
+      isPlainText,
+      isCollab,
+    }) => {
+      await initialize({isCollab, page});
+      test.skip(isPlainText);
+
+      await focusEditor(page);
+      await insertTable(page, 2, 2);
+
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('ArrowRight');
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [1, 1, 1, 0],
+        focusOffset: 0,
+        focusPath: [1, 1, 1, 0],
+      });
+
+      await page.keyboard.press('ArrowRight');
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [2],
+        focusOffset: 0,
+        focusPath: [2],
+      });
+
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.type('ab');
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [1, 1, 1, 0, 0, 0],
+        focusOffset: 2,
+        focusPath: [1, 1, 1, 0, 0, 0],
+      });
+
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('ArrowRight');
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [2],
+        focusOffset: 0,
+        focusPath: [2],
+      });
+    });
+
+    test(`Can exit the first cell of a nested table into the parent table cell`, async ({
+      page,
+      isPlainText,
+      isCollab,
+    }) => {
+      await initialize({isCollab, page});
+      test.skip(isPlainText);
+
+      await focusEditor(page);
+      await insertTable(page, 2, 2);
+      await insertTable(page, 2, 2);
+
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [1, 0, 0, 1, 0, 0, 0],
+        focusOffset: 0,
+        focusPath: [1, 0, 0, 1, 0, 0, 0],
+      });
+
+      await page.keyboard.press('ArrowLeft');
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [1, 0, 0, 0],
+        focusOffset: 0,
+        focusPath: [1, 0, 0, 0],
+      });
+    });
+
+    test(`Can exit the last cell of a nested table into the parent table cell`, async ({
+      page,
+      isPlainText,
+      isCollab,
+    }) => {
+      await initialize({isCollab, page});
+      test.skip(isPlainText);
+
+      await focusEditor(page);
+      await insertTable(page, 2, 2);
+      await insertTable(page, 2, 2);
+
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('ArrowRight');
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [1, 0, 0, 1, 1, 1, 0],
+        focusOffset: 0,
+        focusPath: [1, 0, 0, 1, 1, 1, 0],
+      });
+
+      await page.keyboard.press('ArrowRight');
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [1, 0, 0, 2],
+        focusOffset: 0,
+        focusPath: [1, 0, 0, 2],
+      });
+    });
+  });
+
+  test(`Can insert a paragraph after a table, that is the last node, with the "Enter" key`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    await initialize({isCollab, page});
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await insertTable(page, 2, 2);
+
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Backspace');
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [1, 1, 1, 0],
+      focusOffset: 0,
+      focusPath: [1, 1, 1, 0],
+    });
+
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('Enter');
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [2],
+      focusOffset: 0,
+      focusPath: [2],
+    });
+    await assertHTML(
+      page,
+      html`
+        <p><br /></p>
+        <table>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <th>
+              <p><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p><br /></p>
+      `,
+      undefined,
+      {ignoreClasses: true},
+    );
+  });
+
+  test(`Can type text after a table that is the last node`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    await initialize({isCollab, page});
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await insertTable(page, 2, 2);
+
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Backspace');
+
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.type('a');
+    await assertSelection(page, {
+      anchorOffset: 1,
+      anchorPath: [2, 0, 0],
+      focusOffset: 1,
+      focusPath: [2, 0, 0],
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <p><br /></p>
+        <table>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <th>
+              <p><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th>
+              <p><br /></p>
+            </th>
+            <td>
+              <p><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p dir="ltr"><span data-lexical-text="true">a</span></p>
+      `,
+      undefined,
+      {ignoreClasses: true},
+    );
+  });
+
+  test(`Can enter a table from a paragraph underneath via the left arrow key`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    await initialize({isCollab, page});
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await insertTable(page, 2, 2);
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [2],
+      focusOffset: 0,
+      focusPath: [2],
+    });
+
+    await page.keyboard.press('ArrowLeft');
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [1, 1, 1, 0],
+      focusOffset: 0,
+      focusPath: [1, 1, 1, 0],
+    });
+  });
+
   test(`Can navigate table with keyboard`, async ({
     page,
     isPlainText,

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -66,17 +66,6 @@ async function fillTablePartiallyWithText(page) {
   await page.keyboard.press('c');
 }
 
-async function focusCollabEditor(page) {
-  await focusEditor(page);
-  // In collaboration mode, the editor starts off empty without a default paragraph.
-  // This will disrupt selection paths when a table is inserted via the select dropdown.
-  // To handle this, we simulate typing 'a' and then deleting it.
-  // This will add the paragraph that guarantees the selection paths are the same
-  // as in the non-collab mode.
-  await page.keyboard.type('a');
-  await page.keyboard.press('Backspace');
-}
-
 test.describe('Tables', () => {
   test(`Can a table be inserted from the toolbar`, async ({
     page,
@@ -169,11 +158,7 @@ test.describe('Tables', () => {
       await initialize({isCollab, page});
       test.skip(isPlainText);
 
-      if (isCollab) {
-        await focusCollabEditor(page);
-      } else {
-        await focusEditor(page);
-      }
+      await focusEditor(page);
       await insertTable(page, 2, 2);
 
       await assertSelection(page, {
@@ -217,11 +202,7 @@ test.describe('Tables', () => {
       await initialize({isCollab, page});
       test.skip(isPlainText);
 
-      if (isCollab) {
-        await focusCollabEditor(page);
-      } else {
-        await focusEditor(page);
-      }
+      await focusEditor(page);
       await insertTable(page, 2, 2);
 
       await moveRight(page, 3);
@@ -266,11 +247,7 @@ test.describe('Tables', () => {
       await initialize({isCollab, page});
       test.skip(isPlainText);
 
-      if (isCollab) {
-        await focusCollabEditor(page);
-      } else {
-        await focusEditor(page);
-      }
+      await focusEditor(page);
       await insertTable(page, 2, 2);
       await insertTable(page, 2, 2);
 
@@ -298,11 +275,7 @@ test.describe('Tables', () => {
       await initialize({isCollab, page});
       test.skip(isPlainText);
 
-      if (isCollab) {
-        await focusCollabEditor(page);
-      } else {
-        await focusEditor(page);
-      }
+      await focusEditor(page);
       await insertTable(page, 2, 2);
       await insertTable(page, 2, 2);
 
@@ -335,11 +308,7 @@ test.describe('Tables', () => {
     // Table edge cursor doesn't show up in Firefox.
     test.fixme(browserName === 'firefox');
 
-    if (isCollab) {
-      await focusCollabEditor(page);
-    } else {
-      await focusEditor(page);
-    }
+    await focusEditor(page);
     await insertTable(page, 2, 2);
 
     await moveDown(page, 2);
@@ -380,7 +349,7 @@ test.describe('Tables', () => {
           </tr>
         </table>
       `,
-      '',
+      undefined,
       {ignoreClasses: true},
     );
 
@@ -426,7 +395,7 @@ test.describe('Tables', () => {
         </table>
         <p><br /></p>
       `,
-      '',
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -444,11 +413,7 @@ test.describe('Tables', () => {
     // After typing, the dom selection gets set back to the internal previous selection during the update.
     test.fixme(LEGACY_EVENTS);
 
-    if (isCollab) {
-      await focusCollabEditor(page);
-    } else {
-      await focusEditor(page);
-    }
+    await focusEditor(page);
     await insertTable(page, 2, 2);
 
     await moveDown(page, 2);
@@ -487,7 +452,7 @@ test.describe('Tables', () => {
         </table>
         <p dir="ltr"><span data-lexical-text="true">a</span></p>
       `,
-      '',
+      undefined,
       {ignoreClasses: true},
     );
   });
@@ -500,11 +465,7 @@ test.describe('Tables', () => {
     await initialize({isCollab, page});
     test.skip(isPlainText);
 
-    if (isCollab) {
-      await focusCollabEditor(page);
-    } else {
-      await focusEditor(page);
-    }
+    await focusEditor(page);
     await insertTable(page, 2, 2);
 
     await moveDown(page, 2);

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -1532,6 +1532,13 @@ function $getTableEdgeCursorPosition(
     return undefined;
   }
 
+  const parentTable = $findMatchingParent(anchorCellNode, (n) =>
+    $isTableNode(n),
+  );
+  if (!$isTableNode(parentTable) || !parentTable.is(tableNode)) {
+    return undefined;
+  }
+
   const [tableMap, cellValue] = $computeTableMap(
     tableNode,
     anchorCellNode,

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -40,6 +40,7 @@ import {
   FOCUS_COMMAND,
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
+  INSERT_PARAGRAPH_COMMAND,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
@@ -742,6 +743,86 @@ export function applyTableHandlers(
         }
 
         return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    ),
+  );
+
+  tableObserver.listenersToRemove.add(
+    editor.registerCommand(
+      INSERT_PARAGRAPH_COMMAND,
+      () => {
+        const nativeSelection = window.getSelection();
+        if (nativeSelection === null) {
+          return false;
+        }
+        const nativeAnchorNode = nativeSelection.anchorNode;
+        if (nativeSelection.anchorNode === null) {
+          return false;
+        }
+        if (nativeAnchorNode !== editor.getRootElement()) {
+          return false;
+        }
+
+        // When the cursor is right after the table on the same line,
+        // there's no following node, the internal selection is within the last table cell
+        // while the native selection is at the root.
+        const selection = $getSelection();
+        if (
+          !$isRangeSelection(selection) ||
+          !selection.isCollapsed() ||
+          !$isSelectionInTable(selection, tableNode)
+        ) {
+          return false;
+        }
+
+        const anchorCellNode = $findMatchingParent(
+          selection.anchor.getNode(),
+          (n) => $isTableCellNode(n),
+        ) as TableCellNode | null;
+        if (!anchorCellNode) {
+          return false;
+        }
+
+        const [tableMap, cellValue] = $computeTableMap(
+          tableNode,
+          anchorCellNode,
+          anchorCellNode,
+        );
+        const firstCell = tableMap[0][0];
+        const lastCell = tableMap[tableMap.length - 1][tableMap[0].length - 1];
+        const {startRow, startColumn} = cellValue;
+
+        const insertParagraphBefore = () => {
+          const newParagraphNode = $createParagraphNode();
+          tableNode.insertBefore(newParagraphNode);
+          newParagraphNode.selectStart();
+        };
+        const insertParagraphAfter = () => {
+          const newParagraphNode = $createParagraphNode();
+          tableNode.insertAfter(newParagraphNode);
+          newParagraphNode.selectStart();
+        };
+
+        if (
+          startRow === firstCell.startRow &&
+          startColumn === firstCell.startColumn
+        ) {
+          insertParagraphBefore();
+          return true;
+        } else if (
+          startRow === lastCell.startRow &&
+          startColumn === lastCell.startColumn
+        ) {
+          if (tableNode.getNextSibling()) {
+            tableNode.selectNext();
+          } else {
+            insertParagraphAfter();
+          }
+          return true;
+        } else {
+          return false;
+        }
       },
       COMMAND_PRIORITY_CRITICAL,
     ),

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -27,8 +27,8 @@ import type {
 import {$findMatchingParent} from '@lexical/utils';
 import {
   $createParagraphNode,
-  $createTextNode,
   $createRangeSelectionFromDom,
+  $createTextNode,
   $getNearestNodeFromDOMNode,
   $getPreviousSelection,
   $getSelection,

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -466,19 +466,12 @@ export function applyTableHandlers(
               selection,
               tableNode,
             );
-            if (!edgePosition) {
-              return false;
+            if (edgePosition) {
+              $insertParagraphAtTableEdge(edgePosition, tableNode, [
+                $createTextNode(payload),
+              ]);
+              return true;
             }
-            // TODO: Add support for nested tables
-            let paragraphNode;
-            if (edgePosition === 'first') {
-              paragraphNode = $insertParagraphAtTableEdge(tableNode, 'before');
-            } else {
-              paragraphNode = $insertParagraphAtTableEdge(tableNode, 'after');
-            }
-            paragraphNode.append($createTextNode(payload));
-            paragraphNode.selectEnd();
-            return true;
           }
         }
 
@@ -850,18 +843,11 @@ export function applyTableHandlers(
           selection,
           tableNode,
         );
-        if (!edgePosition) {
-          return false;
+        if (edgePosition) {
+          $insertParagraphAtTableEdge(edgePosition, tableNode);
+          return true;
         }
-        // TODO: Add support for nested tables
-        let paragraphNode;
-        if (edgePosition === 'first') {
-          paragraphNode = $insertParagraphAtTableEdge(tableNode, 'before');
-        } else {
-          paragraphNode = $insertParagraphAtTableEdge(tableNode, 'after');
-        }
-        paragraphNode.selectEnd();
-        return true;
+        return false;
       },
       COMMAND_PRIORITY_CRITICAL,
     ),
@@ -1610,11 +1596,27 @@ function getExitingToNode(
     : tableNode.getNextSibling();
 }
 
+function $insertParagraphAtTableEdge(
+  edgePosition: 'first' | 'last',
+  tableNode: TableNode,
+  children?: LexicalNode[],
+) {
+  const paragraphNode = $createParagraphNode();
+  if (edgePosition === 'first') {
+    tableNode.insertBefore(paragraphNode);
+  } else {
+    tableNode.insertAfter(paragraphNode);
+  }
+  paragraphNode.append(...(children || []));
+  paragraphNode.selectEnd();
+}
+
 function $getTableEdgeCursorPosition(
   editor: LexicalEditor,
   selection: RangeSelection,
   tableNode: TableNode,
 ) {
+  // TODO: Add support for nested tables
   const domSelection = window.getSelection();
   if (!domSelection || domSelection.anchorNode !== editor.getRootElement()) {
     return undefined;
@@ -1655,17 +1657,4 @@ function $getTableEdgeCursorPosition(
   } else {
     return undefined;
   }
-}
-
-function $insertParagraphAtTableEdge(
-  tableNode: TableNode,
-  location: 'before' | 'after',
-) {
-  const newParagraphNode = $createParagraphNode();
-  if (location === 'before') {
-    tableNode.insertBefore(newParagraphNode);
-  } else {
-    tableNode.insertAfter(newParagraphNode);
-  }
-  return newParagraphNode;
 }


### PR DESCRIPTION
This PR addresses several issues related to table selection and navigation within the editor. The following changes have been made:

- Pressing the "arrow left" key to exit the first cell moves selection directly to the previous sibling node, if exists. Before, the selection is placed after the table and then at the new node. (Video 1)
- Pressing the "arrow right" key to exit the last cell moves selection directly to the next sibling node, if exists. Before, the selection is placed before the table and then at the new node. (Video 2)
- Pressing the"arrow left" key at the start of a paragraph under the table moves selection to the last cell of the table. (Fix #5627) (Video 3)
- Pressing the "Enter" key, when the cursor is before the table on the same line, moves selection to a new preceding paragraph. (Video 4)
- Pressing the "Enter" key, when the cursor is after the table on the same line, moves selection to the next paragraph (if exists), or otherwise,  a new paragraph. (Fix #5627) (Video 5)

https://www.loom.com/share/f16a323757294da7b767ba870fa18421?sid=e7ee42d6-2e59-4ffb-87db-00d8fed838d8

https://www.loom.com/share/b461840c78c443d4816cbb94cad938f7?sid=aa3406b5-b50b-4071-b1ef-b235e57e9154

https://www.loom.com/share/107d1bcac82f497085231858235fe3f3?sid=8dfc4d27-68af-465c-87e6-1e274e48e2bb

https://www.loom.com/share/454f7f63c2b34a3a838c3b0e6ccc6ca4?sid=0b00f765-360c-438e-a8b0-0b47f78ce4d9

https://www.loom.com/share/fed0547e1e894953811a70648c0c3751?sid=b75d789b-db7d-4ddf-a62f-331488bcdb0c

Updated 03/27/2024:
- Can now enter a nested table from the start of a paragraph in a table cell via "arrow left" key. (Video 6)
- Can now exit a nested table into the parent table cell via horizontal arrow keys. (Video 6)
- If a table is the last node and not a nested table, and the cursor is on the same line as the table, typing will insert the text in a new paragraph following the new table. (Video 7)

https://www.loom.com/share/9eedbba40dae4dc4b57090bf9404d0c9?sid=784bd357-fdc9-4206-895e-365714c65680

https://www.loom.com/share/e179a5c87235409fa8d1945636e5ba03?sid=009ab1ed-70b2-47d0-8cf4-891ccf26e62e

