### PR TITLE
fix(@lexical/devtools): Fix of the edge cases with restricted pages in Edge/FF

### DIFF
--- a/packages/lexical-devtools/src/entrypoints/background/ActionIconWatchdog.ts
+++ b/packages/lexical-devtools/src/entrypoints/background/ActionIconWatchdog.ts
@@ -82,7 +82,8 @@ export default class ActionIconWatchdog {
 
   private isRestrictedBrowserPage(url: string | undefined) {
     return (
-      !url || ['chrome:', 'about:', 'file:'].includes(new URL(url).protocol)
+      !url ||
+      ['chrome:', 'about:', 'file:', 'edge:'].includes(new URL(url).protocol)
     );
   }
 

--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/App.tsx
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/App.tsx
@@ -34,10 +34,16 @@ function App({tabID}: Props) {
   const [errorMessage, setErrorMessage] = useState('');
 
   const {lexicalState} = useExtensionStore();
-  const states = lexicalState[tabID] ?? {};
+  const states = lexicalState[tabID];
   const lexicalCount = Object.keys(states ?? {}).length;
 
-  return (
+  return lexicalState[tabID] === null ? (
+    <Alert status="warning">
+      <AlertIcon />
+      This is a restricted browser page. Lexical DevTools cannot access this
+      page.
+    </Alert>
+  ) : (
     <>
       <Flex>
         <Box p="4">

--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/App.tsx
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/App.tsx
@@ -85,7 +85,7 @@ function App({tabID}: Props) {
         ) : (
           <Alert status="info">
             <AlertIcon />
-            No Lexical editor found on the page.
+            No Lexical editors found on the page.
           </Alert>
         )}
       </Box>


### PR DESCRIPTION
Changes:

- [fix(@lexical/devtools): Fixed handling of the restricted pages in Edge](https://github.com/facebook/lexical/commit/f18c87665db35c93a7bf6448afbf3dc9270855f8)
- [fix(@lexical/devtools): Fixed handling of the restricted pages within devtools panel in Firefox](https://github.com/facebook/lexical/commit/afdcceea15bed2d20a8539e039875c0131237859)