### PR TITLE
[playground] Bug Fix: change default dev port to 3000

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "cross-env NODE_ENV=development concurrently \"npm:collab\" \"npm run dev --prefix packages/lexical-playground\"",
     "start:website": "npm run start --prefix packages/lexical-website -- --port 3001",
     "start:playground": "npm run start-test-server",
-    "dev": "npm run dev --prefix packages/lexical-playground",
+    "dev": "npm run dev --prefix packages/lexical-playground --",
     "start-test-server": "npm run preview --prefix packages/lexical-playground -- --port 4000",
     "build": "node scripts/build.js",
     "build-prod": "npm run clean && npm run build -- --prod",

--- a/packages/lexical-playground/package.json
+++ b/packages/lexical-playground/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite --host",
+    "dev": "vite --host --port 3000",
     "build-dev": "vite build",
     "build-prod": "vite build --config vite.prod.config.ts",
     "build-vercel": "(cd ../../ && node ./scripts/build.js) && npm run build-dev",


### PR DESCRIPTION
## Description

`npm run dev` (and associated `npm run start`) used to start on port 3000, which was the old vite default. The default changed to 5173, but no reason we can't keep the previous behavior https://github.com/facebook/lexical/pull/6018#pullrequestreview-2039349437

## Test plan

### Before

`npm run dev` listens on port 5173 (after #6018 was merged)


### After

* `npm run dev` listens on port 3000
* tests and other commands that also specify a port still get the desired choice