### PR TITLE
Fix version script

### DIFF
--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -218,10 +218,21 @@ function sortDependencies(packageJSON, key, deps) {
  * @param {string} version
  */
 function updateDependencies(packageJSON, version) {
-  const {dependencies = {}, peerDependencies = {}} = packageJSON;
+  const {
+    dependencies = {},
+    peerDependencies = {},
+    devDependencies = {},
+  } = packageJSON;
   Object.keys(dependencies).forEach((dep) => {
     if (packages[dep] !== undefined) {
       dependencies[dep] = version;
+    }
+  });
+  // We need to update the dev dependencies of the devtools package since it includes lexical
+  // dev-tools-core.
+  Object.keys(devDependencies).forEach((devDep) => {
+    if (packages[devDep] !== undefined) {
+      devDependencies[devDep] = version;
     }
   });
   // Move peerDependencies on lexical monorepo packages to dependencies


### PR DESCRIPTION
We need to update the devDeps during the release branch action for now. I suspect we can find an easier way to deal with this later. (i.e., should these even be dev dependencies?).

Without this, the devDependencies in the devtools (not core) package don't get bumped, which causes a mismatch between the package-lock and the dev dependencies, which causes npm ci to fail (I think).