### PR TITLE
[examples/react-rich] Fix: Invalid background-image url path cause missing Toolbar format icons in Vite build bundle.

### DIFF
--- a/examples/react-rich/src/styles.css
+++ b/examples/react-rich/src/styles.css
@@ -410,41 +410,41 @@ pre::-webkit-scrollbar-thumb {
 }
 
 i.undo {
-  background-image: url(icons/arrow-counterclockwise.svg);
+  background-image: url(/icons/arrow-counterclockwise.svg);
 }
 
 i.redo {
-  background-image: url(icons/arrow-clockwise.svg);
+  background-image: url(/icons/arrow-clockwise.svg);
 }
 
 i.bold {
-  background-image: url(icons/type-bold.svg);
+  background-image: url(/icons/type-bold.svg);
 }
 
 i.italic {
-  background-image: url(icons/type-italic.svg);
+  background-image: url(/icons/type-italic.svg);
 }
 
 i.underline {
-  background-image: url(icons/type-underline.svg);
+  background-image: url(/icons/type-underline.svg);
 }
 
 i.strikethrough {
-  background-image: url(icons/type-strikethrough.svg);
+  background-image: url(/icons/type-strikethrough.svg);
 }
 
 i.left-align {
-  background-image: url(icons/text-left.svg);
+  background-image: url(/icons/text-left.svg);
 }
 
 i.center-align {
-  background-image: url(icons/text-center.svg);
+  background-image: url(/icons/text-center.svg);
 }
 
 i.right-align {
-  background-image: url(icons/text-right.svg);
+  background-image: url(/icons/text-right.svg);
 }
 
 i.justify-align {
-  background-image: url(icons/justify.svg);
+  background-image: url(/icons/justify.svg);
 }


### PR DESCRIPTION
## Description

Current `vite build` used by `yarn build` does not bundle Toolbar format icon SVG files. This causes missing Toolbar format icons in production build.  This is caused by invalid `background-image url` path in `i.undo` and other Toolbar format icon selectors in 'src/styles.css'. The fix is changing those urls from 

`
i.undo {
  background-image: url(icons/arrow-counterclockwise.svg);
}
`

to set to root directory

`
i.undo {
  background-image: url(/icons/arrow-counterclockwise.svg);
}
` 

Please see more on Static Asset Handling [The public Directory](https://vitejs.dev/guide/assets#the-public-directory) section.

## Test Plan

* Setup: clone the `lexical` repo and run the `react-rich`

`git clone https://github.com/facebook/lexical.git`
`cd examples/react-rich`
`yarn`
`yarn dev`

* The example runs as expected with Toolbar format icons.

![react-rich-expected](https://github.com/facebook/lexical/assets/346543/a751296a-a1fb-42e0-84ae-059bd6557dbd)

### Before

* Now run `yarn build`. The command will complain like this

<pre>
icons/arrow-counterclockwise.svg referenced in /XXX/lexicail/examples/react-rich/src/styles.css didn't resolve at build time, it will remain unchanged to be resolved at runtime
. . .
</pre>

* `yarn preview` shows missing Toolbar format icons in RichText example.

![react-rich-example-missing-formta-icons](https://github.com/facebook/lexical/assets/346543/11051d5e-b89e-4a66-ab80-96230c7ea633)

*  Same errors happen to static bundle in `dist`.

### After

* Changes `background-iamge url` in `src/styles.css`.
* Run `yarn dev`. `react-rich` run as expected.
* Rerun `yarn build`. The command run successfully without complaints.
* Now `yarn preview` and `dist` bundle all have expected Toolbar format icons.

![react-rich-expected](https://github.com/facebook/lexical/assets/346543/eb1d13ea-a1bb-4ddf-b19f-ed113c562022)
