### PR TITLE
feat(core): add experimental decorator element node and nested root node

### DIFF
--- a/packages/lexical-playground/src/nodes/CardNode.tsx
+++ b/packages/lexical-playground/src/nodes/CardNode.tsx
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $applyNodeReplacement,
+  $createNestedRootNode,
+  $createParagraphNode,
+  $createTextNode,
+  EXPERIMENTAL_DecoratorElementNode,
+  EXPERIMENTAL_NestedRootNode,
+  LexicalNode,
+  NodeKey,
+} from 'lexical';
+import * as React from 'react';
+
+export class CardNode extends EXPERIMENTAL_DecoratorElementNode<JSX.Element> {
+  static getType(): string {
+    return 'card';
+  }
+
+  static clone(node: CardNode): CardNode {
+    return new CardNode(node.__key);
+  }
+
+  constructor(key?: NodeKey) {
+    super(key);
+
+    // ElementNode will automatically clone children
+    // So we only need to set the children if the node is new
+    if (key === undefined) {
+      const title = $createNestedRootNode();
+      const titleParagraph = $createParagraphNode();
+      titleParagraph.append($createTextNode('Title sample text'));
+      title.append(titleParagraph);
+      this.append(title);
+      const body = $createNestedRootNode();
+      const bodyParagraph = $createParagraphNode();
+      bodyParagraph.append($createTextNode('Content sample text'));
+      body.append(bodyParagraph);
+      this.append(body);
+    }
+  }
+
+  get title(): EXPERIMENTAL_NestedRootNode {
+    return this.getChildAtIndex(0) as EXPERIMENTAL_NestedRootNode;
+  }
+
+  get body(): EXPERIMENTAL_NestedRootNode {
+    return this.getChildAtIndex(1) as EXPERIMENTAL_NestedRootNode;
+  }
+
+  // View
+
+  createDOM(): HTMLElement {
+    return document.createElement('div');
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  decorate(): JSX.Element {
+    return (
+      <div
+        style={{
+          borderColor: 'black',
+          borderStyle: 'solid',
+          borderWidth: 1,
+        }}>
+        <div>Title</div>
+        <div
+          style={{
+            borderColor: 'red',
+            borderStyle: 'solid',
+            borderWidth: 1,
+            minHeight: 100,
+            minWidth: 300,
+          }}
+          ref={this.title.onRef}
+        />
+        <div>Content</div>
+        <div
+          style={{
+            borderColor: 'blue',
+            borderStyle: 'solid',
+            borderWidth: 1,
+            minHeight: 100,
+            minWidth: 300,
+          }}
+          ref={this.body.onRef}
+        />
+      </div>
+    );
+  }
+}
+
+export function $createCardNode(): CardNode {
+  return $applyNodeReplacement(new CardNode());
+}
+
+export function $isCardNode(
+  node: LexicalNode | null | undefined,
+): node is CardNode {
+  return node instanceof CardNode;
+}

--- a/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
+++ b/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
@@ -6,8 +6,6 @@
  *
  */
 
-import type {Klass, LexicalNode} from 'lexical';
-
 import {CodeHighlightNode, CodeNode} from '@lexical/code';
 import {HashtagNode} from '@lexical/hashtag';
 import {AutoLinkNode, LinkNode} from '@lexical/link';
@@ -17,11 +15,13 @@ import {OverflowNode} from '@lexical/overflow';
 import {HorizontalRuleNode} from '@lexical/react/LexicalHorizontalRuleNode';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
+import {type Klass, type LexicalNode} from 'lexical';
 
 import {CollapsibleContainerNode} from '../plugins/CollapsiblePlugin/CollapsibleContainerNode';
 import {CollapsibleContentNode} from '../plugins/CollapsiblePlugin/CollapsibleContentNode';
 import {CollapsibleTitleNode} from '../plugins/CollapsiblePlugin/CollapsibleTitleNode';
 import {AutocompleteNode} from './AutocompleteNode';
+import {CardNode} from './CardNode';
 import {EmojiNode} from './EmojiNode';
 import {EquationNode} from './EquationNode';
 import {ExcalidrawNode} from './ExcalidrawNode';
@@ -73,6 +73,7 @@ const PlaygroundNodes: Array<Klass<LexicalNode>> = [
   PageBreakNode,
   LayoutContainerNode,
   LayoutItemNode,
+  CardNode,
 ];
 
 export default PlaygroundNodes;

--- a/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
+++ b/packages/lexical-playground/src/nodes/PlaygroundNodes.ts
@@ -34,6 +34,7 @@ import {LayoutItemNode} from './LayoutItemNode';
 import {MentionNode} from './MentionNode';
 import {PageBreakNode} from './PageBreakNode';
 import {PollNode} from './PollNode';
+import {ReactListNode} from './ReactListNode';
 import {StickyNode} from './StickyNode';
 import {TweetNode} from './TweetNode';
 import {YouTubeNode} from './YouTubeNode';
@@ -74,6 +75,7 @@ const PlaygroundNodes: Array<Klass<LexicalNode>> = [
   LayoutContainerNode,
   LayoutItemNode,
   CardNode,
+  ReactListNode,
 ];
 
 export default PlaygroundNodes;

--- a/packages/lexical-playground/src/nodes/ReactListNode.tsx
+++ b/packages/lexical-playground/src/nodes/ReactListNode.tsx
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {
+  $applyNodeReplacement,
+  $createNestedRootNode,
+  $createParagraphNode,
+  $createTextNode,
+  $getNodeByKey,
+  $isNestedRootNode,
+  EXPERIMENTAL_DecoratorElementNode,
+  LexicalNode,
+  NodeKey,
+} from 'lexical';
+import * as React from 'react';
+
+export class ReactListNode extends EXPERIMENTAL_DecoratorElementNode<JSX.Element> {
+  static getType(): string {
+    return 'reactlist';
+  }
+
+  static clone(node: ReactListNode): ReactListNode {
+    return new ReactListNode(node.__key);
+  }
+
+  constructor(key?: NodeKey) {
+    super(key);
+  }
+
+  createDOM(): HTMLElement {
+    return document.createElement('div');
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  decorate(): JSX.Element {
+    return <ReactListComponent nodeKey={this.__key} />;
+  }
+}
+
+export function $createReactListNode(): ReactListNode {
+  return $applyNodeReplacement(new ReactListNode());
+}
+
+export function $isReactListNode(
+  node: LexicalNode | null | undefined,
+): node is ReactListNode {
+  return node instanceof ReactListNode;
+}
+
+function ReactListComponent({nodeKey}: {nodeKey: NodeKey}) {
+  const [editor] = useLexicalComposerContext();
+  const addAtBeginning = React.useCallback(() => {
+    editor.update(() => {
+      const node = $getNodeByKey(nodeKey);
+      if ($isReactListNode(node)) {
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode('New text'));
+        const nestedRoot = $createNestedRootNode();
+        nestedRoot.append(paragraph);
+        node.splice(0, 0, [nestedRoot]);
+      }
+    });
+  }, [editor, nodeKey]);
+  const childKeys = editor.getEditorState().read(() => {
+    const node = $getNodeByKey(nodeKey);
+    return $isReactListNode(node) ? node.getChildrenKeys() : [];
+  });
+  return (
+    <div
+      style={{
+        borderColor: 'black',
+        borderStyle: 'solid',
+        borderWidth: 1,
+      }}>
+      <button onClick={addAtBeginning}>Add one item at beginning</button>
+      {childKeys.map((childKey, index) => (
+        <ReactListItem key={childKey} index={index} nodeKey={childKey} />
+      ))}
+    </div>
+  );
+}
+
+function ReactListItem({
+  index,
+  nodeKey,
+}: {
+  index: number;
+  nodeKey: NodeKey;
+}): JSX.Element {
+  const [editor] = useLexicalComposerContext();
+  const onRef = React.useCallback(
+    (element: HTMLElement | null) => {
+      editor.setNestedRootElement(nodeKey, element);
+    },
+    [editor, nodeKey],
+  );
+  const removeSelf = React.useCallback(() => {
+    editor.update(() => {
+      const node = $getNodeByKey(nodeKey);
+      if ($isNestedRootNode(node)) {
+        node.remove();
+      }
+    });
+  }, [editor, nodeKey]);
+  const addOneAfter = React.useCallback(() => {
+    editor.update(() => {
+      const node = $getNodeByKey(nodeKey);
+      if ($isNestedRootNode(node)) {
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode('New text'));
+        const nestedRoot = $createNestedRootNode();
+        nestedRoot.append(paragraph);
+        node.insertAfter(nestedRoot);
+      }
+    });
+  }, [editor, nodeKey]);
+  return (
+    <div>
+      Item No.{index} Key:{nodeKey}
+      <div
+        style={{
+          borderColor: 'red',
+          borderStyle: 'solid',
+          borderWidth: 1,
+          minHeight: 30,
+          minWidth: 100,
+        }}
+        ref={onRef}
+      />
+      <button onClick={removeSelf}>Remove</button>
+      <button onClick={addOneAfter}>Add one after</button>
+    </div>
+  );
+}

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -43,6 +43,7 @@ import {
   $findMatchingParent,
   $getNearestBlockElementAncestorOrThrow,
   $getNearestNodeOfType,
+  $insertNodeToNearestRoot,
   mergeRegister,
 } from '@lexical/utils';
 import {
@@ -76,6 +77,7 @@ import {IS_APPLE} from 'shared/environment';
 
 import useModal from '../../hooks/useModal';
 import catTypingGif from '../../images/cat-typing.gif';
+import {$createCardNode} from '../../nodes/CardNode';
 import {$createStickyNode} from '../../nodes/StickyNode';
 import DropDown, {DropDownItem} from '../../ui/DropDown';
 import DropdownColorPicker from '../../ui/DropdownColorPicker';
@@ -1041,6 +1043,16 @@ export default function ToolbarPlugin({
             buttonLabel="Insert"
             buttonAriaLabel="Insert specialized editor node"
             buttonIconClassName="icon plus">
+            <DropDownItem
+              onClick={() => {
+                activeEditor.update(() => {
+                  const cardNode = $createCardNode();
+                  $insertNodeToNearestRoot(cardNode);
+                });
+              }}
+              className="item">
+              <span className="text">Card Node</span>
+            </DropDownItem>
             <DropDownItem
               onClick={() => {
                 activeEditor.dispatchCommand(

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -78,6 +78,7 @@ import {IS_APPLE} from 'shared/environment';
 import useModal from '../../hooks/useModal';
 import catTypingGif from '../../images/cat-typing.gif';
 import {$createCardNode} from '../../nodes/CardNode';
+import {$createReactListNode} from '../../nodes/ReactListNode';
 import {$createStickyNode} from '../../nodes/StickyNode';
 import DropDown, {DropDownItem} from '../../ui/DropDown';
 import DropdownColorPicker from '../../ui/DropdownColorPicker';
@@ -1043,6 +1044,16 @@ export default function ToolbarPlugin({
             buttonLabel="Insert"
             buttonAriaLabel="Insert specialized editor node"
             buttonIconClassName="icon plus">
+            <DropDownItem
+              onClick={() => {
+                activeEditor.update(() => {
+                  const reactListNode = $createReactListNode();
+                  $insertNodeToNearestRoot(reactListNode);
+                });
+              }}
+              className="item">
+              <span className="text">React List Node</span>
+            </DropDownItem>
             <DropDownItem
               onClick={() => {
                 activeEditor.update(() => {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1045,11 +1045,17 @@ export class LexicalEditor {
         style.whiteSpace = 'pre-wrap';
         style.wordBreak = 'break-word';
         this._keyToDOMMap.set(key, nextNestedRootElement);
+        this._pendingNestedRootNodeKeys.add(key);
       } else {
         this._keyToDOMMap.delete(key);
+        // There are two cases that nextNestedRootElement is null:
+        // 1. The nested root node is removed from Lexical
+        // 2. The nested root node remains unchanged, but the HTML Element no longer exists
+        // Only in the second case, we need to further process Lexical node children.
+        if (this._editorState._nodeMap.get(key)) {
+          this._pendingNestedRootNodeKeys.add(key);
+        }
       }
-
-      this._pendingNestedRootNodeKeys.add(key);
 
       // Defer to next microtask, so multiple simultaneous root element update
       // can trigger only one reconciliation.

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -46,7 +46,10 @@ import {EXPERIMENTAL_DecoratorElementNode} from './nodes/LexicalDecoratorElement
 import {ArtificialNode__DO_NOT_USE} from './nodes/ArtificialNode';
 import {DecoratorNode} from './nodes/LexicalDecoratorNode';
 import {LineBreakNode} from './nodes/LexicalLineBreakNode';
-import {EXPERIMENTAL_NestedRootNode} from './nodes/LexicalNestedRootNode';
+import {
+  $isNestedRootNode,
+  EXPERIMENTAL_NestedRootNode,
+} from './nodes/LexicalNestedRootNode';
 import {ParagraphNode} from './nodes/LexicalParagraphNode';
 import {RootNode} from './nodes/LexicalRootNode';
 import {TabNode} from './nodes/LexicalTabNode';
@@ -1029,6 +1032,10 @@ export class LexicalEditor {
     key: NodeKey,
     nextNestedRootElement: null | HTMLElement,
   ): void {
+    invariant(
+      $isNestedRootNode(this._editorState._nodeMap.get(key)),
+      'Cannot set nested root element for non-nested root node.',
+    );
     const prevNestedRootElement = this._keyToDOMMap.get(key) || null;
     if (nextNestedRootElement !== prevNestedRootElement) {
       if (nextNestedRootElement !== null) {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1029,7 +1029,7 @@ export class LexicalEditor {
     key: NodeKey,
     nextNestedRootElement: null | HTMLElement,
   ): void {
-    const prevNestedRootElement = this._keyToDOMMap.get(key) ?? null;
+    const prevNestedRootElement = this._keyToDOMMap.get(key) || null;
     if (nextNestedRootElement !== prevNestedRootElement) {
       if (nextNestedRootElement !== null) {
         const style = nextNestedRootElement.style;

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1032,13 +1032,14 @@ export class LexicalEditor {
     key: NodeKey,
     nextNestedRootElement: null | HTMLElement,
   ): void {
-    invariant(
-      $isNestedRootNode(this._editorState._nodeMap.get(key)),
-      'Cannot set nested root element for non-nested root node.',
-    );
     const prevNestedRootElement = this._keyToDOMMap.get(key) || null;
     if (nextNestedRootElement !== prevNestedRootElement) {
       if (nextNestedRootElement !== null) {
+        invariant(
+          $isNestedRootNode(this._editorState._nodeMap.get(key)),
+          'Cannot set nested root element for non-nested root node.',
+        );
+
         const style = nextNestedRootElement.style;
         style.userSelect = 'text';
         style.whiteSpace = 'pre-wrap';

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -14,6 +14,7 @@ import {IS_FIREFOX} from 'shared/environment';
 
 import {
   $getSelection,
+  $isDecoratorElementNode,
   $isDecoratorNode,
   $isElementNode,
   $isRangeSelection,
@@ -140,7 +141,8 @@ export function $flushMutations(
 
         if (
           (targetNode === null && targetDOM !== rootElement) ||
-          $isDecoratorNode(targetNode)
+          $isDecoratorNode(targetNode) ||
+          $isDecoratorElementNode(targetNode)
         ) {
           continue;
         }

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -214,7 +214,7 @@ export class LexicalNode {
     $setNodeKey(this, key);
 
     if (__DEV__) {
-      if (this.__type !== 'root') {
+      if (!['root', 'nestedroot'].includes(this.__type)) {
         errorOnReadOnly();
         errorOnTypeKlassMismatch(this.__type, this.constructor);
       }

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -85,17 +85,7 @@ function destroyNode(key: NodeKey, parentDOM: null | HTMLElement): void {
     activeEditor._keyToDOMMap.delete(key);
   }
 
-  if ($isDecoratorElementNode(node)) {
-    for (const child of node.getChildren()) {
-      const childKey = child.getKey();
-
-      // child's dom is handled by external frameworks (frameworks that uses the decorators)
-      // we want to make sure activeEditor._keyToDOMMap release them
-      if (activeEditor._keyToDOMMap.has(childKey)) {
-        destroyNode(childKey, null);
-      }
-    }
-  } else if ($isElementNode(node)) {
+  if ($isDecoratorElementNode(node) || $isElementNode(node)) {
     const children = createChildrenArray(node, activePrevNodeMap);
     destroyChildren(children, 0, children.length - 1, null);
   }
@@ -208,9 +198,8 @@ function createNode(
       reconcileDecorator(key, decorator);
     }
 
-    for (const child of node.getChildren()) {
-      const childKey = child.getKey();
-
+    const children = createChildrenArray(node, activeNextNodeMap);
+    for (const childKey of children) {
       // child's dom is handled by external frameworks (frameworks that uses the decorators)
       // proceed to nested child creation
       // normally, this should not happen (until decorators are mounted by external frameworks,
@@ -663,9 +652,8 @@ function reconcileNode(
       }
     }
 
-    for (const child of nextNode.getChildren()) {
-      const childKey = child.getKey();
-
+    const children = createChildrenArray(nextNode, activeNextNodeMap);
+    for (const childKey of children) {
       // child's dom is handled by external frameworks (frameworks that uses the decorators)
       // proceed to nested child reconciliation
       if (activeEditor._keyToDOMMap.has(childKey)) {

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -164,6 +164,10 @@ export {
   isSelectionCapturedInDecoratorInput,
   isSelectionWithinEditor,
 } from './LexicalUtils';
+export {
+  $isDecoratorElementNode,
+  EXPERIMENTAL_DecoratorElementNode,
+} from './nodes/LexicalDecoratorElementNode';
 export {ArtificialNode__DO_NOT_USE} from './nodes/ArtificialNode';
 export {$isDecoratorNode, DecoratorNode} from './nodes/LexicalDecoratorNode';
 export {$isElementNode, ElementNode} from './nodes/LexicalElementNode';
@@ -173,6 +177,11 @@ export {
   $isLineBreakNode,
   LineBreakNode,
 } from './nodes/LexicalLineBreakNode';
+export {
+  $createNestedRootNode,
+  $isNestedRootNode,
+  EXPERIMENTAL_NestedRootNode,
+} from './nodes/LexicalNestedRootNode';
 export type {SerializedParagraphNode} from './nodes/LexicalParagraphNode';
 export {
   $createParagraphNode,

--- a/packages/lexical/src/nodes/LexicalDecoratorElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalDecoratorElementNode.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import invariant from 'shared/invariant';
+
+import {EditorConfig, KlassConstructor, LexicalEditor} from '../LexicalEditor';
+import {LexicalNode} from '../LexicalNode';
+import {ElementNode} from './LexicalElementNode';
+import {$isNestedRootNode} from './LexicalNestedRootNode';
+
+export class EXPERIMENTAL_DecoratorElementNode<T> extends ElementNode {
+  ['constructor']!: KlassConstructor<
+    typeof EXPERIMENTAL_DecoratorElementNode<T>
+  >;
+
+  /**
+   * The returned value is added to the LexicalEditor._decorators
+   */
+  decorate(editor: LexicalEditor, config: EditorConfig): T {
+    invariant(false, 'decorate: base method not extended');
+  }
+
+  splice(
+    start: number,
+    deleteCount: number,
+    nodesToInsert: Array<LexicalNode>,
+  ): this {
+    for (const node of nodesToInsert) {
+      invariant(
+        $isNestedRootNode(node),
+        'splice: only nested root nodes can be inserted',
+      );
+    }
+    return super.splice(start, deleteCount, nodesToInsert);
+  }
+}
+
+export function $isDecoratorElementNode<T>(
+  node: EXPERIMENTAL_DecoratorElementNode<T> | LexicalNode | null | undefined,
+): node is EXPERIMENTAL_DecoratorElementNode<T> {
+  return node instanceof EXPERIMENTAL_DecoratorElementNode;
+}

--- a/packages/lexical/src/nodes/LexicalNestedRootNode.ts
+++ b/packages/lexical/src/nodes/LexicalNestedRootNode.ts
@@ -44,7 +44,7 @@ export class EXPERIMENTAL_NestedRootNode extends RootNodeBase {
       $isNestedRootNode(nodeToInsert),
       'insertAfter: only nested root nodes can be inserted',
     );
-    return super.insertBefore(nodeToInsert);
+    return super.insertAfter(nodeToInsert);
   }
 
   // View

--- a/packages/lexical/src/nodes/LexicalNestedRootNode.ts
+++ b/packages/lexical/src/nodes/LexicalNestedRootNode.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {LexicalNode, SerializedLexicalNode} from '../LexicalNode';
+import type {SerializedElementNode} from './LexicalElementNode';
+
+import invariant from 'shared/invariant';
+
+import {KlassConstructor} from '../LexicalEditor';
+import {getActiveEditor} from '../LexicalUpdates';
+import {$applyNodeReplacement} from '../LexicalUtils';
+import {RootNodeBase} from './LexicalRootNodeBase';
+
+export type SerializedRootNode<
+  T extends SerializedLexicalNode = SerializedLexicalNode,
+> = SerializedElementNode<T>;
+
+/** @noInheritDoc */
+export class EXPERIMENTAL_NestedRootNode extends RootNodeBase {
+  ['constructor']!: KlassConstructor<typeof EXPERIMENTAL_NestedRootNode>;
+
+  static getType(): string {
+    return 'nestedroot';
+  }
+
+  static clone(node: EXPERIMENTAL_NestedRootNode): EXPERIMENTAL_NestedRootNode {
+    return new EXPERIMENTAL_NestedRootNode(node.__key);
+  }
+
+  get onRef(): (nestedRootElement: null | HTMLElement) => void {
+    const editor = getActiveEditor();
+    return (nestedRootElement) => {
+      editor.setNestedRootElement(this.__key, nestedRootElement);
+    };
+  }
+
+  insertBefore(nodeToInsert: EXPERIMENTAL_NestedRootNode): LexicalNode {
+    invariant(
+      $isNestedRootNode(nodeToInsert),
+      'insertBefore: only nested root nodes can be inserted',
+    );
+    return super.insertBefore(nodeToInsert);
+  }
+
+  insertAfter(nodeToInsert: EXPERIMENTAL_NestedRootNode): LexicalNode {
+    invariant(
+      $isNestedRootNode(nodeToInsert),
+      'insertAfter: only nested root nodes can be inserted',
+    );
+    return super.insertBefore(nodeToInsert);
+  }
+
+  // View
+  // Mutate
+
+  static importJSON(
+    serializedNode: SerializedRootNode,
+  ): EXPERIMENTAL_NestedRootNode {
+    const node = new EXPERIMENTAL_NestedRootNode();
+    node.setFormat(serializedNode.format);
+    node.setIndent(serializedNode.indent);
+    node.setDirection(serializedNode.direction);
+    return node;
+  }
+
+  exportJSON(): SerializedRootNode {
+    return {
+      children: [],
+      direction: this.getDirection(),
+      format: this.getFormatType(),
+      indent: this.getIndent(),
+      type: 'nestedroot',
+      version: 1,
+    };
+  }
+}
+
+export function $createNestedRootNode(): EXPERIMENTAL_NestedRootNode {
+  return $applyNodeReplacement(new EXPERIMENTAL_NestedRootNode());
+}
+
+export function $isNestedRootNode(
+  node: EXPERIMENTAL_NestedRootNode | LexicalNode | null | undefined,
+): node is EXPERIMENTAL_NestedRootNode {
+  return node instanceof EXPERIMENTAL_NestedRootNode;
+}

--- a/packages/lexical/src/nodes/LexicalNestedRootNode.ts
+++ b/packages/lexical/src/nodes/LexicalNestedRootNode.ts
@@ -12,7 +12,6 @@ import type {SerializedElementNode} from './LexicalElementNode';
 import invariant from 'shared/invariant';
 
 import {KlassConstructor} from '../LexicalEditor';
-import {getActiveEditor} from '../LexicalUpdates';
 import {$applyNodeReplacement} from '../LexicalUtils';
 import {RootNodeBase} from './LexicalRootNodeBase';
 
@@ -30,13 +29,6 @@ export class EXPERIMENTAL_NestedRootNode extends RootNodeBase {
 
   static clone(node: EXPERIMENTAL_NestedRootNode): EXPERIMENTAL_NestedRootNode {
     return new EXPERIMENTAL_NestedRootNode(node.__key);
-  }
-
-  get onRef(): (nestedRootElement: null | HTMLElement) => void {
-    const editor = getActiveEditor();
-    return (nestedRootElement) => {
-      editor.setNestedRootElement(this.__key, nestedRootElement);
-    };
   }
 
   insertBefore(nodeToInsert: EXPERIMENTAL_NestedRootNode): LexicalNode {

--- a/packages/lexical/src/nodes/LexicalRootNode.ts
+++ b/packages/lexical/src/nodes/LexicalRootNode.ts
@@ -14,15 +14,14 @@ import invariant from 'shared/invariant';
 import {NO_DIRTY_NODES} from '../LexicalConstants';
 import {getActiveEditor, isCurrentlyReadOnlyMode} from '../LexicalUpdates';
 import {$getRoot} from '../LexicalUtils';
-import {$isDecoratorNode} from './LexicalDecoratorNode';
-import {$isElementNode, ElementNode} from './LexicalElementNode';
+import {RootNodeBase} from './LexicalRootNodeBase';
 
 export type SerializedRootNode<
   T extends SerializedLexicalNode = SerializedLexicalNode,
 > = SerializedElementNode<T>;
 
 /** @noInheritDoc */
-export class RootNode extends ElementNode {
+export class RootNode extends RootNodeBase {
   /** @internal */
   __cachedText: null | string;
 
@@ -76,25 +75,7 @@ export class RootNode extends ElementNode {
   }
 
   // View
-
-  updateDOM(prevNode: RootNode, dom: HTMLElement): false {
-    return false;
-  }
-
   // Mutate
-
-  append(...nodesToAppend: LexicalNode[]): this {
-    for (let i = 0; i < nodesToAppend.length; i++) {
-      const node = nodesToAppend[i];
-      if (!$isElementNode(node) && !$isDecoratorNode(node)) {
-        invariant(
-          false,
-          'rootNode.append: Only element or decorator nodes can be appended to the root node',
-        );
-      }
-    }
-    return super.append(...nodesToAppend);
-  }
 
   static importJSON(serializedNode: SerializedRootNode): RootNode {
     // We don't create a root, and instead use the existing root.
@@ -114,10 +95,6 @@ export class RootNode extends ElementNode {
       type: 'root',
       version: 1,
     };
-  }
-
-  collapseAtStart(): true {
-    return true;
   }
 }
 

--- a/packages/lexical/src/nodes/LexicalRootNodeBase.ts
+++ b/packages/lexical/src/nodes/LexicalRootNodeBase.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {LexicalNode, SerializedLexicalNode} from '../LexicalNode';
+import type {SerializedElementNode} from './LexicalElementNode';
+
+import invariant from 'shared/invariant';
+
+import {$isDecoratorNode} from './LexicalDecoratorNode';
+import {$isElementNode, ElementNode} from './LexicalElementNode';
+
+export type SerializedRootNode<
+  T extends SerializedLexicalNode = SerializedLexicalNode,
+> = SerializedElementNode<T>;
+
+/** @noInheritDoc */
+export class RootNodeBase extends ElementNode {
+  // View
+
+  updateDOM(prevNode: RootNodeBase, dom: HTMLElement): false {
+    return false;
+  }
+
+  // Mutate
+
+  append(...nodesToAppend: LexicalNode[]): this {
+    for (let i = 0; i < nodesToAppend.length; i++) {
+      const node = nodesToAppend[i];
+      if (!$isElementNode(node) && !$isDecoratorNode(node)) {
+        invariant(
+          false,
+          'rootNodeBase.append: Only element or decorator nodes can be appended to the root node',
+        );
+      }
+    }
+    return super.append(...nodesToAppend);
+  }
+
+  collapseAtStart(): true {
+    return true;
+  }
+}


### PR DESCRIPTION
# DecoratorElementNode
This is a VERY EARLY draft of DecoratorElementNode (#5930).

I submit this PR because I want to:
1. Confirm the API design.
2. Allow the maintenance team and the community to review the codes as early as possible, because I am not an expert of reconciliation, your guidance/your bug report may help me work faster to deal with the reconciliation correctly.

## Naive Demo
- CardNode (Fixed children)

https://github.com/facebook/lexical/assets/36890796/61a83c26-02cc-47d4-ab9e-08755512b988

- ReactListNode(Variable children)

https://github.com/facebook/lexical/assets/36890796/812dd021-22a5-4a8a-bdc2-155d71c0dc76

## Tasks to do before this PR is submitted
- [ ] Confirm the API design is good enough (I don't like `editor.setNestedRootElement()`, could it be better?)
- [ ] Fix the most conspicuous reconciliation bugs
- [x] Provide a demo including two fixed nested roots (CardNode)
- [x] Provide a demo of a node containing arbitrary number of child nested roots (ReactListNode)
- [x] Provide a demo that the nested root could be mounted and unmounted with a button (Add a show/hide button to CardNode)

## Tasks I don't plan to do in this PR
Since I don't have so much spare time, I plan to deal with those issues later, maybe the community can offer some help.

- Add enough test cases
- Document the node well
- Deal with IO and copy/paste
- Deal with corner cases of the selection change (there are many many bugs with it)
- Guarantee deeply nested decorator element nodes are working correctly
- Make UI of the demo nodes beautiful

# API Documentation Draft
## DecoratorElementNode
To combine external framework and Lexical node trees, decorator element node could be an option. It offers a `decorate()` method to allow external framework to render the DOM, but the external can also have child Lexical nodes handled by Lexical.

``` typescript
export class CardNode extends EXPERIMENTAL_DecoratorElementNode<JSX.Element> {
  static getType(): string {
    return 'card';
  }

  static clone(node: CardNode): CardNode {
    return new CardNode(node.__key);
  }

  constructor(key?: NodeKey) {
    super(key);

    // ElementNode will automatically clone children
    // So we only need to set the children if the node is new
    if (key === undefined) {
      this.append($createNestedRootNode());
      this.append($createNestedRootNode());
    }
  }

  createDOM(): HTMLElement {
    return document.createElement('div');
  }

  updateDOM(): false {
    return false;
  }

  decorate(editor): JSX.Element {
    const onTitleRef = (element) => {
      editor.setNestedRootElement(this.getChildAtIndex(0).getKey(), element);
    }
    const onBodyRef = (element) => {
      editor.setNestedRootElement(this.getChildAtIndex(1).getKey(), element);
    }
   
    return (
      <div>
        <div ref={onTitleRef} />
        <div ref={onBodyRef} />
      </div>
    );
  }
}
```
Take the `CardNode` as an example:
- DecoratorElementNode is a subclass of ElementNode, so it can have an array of LexicalNodes. However, for DecoratorElementNode, the only valid type of its children is `NestedRootNode`. To use other nodes, they should be NestedRootNode's children.
- Like DecoratorNode, DecoratorElementNode provides `decorate()` method, where developers can implement a render function to be handled by external frameworks.
- To allow Lexical handle external framework's DOMs and mount Lexical's dom to them, `LexicalEditor` provides an `setNestedRootElement` method. When a new HTMLElement is set, Lexical will render its children DOMs.

If a DecoratorElementNode has a fixed set of children, developers are responsible to record each child's index and meaning. If it has a variable array of children, then just make sure the `onRef`'s order in `decorate` function maps to each child correctly.