### PR TITLE
[lexical-text] Bug Fix: for handling multiple matches on hashtags

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
@@ -17,6 +17,7 @@ import {
   focusEditor,
   html,
   initialize,
+  pasteFromClipboard,
   pressToggleBold,
   repeat,
   test,
@@ -379,6 +380,91 @@ test.describe('Hashtags', () => {
           <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
             #next
           </span>
+        </p>
+      `,
+    );
+  });
+
+  test('Can handle hashtags following multiple invalid hashtags', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('#hello');
+
+    await page.keyboard.press('Space');
+
+    await page.keyboard.type('#world');
+    await page.keyboard.type('#invalid');
+    await page.keyboard.type('#invalid');
+    await page.keyboard.type('#invalid');
+
+    await page.keyboard.press('Space');
+
+    await page.keyboard.type('#valid');
+
+    await page.keyboard.press('Space');
+
+    await page.keyboard.type('#valid');
+    await page.keyboard.type('#invalid');
+
+    await page.keyboard.press('Space');
+    await page.keyboard.type('#valid');
+
+    await waitForSelector(page, '.PlaygroundEditorTheme__hashtag');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #hello
+          </span>
+          <span data-lexical-text="true"></span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #world
+          </span>
+          <span data-lexical-text="true">#invalid#invalid#invalid</span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #valid
+          </span>
+          <span data-lexical-text="true"></span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #valid
+          </span>
+          <span data-lexical-text="true">#invalid</span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #valid
+          </span>
+        </p>
+      `,
+    );
+  });
+
+  test('Should not break with multiple matches', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    const clipboard = {'text/html': '#hello#world#more#next#matches'};
+    await pasteFromClipboard(page, clipboard);
+
+    await waitForSelector(page, '.PlaygroundEditorTheme__hashtag');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #hello
+          </span>
+          <span data-lexical-text="true">#world#more#next#matches</span>
         </p>
       `,
     );

--- a/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
@@ -14,6 +14,7 @@ import {
 import {
   assertHTML,
   assertSelection,
+  click,
   focusEditor,
   html,
   initialize,
@@ -442,7 +443,7 @@ test.describe('Hashtags', () => {
     );
   });
 
-  test('Should not break with multiple matches', async ({
+  test('Should not break when pasting multiple matches', async ({
     page,
     isPlainText,
   }) => {
@@ -450,10 +451,8 @@ test.describe('Hashtags', () => {
 
     await focusEditor(page);
 
-    const clipboard = {'text/html': '#hello#world#more#next#matches'};
+    const clipboard = {'text/html': '#hello#world'};
     await pasteFromClipboard(page, clipboard);
-
-    await waitForSelector(page, '.PlaygroundEditorTheme__hashtag');
 
     await assertHTML(
       page,
@@ -464,7 +463,39 @@ test.describe('Hashtags', () => {
           <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
             #hello
           </span>
-          <span data-lexical-text="true">#world#more#next#matches</span>
+          <span data-lexical-text="true">#world</span>
+        </p>
+      `,
+    );
+  });
+
+  test('Should not break while importing and exporting multiple matches', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('```markdown #hello#invalid #a #b');
+
+    await click(page, '.action-button .markdown');
+    await click(page, '.action-button .markdown');
+    await click(page, '.action-button .markdown');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #hello
+          </span>
+          <span data-lexical-text="true">#invalid</span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #a
+          </span>
+          <span data-lexical-text="true"></span>
+          <span class="PlaygroundEditorTheme__hashtag" data-lexical-text="true">
+            #b
+          </span>
         </p>
       `,
     );

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -155,7 +155,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
 
       invariant(
         nodeToReplace !== undefined,
-        'nodeToReplace should not be undefined.',
+        'nodeToReplace should not be undefined. You may want to check splitOffsets passed to the splitText.',
       );
 
       const replacementNode = createNode(nodeToReplace);

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -155,7 +155,8 @@ export function registerLexicalTextEntity<T extends TextNode>(
 
       invariant(
         nodeToReplace !== undefined,
-        'nodeToReplace should not be undefined. You may want to check splitOffsets passed to the splitText.',
+        '%s should not be undefined. You may want to check splitOffsets passed to the splitText.',
+        'nodeToReplace',
       );
 
       const replacementNode = createNode(nodeToReplace);

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -14,6 +14,7 @@ import {
   LexicalNode,
   TextNode,
 } from 'lexical';
+import invariant from 'shared/invariant';
 
 export type EntityMatch = {end: number; start: number};
 
@@ -152,9 +153,10 @@ export function registerLexicalTextEntity<T extends TextNode>(
         );
       }
 
-      if (nodeToReplace == null) {
-        return;
-      }
+      invariant(
+        nodeToReplace !== undefined,
+        'nodeToReplace should not be undefined.',
+      );
 
       const replacementNode = createNode(nodeToReplace);
       replacementNode.setFormat(nodeToReplace.getFormat());

--- a/packages/lexical-text/src/registerLexicalTextEntity.ts
+++ b/packages/lexical-text/src/registerLexicalTextEntity.ts
@@ -151,6 +151,11 @@ export function registerLexicalTextEntity<T extends TextNode>(
           match.end + prevMatchLengthToSkip,
         );
       }
+
+      if (nodeToReplace == null) {
+        return;
+      }
+
       const replacementNode = createNode(nodeToReplace);
       replacementNode.setFormat(nodeToReplace.getFormat());
       nodeToReplace.replace(replacementNode);

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -163,5 +163,6 @@
   "161": "Unexpected dirty selection to be null",
   "162": "Root element not registered",
   "163": "node is not a ListNode",
-  "164": "Root element count less than 0"
+  "164": "Root element count less than 0",
+  "165": "%s should not be undefined. You may want to check splitOffsets passed to the splitText."
 }


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

~~#6053 deleted escape on adjacent next matches. but it turns out it was needed in different place (probably after replacement for current match has done ?)~~

~~without it, editor breaks on pasting or importing text that has adjacent matches.~~
 => #6067

And `nodeToReplace` can be `undefined` implicitly. Now it's the case. So I added null check for it. 
This could occur in other places especially around `TextNode.splitText()` unless we use `--noUncheckedIndexedAccess`.

## Test plan

### Before

https://github.com/facebook/lexical/assets/40269597/4f5b1756-a80a-428a-a919-b6075c754c9d


https://github.com/facebook/lexical/assets/40269597/362b301d-1793-4e4d-9903-cb634c08964e


https://github.com/facebook/lexical/assets/40269597/8763cd71-60f9-4d05-a490-050ec6cbdec1



### After


https://github.com/facebook/lexical/assets/40269597/5946d471-2a5f-4e47-9e40-96bc6ea66c9b


https://github.com/facebook/lexical/assets/40269597/66c68640-9f6b-4d38-aada-7ba9497ba0c5


