### PR TITLE
Fix add root element count

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1210,7 +1210,7 @@ export function addRootElementEvents(
   ) {
     doc.addEventListener('selectionchange', onDocumentSelectionChange);
   }
-  rootElementsRegistered.set(doc, documentRootElementsCount || 0 + 1);
+  rootElementsRegistered.set(doc, (documentRootElementsCount || 0) + 1);
 
   // @ts-expect-error: internal field
   rootElement.__lexicalEditor = editor;


### PR DESCRIPTION
Element precendence https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence

Additive > logical or

For reference, the second time

```
> 1 || 0 + 1
1
```