### PR TITLE
Fix table of contents for headings in tables and collapsible sections

### DIFF
--- a/packages/lexical-react/src/LexicalTableOfContents.tsx
+++ b/packages/lexical-react/src/LexicalTableOfContents.tsx
@@ -9,7 +9,16 @@
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$isHeadingNode, HeadingNode, HeadingTagType} from '@lexical/rich-text';
 import {$getPreviousNode} from '@lexical/utils';
-import {$getNodeByKey, $getRoot, $isElementNode, ElementNode, LexicalEditor, NodeKey, NodeMutation,TextNode} from 'lexical';
+import {
+  $getNodeByKey,
+  $getRoot,
+  $isElementNode,
+  ElementNode,
+  LexicalEditor,
+  NodeKey,
+  NodeMutation,
+  TextNode,
+} from 'lexical';
 import {useEffect, useState} from 'react';
 
 export type TableOfContentsEntry = [

--- a/packages/lexical-react/src/LexicalTableOfContents.tsx
+++ b/packages/lexical-react/src/LexicalTableOfContents.tsx
@@ -8,7 +8,7 @@
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$isHeadingNode, HeadingNode, HeadingTagType} from '@lexical/rich-text';
-import {$getPreviousNode} from '@lexical/utils';
+import {$getNextRightPreorderNode} from '@lexical/utils';
 import {
   $getNodeByKey,
   $getRoot,
@@ -126,9 +126,9 @@ function $updateHeadingPosition(
 }
 
 function getPreviousHeading(node: HeadingNode): HeadingNode | null {
-  let prevHeading = $getPreviousNode(node);
+  let prevHeading = $getNextRightPreorderNode(node);
   while (prevHeading !== null && !$isHeadingNode(prevHeading)) {
-    prevHeading = $getPreviousNode(prevHeading);
+    prevHeading = $getNextRightPreorderNode(prevHeading);
   }
   return prevHeading;
 }

--- a/packages/lexical-react/src/LexicalTableOfContents.tsx
+++ b/packages/lexical-react/src/LexicalTableOfContents.tsx
@@ -10,7 +10,7 @@ import type {LexicalEditor, NodeKey, NodeMutation} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$isHeadingNode, HeadingNode, HeadingTagType} from '@lexical/rich-text';
-import {$dfs, DFSNode} from '@lexical/utils';
+import {$dfs} from '@lexical/utils';
 import {$getNodeByKey, $getRoot, TextNode} from 'lexical';
 import {useEffect, useState} from 'react';
 
@@ -88,11 +88,9 @@ export default function LexicalTableOfContentsPlugin({
       HeadingNode,
       (_: Map<string, NodeMutation>) => {
         editor.getEditorState().read(() => {
-          const dfsNodes = $dfs().filter((dfsNode: DFSNode) =>
-            $isHeadingNode(dfsNode.node),
-          );
-          const headingNodes = dfsNodes.map(
-            (dfsNode) => dfsNode.node as HeadingNode,
+          const headingNodes: HeadingNode[] = $dfs().reduce(
+            (acc, {node}) => ($isHeadingNode(node) ? [...acc, node] : acc),
+            [] as HeadingNode[],
           );
           currentTableOfContents = $newTableOfContents(headingNodes);
           setTableOfContents(currentTableOfContents);

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -222,6 +222,29 @@ function $getDepth(node: LexicalNode): number {
   return depth;
 }
 
+export function $getPreviousNode(
+  startingNode: LexicalNode,
+): LexicalNode | null {
+  let node: LexicalNode | null = startingNode;
+
+  if ($isElementNode(node) && node.getChildrenSize() > 0) {
+    node = node.getLastChild();
+  } else {
+    let sibling = null;
+
+    while (sibling === null && node !== null) {
+      sibling = node.getPreviousSibling();
+
+      if (sibling === null) {
+        node = node.getParent();
+      } else {
+        node = sibling;
+      }
+    }
+  }
+  return node;
+}
+
 /**
  * Takes a node and traverses up its ancestors (toward the root node)
  * in order to find a specific type of node.

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -222,7 +222,15 @@ function $getDepth(node: LexicalNode): number {
   return depth;
 }
 
-export function $getPreviousNode(
+/**
+ * Performs a right-to-left preorder tree traversal.
+ * From the starting node it goes to the rightmost child, than backtracks to paret and finds new rightmost path.
+ * It will return the next node in traversal sequence after the startingNode.
+ * The traversal is similar to $dfs functions above, but the nodes are visited right-to-left, not left-to-right.
+ * @param startingNode - The node to start the search.
+ * @returns The next node in pre-order right to left traversal sequence or `null`, if the node does not exist
+ */
+export function $getNextRightPreorderNode(
   startingNode: LexicalNode,
 ): LexicalNode | null {
   let node: LexicalNode | null = startingNode;


### PR DESCRIPTION
Fixes following issues with table of contents:
- The order in table of contents is wrong for heading inside tables and collapsible sections.
- The heading is duplicated when resizing parent table cell

Now on each heading update dfs is used to get all headings and create a new TOC from scratch. It might take more time, but the change shouldn't be noticeable

Before:
![toc-before](https://github.com/facebook/lexical/assets/47710336/f7597cd8-c0f5-446f-afac-3e954cf97b1c)

After:
![toc-after](https://github.com/facebook/lexical/assets/47710336/f0b5743e-e97a-4612-9a2f-dce47fc162fc)
