### PR TITLE
[lexical-playground] Chore: add test for pasting over mentions

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Mentions.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Mentions.spec.mjs
@@ -6,12 +6,11 @@
  *
  */
 
-import {$selectAll} from 'lexical';
-
 import {
   deleteNextWord,
   moveLeft,
   moveToEditorBeginning,
+  selectAll,
 } from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
@@ -952,7 +951,7 @@ test.describe('Mentions', () => {
 
     await waitForSelector(page, '.mention');
 
-    $selectAll();
+    await selectAll(page);
 
     await pasteFromClipboard(page, {
       'text/html':

--- a/packages/lexical-playground/__tests__/e2e/Mentions.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Mentions.spec.mjs
@@ -6,6 +6,8 @@
  *
  */
 
+import {$selectAll} from 'lexical';
+
 import {
   deleteNextWord,
   moveLeft,
@@ -18,6 +20,7 @@ import {
   html,
   initialize,
   IS_WINDOWS,
+  pasteFromClipboard,
   test,
   waitForSelector,
 } from '../utils/index.mjs';
@@ -928,6 +931,57 @@ test.describe('Mentions', () => {
       anchorPath: [0, 0, 0],
       focusOffset: 0,
       focusPath: [0, 0, 0],
+    });
+  });
+
+  test(`Pasting over a mention does not lead to crash`, async ({page}) => {
+    await focusEditor(page);
+    await page.keyboard.type('@Luke');
+    await assertSelection(page, {
+      anchorOffset: 5,
+      anchorPath: [0, 0, 0],
+      focusOffset: 5,
+      focusPath: [0, 0, 0],
+    });
+
+    await waitForSelector(
+      page,
+      '#typeahead-menu ul li:has-text("Luke Skywalker")',
+    );
+    await page.keyboard.press('Enter');
+
+    await waitForSelector(page, '.mention');
+
+    $selectAll();
+
+    await pasteFromClipboard(page, {
+      'text/html':
+        '<meta charset="utf-8"><span data-lexical-mention="true">Luke Skywalker</span>',
+    });
+
+    await page.keyboard.type(' foo bar');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span
+            class="mention"
+            style="background-color: rgba(24, 119, 232, 0.2);"
+            data-lexical-text="true">
+            Luke Skywalker
+          </span>
+          <span data-lexical-text="true">foo bar</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 8,
+      anchorPath: [0, 1, 0],
+      focusOffset: 8,
+      focusPath: [0, 1, 0],
     });
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/Mentions.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Mentions.spec.mjs
@@ -9,6 +9,7 @@
 import {
   deleteNextWord,
   moveLeft,
+  moveRight,
   moveToEditorBeginning,
   selectAll,
 } from '../keyboardShortcuts/index.mjs';
@@ -957,6 +958,8 @@ test.describe('Mentions', () => {
       'text/html':
         '<meta charset="utf-8"><span data-lexical-mention="true">Luke Skywalker</span>',
     });
+
+    await moveRight(page, 2);
 
     await page.keyboard.type(' foo bar');
 


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
add an e2e test for pasting over mentions. part of a sev followup task for lexical crashing when pasting over mentions. fix was in #5954

## Test plan

npm run start & npm run test-e2e-chromium

<img width="1041" alt="Screenshot 2024-05-23 at 12 33 36 PM" src="https://github.com/facebook/lexical/assets/19604232/fbb370d5-d2d7-4f69-b38f-1d4ef640bd04">
