### PR TITLE
CharacterLimit prefer replace over insertBefore

### DIFF
--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -224,7 +224,7 @@ function $wrapOverflowedNodes(offset: number): void {
 
 function $wrapNode(node: LexicalNode): OverflowNode {
   const overflowNode = $createOverflowNode();
-  node.insertBefore(overflowNode);
+  node.replace(overflowNode);
   overflowNode.append(node);
   return overflowNode;
 }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -264,6 +264,7 @@ function internalMarkParentElementsAsDirty(
   }
 }
 
+// TODO #6031 this function or their callers have to adjust selection (i.e. insertBefore)
 export function removeFromParent(node: LexicalNode): void {
   const oldParent = node.getParent();
   if (oldParent !== null) {


### PR DESCRIPTION
So I was just minding my business adding this plugin https://github.com/facebook/lexical/pull/6025 when I found one bug leading to another... I won't fix this one now but at least I'm providing a workaround here and a tracking issue.

The root cause here appears to be element selection, which needs to be recomputed when nodes are removed and currently neither `insertBefore` nor `removeFromParent` do it. #6031