### PR TITLE
Use updated docRoot count in removeRootElementEvents

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1302,7 +1302,7 @@ export function removeRootElementEvents(rootElement: HTMLElement): void {
   // We only want to have a single global selectionchange event handler, shared
   // between all editor instances.
   rootElementsRegistered.set(doc, documentRootElementsCount - 1);
-  if (documentRootElementsCount === 1) {
+  if (rootElementsRegistered.get(doc) === 1) {
     doc.removeEventListener('selectionchange', onDocumentSelectionChange);
   }
 


### PR DESCRIPTION
Refactored in #5070, this is introducing some subtle bugs internally.

We should be using the updated `documentRootElementsCount` before deciding whether or not to remove the selectionchange listener, to make the logic consistent with the old implementation.