### PR TITLE
fix: removed overwrite of copyright

### DIFF
--- a/packages/lexical-website/i18n/en/docusaurus-theme-classic/footer.json
+++ b/packages/lexical-website/i18n/en/docusaurus-theme-classic/footer.json
@@ -42,9 +42,5 @@
   "link.item.label.Terms": {
     "message": "Terms",
     "description": "The label of footer link with label=Terms linking to https://opensource.facebook.com/legal/terms/"
-  },
-  "copyright": {
-    "message": "Copyright © 2022 Meta Platforms, Inc. Built with Docusaurus.",
-    "description": "The footer copyright"
   }
 }


### PR DESCRIPTION
The copyright object in footer.json was overriding the copyright value set in docusaurus.config.js, where the year is correctly utilized. The removed copyright object in footer.json also had the year 2022 hardcoded.