### PR TITLE
export toggleTextFormatType from LexicalUtils

### DIFF
--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -160,6 +160,7 @@ export {
   isHTMLElement,
   isSelectionCapturedInDecoratorInput,
   isSelectionWithinEditor,
+  toggleTextFormatType,
 } from './LexicalUtils';
 export {$isDecoratorNode, DecoratorNode} from './nodes/LexicalDecoratorNode';
 export {$isElementNode, ElementNode} from './nodes/LexicalElementNode';


### PR DESCRIPTION
this is necessary so we can override toggleFormat on an extended TextNode that selectively disallows certain format types.