### PR TITLE
fix: restore playground esm build

### DIFF
--- a/packages/lexical-playground/vite.config.ts
+++ b/packages/lexical-playground/vite.config.ts
@@ -11,6 +11,7 @@ import react from '@vitejs/plugin-react';
 import {defineConfig} from 'vite';
 import {replaceCodePlugin} from 'vite-plugin-replace';
 
+import viteCopyEsm from './viteCopyEsm';
 import moduleResolution from './viteModuleResolution';
 
 // https://vitejs.dev/config/
@@ -54,6 +55,7 @@ export default defineConfig({
       presets: ['@babel/preset-react'],
     }),
     react(),
+    viteCopyEsm(),
   ],
   resolve: {
     alias: moduleResolution,

--- a/packages/lexical-playground/vite.prod.config.ts
+++ b/packages/lexical-playground/vite.prod.config.ts
@@ -11,6 +11,7 @@ import react from '@vitejs/plugin-react';
 import {defineConfig} from 'vite';
 import {replaceCodePlugin} from 'vite-plugin-replace';
 
+import viteCopyEsm from './viteCopyEsm';
 import moduleResolution from './viteModuleResolution';
 
 // https://vitejs.dev/config/
@@ -53,6 +54,7 @@ export default defineConfig({
       presets: ['@babel/preset-react'],
     }),
     react(),
+    viteCopyEsm(),
   ],
   resolve: {
     alias: moduleResolution,

--- a/packages/lexical-playground/viteCopyEsm.ts
+++ b/packages/lexical-playground/viteCopyEsm.ts
@@ -27,7 +27,7 @@ export default function viteCopyEsm() {
       {dest: './build/esm/', src: './esm/*'},
       {dest: './build/', src: ['./*.png', './*.ico']},
       ...parseImportMapImportEntries().map(([mod, fn]) => ({
-        dest: path.join('./build/esm/dist', fn),
+        dest: './build/esm/dist/',
         src: path.join(
           `../${mod.replace(/^@/, '').replace(/\//g, '-')}`,
           // Fork modules are only produced by build-release, which is not run

--- a/packages/lexical-playground/viteCopyEsm.ts
+++ b/packages/lexical-playground/viteCopyEsm.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import fs from 'fs';
+import path from 'path';
+import copy from 'rollup-plugin-copy';
+
+function parseImportMapImportEntries() {
+  const m = /<script type="importmap">([\s\S]+?)<\/script>/g.exec(
+    fs.readFileSync('./esm/index.html', 'utf8'),
+  );
+  if (!m) {
+    throw new Error('Could not parse importmap from esm/index.html');
+  }
+  return Object.entries<string>(JSON.parse(m[1]).imports);
+}
+
+// Fork modules are only produced by the build script
+export default function viteCopyEsm() {
+  return copy({
+    hook: 'writeBundle',
+    targets: [
+      {dest: './build/esm/', src: './esm/*'},
+      {dest: './build/', src: ['./*.png', './*.ico']},
+      ...parseImportMapImportEntries().map(([mod, fn]) => ({
+        dest: path.join('./build/esm/dist', fn),
+        src: path.join(
+          `../${mod.replace(/^@/, '').replace(/\//g, '-')}`,
+          // Fork modules are only produced by build-release, which is not run
+          // in CI, so we don't need to worry about choosing dev or prod
+          fn,
+        ),
+      })),
+    ],
+    verbose: true,
+  });
+}

--- a/packages/lexical-playground/viteCopyEsm.ts
+++ b/packages/lexical-playground/viteCopyEsm.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import copy from 'rollup-plugin-copy';
 
 function parseImportMapImportEntries() {


### PR DESCRIPTION
The /esm/ build of the playground added in #5618 was reverted by the #5744 vite config refactor. This adds it back using the same strategy of a sibling module to avoid code duplication.