### PR TITLE
#4618 combine list if next sibling is list node

### DIFF
--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -31,7 +31,10 @@ import invariant from 'shared/invariant';
 import normalizeClassNames from 'shared/normalizeClassNames';
 
 import {$createListItemNode, $isListItemNode, ListItemNode} from '.';
-import {mergeLists, updateChildrenListItemValue} from './formatList';
+import {
+  mergeNextSiblingListIfSameType,
+  updateChildrenListItemValue,
+} from './formatList';
 import {$getListDepth, wrapInListItem} from './utils';
 
 export type SerializedListNode = Spread<
@@ -125,10 +128,7 @@ export class ListNode extends ElementNode {
   static transform(): (node: LexicalNode) => void {
     return (node: LexicalNode) => {
       invariant($isListNode(node), 'node is not a ListNode');
-      const nextSibling = node.getNextSibling();
-      if ($isListNode(nextSibling)) {
-        mergeLists(node, nextSibling);
-      }
+      mergeNextSiblingListIfSameType(node);
       updateChildrenListItemValue(node);
     };
   }

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -31,7 +31,7 @@ import invariant from 'shared/invariant';
 import normalizeClassNames from 'shared/normalizeClassNames';
 
 import {$createListItemNode, $isListItemNode, ListItemNode} from '.';
-import {updateChildrenListItemValue} from './formatList';
+import {mergeLists, updateChildrenListItemValue} from './formatList';
 import {$getListDepth, wrapInListItem} from './utils';
 
 export type SerializedListNode = Spread<
@@ -125,6 +125,10 @@ export class ListNode extends ElementNode {
   static transform(): (node: LexicalNode) => void {
     return (node: LexicalNode) => {
       invariant($isListNode(node), 'node is not a ListNode');
+      const nextSibling = node.getNextSibling();
+      if ($isListNode(nextSibling)) {
+        mergeLists(node, nextSibling);
+      }
       updateChildrenListItemValue(node);
     };
   }

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -308,6 +308,21 @@ export function updateChildrenListItemValue(list: ListNode): void {
 }
 
 /**
+ * Merge the next sibling list if same type.
+ * <ul> will merge with <ul>, but NOT <ul> with <ol>.
+ * @param list - The list whose next sibling should be potentially merged
+ */
+export function mergeNextSiblingListIfSameType(list: ListNode): void {
+  const nextSibling = list.getNextSibling();
+  if (
+    $isListNode(nextSibling) &&
+    list.getListType() === nextSibling.getListType()
+  ) {
+    mergeLists(list, nextSibling);
+  }
+}
+
+/**
  * Adds an empty ListNode/ListItemNode chain at listItemNode, so as to
  * create an indent effect. Won't indent ListItemNodes that have a ListNode as
  * a child, but does merge sibling ListItemNodes if one has a nested ListNode.

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -1244,6 +1244,7 @@ line after
     1. And can be nested
     and multiline as well
 
+.
 31. Have any starting number
 ### Inline code
 Inline \`code\` format which also \`preserves **_~~any markdown-like~~_** text\` within
@@ -1480,6 +1481,9 @@ const IMPORTED_MARKDOWN_HTML = html`
       </ol>
     </li>
   </ol>
+  <p class="PlaygroundEditorTheme__paragraph">
+    <span data-lexical-text="true">.</span>
+  </p>
   <ol start="31" class="PlaygroundEditorTheme__ol1">
     <li
       value="31"


### PR DESCRIPTION
Fix for issue 4618
**Before**
see #4618

**After**

https://github.com/facebook/lexical/assets/19604232/7c44c505-38dd-441d-b3ca-bce273777ca2





^list of same types merged


<img width="399" alt="Screenshot 2024-04-02 at 2 28 40 PM" src="https://github.com/facebook/lexical/assets/19604232/9feb8871-8e32-413d-91fa-68d857b50a28">

^ lists of different types not merged


