### PR TITLE
Add setTimeout for mousemove handler

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -102,15 +102,17 @@ export function applyTableHandlers(
     };
 
     const onMouseMove = (moveEvent: MouseEvent) => {
-      const focusCell = getDOMCellFromTarget(moveEvent.target as Node);
-      if (
-        focusCell !== null &&
-        (tableObserver.anchorX !== focusCell.x ||
-          tableObserver.anchorY !== focusCell.y)
-      ) {
-        moveEvent.preventDefault();
-        tableObserver.setFocusCellForSelection(focusCell);
-      }
+      setTimeout(() => {
+        const focusCell = getDOMCellFromTarget(moveEvent.target as Node);
+        if (
+          focusCell !== null &&
+          (tableObserver.anchorX !== focusCell.x ||
+            tableObserver.anchorY !== focusCell.y)
+        ) {
+          moveEvent.preventDefault();
+          tableObserver.setFocusCellForSelection(focusCell);
+        }
+      }, 0);
     };
     return {onMouseMove: onMouseMove, onMouseUp: onMouseUp};
   };


### PR DESCRIPTION
Fixes
![table-selection-scroll](https://github.com/facebook/lexical/assets/29728044/d0f6ae4e-cab4-48d7-acce-7444113fccac)
Selection is getting stuck and the page is not getting scrolled automatically

Happens in Chrome, not in Firefox
The problem is that the order of events `mousemove` and 'selectionchange` is not deterministic. When `mousemove` is handled before it prevents `selectionchange` handler from executing fully resulting in this bug.
