### PR TITLE
Fix bug with block decorator nodes erroring on indent

### DIFF
--- a/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
+++ b/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
@@ -39,6 +39,10 @@ export class DecoratorBlockNode extends DecoratorNode<JSX.Element> {
     };
   }
 
+  canIndent(): false {
+    return false;
+  }
+
   createDOM(): HTMLElement {
     return document.createElement('div');
   }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -509,7 +509,14 @@ function handleIndentAndOutdent(
     if (alreadyHandled.has(key)) {
       continue;
     }
-    const parentBlock = $getNearestBlockElementAncestorOrThrow(node);
+    const parentBlock = $findMatchingParent(
+      node,
+      (parentNode): parentNode is ElementNode =>
+        $isElementNode(parentNode) && !parentNode.isInline(),
+    );
+    if (parentBlock === null) {
+      continue;
+    }
     const parentKey = parentBlock.getKey();
     if (parentBlock.canIndent() && !alreadyHandled.has(parentKey)) {
       alreadyHandled.add(parentKey);


### PR DESCRIPTION
Closes #5650.

### Test Plan

Ensure no errors appear when trying to indent a block decorator node. 

<img width="1691" alt="image" src="https://github.com/facebook/lexical/assets/7748470/0df9648c-f0fe-4a87-92c7-2866a6d9cdfe">
