### PR TITLE
fix(lexical/createEditor): avoid implicit any type

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -433,8 +433,8 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
     registeredNodes = new Map();
     for (let i = 0; i < nodes.length; i++) {
       let klass = nodes[i];
-      let replace = null;
-      let replaceWithKlass = null;
+      let replace: RegisteredNode['replace'] = null;
+      let replaceWithKlass: RegisteredNode['replaceWithKlass'] = null;
 
       if (typeof klass !== 'function') {
         const options = klass;


### PR DESCRIPTION
## Why

We should avoid implicit `any` type because it may cause problems in the future.

## What

Explicitly setup the type of the `replace` and `replaceWithKlass` when creating them.

## Additional information

before
<img width="1624" alt="image" src="https://github.com/facebook/lexical/assets/47748132/cd20a69a-d1b8-432a-8cf0-49e99fa88abc">
