### PR TITLE
Remove a special case in table deleteTextHandler

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -26,6 +26,7 @@ import {
   focusEditor,
   html,
   initialize,
+  insertCollapsible,
   insertHorizontalRule,
   insertSampleImage,
   insertTable,
@@ -1289,6 +1290,95 @@ test.describe('Tables', () => {
                 dir="ltr">
                 <span data-lexical-text="true">cell one</span>
               </p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test('Can remove new lines in a collapsible section inside of a table', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    await initialize({isCollab, page});
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await insertTable(page, 1, 2);
+    await insertCollapsible(page);
+
+    await page.keyboard.type('123');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.type('123');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+              <details class="Collapsible__container" open="">
+                <summary class="Collapsible__title">
+                  <p class="PlaygroundEditorTheme__paragraph">
+                    <span data-lexical-text="true">123</span>
+                  </p>
+                </summary>
+                <div class="Collapsible__content">
+                  <p class="PlaygroundEditorTheme__paragraph">
+                    <span data-lexical-text="true">123</span>
+                  </p>
+                  <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+                  <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+                  <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+                </div>
+              </details>
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    await pressBackspace(page, 10);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+              <details class="Collapsible__container" open="">
+                <summary class="Collapsible__title">
+                  <p class="PlaygroundEditorTheme__paragraph">
+                    <span data-lexical-text="true">123</span>
+                  </p>
+                </summary>
+                <div class="Collapsible__content">
+                  <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+                </div>
+              </details>
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -282,22 +282,6 @@ export function applyTableHandlers(
         // TODO: Fix Delete Line in Table Cells.
         return true;
       }
-
-      if (
-        command === DELETE_CHARACTER_COMMAND ||
-        command === DELETE_WORD_COMMAND
-      ) {
-        if (selection.isCollapsed() && selection.anchor.offset === 0) {
-          if (nearestElementNode !== topLevelCellElementNode) {
-            const children = nearestElementNode.getChildren();
-            const newParagraphNode = $createParagraphNode();
-            children.forEach((child) => newParagraphNode.append(child));
-            nearestElementNode.replace(newParagraphNode);
-            nearestElementNode.getWritable().__parent = tableCellNode.getKey();
-            return true;
-          }
-        }
-      }
     }
 
     return false;


### PR DESCRIPTION
This was introduced in https://github.com/facebook/lexical/pull/3213 but wasn't cleaned up after a proper fix.
Currently this does not allow the removal of empty lines in a collapsible section inside of a table.

Before:
![table-collapsible-paragraph](https://github.com/facebook/lexical/assets/29728044/ef7dc844-c3fa-4b08-901a-c6fb4d714e5d)

After:
![table-collapsible-paragraph-after](https://github.com/facebook/lexical/assets/29728044/f326c58d-ffaa-4b22-83d7-6aeb5a75fe09)
