### PR TITLE
Fix #5703 Infinite loop on hashtag transform

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
@@ -345,4 +345,42 @@ test.describe('Hashtags', () => {
       `,
     );
   });
+
+  test('Should not break while skipping invalid hashtags #5703', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('#hello');
+
+    await page.keyboard.press('Space');
+
+    await page.keyboard.type('#world');
+    await page.keyboard.type('#invalid');
+
+    await page.keyboard.press('Space');
+    await page.keyboard.type('#next');
+
+    await waitForSelector(page, '.PlaygroundEditorTheme__hashtag');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #hello
+          </span>
+          <span data-lexical-text="true"></span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #world
+          </span>
+          <span data-lexical-text="true">#invalid</span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #next
+          </span>
+        </p>
+      `,
+    );
+  });
 });

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -101,7 +101,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
     }
 
     // eslint-disable-next-line no-constant-condition
-    let charLengthsToSkip = 0;
+    let prevMatchLengthToSkip = 0;
     // eslint-disable-next-line no-constant-condition
     while (true) {
       match = getMatch(text);
@@ -145,7 +145,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
         $isTextNode(prevSibling) &&
         prevSibling.isTextEntity()
       ) {
-        charLengthsToSkip = match.end;
+        prevMatchLengthToSkip = match.end;
         continue;
       }
 
@@ -154,8 +154,8 @@ export function registerLexicalTextEntity<T extends TextNode>(
         [nodeToReplace, currentNode] = currentNode.splitText(match.end);
       } else {
         [, nodeToReplace, currentNode] = currentNode.splitText(
-          match.start + charLengthsToSkip,
-          match.end + charLengthsToSkip,
+          match.start + prevMatchLengthToSkip,
+          match.end + prevMatchLengthToSkip,
         );
       }
       const replacementNode = createNode(nodeToReplace);

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -145,7 +145,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
         $isTextNode(prevSibling) &&
         prevSibling.isTextEntity()
       ) {
-        charLengthsToSkip = text.length;
+        charLengthsToSkip = match.end;
         continue;
       }
 
@@ -154,11 +154,8 @@ export function registerLexicalTextEntity<T extends TextNode>(
         [nodeToReplace, currentNode] = currentNode.splitText(match.end);
       } else {
         [, nodeToReplace, currentNode] = currentNode.splitText(
-          match.start +
-            (charLengthsToSkip === 0
-              ? 0
-              : currentNode.getTextContentSize() - charLengthsToSkip),
-          match.end,
+          match.start + charLengthsToSkip,
+          match.end + charLengthsToSkip,
         );
       }
       const replacementNode = createNode(nodeToReplace);

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -150,24 +150,20 @@ export function registerLexicalTextEntity<T extends TextNode>(
       }
 
       let nodeToReplace;
