### PR TITLE
[lexical-utils] ci: fix typing to fix integrity test

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -207,7 +207,7 @@ describe('LexicalNodeHelpers tests', () => {
     test('DFS of empty ParagraphNode returns only itself', async () => {
       const editor: LexicalEditor = testEnv.editor;
 
-      let paragraphKey;
+      let paragraphKey: string;
 
       await editor.update(() => {
         const root = $getRoot();
@@ -224,10 +224,10 @@ describe('LexicalNodeHelpers tests', () => {
       await editor.update(() => {
         const paragraph = $getNodeByKey(paragraphKey);
 
-        expect($dfs(paragraph)).toEqual([
+        expect($dfs(paragraph ?? undefined)).toEqual([
           {
             depth: 1,
-            node: paragraph.getLatest(),
+            node: paragraph?.getLatest(),
           },
         ]);
       });


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
PR #5977 adds code which fails `npm run ci-check`, due to typing issues

fix the typing issues so `npm run ci-check` passes and integrity test will pass again on main branch

**Closes:** #nothing, fix integrity test

## Test plan

### Before

https://github.com/facebook/lexical/actions/runs/8933219843/job/24538272365

<img width="946" alt="Screenshot 2024-05-03 at 11 20 38 AM" src="https://github.com/facebook/lexical/assets/19604232/c8c2af7e-d792-4286-814e-abaaf3a91db1">



### After

on local:
<img width="424" alt="Screenshot 2024-05-03 at 11 21 34 AM" src="https://github.com/facebook/lexical/assets/19604232/ea56540a-ac78-4023-9767-667c5328e711">


waiting for workflow integrity test to pass

