### PR TITLE
[lexical-plaintext] Feature: add escape key handler

### DIFF
--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -37,6 +37,7 @@ import {
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
   KEY_ENTER_COMMAND,
+  KEY_ESCAPE_COMMAND,
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
   SELECT_ALL_COMMAND,
@@ -321,6 +322,18 @@ export function registerPlainText(editor: LexicalEditor): () => void {
         }
 
         return editor.dispatchCommand(INSERT_LINE_BREAK_COMMAND, false);
+      },
+      COMMAND_PRIORITY_EDITOR,
+    ),
+    editor.registerCommand(
+      KEY_ESCAPE_COMMAND,
+      () => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          return false;
+        }
+        editor.blur();
+        return true;
       },
       COMMAND_PRIORITY_EDITOR,
     ),


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
Adds the same escape key handler to the plain text package as exists in lexical/richtext.

**Closes:** #5922

## Test plan

### Before
In the plaintext playground, pressing `Esc` doesn't blur the editor.

https://github.com/facebook/lexical/assets/55211974/a34cdd6e-d0a4-483e-ae46-f80759b39340

### After
In the plaintext playground, pressing `Esc` blurs the editor.

https://github.com/facebook/lexical/assets/55211974/3a219753-03c5-4c92-9eeb-d44ce421d112


