### PR TITLE
Fix insertText with element selection

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -1121,6 +1121,30 @@ describe('LexicalSelection tests', () => {
     });
   });
 
+  test('insert text one selected node element selection', async () => {
+    await ReactTestUtils.act(async () => {
+      await editor.update(() => {
+        const root = $getRoot();
+
+        const paragraph = root.getFirstChild<ParagraphNode>();
+
+        const elementNode = $createTestElementNode();
+        const text = $createTextNode('foo');
+
+        paragraph.append(elementNode);
+        elementNode.append(text);
+
+        const selection = $createRangeSelection();
+        selection.anchor.set(text.__key, 0, 'text');
+        selection.focus.set(paragraph.__key, 1, 'element');
+
+        selection.insertText('');
+
+        expect(root.getTextContent()).toBe('');
+      });
+    });
+  });
+
   test('getNodes resolves nested block nodes', async () => {
     await ReactTestUtils.act(async () => {
       await editor.update(() => {


### PR DESCRIPTION
It's valid to have an text + element selection that `selection.getNodes()` will only recognize as one node. This happens fairly often in FF when trying to span the entire text node selection to the entire line and is followed by a line break. See test to understand the problem at hand better.

I believe this PR fixes the entire problem and we don't need to understand further combinations, as `insertText` relies on normalized selection.

Closes https://github.com/facebook/lexical/issues/5233