### PR TITLE
Quick fix for #5754: Numbered list does not increment in ImageNode caption #5754

### DIFF
--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -20,6 +20,7 @@ import {
   LexicalNode,
   LexicalNodeReplacement,
 } from 'lexical';
+import {Transform} from 'packages/lexical/src/LexicalEditor';
 import * as React from 'react';
 import {ReactNode, useContext, useEffect, useMemo, useRef} from 'react';
 import invariant from 'shared/invariant';
@@ -67,12 +68,18 @@ export function LexicalNestedComposer({
           parentEditor._nodes,
         ));
         for (const [type, entry] of parentNodes) {
+          const transform = entry.klass.transform();
+          const transforms = new Set<Transform<LexicalNode>>();
+          if (transform !== null) {
+            transforms.add(transform);
+          }
+
           initialEditor._nodes.set(type, {
             exportDOM: entry.exportDOM,
             klass: entry.klass,
             replace: entry.replace,
             replaceWithKlass: entry.replaceWithKlass,
-            transforms: new Set(),
+            transforms: transforms,
           });
         }
       } else {
@@ -87,12 +94,19 @@ export function LexicalNestedComposer({
             replaceWithKlass = options.withKlass || null;
           }
           const registeredKlass = initialEditor._nodes.get(klass.getType());
+
+          const transform = klass.transform();
+          const transforms = new Set<Transform<LexicalNode>>();
+          if (transform !== null) {
+            transforms.add(transform);
+          }
+
           initialEditor._nodes.set(klass.getType(), {
             exportDOM: registeredKlass ? registeredKlass.exportDOM : undefined,
             klass,
             replace,
             replaceWithKlass,
-            transforms: new Set(),
+            transforms: transforms,
           });
         }
       }

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -20,10 +20,19 @@ import {
   LexicalNode,
   LexicalNodeReplacement,
 } from 'lexical';
-import {Transform} from 'packages/lexical/src/LexicalEditor';
+import {KlassConstructor, Transform} from 'packages/lexical/src/LexicalEditor';
 import * as React from 'react';
 import {ReactNode, useContext, useEffect, useMemo, useRef} from 'react';
 import invariant from 'shared/invariant';
+
+function getTransformSetFromKlass(
+  klass: KlassConstructor<typeof LexicalNode>,
+): Set<Transform<LexicalNode>> {
+  const transform = klass.transform();
+  return transform !== null
+    ? new Set<Transform<LexicalNode>>([transform])
+    : new Set<Transform<LexicalNode>>();
+}
 
 export function LexicalNestedComposer({
   initialEditor,
@@ -68,18 +77,12 @@ export function LexicalNestedComposer({
           parentEditor._nodes,
         ));
         for (const [type, entry] of parentNodes) {
-          const transform = entry.klass.transform();
-          const transforms = new Set<Transform<LexicalNode>>();
-          if (transform !== null) {
-            transforms.add(transform);
-          }
-
           initialEditor._nodes.set(type, {
             exportDOM: entry.exportDOM,
             klass: entry.klass,
             replace: entry.replace,
             replaceWithKlass: entry.replaceWithKlass,
-            transforms: transforms,
+            transforms: getTransformSetFromKlass(entry.klass),
           });
         }
       } else {
@@ -95,18 +98,12 @@ export function LexicalNestedComposer({
           }
           const registeredKlass = initialEditor._nodes.get(klass.getType());
 
-          const transform = klass.transform();
-          const transforms = new Set<Transform<LexicalNode>>();
-          if (transform !== null) {
-            transforms.add(transform);
-          }
-
           initialEditor._nodes.set(klass.getType(), {
             exportDOM: registeredKlass ? registeredKlass.exportDOM : undefined,
             klass,
             replace,
             replaceWithKlass,
-            transforms: transforms,
+            transforms: getTransformSetFromKlass(klass),
           });
         }
       }

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {LexicalComposerContextType} from '@lexical/react/LexicalComposerContext';
+import type {KlassConstructor, Transform} from 'lexical';
 
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {
@@ -20,7 +21,6 @@ import {
   LexicalNode,
   LexicalNodeReplacement,
 } from 'lexical';
-import {KlassConstructor, Transform} from 'packages/lexical/src/LexicalEditor';
 import * as React from 'react';
 import {ReactNode, useContext, useEffect, useMemo, useRef} from 'react';
 import invariant from 'shared/invariant';

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -26,6 +26,7 @@ export type {
   NodeMutation,
   SerializedEditor,
   Spread,
+  Transform,
 } from './LexicalEditor';
 export type {EditorState, SerializedEditorState} from './LexicalEditorState';
 export type {


### PR DESCRIPTION
**Before**:
see #5646 

**After**:


https://github.com/facebook/lexical/assets/19604232/d48f4880-364e-446b-91e1-44f47b0f2d3c



---

reason for failure: nested editor does not set the transforms of the nodes when creating the editor. This lead to updateChildrenListItemValue, which increments the value of `<li>` (ie, `1.`, `2`. ...), to not be called for nested editors.

- this is a short term fix
- did not add list plugin or markdown plugin to caption nested editor to keep size small
- the long term fix is something like https://github.com/facebook/lexical/tree/nestedsomething