### PR TITLE
[lexical-playground][TableCellRecizer] Bug Fix: Correctly take zoom into account when calculating table drag zones

### DIFF
--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -333,23 +333,27 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
       const {height, width, top, left} =
         activeCell.elem.getBoundingClientRect();
       const zoom = calculateZoomLevel(activeCell.elem);
-
+      const zoneWidth = 10; // Pixel width of the zone where you can drag the edge
       const styles = {
         bottom: {
           backgroundColor: 'none',
           cursor: 'row-resize',
-          height: '10px',
-          left: `${window.pageXOffset + left}px`,
-          top: `${window.pageYOffset + top + height}px`,
-          width: `${width}px`,
+          height: `${zoom * zoneWidth}px`,
+          left: `${window.pageXOffset + zoom * left}px`,
+          top: `${
+            window.pageYOffset + zoom * (top + height) - (zoom * zoneWidth) / 2
+          }px`,
+          width: `${zoom * width}px`,
         },
         right: {
           backgroundColor: 'none',
           cursor: 'col-resize',
-          height: `${height}px`,
-          left: `${window.pageXOffset + left + width}px`,
-          top: `${window.pageYOffset + top}px`,
-          width: '10px',
+          height: `${zoom * height}px`,
+          left: `${
+            window.pageXOffset + zoom * (left + width) - (zoom * zoneWidth) / 2
+          }px`,
+          top: `${window.pageYOffset + zoom * top}px`,
+          width: `${zoom * zoneWidth}px`,
         },
       };
 
@@ -358,22 +362,22 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
       if (draggingDirection && mouseCurrentPos && tableRect) {
         if (isHeightChanging(draggingDirection)) {
           styles[draggingDirection].left = `${
-            window.pageXOffset + tableRect.left
+            window.pageXOffset + zoom * tableRect.left
           }px`;
           styles[draggingDirection].top = `${
-            window.pageYOffset + mouseCurrentPos.y / zoom
+            window.pageYOffset + mouseCurrentPos.y
           }px`;
           styles[draggingDirection].height = '3px';
-          styles[draggingDirection].width = `${tableRect.width}px`;
+          styles[draggingDirection].width = `${zoom * tableRect.width}px`;
         } else {
           styles[draggingDirection].top = `${
-            window.pageYOffset + tableRect.top
+            window.pageYOffset + zoom * tableRect.top
           }px`;
           styles[draggingDirection].left = `${
-            window.pageXOffset + mouseCurrentPos.x / zoom
+            window.pageXOffset + mouseCurrentPos.x
           }px`;
           styles[draggingDirection].width = '3px';
-          styles[draggingDirection].height = `${tableRect.height}px`;
+          styles[draggingDirection].height = `${zoom * tableRect.height}px`;
         }
 
         styles[draggingDirection].backgroundColor = '#adf';


### PR DESCRIPTION

## Description
In our implementation of this editor, the user can modify the zoom of the editor area independently of the rest of the page. This skews the selection areas of the table cell resizer. This commit fixes that.

It also slightly shifts the rectangles to *center* on the edge, instead of being outside the cell, and scales these rectangles proportionally. This makes for a more intuitive user experience as the user will try to select the edge, not the outside.


**Closes:** #<!-- issue number -->

## Test plan

### Before
![lexical-zoom-original](https://github.com/facebook/lexical/assets/61593443/ae505c54-8277-497a-b77c-5f951d1b27e0)

![cell-resizer-old-regions](https://github.com/facebook/lexical/assets/61593443/77b37bbd-de6c-46a7-bb0a-a4a6618f699b)


### After
![lexical-zoom-fixed](https://github.com/facebook/lexical/assets/61593443/e6110311-9030-4aba-8fdf-4df3edb9b443)

(selection zones were temporarily coloured yellow to display the zones. Notice how they now overlap with the cell border)
![cell-resizer-new](https://github.com/facebook/lexical/assets/61593443/88ba5d02-bf6c-452c-9a13-1f13faff029e)
