### PR TITLE
Refactor ClickableLinkPlugin

### DIFF
--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -191,7 +191,7 @@ export default function Editor(): JSX.Element {
             <TwitterPlugin />
             <YouTubePlugin />
             <FigmaPlugin />
-            <LexicalClickableLinkPlugin active={!isEditable} />
+            <LexicalClickableLinkPlugin disabled={isEditable} />
             <HorizontalRulePlugin />
             <EquationsPlugin />
             <ExcalidrawPlugin />

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -191,7 +191,7 @@ export default function Editor(): JSX.Element {
             <TwitterPlugin />
             <YouTubePlugin />
             <FigmaPlugin />
-            {!isEditable && <LexicalClickableLinkPlugin />}
+            <LexicalClickableLinkPlugin active={!isEditable} />
             <HorizontalRulePlugin />
             <EquationsPlugin />
             <ExcalidrawPlugin />

--- a/packages/lexical-react/src/LexicalClickableLinkPlugin.tsx
+++ b/packages/lexical-react/src/LexicalClickableLinkPlugin.tsx
@@ -34,13 +34,20 @@ function findMatchingDOM<T extends Node>(
 
 export default function LexicalClickableLinkPlugin({
   newTab = true,
+  active = true,
 }: {
   newTab?: boolean;
+  active?: boolean;
 }): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
     const onClick = (event: MouseEvent) => {
+      if (!active) {
+        event.preventDefault();
+        return;
+      }
+
       const target = event.target;
       if (!(target instanceof Node)) {
         return;
@@ -99,7 +106,7 @@ export default function LexicalClickableLinkPlugin({
     };
 
     const onMouseUp = (event: MouseEvent) => {
-      if (event.button === 1 && editor.isEditable()) {
+      if (active && event.button === 1) {
         onClick(event);
       }
     };
@@ -114,7 +121,7 @@ export default function LexicalClickableLinkPlugin({
         rootElement.addEventListener('mouseup', onMouseUp);
       }
     });
-  }, [editor, newTab]);
+  }, [editor, newTab, active]);
 
   return null;
 }

--- a/packages/lexical-react/src/LexicalClickableLinkPlugin.tsx
+++ b/packages/lexical-react/src/LexicalClickableLinkPlugin.tsx
@@ -34,16 +34,16 @@ function findMatchingDOM<T extends Node>(
 
 export default function LexicalClickableLinkPlugin({
   newTab = true,
-  active = true,
+  disabled = false,
 }: {
   newTab?: boolean;
-  active?: boolean;
+  disabled?: boolean;
 }): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
     const onClick = (event: MouseEvent) => {
-      if (!active) {
+      if (disabled) {
         event.preventDefault();
         return;
       }
@@ -106,7 +106,7 @@ export default function LexicalClickableLinkPlugin({
     };
 
     const onMouseUp = (event: MouseEvent) => {
-      if (active && event.button === 1) {
+      if (!disabled && event.button === 1) {
         onClick(event);
       }
     };
@@ -121,7 +121,7 @@ export default function LexicalClickableLinkPlugin({
         rootElement.addEventListener('mouseup', onMouseUp);
       }
     });
-  }, [editor, newTab, active]);
+  }, [editor, newTab, disabled]);
 
   return null;
 }


### PR DESCRIPTION
The ClickableLinkPlugin needed a small refactor, because in its current implementation it cannot disable the clickability of links in read-only mode. Moving the activeness state to a prop and that prop replacing the internal isEditable, allows for full control on links behaviour in either editor state.