### PR TITLE
Revert importDOM changes from #5951

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -11,6 +11,7 @@ import type {
   DOMChildConversion,
   DOMConversion,
   DOMConversionFn,
+  ElementFormatType,
   LexicalEditor,
   LexicalNode,
 } from 'lexical';
@@ -58,7 +59,7 @@ export function $generateNodesFromDOM(
       }
     }
   }
-  unwrapArtificalNodes(allArtificialNodes);
+  $unwrapArtificalNodes(allArtificialNodes);
 
   return lexicalNodes;
 }
@@ -312,12 +313,15 @@ function wrapContinuousInlines(
   nodes: Array<LexicalNode>,
   createWrapperFn: () => ElementNode,
 ): Array<LexicalNode> {
+  const textAlign = (domNode as HTMLElement).style
+    .textAlign as ElementFormatType;
   const out: Array<LexicalNode> = [];
   let continuousInlines: Array<LexicalNode> = [];
   // wrap contiguous inline child nodes in para
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     if ($isBlockElementNode(node)) {
+      node.setFormat(textAlign);
       out.push(node);
     } else {
       continuousInlines.push(node);
@@ -326,6 +330,7 @@ function wrapContinuousInlines(
         (i < nodes.length - 1 && $isBlockElementNode(nodes[i + 1]))
       ) {
         const wrapper = createWrapperFn();
+        wrapper.setFormat(textAlign);
         wrapper.append(...continuousInlines);
         out.push(wrapper);
         continuousInlines = [];
@@ -335,7 +340,7 @@ function wrapContinuousInlines(
   return out;
 }
 
-function unwrapArtificalNodes(
+function $unwrapArtificalNodes(
   allArtificialNodes: Array<ArtificialNode__DO_NOT_USE>,
 ) {
   for (const node of allArtificialNodes) {

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/LinksHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/LinksHTMLCopyAndPaste.spec.mjs
@@ -191,13 +191,15 @@ test.describe('HTML Links CopyAndPaste', () => {
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
+          dir="ltr"
+          style="text-align: left">
           <span data-lexical-text="true">Line 0</span>
         </p>
         <ul class="PlaygroundEditorTheme__ul">
           <li
             class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
             dir="ltr"
+            style="text-align: left"
             value="1">
             <span data-lexical-text="true">â..ï¸.Â&nbsp;Line 1Â&nbsp;</span>
             <a
@@ -213,6 +215,7 @@ test.describe('HTML Links CopyAndPaste', () => {
           <li
             class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
             dir="ltr"
+            style="text-align: left"
             value="2">
             <span data-lexical-text="true">â..ï¸.Â&nbsp;Line 2.</span>
           </li>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
@@ -322,7 +322,8 @@ test.describe('HTML Tables CopyAndPaste', () => {
               style="background-color: rgb(172, 206, 247); caret-color: transparent">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                dir="ltr">
+                dir="ltr"
+                style="text-align: start">
                 <span data-lexical-text="true">d</span>
               </p>
             </td>

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -11,7 +11,6 @@ import type {
   DOMConversionOutput,
   DOMExportOutput,
   EditorConfig,
-  ElementFormatType,
   LexicalEditor,
   LexicalNode,
   NodeKey,
@@ -23,7 +22,6 @@ import {addClassNamesToElement} from '@lexical/utils';
 import {
   $applyNodeReplacement,
   $createParagraphNode,
-  $isBlockElementNode,
   $isElementNode,
   $isLineBreakNode,
   $isTextNode,
@@ -85,11 +83,11 @@ export class TableCellNode extends ElementNode {
   static importDOM(): DOMConversionMap | null {
     return {
       td: (node: Node) => ({
-        conversion: convertTableCellNodeElement,
+        conversion: $convertTableCellNodeElement,
         priority: 0,
       }),
       th: (node: Node) => ({
-        conversion: convertTableCellNodeElement,
+        conversion: $convertTableCellNodeElement,
         priority: 0,
       }),
     };
@@ -292,7 +290,7 @@ export class TableCellNode extends ElementNode {
   }
 }
 
-export function convertTableCellNodeElement(
+export function $convertTableCellNodeElement(
   domNode: Node,
 ): DOMConversionOutput {
   const domNode_ = domNode as HTMLTableCellElement;
@@ -325,39 +323,16 @@ export function convertTableCellNodeElement(
   const hasLinethroughTextDecoration = textDecoration.includes('line-through');
   const hasItalicFontStyle = style.fontStyle === 'italic';
   const hasUnderlineTextDecoration = textDecoration.includes('underline');
-  const textAlign = style.textAlign;
   return {
     after: (childLexicalNodes) => {
-      const children = [];
-      let paragraphNode = $createParagraphNode().setFormat(
-        textAlign as ElementFormatType,
-      );
       if (childLexicalNodes.length === 0) {
-        children.push(paragraphNode);
+        childLexicalNodes.push($createParagraphNode());
       }
-
-      childLexicalNodes.forEach((node) => {
-        if ($isBlockElementNode(node)) {
-          if (paragraphNode.getChildrenSize() !== 0) {
-            children.push(paragraphNode);
-            paragraphNode = $createParagraphNode().setFormat(
-              textAlign as ElementFormatType,
-            );
-          }
-          children.push(node);
-        } else {
-          paragraphNode.append(node);
-        }
-      });
-      if (paragraphNode.getChildrenSize() !== 0) {
-        children.push(paragraphNode);
-      }
-      return children;
+      return childLexicalNodes;
     },
     forChild: (lexicalNode, parentLexicalNode) => {
       if ($isTableCellNode(parentLexicalNode) && !$isElementNode(lexicalNode)) {
         const paragraphNode = $createParagraphNode();
-        paragraphNode.setFormat(textAlign as ElementFormatType);
         if (
           $isLineBreakNode(lexicalNode) &&
           lexicalNode.getTextContent() === '\n'
@@ -387,6 +362,8 @@ export function convertTableCellNodeElement(
     node: tableCellNode,
   };
 }
+/** @deprecated renamed to $convertTableCellNodeElement by @lexical/eslint-plugin rules-of-lexical */
+export const convertTableCellNodeElement = $convertTableCellNodeElement;
 
 export function $createTableCellNode(
   headerState: TableCellHeaderState,


### PR DESCRIPTION
As discussed in the comments for #5951, reverting the changes to the TableCellNode importDOM as now we have a generic solution available through #5857.

Also, made additional changes in the `wrapContinuousInlines()` to correctly set the alignment as reverting the changes led to incorrect alignment within the table cells.