### PR TITLE
Fix inserting text from Grammarly when full node is selected with forward selection

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Extensions.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Extensions.spec.mjs
@@ -7,6 +7,10 @@
  */
 
 import {
+  moveToEditorBeginning,
+  moveToEditorEnd,
+} from '../keyboardShortcuts/index.mjs';
+import {
   assertHTML,
   assertSelection,
   evaluate,
@@ -253,6 +257,92 @@ test.describe('Extensions', () => {
       anchorPath: [1, 0, 0],
       focusOffset: 3,
       focusPath: [1, 0, 0],
+    });
+  });
+
+  test('document.execCommand("insertText") with all text backward selection', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    await page.keyboard.type('Paragraph 1');
+    await moveToEditorEnd(page);
+    await page.keyboard.down('Shift');
+    await moveToEditorBeginning(page);
+    await page.keyboard.up('Shift');
+
+    await assertSelection(page, {
+      anchorOffset: 11,
+      anchorPath: [0, 0, 0],
+      focusOffset: 0,
+      focusPath: [0, 0, 0],
+    });
+
+    await evaluate(
+      page,
+      () => {
+        document.execCommand('insertText', false, 'New text');
+      },
+      [],
+    );
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">New text</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 8,
+      anchorPath: [0, 0, 0],
+      focusOffset: 8,
+      focusPath: [0, 0, 0],
+    });
+  });
+
+  test('document.execCommand("insertText") with all text forward selection', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    await page.keyboard.type('Paragraph 1');
+    await moveToEditorBeginning(page);
+    await page.keyboard.down('Shift');
+    await moveToEditorEnd(page);
+    await page.keyboard.up('Shift');
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0, 0, 0],
+      focusOffset: 11,
+      focusPath: [0, 0, 0],
+    });
+
+    await evaluate(
+      page,
+      () => {
+        document.execCommand('insertText', false, 'New text');
+      },
+      [],
+    );
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">New text</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 8,
+      anchorPath: [0, 0, 0],
+      focusOffset: 8,
+      focusPath: [0, 0, 0],
     });
   });
 });

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -826,7 +826,13 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
       if (domSelection === null) {
         return;
       }
-      const offset = anchor.offset;
+      const isBackward = selection.isBackward();
+      const startOffset = isBackward
+        ? selection.anchor.offset
+        : selection.focus.offset;
+      const endOffset = isBackward
+        ? selection.focus.offset
+        : selection.anchor.offset;
       // If the content is the same as inserted, then don't dispatch an insertion.
       // Given onInput doesn't take the current selection (it uses the previous)
       // we can compare that against what the DOM currently says.
@@ -835,9 +841,9 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
         selection.isCollapsed() ||
         !$isTextNode(anchorNode) ||
         domSelection.anchorNode === null ||
-        anchorNode.getTextContent().slice(0, offset) +
+        anchorNode.getTextContent().slice(0, startOffset) +
           data +
-          anchorNode.getTextContent().slice(offset + selection.focus.offset) !==
+          anchorNode.getTextContent().slice(startOffset + endOffset) !==
           getAnchorTextFromDOM(domSelection.anchorNode)
       ) {
         dispatchCommand(editor, CONTROLLED_TEXT_INSERTION_COMMAND, data);


### PR DESCRIPTION
## Problem
Inserting text from Grammarly fails to save the state when a full-text node is selected in the forward direction (from start to end).

https://github.com/facebook/lexical/assets/1575198/bc336023-2447-4524-9dda-a60530667d64



## Solution
Check the selection direction when comparing inserted content.

https://github.com/facebook/lexical/assets/1575198/74d15054-e6c4-4707-9209-8e9dc453b867

