### PR TITLE
Table selection stuck fix

### DIFF
--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -72,7 +72,7 @@ export class TableObserver {
   editor: LexicalEditor;
   tableSelection: TableSelection | null;
   hasHijackedSelectionStyles: boolean;
-  inSelectionProgress: boolean;
+  isSelecting: boolean;
 
   constructor(editor: LexicalEditor, tableNodeKey: string) {
     this.isHighlightingCells = false;
@@ -95,7 +95,7 @@ export class TableObserver {
     this.focusCell = null;
     this.hasHijackedSelectionStyles = false;
     this.trackTable();
-    this.inSelectionProgress = false;
+    this.isSelecting = false;
   }
 
   getTable(): TableDOMTable {

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -72,6 +72,7 @@ export class TableObserver {
   editor: LexicalEditor;
   tableSelection: TableSelection | null;
   hasHijackedSelectionStyles: boolean;
+  inSelectionProgress: boolean;
 
   constructor(editor: LexicalEditor, tableNodeKey: string) {
     this.isHighlightingCells = false;
@@ -94,6 +95,7 @@ export class TableObserver {
     this.focusCell = null;
     this.hasHijackedSelectionStyles = false;
     this.trackTable();
+    this.inSelectionProgress = false;
   }
 
   getTable(): TableDOMTable {

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -88,6 +88,23 @@ export function applyTableHandlers(
 
   attachTableObserverToTableElement(tableElement, tableObserver);
 
+  const onMouseUp = () => {
+    editorWindow.removeEventListener('mouseup', onMouseUp);
+    editorWindow.removeEventListener('mousemove', onMouseMove);
+  };
+
+  const onMouseMove = (moveEvent: MouseEvent) => {
+    const focusCell = getDOMCellFromTarget(moveEvent.target as Node);
+    if (
+      focusCell !== null &&
+      (tableObserver.anchorX !== focusCell.x ||
+        tableObserver.anchorY !== focusCell.y)
+    ) {
+      moveEvent.preventDefault();
+      tableObserver.setFocusCellForSelection(focusCell);
+    }
+  };
+
   tableElement.addEventListener('mousedown', (event: MouseEvent) => {
     setTimeout(() => {
       if (event.button !== 0) {
@@ -103,23 +120,6 @@ export function applyTableHandlers(
         stopEvent(event);
         tableObserver.setAnchorCellForSelection(anchorCell);
       }
-
-      const onMouseUp = () => {
-        editorWindow.removeEventListener('mouseup', onMouseUp);
-        editorWindow.removeEventListener('mousemove', onMouseMove);
-      };
-
-      const onMouseMove = (moveEvent: MouseEvent) => {
-        const focusCell = getDOMCellFromTarget(moveEvent.target as Node);
-        if (
-          focusCell !== null &&
-          (tableObserver.anchorX !== focusCell.x ||
-            tableObserver.anchorY !== focusCell.y)
-        ) {
-          moveEvent.preventDefault();
-          tableObserver.setFocusCellForSelection(focusCell);
-        }
-      };
 
       editorWindow.addEventListener('mouseup', onMouseUp);
       editorWindow.addEventListener('mousemove', onMouseMove);
@@ -717,6 +717,8 @@ export function applyTableHandlers(
                 getObserverCellFromCellNode(focusCellNode),
                 true,
               );
+              editorWindow.addEventListener('mouseup', onMouseUp);
+              editorWindow.addEventListener('mousemove', onMouseMove);
             }
           }
         } else if (

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -90,7 +90,7 @@ export function applyTableHandlers(
 
   const createMouseHandlers = () => {
     const onMouseUp = () => {
-      tableObserver.inSelectionProgress = false;
+      tableObserver.isSelecting = false;
       editorWindow.removeEventListener('mouseup', onMouseUp);
       editorWindow.removeEventListener('mousemove', onMouseMove);
     };
@@ -126,7 +126,7 @@ export function applyTableHandlers(
       }
 
       const {onMouseUp, onMouseMove} = createMouseHandlers();
-      tableObserver.inSelectionProgress = true;
+      tableObserver.isSelecting = true;
       editorWindow.addEventListener('mouseup', onMouseUp);
       editorWindow.addEventListener('mousemove', onMouseMove);
     }, 0);
@@ -723,10 +723,10 @@ export function applyTableHandlers(
                 getObserverCellFromCellNode(focusCellNode),
                 true,
               );
-              if (!tableObserver.inSelectionProgress) {
+              if (!tableObserver.isSelecting) {
                 setTimeout(() => {
                   const {onMouseUp, onMouseMove} = createMouseHandlers();
-                  tableObserver.inSelectionProgress = true;
+                  tableObserver.isSelecting = true;
                   editorWindow.addEventListener('mouseup', onMouseUp);
                   editorWindow.addEventListener('mousemove', onMouseMove);
                 }, 0);


### PR DESCRIPTION
Starting selection in front of the table didn't trigger adding event listeners for mouseMove and mouseUp. Fixing this.

Before:
![Selection stuck before](https://github.com/facebook/lexical/assets/29728044/cbc9d34b-8235-419a-b37c-6ca9ffc54c4e)


After:
![Selection stuck after](https://github.com/facebook/lexical/assets/29728044/72ea8a35-6da4-45f4-a20a-bccb3367efb6)
