### PR TITLE
[lexical-playground] Bug Fix: skip auto-scrolling on table resize

### DIFF
--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -154,30 +154,34 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
         throw new Error('TableCellResizer: Expected active cell.');
       }
 
-      editor.update(() => {
-        const tableCellNode = $getNearestNodeFromDOMNode(activeCell.elem);
-        if (!$isTableCellNode(tableCellNode)) {
-          throw new Error('TableCellResizer: Table cell node not found.');
-        }
+      editor.update(
+        () => {
+          const tableCellNode = $getNearestNodeFromDOMNode(activeCell.elem);
+          if (!$isTableCellNode(tableCellNode)) {
+            throw new Error('TableCellResizer: Table cell node not found.');
+          }
 
-        const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
+          const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
 
-        const tableRowIndex = $getTableRowIndexFromTableCellNode(tableCellNode);
+          const tableRowIndex =
+            $getTableRowIndexFromTableCellNode(tableCellNode);
 
-        const tableRows = tableNode.getChildren();
+          const tableRows = tableNode.getChildren();
 
-        if (tableRowIndex >= tableRows.length || tableRowIndex < 0) {
-          throw new Error('Expected table cell to be inside of table row.');
-        }
+          if (tableRowIndex >= tableRows.length || tableRowIndex < 0) {
+            throw new Error('Expected table cell to be inside of table row.');
+          }
 
-        const tableRow = tableRows[tableRowIndex];
+          const tableRow = tableRows[tableRowIndex];
 
-        if (!$isTableRowNode(tableRow)) {
-          throw new Error('Expected table row');
-        }
+          if (!$isTableRowNode(tableRow)) {
+            throw new Error('Expected table row');
+          }
 
-        tableRow.setHeight(newHeight);
-      });
+          tableRow.setHeight(newHeight);
+        },
+        {tag: 'skip-scroll-into-view'},
+      );
     },
     [activeCell, editor],
   );

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -187,57 +187,60 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
       if (!activeCell) {
         throw new Error('TableCellResizer: Expected active cell.');
       }
-      editor.update(() => {
-        const tableCellNode = $getNearestNodeFromDOMNode(activeCell.elem);
-        if (!$isTableCellNode(tableCellNode)) {
-          throw new Error('TableCellResizer: Table cell node not found.');
-        }
-
-        const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
-
-        const tableColumnIndex =
-          $getTableColumnIndexFromTableCellNode(tableCellNode);
-
-        const tableRows = tableNode.getChildren();
-
-        for (let r = 0; r < tableRows.length; r++) {
-          const tableRow = tableRows[r];
-
-          if (!$isTableRowNode(tableRow)) {
-            throw new Error('Expected table row');
+      editor.update(
+        () => {
+          const tableCellNode = $getNearestNodeFromDOMNode(activeCell.elem);
+          if (!$isTableCellNode(tableCellNode)) {
+            throw new Error('TableCellResizer: Table cell node not found.');
           }
 
-          const rowCells = tableRow.getChildren<TableCellNode>();
-          const rowCellsSpan = rowCells.map((cell) => cell.getColSpan());
+          const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
 
-          const aggregatedRowSpans = rowCellsSpan.reduce(
-            (rowSpans: number[], cellSpan) => {
-              const previousCell = rowSpans[rowSpans.length - 1] ?? 0;
-              rowSpans.push(previousCell + cellSpan);
-              return rowSpans;
-            },
-            [],
-          );
-          const rowColumnIndexWithSpan = aggregatedRowSpans.findIndex(
-            (cellSpan: number) => cellSpan > tableColumnIndex,
-          );
+          const tableColumnIndex =
+            $getTableColumnIndexFromTableCellNode(tableCellNode);
 
-          if (
-            rowColumnIndexWithSpan >= rowCells.length ||
-            rowColumnIndexWithSpan < 0
-          ) {
-            throw new Error('Expected table cell to be inside of table row.');
+          const tableRows = tableNode.getChildren();
+
+          for (let r = 0; r < tableRows.length; r++) {
+            const tableRow = tableRows[r];
+
+            if (!$isTableRowNode(tableRow)) {
+              throw new Error('Expected table row');
+            }
+
+            const rowCells = tableRow.getChildren<TableCellNode>();
+            const rowCellsSpan = rowCells.map((cell) => cell.getColSpan());
+
+            const aggregatedRowSpans = rowCellsSpan.reduce(
+              (rowSpans: number[], cellSpan) => {
+                const previousCell = rowSpans[rowSpans.length - 1] ?? 0;
+                rowSpans.push(previousCell + cellSpan);
+                return rowSpans;
+              },
+              [],
+            );
+            const rowColumnIndexWithSpan = aggregatedRowSpans.findIndex(
+              (cellSpan: number) => cellSpan > tableColumnIndex,
+            );
+
+            if (
+              rowColumnIndexWithSpan >= rowCells.length ||
+              rowColumnIndexWithSpan < 0
+            ) {
+              throw new Error('Expected table cell to be inside of table row.');
+            }
+
+            const tableCell = rowCells[rowColumnIndexWithSpan];
+
+            if (!$isTableCellNode(tableCell)) {
+              throw new Error('Expected table cell');
+            }
+
+            tableCell.setWidth(newWidth);
           }
-
-          const tableCell = rowCells[rowColumnIndexWithSpan];
-
-          if (!$isTableCellNode(tableCell)) {
-            throw new Error('Expected table cell');
-          }
-
-          tableCell.setWidth(newWidth);
-        }
-      });
+        },
+        {tag: 'skip-scroll-into-view'},
+      );
     },
     [activeCell, editor],
   );


### PR DESCRIPTION
## Description
Skip auto-scrolling on table row or column resize.

## Test plan

### Before
scrolls back to cursor

![scroll-resize-old](https://github.com/facebook/lexical/assets/47710336/8b19a8b5-a6b4-4b19-994f-31135dc64cd1)

### After
no auto-scroll
![scroll-resize-new](https://github.com/facebook/lexical/assets/47710336/210d8ac9-e55e-4a3d-b4ea-8fa74555c012)
