### PR TITLE
docs: clarify read/update language in intro, readme & editor state

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,41 @@ workflow to prevent cascading/waterfalling of updates. You can retrieve the curr
 
 Editor States are also fully serializable to JSON and can easily be serialized back into the editor using `editor.parseEditorState()`.
 
-### Editor Updates
+### Reading and Updating Editor State
 
-When you want to change something in an Editor State, you must do it via an update, `editor.update(() => {...})`. The closure passed
-to the update call is important. It's a place where you have full "lexical" context of the active editor state, and it exposes
-access to the underlying Editor State's node tree. We promote using `$` prefixed functions in this context, as it signifies a place
-where they can be used exclusively. Attempting to use them outside of an update will trigger a runtime error with an appropriate error.
-For those familiar with React Hooks, you can think of these as having a similar functionality (except `$` functions can be used in any order).
+When you want to read and/or update the Lexical node tree, you must do it via `editor.update(() => {...})`. You may also do
+read-only operations with the editor state via `editor.getEditorState().read(() => {...})`. The closure passed to the update or read
+call is important, and must be synchronous. It's the only place where you have full "lexical" context of the active editor state,
+and providing you with access to the Editor State's node tree. We promote using the convention of using `$` prefixed functions
+(such as `$getRoot()`) to convey that these functions must be called in this context. Attempting to use them outside of a read
+or update will trigger a runtime error.
+
+For those familiar with React Hooks, you can think of these $functions as having similar functionality:
+| *Feature* | React Hooks | Lexical $functions |
+| -- | -- | -- |
+| Naming Convention | `useFunction` | `$function` |
+| Context Required | Can only be called while rendering | Can only be called while in an update or read |
+| Can be composed | Hooks can call other hooks | $functions can call other $functions |
+| Must be synchronous | ✅ | ✅ |
+| Other rules | ❌ Must be called unconditionally in the same order | ✅ None |
+
+Node Transforms and Command Listeners are called with an implicit `editor.update(() => {...})` context.
+
+It is permitted to do nest updates within reads and updates, but an update may not be nested in a read.
+For example, `editor.update(() => editor.update(() => {...}))` is allowed.
+
+All Lexical Nodes are dependent on the associated Editor State. With few exceptions, you should only call methods
+and access properties of a Lexical Node while in a read or update call (just like `$` functions). Methods
+on Lexical Nodes will first attempt to locate the latest (and possibly a writable) version of the node from the
+active editor state using the node's unique key. All versions of a logical node have the same key. These keys
+are managed by the Editor, are only present at runtime (not serialized), and should be considered to be random and
+opaque (do not write tests that assume hard-coded values for keys).
+
+This is done because the editor state's node tree is recursively frozen after reconciliation to
+support efficient time travel (undo/redo and similar use cases). Methods that update nodes
+first call `node.getWritable()`, which will create a writable clone of a frozen node. This would normally
+mean that any existing references (such as local variables) would refer to a stale version of the node, but
+having Lexical Nodes always refer to the editor state allows for a simpler and less error-prone data model.
 
 ### DOM Reconciler
 
@@ -253,11 +281,11 @@ used as the starting point. From a technical perspective, this means that Lexica
 called double-buffering during updates. There's an editor state to represent what is current on
 the screen, and another work-in-progress editor state that represents future changes.
 
-Creating an update is typically an async process that allows Lexical to batch multiple updates together in
-a single update – improving performance. When Lexical is ready to commit the update to
-the DOM, the underlying mutations and changes in the update will form a new immutable
-editor state. Calling `editor.getEditorState()` will then return the latest editor state
-based on the changes from the update.
+Reconciling an update is typically an async process that allows Lexical to batch multiple synchronous
+updates of the editor state together in a single update to the DOM – improving performance. When
+Lexical is ready to commit the update to the DOM, the underlying mutations and changes in the update
+batch will form a new immutable editor state. Calling `editor.getEditorState()` will then return the
+latest editor state based on the changes from the update.
 
 Here's an example of how you can update an editor instance:
 

--- a/packages/lexical-website/docs/getting-started/react.md
+++ b/packages/lexical-website/docs/getting-started/react.md
@@ -87,7 +87,7 @@ However no UI can be created w/o CSS and Lexical is not an exception here. Pay a
 ## Saving Lexical State
 
 :::tip
