### PR TITLE
fix: avoid auto-embed menu overflowing off right side of page

### DIFF
--- a/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
@@ -329,7 +329,10 @@ export default function AutoEmbedPlugin(): JSX.Element {
                 <div
                   className="typeahead-popover auto-embed-menu"
                   style={{
-                    marginLeft: anchorElementRef.current.style.width,
+                    marginLeft: `${Math.max(
+                      parseFloat(anchorElementRef.current.style.width) - 200,
+                      0,
+                    )}px`,
                     width: 200,
                   }}>
                   <AutoEmbedMenu


### PR DESCRIPTION

**Before fix**: 

![image](https://github.com/facebook/lexical/assets/24994263/52a21cb4-269f-47fc-9012-5879f59fa3f6)



**After fix**:

![image](https://github.com/facebook/lexical/assets/24994263/c4a0d864-74f4-4d10-a8ec-1addf35a9334)

