### PR TITLE
fix: iOS Autocorrect strips formatting by reporting wrong dataType

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -153,7 +153,7 @@ export function $insertDataTransferForRichText(
   // Skip HTML handling if it matches the plain text representation.
   // This avoids unnecessary processing for plain text strings created by
   // iOS Safari autocorrect, which incorrectly includes a `text/html` type.
-  if (htmlString && !(plainString && plainString === htmlString)) {
+  if (htmlString && plainString !== htmlString) {
     try {
       const parser = new DOMParser();
       const dom = parser.parseFromString(

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -148,7 +148,12 @@ export function $insertDataTransferForRichText(
   }
 
   const htmlString = dataTransfer.getData('text/html');
-  if (htmlString) {
+  const plainString = dataTransfer.getData('text/plain');
+
+  // Skip HTML handling if it matches the plain text representation.
+  // This avoids unnecessary processing for plain text strings created by
+  // iOS Safari autocorrect, which incorrectly includes a `text/html` type.
+  if (htmlString && !(plainString && plainString === htmlString)) {
     try {
       const parser = new DOMParser();
       const dom = parser.parseFromString(
@@ -165,8 +170,7 @@ export function $insertDataTransferForRichText(
   // Multi-line plain text in rich text mode pasted as separate paragraphs
   // instead of single paragraph with linebreaks.
   // Webkit-specific: Supports read 'text/uri-list' in clipboard.
-  const text =
-    dataTransfer.getData('text/plain') || dataTransfer.getData('text/uri-list');
+  const text = plainString || dataTransfer.getData('text/uri-list');
   if (text != null) {
     if ($isRangeSelection(selection)) {
       const parts = text.split(/(\r?\n|\t)/);

--- a/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
+++ b/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
@@ -119,8 +119,8 @@ describe('HTMLCopyAndPaste tests', () => {
 
         // we simulate choosing an iOS Safari `autocorrect` or `word prediction`
         // which pastes the word into the editor with both the `text/plain` and `text/html` data types
-        dataTransfer.setData('text/plain', 'Hello world');
-        dataTransfer.setData('text/html', 'Hello world');
+        dataTransfer.setData('text/plain', 'Prediction');
+        dataTransfer.setData('text/html', 'Prediction');
 
         // to compensate, the clipboard content will only be inserted as HTML if the `text/html` content differs from the `text/plain` content
         await editor.update(() => {
@@ -135,7 +135,7 @@ describe('HTMLCopyAndPaste tests', () => {
 
         // the editor's selection formatting is maintained because the text has been inserted as plain text
         expect(testEnv.innerHTML).toBe(
-          '<p dir="ltr"><span style="background-color: rgb(255, 170, 45);" data-lexical-text="true">Hello world</span></p>',
+          '<p dir="ltr"><span style="background-color: rgb(255, 170, 45);" data-lexical-text="true">Prediction</span></p>',
         );
       });
     },

--- a/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
+++ b/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
@@ -125,11 +125,9 @@ describe('HTMLCopyAndPaste tests', () => {
         // to compensate, the clipboard content will only be inserted as HTML if the `text/html` content differs from the `text/plain` content
         await editor.update(() => {
           const selection = $getSelection();
-          if (null !== selection) {
-            $patchStyleText(selection, {
-              'background-color': 'rgb(255,170,45)',
-            });
-          }
+          $patchStyleText(selection, {
+            'background-color': 'rgb(255,170,45)',
+          });
           $insertDataTransferForRichText(dataTransfer, selection, editor);
         });
 

--- a/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
+++ b/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
@@ -125,6 +125,10 @@ describe('HTMLCopyAndPaste tests', () => {
         // to compensate, the clipboard content will only be inserted as HTML if the `text/html` content differs from the `text/plain` content
         await editor.update(() => {
           const selection = $getSelection();
+          invariant(
+            $isRangeSelection(selection),
+            'isRangeSelection(selection)',
+          );
           $patchStyleText(selection, {
             'background-color': 'rgb(255,170,45)',
           });

--- a/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
+++ b/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
@@ -7,6 +7,7 @@
  */
 
 import {$insertDataTransferForRichText} from '@lexical/clipboard';
+import {$patchStyleText} from '@lexical/selection';
 import {
   $createParagraphNode,
   $getRoot,
@@ -109,6 +110,33 @@ describe('HTMLCopyAndPaste tests', () => {
           });
           expect(testEnv.innerHTML).toBe(testCase.expectedHTML);
         });
+      });
+
+      test('iOS fix: Word predictions should be handled as plain text to maintain selection formatting', async () => {
+        const {editor} = testEnv;
+
+        const dataTransfer = new DataTransferMock();
+
+        // we simulate choosing an iOS Safari `autocorrect` or `word prediction`
+        // which pastes the word into the editor with both the `text/plain` and `text/html` data types
+        dataTransfer.setData('text/plain', 'Hello world');
+        dataTransfer.setData('text/html', 'Hello world');
+
+        // to compensate, the clipboard content will only be inserted as HTML if the `text/html` content differs from the `text/plain` content
+        await editor.update(() => {
+          const selection = $getSelection();
+          if (null !== selection) {
+            $patchStyleText(selection, {
+              'background-color': 'rgb(255,170,45)',
+            });
+          }
+          $insertDataTransferForRichText(dataTransfer, selection, editor);
+        });
+
+        // the editor's selection formatting is maintained because the text has been inserted as plain text
+        expect(testEnv.innerHTML).toBe(
+          '<p dir="ltr"><span style="background-color: rgb(255, 170, 45);" data-lexical-text="true">Hello world</span></p>',
+        );
       });
     },
     {


### PR DESCRIPTION
fixes https://github.com/facebook/lexical/issues/4801

A troubling issue has been identified with the iOS keyboard's autocorrect behavior and how it affects text formatting.

When a user selects a word prediction, or, when the operating system injects an autocorrected word (such as when typing `its` and not including the apostrophe), the data transfer type is incorrectly reported as `text/html`.  This does not reflect the actual content, as the payload only contains plain text.

Addressing this issue involves a very straightforward validation to ensure the presence of element nodes within the parsed DOM when the data type is reported as `text/html`, before proceeding with inserting the DOM nodes.

My solution simply checks for the presence of element nodes in the parsed DOM using `querySelector('*')`.  An alternative condition, `Array.from(dom.body.childNodes).some(node => node.nodeType === 1)` could be considered; however `querySelector` offers a more concise expression.

Since iOS reports both `text/plain` and `text/html` data types for it's keyboard corrections, this case falls back to `text/plain` and works properly.  My only concern is if there could be some data transfers that might contain only plain text while reporting only `text/html`.  Perhaps we could condition for those and fall through to the `text/plain` handler if no DOM nodes exist as a result of the predicate that checks for elements.

In my opinion, this simple fix takes the editor from unusable to usable on iOS devices. See the before and after videos. 

Before:

https://github.com/facebook/lexical/assets/1311325/e411b7a5-4e90-4743-be32-346fa4eb4771

After:

https://github.com/facebook/lexical/assets/1311325/54adad94-3e53-4c44-84ca-edfa3bff1543
