### PR TITLE
[lexical-markdown][lexical-playground] Feature: Option to include blanklines in markdown render

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -26,9 +26,10 @@ import {isEmptyParagraph, transformersByType} from './utils';
 
 export function createMarkdownExport(
   transformers: Array<Transformer>,
-  isNewlineDelimited: boolean = true,
+  shouldPreserveNewLines: boolean = false,
 ): (node?: ElementNode) => string {
   const byType = transformersByType(transformers);
+  const isNewlineDelimited = !shouldPreserveNewLines;
 
   // Export only uses text formats that are responsible for single format
   // e.g. it will filter out *** (bold, italic) and instead use separate ** and *

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -26,6 +26,7 @@ import {isEmptyParagraph, transformersByType} from './utils';
 
 export function createMarkdownExport(
   transformers: Array<Transformer>,
+  isNewlineDelimited: boolean = true,
 ): (node?: ElementNode) => string {
   const byType = transformersByType(transformers);
 
@@ -51,7 +52,8 @@ export function createMarkdownExport(
       if (result != null) {
         output.push(
           // seperate consecutive group of texts with a line break: eg. ["hello", "world"] -> ["hello", "/nworld"]
-          i > 0 &&
+          isNewlineDelimited &&
+            i > 0 &&
             !isEmptyParagraph(child) &&
             !isEmptyParagraph(children[i - 1])
             ? '\n'.concat(result)

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -128,7 +128,7 @@ function exportChildren(
         exportTextFormat(child, child.getTextContent(), textTransformersIndex),
       );
     } else if ($isElementNode(child)) {
-      // empty para returns ""
+      // empty paragraph returns ""
       output.push(
         exportChildren(child, textTransformersIndex, textMatchTransformers),
       );

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -22,7 +22,7 @@ import {
   $isTextNode,
 } from 'lexical';
 
-import {transformersByType} from './utils';
+import {isEmptyParagraph, transformersByType} from './utils';
 
 export function createMarkdownExport(
   transformers: Array<Transformer>,
@@ -39,7 +39,8 @@ export function createMarkdownExport(
     const output = [];
     const children = (node || $getRoot()).getChildren();
 
-    for (const child of children) {
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
       const result = exportTopLevelElements(
         child,
         byType.element,
@@ -48,11 +49,19 @@ export function createMarkdownExport(
       );
 
       if (result != null) {
-        output.push(result);
+        output.push(
+          // seperate consecutive group of texts with a line break: eg. ["hello", "world"] -> ["hello", "/nworld"]
+          i > 0 &&
+            !isEmptyParagraph(child) &&
+            !isEmptyParagraph(children[i - 1])
+            ? '\n'.concat(result)
+            : result,
+        );
       }
     }
-
-    return output.join('\n\n');
+    // Ensure consecutive groups of texts are atleast \n\n apart while each empty paragraph render as a newline.
+    // Eg. ["hello", "", "", "hi", "\nworld"] -> ["hello\n\n\nhi\n\nworld"]
+    return output.join('\n');
   };
 }
 
@@ -116,6 +125,7 @@ function exportChildren(
         exportTextFormat(child, child.getTextContent(), textTransformersIndex),
       );
     } else if ($isElementNode(child)) {
+      // empty para returns ""
       output.push(
         exportChildren(child, textTransformersIndex, textMatchTransformers),
       );

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -60,7 +60,7 @@ export function createMarkdownExport(
       }
     }
     // Ensure consecutive groups of texts are atleast \n\n apart while each empty paragraph render as a newline.
-    // Eg. ["hello", "", "", "hi", "\nworld"] -> ["hello\n\n\nhi\n\nworld"]
+    // Eg. ["hello", "", "", "hi", "\nworld"] -> "hello\n\n\nhi\n\nworld"
     return output.join('\n');
   };
 }

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -86,9 +86,9 @@ export function createMarkdownImport(
     const children = root.getChildren();
     for (const child of children) {
       if (
+        !shouldIncludeBlankLines &&
         isEmptyParagraph(child) &&
-        root.getChildrenSize() > 1 &&
-        !shouldIncludeBlankLines
+        root.getChildrenSize() > 1
       ) {
         child.remove();
       }

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -43,6 +43,7 @@ type TextFormatTransformersIndex = Readonly<{
 
 export function createMarkdownImport(
   transformers: Array<Transformer>,
+  includeBlankLines = false,
 ): (markdownString: string, node?: ElementNode) => void {
   const byType = transformersByType(transformers);
   const textFormatTransformersIndex = createTextFormatTransformersIndex(
@@ -77,11 +78,16 @@ export function createMarkdownImport(
       );
     }
 
-    // Removing empty paragraphs as md does not really
-    // allow empty lines and uses them as delimiter
+    // By default, removing empty paragraphs as md does not really
+    // allow empty lines and uses them as delimiter.
+    // If you need empty lines set includeBankLines = true.
     const children = root.getChildren();
     for (const child of children) {
-      if (isEmptyParagraph(child) && root.getChildrenSize() > 1) {
+      if (
+        isEmptyParagraph(child) &&
+        root.getChildrenSize() > 1 &&
+        !includeBlankLines
+      ) {
         child.remove();
       }
     }

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -45,7 +45,7 @@ type TextFormatTransformersIndex = Readonly<{
 
 export function createMarkdownImport(
   transformers: Array<Transformer>,
-  shouldIncludeBlankLines = false,
+  shouldPreserveNewLines = false,
 ): (markdownString: string, node?: ElementNode) => void {
   const byType = transformersByType(transformers);
   const textFormatTransformersIndex = createTextFormatTransformersIndex(
@@ -86,7 +86,7 @@ export function createMarkdownImport(
     const children = root.getChildren();
     for (const child of children) {
       if (
-        !shouldIncludeBlankLines &&
+        !shouldPreserveNewLines &&
         isEmptyParagraph(child) &&
         root.getChildrenSize() > 1
       ) {

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -82,7 +82,7 @@ export function createMarkdownImport(
 
     // By default, removing empty paragraphs as md does not really
     // allow empty lines and uses them as delimiter.
-    // If you need empty lines set shouldIncludeBankLines = true.
+    // If you need empty lines set shouldPreserveNewLines = true.
     const children = root.getChildren();
     for (const child of children) {
       if (

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -82,7 +82,7 @@ export function createMarkdownImport(
 
     // By default, removing empty paragraphs as md does not really
     // allow empty lines and uses them as delimiter.
-    // If you need empty lines set includeBankLines = true.
+    // If you need empty lines set shouldIncludeBankLines = true.
     const children = root.getChildren();
     for (const child of children) {
       if (

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -29,6 +29,7 @@ describe('Markdown', () => {
     skipExport?: true;
     skipImport?: true;
     shouldIncludeBlankLines?: true;
+    isNewlineDelimited?: false;
   }>;
 
   const URL = 'https://lexical.dev';
@@ -150,6 +151,7 @@ describe('Markdown', () => {
     },
     {
       html: '<h1><span style="white-space: pre-wrap;">Hello</span></h1><p><br></p><p><br></p><p><br></p><p><b><strong style="white-space: pre-wrap;">world</strong></b><span style="white-space: pre-wrap;">!</span></p>',
+      isNewlineDelimited: false,
       md: '# Hello\n\n\n\n**world**!',
       shouldIncludeBlankLines: true,
     },
@@ -268,7 +270,7 @@ describe('Markdown', () => {
     });
   }
 
-  for (const {html, md, skipExport} of IMPORT_AND_EXPORT) {
+  for (const {html, md, skipExport, isNewlineDelimited} of IMPORT_AND_EXPORT) {
     if (skipExport) {
       continue;
     }
@@ -301,7 +303,13 @@ describe('Markdown', () => {
       expect(
         editor
           .getEditorState()
-          .read(() => $convertToMarkdownString(TRANSFORMERS)),
+          .read(() =>
+            $convertToMarkdownString(
+              TRANSFORMERS,
+              undefined,
+              isNewlineDelimited,
+            ),
+          ),
       ).toBe(md);
     });
   }

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -211,6 +211,12 @@ describe('Markdown', () => {
       md: `Hello [world](${URL})! Hello $world$! [Hello](${URL}) world! Hello $world$!`,
       skipExport: true,
     },
+    {
+      // Export only: import will use $...$ to transform <span /> to <mark /> due to HIGHLIGHT_TEXT_MATCH_IMPORT
+      html: "<p><span style='white-space: pre-wrap;'>$$H$&e$`l$'l$o$</span></p>",
+      md: "$$H$&e$`l$'l$o$",
+      skipImport: true,
+    },
   ];
 
   const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -28,8 +28,7 @@ describe('Markdown', () => {
     md: string;
     skipExport?: true;
     skipImport?: true;
-    shouldIncludeBlankLines?: true;
-    isNewlineDelimited?: false;
+    shouldPreserveNewLines?: true;
   }>;
 
   const URL = 'https://lexical.dev';
@@ -152,13 +151,12 @@ describe('Markdown', () => {
     {
       html: '<h1><span style="white-space: pre-wrap;">Hello</span></h1><p><br></p><p><br></p><p><br></p><p><b><strong style="white-space: pre-wrap;">world</strong></b><span style="white-space: pre-wrap;">!</span></p>',
       md: '# Hello\n\n\n\n**world**!',
-      shouldIncludeBlankLines: true,
+      shouldPreserveNewLines: true,
     },
     {
       html: '<h1><span style="white-space: pre-wrap;">Hello</span></h1><p><span style="white-space: pre-wrap;">hi</span></p><p><br></p><p><b><strong style="white-space: pre-wrap;">world</strong></b></p><p><br></p><p><span style="white-space: pre-wrap;">hi</span></p><blockquote><span style="white-space: pre-wrap;">hello</span><br><span style="white-space: pre-wrap;">hello</span></blockquote><p><br></p><h1><span style="white-space: pre-wrap;">hi</span></h1><p><br></p><p><span style="white-space: pre-wrap;">hi</span></p>',
-      isNewlineDelimited: false,
       md: '# Hello\nhi\n\n**world**\n\nhi\n> hello\n> hello\n\n# hi\n\nhi',
-      shouldIncludeBlankLines: true,
+      shouldPreserveNewLines: true,
     },
     {
       // Import only: export will use * instead of _ due to registered transformers order
@@ -238,7 +236,7 @@ describe('Markdown', () => {
     html,
     md,
     skipImport,
-    shouldIncludeBlankLines,
+    shouldPreserveNewLines,
   } of IMPORT_AND_EXPORT) {
     if (skipImport) {
       continue;
@@ -262,7 +260,7 @@ describe('Markdown', () => {
             md,
             [...TRANSFORMERS, HIGHLIGHT_TEXT_MATCH_IMPORT],
             undefined,
-            shouldIncludeBlankLines,
+            shouldPreserveNewLines,
           ),
         {
           discrete: true,
@@ -275,7 +273,12 @@ describe('Markdown', () => {
     });
   }
 
-  for (const {html, md, skipExport, isNewlineDelimited} of IMPORT_AND_EXPORT) {
+  for (const {
+    html,
+    md,
+    skipExport,
+    shouldPreserveNewLines,
+  } of IMPORT_AND_EXPORT) {
     if (skipExport) {
       continue;
     }
@@ -312,7 +315,7 @@ describe('Markdown', () => {
             $convertToMarkdownString(
               TRANSFORMERS,
               undefined,
-              isNewlineDelimited,
+              shouldPreserveNewLines,
             ),
           ),
       ).toBe(md);

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -151,8 +151,13 @@ describe('Markdown', () => {
     },
     {
       html: '<h1><span style="white-space: pre-wrap;">Hello</span></h1><p><br></p><p><br></p><p><br></p><p><b><strong style="white-space: pre-wrap;">world</strong></b><span style="white-space: pre-wrap;">!</span></p>',
-      isNewlineDelimited: false,
       md: '# Hello\n\n\n\n**world**!',
+      shouldIncludeBlankLines: true,
+    },
+    {
+      html: '<h1><span style="white-space: pre-wrap;">Hello</span></h1><p><span style="white-space: pre-wrap;">hi</span></p><p><br></p><p><b><strong style="white-space: pre-wrap;">world</strong></b></p><p><br></p><p><span style="white-space: pre-wrap;">hi</span></p><blockquote><span style="white-space: pre-wrap;">hello</span><br><span style="white-space: pre-wrap;">hello</span></blockquote><p><br></p><h1><span style="white-space: pre-wrap;">hi</span></h1><p><br></p><p><span style="white-space: pre-wrap;">hi</span></p>',
+      isNewlineDelimited: false,
+      md: '# Hello\nhi\n\n**world**\n\nhi\n> hello\n> hello\n\n# hi\n\nhi',
       shouldIncludeBlankLines: true,
     },
     {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -28,6 +28,7 @@ describe('Markdown', () => {
     md: string;
     skipExport?: true;
     skipImport?: true;
+    shouldIncludeBlankLines?: true;
   }>;
 
   const URL = 'https://lexical.dev';
@@ -148,6 +149,11 @@ describe('Markdown', () => {
       md: '*Hello **world**!*',
     },
     {
+      html: '<h1><span style="white-space: pre-wrap;">Hello</span></h1><p><br></p><p><br></p><p><br></p><p><b><strong style="white-space: pre-wrap;">world</strong></b><span style="white-space: pre-wrap;">!</span></p>',
+      md: '# Hello\n\n\n\n**world**!',
+      shouldIncludeBlankLines: true,
+    },
+    {
       // Import only: export will use * instead of _ due to registered transformers order
       html: '<p><i><em style="white-space: pre-wrap;">Hello</em></i><span style="white-space: pre-wrap;"> world</span></p>',
       md: '_Hello_ world',
@@ -205,12 +211,6 @@ describe('Markdown', () => {
       md: `Hello [world](${URL})! Hello $world$! [Hello](${URL}) world! Hello $world$!`,
       skipExport: true,
     },
-    {
-      // Export only: import will use $...$ to transform <span /> to <mark /> due to HIGHLIGHT_TEXT_MATCH_IMPORT
-      html: "<p><span style='white-space: pre-wrap;'>$$H$&e$`l$'l$o$</span></p>",
-      md: "$$H$&e$`l$'l$o$",
-      skipImport: true,
-    },
   ];
 
   const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {
@@ -221,7 +221,12 @@ describe('Markdown', () => {
     },
   };
 
-  for (const {html, md, skipImport} of IMPORT_AND_EXPORT) {
+  for (const {
+    html,
+    md,
+    skipImport,
+    shouldIncludeBlankLines,
+  } of IMPORT_AND_EXPORT) {
     if (skipImport) {
       continue;
     }
@@ -240,10 +245,12 @@ describe('Markdown', () => {
 
       editor.update(
         () =>
-          $convertFromMarkdownString(md, [
-            ...TRANSFORMERS,
-            HIGHLIGHT_TEXT_MATCH_IMPORT,
-          ]),
+          $convertFromMarkdownString(
+            md,
+            [...TRANSFORMERS, HIGHLIGHT_TEXT_MATCH_IMPORT],
+            undefined,
+            shouldIncludeBlankLines,
+          ),
         {
           discrete: true,
         },

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -72,11 +72,11 @@ function $convertFromMarkdownString(
   markdown: string,
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
-  shouldIncludeBlankLines = false,
+  shouldPreserveNewLines = false,
 ): void {
   const importMarkdown = createMarkdownImport(
     transformers,
-    shouldIncludeBlankLines,
+    shouldPreserveNewLines,
   );
   return importMarkdown(markdown, node);
 }
@@ -84,9 +84,12 @@ function $convertFromMarkdownString(
 function $convertToMarkdownString(
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
-  isNewlineDelimited: boolean = true,
+  shouldPreserveNewLines: boolean = false,
 ): string {
-  const exportMarkdown = createMarkdownExport(transformers, isNewlineDelimited);
+  const exportMarkdown = createMarkdownExport(
+    transformers,
+    shouldPreserveNewLines,
+  );
   return exportMarkdown(node);
 }
 

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -84,8 +84,9 @@ function $convertFromMarkdownString(
 function $convertToMarkdownString(
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
+  isNewlineDelimited: boolean = true,
 ): string {
-  const exportMarkdown = createMarkdownExport(transformers);
+  const exportMarkdown = createMarkdownExport(transformers, isNewlineDelimited);
   return exportMarkdown(node);
 }
 

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -72,8 +72,9 @@ function $convertFromMarkdownString(
   markdown: string,
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
+  includeBlankLines = false,
 ): void {
-  const importMarkdown = createMarkdownImport(transformers);
+  const importMarkdown = createMarkdownImport(transformers, includeBlankLines);
   return importMarkdown(markdown, node);
 }
 

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -72,9 +72,12 @@ function $convertFromMarkdownString(
   markdown: string,
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
-  includeBlankLines = false,
+  shouldIncludeBlankLines = false,
 ): void {
-  const importMarkdown = createMarkdownImport(transformers, includeBlankLines);
+  const importMarkdown = createMarkdownImport(
+    transformers,
+    shouldIncludeBlankLines,
+  );
   return importMarkdown(markdown, node);
 }
 

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -18,11 +18,11 @@ import {$isCodeNode} from '@lexical/code';
 import {$isListItemNode, $isListNode} from '@lexical/list';
 import {$isHeadingNode, $isQuoteNode} from '@lexical/rich-text';
 import {
+  $isParagraphNode,
+  $isTextNode,
   type ElementNode,
   type LexicalNode,
   type TextFormatType,
-  $isParagraphNode,
-  $isTextNode,
 } from 'lexical';
 
 type MarkdownFormatKind =

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -13,11 +13,17 @@ import type {
   TextMatchTransformer,
   Transformer,
 } from '@lexical/markdown';
-import type {ElementNode, LexicalNode, TextFormatType} from 'lexical';
 
 import {$isCodeNode} from '@lexical/code';
 import {$isListItemNode, $isListNode} from '@lexical/list';
 import {$isHeadingNode, $isQuoteNode} from '@lexical/rich-text';
+import {
+  type ElementNode,
+  type LexicalNode,
+  type TextFormatType,
+  $isParagraphNode,
+  $isTextNode,
+} from 'lexical';
 
 type MarkdownFormatKind =
   | 'noTransformation'
@@ -429,3 +435,19 @@ export function transformersByType(transformers: Array<Transformer>): Readonly<{
 }
 
 export const PUNCTUATION_OR_SPACE = /[!-/:-@[-`{-~\s]/;
+
+const MARKDOWN_EMPTY_LINE_REG_EXP = /^\s{0,3}$/;
+
+export function isEmptyParagraph(node: LexicalNode): boolean {
+  if (!$isParagraphNode(node)) {
+    return false;
+  }
+
+  const firstChild = node.getFirstChild();
+  return (
+    firstChild == null ||
+    (node.getChildrenSize() === 1 &&
+      $isTextNode(firstChild) &&
+      MARKDOWN_EMPTY_LINE_REG_EXP.test(firstChild.getTextContent()))
+  );
+}

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -88,6 +88,7 @@ export default function Editor(): JSX.Element {
       showTreeView,
       showTableOfContents,
       shouldUseLexicalContextMenu,
+      shouldPreserveNewLinesInMarkdown,
       tableCellMerge,
       tableCellBackgroundColor,
     },
@@ -239,7 +240,10 @@ export default function Editor(): JSX.Element {
         {isAutocomplete && <AutocompletePlugin />}
         <div>{showTableOfContents && <TableOfContentsPlugin />}</div>
         {shouldUseLexicalContextMenu && <ContextMenuPlugin />}
-        <ActionsPlugin isRichText={isRichText} />
+        <ActionsPlugin
+          isRichText={isRichText}
+          shouldPreserveNewLinesInMarkdown={shouldPreserveNewLinesInMarkdown}
+        />
       </div>
       {showTreeView && <TreeViewPlugin />}
     </>

--- a/packages/lexical-playground/src/Settings.tsx
+++ b/packages/lexical-playground/src/Settings.tsx
@@ -30,6 +30,7 @@ export default function Settings(): JSX.Element {
       disableBeforeInput,
       showTableOfContents,
       shouldUseLexicalContextMenu,
+      shouldPreserveNewLinesInMarkdown,
     },
   } = useSettings();
   useEffect(() => {
@@ -149,6 +150,16 @@ export default function Settings(): JSX.Element {
             }}
             checked={shouldUseLexicalContextMenu}
             text="Use Lexical Context Menu"
+          />
+          <Switch
+            onClick={() => {
+              setOption(
+                'shouldPreserveNewLinesInMarkdown',
+                !shouldPreserveNewLinesInMarkdown,
+              );
+            }}
+            checked={shouldPreserveNewLinesInMarkdown}
+            text="Preserve newlines in Markdown"
           />
         </div>
       ) : null}

--- a/packages/lexical-playground/src/appSettings.ts
+++ b/packages/lexical-playground/src/appSettings.ts
@@ -21,6 +21,7 @@ export const DEFAULT_SETTINGS = {
   isMaxLength: false,
   isRichText: true,
   measureTypingPerf: false,
+  shouldPreserveNewLinesInMarkdown: false,
   shouldUseLexicalContextMenu: false,
   showNestedEditorTreeView: false,
   showTableOfContents: false,

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -177,7 +177,11 @@ export default function ActionsPlugin({
           true, // include blank lines
         );
       } else {
-        const markdown = $convertToMarkdownString(PLAYGROUND_TRANSFORMERS);
+        const markdown = $convertToMarkdownString(
+          PLAYGROUND_TRANSFORMERS,
+          undefined, //node
+          false, // isNewlineDelimited
+        );
         root
           .clear()
           .append(

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -172,6 +172,8 @@ export default function ActionsPlugin({
         $convertFromMarkdownString(
           firstChild.getTextContent(),
           PLAYGROUND_TRANSFORMERS,
+          undefined, // node
+          true, // include blank lines
         );
       } else {
         const markdown = $convertToMarkdownString(PLAYGROUND_TRANSFORMERS);

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -174,13 +174,13 @@ export default function ActionsPlugin({
           PLAYGROUND_TRANSFORMERS,
           undefined, // node
           // TODO: make a playground setting for this in lexical-playground/src/Settings.tsx
-          true, // include blank lines
+          true, // shouldPreserveNewLines
         );
       } else {
         const markdown = $convertToMarkdownString(
           PLAYGROUND_TRANSFORMERS,
           undefined, //node
-          false, // isNewlineDelimited
+          true, // shouldPreserveNewLines
         );
         root
           .clear()

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -93,8 +93,10 @@ async function shareDoc(doc: SerializedDocument): Promise<void> {
 
 export default function ActionsPlugin({
   isRichText,
+  shouldPreserveNewLinesInMarkdown,
 }: {
   isRichText: boolean;
+  shouldPreserveNewLinesInMarkdown: boolean;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
   const [isEditable, setIsEditable] = useState(() => editor.isEditable());
@@ -173,14 +175,13 @@ export default function ActionsPlugin({
           firstChild.getTextContent(),
           PLAYGROUND_TRANSFORMERS,
           undefined, // node
-          // TODO: make a playground setting for this in lexical-playground/src/Settings.tsx
-          true, // shouldPreserveNewLines
+          shouldPreserveNewLinesInMarkdown,
         );
       } else {
         const markdown = $convertToMarkdownString(
           PLAYGROUND_TRANSFORMERS,
           undefined, //node
-          true, // shouldPreserveNewLines
+          shouldPreserveNewLinesInMarkdown,
         );
         root
           .clear()
@@ -190,7 +191,7 @@ export default function ActionsPlugin({
       }
       root.selectEnd();
     });
-  }, [editor]);
+  }, [editor, shouldPreserveNewLinesInMarkdown]);
 
   return (
     <div className="actions">

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -173,6 +173,7 @@ export default function ActionsPlugin({
           firstChild.getTextContent(),
           PLAYGROUND_TRANSFORMERS,
           undefined, // node
+          // TODO: make a playground setting for this in lexical-playground/src/Settings.tsx
           true, // include blank lines
         );
       } else {


### PR DESCRIPTION
## Description
<!-- 
https://github.com/facebook/lexical/assets/19604232/e2115179-0e1f-4c43-8d79-3a88fd84f320
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

option to make the number of blank lines consistent between markdown and the rendered markdown

**Closes:** #<!-- issue number -->

To enable:
```
$convertFromMarkdownString(
  ...,
  true // shouldPreserveNewLines -> set to true,
)

$convertToMarkdownString(
   ...,
   true // shouldPreserveNewLines -> set to true,
);
```

These flags are optional. Defaults to old behavior of removing newlines on import and delimiting with newlines on export.

## Test plan

### Before


https://github.com/facebook/lexical/assets/19604232/108fdd80-0cde-4678-b4dd-b301132082fa


blank lines are ignored and removed

### After



https://github.com/facebook/lexical/assets/19604232/b8ce7e72-e1c2-4b60-9b96-c92a95791faf

number of blank lines consistent between markdown and rendered markdown


---
### Added settings in playground to toggle newline preservation


https://github.com/facebook/lexical/assets/19604232/3e4d6c1e-e25a-45d7-8cdc-5a77a4afce08

---

Unit and e2e tests pass locally








