### PR TITLE
Fixed the issue of playground crashing when the selected node contain…

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -744,6 +744,7 @@ export default function ToolbarPlugin({
         const anchor = selection.anchor;
         const focus = selection.focus;
         const nodes = selection.getNodes();
+        const extractedNodes = selection.extract();
 
         if (anchor.key === focus.key && anchor.offset === focus.offset) {
           return;
@@ -769,7 +770,7 @@ export default function ToolbarPlugin({
              * The cleared text is based on the length of the selected text.
              */
             // We need this in case the selected text only has one format
-            const extractedTextNode = selection.extract()[0];
+            const extractedTextNode = extractedNodes[0];
             if (nodes.length === 1 && $isTextNode(extractedTextNode)) {
               textNode = extractedTextNode;
             }


### PR DESCRIPTION
When the selected node contains HeadingNode or QuoteNode, the selected node will be replaced by ParagraphNode, and execution of selection.extract will crash.

Fix: https://github.com/facebook/lexical/pull/5849#issuecomment-2076631398


https://github.com/facebook/lexical/assets/1763168/feba027b-39a7-4eba-b41b-ce3dd1b531e0


