### PR TITLE
[WIP][lexical-react] Bug Fix: React 19 StrictMode correctness

### DIFF
--- a/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
@@ -7,7 +7,12 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {LexicalEditor} from 'lexical';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  LexicalEditor,
+} from 'lexical';
 import * as React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
@@ -76,6 +81,11 @@ describe('LexicalComposer tests', () => {
             initialConfig={{
               editorState(editor) {
                 editors.add(editor);
+                editor.update(() => {
+                  const p = $createParagraphNode();
+                  p.append($createTextNode('initial state'));
+                  $getRoot().append(p);
+                });
               },
               namespace: '',
               nodes: [],
@@ -95,6 +105,12 @@ describe('LexicalComposer tests', () => {
           );
         });
         expect(editors.size).toBe(size);
+        [...editors].forEach((editor, i) => {
+          expect([
+            i,
+            editor.getEditorState().read(() => $getRoot().getTextContent()),
+          ]).toEqual([i, 'initial state']);
+        });
       });
     });
   });

--- a/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
@@ -7,13 +7,14 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {LexicalEditor} from 'lexical';
 import * as React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'react-dom/test-utils';
 
 import {LexicalComposer} from '../../LexicalComposer';
 
-describe('LexicalNodeHelpers tests', () => {
+describe('LexicalComposer tests', () => {
   let container: HTMLDivElement | null = null;
   let reactRoot: Root;
 
@@ -57,6 +58,44 @@ describe('LexicalNodeHelpers tests', () => {
 
     await ReactTestUtils.act(async () => {
       reactRoot.render(<App />);
+    });
+  });
+
+  describe('LexicalComposerContext editor identity', () => {
+    (
+      [
+        {name: 'StrictMode', size: 2},
+        {name: 'Fragment', size: 1},
+      ] as const
+    ).forEach(({name, size}) => {
+      const Wrapper = React[name];
+      const editors = new Set<LexicalEditor>();
+      function App() {
+        return (
+          <LexicalComposer
+            initialConfig={{
+              editorState(editor) {
+                editors.add(editor);
+              },
+              namespace: '',
+              nodes: [],
+              onError: () => {
+                throw Error();
+              },
+            }}
+          />
+        );
+      }
+      it(`renders ${size} editors under ${name}`, async () => {
+        await ReactTestUtils.act(async () => {
+          reactRoot.render(
+            <Wrapper>
+              <App />
+            </Wrapper>,
+          );
+        });
+        expect(editors.size).toBe(size);
+      });
     });
   });
 });

--- a/packages/lexical-react/src/shared/usePlainTextSetup.ts
+++ b/packages/lexical-react/src/shared/usePlainTextSetup.ts
@@ -19,8 +19,5 @@ export function usePlainTextSetup(editor: LexicalEditor): void {
       registerPlainText(editor),
       registerDragonSupport(editor),
     );
-
-    // We only do this for init
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor]);
 }

--- a/packages/lexical-react/src/shared/useRichTextSetup.ts
+++ b/packages/lexical-react/src/shared/useRichTextSetup.ts
@@ -19,8 +19,5 @@ export function useRichTextSetup(editor: LexicalEditor): void {
       registerRichText(editor),
       registerDragonSupport(editor),
     );
-
-    // We only do this for init
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor]);
 }

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -447,7 +447,7 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
       // Ensure custom nodes implement required methods.
       if (__DEV__) {
         const name = klass.name;
-        if (name !== 'RootNode') {
+        if (name !== 'RootNode' && name !== 'ArtificialNode__DO_NOT_USE') {
           const proto = klass.prototype;
           ['getType', 'clone'].forEach((method) => {
             // eslint-disable-next-line no-prototype-builtins


### PR DESCRIPTION
## Description

React 19's StrictMode re-uses the results of useMemo between renders ([notes](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#strict-mode-improvements)). We have code in the composers that uses useMemo to create LexicalEditor which are a mutable state nightmare if shared, causing all sorts of hard to understand bugs and makes us look pretty bad in dev modes everywhere. `useState(…)[0]` should not have this issue.

We can't fix the fact that you can of course make similar mistakes in your own components. We could also add documentation to the FAQ or somewhere else that shows best practices. I'm not sure exactly what practice we would recommend if you want to do some sort of editor mutation that the cleanup function doesn't take care of (e.g. set up some initial editor state with a plugin).

**Closes:** #6040

## Test plan

### Before

See #6040 for a full example

### After

Unit tests pass. Not sure what the best way to run the test suite with React 19 in CI would be?
