### PR TITLE
[lexical-playground] Bug Fix: Emoji menu item not getting targeted styles

### DIFF
--- a/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
@@ -173,20 +173,19 @@ export default function EmojiPickerPlugin() {
               <div className="typeahead-popover emoji-menu">
                 <ul>
                   {options.map((option: EmojiOption, index) => (
-                    <div key={option.key}>
-                      <EmojiMenuItem
-                        index={index}
-                        isSelected={selectedIndex === index}
-                        onClick={() => {
-                          setHighlightedIndex(index);
-                          selectOptionAndCleanUp(option);
-                        }}
-                        onMouseEnter={() => {
-                          setHighlightedIndex(index);
-                        }}
-                        option={option}
-                      />
-                    </div>
+                    <EmojiMenuItem
+                      key={option.key}
+                      index={index}
+                      isSelected={selectedIndex === index}
+                      onClick={() => {
+                        setHighlightedIndex(index);
+                        selectOptionAndCleanUp(option);
+                      }}
+                      onMouseEnter={() => {
+                        setHighlightedIndex(index);
+                      }}
+                      option={option}
+                    />
                   ))}
                 </ul>
               </div>,


### PR DESCRIPTION
## Description
Menu items in the emoji picker weren't getting the expected border radius styles on selection. This PR removes the `div` that wrapped emoji menu items so the global `li` pseudo selectors can target the items.

## Test plan

### Before

![CleanShot 2024-05-07 at 19 01 49@2x](https://github.com/facebook/lexical/assets/18369969/a458cd0a-3cf1-4cb1-821b-67386e3b97d8)

### After

![CleanShot 2024-05-07 at 19 01 25@2x](https://github.com/facebook/lexical/assets/18369969/276d1648-510f-4294-bf46-a8bd67db7200)