### PR TITLE
[CI] Refactor: clean up github workflows for cache correctness

### DIFF
--- a/.github/workflows/devtools-extension-publish.yml
+++ b/.github/workflows/devtools-extension-publish.yml
@@ -22,17 +22,7 @@ jobs:
           node-version: 20.x
           cache: 'npm'
 
-      - uses: actions/cache@v4
-        id: devtools-cache
-        with:
-          path: |
-            node_modules
-            packages/lexical-devtools/.wxt
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-
       - name: Install dependencies
-        if: steps.devtools-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Zip & submit to stores

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -11,9 +11,9 @@ on:
       prod: {required: false, type: boolean}
 
 jobs:
-  e2e:
+  e2e-tests:
     runs-on: ${{ inputs.os }}
-    if: inputs.browser != 'webkit' || inputs.os == 'macos-latest'
+    if: (inputs.browser != 'webkit' || inputs.os == 'macos-latest') && (inputs.editor-mode != 'rich-text-with-collab' || inputs.events-mode != 'legacy-events')
     env:
       CI: true
       E2E_EDITOR_MODE: ${{ inputs.editor-mode }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -3,12 +3,12 @@ name: Lexical e2e Tests
 on:
   workflow_call:
     inputs:
-      os: { required: true, type: string }
-      node-version: { required: true, type: string }
-      browser: { required: true, type: string }
-      editor-mode: { required: true, type: string }
-      events-mode: { required: true, type: string }
-      prod: { required: false, type: boolean }
+      os: {required: true, type: string}
+      node-version: {required: true, type: string}
+      browser: {required: true, type: string}
+      editor-mode: {required: true, type: string}
+      events-mode: {required: true, type: string}
+      prod: {required: false, type: boolean}
 
 jobs:
   e2e:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,59 @@
+name: Lexical e2e Tests
+
+on:
+  workflow_call:
+    inputs:
+      os: { required: true, type: string }
+      node-version: { required: true, type: string }
+      browser: { required: true, type: string }
+      editor-mode: { required: true, type: string }
+      events-mode: { required: true, type: string }
+      prod: { required: false, type: boolean }
+
+jobs:
+  e2e:
+    runs-on: ${{ inputs.os }}
+    if: inputs.browser != 'webkit' || inputs.os == 'macos-latest'
+    env:
+      CI: true
+      E2E_EDITOR_MODE: ${{ inputs.editor-mode }}
+      E2E_EVENTS_MODE: ${{ inputs.events-mode }}
+      cache_playwright_path: ${{ inputs.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || inputs.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright'}}
+      test_results_path: ${{ inputs.os == 'windows-latest' && '~/.npm/_logs/' || 'test-results/' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ inputs.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+      - name: Install required ubuntu-latest packages
+        if: inputs.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install xvfb
+      - name: Install dependencies
+        run: npm ci
+      - name: Restore playwright from cache
+        uses: actions/cache/restore@v4
+        id: playwright-cache
+        with:
+          path: ${{ env.cache_playwright_path }}
+          key: playwright-${{ inputs.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - name: Install playwright
+        run: npx playwright install
+      - name: Save playwright to cache
+        uses: actions/cache/save@v4
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ env.cache_playwright_path }}
+          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
+      - name: Run tests
+        run: npm run test-e2e-${{ inputs.editor-mode == 'rich-text-with-collab' && 'collab-' || ''}}${{ inputs.prod && 'prod-' || '' }}ci-${{ inputs.browser }}
+      - name: Upload Artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Results
+          path: ${{ env.test_results_path }}
+          retention-days: 7

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,7 +1,8 @@
 name: Nightly Release Branch
 on:
   # remove the [] when this is turned on
-  schedule: []
+  schedule:
+    []
     # Run daily at 2:30am UTC
     # - cron: '30 2 * * 1-5'
 jobs:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,10 +1,10 @@
 name: Nightly Release Branch
 on:
   # remove the [] when this is turned on
-  schedule:
-    []
-    # Run daily at 2:30am UTC
-    # - cron: '30 2 * * 1-5'
+  []
+  # Run daily at 2:30am UTC
+  # schedule:
+  #  - cron: '30 2 * * 1-5'
 jobs:
   release:
     # prevents this action from running on forks

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,6 +1,7 @@
 name: Nightly Release Branch
 on:
-  schedule:
+  # remove the [] when this is turned on
+  schedule: []
     # Run daily at 2:30am UTC
     # - cron: '30 2 * * 1-5'
 jobs:
@@ -16,10 +17,11 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
+          node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
       - run: |
           git config user.name "Lexical GitHub Actions Bot"
           git config user.email "<>"
-      - run: npm install
+      - run: npm ci
       - run: npm run increment-version -- --i prerelease
       - run: git push -u git@github.com:facebook/lexical.git --follow-tags

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,7 +1,7 @@
 name: Nightly Release Branch
 on:
-  # remove the [] when this is turned on
-  []
+  # remove the workflow_dispatch when this is turned on
+  workflow_dispatch
   # Run daily at 2:30am UTC
   # schedule:
   #  - cron: '30 2 * * 1-5'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -9,8 +9,9 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
+          node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install
+      - run: npm ci
       - run: npm run prepare-release
       - run: node ./scripts/npm/release.js --non-interactive --dry-run=${{ secrets.RELEASE_DRY_RUN }} --channel='latest'
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,12 +87,79 @@ jobs:
         events-mode: ['legacy-events', 'modern-events']
         test-prefix: ['test-e2e-']
         include:
-          - browser: chromium
-            events-mode: modern-events
-            os: macos-latest
-            test-prefix: test-e2e-prod
-          - events-mode: modern-events
-            editor-mode: rich-text-with-collab
+          - os: macos-latest
+            browser: webkit
+          - os: macos-latest
+            playwright-cache: |
+              ~/Library/Caches/ms-playwright
+            test-results: |
+              test-results/
+          - os: windows-latest
+            playwright-cache: |
+              C:\Users\runneradmin\AppData\Local\ms-playwright
+            test-results: |
+              ~/.npm/_logs/
+          - os: ubuntu-latest
+            playwright-cache: |
+              ~/.cache/ms-playwright
+            test-results: |
+              test-results/
+    runs-on: ${{ matrix.os }}
+    env:
+      CI: true
+      E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
+      E2E_EVENTS_MODE: ${{ matrix.events-mode }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - name: Install required ubuntu-latest packages
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install xvfb
+      - name: Install dependencies
+        run: npm ci
+      - name: Restore playwright from cache
+        uses: actions/cache/restore@v4
+        id: playwright-cache
+        with:
+          path: ${{ matrix.playwright-cache }}
+          key: playwright-${{ matrix.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - name: Install playwright
+        run: npx playwright install
+      - name: Save playwright to cache
+        uses: actions/cache/save@v4
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ matrix.playwright-cache }}
+          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
+      - name: Run tests
+        run: npm run ${{ matrix.test-prefix }}${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
+      - name: Upload Artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Results
+          path: ${{ matrix.test-results }}
+          retention-days: 7
+
+  e2e-collab:
+    if: github.repository_owner == 'facebook'
+    strategy:
+      matrix:
+        os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
+        node-version: [18.18.0]
+        browser: ['chromium', 'firefox']
+        editor-mode: ['rich-text-with-collab']
+        events-mode: ['modern-events']
+        test-prefix: ['test-e2e-']
+        include:
+          - os: macos-latest
+            browser: webkit
           - os: macos-latest
             playwright-cache: |
               ~/Library/Caches/ms-playwright
@@ -126,6 +193,61 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install xvfb
+      - name: Install dependencies
+        run: npm ci
+      - name: Restore playwright from cache
+        uses: actions/cache/restore@v4
+        id: playwright-cache
+        with:
+          path: ${{ matrix.playwright-cache }}
+          key: playwright-${{ matrix.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - name: Install playwright
+        run: npx playwright install
+      - name: Save playwright to cache
+        uses: actions/cache/save@v4
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ matrix.playwright-cache }}
+          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
+      - name: Run tests
+        run: npm run ${{ matrix.test-prefix }}${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
+      - name: Upload Artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Results
+          path: ${{ matrix.test-results }}
+          retention-days: 7
+
+  e2e-prod:
+    if: github.repository_owner == 'facebook'
+    strategy:
+      matrix:
+        os: ['macos-latest']
+        node-version: [18.18.0]
+        browser: ['chromium']
+        editor-mode: ['rich-text', 'plain-text', 'rich-text-with-collab']
+        events-mode: ['modern-events']
+        test-prefix: ['test-e2e-prod']
+        include:
+          - os: macos-latest
+            playwright-cache: |
+              ~/Library/Caches/ms-playwright
+            test-results: |
+              test-results/
+            browser: webkit
+    runs-on: ${{ matrix.os }}
+    env:
+      CI: true
+      E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
+      E2E_EVENTS_MODE: ${{ matrix.events-mode }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Restore playwright from cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,9 +82,32 @@ jobs:
       matrix:
         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
         node-version: [18.18.0]
-        browser: ['chromium', 'firefox', 'webkit']
+        browser: ['chromium', 'firefox']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['legacy-events', 'modern-events']
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      os: ${{ matrix.os }}
+      node-version: ${{ matrix.node-version }}
+      browser: ${{ matrix.browser }}
+      editor-mode: ${{ matrix.editor-mode }}
+      events-mode: ${{ matrix.events-mode }}
+
+  e2e-webkit:
+    if: github.repository_owner == 'facebook'
+    strategy:
+      matrix:
+        os: ['macos-latest']
+        node-version: [18.18.0]
+        browser: ['webkit']
+        editor-mode: ['rich-text', 'plain-text', 'rich-text-with-collab']
+        events-mode: ['legacy-events', 'modern-events']
+        exclude:
+          - os: macos-latest
+            node-version: 18.18.0
+            browser: webkit
+            editor-mode: rich-text-with-collab
+            events-mode: legacy-events
     uses: ./.github/workflows/e2e-test.yml
     with:
       os: ${{ matrix.os }}
@@ -99,7 +122,7 @@ jobs:
       matrix:
         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
         node-version: [18.18.0]
-        browser: ['chromium', 'firefox', 'webkit']
+        browser: ['chromium', 'firefox']
         editor-mode: ['rich-text-with-collab']
         events-mode: ['modern-events']
     uses: ./.github/workflows/e2e-test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,21 +89,14 @@ jobs:
         include:
           - os: macos-latest
             browser: webkit
-          - os: macos-latest
-            playwright-cache: |
-              ~/Library/Caches/ms-playwright
-            test-results: |
-              test-results/
+            playwright-cache: '~/Library/Caches/ms-playwright'
+            test-results: 'test-results/'
           - os: windows-latest
-            playwright-cache: |
-              C:\Users\runneradmin\AppData\Local\ms-playwright
-            test-results: |
-              ~/.npm/_logs/
+            playwright-cache: 'C:\Users\runneradmin\AppData\Local\ms-playwright'
+            test-results: '~/.npm/_logs/'
           - os: ubuntu-latest
-            playwright-cache: |
-              ~/.cache/ms-playwright
-            test-results: |
-              test-results/
+            playwright-cache: '~/.cache/ms-playwright'
+            test-results: 'test-results/'
     runs-on: ${{ matrix.os }}
     env:
       CI: true
@@ -160,22 +153,14 @@ jobs:
         include:
           - os: macos-latest
             browser: webkit
-          - os: macos-latest
-            playwright-cache: |
-              ~/Library/Caches/ms-playwright
-            test-results: |
-              test-results/
-            browser: webkit
+            playwright-cache: '~/Library/Caches/ms-playwright'
+            test-results: 'test-results/'
           - os: windows-latest
-            playwright-cache: |
-              C:\Users\runneradmin\AppData\Local\ms-playwright
-            test-results: |
-              ~/.npm/_logs/
+            playwright-cache: 'C:\Users\runneradmin\AppData\Local\ms-playwright'
+            test-results: '~/.npm/_logs/'
           - os: ubuntu-latest
-            playwright-cache: |
-              ~/.cache/ms-playwright
-            test-results: |
-              test-results/
+            playwright-cache: '~/.cache/ms-playwright'
+            test-results: 'test-results/'
     runs-on: ${{ matrix.os }}
     env:
       CI: true
@@ -231,11 +216,9 @@ jobs:
         test-prefix: ['test-e2e-prod']
         include:
           - os: macos-latest
-            playwright-cache: |
-              ~/Library/Caches/ms-playwright
-            test-results: |
-              test-results/
             browser: webkit
+            playwright-cache: '~/Library/Caches/ms-playwright'
+            test-results: 'test-results/'
     runs-on: ${{ matrix.os }}
     env:
       CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
         browser: ['chromium', 'firefox']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['legacy-events', 'modern-events']
-        test-prefix: ['test-e2e-']
+        test-prefix: ['test-e2e']
         include:
           - os: macos-latest
             browser: webkit
@@ -125,7 +125,7 @@ jobs:
           path: ${{ env.cache_playwright_path }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
       - name: Run tests
-        run: npm run ${{ matrix.test-prefix }}${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
+        run: npm run ${{ matrix.test-prefix }}-${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
       - name: Upload Artifacts
         if: failure()
         uses: actions/upload-artifact@v4
@@ -143,7 +143,7 @@ jobs:
         browser: ['chromium', 'firefox']
         editor-mode: ['rich-text-with-collab']
         events-mode: ['modern-events']
-        test-prefix: ['test-e2e-']
+        test-prefix: ['test-e2e']
         include:
           - os: macos-latest
             browser: webkit
@@ -183,13 +183,13 @@ jobs:
           path: ${{ env.cache_playwright_path }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
       - name: Run tests
-        run: npm run ${{ matrix.test-prefix }}${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
+        run: npm run ${{ matrix.test-prefix }}-${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
       - name: Upload Artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: Test Results
-          path: ${{ env.cache_playwright_path }}
+          path: ${{ env.test_results_path }}
           retention-days: 7
 
   e2e-prod:
@@ -236,7 +236,7 @@ jobs:
           path: ${{ env.cache_playwright_path }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
       - name: Run tests
-        run: npm run ${{ matrix.test-prefix }}${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
+        run: npm run ${{ matrix.test-prefix }}-${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
       - name: Upload Artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,55 +85,13 @@ jobs:
         browser: ['chromium', 'firefox', 'webkit']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['legacy-events', 'modern-events']
-        exclude:
-          - browser: webkit
-            os: ubuntu-latest
-          - browser: windows-latest
-            os: ubuntu-latest
-    runs-on: ${{ matrix.os }}
-    env:
-      CI: true
-      E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
-      E2E_EVENTS_MODE: ${{ matrix.events-mode }}
-      cache_playwright_path: ${{ matrix.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || matrix.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright'}}
-      test_results_path: ${{ matrix.os == 'windows-latest' && '~/.npm/_logs/' || 'test-results/' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: npm
-      - name: Install required ubuntu-latest packages
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install xvfb
-      - name: Install dependencies
-        run: npm ci
-      - name: Restore playwright from cache
-        uses: actions/cache/restore@v4
-        id: playwright-cache
-        with:
-          path: ${{ env.cache_playwright_path }}
-          key: playwright-${{ matrix.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - name: Install playwright
-        run: npx playwright install
-      - name: Save playwright to cache
-        uses: actions/cache/save@v4
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ env.cache_playwright_path }}
-          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
-      - name: Run tests
-        run: npm run test-e2e-ci-${{ matrix.browser }}
-      - name: Upload Artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Results
-          path: ${{ env.test_results_path }}
-          retention-days: 7
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      os: ${{ matrix.os }}
+      node-version: ${{ matrix.node-version }}
+      browser: ${{ matrix.browser }}
+      editor-mode: ${{ matrix.editor-mode }}
+      events-mode: ${{ matrix.events-mode }}
 
   e2e-collab:
     if: github.repository_owner == 'facebook'
@@ -144,55 +102,13 @@ jobs:
         browser: ['chromium', 'firefox', 'webkit']
         editor-mode: ['rich-text-with-collab']
         events-mode: ['modern-events']
-        exclude:
-          - browser: webkit
-            os: ubuntu-latest
-          - browser: windows-latest
-            os: ubuntu-latest
-    runs-on: ${{ matrix.os }}
-    env:
-      CI: true
-      E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
-      E2E_EVENTS_MODE: ${{ matrix.events-mode }}
-      cache_playwright_path: ${{ matrix.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || matrix.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright'}}
-      test_results_path: ${{ matrix.os == 'windows-latest' && '~/.npm/_logs/' || 'test-results/' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: npm
-      - name: Install required ubuntu-latest packages
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install xvfb
-      - name: Install dependencies
-        run: npm ci
-      - name: Restore playwright from cache
-        uses: actions/cache/restore@v4
-        id: playwright-cache
-        with:
-          path: ${{ env.cache_playwright_path }}
-          key: playwright-${{ matrix.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - name: Install playwright
-        run: npx playwright install
-      - name: Save playwright to cache
-        uses: actions/cache/save@v4
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ env.cache_playwright_path }}
-          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
-      - name: Run tests
-        run: npm run test-e2e-collab-ci-${{ matrix.browser }}
-      - name: Upload Artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Results
-          path: ${{ env.test_results_path }}
-          retention-days: 7
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      os: ${{ matrix.os }}
+      node-version: ${{ matrix.node-version }}
+      browser: ${{ matrix.browser }}
+      editor-mode: ${{ matrix.editor-mode }}
+      events-mode: ${{ matrix.events-mode }}
 
   e2e-prod:
     if: github.repository_owner == 'facebook'
@@ -203,42 +119,11 @@ jobs:
         browser: ['chromium']
         editor-mode: ['rich-text', 'plain-text', 'rich-text-with-collab']
         events-mode: ['modern-events']
-    runs-on: ${{ matrix.os }}
-    env:
-      CI: true
-      E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
-      E2E_EVENTS_MODE: ${{ matrix.events-mode }}
-      cache_playwright_path: ${{ matrix.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || matrix.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright'}}
-      test_results_path: ${{ matrix.os == 'windows-latest' && '~/.npm/_logs/' || 'test-results/' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: npm
-      - name: Install dependencies
-        run: npm ci
-      - name: Restore playwright from cache
-        uses: actions/cache/restore@v4
-        id: playwright-cache
-        with:
-          path: ${{ env.cache_playwright_path }}
-          key: playwright-${{ matrix.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - name: Install playwright
-        run: npx playwright install
-      - name: Save playwright to cache
-        uses: actions/cache/save@v4
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ env.cache_playwright_path }}
-          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
-      - name: Run tests
-        run: npm run test-e2e-${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-prod' || 'prod' }}-ci-${{ matrix.browser }}
-      - name: Upload Artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Results
-          path: ${{ env.test_results_path }}
-          retention-days: 7
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      os: ${{ matrix.os }}
+      node-version: ${{ matrix.node-version }}
+      browser: ${{ matrix.browser }}
+      editor-mode: ${{ matrix.editor-mode }}
+      events-mode: ${{ matrix.events-mode }}
+    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,62 +76,95 @@ jobs:
         run: npm ci
       - run: npm run test-integration
 
-  e2e:
+  e2e-mac:
     if: github.repository_owner == 'facebook'
     strategy:
       matrix:
-        os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
+        node-version: [18.18.0]
+        browser: ['chromium', 'firefox', 'webkit']
+        editor-mode: ['rich-text', 'plain-text']
+        events-mode: ['legacy-events', 'modern-events']
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      os: 'macos-latest'
+      node-version: ${{ matrix.node-version }}
+      browser: ${{ matrix.browser }}
+      editor-mode: ${{ matrix.editor-mode }}
+      events-mode: ${{ matrix.events-mode }}
+
+  e2e-linux:
+    if: github.repository_owner == 'facebook'
+    strategy:
+      matrix:
         node-version: [18.18.0]
         browser: ['chromium', 'firefox']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['legacy-events', 'modern-events']
     uses: ./.github/workflows/e2e-test.yml
     with:
-      os: ${{ matrix.os }}
+      os: 'ubuntu-latest'
       node-version: ${{ matrix.node-version }}
       browser: ${{ matrix.browser }}
       editor-mode: ${{ matrix.editor-mode }}
       events-mode: ${{ matrix.events-mode }}
 
-  e2e-webkit:
+  e2e-windows:
     if: github.repository_owner == 'facebook'
     strategy:
       matrix:
-        os: ['macos-latest']
-        node-version: [18.18.0]
-        browser: ['webkit']
-        editor-mode: ['rich-text', 'plain-text', 'rich-text-with-collab']
-        events-mode: ['legacy-events', 'modern-events']
-        exclude:
-          - os: macos-latest
-            node-version: 18.18.0
-            browser: webkit
-            editor-mode: rich-text-with-collab
-            events-mode: legacy-events
-    uses: ./.github/workflows/e2e-test.yml
-    with:
-      os: ${{ matrix.os }}
-      node-version: ${{ matrix.node-version }}
-      browser: ${{ matrix.browser }}
-      editor-mode: ${{ matrix.editor-mode }}
-      events-mode: ${{ matrix.events-mode }}
-
-  e2e-collab:
-    if: github.repository_owner == 'facebook'
-    strategy:
-      matrix:
-        os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
         node-version: [18.18.0]
         browser: ['chromium', 'firefox']
-        editor-mode: ['rich-text-with-collab']
-        events-mode: ['modern-events']
+        editor-mode: ['rich-text', 'plain-text']
+        events-mode: ['legacy-events', 'modern-events']
     uses: ./.github/workflows/e2e-test.yml
     with:
-      os: ${{ matrix.os }}
+      os: 'windows-latest'
       node-version: ${{ matrix.node-version }}
       browser: ${{ matrix.browser }}
       editor-mode: ${{ matrix.editor-mode }}
       events-mode: ${{ matrix.events-mode }}
+
+  e2e-collab-mac:
+    if: github.repository_owner == 'facebook'
+    strategy:
+      matrix:
+        node-version: [18.18.0]
+        browser: ['chromium', 'firefox', 'webkit']
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      os: 'macos-latest'
+      node-version: ${{ matrix.node-version }}
+      browser: ${{ matrix.browser }}
+      editor-mode: 'rich-text-with-collab'
+      events-mode: 'modern-events'
+
+  e2e-collab-linux:
+    if: github.repository_owner == 'facebook'
+    strategy:
+      matrix:
+        node-version: [18.18.0]
+        browser: ['chromium', 'firefox']
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      os: 'ubuntu-latest'
+      node-version: ${{ matrix.node-version }}
+      browser: ${{ matrix.browser }}
+      editor-mode: 'rich-text-with-collab'
+      events-mode: 'modern-events'
+
+  e2e-collab-windows:
+    if: github.repository_owner == 'facebook'
+    strategy:
+      matrix:
+        node-version: [18.18.0]
+        browser: ['chromium', 'firefox']
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      os: 'windows-latest'
+      node-version: ${{ matrix.node-version }}
+      browser: ${{ matrix.browser }}
+      editor-mode: 'rich-text-with-collab'
+      events-mode: 'modern-events'
 
   e2e-prod:
     if: github.repository_owner == 'facebook'
@@ -140,10 +173,29 @@ jobs:
         os: ['macos-latest']
         node-version: [18.18.0]
         browser: ['chromium']
-        editor-mode: ['rich-text', 'plain-text', 'rich-text-with-collab']
+        editor-mode: ['rich-text']
         events-mode: ['modern-events']
     uses: ./.github/workflows/e2e-test.yml
     with:
+      prod: true
+      os: ${{ matrix.os }}
+      node-version: ${{ matrix.node-version }}
+      browser: ${{ matrix.browser }}
+      editor-mode: ${{ matrix.editor-mode }}
+      events-mode: ${{ matrix.events-mode }}
+
+  e2e-collab-prod:
+    if: github.repository_owner == 'facebook'
+    strategy:
+      matrix:
+        os: ['macos-latest']
+        node-version: [18.18.0]
+        browser: ['chromium']
+        editor-mode: ['rich-text-with-collab']
+        events-mode: ['modern-events']
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      prod: true
       os: ${{ matrix.os }}
       node-version: ${{ matrix.node-version }}
       browser: ${{ matrix.browser }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install xvfb  
+          sudo apt-get install xvfb
       - name: Install dependencies
         run: npm ci
       - name: Restore playwright from cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,9 +199,6 @@ jobs:
         browser: ['chromium']
         editor-mode: ['rich-text', 'plain-text', 'rich-text-with-collab']
         events-mode: ['modern-events']
-        include:
-          - os: macos-latest
-            browser: webkit
     runs-on: ${{ matrix.os }}
     env:
       CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,6 @@ jobs:
         browser: ['chromium', 'firefox']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['legacy-events', 'modern-events']
-        test-prefix: ['test-e2e']
         include:
           - os: macos-latest
             browser: webkit
@@ -125,7 +124,7 @@ jobs:
           path: ${{ env.cache_playwright_path }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
       - name: Run tests
-        run: npm run ${{ matrix.test-prefix }}-${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
+        run: npm run test-e2e-ci-${{ matrix.browser }}
       - name: Upload Artifacts
         if: failure()
         uses: actions/upload-artifact@v4
@@ -143,7 +142,6 @@ jobs:
         browser: ['chromium', 'firefox']
         editor-mode: ['rich-text-with-collab']
         events-mode: ['modern-events']
-        test-prefix: ['test-e2e']
         include:
           - os: macos-latest
             browser: webkit
@@ -183,7 +181,7 @@ jobs:
           path: ${{ env.cache_playwright_path }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
       - name: Run tests
-        run: npm run ${{ matrix.test-prefix }}-${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
+        run: npm run test-e2e-collab-ci-${{ matrix.browser }}
       - name: Upload Artifacts
         if: failure()
         uses: actions/upload-artifact@v4
@@ -201,7 +199,6 @@ jobs:
         browser: ['chromium']
         editor-mode: ['rich-text', 'plain-text', 'rich-text-with-collab']
         events-mode: ['modern-events']
-        test-prefix: ['test-e2e-prod']
         include:
           - os: macos-latest
             browser: webkit
@@ -236,7 +233,7 @@ jobs:
           path: ${{ env.cache_playwright_path }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
       - name: Run tests
-        run: npm run ${{ matrix.test-prefix }}-${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
+        run: npm run test-e2e-${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-prod' || 'prod' }}-ci-${{ matrix.browser }}
       - name: Upload Artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,16 +31,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm@8
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            node_modules
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          cache: npm
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - run: npm run ci-check
       - run: npm run build
@@ -60,16 +52,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm@8
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            node_modules
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          cache: npm
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - run: npm run test-unit
 
@@ -87,70 +71,45 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm@8
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            node_modules
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          cache: npm
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - run: npm run test-integration
 
-  e2e-mac:
+  e2e:
     if: github.repository_owner == 'facebook'
-    runs-on: macos-latest
     strategy:
       matrix:
-        node-version: [18.18.0]
-        browser: ['chromium', 'firefox', 'webkit']
-        editor-mode: ['rich-text', 'plain-text']
-        events-mode: ['legacy-events', 'modern-events']
-    env:
-      CI: true
-      E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
-      E2E_EVENTS_MODE: ${{ matrix.events-mode }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm@8
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            node_modules
-            packages/playwright-core/node_modules
-            ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
-      - name: Download browsers
-        run: npx playwright install
-      - run: npm run test-e2e-ci-${{ matrix.browser }}
-      - name: Upload Artifacts
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test Results
-          path: test-results/
-          retention-days: 7
-
-  e2e-linux:
-    if: github.repository_owner == 'facebook'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
+        os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
         node-version: [18.18.0]
         browser: ['chromium', 'firefox']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['legacy-events', 'modern-events']
+        prod-prefix: ['']
+        include:
+          - browser: chromium
+            events-mode: modern-events
+            os: macos-latest
+            prod-prefix: prod-
+          - events-mode: modern-events
+            editor-mode: rich-text-with-collab
+          - os: macos-latest
+            playwright-cache: |
+              ~/Library/Caches/ms-playwright
+            test-results: |
+              test-results/
+            browser: webkit
+          - os: windows-latest
+            playwright-cache: |
+              C:\Users\runneradmin\AppData\Local\ms-playwright
+            test-results: |
+              ~/.npm/_logs/
+          - os: ubuntu-latest
+            playwright-cache: |
+              ~/.cache/ms-playwright
+            test-results: |
+              test-results/
+    runs-on: ${{ matrix.os }}
     env:
       CI: true
       E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
@@ -161,271 +120,35 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: install required packages
+          cache: npm
+      - name: Install required ubuntu-latest packages
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install xvfb
-      - run: npm i -g npm@8
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            node_modules
-            packages/playwright-core/node_modules
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+          sudo apt-get install xvfb  
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
-      - name: Download browsers
+      - name: Restore playwright from cache
+        uses: actions/cache/restore@v4
+        id: playwright-cache
+        with:
+          path: ${{ matrix.playwright-cache }}
+          key: playwright-${{ matrix.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - name: Install playwright
         run: npx playwright install
-      - run: npm run test-e2e-ci-${{ matrix.browser }}
+      - name: Save playwright to cache
+        uses: actions/cache/save@v4
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ matrix.playwright-cache }}
+          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
+      - name: Run tests
+        run: npm run test-e2e-${{ matrix.prod-prefix }}${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
+        if: matrix.editor-mode != 'rich-text-with-collab'
       - name: Upload Artifacts
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
-          path: test-results/
-          retention-days: 7
-
-  e2e-windows:
-    if: github.repository_owner == 'facebook'
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        node-version: [18.18.0]
-        browser: ['chromium', 'firefox']
-        editor-mode: ['rich-text', 'plain-text']
-        events-mode: ['legacy-events', 'modern-events']
-    env:
-      CI: true
-      E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
-      E2E_EVENTS_MODE: ${{ matrix.events-mode }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm@8
-      # - uses: actions/cache@v4
-      #   id: cache
-      #   with:
-      #     path: |
-      #       node_modules
-      #       C:\Users\runneradmin\AppData\Local\ms-playwright
-      #     key: ${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      # - name: Install dependencies
-      #   if: steps.cache.outputs.cache-hit != 'true'
-      - run: npm ci
-      - name: Download browsers
-        run: npx playwright install
-      - run: npm run test-e2e-ci-${{ matrix.browser }}
-      - name: Upload Artifacts
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test Results
-          path: ~/.npm/_logs/
-          retention-days: 7
-
-  e2e-collab-mac:
-    if: github.repository_owner == 'facebook'
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        node-version: [18.18.0]
-        browser: ['chromium', 'firefox', 'webkit']
-    env:
-      CI: true
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm@8
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            node_modules
-            packages/playwright-core/node_modules
-            ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
-      - name: Download browsers
-        run: npx playwright install
-      - run: npm run test-e2e-collab-ci-${{ matrix.browser }}
-      - name: Upload Artifacts
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test Results
-          path: test-results/
-          retention-days: 7
-
-  e2e-collab-linux:
-    if: github.repository_owner == 'facebook'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.18.0]
-        browser: ['chromium', 'firefox']
-    env:
-      CI: true
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm@8
-      - name: install required packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install xvfb
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            node_modules
-            packages/playwright-core/node_modules
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
-      - name: Download browsers
-        run: npx playwright install
-      - run: npm run test-e2e-collab-ci-${{ matrix.browser }}
-      - name: Upload Artifacts
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test Results
-          path: test-results/
-          retention-days: 7
-
-  e2e-collab-windows:
-    if: github.repository_owner == 'facebook'
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        node-version: [18.18.0]
-        browser: ['chromium', 'firefox']
-    env:
-      CI: true
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm@8
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            node_modules
-            C:\Users\runneradmin\AppData\Local\ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        #   if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
-      - name: Download browsers
-        run: npx playwright install
-      - run: npm run test-e2e-collab-ci-${{ matrix.browser }}
-      - name: Upload Artifacts
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test Results
-          path: test-results/
-          retention-days: 7
-
-  e2e-prod:
-    if: github.repository_owner == 'facebook'
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        node-version: [18.18.0]
-        browser: ['chromium']
-        editor-mode: ['rich-text', 'plain-text']
-        events-mode: ['modern-events']
-    env:
-      CI: true
-      E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
-      E2E_EVENTS_MODE: ${{ matrix.events-mode }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm@8
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            node_modules
-            packages/playwright-core/node_modules
-            ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
-      - name: Download browsers
-        run: npx playwright install
-      - run: npm run test-e2e-prod-ci-${{ matrix.browser }}
-      - name: Upload Artifacts
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test Results
-          path: test-results/
-          retention-days: 7
-
-  e2e-collab-prod:
-    if: github.repository_owner == 'facebook'
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        node-version: [18.18.0]
-        browser: ['chromium']
-        editor-mode: ['rich-text']
-        events-mode: ['modern-events']
-    env:
-      CI: true
-      E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
-      E2E_EVENTS_MODE: ${{ matrix.events-mode }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm@8
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            node_modules
-            packages/playwright-core/node_modules
-            ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
-      - name: Download browsers
-        run: npx playwright install
-      - run: npm run test-e2e-collab-prod-ci-${{ matrix.browser }}
-      - name: Upload Artifacts
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test Results
-          path: test-results/
+          path: ${{ matrix.test-results }}
           retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,12 +82,14 @@ jobs:
       matrix:
         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
         node-version: [18.18.0]
-        browser: ['chromium', 'firefox']
+        browser: ['chromium', 'firefox', 'webkit']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['legacy-events', 'modern-events']
-        include:
-          - os: macos-latest
-            browser: webkit
+        exclude:
+          - browser: webkit
+            os: ubuntu-latest
+          - browser: windows-latest
+            os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     env:
       CI: true
@@ -139,12 +141,14 @@ jobs:
       matrix:
         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
         node-version: [18.18.0]
-        browser: ['chromium', 'firefox']
+        browser: ['chromium', 'firefox', 'webkit']
         editor-mode: ['rich-text-with-collab']
         events-mode: ['modern-events']
-        include:
-          - os: macos-latest
-            browser: webkit
+        exclude:
+          - browser: webkit
+            os: ubuntu-latest
+          - browser: windows-latest
+            os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     env:
       CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,19 +89,13 @@ jobs:
         include:
           - os: macos-latest
             browser: webkit
-            playwright-cache: '~/Library/Caches/ms-playwright'
-            test-results: 'test-results/'
-          - os: windows-latest
-            playwright-cache: 'C:\Users\runneradmin\AppData\Local\ms-playwright'
-            test-results: '~/.npm/_logs/'
-          - os: ubuntu-latest
-            playwright-cache: '~/.cache/ms-playwright'
-            test-results: 'test-results/'
     runs-on: ${{ matrix.os }}
     env:
       CI: true
       E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
       E2E_EVENTS_MODE: ${{ matrix.events-mode }}
+      cache_playwright_path: ${{ matrix.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || matrix.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright'}}
+      test_results_path: ${{ matrix.os == 'windows-latest' && '~/.npm/_logs/' || 'test-results/' }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
@@ -120,7 +114,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: playwright-cache
         with:
-          path: ${{ matrix.playwright-cache }}
+          path: ${{ env.cache_playwright_path }}
           key: playwright-${{ matrix.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install playwright
         run: npx playwright install
@@ -128,7 +122,7 @@ jobs:
         uses: actions/cache/save@v4
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         with:
-          path: ${{ matrix.playwright-cache }}
+          path: ${{ env.cache_playwright_path }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
       - name: Run tests
         run: npm run ${{ matrix.test-prefix }}${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
@@ -137,7 +131,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Test Results
-          path: ${{ matrix.test-results }}
+          path: ${{ env.test_results_path }}
           retention-days: 7
 
   e2e-collab:
@@ -153,19 +147,13 @@ jobs:
         include:
           - os: macos-latest
             browser: webkit
-            playwright-cache: '~/Library/Caches/ms-playwright'
-            test-results: 'test-results/'
-          - os: windows-latest
-            playwright-cache: 'C:\Users\runneradmin\AppData\Local\ms-playwright'
-            test-results: '~/.npm/_logs/'
-          - os: ubuntu-latest
-            playwright-cache: '~/.cache/ms-playwright'
-            test-results: 'test-results/'
     runs-on: ${{ matrix.os }}
     env:
       CI: true
       E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
       E2E_EVENTS_MODE: ${{ matrix.events-mode }}
+      cache_playwright_path: ${{ matrix.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || matrix.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright'}}
+      test_results_path: ${{ matrix.os == 'windows-latest' && '~/.npm/_logs/' || 'test-results/' }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
@@ -184,7 +172,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: playwright-cache
         with:
-          path: ${{ matrix.playwright-cache }}
+          path: ${{ env.cache_playwright_path }}
           key: playwright-${{ matrix.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install playwright
         run: npx playwright install
@@ -192,7 +180,7 @@ jobs:
         uses: actions/cache/save@v4
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         with:
-          path: ${{ matrix.playwright-cache }}
+          path: ${{ env.cache_playwright_path }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
       - name: Run tests
         run: npm run ${{ matrix.test-prefix }}${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
@@ -201,7 +189,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Test Results
-          path: ${{ matrix.test-results }}
+          path: ${{ env.cache_playwright_path }}
           retention-days: 7
 
   e2e-prod:
@@ -217,13 +205,13 @@ jobs:
         include:
           - os: macos-latest
             browser: webkit
-            playwright-cache: '~/Library/Caches/ms-playwright'
-            test-results: 'test-results/'
     runs-on: ${{ matrix.os }}
     env:
       CI: true
       E2E_EDITOR_MODE: ${{ matrix.editor-mode }}
       E2E_EVENTS_MODE: ${{ matrix.events-mode }}
+      cache_playwright_path: ${{ matrix.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || matrix.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright'}}
+      test_results_path: ${{ matrix.os == 'windows-latest' && '~/.npm/_logs/' || 'test-results/' }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
@@ -237,7 +225,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: playwright-cache
         with:
-          path: ${{ matrix.playwright-cache }}
+          path: ${{ env.cache_playwright_path }}
           key: playwright-${{ matrix.node-version }}-${{ runner.os }}-${{ runner.arch }}-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Install playwright
         run: npx playwright install
@@ -245,7 +233,7 @@ jobs:
         uses: actions/cache/save@v4
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         with:
-          path: ${{ matrix.playwright-cache }}
+          path: ${{ env.cache_playwright_path }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
       - name: Run tests
         run: npm run ${{ matrix.test-prefix }}${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
@@ -254,5 +242,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Test Results
-          path: ${{ matrix.test-results }}
+          path: ${{ env.test_results_path }}
           retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,4 +126,3 @@ jobs:
       browser: ${{ matrix.browser }}
       editor-mode: ${{ matrix.editor-mode }}
       events-mode: ${{ matrix.events-mode }}
-    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,12 +85,12 @@ jobs:
         browser: ['chromium', 'firefox']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['legacy-events', 'modern-events']
-        prod-prefix: ['']
+        test-prefix: ['test-e2e-']
         include:
           - browser: chromium
             events-mode: modern-events
             os: macos-latest
-            prod-prefix: prod-
+            test-prefix: test-e2e-prod
           - events-mode: modern-events
             editor-mode: rich-text-with-collab
           - os: macos-latest
@@ -143,8 +143,7 @@ jobs:
           path: ${{ matrix.playwright-cache }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
       - name: Run tests
-        run: npm run test-e2e-${{ matrix.prod-prefix }}${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
-        if: matrix.editor-mode != 'rich-text-with-collab'
+        run: npm run ${{ matrix.test-prefix }}${{ matrix.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}ci-${{ matrix.browser }}
       - name: Upload Artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -22,6 +22,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
+          node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
       - run: |
           git config user.name "Lexical GitHub Actions Bot"

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -8,14 +8,13 @@
 'use strict';
 
 /**
- * We use this file to configure the size-lmit tool, rather than their simpler
+ * We use this file to configure the size-limit tool, rather than their simpler
  * yaml package.json configuration, because we need to override the resolution
  * of modules to ensure we are pulling in monorepo build products as
  * dependencies rather than trying to use something stale from node_modules.
  */
 const glob = require('glob');
 const path = require('node:path');
-const fs = require('fs-extra');
 
 /**
  * Build a alias map so that we can be sure that we are resolving monorepo

--- a/packages/lexical-devtools/wxt.config.ts
+++ b/packages/lexical-devtools/wxt.config.ts
@@ -127,7 +127,7 @@ export default defineConfig({
           find: 'lexicalOriginal',
           replacement: path.resolve('../lexical/src/index.ts'),
         },
-        ...moduleResolution('preview'),
+        ...moduleResolution('source'),
       ],
     },
   }),


### PR DESCRIPTION
## Description

We have a lot of test workflow. The workflows could get in various states where the cache was poisoned. 

The cache correctness related changes:
* Use the actions/setup-node@v4 `cache: npm` option which also considers the node version, and should in theory do the right thing (the actions/cache docs recommend to [not cache node_modules](https://github.com/actions/cache/blob/main/examples.md#node---npm) as we were doing)
* Use `npm ci`. Maybe a little slower than caching node_modules, takes about 30s, but the global artifacts should be cached and we have a postinstall action to run for wxt with the lexical-devtools package which was the cause of some of the problems.
* Move playwright caching to its own step which a cache key that includes all the things
* Add a reusable e2e-test workflow to make the multiple matrix jobs easier to manage

## Test plan

### Before

Sometimes get strange build failures due to poisoned cache (hard to intentionally repro)

### After

* All expected matrix combinations are still tested
* Tests pass
* Hopefully cache poisoning won't happen anymore
