### PR TITLE
fix: markdown import code block with prefix

### DIFF
--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -34,7 +34,7 @@ import {IS_APPLE_WEBKIT, IS_IOS, IS_SAFARI} from 'shared/environment';
 import {PUNCTUATION_OR_SPACE, transformersByType} from './utils';
 
 const MARKDOWN_EMPTY_LINE_REG_EXP = /^\s{0,3}$/;
-const CODE_BLOCK_REG_EXP = /^```(\w{1,10})?\s?$/;
+const CODE_BLOCK_REG_EXP = /^[ \t]*```(\w{1,10})?\s?$/;
 type TextFormatTransformersIndex = Readonly<{
   fullMatchRegExpByTag: Readonly<Record<string, RegExp>>;
   openTagsRegExp: RegExp;

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -256,7 +256,7 @@ export const CODE: ElementTransformer = {
       '```'
     );
   },
-  regExp: /^```(\w{1,10})?\s/,
+  regExp: /^[ \t]*```(\w{1,10})?\s/,
   replace: createBlockNode((match) => {
     return $createCodeNode(match ? match[1] : undefined);
   }),

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -176,6 +176,18 @@ describe('Markdown', () => {
       md: '```\nCode\n```',
     },
     {
+      // Import only: prefix tabs will be removed for export
+      html: '<pre spellcheck="false"><span style="white-space: pre-wrap;">Code</span></pre>',
+      md: '\t```\nCode\n```',
+      skipExport: true,
+    },
+    {
+      // Import only: prefix spaces will be removed for export
+      html: '<pre spellcheck="false"><span style="white-space: pre-wrap;">Code</span></pre>',
+      md: '   ```\nCode\n```',
+      skipExport: true,
+    },
+    {
       // Import only: extra empty lines will be removed for export
       html: '<p><span style="white-space: pre-wrap;">Hello</span></p><p><span style="white-space: pre-wrap;">world</span></p>',
       md: ['Hello', '', '', '', 'world'].join('\n'),


### PR DESCRIPTION
## Problem
When triple backtick bloc code is prefix with tabs or spaces, the parser does not recognize text as a block code.

Not parsed:
```markdown
   \```typescript
   const a = 'hello';
   \```
```

A concret use case, is when code block is under a list.
Example of markdown string to be loaded to lexical:
```
1. First step
   \```bash
   echo "hello"
   \```
2. Second step
   \```bash
   echo "world"
   \```
```
**Note:** `\` is only there to escape code block rendering. The real use case does not have the `\`

## Solution
Change CODE Transformer & MarkdownImport regex to accept tabs or spaces in prefix.

### Current regex
<img width="313" alt="image" src="https://github.com/facebook/lexical/assets/5473142/665d723b-fed5-4187-9f0d-1a3c226d0ca0">

### Updated regex
<img width="313" alt="image" src="https://github.com/facebook/lexical/assets/5473142/01ed9314-6198-4488-aef1-a1a69e876baf">
