### PR TITLE
[lexical-playground][lexical-text] Bug Fix: handling hashtag following multiple invalid matches

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
@@ -383,4 +383,61 @@ test.describe('Hashtags', () => {
       `,
     );
   });
+
+  test('Can handle hashtags following multiple invalid hashtags', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('#hello');
+
+    await page.keyboard.press('Space');
+
+    await page.keyboard.type('#world');
+    await page.keyboard.type('#invalid');
+    await page.keyboard.type('#invalid');
+    await page.keyboard.type('#invalid');
+
+    await page.keyboard.press('Space');
+
+    await page.keyboard.type('#valid');
+
+    await page.keyboard.press('Space');
+
+    await page.keyboard.type('#valid');
+    await page.keyboard.type('#invalid');
+
+    await page.keyboard.press('Space');
+    await page.keyboard.type('#valid');
+
+    await waitForSelector(page, '.PlaygroundEditorTheme__hashtag');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #hello
+          </span>
+          <span data-lexical-text="true"></span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #world
+          </span>
+          <span data-lexical-text="true">#invalid#invalid#invalid</span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #valid
+          </span>
+          <span data-lexical-text="true"></span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #valid
+          </span>
+          <span data-lexical-text="true">#invalid</span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #valid
+          </span>
+        </p>
+      `,
+    );
+  });
 });

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -100,7 +100,6 @@ export function registerLexicalTextEntity<T extends TextNode>(
       }
     }
 
-    // eslint-disable-next-line no-constant-condition
     let prevMatchLengthToSkip = 0;
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -127,12 +126,6 @@ export function registerLexicalTextEntity<T extends TextNode>(
           } else if (nextMatch.start !== 0) {
             return;
           }
-        }
-      } else {
-        const nextMatch = getMatch(nextText);
-
-        if (nextMatch !== null && nextMatch.start === 0) {
-          return;
         }
       }
 


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

`prevMatchLengthToSkip` is introduced in #6045 to handle invalid previous match.
So I believe we should let `prevMatchLengthToSkip` do its job instead of early returning `$textNodeTransform` when the next match is followed.

## Test plan

### Before

https://github.com/facebook/lexical/assets/40269597/f5f4637d-4d29-4a23-a294-017f61b5e531

### After

https://github.com/facebook/lexical/assets/40269597/faa609ab-aa7e-4492-bbdf-d0b600c46e8a
