### PR TITLE
[lexical] Feature: error checking for node key re-use with type mismatch in __DEV__

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,12 +15,17 @@ const common = {
 };
 
 // Use tsconfig's paths to configure jest's module name mapper
-const moduleNameMapper = Object.fromEntries(
-  Object.entries(tsconfig.compilerOptions.paths).map(([name, [firstPath]]) => [
-    `^${name}$`,
-    firstPath.replace(/^\./, '<rootDir>'),
-  ]),
-);
+const moduleNameMapper = {
+  ...Object.fromEntries(
+    Object.entries(tsconfig.compilerOptions.paths).map(
+      ([name, [firstPath]]) => [
+        `^${name}$`,
+        firstPath.replace(/^\./, '<rootDir>'),
+      ],
+    ),
+  ),
+  '^shared/invariant$': '<rootDir>/packages/shared/src/__mocks__/invariant.ts',
+};
 
 module.exports = {
   projects: [

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -121,6 +121,10 @@ export function internalGetActiveEditor(): LexicalEditor | null {
   return activeEditor;
 }
 
+export function internalGetActiveEditorState(): EditorState | null {
+  return activeEditorState;
+}
+
 export function $applyTransforms(
   editor: LexicalEditor,
   node: LexicalNode,

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -64,6 +64,7 @@ import {
   errorOnReadOnly,
   getActiveEditor,
   getActiveEditorState,
+  internalGetActiveEditorState,
   isCurrentlyReadOnlyMode,
   triggerCommandListeners,
   updateEditor,
@@ -223,6 +224,9 @@ export function $setNodeKey(
   existingKey: NodeKey | null | undefined,
 ): void {
   if (existingKey != null) {
+    if (__DEV__) {
+      errorOnNodeKeyConstructorMismatch(node, existingKey);
+    }
     node.__key = existingKey;
     return;
   }
@@ -241,6 +245,35 @@ export function $setNodeKey(
   editor._cloneNotNeeded.add(key);
   editor._dirtyType = HAS_DIRTY_NODES;
   node.__key = key;
+}
+
+function errorOnNodeKeyConstructorMismatch(
+  node: LexicalNode,
+  existingKey: NodeKey,
+) {
+  const editorState = internalGetActiveEditorState();
+  if (!editorState) {
+    // tests expect to be able to do this kind of clone without an active editor state
+    return;
+  }
+  const existingNode = editorState._nodeMap.get(existingKey);
+  if (existingNode && existingNode.constructor !== node.constructor) {
+    // Lifted condition to if statement because the inverted logic is a bit confusing
+    if (node.constructor.name !== existingNode.constructor.name) {
+      invariant(
+        false,
+        'Lexical node with constructor %s attempted to re-use key from node in active editor state with constructor %s. Keys must not be re-used when the type is changed.',
+        node.constructor.name,
+        existingNode.constructor.name,
+      );
+    } else {
+      invariant(
+        false,
+        'Lexical node with constructor %s attempted to re-use key from node in active editor state with different constructor with the same name (possibly due to invalid Hot Module Replacement). Keys must not be re-used when the type is changed.',
+        node.constructor.name,
+      );
+    }
+  }
 }
 
 type IntentionallyMarkedAsDirtyElement = boolean;

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -87,6 +87,19 @@ describe('LexicalNode tests', () => {
         });
       });
 
+      test('LexicalNode.constructor: type change detected', async () => {
+        const {editor} = testEnv;
+
+        await editor.update(() => {
+          const validNode = new TextNode(textNode.__text, textNode.__key);
+          expect(textNode.getLatest()).toBe(textNode);
+          expect(validNode.getLatest()).toBe(textNode);
+          expect(() => new TestNode(textNode.__key)).toThrowError(
+            /TestNode.*re-use key.*TextNode/,
+          );
+        });
+      });
+
       test('LexicalNode.clone()', async () => {
         const {editor} = testEnv;
 

--- a/packages/shared/src/__mocks__/invariant.ts
+++ b/packages/shared/src/__mocks__/invariant.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// invariant(condition, message) will refine types based on "condition", and
+// if "condition" is false will throw an error. This function is special-cased
+// in flow itself, so we can't name it anything else.
+export default function invariant(
+  cond?: boolean,
+  message?: string,
+  ...args: string[]
+): asserts cond {
+  if (cond) {
+    return;
+  }
+
+  throw new Error(
+    args.reduce((msg, arg) => msg.replace('%s', String(arg)), message || ''),
+  );
+}


### PR DESCRIPTION
## Description

Based on issues that several people have run into, it seems useful to add some additional invariant checking around node keys.

See also: [discord message](https://discord.com/channels/953974421008293909/953974421486436393/1235675644726083745)

- Adds a stub implementation of shared/invariant for use under jest to make development easier
- Adds a `__DEV__` check to make sure that if a new Node is created with an explicit existing key, that the type of the node did not change

## Test plan

### Before

Bad things will silently happen if you accidentally re-use node keys, such as with a subtly incorrect node replacement function:

```js
const config = {
  // ...
  nodes: [
    EdifactTextNode,
    {
      replace: TextNode,
      with: (node) => {
        return new EdifactTextNode(node.text, node.__key)
      },
    },
  ],
}
```

### After

An error message is shows up now, in `__DEV__.` There are unit tests that verify that the specific error message comes up when creating a new node in this way (tested in isolation and with a node replacer).