### PR TITLE
Fix font size update in table selection

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -620,9 +620,6 @@ export default function ToolbarPlugin({
         }
       }
       // Handle buttons
-      setFontSize(
-        $getSelectionStyleValueForProperty(selection, 'font-size', '15px'),
-      );
       setFontColor(
         $getSelectionStyleValueForProperty(selection, 'color', '#000'),
       );
@@ -652,6 +649,11 @@ export default function ToolbarPlugin({
           : $isElementNode(node)
           ? node.getFormatType()
           : parent?.getFormatType() || 'left',
+      );
+    }
+    if ($isRangeSelection(selection) || $isTableSelection(selection)) {
+      setFontSize(
+        $getSelectionStyleValueForProperty(selection, 'font-size', '15px'),
       );
     }
   }, [activeEditor]);

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -16,6 +16,7 @@ import type {
   TextNode,
 } from 'lexical';
 
+import {TableSelection} from '@lexical/table';
 import {
   $getAdjacentNode,
   $getPreviousSelection,
@@ -517,7 +518,7 @@ function $getNodeStyleValueForProperty(
  * @returns The value of the property for the selected TextNodes.
  */
 export function $getSelectionStyleValueForProperty(
-  selection: RangeSelection,
+  selection: RangeSelection | TableSelection,
   styleProperty: string,
   defaultValue = '',
 ): string {
@@ -529,7 +530,11 @@ export function $getSelectionStyleValueForProperty(
   const endOffset = isBackward ? focus.offset : anchor.offset;
   const endNode = isBackward ? focus.getNode() : anchor.getNode();
 
-  if (selection.isCollapsed() && selection.style !== '') {
+  if (
+    $isRangeSelection(selection) &&
+    selection.isCollapsed() &&
+    selection.style !== ''
+  ) {
     const css = selection.style;
     const styleObject = getStyleObjectFromCSS(css);
 


### PR DESCRIPTION
This PR fixes the issue with font size not updating with the +/- buttons when there's a table selection with the cells having text with the same font size.
The `$getSelectionStyleValueForProperty` method was not returning the correct updated font size for table selection hence the size updates didn't apply correctly.

### Before
![table-font-size-before](https://github.com/facebook/lexical/assets/33776279/52ec553d-c455-42c6-9cd5-874f6a5521fb)

### After
![table-font-size-after](https://github.com/facebook/lexical/assets/33776279/507f459b-e984-420e-ac0b-db80b4c7877a)
