### PR TITLE
Fix #5812 copy paste cell crashes if it has no paragraph

### DIFF
--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -331,7 +331,10 @@ export function convertTableCellNodeElement(
       return childLexicalNodes;
     },
     forChild: (lexicalNode, parentLexicalNode) => {
-      if ($isTableCellNode(parentLexicalNode) && !$isElementNode(lexicalNode)) {
+      if (
+        ($isTableCellNode(parentLexicalNode) || parentLexicalNode == null) &&
+        !$isElementNode(lexicalNode)
+      ) {
         const paragraphNode = $createParagraphNode();
         if (
           $isLineBreakNode(lexicalNode) &&


### PR DESCRIPTION
Before:
#5812 
After:

https://github.com/facebook/lexical/assets/163521239/53f2e13c-060f-43cb-8897-cd90255c3fd7

