### PR TITLE
Fixed playground draggable block while scrolled

### DIFF
--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -231,7 +231,8 @@ function setTargetLine(
     anchorElem.getBoundingClientRect();
   const {marginTop, marginBottom} = getCollapsedMargins(targetBlockElem);
   let lineTop = targetBlockElemTop;
-  if (mouseY >= targetBlockElemTop) {
+  const scrollAjustedBlockElmTop = targetBlockElemTop + window.scrollY;
+  if (mouseY >= scrollAjustedBlockElmTop) {
     lineTop += targetBlockElemHeight + marginBottom / 2;
   } else {
     lineTop -= marginTop / 2;


### PR DESCRIPTION
When using the playground in a smaller window and scrolling down, it is impossible to move a node to the top node.

This fix adjusts the draggableBlockPlugin to allow the placement of a node at the root while scrolled. It was improperly calculated, as the mouseY variable is tied to the location relative to the page and not the screen. 

I encountered this bug in my own build of this plugin.