### PR TITLE
Playground - Clear Format button fix

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -68,6 +68,7 @@ import {
   OUTDENT_CONTENT_COMMAND,
   REDO_COMMAND,
   SELECTION_CHANGE_COMMAND,
+  TextNode,
   UNDO_COMMAND,
 } from 'lexical';
 import {Dispatch, useCallback, useEffect, useState} from 'react';

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -761,6 +761,16 @@ export default function ToolbarPlugin({
             if (idx === nodes.length - 1) {
               textNode = textNode.splitText(focus.offset)[0] || textNode;
             }
+            /**
+             * If the selected text has one format applied
+             * selecting a portion of the text, could
+             * clear the format to the wrong portion of the text.
+             *
+             * The cleared text is based on the length of the selected text.
+             */
+            if (nodes.length === 1) {
+              textNode = selection.extract()[0] as TextNode;
+            }
 
             if (textNode.__style !== '') {
               textNode.setStyle('');

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -68,7 +68,6 @@ import {
   OUTDENT_CONTENT_COMMAND,
   REDO_COMMAND,
   SELECTION_CHANGE_COMMAND,
-  TextNode,
   UNDO_COMMAND,
 } from 'lexical';
 import {Dispatch, useCallback, useEffect, useState} from 'react';
@@ -769,8 +768,10 @@ export default function ToolbarPlugin({
              *
              * The cleared text is based on the length of the selected text.
              */
-            if (nodes.length === 1) {
-              textNode = selection.extract()[0] as TextNode;
+            // We need this in case the selected text only has one format
+            const extractedTextNode = selection.extract()[0];
+            if (nodes.length === 1 && $isTextNode(extractedTextNode)) {
+              textNode = extractedTextNode;
             }
 
             if (textNode.__style !== '') {


### PR DESCRIPTION
This PR fixes an issue found in the Playground. When you select a portion of a selected text with the format applied, it could wrongly remove the format to another portion of the sentence with the same format applied.

Reference:

https://github.com/facebook/lexical/assets/105524386/5d5b3470-3b07-4495-b9df-dd70865a402d

