### PR TITLE
Set eqeqeq rule to always and clarify type checks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -133,7 +133,7 @@ module.exports = {
     'dot-notation': [ERROR, {allowPattern: '^(error|warn)$'}],
 
     'eol-last': ERROR,
-    eqeqeq: [ERROR, 'allow-null'],
+    eqeqeq: [ERROR, 'always'],
     // Prettier forces semicolons in a few places
     'flowtype/object-type-delimiter': OFF,
 

--- a/examples/vanilla-js-plugin/src/emoji-plugin/findEmoji.ts
+++ b/examples/vanilla-js-plugin/src/emoji-plugin/findEmoji.ts
@@ -24,10 +24,10 @@ const emojiReplacementMap = emojis.reduce<Map<string, string>>((acc, row) => {
   }
   acc.set(`:${row.short_name}:`, row.unified);
 
-  if (row.text != null) {
+  if (row.text !== null) {
     acc.set(row.text, row.unified);
   }
-  if (row.texts != null) {
+  if (row.texts !== null) {
     row.texts.forEach((text) => acc.set(text, row.unified));
   }
 

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -49,7 +49,7 @@ const getDOMSelection = (targetWindow: Window | null): Selection | null =>
 export function $getHtmlContent(editor: LexicalEditor): string {
   const selection = $getSelection();
 
-  if (selection == null) {
+  if (selection === null) {
     invariant(false, 'Expected valid LexicalSelection');
   }
 
@@ -76,7 +76,7 @@ export function $getHtmlContent(editor: LexicalEditor): string {
 export function $getLexicalContent(editor: LexicalEditor): null | string {
   const selection = $getSelection();
 
-  if (selection == null) {
+  if (selection === null) {
     invariant(false, 'Expected valid LexicalSelection');
   }
 
@@ -106,9 +106,7 @@ export function $insertDataTransferForPlainText(
   const text =
     dataTransfer.getData('text/plain') || dataTransfer.getData('text/uri-list');
 
-  if (text != null) {
-    selection.insertRawText(text);
-  }
+  selection.insertRawText(text);
 }
 
 /**
@@ -159,25 +157,24 @@ export function $insertDataTransferForRichText(
   // Webkit-specific: Supports read 'text/uri-list' in clipboard.
   const text =
     dataTransfer.getData('text/plain') || dataTransfer.getData('text/uri-list');
-  if (text != null) {
-    if ($isRangeSelection(selection)) {
-      const parts = text.split(/(\r?\n|\t)/);
-      if (parts[parts.length - 1] === '') {
-        parts.pop();
-      }
-      for (let i = 0; i < parts.length; i++) {
-        const part = parts[i];
-        if (part === '\n' || part === '\r\n') {
-          selection.insertParagraph();
-        } else if (part === '\t') {
-          selection.insertNodes([$createTabNode()]);
-        } else {
-          selection.insertText(part);
-        }
-      }
-    } else {
-      selection.insertRawText(text);
+
+  if ($isRangeSelection(selection)) {
+    const parts = text.split(/(\r?\n|\t)/);
+    if (parts[parts.length - 1] === '') {
+      parts.pop();
     }
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (part === '\n' || part === '\r\n') {
+        selection.insertParagraph();
+      } else if (part === '\t') {
+        selection.insertNodes([$createTabNode()]);
+      } else {
+        selection.insertText(part);
+      }
+    }
+  } else {
+    selection.insertRawText(text);
   }
 }
 
@@ -399,7 +396,7 @@ export async function copyToClipboard(
 
   const rootElement = editor.getRootElement();
   const windowDocument =
-    editor._window == null ? window.document : editor._window.document;
+    editor._window === null ? window.document : editor._window.document;
   const domSelection = getDOMSelection(editor._window);
   if (rootElement === null || domSelection === null) {
     return false;

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -214,24 +214,20 @@ function exportNodeToJSON<T extends LexicalNode>(node: T): BaseSerializedNode {
   const serializedNode = node.exportJSON();
   const nodeClass = node.constructor;
 
-  if (serializedNode.type !== nodeClass.getType()) {
-    invariant(
-      false,
-      'LexicalNode: Node %s does not implement .exportJSON().',
-      nodeClass.name,
-    );
-  }
+  invariant(
+    serializedNode.type === nodeClass.getType(),
+    'LexicalNode: Node %s does not implement .exportJSON().',
+    nodeClass.name,
+  );
 
   if ($isElementNode(node)) {
     const serializedChildren = (serializedNode as SerializedElementNode)
       .children;
-    if (!Array.isArray(serializedChildren)) {
-      invariant(
-        false,
-        'LexicalNode: Node %s is an element but .exportJSON() does not have a children array.',
-        nodeClass.name,
-      );
-    }
+    invariant(
+      Array.isArray(serializedChildren),
+      'LexicalNode: Node %s is an element but .exportJSON() does not have a children array.',
+      nodeClass.name,
+    );
   }
 
   return serializedNode;

--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -194,10 +194,9 @@ export function getEndOfCodeInLine(
   anchor: CodeHighlightNode | TabNode,
 ): CodeHighlightNode | TabNode {
   const lastNode = getLastCodeNodeOfLine(anchor);
-  invariant(
-    !$isLineBreakNode(lastNode),
-    'Unexpected lineBreakNode in getEndOfCodeInLine',
-  );
+  if ($isLineBreakNode(lastNode)) {
+    invariant(false, 'Unexpected lineBreakNode in getEndOfCodeInLine');
+  }
   return lastNode;
 }
 

--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -695,7 +695,7 @@ function handleShiftLines(
     start = getFirstCodeNodeOfLine(focusNode);
     end = getLastCodeNodeOfLine(anchorNode);
   }
-  if (start == null || end == null) {
+  if (start === null || end === null) {
     return false;
   }
 
@@ -726,7 +726,7 @@ function handleShiftLines(
   const sibling = arrowIsUp
     ? linebreak.getPreviousSibling()
     : linebreak.getNextSibling();
-  if (sibling == null) {
+  if (sibling === null) {
     return true;
   }
 
@@ -739,7 +739,7 @@ function handleShiftLines(
         : getLastCodeNodeOfLine(sibling)
       : null;
   let insertionPoint =
-    maybeInsertionPoint != null ? maybeInsertionPoint : sibling;
+    maybeInsertionPoint !== null ? maybeInsertionPoint : sibling;
   linebreak.remove();
   range.forEach((node) => node.remove());
   if (type === KEY_ARROW_UP_COMMAND) {
@@ -813,7 +813,7 @@ export function registerCodeHighlighting(
     );
   }
 
-  if (tokenizer == null) {
+  if (tokenizer === undefined) {
     tokenizer = PrismTokenizer;
   }
 

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -51,8 +51,9 @@ export type SerializedCodeNode = Spread<
 const mapToPrismLanguage = (
   language: string | null | undefined,
 ): string | null | undefined => {
-  // eslint-disable-next-line no-prototype-builtins
-  return language != null && window.Prism.languages.hasOwnProperty(language)
+  return language !== null &&
+    language !== undefined &&
+    Object.hasOwn(window.Prism.languages, language)
     ? language
     : undefined;
 };
@@ -134,7 +135,7 @@ export class CodeNode extends ElementNode {
       // inline format handled by TextNode otherwise.
       code: (node: Node) => {
         const isMultiLine =
-          node.textContent != null &&
+          node.textContent !== null &&
           (/\r?\n/.test(node.textContent) || hasChildDOMNodeTag(node, 'BR'));
 
         return isMultiLine
@@ -350,7 +351,7 @@ function convertDivElement(domNode: Node): DOMConversionOutput {
   return {
     after: (childLexicalNodes) => {
       const domParent = domNode.parentNode;
-      if (domParent != null && domNode !== domParent.lastChild) {
+      if (domParent !== null && domNode !== domParent.lastChild) {
         childLexicalNodes.push($createLineBreakNode());
       }
       return childLexicalNodes;

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -53,7 +53,8 @@ const mapToPrismLanguage = (
 ): string | null | undefined => {
   return language !== null &&
     language !== undefined &&
-    Object.hasOwn(window.Prism.languages, language)
+    // eslint-disable-next-line no-prototype-builtins
+    window.Prism.languages.hasOwnProperty(language)
     ? language
     : undefined;
 };

--- a/packages/lexical-devtools-core/src/generateContent.ts
+++ b/packages/lexical-devtools-core/src/generateContent.ts
@@ -340,7 +340,7 @@ function printFormatProperties(nodeOrSelection: TextNode | RangeSelection) {
 function printTargetProperties(node: LinkNode) {
   let str = node.getTarget();
   // TODO Fix nullish on LinkNode
-  if (str != null) {
+  if (str !== null) {
     str = 'target: ' + str;
   }
   return str;
@@ -349,7 +349,7 @@ function printTargetProperties(node: LinkNode) {
 function printRelProperties(node: LinkNode) {
   let str = node.getRel();
   // TODO Fix nullish on LinkNode
-  if (str != null) {
+  if (str !== null) {
     str = 'rel: ' + str;
   }
   return str;
@@ -358,7 +358,7 @@ function printRelProperties(node: LinkNode) {
 function printTitleProperties(node: LinkNode) {
   let str = node.getTitle();
   // TODO Fix nullish on LinkNode
-  if (str != null) {
+  if (str !== null) {
     str = 'title: ' + str;
   }
   return str;

--- a/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
+++ b/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
@@ -86,7 +86,7 @@ export class InjectedPegasusService
   }
 
   toggleEditorPicker(): void {
-    if (this.pickerActive != null) {
+    if (this.pickerActive !== null) {
       this.pickerActive?.stop();
       this.pickerActive = null;
 
@@ -97,7 +97,7 @@ export class InjectedPegasusService
     this.pickerActive.start({
       elementFilter: (el) => {
         let parent: HTMLElement | null = el;
-        while (parent != null && parent.tagName !== 'BODY') {
+        while (parent !== null && parent.tagName !== 'BODY') {
           if ('__lexicalEditor' in parent) {
             return parent;
           }

--- a/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
+++ b/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
@@ -50,7 +50,7 @@ export class InjectedPegasusService
     isReadonly: boolean,
   ): void {
     const editorNode = queryLexicalNodeByKey(editorKey);
-    if (editorNode == null) {
+    if (editorNode === undefined) {
       throw new Error(`Can't find editor with key: ${editorKey}`);
     }
 
@@ -63,7 +63,7 @@ export class InjectedPegasusService
     exportDOM: boolean,
   ): string {
     const editor = queryLexicalEditorByKey(editorKey);
-    if (editor == null) {
+    if (editor === undefined) {
       throw new Error(`Can't find editor with key: ${editorKey}`);
     }
 
@@ -78,7 +78,7 @@ export class InjectedPegasusService
     editorState: SerializedRawEditorState,
   ): void {
     const editor = queryLexicalEditorByKey(editorKey);
-    if (editor == null) {
+    if (editor === undefined) {
       throw new Error(`Can't find editor with key: ${editorKey}`);
     }
 

--- a/packages/lexical-devtools/src/lexicalForExtension.ts
+++ b/packages/lexical-devtools/src/lexicalForExtension.ts
@@ -79,13 +79,13 @@ export function $isTextNode(
 export function $isRangeSelection(x: unknown): x is lexical.RangeSelection {
   // Duck typing :P (and not instanceof RangeSelection) because extension operates
   // from different JS bundle and has no reference to the RangeSelection used on the page
-  return x != null && typeof x === 'object' && 'applyDOMRange' in x;
+  return x !== null && typeof x === 'object' && 'applyDOMRange' in x;
 }
 
 export function $isNodeSelection(x: unknown): x is lexical.NodeSelection {
   // Duck typing :P (and not instanceof NodeSelection) because extension operates
   // from different JS bundle and has no reference to the NodeSelection used on the page
-  return x != null && typeof x === 'object' && '_nodes' in x;
+  return x !== null && typeof x === 'object' && '_nodes' in x;
 }
 
 export function readEditorState<V>(

--- a/packages/lexical-devtools/src/serializeEditorState.ts
+++ b/packages/lexical-devtools/src/serializeEditorState.ts
@@ -37,7 +37,7 @@ export function deserializeEditorState(
     typeof editorState.deserealizationID === 'number'
   ) {
     const state = deserealizationMap.get(editorState.deserealizationID);
-    if (state == null) {
+    if (state === undefined) {
       throw new Error(
         `Can't find deserealization ref for state with id ${editorState.deserealizationID}`,
       );
@@ -64,7 +64,7 @@ export function serializeEditorState(
     selection &&
     'anchor' in selection &&
     typeof selection.anchor === 'object' &&
-    selection.anchor != null
+    selection.anchor !== null
   ) {
     // remove _selection.anchor._selection property if present in RangeSelection or GridSelection
     // otherwise, the recursive structure makes the selection object unserializable
@@ -74,7 +74,7 @@ export function serializeEditorState(
     selection &&
     'focus' in selection &&
     typeof selection.focus === 'object' &&
-    selection.focus != null
+    selection.focus !== null
   ) {
     // remove _selection.anchor._selection property if present in RangeSelection or GridSelection
     // otherwise, the recursive structure makes the selection object unserializable

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -224,7 +224,7 @@ function $createNodesFromDOM(
       }
     }
 
-    if (transformOutput.forChild != null) {
+    if (transformOutput.forChild !== undefined) {
       forChildMap.set(node.nodeName, transformOutput.forChild);
     }
   }
@@ -245,11 +245,11 @@ function $createNodesFromDOM(
     );
   }
 
-  if (postTransform != null) {
+  if (postTransform !== null && postTransform !== undefined) {
     childLexicalNodes = postTransform(childLexicalNodes);
   }
 
-  if (currentLexicalNode == null) {
+  if (currentLexicalNode === null || currentLexicalNode === undefined) {
     // If it hasn't been converted to a LexicalNode, we hoist its children
     // up to the same level as it.
     lexicalNodes = lexicalNodes.concat(childLexicalNodes);

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -216,12 +216,10 @@ export class ListItemNode extends ElementNode {
   insertAfter(node: LexicalNode, restoreSelection = true): LexicalNode {
     const listNode = this.getParentOrThrow();
 
-    if (!$isListNode(listNode)) {
-      invariant(
-        false,
-        'insertAfter: list node is not parent of list item node',
-      );
-    }
+    invariant(
+      $isListNode(listNode),
+      'insertAfter: list node is not parent of list item node',
+    );
 
     if ($isListItemNode(node)) {
       return super.insertAfter(node, restoreSelection);

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -102,12 +102,15 @@ export class ListItemNode extends ElementNode {
   static transform(): (node: LexicalNode) => void {
     return (node: LexicalNode) => {
       invariant($isListItemNode(node), 'node is not a ListItemNode');
-      if (node.__checked == null) {
+      if (node.__checked === undefined) {
         return;
       }
       const parent = node.getParent();
       if ($isListNode(parent)) {
-        if (parent.getListType() !== 'check' && node.getChecked() != null) {
+        if (
+          parent.getListType() !== 'check' &&
+          node.getChecked() !== undefined
+        ) {
           node.setChecked(undefined);
         }
       }
@@ -261,7 +264,7 @@ export class ListItemNode extends ElementNode {
     restoreSelection = true,
   ): ListItemNode | ParagraphNode {
     const newElement = $createListItemNode(
-      this.__checked == null ? undefined : false,
+      this.__checked === undefined ? undefined : false,
     );
     this.insertAfter(newElement, restoreSelection);
 

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -115,7 +115,7 @@ export function insertList(editor: LexicalEditor, listType: ListType): void {
 
         if ($isLeafNode(node)) {
           let parent = node.getParent();
-          while (parent != null) {
+          while (parent !== null) {
             const parentKey = parent.getKey();
 
             if ($isListNode(parent)) {
@@ -242,7 +242,7 @@ export function removeList(editor: LexicalEditor): void {
           if ($isLeafNode(node)) {
             const listItemNode = $getNearestNodeOfType(node, ListItemNode);
 
-            if (listItemNode != null) {
+            if (listItemNode !== null) {
               listNodes.add($getTopListNode(listItemNode));
             }
           }
@@ -297,7 +297,7 @@ export function updateChildrenListItemValue(list: ListNode): void {
       if (child.getValue() !== value) {
         child.setValue(value);
       }
-      if (isNotChecklist && child.getChecked() != null) {
+      if (isNotChecklist && child.getChecked() !== undefined) {
         child.setChecked(undefined);
       }
       if (!$isListNode(child.getFirstChild())) {

--- a/packages/lexical-list/src/utils.ts
+++ b/packages/lexical-list/src/utils.ts
@@ -28,7 +28,7 @@ export function $getListDepth(listNode: ListNode): number {
   let depth = 1;
   let parent = listNode.getParent();
 
-  while (parent != null) {
+  while (parent !== null) {
     if ($isListItemNode(parent)) {
       const parentList = parent.getParent();
 
@@ -176,13 +176,13 @@ export function $removeHighestEmptyListParent(
   let emptyListPtr = sublist;
 
   while (
-    emptyListPtr.getNextSibling() == null &&
-    emptyListPtr.getPreviousSibling() == null
+    emptyListPtr.getNextSibling() === null &&
+    emptyListPtr.getPreviousSibling() === null
   ) {
     const parent = emptyListPtr.getParent<ListItemNode | ListNode>();
 
     if (
-      parent == null ||
+      parent === null ||
       !($isListItemNode(emptyListPtr) || $isListNode(emptyListPtr))
     ) {
       break;

--- a/packages/lexical-list/src/utils.ts
+++ b/packages/lexical-list/src/utils.ts
@@ -54,9 +54,10 @@ export function $getListDepth(listNode: ListNode): number {
 export function $getTopListNode(listItem: LexicalNode): ListNode {
   let list = listItem.getParent<ListNode>();
 
-  if (!$isListNode(list)) {
-    invariant(false, 'A ListItemNode must have a ListNode for a parent.');
-  }
+  invariant(
+    $isListNode(list),
+    'A ListItemNode must have a ListNode for a parent.',
+  );
 
   let parent: ListNode | null = list;
 

--- a/packages/lexical-mark/src/index.ts
+++ b/packages/lexical-mark/src/index.ts
@@ -99,7 +99,7 @@ export function $wrapSelectionInMarkNode(
         continue;
       }
       const parentNode = targetNode.getParent();
-      if (parentNode == null || !parentNode.is(currentNodeParent)) {
+      if (parentNode === null || !parentNode.is(currentNodeParent)) {
         // If the parent node is not the current node's parent node, we can
         // clear the last created mark node.
         lastCreatedMarkNode = undefined;

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -47,7 +47,7 @@ export function createMarkdownExport(
         byType.textMatch,
       );
 
-      if (result != null) {
+      if (result !== null) {
         output.push(result);
       }
     }
@@ -67,7 +67,7 @@ function exportTopLevelElements(
       exportChildren(_node, textTransformersIndex, textMatchTransformers),
     );
 
-    if (result != null) {
+    if (result !== null) {
       return result;
     }
   }
@@ -103,7 +103,7 @@ function exportChildren(
           exportTextFormat(textNode, textContent, textTransformersIndex),
       );
 
-      if (result != null) {
+      if (result !== null) {
         output.push(result);
         continue mainLoop;
       }

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -36,9 +36,9 @@ import {PUNCTUATION_OR_SPACE, transformersByType} from './utils';
 const MARKDOWN_EMPTY_LINE_REG_EXP = /^\s{0,3}$/;
 const CODE_BLOCK_REG_EXP = /^```(\w{1,10})?\s?$/;
 type TextFormatTransformersIndex = Readonly<{
-  fullMatchRegExpByTag: Readonly<Record<string, RegExp>>;
+  fullMatchRegExpByTag: Readonly<Partial<Record<string, RegExp>>>;
   openTagsRegExp: RegExp;
-  transformersByTag: Readonly<Record<string, TextFormatTransformer>>;
+  transformersByTag: Readonly<Partial<Record<string, TextFormatTransformer>>>;
 }>;
 
 export function createMarkdownImport(
@@ -63,7 +63,7 @@ export function createMarkdownImport(
       // Abstract it to be dynamic as other transformers (add multiline match option)
       const [codeBlockNode, shiftedIndex] = importCodeBlock(lines, i, root);
 
-      if (codeBlockNode != null) {
+      if (codeBlockNode !== null) {
         i = shiftedIndex;
         continue;
       }
@@ -99,7 +99,7 @@ function isEmptyParagraph(node: LexicalNode): boolean {
 
   const firstChild = node.getFirstChild();
   return (
-    firstChild == null ||
+    firstChild === null ||
     (node.getChildrenSize() === 1 &&
       $isTextNode(firstChild) &&
       MARKDOWN_EMPTY_LINE_REG_EXP.test(firstChild.getTextContent()))
@@ -149,14 +149,14 @@ function importBlocks(
 
       if ($isListNode(previousNode)) {
         const lastDescendant = previousNode.getLastDescendant();
-        if (lastDescendant == null) {
+        if (lastDescendant === null) {
           targetNode = null;
         } else {
           targetNode = $findMatchingParent(lastDescendant, $isListItemNode);
         }
       }
 
-      if (targetNode != null && targetNode.getTextContentSize() > 0) {
+      if (targetNode !== null && targetNode.getTextContentSize() > 0) {
         targetNode.splice(targetNode.getChildrenSize(), 0, [
           $createLineBreakNode(),
           ...elementNode.getChildren(),
@@ -319,7 +319,7 @@ function findOutermostMatch(
 ): RegExpMatchArray | null {
   const openTagsMatch = textContent.match(textTransformersIndex.openTagsRegExp);
 
-  if (openTagsMatch == null) {
+  if (openTagsMatch === null) {
     return null;
   }
 
@@ -328,13 +328,13 @@ function findOutermostMatch(
     // before using match to find transformer
     const tag = match.replace(/^\s/, '');
     const fullMatchRegExp = textTransformersIndex.fullMatchRegExpByTag[tag];
-    if (fullMatchRegExp == null) {
+    if (fullMatchRegExp === undefined) {
       continue;
     }
 
     const fullMatch = textContent.match(fullMatchRegExp);
     const transformer = textTransformersIndex.transformersByTag[tag];
-    if (fullMatch != null && transformer != null) {
+    if (fullMatch !== null && transformer !== undefined) {
       if (transformer.intraword !== false) {
         return fullMatch;
       }

--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -341,13 +341,11 @@ export function registerMarkdownShortcuts(
     if (type === 'element' || type === 'text-match') {
       const dependencies = transformer.dependencies;
       for (const node of dependencies) {
-        if (!editor.hasNode(node)) {
-          invariant(
-            false,
-            'MarkdownShortcuts: missing dependency %s for transformer. Ensure node dependency is included in editor initial config.',
-            node.getType(),
-          );
-        }
+        invariant(
+          editor.hasNode(node),
+          'MarkdownShortcuts: missing dependency %s for transformer. Ensure node dependency is included in editor initial config.',
+          node.getType(),
+        );
       }
     }
   }

--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -77,13 +77,15 @@ function runElementTransformers(
 function runTextMatchTransformers(
   anchorNode: TextNode,
   anchorOffset: number,
-  transformersByTrigger: Readonly<Record<string, Array<TextMatchTransformer>>>,
+  transformersByTrigger: Readonly<
+    Partial<Record<string, Array<TextMatchTransformer>>>
+  >,
 ): boolean {
   let textContent = anchorNode.getTextContent();
   const lastChar = textContent[anchorOffset - 1];
   const transformers = transformersByTrigger[lastChar];
 
-  if (transformers == null) {
+  if (transformers === undefined) {
     return false;
   }
 

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -59,7 +59,7 @@ function onCopyForPlainText(
         : (event as ClipboardEvent).clipboardData;
       const selection = $getSelection();
 
-      if (selection !== null && clipboardData != null) {
+      if (selection !== null && clipboardData !== null) {
         event.preventDefault();
         const htmlString = $getHtmlContent(editor);
 
@@ -82,7 +82,7 @@ function onPasteForPlainText(
     () => {
       const selection = $getSelection();
       const {clipboardData} = event as ClipboardEvent;
-      if (clipboardData != null && $isRangeSelection(selection)) {
+      if (clipboardData !== null && $isRangeSelection(selection)) {
         $insertDataTransferForPlainText(clipboardData, selection);
       }
     },
@@ -164,7 +164,7 @@ export function registerPlainText(editor: LexicalEditor): () => void {
         } else {
           const dataTransfer = eventOrText.dataTransfer;
 
-          if (dataTransfer != null) {
+          if (dataTransfer !== null) {
             $insertDataTransferForPlainText(dataTransfer, selection);
           } else {
             const data = eventOrText.data;

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -73,7 +73,7 @@ import Placeholder from './ui/Placeholder';
 
 const skipCollaborationInit =
   // @ts-expect-error
-  window.parent != null && window.parent.frames.right === window;
+  window.parent !== null && window.parent.frames.right === window;
 
 export default function Editor(): JSX.Element {
   const {historyState} = useSharedHistoryContext();

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
@@ -64,7 +64,7 @@ const removeStyleFromSvg_HACK = (svg: SVGElement) => {
   // Generated SVG is getting double-sized by height and width attributes
   // We want to match the real size of the SVG element
   const viewBox = svg.getAttribute('viewBox');
-  if (viewBox != null) {
+  if (viewBox !== null) {
     const viewBoxDimensions = viewBox.split(' ');
     svg.setAttribute('width', viewBoxDimensions[2]);
     svg.setAttribute('height', viewBoxDimensions[3]);

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -205,7 +205,7 @@ export default function StickyComponent({
         onPointerDown={(event) => {
           const stickyContainer = stickyContainerRef.current;
           if (
-            stickyContainer == null ||
+            stickyContainer === null ||
             event.button === 2 ||
             event.target !== stickyContainer.firstChild
           ) {

--- a/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
@@ -65,7 +65,7 @@ export const YoutubeEmbedConfig: PlaygroundEmbedConfig = {
 
     const id = match ? (match?.[2].length === 11 ? match[2] : null) : null;
 
-    if (id != null) {
+    if (id !== null) {
       return {
         id,
         url,
@@ -102,7 +102,7 @@ export const TwitterEmbedConfig: PlaygroundEmbedConfig = {
         text,
       );
 
-    if (match != null) {
+    if (match !== null) {
       return {
         id: match[5],
         url: match[1],
@@ -135,7 +135,7 @@ export const FigmaEmbedConfig: PlaygroundEmbedConfig = {
         text,
       );
 
-    if (match != null) {
+    if (match !== null) {
       return {
         id: match[3],
         url: match[0],
@@ -241,13 +241,13 @@ export function AutoEmbedDialog({
     () =>
       debounce((inputText: string) => {
         const urlMatch = URL_MATCHER.exec(inputText);
-        if (embedConfig != null && inputText != null && urlMatch != null) {
+        if (urlMatch !== null) {
           Promise.resolve(embedConfig.parseUrl(inputText)).then(
             (parseResult) => {
               setEmbedResult(parseResult);
             },
           );
-        } else if (embedResult != null) {
+        } else if (embedResult !== null) {
           setEmbedResult(null);
         }
       }, 200),
@@ -255,7 +255,7 @@ export function AutoEmbedDialog({
   );
 
   const onClick = () => {
-    if (embedResult != null) {
+    if (embedResult !== null) {
       embedConfig.insertNode(editor, embedResult);
       onClose();
     }

--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -114,10 +114,6 @@ function ComponentPickerMenuItem({
 function getDynamicOptions(editor: LexicalEditor, queryString: string) {
   const options: Array<ComponentPickerOption> = [];
 
-  if (queryString == null) {
-    return options;
-  }
-
   const tableMatch = queryString.match(/^([1-9]\d?)(?:x([1-9]\d?)?)?$/);
 
   if (tableMatch !== null) {

--- a/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
@@ -99,14 +99,12 @@ export default function EmojiPickerPlugin() {
 
   const emojiOptions = useMemo(
     () =>
-      emojis != null
-        ? emojis.map(
-            ({emoji, aliases, tags}) =>
-              new EmojiOption(aliases[0], emoji, {
-                keywords: [...aliases, ...tags],
-              }),
-          )
-        : [],
+      emojis.map(
+        ({emoji, aliases, tags}) =>
+          new EmojiOption(aliases[0], emoji, {
+            keywords: [...aliases, ...tags],
+          }),
+      ),
     [emojis],
   );
 
@@ -117,13 +115,11 @@ export default function EmojiPickerPlugin() {
   const options: Array<EmojiOption> = useMemo(() => {
     return emojiOptions
       .filter((option: EmojiOption) => {
-        return queryString != null
+        return queryString !== null
           ? new RegExp(queryString, 'gi').exec(option.title) ||
-            option.keywords != null
-            ? option.keywords.some((keyword: string) =>
+              option.keywords.some((keyword: string) =>
                 new RegExp(queryString, 'gi').exec(keyword),
               )
-            : false
           : emojiOptions;
       })
       .slice(0, MAX_EMOJI_SUGGESTION_COUNT);
@@ -138,7 +134,7 @@ export default function EmojiPickerPlugin() {
       editor.update(() => {
         const selection = $getSelection();
 
-        if (!$isRangeSelection(selection) || selectedOption == null) {
+        if (!$isRangeSelection(selection)) {
           return;
         }
 
@@ -164,7 +160,7 @@ export default function EmojiPickerPlugin() {
         anchorElementRef,
         {selectedIndex, selectOptionAndCleanUp, setHighlightedIndex},
       ) => {
-        if (anchorElementRef.current == null || options.length === 0) {
+        if (anchorElementRef.current === null || options.length === 0) {
           return null;
         }
 

--- a/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
@@ -372,7 +372,7 @@ function getDragSelection(event: DragEvent): Range | null | undefined {
   let range;
   const target = event.target as null | Element | Document;
   const targetWindow =
-    target == null
+    target === null
       ? null
       : target.nodeType === 9
       ? (target as Document).defaultView

--- a/packages/lexical-playground/src/plugins/InlineImagePlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/InlineImagePlugin/index.tsx
@@ -324,7 +324,7 @@ function getDragSelection(event: DragEvent): Range | null | undefined {
   let range;
   const target = event.target as null | Element | Document;
   const targetWindow =
-    target == null
+    target === null
       ? null
       : target.nodeType === 9
       ? (target as Document).defaultView

--- a/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
+++ b/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
@@ -60,7 +60,7 @@ export const HR: ElementTransformer = {
     const line = $createHorizontalRuleNode();
 
     // TODO: Get rid of isImport flag
-    if (isImport || parentNode.getNextSibling() != null) {
+    if (isImport || parentNode.getNextSibling() !== null) {
       parentNode.replace(line);
     } else {
       parentNode.insertBefore(line);
@@ -221,7 +221,7 @@ export const TABLE: ElementTransformer = {
 
     const matchCells = mapToTableCells(match[0]);
 
-    if (matchCells == null) {
+    if (matchCells === null) {
       return;
     }
 
@@ -246,7 +246,7 @@ export const TABLE: ElementTransformer = {
 
       const cells = mapToTableCells(firstChild.getTextContent());
 
-      if (cells == null) {
+      if (cells === null) {
         break;
       }
 

--- a/packages/lexical-playground/src/plugins/MentionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/MentionsPlugin/index.tsx
@@ -508,7 +508,7 @@ function useMentionLookupService(mentionString: string | null) {
   useEffect(() => {
     const cachedResults = mentionsCache.get(mentionString);
 
-    if (mentionString == null) {
+    if (mentionString === null) {
       setResults([]);
       return;
     }

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -220,9 +220,9 @@ function TableActionMenu({
     const rootElement = editor.getRootElement();
 
     if (
-      menuButtonElement != null &&
-      dropDownElement != null &&
-      rootElement != null
+      menuButtonElement !== null &&
+      dropDownElement !== null &&
+      rootElement !== null
     ) {
       const rootEleRect = rootElement.getBoundingClientRect();
       const menuButtonRect = menuButtonElement.getBoundingClientRect();
@@ -252,8 +252,8 @@ function TableActionMenu({
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (
-        dropDownRef.current != null &&
-        contextRef.current != null &&
+        dropDownRef.current !== null &&
+        contextRef.current !== null &&
         !dropDownRef.current.contains(event.target as Node) &&
         !contextRef.current.contains(event.target as Node)
       ) {
@@ -661,7 +661,7 @@ function TableCellActionMenuContainer({
     const nativeSelection = window.getSelection();
     const activeElement = document.activeElement;
 
-    if (selection == null || menu == null) {
+    if (selection === null || menu === null) {
       setTableMenuCellNode(null);
       return;
     }
@@ -678,7 +678,7 @@ function TableCellActionMenuContainer({
         selection.anchor.getNode(),
       );
 
-      if (tableCellNodeFromSelection == null) {
+      if (tableCellNodeFromSelection === null) {
         setTableMenuCellNode(null);
         return;
       }
@@ -687,7 +687,7 @@ function TableCellActionMenuContainer({
         tableCellNodeFromSelection.getKey(),
       );
 
-      if (tableCellParentNodeDOM == null) {
+      if (tableCellParentNodeDOM === null) {
         setTableMenuCellNode(null);
         return;
       }
@@ -709,10 +709,10 @@ function TableCellActionMenuContainer({
   useEffect(() => {
     const menuButtonDOM = menuButtonRef.current as HTMLButtonElement | null;
 
-    if (menuButtonDOM != null && tableCellNode != null) {
+    if (menuButtonDOM !== null && tableCellNode !== null) {
       const tableCellNodeDOM = editor.getElementByKey(tableCellNode.getKey());
 
-      if (tableCellNodeDOM != null) {
+      if (tableCellNodeDOM !== null) {
         const tableCellRect = tableCellNodeDOM.getBoundingClientRect();
         const menuRect = menuButtonDOM.getBoundingClientRect();
         const anchorRect = anchorElem.getBoundingClientRect();
@@ -742,7 +742,7 @@ function TableCellActionMenuContainer({
 
   return (
     <div className="table-cell-action-button-container" ref={menuButtonRef}>
-      {tableCellNode != null && (
+      {tableCellNode !== null && (
         <>
           <button
             type="button"

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -130,7 +130,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
               tableRectRef.current = tableElement.getBoundingClientRect();
               updateActiveCell(cell);
             });
-          } else if (cell == null) {
+          } else if (cell === null) {
             resetState();
           }
         }
@@ -390,7 +390,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
 
   return (
     <div ref={resizerRef}>
-      {activeCell != null && !isSelectingGrid && (
+      {activeCell !== null && !isSelectingGrid && (
         <>
           <div
             className="TableCellResizer__resizer TableCellResizer__ui"

--- a/packages/lexical-playground/src/plugins/TablePlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TablePlugin.tsx
@@ -157,9 +157,10 @@ export function TablePlugin({
   const cellContext = useContext(CellContext);
 
   useEffect(() => {
-    if (!editor.hasNodes([TableNode])) {
-      invariant(false, 'TablePlugin: TableNode is not registered on editor');
-    }
+    invariant(
+      editor.hasNodes([TableNode]),
+      'TablePlugin: TableNode is not registered on editor',
+    );
 
     cellContext.set(cellEditorConfig, children);
 

--- a/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
@@ -167,10 +167,10 @@ function useTestRecorder(
     const browserSelection = window.getSelection();
 
     if (
-      rootElement == null ||
-      browserSelection == null ||
-      browserSelection.anchorNode == null ||
-      browserSelection.focusNode == null ||
+      rootElement === null ||
+      browserSelection === null ||
+      browserSelection.anchorNode === null ||
+      browserSelection.focusNode === null ||
       !rootElement.contains(browserSelection.anchorNode) ||
       !rootElement.contains(browserSelection.focusNode)
     ) {
@@ -322,8 +322,8 @@ ${steps.map(formatStep).join(`\n`)}
             const browserSelection = window.getSelection();
             if (
               browserSelection &&
-              (browserSelection.anchorNode == null ||
-                browserSelection.focusNode == null)
+              (browserSelection.anchorNode === null ||
+                browserSelection.focusNode === null)
             ) {
               return;
             }
@@ -379,8 +379,8 @@ ${steps.map(formatStep).join(`\n`)}
     const browserSelection = window.getSelection();
     if (
       browserSelection === null ||
-      browserSelection.anchorNode == null ||
-      browserSelection.focusNode == null
+      browserSelection.anchorNode === null ||
+      browserSelection.focusNode === null
     ) {
       return;
     }

--- a/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
@@ -39,7 +39,7 @@ export default function TypingPerfPlugin(): JSX.Element | null {
     let invalidatingEvent = false;
 
     const measureEventEnd = function logKeyPress() {
-      if (keyPressTimerId != null) {
+      if (keyPressTimerId !== null) {
         if (invalidatingEvent) {
           invalidatingEvent = false;
         } else {
@@ -52,7 +52,7 @@ export default function TypingPerfPlugin(): JSX.Element | null {
     };
 
     const measureEventStart = function measureEvent() {
-      if (timerId != null) {
+      if (timerId !== null) {
         clearTimeout(timerId);
         timerId = null;
       }

--- a/packages/lexical-playground/src/utils/getDOMRangeRect.ts
+++ b/packages/lexical-playground/src/utils/getDOMRangeRect.ts
@@ -15,7 +15,7 @@ export function getDOMRangeRect(
 
   if (nativeSelection.anchorNode === rootElement) {
     let inner = rootElement;
-    while (inner.firstElementChild != null) {
+    while (inner.firstElementChild !== null) {
       inner = inner.firstElementChild as HTMLElement;
     }
     rect = inner.getBoundingClientRect();

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -116,7 +116,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
               embedConfig.parseUrl(linkNode.__url),
             );
 
-            if (urlMatch != null) {
+            if (urlMatch !== null) {
               setActiveEmbedConfig(embedConfig);
               setNodeKey(linkNode.getKey());
             }
@@ -170,7 +170,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
 
   const embedLinkViaActiveEmbedConfig = useCallback(
     async function () {
-      if (activeEmbedConfig != null && nodeKey != null) {
+      if (activeEmbedConfig !== null && nodeKey !== null) {
         const linkNode = editor.getEditorState().read(() => {
           const node = $getNodeByKey(nodeKey);
           if ($isLinkNode(node)) {
@@ -183,7 +183,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
           const result = await Promise.resolve(
             activeEmbedConfig.parseUrl(linkNode.__url),
           );
-          if (result != null) {
+          if (result !== null) {
             editor.update(() => {
               if (!$getSelection()) {
                 linkNode.selectEnd();
@@ -201,7 +201,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
   );
 
   const options = useMemo(() => {
-    return activeEmbedConfig != null && nodeKey != null
+    return activeEmbedConfig !== null && nodeKey !== null
       ? getMenuOptions(activeEmbedConfig, embedLinkViaActiveEmbedConfig, reset)
       : [];
   }, [
@@ -226,7 +226,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
     [editor],
   );
 
-  return nodeKey != null ? (
+  return nodeKey !== null ? (
     <LexicalNodeMenuPlugin<AutoEmbedOption>
       nodeKey={nodeKey}
       onClose={reset}

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -423,12 +423,10 @@ function useAutoLink(
   onChange?: ChangeHandler,
 ): void {
   useEffect(() => {
-    if (!editor.hasNodes([AutoLinkNode])) {
-      invariant(
-        false,
-        'LexicalAutoLinkPlugin: AutoLinkNode not registered on editor',
-      );
-    }
+    invariant(
+      editor.hasNodes([AutoLinkNode]),
+      'LexicalAutoLinkPlugin: AutoLinkNode not registered on editor',
+    );
 
     const onChangeWrapped = (url: string | null, prevUrl: string | null) => {
       if (onChange) {

--- a/packages/lexical-react/src/LexicalCheckListPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCheckListPlugin.tsx
@@ -68,10 +68,10 @@ export function CheckListPlugin(): null {
         (event) => {
           const activeItem = getActiveCheckListItem();
 
-          if (activeItem != null) {
+          if (activeItem !== null) {
             const rootElement = editor.getRootElement();
 
-            if (rootElement != null) {
+            if (rootElement !== null) {
               rootElement.focus();
             }
 
@@ -87,7 +87,7 @@ export function CheckListPlugin(): null {
         (event) => {
           const activeItem = getActiveCheckListItem();
 
-          if (activeItem != null && editor.isEditable()) {
+          if (activeItem !== null && editor.isEditable()) {
             editor.update(() => {
               const listItemNode = $getNearestNodeFromDOMNode(activeItem);
 
@@ -129,7 +129,10 @@ export function CheckListPlugin(): null {
                   ) {
                     const domNode = editor.getElementByKey(elementNode.__key);
 
-                    if (domNode != null && document.activeElement !== domNode) {
+                    if (
+                      domNode !== null &&
+                      document.activeElement !== domNode
+                    ) {
                       domNode.focus();
                       event.preventDefault();
                       return true;
@@ -172,7 +175,7 @@ function handleCheckItemEvent(event: PointerEvent, callback: () => void) {
   const firstChild = target.firstChild;
 
   if (
-    firstChild != null &&
+    firstChild !== null &&
     isHTMLElement(firstChild) &&
     (firstChild.tagName === 'UL' || firstChild.tagName === 'OL')
   ) {
@@ -202,7 +205,7 @@ function handleClick(event: Event) {
     const domNode = event.target as HTMLElement;
     const editor = findEditor(domNode);
 
-    if (editor != null && editor.isEditable()) {
+    if (editor !== null && editor.isEditable()) {
       editor.update(() => {
         if (event.target) {
           const node = $getNearestNodeFromDOMNode(domNode);
@@ -231,7 +234,12 @@ function findEditor(target: Node) {
     // @ts-ignore internal field
     if (node.__lexicalEditor) {
       // @ts-ignore internal field
-      return node.__lexicalEditor;
+      const editor: LexicalEditor | undefined = node.__lexicalEditor;
+      if (editor === undefined) {
+        return null;
+      }
+
+      return editor;
     }
 
     node = node.parentNode;
@@ -241,11 +249,11 @@ function findEditor(target: Node) {
 }
 
 function getActiveCheckListItem(): HTMLElement | null {
-  const activeElement = document.activeElement as HTMLElement;
+  const activeElement = document.activeElement as HTMLElement | null;
 
-  return activeElement != null &&
+  return activeElement !== null &&
     activeElement.tagName === 'LI' &&
-    activeElement.parentNode != null &&
+    activeElement.parentNode !== null &&
     // @ts-ignore internal field
     activeElement.parentNode.__lexicalListType === 'check'
     ? activeElement
@@ -260,11 +268,11 @@ function findCheckListItemSibling(
   let parent: ListItemNode | null = node;
 
   // Going up in a tree to get non-null sibling
-  while (sibling == null && $isListItemNode(parent)) {
+  while (sibling === null && $isListItemNode(parent)) {
     // Get li -> parent ul/ol -> parent li
     parent = parent.getParentOrThrow().getParent();
 
-    if (parent != null) {
+    if (parent !== null) {
       sibling = backward
         ? parent.getPreviousSibling()
         : parent.getNextSibling();
@@ -294,7 +302,7 @@ function handleArrownUpOrDown(
 ) {
   const activeItem = getActiveCheckListItem();
 
-  if (activeItem != null) {
+  if (activeItem !== null) {
     editor.update(() => {
       const listItem = $getNearestNodeFromDOMNode(activeItem);
 
@@ -304,11 +312,11 @@ function handleArrownUpOrDown(
 
       const nextListItem = findCheckListItemSibling(listItem, backward);
 
-      if (nextListItem != null) {
+      if (nextListItem !== null) {
         nextListItem.selectStart();
         const dom = editor.getElementByKey(nextListItem.__key);
 
-        if (dom != null) {
+        if (dom !== null) {
           event.preventDefault();
           setTimeout(() => {
             dom.focus();

--- a/packages/lexical-react/src/LexicalCheckListPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCheckListPlugin.tsx
@@ -232,13 +232,9 @@ function findEditor(target: Node) {
 
   while (node) {
     // @ts-ignore internal field
-    if (node.__lexicalEditor) {
-      // @ts-ignore internal field
-      const editor: LexicalEditor | undefined | null = node.__lexicalEditor;
-      if (editor === undefined || editor === null) {
-        return null;
-      }
+    const editor: LexicalEditor | undefined | null = node.__lexicalEditor;
 
+    if (editor !== undefined && editor !== null) {
       return editor;
     }
 

--- a/packages/lexical-react/src/LexicalCheckListPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCheckListPlugin.tsx
@@ -234,8 +234,8 @@ function findEditor(target: Node) {
     // @ts-ignore internal field
     if (node.__lexicalEditor) {
       // @ts-ignore internal field
-      const editor: LexicalEditor | undefined = node.__lexicalEditor;
-      if (editor === undefined) {
+      const editor: LexicalEditor | undefined | null = node.__lexicalEditor;
+      if (editor === undefined || editor === null) {
         return null;
       }
 

--- a/packages/lexical-react/src/LexicalClearEditorPlugin.ts
+++ b/packages/lexical-react/src/LexicalClearEditorPlugin.ts
@@ -29,7 +29,7 @@ export function ClearEditorPlugin({onClear}: Props): JSX.Element | null {
       CLEAR_EDITOR_COMMAND,
       (payload) => {
         editor.update(() => {
-          if (onClear == null) {
+          if (onClear === undefined) {
             const root = $getRoot();
             const selection = $getSelection();
             const paragraph = $createParagraphNode();

--- a/packages/lexical-react/src/LexicalClickableLinkPlugin.tsx
+++ b/packages/lexical-react/src/LexicalClickableLinkPlugin.tsx
@@ -23,7 +23,7 @@ function findMatchingDOM<T extends Node>(
   predicate: (node: Node) => node is T,
 ): T | null {
   let node: Node | null = startNode;
-  while (node != null) {
+  while (node !== null) {
     if (predicate(node)) {
       return node;
     }

--- a/packages/lexical-react/src/LexicalCollaborationContext.ts
+++ b/packages/lexical-react/src/LexicalCollaborationContext.ts
@@ -52,11 +52,11 @@ export function useCollaborationContext(
 ): CollaborationContextType {
   const collabContext = useContext(CollaborationContext);
 
-  if (username != null) {
+  if (username !== undefined) {
     collabContext.name = username;
   }
 
-  if (color != null) {
+  if (color !== undefined) {
     collabContext.color = color;
   }
 

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.ts
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.ts
@@ -61,7 +61,7 @@ export function CollaborationPlugin({
     return () => {
       // Reseting flag only when unmount top level editor collab plugin. Nested
       // editors (e.g. image caption) should unmount without affecting it
-      if (editor._parentEditor == null) {
+      if (editor._parentEditor === null) {
         collabContext.isCollabActive = false;
       }
     };

--- a/packages/lexical-react/src/LexicalComposerContext.ts
+++ b/packages/lexical-react/src/LexicalComposerContext.ts
@@ -32,16 +32,16 @@ export function createLexicalComposerContext(
 ): LexicalComposerContextType {
   let parentContext: LexicalComposerContextType | null = null;
 
-  if (parent != null) {
+  if (parent !== null && parent !== undefined) {
     parentContext = parent[1];
   }
 
   function getTheme() {
-    if (theme != null) {
+    if (theme !== null && theme !== undefined) {
       return theme;
     }
 
-    return parentContext != null ? parentContext.getTheme() : null;
+    return parentContext !== null ? parentContext.getTheme() : null;
   }
 
   return {
@@ -52,7 +52,7 @@ export function createLexicalComposerContext(
 export function useLexicalComposerContext(): LexicalComposerContextWithEditor {
   const composerContext = useContext(LexicalComposerContext);
 
-  if (composerContext == null) {
+  if (composerContext === null || composerContext === undefined) {
     invariant(
       false,
       'LexicalComposerContext.useLexicalComposerContext: cannot find a LexicalComposerContext',

--- a/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
@@ -81,7 +81,7 @@ export function LexicalContextMenuPlugin<TOption extends MenuOption>({
 
   const closeNodeMenu = useCallback(() => {
     setResolution(null);
-    if (onClose != null && resolution !== null) {
+    if (onClose !== undefined && resolution !== null) {
       onClose();
     }
   }, [onClose, resolution]);
@@ -89,7 +89,7 @@ export function LexicalContextMenuPlugin<TOption extends MenuOption>({
   const openNodeMenu = useCallback(
     (res: MenuResolution) => {
       setResolution(res);
-      if (onOpen != null && resolution === null) {
+      if (onOpen !== undefined && resolution === null) {
         onOpen(res);
       }
     },
@@ -99,7 +99,7 @@ export function LexicalContextMenuPlugin<TOption extends MenuOption>({
   const handleContextMenu = useCallback(
     (event: MouseEvent) => {
       event.preventDefault();
-      if (onWillOpen != null) {
+      if (onWillOpen !== undefined) {
         onWillOpen(event);
       }
       const zoom = calculateZoomLevel(event.target as Element);
@@ -120,8 +120,8 @@ export function LexicalContextMenuPlugin<TOption extends MenuOption>({
     (event: MouseEvent) => {
       if (
         resolution !== null &&
-        menuRef.current != null &&
-        event.target != null &&
+        menuRef.current !== null &&
+        event.target !== null &&
         !menuRef.current.contains(event.target as Node)
       ) {
         closeNodeMenu();

--- a/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.tsx
+++ b/packages/lexical-react/src/LexicalMarkdownShortcutPlugin.tsx
@@ -28,7 +28,7 @@ const HR: ElementTransformer = {
     const line = $createHorizontalRuleNode();
 
     // TODO: Get rid of isImport flag
-    if (isImport || parentNode.getNextSibling() != null) {
+    if (isImport || parentNode.getNextSibling() !== null) {
       parentNode.replace(line);
     } else {
       parentNode.insertBefore(line);

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -50,7 +50,7 @@ export function LexicalNestedComposer({
   const wasCollabPreviouslyReadyRef = useRef(false);
   const parentContext = useContext(LexicalComposerContext);
 
-  if (parentContext == null) {
+  if (parentContext === null || parentContext === undefined) {
     invariant(false, 'Unexpected parent context null on a nested composer');
   }
 

--- a/packages/lexical-react/src/LexicalNodeMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeMenuPlugin.tsx
@@ -68,7 +68,7 @@ export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
 
   const closeNodeMenu = useCallback(() => {
     setResolution(null);
-    if (onClose != null && resolution !== null) {
+    if (onClose !== undefined && resolution !== null) {
       onClose();
     }
   }, [onClose, resolution]);
@@ -76,7 +76,7 @@ export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
   const openNodeMenu = useCallback(
     (res: MenuResolution) => {
       setResolution(res);
-      if (onOpen != null && resolution === null) {
+      if (onOpen !== undefined && resolution === null) {
         onOpen(res);
       }
     },
@@ -88,8 +88,8 @@ export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
       editor.update(() => {
         const node = $getNodeByKey(nodeKey);
         const domElement = editor.getElementByKey(nodeKey);
-        if (node != null && domElement != null) {
-          if (resolution == null) {
+        if (node !== null && domElement !== null) {
+          if (resolution === null) {
             startTransition(() =>
               openNodeMenu({
                 getRect: () => domElement.getBoundingClientRect(),
@@ -98,7 +98,7 @@ export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
           }
         }
       });
-    } else if (nodeKey == null && resolution != null) {
+    } else if (nodeKey === null && resolution !== null) {
       closeNodeMenu();
     }
   }, [closeNodeMenu, editor, nodeKey, openNodeMenu, resolution]);
@@ -108,7 +108,7 @@ export function LexicalNodeMenuPlugin<TOption extends MenuOption>({
   }, [positionOrCloseMenu, nodeKey]);
 
   useEffect(() => {
-    if (nodeKey != null) {
+    if (nodeKey !== null) {
       return editor.registerUpdateListener(({dirtyElements}) => {
         if (dirtyElements.get(nodeKey)) {
           positionOrCloseMenu();

--- a/packages/lexical-react/src/LexicalTablePlugin.ts
+++ b/packages/lexical-react/src/LexicalTablePlugin.ts
@@ -56,12 +56,10 @@ export function TablePlugin({
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    if (!editor.hasNodes([TableNode, TableCellNode, TableRowNode])) {
-      invariant(
-        false,
-        'TablePlugin: TableNode, TableCellNode or TableRowNode not registered on editor',
-      );
-    }
+    invariant(
+      editor.hasNodes([TableNode, TableCellNode, TableRowNode]),
+      'TablePlugin: TableNode, TableCellNode or TableRowNode not registered on editor',
+    );
 
     return mergeRegister(
       editor.registerCommand<InsertTableCommandPayload>(

--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -68,7 +68,7 @@ export function TreeView({
 
   const handleEditorReadOnly = (isReadonly: boolean) => {
     const rootElement = editor.getRootElement();
-    if (rootElement == null) {
+    if (rootElement === null) {
       return;
     }
 

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -60,7 +60,7 @@ function tryToPositionRange(
   const startOffset = leadOffset;
   const endOffset = domSelection.anchorOffset;
 
-  if (anchorNode == null || endOffset == null) {
+  if (anchorNode === null) {
     return false;
   }
 
@@ -229,7 +229,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
 
   const closeTypeahead = useCallback(() => {
     setResolution(null);
-    if (onClose != null && resolution !== null) {
+    if (onClose !== undefined && resolution !== null) {
       onClose();
     }
   }, [onClose, resolution]);
@@ -237,7 +237,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
   const openTypeahead = useCallback(
     (res: MenuResolution) => {
       setResolution(res);
-      if (onOpen != null && resolution === null) {
+      if (onOpen !== undefined && resolution === null) {
         onOpen(res);
       }
     },

--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -203,10 +203,10 @@ export function useDynamicPositioning(
 ) {
   const [editor] = useLexicalComposerContext();
   useEffect(() => {
-    if (targetElement != null && resolution != null) {
+    if (targetElement !== null && resolution !== null) {
       const rootElement = editor.getRootElement();
       const rootScrollParent =
-        rootElement != null
+        rootElement !== null
           ? getScrollParent(rootElement, false)
           : document.body;
       let ticking = false;
@@ -228,7 +228,7 @@ export function useDynamicPositioning(
         );
         if (isInView !== previousIsInView) {
           previousIsInView = isInView;
-          if (onVisibilityChange != null) {
+          if (onVisibilityChange !== undefined) {
             onVisibilityChange(isInView);
           }
         }
@@ -292,7 +292,7 @@ export function LexicalMenu<TOption extends MenuOption>({
     (selectedEntry: TOption) => {
       editor.update(() => {
         const textNodeContainingQuery =
-          resolution.match != null && shouldSplitNodeWithQuery
+          resolution.match !== undefined && shouldSplitNodeWithQuery
             ? $splitNodeContainingQuery(resolution.match)
             : null;
 
@@ -343,7 +343,7 @@ export function LexicalMenu<TOption extends MenuOption>({
       editor.registerCommand(
         SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND,
         ({option}) => {
-          if (option.ref && option.ref.current != null) {
+          if (option.ref && option.ref.current !== null) {
             scrollIntoViewIfNeeded(option.ref.current);
             return true;
           }
@@ -366,7 +366,7 @@ export function LexicalMenu<TOption extends MenuOption>({
               selectedIndex !== options.length - 1 ? selectedIndex + 1 : 0;
             updateSelectedIndex(newSelectedIndex);
             const option = options[newSelectedIndex];
-            if (option.ref != null && option.ref.current) {
+            if (option.ref !== undefined && option.ref.current) {
               editor.dispatchCommand(
                 SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND,
                 {
@@ -391,7 +391,7 @@ export function LexicalMenu<TOption extends MenuOption>({
               selectedIndex !== 0 ? selectedIndex - 1 : options.length - 1;
             updateSelectedIndex(newSelectedIndex);
             const option = options[newSelectedIndex];
-            if (option.ref != null && option.ref.current) {
+            if (option.ref !== undefined && option.ref.current) {
               scrollIntoViewIfNeeded(option.ref.current);
             }
             event.preventDefault();
@@ -419,7 +419,7 @@ export function LexicalMenu<TOption extends MenuOption>({
           if (
             options === null ||
             selectedIndex === null ||
-            options[selectedIndex] == null
+            options[selectedIndex] === undefined
           ) {
             return false;
           }
@@ -436,7 +436,7 @@ export function LexicalMenu<TOption extends MenuOption>({
           if (
             options === null ||
             selectedIndex === null ||
-            options[selectedIndex] == null
+            options[selectedIndex] === undefined
           ) {
             return false;
           }
@@ -525,7 +525,7 @@ export function useMenuAnchorRef(
       }
 
       if (!containerDiv.isConnected) {
-        if (className != null) {
+        if (className !== undefined) {
           containerDiv.className = className;
         }
         containerDiv.setAttribute('aria-label', 'Typeahead menu');

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -44,12 +44,10 @@ export function useCharacterLimit(
   } = optional;
 
   useEffect(() => {
-    if (!editor.hasNodes([OverflowNode])) {
-      invariant(
-        false,
-        'useCharacterLimit: OverflowNode not registered on editor',
-      );
-    }
+    invariant(
+      editor.hasNodes([OverflowNode]),
+      'useCharacterLimit: OverflowNode not registered on editor',
+    );
   }, [editor]);
 
   useEffect(() => {

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -388,18 +388,10 @@ function clearEditorSkipCollab(editor: LexicalEditor, binding: Binding) {
     },
   );
 
-  if (binding.cursors == null) {
-    return;
-  }
-
   const cursors = binding.cursors;
-
-  if (cursors == null) {
-    return;
-  }
   const cursorsContainer = binding.cursorsContainer;
 
-  if (cursorsContainer == null) {
+  if (cursorsContainer === null) {
     return;
   }
 
@@ -410,7 +402,7 @@ function clearEditorSkipCollab(editor: LexicalEditor, binding: Binding) {
     const cursor = cursorsArr[i];
     const selection = cursor.selection;
 
-    if (selection && selection.selections != null) {
+    if (selection) {
       const selections = selection.selections;
 
       for (let j = 0; j < selections.length; j++) {

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -442,7 +442,7 @@ function onPasteForRichText(
         objectKlassEquals(event, KeyboardEvent)
           ? null
           : (event as ClipboardEvent).clipboardData;
-      if (clipboardData != null && selection !== null) {
+      if (clipboardData !== null && selection !== null) {
         $insertDataTransferForRichText(clipboardData, selection, editor);
       }
     },
@@ -601,7 +601,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
           }
 
           const dataTransfer = eventOrText.dataTransfer;
-          if (dataTransfer != null) {
+          if (dataTransfer !== null) {
             $insertDataTransferForRichText(dataTransfer, selection, editor);
           } else if ($isRangeSelection(selection)) {
             const data = eventOrText.data;

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -227,7 +227,7 @@ export function trimTextContentFromAnchor(
       const parent = currentNode.getParent();
       currentNode.remove();
       if (
-        parent != null &&
+        parent !== null &&
         parent.getChildrenSize() === 0 &&
         !$isRootNode(parent)
       ) {

--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -14,7 +14,7 @@ import {CSS_TO_STYLES} from './constants';
 function getDOMTextNode(element: Node | null): Text | null {
   let node = element;
 
-  while (node != null) {
+  while (node !== null) {
     if (node.nodeType === Node.TEXT_NODE) {
       return node as Text;
     }
@@ -28,7 +28,7 @@ function getDOMTextNode(element: Node | null): Text | null {
 function getDOMIndexWithinParent(node: ChildNode): [ParentNode, number] {
   const parent = node.parentNode;
 
-  if (parent == null) {
+  if (parent === null) {
     throw new Error('Should never happen');
   }
 
@@ -88,7 +88,7 @@ export function createDOMRange(
 
   if (
     anchorDOM === focusDOM &&
-    firstChild != null &&
+    firstChild !== null &&
     firstChild.nodeName === 'BR' &&
     anchorOffset === 0 &&
     focusOffset === 0

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -128,7 +128,7 @@ export class TableNode extends ElementNode {
     for (let y = 0; y < rows; y++) {
       const row = domRows[y];
 
-      if (row == null) {
+      if (row === undefined) {
         continue;
       }
 
@@ -158,13 +158,13 @@ export class TableNode extends ElementNode {
 
     const row = domRows[y];
 
-    if (row == null) {
+    if (row === undefined) {
       return null;
     }
 
     const cell = row[x];
 
-    if (cell == null) {
+    if (cell === undefined) {
       return null;
     }
 
@@ -192,7 +192,7 @@ export class TableNode extends ElementNode {
   ): null | TableCellNode {
     const cell = this.getDOMCellFromCords(x, y, table);
 
-    if (cell == null) {
+    if (cell === null) {
       return null;
     }
 
@@ -234,7 +234,7 @@ export function $getElementForTableNode(
 ): TableDOMTable {
   const tableElement = editor.getElementByKey(tableNode.getKey());
 
-  if (tableElement == null) {
+  if (tableElement === null) {
     throw new Error('Table Element Not Found');
   }
 

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -227,7 +227,7 @@ export class TableObserver {
       this.isHighlightingCells = true;
       this.disableHighlightStyle();
       $updateDOMForSelection(editor, this.table, this.tableSelection);
-    } else if (selection == null) {
+    } else if (selection === null) {
       this.clearHighlight();
     } else {
       this.tableNodeKey = selection.tableKey;
@@ -284,8 +284,8 @@ export class TableObserver {
         const focusTableCellNode = $getNearestNodeFromDOMNode(cell.elem);
 
         if (
-          this.tableSelection != null &&
-          this.anchorCellNodeKey != null &&
+          this.tableSelection !== null &&
+          this.anchorCellNodeKey !== null &&
           $isTableCellNode(focusTableCellNode) &&
           tableNode.is($findTableNode(focusTableCellNode))
         ) {
@@ -323,7 +323,7 @@ export class TableObserver {
       if ($isTableCellNode(anchorTableCellNode)) {
         const anchorNodeKey = anchorTableCellNode.getKey();
         this.tableSelection =
-          this.tableSelection != null
+          this.tableSelection !== null
             ? this.tableSelection.clone()
             : $createTableSelection();
         this.anchorCellNodeKey = anchorNodeKey;

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -335,9 +335,7 @@ export class TableObserver {
     this.editor.update(() => {
       const selection = $getSelection();
 
-      if (!$isTableSelection(selection)) {
-        invariant(false, 'Expected grid selection');
-      }
+      invariant($isTableSelection(selection), 'Expected grid selection');
 
       const formatSelection = $createRangeSelection();
 
@@ -369,9 +367,7 @@ export class TableObserver {
 
       const selection = $getSelection();
 
-      if (!$isTableSelection(selection)) {
-        invariant(false, 'Expected grid selection');
-      }
+      invariant($isTableSelection(selection), 'Expected grid selection');
 
       const selectedNodes = selection.getNodes().filter($isTableCellNode);
 

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -213,13 +213,13 @@ export class TableSelection implements BaseSelection {
       if (!tableNode.isParentOf(focusCell)) {
         // focus is on higher Grid level than anchor
         const gridParent = tableNode.getParent();
-        invariant(gridParent != null, 'Expected gridParent to have a parent');
+        invariant(gridParent !== null, 'Expected gridParent to have a parent');
         this.set(this.tableKey, gridParent.getKey(), focusCell.getKey());
       } else {
         // anchor is on higher Grid level than focus
         const focusCellParent = focusCellGrid.getParent();
         invariant(
-          focusCellParent != null,
+          focusCellParent !== null,
           'Expected focusCellParent to have a parent',
         );
         this.set(this.tableKey, focusCell.getKey(), focusCellParent.getKey());

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -878,7 +878,7 @@ export function getTableObserverFromTableElement(
 export function getDOMCellFromTarget(node: Node): TableDOMCell | null {
   let currentNode: ParentNode | Node | null = node;
 
-  while (currentNode != null) {
+  while (currentNode !== null) {
     const nodeName = currentNode.nodeName;
 
     if (nodeName === 'TD' || nodeName === 'TH') {
@@ -923,7 +923,7 @@ export function getTable(tableElement: HTMLElement): TableDOMTable {
   let y = 0;
   domRows.length = 0;
 
-  while (currentNode != null) {
+  while (currentNode !== null) {
     const nodeMame = currentNode.nodeName;
 
     if (nodeMame === 'TD' || nodeMame === 'TH') {
@@ -948,7 +948,7 @@ export function getTable(tableElement: HTMLElement): TableDOMTable {
     } else {
       const child = currentNode.firstChild;
 
-      if (child != null) {
+      if (child !== null) {
         currentNode = child;
         continue;
       }
@@ -956,7 +956,7 @@ export function getTable(tableElement: HTMLElement): TableDOMTable {
 
     const sibling = currentNode.nextSibling;
 
-    if (sibling != null) {
+    if (sibling !== null) {
       x++;
       currentNode = sibling;
       continue;
@@ -964,10 +964,10 @@ export function getTable(tableElement: HTMLElement): TableDOMTable {
 
     const parent = currentNode.parentNode;
 
-    if (parent != null) {
+    if (parent !== null) {
       const parentSibling = parent.nextSibling;
 
-      if (parentSibling == null) {
+      if (parentSibling === null) {
         break;
       }
 
@@ -1325,11 +1325,11 @@ function $handleArrowKey(
       return false;
     }
     const anchorCellTable = $findTableNode(anchorCellNode);
-    if (anchorCellTable !== tableNode && anchorCellTable != null) {
+    if (anchorCellTable !== tableNode && anchorCellTable !== null) {
       const anchorCellTableElement = editor.getElementByKey(
         anchorCellTable.getKey(),
       );
-      if (anchorCellTableElement != null) {
+      if (anchorCellTableElement !== null) {
         tableObserver.table = getTable(anchorCellTableElement);
         return $handleArrowKey(
           editor,
@@ -1360,7 +1360,7 @@ function $handleArrowKey(
 
     const anchorCellDom = editor.getElementByKey(anchorCellNode.__key);
     const anchorDOM = editor.getElementByKey(anchor.key);
-    if (anchorDOM == null || anchorCellDom == null) {
+    if (anchorDOM === null || anchorCellDom === null) {
       return false;
     }
 
@@ -1381,13 +1381,13 @@ function $handleArrowKey(
       direction === 'up'
         ? anchorCellNode.getFirstChild()
         : anchorCellNode.getLastChild();
-    if (edgeChild == null) {
+    if (edgeChild === null) {
       return false;
     }
 
     const edgeChildDOM = editor.getElementByKey(edgeChild.__key);
 
-    if (edgeChildDOM == null) {
+    if (edgeChildDOM === null) {
       return false;
     }
 
@@ -1444,7 +1444,7 @@ function $handleArrowKey(
       !$isTableCellNode(anchorCellNode) ||
       !$isTableCellNode(focusCellNode) ||
       !$isTableNode(tableNodeFromSelection) ||
-      tableElement == null
+      tableElement === null
     ) {
       return false;
     }

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -641,7 +641,7 @@ export function $deleteTableColumn__EXPERIMENTAL(): void {
 
 function $moveSelectionToCell(cell: TableCellNode): void {
   const firstDescendant = cell.getFirstDescendant();
-  if (firstDescendant == null) {
+  if (firstDescendant === null) {
     cell.selectStart();
   } else {
     firstDescendant.getParentOrThrow().selectStart();

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -63,8 +63,8 @@ export function registerLexicalTextEntity<T extends TextNode>(
 
     const prevSibling = node.getPreviousSibling();
     let text = node.getTextContent();
-    let currentNode = node;
-    let match;
+    let currentNode: TextNode | undefined = node;
+    let match: EntityMatch | null = null;
 
     if ($isTextNode(prevSibling)) {
       const previousText = prevSibling.getTextContent();
@@ -146,7 +146,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
         continue;
       }
 
-      let nodeToReplace;
+      let nodeToReplace: TextNode;
 
       if (match.start === 0) {
         [nodeToReplace, currentNode] = currentNode.splitText(match.end);
@@ -161,7 +161,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
       replacementNode.setFormat(nodeToReplace.getFormat());
       nodeToReplace.replace(replacementNode);
 
-      if (currentNode == null) {
+      if (currentNode === undefined) {
         return;
       }
     }

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -258,13 +258,11 @@ export function $getNearestBlockElementAncestorOrThrow(
     startNode,
     (node) => $isElementNode(node) && !node.isInline(),
   );
-  if (!$isElementNode(blockNode)) {
-    invariant(
-      false,
-      'Expected node %s to have closest block element node.',
-      startNode.__key,
-    );
-  }
+  invariant(
+    $isElementNode(blockNode),
+    'Expected node %s to have closest block element node.',
+    startNode.__key,
+  );
   return blockNode;
 }
 

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -235,7 +235,7 @@ export function $getNearestNodeOfType<T extends ElementNode>(
 ): T | null {
   let parent: ElementNode | LexicalNode | null = node;
 
-  while (parent != null) {
+  while (parent !== null) {
     if (parent instanceof klass) {
       return parent as T;
     }
@@ -298,7 +298,7 @@ export const $findMatchingParent: {
 ): LexicalNode | null => {
   let curr: ElementNode | LexicalNode | null = startingNode;
 
-  while (curr !== $getRoot() && curr != null) {
+  while (curr !== $getRoot() && curr !== null) {
     if (findFn(curr)) {
       return curr;
     }
@@ -443,7 +443,7 @@ export function $insertNodeToNearestRoot<T extends LexicalNode>(node: T): T {
 
     if ($isRootOrShadowRoot(focusNode)) {
       const focusChild = focusNode.getChildAtIndex(focusOffset);
-      if (focusChild == null) {
+      if (focusChild === null) {
         focusNode.append(node);
       } else {
         focusChild.insertBefore(node);
@@ -468,7 +468,7 @@ export function $insertNodeToNearestRoot<T extends LexicalNode>(node: T): T {
       rightTree.selectStart();
     }
   } else {
-    if (selection != null) {
+    if (selection !== null) {
       const nodes = selection.getNodes();
       nodes[nodes.length - 1].getTopLevelElementOrThrow().insertAfter(node);
     } else {

--- a/packages/lexical-yjs/src/CollabElementNode.ts
+++ b/packages/lexical-yjs/src/CollabElementNode.ts
@@ -135,7 +135,7 @@ export class CollabElementNode {
       const insertDelta = delta.insert;
       const deleteDelta = delta.delete;
 
-      if (delta.retain != null) {
+      if (delta.retain !== undefined) {
         currIndex += delta.retain;
       } else if (typeof deleteDelta === 'number') {
         let deletionSize = deleteDelta;
@@ -182,7 +182,7 @@ export class CollabElementNode {
             break;
           }
         }
-      } else if (insertDelta != null) {
+      } else if (insertDelta !== undefined) {
         if (typeof insertDelta === 'string') {
           const {node, offset} = getPositionFromElementAndOffset(
             this,
@@ -274,9 +274,9 @@ export class CollabElementNode {
             childCollabNode.syncPropertiesAndTextFromYjs(binding, null);
           } else if (childCollabNode instanceof CollabDecoratorNode) {
             childCollabNode.syncPropertiesFromYjs(binding, null);
-          } else if (!(childCollabNode instanceof CollabLineBreakNode)) {
+          } else {
             invariant(
-              false,
+              childCollabNode instanceof CollabLineBreakNode,
               'syncChildrenFromYjs: expected text, element, decorator, or linebreak collab node',
             );
           }

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -113,11 +113,15 @@ function shouldUpdatePosition(
   currentPos: RelativePosition | null | undefined,
   pos: RelativePosition | null | undefined,
 ): boolean {
-  if (currentPos == null) {
-    if (pos != null) {
+  if (currentPos === null || currentPos === undefined) {
+    if (pos !== null && pos !== undefined) {
       return true;
     }
-  } else if (pos == null || !compareRelativePositions(currentPos, pos)) {
+  } else if (
+    pos === null ||
+    pos === undefined ||
+    !compareRelativePositions(currentPos, pos)
+  ) {
     return true;
   }
 
@@ -227,7 +231,7 @@ function updateCursor(
   const anchorNode = nodeMap.get(anchorKey);
   const focusNode = nodeMap.get(focusKey);
 
-  if (anchorNode == null || focusNode == null) {
+  if (anchorNode === undefined || focusNode === undefined) {
     return;
   }
   let selectionRects: Array<DOMRect>;

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -78,7 +78,7 @@ function isExcludedProperty(
 
   const nodeKlass = node.constructor;
   const excludedProperties = binding.excludedProperties.get(nodeKlass);
-  return excludedProperties != null && excludedProperties.has(name);
+  return excludedProperties !== undefined && excludedProperties.has(name);
 }
 
 export function getIndexOfYjsNode(
@@ -166,7 +166,12 @@ function getNodeTypeFromSharedType(
     sharedType instanceof YMap
       ? sharedType.get('__type')
       : sharedType.getAttribute('__type');
-  invariant(type != null, 'Expected shared type to include type attribute');
+
+  invariant(
+    typeof type === 'string',
+    'Expected shared type to include type attribute',
+  );
+
   return type;
 }
 

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -379,7 +379,7 @@ function initializeConversionCache(
   nodes.forEach((node) => {
     const importDOM = node.klass.importDOM;
 
-    if (importDOM == null || handledConversions.has(importDOM)) {
+    if (importDOM === undefined || handledConversions.has(importDOM)) {
       return;
     }
 
@@ -448,41 +448,31 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
         if (name !== 'RootNode') {
           const proto = klass.prototype;
           ['getType', 'clone'].forEach((method) => {
-            // eslint-disable-next-line no-prototype-builtins
-            if (!klass.hasOwnProperty(method)) {
+            if (!Object.hasOwn(klass, method)) {
               console.warn(`${name} must implement static "${method}" method`);
             }
           });
           if (
-            // eslint-disable-next-line no-prototype-builtins
-            !klass.hasOwnProperty('importDOM') &&
-            // eslint-disable-next-line no-prototype-builtins
-            klass.hasOwnProperty('exportDOM')
+            !Object.hasOwn(klass, 'importDOM') &&
+            Object.hasOwn(klass, 'exportDOM')
           ) {
             console.warn(
               `${name} should implement "importDOM" if using a custom "exportDOM" method to ensure HTML serialization (important for copy & paste) works as expected`,
             );
           }
           if (proto instanceof DecoratorNode) {
-            // eslint-disable-next-line no-prototype-builtins
-            if (!proto.hasOwnProperty('decorate')) {
+            if (!Object.hasOwn(proto, 'decorate')) {
               console.warn(
                 `${proto.constructor.name} must implement "decorate" method`,
               );
             }
           }
-          if (
-            // eslint-disable-next-line no-prototype-builtins
-            !klass.hasOwnProperty('importJSON')
-          ) {
+          if (!Object.hasOwn(klass, 'importJSON')) {
             console.warn(
               `${name} should implement "importJSON" method to ensure JSON and default HTML serialization works as expected`,
             );
           }
-          if (
-            // eslint-disable-next-line no-prototype-builtins
-            !proto.hasOwnProperty('exportJSON')
-          ) {
+          if (!Object.hasOwn(proto, 'exportJSON')) {
             console.warn(
               `${name} should implement "exportJSON" method to ensure JSON and default HTML serialization works as expected`,
             );
@@ -655,7 +645,7 @@ export class LexicalEditor {
    * through an IME, or 3P extension, for example. Returns false otherwise.
    */
   isComposing(): boolean {
-    return this._compositionKey != null;
+    return this._compositionKey !== null;
   }
   /**
    * Registers a listener for Editor update event. Will trigger the provided callback
@@ -869,7 +859,7 @@ export class LexicalEditor {
     const registeredNodes = [registeredNode];
 
     const replaceWithKlass = registeredNode.replaceWithKlass;
-    if (replaceWithKlass != null) {
+    if (replaceWithKlass !== null) {
       const registeredReplaceWithNode = this.registerNodeTransformToKlass(
         replaceWithKlass,
         listener as Transform<LexicalNode>,
@@ -961,7 +951,7 @@ export class LexicalEditor {
         if (!this._config.disableEvents) {
           removeRootElementEvents(prevRootElement);
         }
-        if (classNames != null) {
+        if (classNames !== undefined) {
           prevRootElement.classList.remove(...classNames);
         }
       }
@@ -985,7 +975,7 @@ export class LexicalEditor {
         if (!this._config.disableEvents) {
           addRootElementEvents(nextRootElement, this);
         }
-        if (classNames != null) {
+        if (classNames !== undefined) {
           nextRootElement.classList.add(...classNames);
         }
       } else {
@@ -1036,7 +1026,7 @@ export class LexicalEditor {
     const tag = options !== undefined ? options.tag : null;
 
     if (pendingEditorState !== null && !pendingEditorState.isEmpty()) {
-      if (tag != null) {
+      if (tag !== null && tag !== undefined) {
         tags.add(tag);
       }
 
@@ -1048,7 +1038,7 @@ export class LexicalEditor {
     this._dirtyElements.set('root', false);
     this._compositionKey = null;
 
-    if (tag != null) {
+    if (tag !== null && tag !== undefined) {
       tags.add(tag);
     }
 

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -448,31 +448,37 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
         if (name !== 'RootNode') {
           const proto = klass.prototype;
           ['getType', 'clone'].forEach((method) => {
-            if (!Object.hasOwn(klass, method)) {
+            // eslint-disable-next-line no-prototype-builtins
+            if (!klass.hasOwnProperty(method)) {
               console.warn(`${name} must implement static "${method}" method`);
             }
           });
           if (
-            !Object.hasOwn(klass, 'importDOM') &&
-            Object.hasOwn(klass, 'exportDOM')
+            // eslint-disable-next-line no-prototype-builtins
+            !klass.hasOwnProperty('importDOM') &&
+            // eslint-disable-next-line no-prototype-builtins
+            klass.hasOwnProperty('exportDOM')
           ) {
             console.warn(
               `${name} should implement "importDOM" if using a custom "exportDOM" method to ensure HTML serialization (important for copy & paste) works as expected`,
             );
           }
           if (proto instanceof DecoratorNode) {
-            if (!Object.hasOwn(proto, 'decorate')) {
+            // eslint-disable-next-line no-prototype-builtins
+            if (!proto.hasOwnProperty('decorate')) {
               console.warn(
                 `${proto.constructor.name} must implement "decorate" method`,
               );
             }
           }
-          if (!Object.hasOwn(klass, 'importJSON')) {
+          // eslint-disable-next-line no-prototype-builtins
+          if (!klass.hasOwnProperty('importJSON')) {
             console.warn(
               `${name} should implement "importJSON" method to ensure JSON and default HTML serialization works as expected`,
             );
           }
-          if (!Object.hasOwn(proto, 'exportJSON')) {
+          // eslint-disable-next-line no-prototype-builtins
+          if (!proto.hasOwnProperty('exportJSON')) {
             console.warn(
               `${name} should implement "exportJSON" method to ensure JSON and default HTML serialization works as expected`,
             );

--- a/packages/lexical/src/LexicalEditorState.ts
+++ b/packages/lexical/src/LexicalEditorState.ts
@@ -58,24 +58,20 @@ function exportNodeToJSON<SerializedNode extends SerializedLexicalNode>(
   const serializedNode = node.exportJSON();
   const nodeClass = node.constructor;
 
-  if (serializedNode.type !== nodeClass.getType()) {
-    invariant(
-      false,
-      'LexicalNode: Node %s does not match the serialized type. Check if .exportJSON() is implemented and it is returning the correct type.',
-      nodeClass.name,
-    );
-  }
+  invariant(
+    serializedNode.type === nodeClass.getType(),
+    'LexicalNode: Node %s does not match the serialized type. Check if .exportJSON() is implemented and it is returning the correct type.',
+    nodeClass.name,
+  );
 
   if ($isElementNode(node)) {
     const serializedChildren = (serializedNode as SerializedElementNode)
       .children;
-    if (!Array.isArray(serializedChildren)) {
-      invariant(
-        false,
-        'LexicalNode: Node %s is an element but .exportJSON() does not have a children array.',
-        nodeClass.name,
-      );
-    }
+    invariant(
+      Array.isArray(serializedChildren),
+      'LexicalNode: Node %s is an element but .exportJSON() does not have a children array.',
+      nodeClass.name,
+    );
 
     const children = node.getChildren();
 

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -641,13 +641,13 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
       } else if (data === DOUBLE_LINE_BREAK) {
         event.preventDefault();
         dispatchCommand(editor, INSERT_PARAGRAPH_COMMAND, undefined);
-      } else if (data == null && event.dataTransfer) {
+      } else if (data === null && event.dataTransfer) {
         // Gets around a Safari text replacement bug.
         const text = event.dataTransfer.getData('text/plain');
         event.preventDefault();
         selection.insertRawText(text);
       } else if (
-        data != null &&
+        data !== null &&
         $shouldPreventDefaultAndInsertText(
           selection,
           targetRange,
@@ -803,7 +803,7 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
     const targetRange = getTargetRange(event);
 
     if (
-      data != null &&
+      data !== null &&
       $isRangeSelection(selection) &&
       $shouldPreventDefaultAndInsertText(
         selection,
@@ -928,7 +928,7 @@ function onCompositionEndImpl(editor: LexicalEditor, data?: string): void {
   $setCompositionKey(null);
 
   // Handle termination of composition.
-  if (compositionKey !== null && data != null) {
+  if (compositionKey !== null && data !== undefined) {
     // Composition can sometimes move to an adjacent DOM node when backspacing.
     // So check for the empty case.
     if (data === '') {
@@ -1118,7 +1118,7 @@ const activeNestedEditorsMap: Map<string, LexicalEditor> = new Map();
 function onDocumentSelectionChange(event: Event): void {
   const target = event.target as null | Element | Document;
   const targetWindow =
-    target == null
+    target === null
       ? null
       : target.nodeType === 9
       ? (target as Document).defaultView

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -240,7 +240,6 @@ export function $flushMutations(
                 continue;
               }
 
-              // TODO: undefined or null ?
               if (currentDOM === null || currentDOM === undefined) {
                 targetDOM.appendChild(correctDOM);
                 currentDOM = correctDOM;

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -173,7 +173,7 @@ export function $flushMutations(
             const parentDOM = addedDOM.parentNode;
 
             if (
-              parentDOM != null &&
+              parentDOM !== null &&
               addedDOM !== blockCursorElement &&
               node === null &&
               (addedDOM.nodeName !== 'BR' ||
@@ -240,7 +240,8 @@ export function $flushMutations(
                 continue;
               }
 
-              if (currentDOM == null) {
+              // TODO: undefined or null ?
+              if (currentDOM === null || currentDOM === undefined) {
                 targetDOM.appendChild(correctDOM);
                 currentDOM = correctDOM;
               } else if (currentDOM !== correctDOM) {
@@ -274,7 +275,7 @@ export function $flushMutations(
             const parentDOM = addedDOM.parentNode;
 
             if (
-              parentDOM != null &&
+              parentDOM !== null &&
               addedDOM.nodeName === 'BR' &&
               !isManagedLineBreak(addedDOM, target, editor)
             ) {

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -268,7 +268,7 @@ export class LexicalNode {
    */
   isSelected(selection?: null | BaseSelection): boolean {
     const targetSelection = selection || $getSelection();
-    if (targetSelection == null) {
+    if (targetSelection === null) {
       return false;
     }
 
@@ -509,7 +509,7 @@ export class LexicalNode {
    * @param object - the node to perform the equality comparison on.
    */
   is(object: LexicalNode | null | undefined): boolean {
-    if (object == null) {
+    if (object === null || object === undefined) {
       return false;
     }
     return this.__key === object.__key;

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -237,7 +237,7 @@ function createNode(
       // @ts-expect-error: internal field
       const possibleLineBreak = parentDOM.__lexicalLineBreak;
 
-      if (possibleLineBreak !== undefined) {
+      if (possibleLineBreak !== undefined && possibleLineBreak !== null) {
         parentDOM.insertBefore(dom, possibleLineBreak);
       } else {
         parentDOM.appendChild(dom);

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -278,7 +278,7 @@ function createChildren(
   element: ElementNode,
   _startIndex: number,
   endIndex: number,
-  dom: null | HTMLElement,
+  dom: HTMLElement,
   insertDOM: null | HTMLElement,
 ): void {
   const previousSubTreeTextContent = subTreeTextContent;

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -231,13 +231,13 @@ function createNode(
   }
 
   if (parentDOM !== null) {
-    if (insertDOM != null) {
+    if (insertDOM !== null) {
       parentDOM.insertBefore(dom, insertDOM);
     } else {
       // @ts-expect-error: internal field
       const possibleLineBreak = parentDOM.__lexicalLineBreak;
 
-      if (possibleLineBreak != null) {
+      if (possibleLineBreak !== undefined) {
         parentDOM.insertBefore(dom, possibleLineBreak);
       } else {
         parentDOM.appendChild(dom);
@@ -333,7 +333,7 @@ function reconcileElementTerminatingLineBreak(
       // @ts-expect-error: internal field
       const element = dom.__lexicalLineBreak;
 
-      if (element != null) {
+      if (element !== undefined) {
         dom.removeChild(element);
       }
 
@@ -351,7 +351,7 @@ function reconcileElementTerminatingLineBreak(
 function reconcileParagraphFormat(element: ElementNode): void {
   if (
     $isParagraphNode(element) &&
-    subTreeTextFormat != null &&
+    subTreeTextFormat !== null &&
     subTreeTextFormat !== element.__textFormat
   ) {
     element.setTextFormat(subTreeTextFormat);
@@ -507,7 +507,7 @@ function reconcileChildren(
       if (prevChildrenSize !== 0) {
         // @ts-expect-error: internal field
         const lexicalLineBreak = dom.__lexicalLineBreak;
-        const canUseFastPath = lexicalLineBreak == null;
+        const canUseFastPath = lexicalLineBreak === undefined;
         destroyChildren(
           prevChildren,
           0,
@@ -761,7 +761,7 @@ function reconcileNodeChildren(
         if (childDOM === siblingDOM) {
           siblingDOM = getNextSibling(reconcileNode(nextKey, dom));
         } else {
-          if (siblingDOM != null) {
+          if (siblingDOM !== null) {
             dom.insertBefore(childDOM, siblingDOM);
           } else {
             dom.appendChild(childDOM);

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -117,11 +117,11 @@ export class Point {
 
     if ($isElementNode(aNode)) {
       const aNodeDescendant = aNode.getDescendantByIndex<ElementNode>(aOffset);
-      aNode = aNodeDescendant != null ? aNodeDescendant : aNode;
+      aNode = aNodeDescendant !== null ? aNodeDescendant : aNode;
     }
     if ($isElementNode(bNode)) {
       const bNodeDescendant = bNode.getDescendantByIndex<ElementNode>(bOffset);
-      bNode = bNodeDescendant != null ? bNodeDescendant : bNode;
+      bNode = bNodeDescendant !== null ? bNodeDescendant : bNode;
     }
     if (aNode === bNode) {
       return aOffset < bOffset;
@@ -478,7 +478,8 @@ export class RangeSelection implements BaseSelection {
     if ($isElementNode(firstNode)) {
       const firstNodeDescendant =
         firstNode.getDescendantByIndex<ElementNode>(startOffset);
-      firstNode = firstNodeDescendant != null ? firstNodeDescendant : firstNode;
+      firstNode =
+        firstNodeDescendant !== null ? firstNodeDescendant : firstNode;
     }
     if ($isElementNode(lastNode)) {
       let lastNodeDescendant =
@@ -492,7 +493,7 @@ export class RangeSelection implements BaseSelection {
       ) {
         lastNodeDescendant = lastNodeDescendant.getPreviousSibling();
       }
-      lastNode = lastNodeDescendant != null ? lastNodeDescendant : lastNode;
+      lastNode = lastNodeDescendant !== null ? lastNodeDescendant : lastNode;
     }
 
     let nodes: Array<LexicalNode>;
@@ -1095,15 +1096,12 @@ export class RangeSelection implements BaseSelection {
     // In case selection started at the end of text node use next text node
     if (
       startPoint.type === 'text' &&
-      startOffset === firstNode.getTextContentSize()
+      startOffset === firstNode.getTextContentSize() &&
+      selectedTextNodesLength > 1
     ) {
       firstIndex = 1;
       firstNode = selectedTextNodes[1];
       startOffset = 0;
-    }
-
-    if (firstNode == null) {
-      return;
     }
 
     const firstNextFormat = firstNode.getFormatFlags(formatType, null);
@@ -1358,7 +1356,7 @@ export class RangeSelection implements BaseSelection {
           anchorOffset > focusOffset ? anchorOffset : focusOffset;
         const splitNodes = firstNode.splitText(startOffset, endOffset);
         const node = startOffset === 0 ? splitNodes[0] : splitNodes[1];
-        return node != null ? [node] : [];
+        return node !== undefined ? [node] : [];
       }
       return [firstNode];
     }
@@ -1888,7 +1886,7 @@ function internalResolveSelectionPoint(
   editor: LexicalEditor,
 ): null | PointType {
   let resolvedOffset = offset;
-  let resolvedNode: TextNode | LexicalNode | null;
+  let resolvedNode: TextNode | LexicalNode | null = null;
   // If we have selection on an element, we will
   // need to figure out (using the offset) what text
   // node should be selected.
@@ -1915,7 +1913,10 @@ function internalResolveSelectionPoint(
     } else if (editor._blockCursorElement !== null) {
       resolvedOffset--;
     }
-    resolvedNode = getNodeFromDOM(childDOM);
+
+    if (childDOM) {
+      resolvedNode = getNodeFromDOM(childDOM);
+    }
 
     if ($isTextNode(resolvedNode)) {
       resolvedOffset = getTextNodeOffset(resolvedNode, moveSelectionToEnd);
@@ -2105,6 +2106,7 @@ function internalResolveSelectionPoints(
   ) {
     return null;
   }
+
   const resolvedAnchorPoint = internalResolveSelectionPoint(
     anchorDOM,
     anchorOffset,
@@ -2194,7 +2196,7 @@ export function internalCreateSelection(
   const lastSelection = currentEditorState._selection;
   const domSelection = getDOMSelection(editor._window);
 
-  if ($isRangeSelection(lastSelection) || lastSelection == null) {
+  if ($isRangeSelection(lastSelection) || lastSelection === null) {
     return internalCreateRangeSelection(
       lastSelection,
       domSelection,

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -311,13 +311,11 @@ function $parseSerializedNodeImpl<
 
   const nodeClass = registeredNode.klass;
 
-  if (serializedNode.type !== nodeClass.getType()) {
-    invariant(
-      false,
-      'LexicalNode: Node %s does not implement .importJSON().',
-      nodeClass.name,
-    );
-  }
+  invariant(
+    serializedNode.type === nodeClass.getType(),
+    'LexicalNode: Node %s does not implement .importJSON().',
+    nodeClass.name,
+  );
 
   const node = nodeClass.importJSON(serializedNode);
   const children = serializedNode.children;

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -820,8 +820,8 @@ function beginUpdate(
   options?: EditorUpdateOptions,
 ): void {
   const updateTags = editor._updateTags;
-  let onUpdate;
-  let tag;
+  let onUpdate: (() => void) | undefined;
+  let tag: string | undefined;
   let skipTransforms = false;
   let discrete = false;
 
@@ -829,7 +829,7 @@ function beginUpdate(
     onUpdate = options.onUpdate;
     tag = options.tag;
 
-    if (tag != null) {
+    if (tag !== undefined) {
       updateTags.add(tag);
     }
 

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -122,7 +122,7 @@ export function isSelectionCapturedInDecoratorInput(anchorDOM: Node): boolean {
       nodeName === 'TEXTAREA' ||
       (activeElement.contentEditable === 'true' &&
         // @ts-ignore iternal field
-        activeElement.__lexicalEditor == null))
+        activeElement.__lexicalEditor === undefined))
   );
 }
 
@@ -151,10 +151,10 @@ export function getNearestEditorFromDOMNode(
   node: Node | null,
 ): LexicalEditor | null {
   let currentNode = node;
-  while (currentNode != null) {
+  while (currentNode !== null) {
     // @ts-expect-error: internal field
-    const editor: LexicalEditor = currentNode.__lexicalEditor;
-    if (editor != null) {
+    const editor: LexicalEditor | undefined = currentNode.__lexicalEditor;
+    if (editor !== undefined) {
       return editor;
     }
     currentNode = getParentElement(currentNode);
@@ -182,7 +182,7 @@ function isDOMNodeLexicalTextNode(node: Node): node is Text {
 
 export function getDOMTextNode(element: Node | null): Text | null {
   let node = element;
-  while (node != null) {
+  while (node !== null) {
     if (isDOMNodeLexicalTextNode(node)) {
       return node;
     }
@@ -222,7 +222,7 @@ export function $setNodeKey(
   node: LexicalNode,
   existingKey: NodeKey | null | undefined,
 ): void {
-  if (existingKey != null) {
+  if (existingKey !== null && existingKey !== undefined) {
     node.__key = existingKey;
     return;
   }
@@ -408,7 +408,7 @@ export function $getNearestNodeFromDOMNode(
   editorState?: EditorState,
 ): LexicalNode | null {
   let dom: Node | null = startingDOM;
-  while (dom != null) {
+  while (dom !== null) {
     const node = getNodeFromDOMNode(dom, editorState);
     if (node !== null) {
       return node;
@@ -515,7 +515,7 @@ function getNodeKeyFromDOM(
   editor: LexicalEditor,
 ): NodeKey | null {
   let node: Node | null = dom;
-  while (node != null) {
+  while (node !== null) {
     // @ts-ignore We intentionally add this to the Node.
     const key: NodeKey = node[`__lexicalKey_${editor._key}`];
     if (key !== undefined) {
@@ -1022,7 +1022,7 @@ export function $selectAll(): void {
 export function getCachedClassNameArray(
   classNamesTheme: EditorThemeClasses,
   classNameThemeType: string,
-): Array<string> {
+): Array<string> | undefined {
   if (classNamesTheme.__lexicalClassNameCache === undefined) {
     classNamesTheme.__lexicalClassNameCache = {};
   }
@@ -1499,7 +1499,7 @@ export function updateDOMBlockCursorElement(
 }
 
 export function getDOMSelection(targetWindow: null | Window): null | Selection {
-  return !CAN_USE_DOM ? null : (targetWindow || window).getSelection();
+  return CAN_USE_DOM ? (targetWindow || window).getSelection() : null;
 }
 
 export function $splitNode(
@@ -1507,7 +1507,7 @@ export function $splitNode(
   offset: number,
 ): [ElementNode | null, ElementNode] {
   let startNode = node.getChildAtIndex(offset);
-  if (startNode == null) {
+  if (startNode === null) {
     startNode = node;
   }
 
@@ -1556,7 +1556,7 @@ export function $findMatchingParent(
 ): LexicalNode | null {
   let curr: ElementNode | LexicalNode | null = startingNode;
 
-  while (curr !== $getRoot() && curr != null) {
+  while (curr !== $getRoot() && curr !== null) {
     if (findFn(curr)) {
       return curr;
     }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -122,7 +122,9 @@ export function isSelectionCapturedInDecoratorInput(anchorDOM: Node): boolean {
       nodeName === 'TEXTAREA' ||
       (activeElement.contentEditable === 'true' &&
         // @ts-ignore iternal field
-        activeElement.__lexicalEditor === undefined))
+        (activeElement.__lexicalEditor === undefined ||
+          // @ts-ignore iternal field
+          activeElement.__lexicalEditor === null)))
   );
 }
 
@@ -152,9 +154,10 @@ export function getNearestEditorFromDOMNode(
 ): LexicalEditor | null {
   let currentNode = node;
   while (currentNode !== null) {
-    // @ts-expect-error: internal field
-    const editor: LexicalEditor | undefined = currentNode.__lexicalEditor;
-    if (editor !== undefined) {
+    const editor: LexicalEditor | undefined | null =
+      // @ts-expect-error: internal field
+      currentNode.__lexicalEditor;
+    if (editor !== undefined && editor !== null) {
       return editor;
     }
     currentNode = getParentElement(currentNode);

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1359,12 +1359,10 @@ export function $applyNodeReplacement<N extends LexicalNode>(
   const replaceFunc = registeredNode.replace;
   if (replaceFunc !== null) {
     const replacementNode = replaceFunc(node) as N;
-    if (!(replacementNode instanceof node.constructor)) {
-      invariant(
-        false,
-        '$initializeNode failed. Ensure replacement node is a subclass of the original node.',
-      );
-    }
+    invariant(
+      replacementNode instanceof node.constructor,
+      '$initializeNode failed. Ensure replacement node is a subclass of the original node.',
+    );
     return replacementNode;
   }
   return node as N;
@@ -1511,10 +1509,9 @@ export function $splitNode(
     startNode = node;
   }
 
-  invariant(
-    !$isRootOrShadowRoot(node),
-    'Can not call $splitNode() on root element',
-  );
+  if ($isRootOrShadowRoot(node)) {
+    invariant(false, 'Can not call $splitNode() on root element');
+  }
 
   const recurse = <T extends LexicalNode>(
     currentNode: T,

--- a/packages/lexical/src/nodes/LexicalRootNode.ts
+++ b/packages/lexical/src/nodes/LexicalRootNode.ts
@@ -86,12 +86,10 @@ export class RootNode extends ElementNode {
   append(...nodesToAppend: LexicalNode[]): this {
     for (let i = 0; i < nodesToAppend.length; i++) {
       const node = nodesToAppend[i];
-      if (!$isElementNode(node) && !$isDecoratorNode(node)) {
-        invariant(
-          false,
-          'rootNode.append: Only element or decorator nodes can be appended to the root node',
-        );
-      }
+      invariant(
+        $isElementNode(node) || $isDecoratorNode(node),
+        'rootNode.append: Only element or decorator nodes can be appended to the root node',
+      );
     }
     return super.append(...nodesToAppend);
   }

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -221,7 +221,7 @@ function setTextContent(
   const suffix = isComposing ? COMPOSITION_SUFFIX : '';
   const text: string = nextText + suffix;
 
-  if (firstChild == null) {
+  if (firstChild === null) {
     dom.textContent = text;
   } else {
     const nodeValue = firstChild.nodeValue;
@@ -494,7 +494,7 @@ export class TextNode extends LexicalNode {
     if (prevOuterTag === nextOuterTag && prevInnerTag !== nextInnerTag) {
       // should always be an element
       const prevInnerDOM: HTMLElement = dom.firstChild as HTMLElement;
-      if (prevInnerDOM == null) {
+      if (prevInnerDOM === null || prevInnerDOM === undefined) {
         invariant(false, 'updateDOM: prevInnerDOM is null or undefined');
       }
       const nextInnerDOM = document.createElement(nextInnerTag);
@@ -513,7 +513,7 @@ export class TextNode extends LexicalNode {
     if (nextOuterTag !== null) {
       if (prevOuterTag !== null) {
         innerDOM = dom.firstChild as HTMLElement;
-        if (innerDOM == null) {
+        if (innerDOM === null || innerDOM === undefined) {
           invariant(false, 'updateDOM: innerDOM is null or undefined');
         }
       }

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -1027,12 +1027,10 @@ export class TextNode extends LexicalNode {
    */
   mergeWithSibling(target: TextNode): TextNode {
     const isBefore = target === this.getPreviousSibling();
-    if (!isBefore && target !== this.getNextSibling()) {
-      invariant(
-        false,
-        'mergeWithSibling: sibling must be a previous or next sibling',
-      );
-    }
+    invariant(
+      isBefore || target === this.getNextSibling(),
+      'mergeWithSibling: sibling must be a previous or next sibling',
+    );
     const key = this.__key;
     const targetKey = target.__key;
     const text = this.__text;
@@ -1185,10 +1183,10 @@ export function findParentPreDOMNode(node: Node) {
 function convertTextDOMNode(domNode: Node): DOMConversionOutput {
   const domNode_ = domNode as Text;
   const parentDom = domNode.parentElement;
-  invariant(
-    parentDom !== null,
-    'Expected parentElement of Text not to be null',
-  );
+
+  if (parentDom === null) {
+    invariant(false, 'Expected parentElement of Text not to be null');
+  }
   let textContent = domNode_.textContent || '';
   // No collapse and preserve segment break for pre, pre-wrap and pre-line
   if (findParentPreDOMNode(domNode_) !== null) {


### PR DESCRIPTION
I tried to improve readability and type safety.

### Changes

- Set `eqeqeq` eslint rule to [`always`](https://eslint.org/docs/latest/rules/eqeqeq#always), which forces `===`, `!==` instead of `==`, `!=`. 
- Simplified some assertions which has double negation around `invariant`.
- Tweaked some types and removed unnecessary type checks.

### Further steps
- Unifying some unnecessary `undefined` and `null` where one of both would suffice.
- ~~Developing a general method to infer correct types from arrays or objects considering when index or key is not valid.~~ -> `--noUncheckedIndexedAccess` introduced in TS4.1 is for this.
- Implementing proper handling for `__lexical**` fields on the global namespace (mostly with `@ts-expect-error: internal field`), similar to [the way in devtools](https://github.com/facebook/lexical/blob/main/packages/lexical-devtools/src/types.ts).
 