### PR TITLE
Fix #5738 wrong selection on mouse click

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1941,6 +1941,9 @@ function internalResolveSelectionPoint(
           resolvedElement.getChildrenSize(),
           resolvedOffset,
         );
+        if (resolvedOffset === -1) {
+          resolvedOffset = resolvedElement.getChildrenSize();
+        }
         let child = resolvedElement.getChildAtIndex(resolvedOffset);
         if (
           $isElementNode(child) &&


### PR DESCRIPTION
The Crash looks partially resolved before this fix - it doesn't crash anymore.
But the wrong selection leads to wrong behaviour on backspace command and doesn't delete hr correctly if we try delete from the wrong selection state

Before ( delete command doesn't delete hr element)

https://github.com/facebook/lexical/assets/163521239/4534123b-fc24-4508-ad60-89b8c8262e62

After ( delete command deletes hr element correctly )


https://github.com/facebook/lexical/assets/163521239/b2c1947d-b643-44c7-879a-066128334d78

