### PR TITLE
feat: export 'IS_' and 'CAN_*' environment constants from @lexical/utils

### DIFF
--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -33,6 +33,18 @@ export {default as markSelection} from './markSelection';
 export {default as mergeRegister} from './mergeRegister';
 export {default as positionNodeOnRange} from './positionNodeOnRange';
 export {$splitNode, isHTMLAnchorElement, isHTMLElement} from 'lexical';
+export {CAN_USE_DOM} from 'shared/canUseDOM';
+export {
+  CAN_USE_BEFORE_INPUT,
+  IS_ANDROID,
+  IS_ANDROID_CHROME,
+  IS_APPLE,
+  IS_APPLE_WEBKIT,
+  IS_CHROME,
+  IS_FIREFOX,
+  IS_IOS,
+  IS_SAFARI,
+} from 'shared/environment';
 
 export type DFSNode = Readonly<{
   depth: number;


### PR DESCRIPTION
<details>
<summary>Exports all of the `IS_*` and `CAN_*` environment constants from @lexical/utils.</summary>

```typescript
export {CAN_USE_DOM} from 'shared/canUseDOM';
export {
  CAN_USE_BEFORE_INPUT,
  IS_ANDROID,
  IS_ANDROID_CHROME,
  IS_APPLE,
  IS_APPLE_WEBKIT,
  IS_CHROME,
  IS_FIREFOX,
  IS_IOS,
  IS_SAFARI,
} from 'shared/environment';
```
</details>

While browser detection isn't really the purview of Lexical, these constants (or copy-pasted equivalents) are often necessary when implementing lower level features or just working around browser quirks. I found them useful to copy when I was working on a project that blended the code from lexical/plain-text and lexical/rich-text, which I found easier to understand and maintain by creating an independent "registerCustomText" rather than picking one and overriding functionality with higher command priorities.

Resolves #5827