-      if ($isTextNode(currentNode)) {
-        if (match.start === 0) {
-          [nodeToReplace, currentNode] = currentNode.splitText(match.end);
-        } else {
-          [, nodeToReplace, currentNode] = currentNode.splitText(
-            match.start +
-              (charLengthsToSkip === 0
-                ? 0
-                : currentNode.getTextContentSize() - charLengthsToSkip),
-            match.end,
-          );
-        }
-        if ($isTextNode(nodeToReplace)) {
-          const replacementNode = createNode(nodeToReplace);
-          replacementNode.setFormat(nodeToReplace.getFormat());
-          nodeToReplace.replace(replacementNode);
-        }
+      if (match.start === 0) {
+        [nodeToReplace, currentNode] = currentNode.splitText(match.end);
+      } else {
+        [, nodeToReplace, currentNode] = currentNode.splitText(
+          match.start +
+            (charLengthsToSkip === 0
+              ? 0
+              : currentNode.getTextContentSize() - charLengthsToSkip),
+          match.end,
+        );
       }
+      const replacementNode = createNode(nodeToReplace);
+      replacementNode.setFormat(nodeToReplace.getFormat());
+      nodeToReplace.replace(replacementNode);
 
       if (currentNode == null) {
         return;

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -46,7 +46,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
     return node instanceof targetNode;
   };
 
-  const replaceWithSimpleText = (node: TextNode): void => {
+  const $replaceWithSimpleText = (node: TextNode): void => {
     const textNode = $createTextNode(node.getTextContent());
     textNode.setFormat(node.getFormat());
     node.replace(textNode);
@@ -56,7 +56,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
     return node.getLatest().__mode;
   };
 
-  const textNodeTransform = (node: TextNode) => {
+  const $textNodeTransform = (node: TextNode) => {
     if (!node.isSimpleText()) {
       return;
     }
@@ -73,7 +73,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
 
       if (isTargetNode(prevSibling)) {
         if (prevMatch === null || getMode(prevSibling) !== 0) {
-          replaceWithSimpleText(prevSibling);
+          $replaceWithSimpleText(prevSibling);
 
           return;
         } else {
@@ -101,6 +101,8 @@ export function registerLexicalTextEntity<T extends TextNode>(
     }
 
     // eslint-disable-next-line no-constant-condition
+    let charLengthsToSkip = 0;
+    // eslint-disable-next-line no-constant-condition
     while (true) {
       match = getMatch(text);
       let nextText = match === null ? '' : text.slice(match.end);
@@ -116,7 +118,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
 
           if (nextMatch === null) {
             if (isTargetNode(nextSibling)) {
-              replaceWithSimpleText(nextSibling);
+              $replaceWithSimpleText(nextSibling);
             } else {
               nextSibling.markDirty();
             }
@@ -143,23 +145,29 @@ export function registerLexicalTextEntity<T extends TextNode>(
         $isTextNode(prevSibling) &&
         prevSibling.isTextEntity()
       ) {
+        charLengthsToSkip = text.length;
         continue;
       }
 
       let nodeToReplace;
-
-      if (match.start === 0) {
-        [nodeToReplace, currentNode] = currentNode.splitText(match.end);
-      } else {
-        [, nodeToReplace, currentNode] = currentNode.splitText(
-          match.start,
-          match.end,
-        );
+      if ($isTextNode(currentNode)) {
+        if (match.start === 0) {
+          [nodeToReplace, currentNode] = currentNode.splitText(match.end);
+        } else {
+          [, nodeToReplace, currentNode] = currentNode.splitText(
+            match.start +
+              (charLengthsToSkip === 0
+                ? 0
+                : currentNode.getTextContentSize() - charLengthsToSkip),
+            match.end,
+          );
+        }
+        if ($isTextNode(nodeToReplace)) {
+          const replacementNode = createNode(nodeToReplace);
+          replacementNode.setFormat(nodeToReplace.getFormat());
+          nodeToReplace.replace(replacementNode);
+        }
       }
-
-      const replacementNode = createNode(nodeToReplace);
-      replacementNode.setFormat(nodeToReplace.getFormat());
-      nodeToReplace.replace(replacementNode);
 
       if (currentNode == null) {
         return;
@@ -167,12 +175,12 @@ export function registerLexicalTextEntity<T extends TextNode>(
     }
   };
 
-  const reverseNodeTransform = (node: T) => {
+  const $reverseNodeTransform = (node: T) => {
     const text = node.getTextContent();
     const match = getMatch(text);
 
     if (match === null || match.start !== 0) {
-      replaceWithSimpleText(node);
+      $replaceWithSimpleText(node);
 
       return;
     }
@@ -187,29 +195,29 @@ export function registerLexicalTextEntity<T extends TextNode>(
     const prevSibling = node.getPreviousSibling();
 
     if ($isTextNode(prevSibling) && prevSibling.isTextEntity()) {
-      replaceWithSimpleText(prevSibling);
-      replaceWithSimpleText(node);
+      $replaceWithSimpleText(prevSibling);
+      $replaceWithSimpleText(node);
     }
 
     const nextSibling = node.getNextSibling();
 
     if ($isTextNode(nextSibling) && nextSibling.isTextEntity()) {
-      replaceWithSimpleText(nextSibling);
+      $replaceWithSimpleText(nextSibling);
 
       // This may have already been converted in the previous block
       if (isTargetNode(node)) {
-        replaceWithSimpleText(node);
+        $replaceWithSimpleText(node);
       }
     }
   };
 
   const removePlainTextTransform = editor.registerNodeTransform(
     TextNode,
-    textNodeTransform,
+    $textNodeTransform,
   );
   const removeReverseNodeTransform = editor.registerNodeTransform<T>(
     targetNode,
-    reverseNodeTransform,
+    $reverseNodeTransform,
   );
 
   return [removePlainTextTransform, removeReverseNodeTransform];

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -145,7 +145,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
         $isTextNode(prevSibling) &&
         prevSibling.isTextEntity()
       ) {
-        prevMatchLengthToSkip = match.end;
+        prevMatchLengthToSkip += match.end;
         continue;
       }
 


### PR DESCRIPTION
<!-- Fix #5703  Infinite loop on hashtag transform-->

## Description
- while transforming the hashtag text entity, 
- if we are skipping a text entity we are not adding the skip length to the next hash tag entity found in the transform logic for the text entity resulting into wrong split and infinite loop
- Fix to add the previous match length to the next match start and end offset before splitting the text node for the next match 

Closes #5703 and #3468 as well

## Test plan

### Before


https://github.com/facebook/lexical/assets/163521239/3482f35c-5f71-4142-b746-79486aa21f3b


### After


https://github.com/facebook/lexical/assets/163521239/56130eb3-3cc9-4905-bc0e-6be4922bc630

