### PR TITLE
Update stackblitz iframes to use ctl=1 to prevent focus stealing

### DIFF
--- a/packages/lexical-website/docs/getting-started/creating-plugin.md
+++ b/packages/lexical-website/docs/getting-started/creating-plugin.md
@@ -183,4 +183,4 @@ mergeRegister(
 );
 ```
 
-<iframe width="100%" height="400" src="https://stackblitz.com/github/StyleT/lexical/tree/feature/vanilla-js-plugin-example/examples/vanilla-js-plugin?embed=1&file=src%2Femoji-plugin%2FEmojiPlugin.ts&terminalHeight=1&ctl=1"></iframe>
+<iframe width="100%" height="400" src="https://stackblitz.com/github/facebook/lexical/tree/main/examples/vanilla-js-plugin?embed=1&file=src%2Femoji-plugin%2FEmojiPlugin.ts&terminalHeight=1&ctl=1"></iframe>

--- a/packages/lexical-website/docs/getting-started/quick-start.md
+++ b/packages/lexical-website/docs/getting-started/quick-start.md
@@ -128,4 +128,4 @@ editor.registerUpdateListener(({editorState}) => {
 
 Here we have simplest Lexical setup in rich text configuration (`@lexical/rich-text`) with history (`@lexical/history`) and accessibility (`@lexical/dragon`) features enabled.
 
-<iframe width="100%" height="400" src="https://stackblitz.com/github/facebook/lexical/tree/main/examples/vanilla-js?embed=1&file=src%2Fmain.ts&terminalHeight=0"></iframe>
+<iframe width="100%" height="400" src="https://stackblitz.com/github/facebook/lexical/tree/main/examples/vanilla-js?embed=1&file=src%2Fmain.ts&terminalHeight=0&ctl=1"></iframe>

--- a/packages/lexical-website/docs/getting-started/react.md
+++ b/packages/lexical-website/docs/getting-started/react.md
@@ -81,7 +81,7 @@ Below you can find an example of the integration from the previous chapter that 
 
 However no UI can be created w/o CSS and Lexical is not an exception here. Pay attention to `ExampleTheme.ts` and how it's used in this example, with corresponding styles defined in `styles.css`.
 
-<iframe width="100%" height="400" src="https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-rich?embed=1&file=src%2FApp.tsx&terminalHeight=0"></iframe>
+<iframe width="100%" height="400" src="https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-rich?embed=1&file=src%2FApp.tsx&terminalHeight=0&ctl=1"></iframe>
 
 
 ## Saving Lexical State

--- a/packages/lexical-website/src/components/HomepageExamples/index.js
+++ b/packages/lexical-website/src/components/HomepageExamples/index.js
@@ -23,7 +23,7 @@ const EXAMPLES = [
     ),
     id: 'example-feature-1',
     label: 'Simple Setup',
-    src: 'https://stackblitz.com/github/facebook/lexical/tree/main/examples/vanilla-js?embed=1&file=src%2Fmain.ts&terminalHeight=0',
+    src: 'https://stackblitz.com/github/facebook/lexical/tree/main/examples/vanilla-js?embed=1&file=src%2Fmain.ts&terminalHeight=0&ctl=1',
   },
   {
     content: (
@@ -38,7 +38,7 @@ const EXAMPLES = [
     ),
     id: 'example-feature-2',
     label: 'Powerful Features',
-    src: 'https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-rich?embed=1&file=src%2FApp.tsx&terminalHeight=0',
+    src: 'https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-rich?embed=1&file=src%2FApp.tsx&terminalHeight=0&ctl=1',
   },
   {
     content: (
@@ -50,7 +50,7 @@ const EXAMPLES = [
     ),
     id: 'example-feature-3',
     label: 'Built to Extend',
-    src: 'https://stackblitz.com/github/StyleT/lexical/tree/feature/vanilla-js-plugin-example/examples/vanilla-js-plugin?embed=1&file=src%2Femoji-plugin%2FEmojiPlugin.ts&terminalHeight=0',
+    src: 'https://stackblitz.com/github/facebook/lexical/tree/main/examples/vanilla-js-plugin?embed=1&file=src%2Femoji-plugin%2FEmojiPlugin.ts&terminalHeight=0&ctl=1',
   },
 ];
 


### PR DESCRIPTION
The stackblitz iframe steals focus after it loads when not using ctl=1. It's a jarring experience when reading the documentation or browsing the homepage because this focus-stealing also scrolls the iframe into view and they're below the fold.

Also uses the main branch here rather than feature branches in other repos that might be deleted later, I suspect this was just missed after merging the vanilla-js-plugin example by @StyleT (#5717)

To notice the difference, try comparing the UX between some of the docs pages (wait a few seconds for stackblitz to load on the before examples):

* homepage [before](https://lexical.dev/) | [after](https://lexical-p4z3hdol5-fbopensource.vercel.app/)
* quickstart [before](https://lexical.dev/docs/getting-started/quick-start) | [after](https://lexical-p4z3hdol5-fbopensource.vercel.app/docs/getting-started/quick-start)