### PR TITLE
fix #4468 Preserv elemement text align format on new paragraph creation

### DIFF
--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -160,6 +160,7 @@ export class ParagraphNode extends ElementNode {
     newElement.setTextFormat(rangeSelection.format);
     const direction = this.getDirection();
     newElement.setDirection(direction);
+    newElement.setFormat(this.getFormatType());
     this.insertAfter(newElement, restoreSelection);
     return newElement;
   }


### PR DESCRIPTION
Before

https://github.com/facebook/lexical/assets/163521239/6e2ae748-acb1-4108-bbee-0f33560a7d04

After

https://github.com/facebook/lexical/assets/163521239/7bfee8e1-f2e7-4ba2-b4c1-4c11a3e6d8e9


closes #4468 