### PR TITLE
[lexical-table][lexical-playground] Bug Fix: Table selection stuck 

### DIFF
--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -612,6 +612,7 @@ export async function dragMouse(
   positionStart = 'middle',
   positionEnd = 'middle',
   mouseUp = true,
+  slow = false,
 ) {
   let fromX = fromBoundingBox.x;
   let fromY = fromBoundingBox.y;
@@ -635,8 +636,11 @@ export async function dragMouse(
     toY += toBoundingBox.height;
   }
 
-  //simulate more than 1 mouse move event to replicate human dragging
-  await page.mouse.move((fromX + toX) / 2, (fromY + toY) / 2);
+  if (slow) {
+    //simulate more than 1 mouse move event to replicate human slow dragging
+    await page.mouse.move((fromX + toX) / 2, (fromY + toY) / 2);
+  }
+
   await page.mouse.move(toX, toY);
 
   if (mouseUp) {
@@ -795,6 +799,10 @@ export async function selectCellsFromTableCords(
     page,
     await firstRowFirstColumnCell.boundingBox(),
     await secondRowSecondCell.boundingBox(),
+    'middle',
+    'middle',
+    true,
+    true,
   );
 }
 

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -635,6 +635,8 @@ export async function dragMouse(
     toY += toBoundingBox.height;
   }
 
+  //simulate more than 1 mouse move event to replicate human dragging
+  await page.mouse.move((fromX + toX) / 2, (fromY + toY) / 2);
   await page.mouse.move(toX, toY);
 
   if (mouseUp) {

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -77,6 +77,10 @@ export const getDOMSelection = (
 ): Selection | null =>
   CAN_USE_DOM ? (targetWindow || window).getSelection() : null;
 
+const isMouseDownOnEvent = (event: MouseEvent) => {
+  return (event.buttons & 1) === 1;
+};
+
 export function applyTableHandlers(
   tableNode: TableNode,
   tableElement: HTMLTableElementWithWithTableSelectionState,
@@ -104,6 +108,12 @@ export function applyTableHandlers(
     const onMouseMove = (moveEvent: MouseEvent) => {
       // delaying mousemove handler to allow selectionchange handler from LexicalEvents.ts to be executed first
       setTimeout(() => {
+        if (!isMouseDownOnEvent(moveEvent) && tableObserver.isSelecting) {
+          tableObserver.isSelecting = false;
+          editorWindow.removeEventListener('mouseup', onMouseUp);
+          editorWindow.removeEventListener('mousemove', onMouseMove);
+          return;
+        }
         const focusCell = getDOMCellFromTarget(moveEvent.target as Node);
         if (
           focusCell !== null &&


### PR DESCRIPTION
## Description
Prevents table selection from being stuck.
The problem is wrong order of handling the mouse events. `mouseup` can happen before `mousedown` handler added a handler for  `mouseup`. This leaves the editor in a state of selecting. 
This PR adds clean up logic into `mousemove` to prevent selection being stuck

The modification of `dragMouse` is required for tests to pass, as it seems that this bug contributed to the successful execution of some test

### Before
![table-selection-stuck](https://github.com/facebook/lexical/assets/29728044/92e30f9e-f275-46b0-b800-c5b0a4003c0c)
