### PR TITLE
Fix "TypeError: Cannot use 'in' operator to search for '__language' in null" in LexicalSelection

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1209,7 +1209,7 @@ export class RangeSelection implements BaseSelection {
     const last = nodes[nodes.length - 1]!;
 
     // CASE 1: insert inside a code block
-    if ('__language' in firstBlock && $isElementNode(firstBlock)) {
+    if ($isElementNode(firstBlock) && '__language' in firstBlock) {
       if ('__language' in nodes[0]) {
         this.insertText(nodes[0].getTextContent());
       } else {


### PR DESCRIPTION
Prevents the error `"TypeError: Cannot use 'in' operator to search for '__language' in null"` from being thrown if `firstBlock` is `null` by putting the `$isElementNode(firstBlock)` first in the if statement.