### PR TITLE
chore(@lexical/history): Remove redundant register call

### DIFF
--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -446,7 +446,7 @@ export function registerHistory(
     };
   };
 
-  const unregisterCommandListener = mergeRegister(
+  const unregister = mergeRegister(
     editor.registerCommand(
       UNDO_COMMAND,
       () => {
@@ -484,12 +484,7 @@ export function registerHistory(
     editor.registerUpdateListener(applyChange),
   );
 
-  const unregisterUpdateListener = editor.registerUpdateListener(applyChange);
-
-  return () => {
-    unregisterCommandListener();
-    unregisterUpdateListener();
-  };
+  return unregister;
 }
 
 /**


### PR DESCRIPTION

```ts
 editor.registerUpdateListener(applyChange)
```

It's called redundantly although there hasn't been any issues as update listeners are managed in a `Set`.