### PR TITLE
fix(playground): wrong logic for FloatingLinkEditorPlugin bad node

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -305,19 +305,19 @@ function useFloatingLinkEditorToolbar(
           setIsLink(false);
           return;
         }
-        const badNode = selection.getNodes().find((node) => {
-          const linkNode = $findMatchingParent(node, $isLinkNode);
-          const autoLinkNode = $findMatchingParent(node, $isAutoLinkNode);
-          if (
-            !linkNode?.is(focusLinkNode) &&
-            !autoLinkNode?.is(focusAutoLinkNode) &&
-            !linkNode &&
-            !autoLinkNode &&
-            !$isLineBreakNode(node)
-          ) {
-            return node;
-          }
-        });
+        const badNode = selection
+          .getNodes()
+          .filter((node) => !$isLineBreakNode(node))
+          .find((node) => {
+            const linkNode = $findMatchingParent(node, $isLinkNode);
+            const autoLinkNode = $findMatchingParent(node, $isAutoLinkNode);
+            return (
+              (focusLinkNode && !focusLinkNode.is(linkNode)) ||
+              (linkNode && !linkNode.is(focusLinkNode)) ||
+              (focusAutoLinkNode && !focusAutoLinkNode.is(autoLinkNode)) ||
+              (autoLinkNode && !autoLinkNode.is(focusAutoLinkNode))
+            );
+          });
         if (!badNode) {
           setIsLink(true);
         } else {


### PR DESCRIPTION
As discussed at https://github.com/facebook/lexical/pull/5551#issuecomment-2032416573

I suspect the lengthy original conditional was attempting to capture the definition of a bad node:

- if we have either a focusLinkNode or a linkNode, it must match the other
- if we have either a focusAutoLinkNode or an autoLinkNode, it must match the other

so I rewrote the logic to say that.