### PR TITLE
Fix broken style for node overrides example on docs

### DIFF
--- a/packages/lexical-website/docs/concepts/node-replacement.md
+++ b/packages/lexical-website/docs/concepts/node-replacement.md
@@ -25,7 +25,7 @@ const editorConfig = {
 Once this is done, Lexical will replace all ParagraphNode instances with CustomParagraphNode instances. One important use case for this feature is overriding the serialization behavior of core nodes. Check out the full example below.
 
 <iframe src="https://codesandbox.io/embed/ecstatic-maxwell-kw5utu?fontsize=14&hidenavigation=1&module=/src/Editor.js,/src/plugins/CollapsiblePlugin.ts,/src/nodes/CollapsibleContainerNode.ts&theme=dark&view=split"
-     style={{width:"100%", height:"700px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     style="width:100%; height:700px; border:0; border-radius:4px; overflow:hidden;"
      title="lexical-collapsible-container-plugin-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"


### PR DESCRIPTION
Styling for the example on [node-replacement](https://lexical.dev/docs/concepts/node-replacement) is broken.

### Before
<img width="1081" alt="image" src="https://github.com/facebook/lexical/assets/40269597/de5a9a6f-2288-4f28-9338-074904d41d66">

### After
<img width="1045" alt="image" src="https://github.com/facebook/lexical/assets/40269597/d1c8bd79-4a41-41ba-92cd-c724724918dc">