-While we attempt to write our own plugin here for demonstration purposes, in real life projects it's better to opt for [LexicalOnchangePlugin](/docs/react/plugins#lexicalonchangeplugin).
+While we attempt to write our own plugin here for demonstration purposes, in real life projects it's better to opt for [LexicalOnChangePlugin](/docs/react/plugins#lexicalonchangeplugin).
 :::
 
 Now that we have a simple editor in React, the next thing we might want to do is access the content of the editor to, for instance,

--- a/packages/lexical-website/docs/intro.md
+++ b/packages/lexical-website/docs/intro.md
@@ -59,13 +59,41 @@ workflow to prevent cascading/water-falling of updates. You can retrieve the cur
 
 Editor States are also fully serializable to JSON and can easily be serialized back into the editor using `editor.parseEditorState()`.
 
-### Editor Updates
+### Reading and Updating Editor State
 
-When you want to change something in an Editor State, you must do it via an update, `editor.update(() => {...})`. The closure passed
-to the update call is important. It's a place where you have full "lexical" context of the active editor state, and it exposes
-access to the underlying Editor State's node tree. We promote using `$` prefixed functions in this context, as it signifies a place
-where they can be used exclusively. Attempting to use them outside of an update will trigger a runtime error with an appropriate error.
-For those familiar with React Hooks, you can think of these as having a similar functionality (except `$` functions can be used in any order).
+When you want to read and/or update the Lexical node tree, you must do it via `editor.update(() => {...})`. You may also do
+read-only operations with the editor state via `editor.getEditorState().read(() => {...})`. The closure passed to the update or read
+call is important, and must be synchronous. It's the only place where you have full "lexical" context of the active editor state,
+and providing you with access to the Editor State's node tree. We promote using the convention of using `$` prefixed functions
+(such as `$getRoot()`) to convey that these functions must be called in this context. Attempting to use them outside of a read
+or update will trigger a runtime error.
+
+For those familiar with React Hooks, you can think of these $functions as having similar functionality:
+| *Feature* | React Hooks | Lexical $functions |
+| -- | -- | -- |
+| Naming Convention | `useFunction` | `$function` |
+| Context Required | Can only be called while rendering | Can only be called while in an update or read |
+| Can be composed | Hooks can call other hooks | $functions can call other $functions |
+| Must be synchronous | ✅ | ✅ |
+| Other rules | ❌ Must be called unconditionally in the same order | ✅ None |
+
+Node Transforms and Command Listeners are called with an implicit `editor.update(() => {...})` context.
+
+It is permitted to do nest updates within reads and updates, but an update may not be nested in a read.
+For example, `editor.update(() => editor.update(() => {...}))` is allowed.
+
+All Lexical Nodes are dependent on the associated Editor State. With few exceptions, you should only call methods
+and access properties of a Lexical Node while in a read or update call (just like `$` functions). Methods
+on Lexical Nodes will first attempt to locate the latest (and possibly a writable) version of the node from the
+active editor state using the node's unique key. All versions of a logical node have the same key. These keys
+are managed by the Editor, are only present at runtime (not serialized), and should be considered to be random and
+opaque (do not write tests that assume hard-coded values for keys).
+
+This is done because the editor state's node tree is recursively frozen after reconciliation to
+support efficient time travel (undo/redo and similar use cases). Methods that update nodes
+first call `node.getWritable()`, which will create a writable clone of a frozen node. This would normally
+mean that any existing references (such as local variables) would refer to a stale version of the node, but
+having Lexical Nodes always refer to the editor state allows for a simpler and less error-prone data model.
 
 ### DOM Reconciler
 


### PR DESCRIPTION
Add some clarifying documentation to the introductory pages:

* [README.md](https://github.com/etrepum/lexical/blob/doc-updates/README.md)
* [Intro](https://lexical-git-fork-etrepum-doc-updates-fbopensource.vercel.app/docs/intro)
* [Editor State](https://lexical-git-fork-etrepum-doc-updates-fbopensource.vercel.app/docs/concepts/editor-state)
