### PR TITLE
Dev warning for failed DOM selection

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2657,6 +2657,9 @@ export function updateDOMSelection(
     // If we encounter an error, continue. This can sometimes
     // occur with FF and there's no good reason as to why it
     // should happen.
+    if (__DEV__) {
+      console.warn(error);
+    }
   }
   if (
     !tags.has('skip-scroll-into-view') &&


### PR DESCRIPTION
Browser can throw this at points, but on a development setup, this error is likely a result from our reconciliation logic. Having it showing on console certainly makes development easier.