### PR TITLE
Fix TableCell child nodes on paste

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CodeBlock.spec.mjs
@@ -1006,7 +1006,7 @@ test.describe('CodeBlock', () => {
           </p>
         </td>
         <td class="PlaygroundEditorTheme__tableCell">
-          <p class="PlaygroundEditorTheme__paragraph">
+          <p class="PlaygroundEditorTheme__paragraph" style="text-align: right">
             <span
               class="PlaygroundEditorTheme__textUnderline"
               data-lexical-text="true">
@@ -1030,15 +1030,17 @@ test.describe('CodeBlock', () => {
             <span data-lexical-text="true">XDS_RICH_TEXT_AREA</span>
           </p>
         </td>
-        <td
-          class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">sdvd</span>
-          <strong
-            class="PlaygroundEditorTheme__textBold"
-            data-lexical-text="true">
-            sdfvsfs
-          </strong>
+        <td class="PlaygroundEditorTheme__tableCell">
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">sdvd</span>
+            <strong
+              class="PlaygroundEditorTheme__textBold"
+              data-lexical-text="true">
+              sdfvsfs
+            </strong>
+          </p>
         </td>
       </tr>
     </table>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
@@ -117,26 +117,30 @@ test.describe('HTML Tables CopyAndPaste', () => {
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                dir="ltr">
+                dir="ltr"
+                style="text-align: left;">
                 <span data-lexical-text="true">a</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                dir="ltr">
+                dir="ltr"
+                style="text-align: left;">
                 <span data-lexical-text="true">b</span>
               </p>
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                dir="ltr">
+                dir="ltr"
+                style="text-align: left;">
                 <span data-lexical-text="true">b</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                dir="ltr">
+                dir="ltr"
+                style="text-align: left;">
                 <span data-lexical-text="true">c</span>
               </p>
             </td>
@@ -145,21 +149,24 @@ test.describe('HTML Tables CopyAndPaste', () => {
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                dir="ltr">
+                dir="ltr"
+                style="text-align: left;">
                 <span data-lexical-text="true">d</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                dir="ltr">
+                dir="ltr"
+                style="text-align: left;">
                 <span data-lexical-text="true">e</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                dir="ltr">
+                dir="ltr"
+                style="text-align: left;">
                 <span data-lexical-text="true">f</span>
               </p>
             </td>

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -11,6 +11,7 @@ import type {
   DOMConversionOutput,
   DOMExportOutput,
   EditorConfig,
+  ElementFormatType,
   LexicalEditor,
   LexicalNode,
   NodeKey,
@@ -22,6 +23,7 @@ import {addClassNamesToElement} from '@lexical/utils';
 import {
   $applyNodeReplacement,
   $createParagraphNode,
+  $isBlockElementNode,
   $isElementNode,
   $isLineBreakNode,
   $isTextNode,
@@ -323,17 +325,39 @@ export function convertTableCellNodeElement(
   const hasLinethroughTextDecoration = textDecoration.includes('line-through');
   const hasItalicFontStyle = style.fontStyle === 'italic';
   const hasUnderlineTextDecoration = textDecoration.includes('underline');
-
+  const textAlign = style.textAlign;
   return {
     after: (childLexicalNodes) => {
+      const children = [];
+      let paragraphNode = $createParagraphNode().setFormat(
+        textAlign as ElementFormatType,
+      );
       if (childLexicalNodes.length === 0) {
-        childLexicalNodes.push($createParagraphNode());
+        children.push(paragraphNode);
       }
-      return childLexicalNodes;
+
+      childLexicalNodes.forEach((node) => {
+        if ($isBlockElementNode(node)) {
+          if (paragraphNode.getChildrenSize() !== 0) {
+            children.push(paragraphNode);
+            paragraphNode = $createParagraphNode().setFormat(
+              textAlign as ElementFormatType,
+            );
+          }
+          children.push(node);
+        } else {
+          paragraphNode.append(node);
+        }
+      });
+      if (paragraphNode.getChildrenSize() !== 0) {
+        children.push(paragraphNode);
+      }
+      return children;
     },
     forChild: (lexicalNode, parentLexicalNode) => {
       if ($isTableCellNode(parentLexicalNode) && !$isElementNode(lexicalNode)) {
         const paragraphNode = $createParagraphNode();
+        paragraphNode.setFormat(textAlign as ElementFormatType);
         if (
           $isLineBreakNode(lexicalNode) &&
           lexicalNode.getTextContent() === '\n'


### PR DESCRIPTION
This PR fixes pasting tables that have the copied html in such format:
```
...
<td>
<span> ... </span>
</td>
...
```
Pasting this results in the following node structure:

![image](https://github.com/facebook/lexical/assets/33776279/7c513eaa-cba0-46ea-80f1-038e9cbdef43)

which causes the editor to freeze and eventually crash on enter key press, as the text node is not wrapped in a paragraph node.
This issue is similar to the one described [here](https://github.com/facebook/lexical/pull/5670#issuecomment-1978455980) and was fixed for the case when pasting empty cells.

This PR addresses the case when on paste the children of the `TableCell` node are not within a block element node. 

Another case to reproduce this issue is when we copy something with such html:
```
...
<td>
<a> ... </a>
</td>
...
```
This results in a link node inside a tablecell node which again crashes on enter key press. 

Also, this PR fixes the issue with alignment of text inside the cell as well, as this formatting can now be applied on the wrapping block element node.
So, copying from google sheets will now have the correct alignment.

### Before
![table-align-before](https://github.com/facebook/lexical/assets/33776279/e9d2aa5c-26bd-4d9f-8c1c-6e9f16df1e35)

### After
![table-align-after](https://github.com/facebook/lexical/assets/33776279/13049d73-eb79-4539-b14b-18083974d79e)

