### PR TITLE
Add the ability to discard history more flexibly

### DIFF
--- a/examples/vanilla-js-plugin/src/main.ts
+++ b/examples/vanilla-js-plugin/src/main.ts
@@ -47,7 +47,10 @@ editor.setRootElement(editorRef);
 mergeRegister(
   registerRichText(editor),
   registerDragonSupport(editor),
-  registerHistory(editor, createEmptyHistoryState(), 300),
+  registerHistory(editor, createEmptyHistoryState(), {
+    delay: 300,
+    discardHistory: false,
+  }),
   registerEmoji(editor),
 );
 

--- a/examples/vanilla-js/src/main.ts
+++ b/examples/vanilla-js/src/main.ts
@@ -49,7 +49,10 @@ editor.setRootElement(editorRef);
 mergeRegister(
   registerRichText(editor),
   registerDragonSupport(editor),
-  registerHistory(editor, createEmptyHistoryState(), 300),
+  registerHistory(editor, createEmptyHistoryState(), {
+    delay: 300,
+    discardHistory: false,
+  }),
 );
 
 editor.update(prepopulatedRichText, {tag: 'history-merge'});

--- a/packages/lexical-history/README.md
+++ b/packages/lexical-history/README.md
@@ -14,7 +14,7 @@ Registers necessary listeners to manage undo/redo history stack and related edit
 function registerHistory(
   editor: LexicalEditor,
   externalHistoryState: HistoryState,
-  delay: number,
+  options: HistoryOptions,
 ): () => void
 ```
 

--- a/packages/lexical-history/flow/LexicalHistory.js.flow
+++ b/packages/lexical-history/flow/LexicalHistory.js.flow
@@ -18,9 +18,13 @@ export type HistoryState = {
   redoStack: Array<HistoryStateEntry>,
   undoStack: Array<HistoryStateEntry>,
 };
+export type HistoryOptions = {
+  delay: number;
+  discardHistory: boolean;
+};
 declare export function registerHistory(
   editor: LexicalEditor,
   historyState: HistoryState,
-  delay: number,
+  options: HistoryOptions,
 ): () => void;
 declare export function createEmptyHistoryState(): HistoryState;

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -272,7 +272,10 @@ describe('LexicalHistory tests', () => {
   test('undoStack selection points to the same editor', async () => {
     const editor_ = createTestEditor({namespace: 'parent'});
     const sharedHistory = createEmptyHistoryState();
-    registerHistory(editor_, sharedHistory, 1000);
+    registerHistory(editor_, sharedHistory, {
+      delay: 1000,
+      discardHistory: false,
+    });
     await editor_.update(() => {
       const root = $getRoot();
       const paragraph = $createParagraphNode();
@@ -299,7 +302,10 @@ describe('LexicalHistory tests', () => {
       },
     );
     nestedEditor._parentEditor = editor_;
-    registerHistory(nestedEditor, sharedHistory, 1000);
+    registerHistory(nestedEditor, sharedHistory, {
+      delay: 1000,
+      discardHistory: false,
+    });
 
     await nestedEditor.update(() => {
       const root = $getRoot();

--- a/packages/lexical-playground/esm/index.mjs
+++ b/packages/lexical-playground/esm/index.mjs
@@ -36,7 +36,10 @@ editor.setRootElement(editorRef);
 mergeRegister(
   registerRichText(editor),
   registerDragonSupport(editor),
-  registerHistory(editor, createEmptyHistoryState(), 300),
+  registerHistory(editor, createEmptyHistoryState(), {
+    delay: 300,
+    discardHistory: false,
+  }),
 );
 
 editor.update(prepopulatedRichText, {tag: 'history-merge'});

--- a/packages/lexical-react/flow/LexicalHistoryPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalHistoryPlugin.js.flow
@@ -21,8 +21,14 @@ export type HistoryState = {
   undoStack: Array<HistoryStateEntry>,
 };
 
+export type HistoryOptions = {
+  delay: number
+  discardHistory: boolean
+}
+
 declare export function HistoryPlugin({
   externalHistoryState?: HistoryState,
+  options?: HistoryOptions
 }): React$Node;
 
 declare export function createEmptyHistoryState(): HistoryState;

--- a/packages/lexical-react/flow/LexicalHistoryPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalHistoryPlugin.js.flow
@@ -26,6 +26,11 @@ export type HistoryOptions = {
   discardHistory: boolean
 }
 
+export type HistoryOptions = {
+  delay: number;
+  discardHistory: boolean;
+};
+
 declare export function HistoryPlugin({
   externalHistoryState?: HistoryState,
   options?: HistoryOptions

--- a/packages/lexical-react/flow/LexicalHistoryPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalHistoryPlugin.js.flow
@@ -27,9 +27,9 @@ export type HistoryOptions = {
 }
 
 export type HistoryOptions = {
-  delay: number;
-  discardHistory: boolean;
-};
+  delay: number
+  discardHistory: boolean
+}
 
 declare export function HistoryPlugin({
   externalHistoryState?: HistoryState,

--- a/packages/lexical-react/flow/LexicalHistoryPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalHistoryPlugin.js.flow
@@ -22,18 +22,13 @@ export type HistoryState = {
 };
 
 export type HistoryOptions = {
-  delay: number
-  discardHistory: boolean
-}
-
-export type HistoryOptions = {
-  delay: number
-  discardHistory: boolean
-}
+  delay: number,
+  discardHistory: boolean,
+};
 
 declare export function HistoryPlugin({
   externalHistoryState?: HistoryState,
-  options?: HistoryOptions
+  options?: HistoryOptions,
 }): React$Node;
 
 declare export function createEmptyHistoryState(): HistoryState;

--- a/packages/lexical-react/src/LexicalHistoryPlugin.ts
+++ b/packages/lexical-react/src/LexicalHistoryPlugin.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import type {HistoryState} from '@lexical/history';
+import type {HistoryOptions,HistoryState} from '@lexical/history';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
@@ -14,16 +14,18 @@ import {useHistory} from './shared/useHistory';
 
 export {createEmptyHistoryState} from '@lexical/history';
 
-export type {HistoryState};
+export type {HistoryOptions,HistoryState};
 
 export function HistoryPlugin({
   externalHistoryState,
+  options,
 }: {
   externalHistoryState?: HistoryState;
+  options?: HistoryOptions;
 }): null {
   const [editor] = useLexicalComposerContext();
 
-  useHistory(editor, externalHistoryState);
+  useHistory(editor, externalHistoryState, options);
 
   return null;
 }

--- a/packages/lexical-react/src/shared/useHistory.ts
+++ b/packages/lexical-react/src/shared/useHistory.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import type {HistoryState} from '@lexical/history';
+import type {HistoryOptions, HistoryState} from '@lexical/history';
 import type {LexicalEditor} from 'lexical';
 
 import {createEmptyHistoryState, registerHistory} from '@lexical/history';
@@ -15,7 +15,10 @@ import {useEffect, useMemo} from 'react';
 export function useHistory(
   editor: LexicalEditor,
   externalHistoryState?: HistoryState,
-  delay = 1000,
+  options: HistoryOptions = {
+    delay: 1000,
+    discardHistory: false,
+  },
 ): void {
   const historyState: HistoryState = useMemo(
     () => externalHistoryState || createEmptyHistoryState(),
@@ -23,6 +26,6 @@ export function useHistory(
   );
 
   useEffect(() => {
-    return registerHistory(editor, historyState, delay);
-  }, [delay, editor, historyState]);
+    return registerHistory(editor, historyState, options);
+  }, [editor, options, historyState]);
 }


### PR DESCRIPTION
Currently the only way to discard history is via the `historic` tag. One problem with this approach is that sometimes you do not have control over the update being sent to the editor, thus making it impossible to append any `tags` to the change.

My proposal is to allow a `discardHistory` option to be passed to `registerHistory` which allows a more dynamic way to prevent history from being pushed.

Example below:
https://github.com/facebook/lexical/assets/27902567/1cacdc9a-0dec-4244-80c5-9f2c30361e4e

