### PR TITLE
[build] Bug Fix: ensure unique artifact name for e2e tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -18,8 +18,9 @@ jobs:
       CI: true
       E2E_EDITOR_MODE: ${{ inputs.editor-mode }}
       E2E_EVENTS_MODE: ${{ inputs.events-mode }}
-      cache_playwright_path: ${{ inputs.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || inputs.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright'}}
+      cache_playwright_path: ${{ inputs.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || inputs.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright' }}
       test_results_path: ${{ inputs.os == 'windows-latest' && '~/.npm/_logs/' || 'test-results/' }}
+      test_script: test-e2e-${{ inputs.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}${{ inputs.prod && 'prod-' || '' }}ci-${{ inputs.browser }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ inputs.node-version }}
@@ -49,11 +50,11 @@ jobs:
           path: ${{ env.cache_playwright_path }}
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
       - name: Run tests
-        run: npm run test-e2e-${{ inputs.editor-mode == 'rich-text-with-collab' && 'collab-' || ''}}${{ inputs.prod && 'prod-' || '' }}ci-${{ inputs.browser }}
+        run: npm run ${{ env.test_script }}
       - name: Upload Artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: Test Results
+          name: Test Results ${{ inputs.os }}-${{ inputs.browser }}-${{ inputs.editor-mode }}-${{ inputs.events-mode }}-${{ inputs.prod && 'prod' || 'dev' }}-${{ inputs.node-version }}
           path: ${{ env.test_results_path }}
           retention-days: 7

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/jsdom": "^21.1.6",
         "@types/katex": "^0.16.7",
         "@types/node": "^17.0.31",
+        "@types/prettier": "^2.7.3",
         "@types/prismjs": "^1.26.0",
         "@types/react": "^18.0.8",
         "@types/react-dom": "^18.0.3",
@@ -8204,9 +8205,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/prettier": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
-      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "dev": true
     },
     "node_modules/@types/prismjs": {
@@ -32884,6 +32885,7 @@
       }
     },
     "packages/lexical-eslint-plugin": {
+      "name": "@lexical/eslint-plugin",
       "version": "0.14.5",
       "license": "MIT",
       "devDependencies": {
@@ -39110,9 +39112,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prettier": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
-      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "dev": true
     },
     "@types/prismjs": {

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@types/jsdom": "^21.1.6",
     "@types/katex": "^0.16.7",
     "@types/node": "^17.0.31",
+    "@types/prettier": "^2.7.3",
     "@types/prismjs": "^1.26.0",
     "@types/react": "^18.0.8",
     "@types/react-dom": "^18.0.3",


### PR DESCRIPTION
## Description

I misinterpreted the scope of the breaking change in actions/upload-artifact@v4 in #6029 - looks like we do need to change the name to include the matrix.

## Test plan

### Before

If a build has more than one e2e test job that fails, uploading the artifacts for that job will fail

### After

All e2e failure artifacts should be uploaded