### PR TITLE
Clamp number of registered editor above 0

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1212,7 +1212,10 @@ export function addRootElementEvents(
   }
   rootElementsRegistered.set(
     doc,
-    Math.max(documentRootElementsCount ?? 0, 0) + 1,
+    Math.max(
+      documentRootElementsCount !== undefined ? documentRootElementsCount : 0,
+      0,
+    ) + 1,
   );
 
   // @ts-expect-error: internal field

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1210,7 +1210,10 @@ export function addRootElementEvents(
   ) {
     doc.addEventListener('selectionchange', onDocumentSelectionChange);
   }
-  rootElementsRegistered.set(doc, documentRootElementsCount || 0 + 1);
+  rootElementsRegistered.set(
+    doc,
+    Math.max(documentRootElementsCount ?? 0, 0) + 1,
+  );
 
   // @ts-expect-error: internal field
   rootElement.__lexicalEditor = editor;
@@ -1319,7 +1322,7 @@ export function removeRootElementEvents(rootElement: HTMLElement): void {
 
   // We only want to have a single global selectionchange event handler, shared
   // between all editor instances.
-  rootElementsRegistered.set(doc, documentRootElementsCount - 1);
+  rootElementsRegistered.set(doc, Math.max(documentRootElementsCount - 1, 0));
   if (rootElementsRegistered.get(doc) === 0) {
     doc.removeEventListener('selectionchange', onDocumentSelectionChange);
   }

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1213,8 +1213,8 @@ export function addRootElementEvents(
   rootElementsRegistered.set(
     doc,
     Math.max(
-      documentRootElementsCount !== undefined ? documentRootElementsCount : 0,
-      0,
+      documentRootElementsCount !== undefined ? documentRootElementsCount : 1,
+      1,
     ) + 1,
   );
 

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1213,8 +1213,8 @@ export function addRootElementEvents(
   rootElementsRegistered.set(
     doc,
     Math.max(
-      documentRootElementsCount !== undefined ? documentRootElementsCount : 1,
-      1,
+      documentRootElementsCount !== undefined ? documentRootElementsCount : 0,
+      0,
     ) + 1,
   );
 


### PR DESCRIPTION
## Description
Since #5070, there are certain circumstances in which the document counts for `rootElementsRegistered` can fall below 0, especially if `removeRootElementEvents` is called more than `addRemoveRootElementEvents`. 

As number of registered root elements should never be fewer than 1 after `addRemoveRootElementEvents` is called, and because the number of root elements should never be fewer than 0 when `removeRootElementEvents` is called, we should clamp these values.