### PR TITLE
Dont run tests on merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,6 @@
 name: Lexical Tests
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - 'packages/lexical-website/**'
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:


### PR DESCRIPTION
We run the tests on PR, then again on merge. There's no reason to do that, really and it almost always gets cancelled by something else getting merged right after.