### PR TITLE
Fix: #5976 Passing an empty ParagraphNode to $dfs incorrectly returns content from subsequent paragraphs

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -203,5 +203,34 @@ describe('LexicalNodeHelpers tests', () => {
         ]);
       });
     });
+
+    test('DFS of empty ParagraphNode returns only itself', async () => {
+      const editor: LexicalEditor = testEnv.editor;
+
+      let paragraphKey;
+
+      await editor.update(() => {
+        const root = $getRoot();
+
+        const paragraph = $createParagraphNode();
+        const paragraph2 = $createParagraphNode();
+        const text = $createTextNode('test');
+
+        paragraphKey = paragraph.getKey();
+
+        paragraph2.append(text);
+        root.append(paragraph, paragraph2);
+      });
+      await editor.update(() => {
+        const paragraph = $getNodeByKey(paragraphKey);
+
+        expect($dfs(paragraph)).toEqual([
+          {
+            depth: 1,
+            node: paragraph.getLatest(),
+          },
+        ]);
+      });
+    });
   });
 });

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -177,7 +177,8 @@ export function $dfs(
   const nodes = [];
   const start = (startingNode || $getRoot()).getLatest();
   const end =
-    endingNode || ($isElementNode(start) ? start.getLastDescendant() : start);
+    endingNode ||
+    ($isElementNode(start) ? start.getLastDescendant() || start : start);
   let node: LexicalNode | null = start;
   let depth = $getDepth(node);
 


### PR DESCRIPTION
fixed #5976

![Screenshot 2024-04-27 at 18 56 27](https://github.com/facebook/lexical/assets/111737064/166ab767-cd61-4838-a2c8-857283892aea)
