### PR TITLE
Bump publish scripts to v4

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -2,21 +2,21 @@ name: Nightly Release Branch
 on:
   schedule:
     # Run daily at 2:30am UTC
-    - cron: '30 2 * * 1-5'
+    # - cron: '30 2 * * 1-5'
 jobs:
   release:
     # prevents this action from running on forks
     if: github.repository_owner == 'facebook'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.SSH_KEY }}
           fetch-depth: 0
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: |
           git config user.name "Lexical GitHub Actions Bot"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -16,7 +16,6 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: |
           git config user.name "Lexical GitHub Actions Bot"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -9,7 +9,6 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run prepare-release

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -9,7 +9,7 @@ jobs:
     env:
       CI_JOB_NUMBER: 1
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,14 +15,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.SSH_KEY }}
           fetch-depth: 0
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: |
           git config user.name "Lexical GitHub Actions Bot"
@@ -37,4 +37,5 @@ jobs:
       - run: LATEST_RELEASE=${{ steps.latest.outputs.release }} npm run increment-version -- --i $INCREMENT
         env:
           INCREMENT: ${{ inputs.increment }}
+      - run: npm install
       - run: git push -u git@github.com:facebook/lexical.git --follow-tags

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -22,7 +22,6 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: |
           git config user.name "Lexical GitHub Actions Bot"


### PR DESCRIPTION
- Bump to checkout@v4 and setup-node@v4, remove explicit node version specification, ie. take latest LTS by default (20 right now)
- Disable the nightly script, which was just creating a branch, but never actually published
- Add an extra 'npm install' after version bump in the package.json's in the versioning script, since currently, it creates an inconsistent package-lock.json and requires a manual run of 'npm install' for when 'npm ci' is run to be correct when tests kick off in the version PR.