### PR TITLE
fix test failing after rebase on bug fix for multiple text nodes styles in a cell node

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
@@ -1033,7 +1033,12 @@ test.describe('CodeBlock', () => {
         <td
           class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__ltr"
           dir="ltr">
-          <span data-lexical-text="true">sdvd sdfvsfs</span>
+          <span data-lexical-text="true">sdvd</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            sdfvsfs
+          </strong>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
Running 10 tests using 1 worker

  ✓  1 [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:1124:5 › CodeBlock › Code block html paste: VS Code (3.6s)
  ✓  2 [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:1124:5 › CodeBlock › Code block html paste: Quip (1.4s)
  ✓  3 [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:1124:5 › CodeBlock › Code block html paste: WebStorm / Idea (1.5s)
  ✓  4 [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:1124:5 › CodeBlock › Code block html paste: Postman IDE (1.5s)
  ✓  5 [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:1124:5 › CodeBlock › Code block html paste: Slack message (1.6s)
  ✓  6 [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:1124:5 › CodeBlock › Code block html paste: CodeHub (1.9s)
  ✓  7 [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:1124:5 › CodeBlock › Code block html paste: GitHub / Gist (1.4s)
  ✓  8 [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:1124:5 › CodeBlock › Code block html paste: Single line <code> (1.4s)
  ✓  9 [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:1124:5 › CodeBlock › Code block html paste: Multiline <code> (2.0s)
  ✓  10 [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs:1124:5 › CodeBlock › Code block html paste: Google Spreadsheet (1.7s)

  Slow test file: [chromium] › packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs (18.1s)
  Consider splitting slow test files to speed up parallel execution
  10 passed (20.0s)