### PR TITLE
Collapsible Section Fixes

### DIFF
--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -96,6 +96,7 @@ export class CollapsibleContainerNode extends ElementNode {
 
   exportDOM(): DOMExportOutput {
     const element = document.createElement('details');
+    element.classList.add('Collapsible__container');
     element.setAttribute('open', this.__open.toString());
     return {element};
   }

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
@@ -62,6 +62,7 @@ export class CollapsibleContentNode extends ElementNode {
 
   exportDOM(): DOMExportOutput {
     const element = document.createElement('div');
+    element.classList.add('Collapsible__content');
     element.setAttribute('data-lexical-collapsible-content', 'true');
     return {element};
   }

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
@@ -11,7 +11,6 @@ import {
   $isElementNode,
   DOMConversionMap,
   DOMConversionOutput,
-  DOMExportOutput,
   EditorConfig,
   ElementNode,
   LexicalEditor,
@@ -68,11 +67,6 @@ export class CollapsibleTitleNode extends ElementNode {
     serializedNode: SerializedCollapsibleTitleNode,
   ): CollapsibleTitleNode {
     return $createCollapsibleTitleNode();
-  }
-
-  exportDOM(): DOMExportOutput {
-    const element = document.createElement('summary');
-    return {element};
   }
 
   exportJSON(): SerializedCollapsibleTitleNode {

--- a/packages/lexical-react/src/LexicalClickableLinkPlugin.tsx
+++ b/packages/lexical-react/src/LexicalClickableLinkPlugin.tsx
@@ -43,11 +43,6 @@ export default function LexicalClickableLinkPlugin({
 
   useEffect(() => {
     const onClick = (event: MouseEvent) => {
-      if (disabled) {
-        event.preventDefault();
-        return;
-      }
-
       const target = event.target;
       if (!(target instanceof Node)) {
         return;
@@ -67,14 +62,16 @@ export default function LexicalClickableLinkPlugin({
             clickedNode,
             $isElementNode,
           );
-          if ($isLinkNode(maybeLinkNode)) {
-            url = maybeLinkNode.sanitizeUrl(maybeLinkNode.getURL());
-            urlTarget = maybeLinkNode.getTarget();
-          } else {
-            const a = findMatchingDOM(target, isHTMLAnchorElement);
-            if (a !== null) {
-              url = a.href;
-              urlTarget = a.target;
+          if (!disabled) {
+            if ($isLinkNode(maybeLinkNode)) {
+              url = maybeLinkNode.sanitizeUrl(maybeLinkNode.getURL());
+              urlTarget = maybeLinkNode.getTarget();
+            } else {
+              const a = findMatchingDOM(target, isHTMLAnchorElement);
+              if (a !== null) {
+                url = a.href;
+                urlTarget = a.target;
+              }
             }
           }
         }
@@ -106,7 +103,7 @@ export default function LexicalClickableLinkPlugin({
     };
 
     const onMouseUp = (event: MouseEvent) => {
-      if (!disabled && event.button === 1) {
+      if (event.button === 1) {
         onClick(event);
       }
     };


### PR DESCRIPTION
- [x] Export collapsible section classes (Fix for https://github.com/facebook/lexical/issues/5910)
- [x] Make the section toggable again by clicking on the arrow icon (I broke this as a byproduct of https://github.com/facebook/lexical/pull/5800)
- [x] Improve the UX by making Enter going from title to content, rather than a newline inside the title. A newline inside the title is still doable via Shift+Enter
- [x] Clean up the Ctrl + Enter shortcut to toggle/expand. It's always been an odd shortcut with no discoverability. Cleaning this up for people who fork the playground to not get surprising selection change behaviours