### PR TITLE
[lexical-website] Bug Fix: add allow-popups-to-escape-sandbox to iframe sandbox flags

### DIFF
--- a/packages/lexical-website/docs/concepts/node-replacement.md
+++ b/packages/lexical-website/docs/concepts/node-replacement.md
@@ -28,5 +28,5 @@ Once this is done, Lexical will replace all ParagraphNode instances with CustomP
      style="width:100%; height:700px; border:0; border-radius:4px; overflow:hidden;"
      title="lexical-collapsible-container-plugin-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+     sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts"
 ></iframe>

--- a/packages/lexical-website/docs/getting-started/creating-plugin.md
+++ b/packages/lexical-website/docs/getting-started/creating-plugin.md
@@ -183,4 +183,4 @@ mergeRegister(
 );
 ```
 
-<iframe width="100%" height="400" src="https://stackblitz.com/github/facebook/lexical/tree/main/examples/vanilla-js-plugin?embed=1&file=src%2Femoji-plugin%2FEmojiPlugin.ts&terminalHeight=1&ctl=1"></iframe>
+<iframe width="100%" height="400" src="https://stackblitz.com/github/facebook/lexical/tree/main/examples/vanilla-js-plugin?embed=1&file=src%2Femoji-plugin%2FEmojiPlugin.ts&terminalHeight=1&ctl=1" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts"></iframe>

--- a/packages/lexical-website/docs/getting-started/quick-start.md
+++ b/packages/lexical-website/docs/getting-started/quick-start.md
@@ -128,4 +128,4 @@ editor.registerUpdateListener(({editorState}) => {
 
 Here we have simplest Lexical setup in rich text configuration (`@lexical/rich-text`) with history (`@lexical/history`) and accessibility (`@lexical/dragon`) features enabled.
 
-<iframe width="100%" height="400" src="https://stackblitz.com/github/facebook/lexical/tree/main/examples/vanilla-js?embed=1&file=src%2Fmain.ts&terminalHeight=0&ctl=1"></iframe>
+<iframe width="100%" height="400" src="https://stackblitz.com/github/facebook/lexical/tree/main/examples/vanilla-js?embed=1&file=src%2Fmain.ts&terminalHeight=0&ctl=1" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts"></iframe>

--- a/packages/lexical-website/docs/getting-started/react.md
+++ b/packages/lexical-website/docs/getting-started/react.md
@@ -81,7 +81,7 @@ Below you can find an example of the integration from the previous chapter that 
 
 However no UI can be created w/o CSS and Lexical is not an exception here. Pay attention to `ExampleTheme.ts` and how it's used in this example, with corresponding styles defined in `styles.css`.
 
-<iframe width="100%" height="400" src="https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-rich?embed=1&file=src%2FApp.tsx&terminalHeight=0&ctl=1"></iframe>
+<iframe width="100%" height="400" src="https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-rich?embed=1&file=src%2FApp.tsx&terminalHeight=0&ctl=1" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts"></iframe>
 
 
 ## Saving Lexical State

--- a/packages/lexical-website/src/components/HomepageExamples/index.js
+++ b/packages/lexical-website/src/components/HomepageExamples/index.js
@@ -79,7 +79,7 @@ export default function HomepageExamples() {
         </ul>
       </Tabs.List>
 
-      {EXAMPLES.map(({id, content, src}) => (
+      {EXAMPLES.map(({id, content, src, label}) => (
         <Tabs.Content asChild={true} value={id} key={id}>
           <div className="grid gap-6 lg:grid-cols-[1fr_2fr]">
             <div className="flex flex-col gap-6">
@@ -98,8 +98,8 @@ export default function HomepageExamples() {
               <iframe
                 className="h-[500px] w-full overflow-hidden"
                 src={src}
-                title="lexical-plain-text-example"
-                sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+                title={label}
+                sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts"
               />
             </div>
           </div>


### PR DESCRIPTION
## Description

When playing with the examples on the website, clicking the "Fork on StackBlitz" button previously opened a blocked popup. With this sandbox flag, the popup loads without being blocked by cross-origin-opener-policy. Can reproduce with Chrome, Firefox and Safari on mac.

## Test plan

### Before

* Start an example from [the homepage](https://lexical.dev/) by clicking "Run Project" and then "Fork on StackBlitz"
* The pop-up will be blocked

### After

* Start an example from [the preview site](https://lexical-git-fork-etrepum-fix-stackblitz-all-bba80e-fbopensource.vercel.app/) by clicking "Run Project" and then "Fork on StackBlitz"
* The pop-up will not be blocked
