### PR TITLE
TextNode support font-weight bold

### DIFF
--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -1090,17 +1090,18 @@ export class TextNode extends LexicalNode {
 function convertSpanElement(domNode: Node): DOMConversionOutput {
   // domNode is a <span> since we matched it by nodeName
   const span = domNode as HTMLSpanElement;
+  const style = span.style;
+  const fontWeight = style.fontWeight;
   // Google Docs uses span tags + font-weight for bold text
-  const hasBoldFontWeight = span.style.fontWeight === '700';
+  const hasBoldFontWeight = fontWeight === '700' || fontWeight === 'bold';
   // Google Docs uses span tags + text-decoration: line-through for strikethrough text
-  const hasLinethroughTextDecoration =
-    span.style.textDecoration === 'line-through';
+  const hasLinethroughTextDecoration = style.textDecoration === 'line-through';
   // Google Docs uses span tags + font-style for italic text
-  const hasItalicFontStyle = span.style.fontStyle === 'italic';
+  const hasItalicFontStyle = style.fontStyle === 'italic';
   // Google Docs uses span tags + text-decoration: underline for underline text
-  const hasUnderlineTextDecoration = span.style.textDecoration === 'underline';
+  const hasUnderlineTextDecoration = style.textDecoration === 'underline';
   // Google Docs uses span tags + vertical-align to specify subscript and superscript
-  const verticalAlign = span.style.verticalAlign;
+  const verticalAlign = style.verticalAlign;
 
   return {
     forChild: (lexicalNode) => {


### PR DESCRIPTION
Turns out that Google Spreadsheets can return bold text in `font-weight=bold` that we weren't handling yet.

<img width="352" alt="Screenshot 2024-04-09 at 12 26 47 PM" src="https://github.com/facebook/lexical/assets/193447/ae6631e4-fab8-4bdd-9c3d-90d11a8975a3">

```
<span
  style="font-size:10pt;font-family:Arial;font-style:normal;">df </span><span
  style="font-size:10pt;font-family:Arial;font-weight:bold;font-style:normal;">dasdf</span>
```