### PR TITLE
fix(build): fix build-www rewriteImports to always rewrite flow modules

### DIFF
--- a/scripts/www/rewriteImports.js
+++ b/scripts/www/rewriteImports.js
@@ -55,6 +55,10 @@ async function transformFlowFileContents(source) {
             / \* @flow strict/g,
             ' * @flow strict\n * @generated\n * @oncall lexical_web_text_editor',
           );
+          // Let the transform know we actually did something.
+          // Could not figure out the right way to update the
+          // docblock without an in-place update
+          context.addLeadingComments(node, '');
         }
       },
     }),


### PR DESCRIPTION
## Description

rewriteImports regression caused some flow modules not to get rewritten. Working theory is that the in-place update only had an effect if a module was also rewritten, and some modules do not have dependencies (such as packages/lexical/dist/Lexical.js.flow)

## Test plan

### Before

build-www outputs some flow modules in dist without rewriting their comments

### After

build-www outputs all flow modules in dist with rewritten comments