### PR TITLE
Respect CSS zoom

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -16,7 +16,6 @@ body {
   -moz-osx-font-smoothing: grayscale;
   background: #eee;
   padding: 0 20px;
-  zoom: 1.5;
 }
 
 header {

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -16,6 +16,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   background: #eee;
   padding: 0 20px;
+  zoom: 1.5;
 }
 
 header {

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -17,6 +17,7 @@ import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {LexicalNestedComposer} from '@lexical/react/LexicalNestedComposer';
 import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
+import {calculateZoomLevel} from '@lexical/utils';
 import {$getNodeByKey} from 'lexical';
 import * as React from 'react';
 import {useEffect, useRef} from 'react';
@@ -146,13 +147,16 @@ export default function StickyComponent({
     const stickyContainer = stickyContainerRef.current;
     const positioning = positioningRef.current;
     const rootElementRect = positioning.rootElementRect;
+    const zoom = calculateZoomLevel(stickyContainer);
     if (
       stickyContainer !== null &&
       positioning.isDragging &&
       rootElementRect !== null
     ) {
-      positioning.x = event.pageX - positioning.offsetX - rootElementRect.left;
-      positioning.y = event.pageY - positioning.offsetY - rootElementRect.top;
+      positioning.x =
+        event.pageX / zoom - positioning.offsetX - rootElementRect.left;
+      positioning.y =
+        event.pageY / zoom - positioning.offsetY - rootElementRect.top;
       positionSticky(stickyContainer, positioning);
     }
   };
@@ -212,8 +216,9 @@ export default function StickyComponent({
           const positioning = positioningRef.current;
           if (stickContainer !== null) {
             const {top, left} = stickContainer.getBoundingClientRect();
-            positioning.offsetX = event.clientX - left;
-            positioning.offsetY = event.clientY - top;
+            const zoom = calculateZoomLevel(stickContainer);
+            positioning.offsetX = event.clientX / zoom - left;
+            positioning.offsetY = event.clientY / zoom - top;
             positioning.isDragging = true;
             stickContainer.classList.add('dragging');
             document.addEventListener('pointermove', handlePointerMove);

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -9,7 +9,7 @@ import './index.css';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {eventFiles} from '@lexical/rich-text';
-import {mergeRegister} from '@lexical/utils';
+import {calculateZoomLevel, mergeRegister} from '@lexical/utils';
 import {
   $getNearestNodeFromDOMNode,
   $getNodeByKey,
@@ -110,9 +110,11 @@ function getBlockElement(
       ];
 
       if (firstNodeRect && lastNodeRect) {
-        if (event.y < firstNodeRect.top) {
+        const firstNodeZoom = firstNode ? calculateZoomLevel(firstNode) : 1;
+        const lastNodeZoom = lastNode ? calculateZoomLevel(lastNode) : 1;
+        if (event.y / firstNodeZoom < firstNodeRect.top) {
           blockElem = firstNode;
-        } else if (event.y > lastNodeRect.bottom) {
+        } else if (event.y / lastNodeZoom > lastNodeRect.bottom) {
           blockElem = lastNode;
         }
 
@@ -131,10 +133,10 @@ function getBlockElement(
       if (elem === null) {
         break;
       }
-      const point = new Point(event.x, event.y);
+      const zoom = calculateZoomLevel(elem);
+      const point = new Point(event.x / zoom, event.y / zoom);
       const domRect = Rect.fromDOM(elem);
       const {marginTop, marginBottom} = getCollapsedMargins(elem);
-
       const rect = domRect.generateNewRect({
         bottom: domRect.bottom + marginBottom,
         left: anchorElementRect.left,

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -110,8 +110,8 @@ function getBlockElement(
       ];
 
       if (firstNodeRect && lastNodeRect) {
-        const firstNodeZoom = firstNode ? calculateZoomLevel(firstNode) : 1;
-        const lastNodeZoom = lastNode ? calculateZoomLevel(lastNode) : 1;
+        const firstNodeZoom = calculateZoomLevel(firstNode);
+        const lastNodeZoom = calculateZoomLevel(lastNode);
         if (event.y / firstNodeZoom < firstNodeRect.top) {
           blockElem = firstNode;
         } else if (event.y / lastNodeZoom > lastNodeRect.bottom) {
@@ -229,7 +229,6 @@ function setTargetLine(
     targetBlockElem.getBoundingClientRect();
   const {top: anchorTop, width: anchorWidth} =
     anchorElem.getBoundingClientRect();
-
   const {marginTop, marginBottom} = getCollapsedMargins(targetBlockElem);
   let lineTop = targetBlockElemTop;
   if (mouseY >= targetBlockElemTop) {
@@ -322,7 +321,12 @@ function useDraggableBlockMenu(
       if (targetBlockElem === null || targetLineElem === null) {
         return false;
       }
-      setTargetLine(targetLineElem, targetBlockElem, pageY, anchorElem);
+      setTargetLine(
+        targetLineElem,
+        targetBlockElem,
+        pageY / calculateZoomLevel(target),
+        anchorElem,
+      );
       // Prevent default event to be able to trigger onDrop events
       event.preventDefault();
       return true;
@@ -357,7 +361,7 @@ function useDraggableBlockMenu(
         return true;
       }
       const targetBlockElemTop = targetBlockElem.getBoundingClientRect().top;
-      if (pageY >= targetBlockElemTop) {
+      if (pageY / calculateZoomLevel(target) >= targetBlockElemTop) {
         targetNode.insertAfter(draggedNode);
       } else {
         targetNode.insertBefore(draggedNode);

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -22,6 +22,7 @@ import {
   getDOMCellFromTarget,
   TableCellNode,
 } from '@lexical/table';
+import {calculateZoomLevel} from '@lexical/utils';
 import {
   $getNearestNodeFromDOMNode,
   $getSelection,
@@ -260,10 +261,13 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
           if (activeCell === null) {
             return;
           }
+          const zoom = event.target
+            ? calculateZoomLevel(event.target as Element)
+            : 1;
 
           if (isHeightChanging(direction)) {
             const height = activeCell.elem.getBoundingClientRect().height;
-            const heightChange = Math.abs(event.clientY - y);
+            const heightChange = Math.abs(event.clientY - y) / zoom;
 
             const isShrinking = direction === 'bottom' && y > event.clientY;
 
@@ -279,7 +283,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
             width -=
               parseFloat(computedStyle.paddingLeft) +
               parseFloat(computedStyle.paddingRight);
-            const widthChange = Math.abs(event.clientX - x);
+            const widthChange = Math.abs(event.clientX - x) / zoom;
 
             const isShrinking = direction === 'right' && x > event.clientX;
 
@@ -326,6 +330,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
     if (activeCell) {
       const {height, width, top, left} =
         activeCell.elem.getBoundingClientRect();
+      const zoom = calculateZoomLevel(activeCell.elem);
 
       const styles = {
         bottom: {
@@ -354,7 +359,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
             window.pageXOffset + tableRect.left
           }px`;
           styles[draggingDirection].top = `${
-            window.pageYOffset + mouseCurrentPos.y
+            window.pageYOffset + mouseCurrentPos.y / zoom
           }px`;
           styles[draggingDirection].height = '3px';
           styles[draggingDirection].width = `${tableRect.width}px`;
@@ -363,7 +368,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
             window.pageYOffset + tableRect.top
           }px`;
           styles[draggingDirection].left = `${
-            window.pageXOffset + mouseCurrentPos.x
+            window.pageXOffset + mouseCurrentPos.x / zoom
           }px`;
           styles[draggingDirection].width = '3px';
           styles[draggingDirection].height = `${tableRect.height}px`;

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -261,9 +261,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
           if (activeCell === null) {
             return;
           }
-          const zoom = event.target
-            ? calculateZoomLevel(event.target as Element)
-            : 1;
+          const zoom = calculateZoomLevel(event.target as Element);
 
           if (isHeightChanging(direction)) {
             const height = activeCell.elem.getBoundingClientRect().height;

--- a/packages/lexical-playground/src/ui/ColorPicker.tsx
+++ b/packages/lexical-playground/src/ui/ColorPicker.tsx
@@ -8,6 +8,7 @@
 
 import './ColorPicker.css';
 
+import {calculateZoomLevel} from '@lexical/utils';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import * as React from 'react';
 
@@ -177,9 +178,9 @@ function MoveWrapper({className, style, onChange, children}: MoveWrapperProps) {
     if (divRef.current) {
       const {current: div} = divRef;
       const {width, height, left, top} = div.getBoundingClientRect();
-
-      const x = clamp(e.clientX - left, width, 0);
-      const y = clamp(e.clientY - top, height, 0);
+      const zoom = calculateZoomLevel(div);
+      const x = clamp(e.clientX / zoom - left, width, 0);
+      const y = clamp(e.clientY / zoom - top, height, 0);
 
       onChange({x, y});
     }

--- a/packages/lexical-playground/src/ui/ImageResizer.tsx
+++ b/packages/lexical-playground/src/ui/ImageResizer.tsx
@@ -8,6 +8,7 @@
 
 import type {LexicalEditor} from 'lexical';
 
+import {calculateZoomLevel} from '@lexical/utils';
 import * as React from 'react';
 import {useRef} from 'react';
 
@@ -148,14 +149,15 @@ export default function ImageResizer({
     if (image !== null && controlWrapper !== null) {
       event.preventDefault();
       const {width, height} = image.getBoundingClientRect();
+      const zoom = calculateZoomLevel(image);
       const positioning = positioningRef.current;
       positioning.startWidth = width;
       positioning.startHeight = height;
       positioning.ratio = width / height;
       positioning.currentWidth = width;
       positioning.currentHeight = height;
-      positioning.startX = event.clientX;
-      positioning.startY = event.clientY;
+      positioning.startX = event.clientX / zoom;
+      positioning.startY = event.clientY / zoom;
       positioning.isResizing = true;
       positioning.direction = direction;
 
@@ -180,9 +182,10 @@ export default function ImageResizer({
       positioning.direction & (Direction.south | Direction.north);
 
     if (image !== null && positioning.isResizing) {
+      const zoom = calculateZoomLevel(image);
       // Corner cursor
       if (isHorizontal && isVertical) {
-        let diff = Math.floor(positioning.startX - event.clientX);
+        let diff = Math.floor(positioning.startX - event.clientX / zoom);
         diff = positioning.direction & Direction.east ? -diff : diff;
 
         const width = clamp(
@@ -197,7 +200,7 @@ export default function ImageResizer({
         positioning.currentHeight = height;
         positioning.currentWidth = width;
       } else if (isVertical) {
-        let diff = Math.floor(positioning.startY - event.clientY);
+        let diff = Math.floor(positioning.startY - event.clientY / zoom);
         diff = positioning.direction & Direction.south ? -diff : diff;
 
         const height = clamp(
@@ -209,7 +212,7 @@ export default function ImageResizer({
         image.style.height = `${height}px`;
         positioning.currentHeight = height;
       } else {
-        let diff = Math.floor(positioning.startX - event.clientX);
+        let diff = Math.floor(positioning.startX - event.clientX / zoom);
         diff = positioning.direction & Direction.east ? -diff : diff;
 
         const width = clamp(

--- a/packages/lexical-react/src/LexicalCheckListPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCheckListPlugin.tsx
@@ -18,6 +18,7 @@ import {
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $findMatchingParent,
+  calculateZoomLevel,
   isHTMLElement,
   mergeRegister,
 } from '@lexical/utils';
@@ -185,9 +186,8 @@ function handleCheckItemEvent(event: PointerEvent, callback: () => void) {
     return;
   }
 
-  const pageX = event.pageX;
   const rect = target.getBoundingClientRect();
-
+  const pageX = event.pageX / calculateZoomLevel(target);
   if (
     target.dir === 'rtl'
       ? pageX < rect.right && pageX > rect.right - 20

--- a/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
@@ -8,6 +8,7 @@
 import type {MenuRenderFn, MenuResolution} from './shared/LexicalMenu';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {calculateZoomLevel} from '@lexical/utils';
 import {
   COMMAND_PRIORITY_LOW,
   CommandListenerPriority,
@@ -96,11 +97,12 @@ export function LexicalContextMenuPlugin<TOption extends MenuOption>({
   const handleContextMenu = useCallback(
     (event: MouseEvent) => {
       event.preventDefault();
+      const zoom = calculateZoomLevel(event.target as Element);
       openNodeMenu({
         getRect: () =>
           new DOMRect(
-            event.clientX,
-            event.clientY,
+            event.clientX / zoom,
+            event.clientY / zoom,
             PRE_PORTAL_DIV_SIZE,
             PRE_PORTAL_DIV_SIZE,
           ),

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -530,12 +530,11 @@ export function $insertFirst(parent: ElementNode, node: LexicalNode): void {
  * css zoom property.
  * @param element
  */
-export function calculateZoomLevel(element: Element): number {
+export function calculateZoomLevel(element: Element | null): number {
   let zoom = 1;
-  let elem: Element | null = element;
-  while (elem) {
-    zoom *= Number(window.getComputedStyle(elem).getPropertyValue('zoom'));
-    elem = elem.parentElement;
+  while (element) {
+    zoom *= Number(window.getComputedStyle(element).getPropertyValue('zoom'));
+    element = element.parentElement;
   }
   return zoom;
 }

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -25,6 +25,7 @@ import {
   LexicalEditor,
   LexicalNode,
 } from 'lexical';
+import { IS_FIREFOX } from 'shared/environment';
 import invariant from 'shared/invariant';
 import normalizeClassNames from 'shared/normalizeClassNames';
 
@@ -531,6 +532,9 @@ export function $insertFirst(parent: ElementNode, node: LexicalNode): void {
  * @param element
  */
 export function calculateZoomLevel(element: Element | null): number {
+  if (IS_FIREFOX) {
+    return 1;
+  }
   let zoom = 1;
   while (element) {
     zoom *= Number(window.getComputedStyle(element).getPropertyValue('zoom'));

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -524,3 +524,18 @@ export function $insertFirst(parent: ElementNode, node: LexicalNode): void {
     parent.append(node);
   }
 }
+
+/**
+ * Calculates the zoom level of an element as a result of using
+ * css zoom property.
+ * @param element
+ */
+export function calculateZoomLevel(element: Element): number {
+  let zoom = 1;
+  let elem: Element | null = element;
+  while (elem) {
+    zoom *= Number(window.getComputedStyle(elem).getPropertyValue('zoom'));
+    elem = elem.parentElement;
+  }
+  return zoom;
+}

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -25,7 +25,7 @@ import {
   LexicalEditor,
   LexicalNode,
 } from 'lexical';
-import { IS_FIREFOX } from 'shared/environment';
+import {IS_FIREFOX} from 'shared/environment';
 import invariant from 'shared/invariant';
 import normalizeClassNames from 'shared/normalizeClassNames';
 


### PR DESCRIPTION
Css `zoom` property affects the mouse position in `event`s. However, functions like `getBoundingClientRect` do not care about the css `zoom`. Hence, the calculations that use mouse positions and `getBoundingClientRect` return wrong values. In this PR those calculations are fixed to return the correct value when css `zoom` property is used.

Css `zoom` has only been implemented in Nightly version of Firefox. So the fix does not apply to Firefox.

In all the examples below the css `zoom` property is set to 2 on the body of the document..

Issue with checklist interactions:
![checklist-zoom](https://github.com/facebook/lexical/assets/7505359/791abcd2-ddfb-4d5e-adb2-758ac7cb469f)
Issue with drag handle:
![drag-handle-zoom](https://github.com/facebook/lexical/assets/7505359/7373ad72-5b1c-4a1d-a5a8-7e921e9396f5)
Issue with context menu:
![context-menu-zoom](https://github.com/facebook/lexical/assets/7505359/685d3ce2-de1a-44bc-80c4-7aac8ba9b947)
