### PR TITLE
[lexical-playground] Bug Fix: Added blur event

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -132,29 +132,6 @@ export default function FontSize({
     [editor],
   );
 
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    const inputValueNumber = Number(inputValue);
-
-    if (['e', 'E', '+', '-'].includes(e.key) || isNaN(inputValueNumber)) {
-      e.preventDefault();
-      setInputValue('');
-      return;
-    }
-
-    if (e.key === 'Enter') {
-      e.preventDefault();
-
-      let updatedFontSize = inputValueNumber;
-      if (inputValueNumber > MAX_ALLOWED_FONT_SIZE) {
-        updatedFontSize = MAX_ALLOWED_FONT_SIZE;
-      } else if (inputValueNumber < MIN_ALLOWED_FONT_SIZE) {
-        updatedFontSize = MIN_ALLOWED_FONT_SIZE;
-      }
-      setInputValue(String(updatedFontSize));
-      updateFontSizeInSelection(String(updatedFontSize) + 'px', null);
-    }
-  };
-
   const handleButtonClick = (updateType: updateFontSizeType) => {
     if (inputValue !== '') {
       const nextFontSize = calculateNextFontSize(
@@ -165,6 +142,18 @@ export default function FontSize({
     } else {
       updateFontSizeInSelection(null, updateType);
     }
+  };
+
+  const handleBlurEvent = () => {
+    const inputValueNumber = Number(inputValue);
+    let updatedFontSize = inputValueNumber;
+    if (inputValueNumber > MAX_ALLOWED_FONT_SIZE) {
+      updatedFontSize = MAX_ALLOWED_FONT_SIZE;
+    } else if (inputValueNumber < MIN_ALLOWED_FONT_SIZE) {
+      updatedFontSize = MIN_ALLOWED_FONT_SIZE;
+    }
+    setInputValue(String(updatedFontSize));
+    updateFontSizeInSelection(String(updatedFontSize) + 'px', null);
   };
 
   React.useEffect(() => {
@@ -193,7 +182,7 @@ export default function FontSize({
         min={MIN_ALLOWED_FONT_SIZE}
         max={MAX_ALLOWED_FONT_SIZE}
         onChange={(e) => setInputValue(e.target.value)}
-        onKeyDown={handleKeyPress}
+        onBlur={handleBlurEvent}
       />
 
       <button

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -132,6 +132,29 @@ export default function FontSize({
     [editor],
   );
 
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const inputValueNumber = Number(inputValue);
+
+    if (['e', 'E', '+', '-'].includes(e.key) || isNaN(inputValueNumber)) {
+      e.preventDefault();
+      setInputValue('');
+      return;
+    }
+
+    if (e.key === 'Enter') {
+      e.preventDefault();
+
+      let updatedFontSize = inputValueNumber;
+      if (inputValueNumber > MAX_ALLOWED_FONT_SIZE) {
+        updatedFontSize = MAX_ALLOWED_FONT_SIZE;
+      } else if (inputValueNumber < MIN_ALLOWED_FONT_SIZE) {
+        updatedFontSize = MIN_ALLOWED_FONT_SIZE;
+      }
+      setInputValue(String(updatedFontSize));
+      updateFontSizeInSelection(String(updatedFontSize) + 'px', null);
+    }
+  };
+
   const handleButtonClick = (updateType: updateFontSizeType) => {
     if (inputValue !== '') {
       const nextFontSize = calculateNextFontSize(
@@ -145,15 +168,10 @@ export default function FontSize({
   };
 
   const handleBlurEvent = () => {
-    const inputValueNumber = Number(inputValue);
-    let updatedFontSize = inputValueNumber;
-    if (inputValueNumber > MAX_ALLOWED_FONT_SIZE) {
-      updatedFontSize = MAX_ALLOWED_FONT_SIZE;
-    } else if (inputValueNumber < MIN_ALLOWED_FONT_SIZE) {
-      updatedFontSize = MIN_ALLOWED_FONT_SIZE;
-    }
-    setInputValue(String(updatedFontSize));
-    updateFontSizeInSelection(String(updatedFontSize) + 'px', null);
+    const inputValueNumber = Number(selectionFontSize);
+    const prevFontSize = inputValueNumber;
+    setInputValue(String(prevFontSize));
+    updateFontSizeInSelection(String(prevFontSize) + 'px', null);
   };
 
   React.useEffect(() => {
@@ -182,7 +200,8 @@ export default function FontSize({
         min={MIN_ALLOWED_FONT_SIZE}
         max={MAX_ALLOWED_FONT_SIZE}
         onChange={(e) => setInputValue(e.target.value)}
-        onBlur={handleBlurEvent}
+        onBlurCapture={handleBlurEvent}
+        onKeyDown={handleKeyPress}
       />
 
       <button

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -168,10 +168,9 @@ export default function FontSize({
   };
 
   const handleBlurEvent = () => {
-    const inputValueNumber = Number(selectionFontSize);
-    const prevFontSize = inputValueNumber;
-    setInputValue(String(prevFontSize));
-    updateFontSizeInSelection(String(prevFontSize) + 'px', null);
+    if (inputValue !== selectionFontSize) {
+      setInputValue(selectionFontSize);
+    }
   };
 
   React.useEffect(() => {

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -199,7 +199,7 @@ export default function FontSize({
         min={MIN_ALLOWED_FONT_SIZE}
         max={MAX_ALLOWED_FONT_SIZE}
         onChange={(e) => setInputValue(e.target.value)}
-        onBlurCapture={handleBlurEvent}
+        onBlur={handleBlurEvent}
         onKeyDown={handleKeyPress}
       />
 


### PR DESCRIPTION

## Description
Current behaviour - > Font size was not changing even after changing the input size field.
Modified behaviour -> triggered the blur event, because of that font is changing as soon as we blur out of the input box.
*Describe the changes in this pull request*

**Closes:** #6000 
