### PR TITLE
Node-aware Context Menu Items

### DIFF
--- a/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
@@ -99,7 +99,7 @@ export function LexicalContextMenuPlugin<TOption extends MenuOption>({
   const handleContextMenu = useCallback(
     (event: MouseEvent) => {
       event.preventDefault();
-      if (onWillOpen) {
+      if (onWillOpen != null) {
         onWillOpen(event);
       }
       const zoom = calculateZoomLevel(event.target as Element);

--- a/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
@@ -47,6 +47,7 @@ export type LexicalContextMenuPluginProps<TOption extends MenuOption> = {
   ) => void;
   options: Array<TOption>;
   onClose?: () => void;
+  onWillOpen?: (event: MouseEvent) => void;
   onOpen?: (resolution: MenuResolution) => void;
   menuRenderFn: ContextMenuRenderFn<TOption>;
   anchorClassName?: string;
@@ -58,6 +59,7 @@ const PRE_PORTAL_DIV_SIZE = 1;
 
 export function LexicalContextMenuPlugin<TOption extends MenuOption>({
   options,
+  onWillOpen,
   onClose,
   onOpen,
   onSelectOption,
@@ -97,6 +99,9 @@ export function LexicalContextMenuPlugin<TOption extends MenuOption>({
   const handleContextMenu = useCallback(
     (event: MouseEvent) => {
       event.preventDefault();
+      if (onWillOpen) {
+        onWillOpen(event);
+      }
       const zoom = calculateZoomLevel(event.target as Element);
       openNodeMenu({
         getRect: () =>
@@ -108,7 +113,7 @@ export function LexicalContextMenuPlugin<TOption extends MenuOption>({
           ),
       });
     },
-    [openNodeMenu],
+    [openNodeMenu, onWillOpen],
   );
 
   const handleClick = useCallback(

--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -494,9 +494,7 @@ export function useMenuAnchorRef(
     if (rootElement !== null && resolution !== null) {
       const {left, top, width, height} = resolution.getRect();
       const anchorHeight = anchorElementRef.current.offsetHeight; // use to position under anchor
-      containerDiv.style.top = `${
-        top + window.pageYOffset + anchorHeight + 3
-      }px`;
+      containerDiv.style.top = `${top + anchorHeight + 3}px`;
       containerDiv.style.left = `${left + window.pageXOffset}px`;
       containerDiv.style.height = `${height}px`;
       containerDiv.style.width = `${width}px`;


### PR DESCRIPTION
Expose a 'onWillOpen' method that passes the 'contextmenu' mouse event, so users can do their logic what items should end up in the context menu before it's rendered. Have added an example for 'Link node', that appends an item to 'Remove Link' when a link node is right-clicked. Also fixed wrong positioning of the context menu when the page is scrolled.