### PR TITLE
Dont sync empty files

### DIFF
--- a/scripts/www/rewriteImports.js
+++ b/scripts/www/rewriteImports.js
@@ -77,11 +77,13 @@ async function rewriteImports() {
     for (const flowFile of glob.sync(pkg.resolve('flow', '*.flow'))) {
       const data = fs.readFileSync(flowFile, 'utf8');
       const result = await transformFlowFileContents(data);
-      fs.writeFileSync(
-        pkg.resolve('dist', path.basename(flowFile)),
-        result,
-        'utf8',
-      );
+      if (result.length > 0) {
+        fs.writeFileSync(
+          pkg.resolve('dist', path.basename(flowFile)),
+          result,
+          'utf8',
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
Flow files that contain only comments are copied over as empty. This is a problem for our internal linters. I couldn't figure out how to make this work in rewriteImports because I don't understand the hermes-transform API, but we can ignore empty files and that should prevent this issue.