### PR TITLE
Fix selecting table selects an image after

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -17,6 +17,7 @@ import type {
 import type {
   BaseSelection,
   ElementFormatType,
+  ElementNode,
   LexicalCommand,
   LexicalEditor,
   LexicalNode,
@@ -674,6 +675,17 @@ export function applyTableHandlers(
     ),
   );
 
+  function getChildNodeOnOffset(
+    parentNode: ElementNode,
+    index: number,
+  ): [string, number] {
+    const node = parentNode.getChildAtIndex(index);
+    if (node === null) {
+      return [parentNode.getKey(), index];
+    }
+    return [node.getKey(), 0];
+  }
+
   tableObserver.listenersToRemove.add(
     editor.registerCommand(
       SELECTION_CHANGE_COMMAND,
@@ -702,13 +714,16 @@ export function applyTableHandlers(
           if (isPartialyWithinTable) {
             const newSelection = selection.clone();
             if (isFocusInside) {
-              newSelection.focus.set(
-                tableNode.getParentOrThrow().getKey(),
-                isBackward
-                  ? tableNode.getIndexWithinParent()
-                  : tableNode.getIndexWithinParent() + 1,
-                'element',
-              );
+              const [newFocusKey, newFocusOffset] = isBackward
+                ? [
+                    tableNode.getParentOrThrow().getKey(),
+                    tableNode.getIndexWithinParent(),
+                  ]
+                : getChildNodeOnOffset(
+                    tableNode.getParentOrThrow(),
+                    tableNode.getIndexWithinParent() + 1,
+                  );
+              newSelection.focus.set(newFocusKey, newFocusOffset, 'element');
             } else {
               newSelection.anchor.set(
                 tableNode.getParentOrThrow().getKey(),

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -17,7 +17,6 @@ import type {
 import type {
   BaseSelection,
   ElementFormatType,
-  ElementNode,
   LexicalCommand,
   LexicalEditor,
   LexicalNode,
@@ -675,17 +674,6 @@ export function applyTableHandlers(
     ),
   );
 
-  function getChildNodeOnOffset(
-    parentNode: ElementNode,
-    index: number,
-  ): [string, number] {
-    const node = parentNode.getChildAtIndex(index);
-    if (node === null) {
-      return [parentNode.getKey(), index];
-    }
-    return [node.getKey(), 0];
-  }
-
   tableObserver.listenersToRemove.add(
     editor.registerCommand(
       SELECTION_CHANGE_COMMAND,
@@ -714,16 +702,11 @@ export function applyTableHandlers(
           if (isPartialyWithinTable) {
             const newSelection = selection.clone();
             if (isFocusInside) {
-              const [newFocusKey, newFocusOffset] = isBackward
-                ? [
-                    tableNode.getParentOrThrow().getKey(),
-                    tableNode.getIndexWithinParent(),
-                  ]
-                : getChildNodeOnOffset(
-                    tableNode.getParentOrThrow(),
-                    tableNode.getIndexWithinParent() + 1,
-                  );
-              newSelection.focus.set(newFocusKey, newFocusOffset, 'element');
+              newSelection.focus.set(
+                tableNode.getParentOrThrow().getKey(),
+                tableNode.getIndexWithinParent(),
+                'element',
+              );
             } else {
               newSelection.anchor.set(
                 tableNode.getParentOrThrow().getKey(),

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1940,13 +1940,13 @@ function internalResolveSelectionPoint(
             : child.getFirstDescendant();
           if (descendant === null) {
             resolvedElement = child;
-            resolvedOffset = 0;
           } else {
             child = descendant;
             resolvedElement = $isElementNode(child)
               ? child
               : child.getParentOrThrow();
           }
+          resolvedOffset = 0;
         }
         if ($isTextNode(child)) {
           resolvedNode = child;


### PR DESCRIPTION
Issue: selection of table by cursor dragging also selects the image after the table
Fix: resolve selection focus to the beginning of the paragraph with an image, not the root element with offset

Before:
![old-table-picture-select](https://github.com/facebook/lexical/assets/47710336/09ff93f0-f665-403f-922e-2a68f2d26990)

After:
![new-table-picture-select](https://github.com/facebook/lexical/assets/47710336/e04611bf-8e4b-4136-92a5-3170fef2b8c3)

