### PR TITLE
Maintain text decoration styles on paste

### DIFF
--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -317,11 +317,12 @@ export function convertTableCellNodeElement(
   }
 
   const style = domNode_.style;
+  const textDecoration = style.textDecoration.split(' ');
   const hasBoldFontWeight =
     style.fontWeight === '700' || style.fontWeight === 'bold';
-  const hasLinethroughTextDecoration = style.textDecoration === 'line-through';
+  const hasLinethroughTextDecoration = textDecoration.includes('line-through');
   const hasItalicFontStyle = style.fontStyle === 'italic';
-  const hasUnderlineTextDecoration = style.textDecoration === 'underline';
+  const hasUnderlineTextDecoration = textDecoration.includes('underline');
 
   return {
     after: (childLexicalNodes) => {

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -1092,14 +1092,15 @@ function convertSpanElement(domNode: Node): DOMConversionOutput {
   const span = domNode as HTMLSpanElement;
   const style = span.style;
   const fontWeight = style.fontWeight;
+  const textDecoration = style.textDecoration.split(' ');
   // Google Docs uses span tags + font-weight for bold text
   const hasBoldFontWeight = fontWeight === '700' || fontWeight === 'bold';
   // Google Docs uses span tags + text-decoration: line-through for strikethrough text
-  const hasLinethroughTextDecoration = style.textDecoration === 'line-through';
+  const hasLinethroughTextDecoration = textDecoration.includes('line-through');
   // Google Docs uses span tags + font-style for italic text
   const hasItalicFontStyle = style.fontStyle === 'italic';
   // Google Docs uses span tags + text-decoration: underline for underline text
-  const hasUnderlineTextDecoration = style.textDecoration === 'underline';
+  const hasUnderlineTextDecoration = textDecoration.includes('underline');
   // Google Docs uses span tags + vertical-align to specify subscript and superscript
   const verticalAlign = style.verticalAlign;
 


### PR DESCRIPTION
Currently pasting text content (eg, from gDocs) with both underline and strikethrough formatting loses both these formatting styles. This PR fixes that issue.

The `text-decoration` property's value can be a string that's a combination of different values like underline and line-through (eg: `text-decoration: underline line-through;`), hence modified the logic accordingly.

### Before
![text-decor-before](https://github.com/facebook/lexical/assets/33776279/b98d0e3e-89e2-41a1-b65c-38b18d84611a)

### After
![text-decor-after](https://github.com/facebook/lexical/assets/33776279/ad34c834-9f35-4ab1-9824-8969f6f3973a)
