### PR TITLE
[lexical-yjs] Bug fix: Fix cursor position after undo in collab mode

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  moveLeft,
+  selectCharacters,
+  toggleBold,
+  undo,
+} from '../keyboardShortcuts/index.mjs';
+import {
+  assertHTML,
+  assertSelection,
+  click,
+  focusEditor,
+  html,
+  initialize,
+  sleep,
+  test,
+} from '../utils/index.mjs';
+
+async function toggleCheckList(page) {
+  await click(page, '.block-controls');
+  await click(page, '.dropdown .icon.check-list');
+}
+
+test.describe('Collaboration', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+
+  test('Undo with collaboration on', async ({isRichText, page, isCollab}) => {
+    test.skip(!isCollab);
+
+    await focusEditor(page);
+    await page.keyboard.type('hello');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('world');
+    await sleep(1050); // default merge interval is 1000, add 50ms as overhead due to CI latency.
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.type('hello world again');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">hello</span>
+        </p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">hello world again</span>
+        </p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 17,
+      anchorPath: [1, 0, 0],
+      focusOffset: 17,
+      focusPath: [1, 0, 0],
+    });
+
+    await undo(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">hello</span>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph">
+          <br />
+        </p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [1],
+      focusOffset: 0,
+      focusPath: [1],
+    });
+
+    await toggleCheckList(page);
+    await page.keyboard.type('a');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('b');
+    await page.keyboard.press('Enter');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">hello</span>
+        </p>
+        <ul class="PlaygroundEditorTheme__ul PlaygroundEditorTheme__checklist">
+          <li
+            aria-checked="false"
+            role="checkbox"
+            tabindex="-1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__listItemUnchecked PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="1">
+            <span data-lexical-text="true">a</span>
+          </li>
+          <li
+            aria-checked="false"
+            role="checkbox"
+            tabindex="-1"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__listItemUnchecked PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="2">
+            <span data-lexical-text="true">b</span>
+          </li>
+          <li
+            aria-checked="false"
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__listItemUnchecked"
+            role="checkbox"
+            tabindex="-1"
+            value="3">
+            <br />
+          </li>
+        </ul>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [1, 2],
+      focusOffset: 0,
+      focusPath: [1, 2],
+    });
+
+    await undo(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">hello</span>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph">
+          <br />
+        </p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 5,
+      anchorPath: [0, 0, 0],
+      focusOffset: 5,
+      focusPath: [0, 0, 0],
+    });
+
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.type('Some bold text');
+
+    // Move caret to end of 'bold'
+    await moveLeft(page, ' text'.length);
+
+    // Select the word 'bold'
+    await selectCharacters(page, 'left', 'bold'.length);
+
+    await toggleBold(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">hello</span>
+        </p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Some</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            bold
+          </strong>
+          <span data-lexical-text="true">text</span>
+        </p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">world</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 4,
+      anchorPath: [1, 1, 0],
+      focusOffset: 0,
+      focusPath: [1, 1, 0],
+    });
+  });
+});

--- a/packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs
@@ -19,6 +19,7 @@ import {
   focusEditor,
   html,
   initialize,
+  IS_MAC,
   sleep,
   test,
 } from '../utils/index.mjs';
@@ -31,8 +32,13 @@ async function toggleCheckList(page) {
 test.describe('Collaboration', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
 
-  test('Undo with collaboration on', async ({isRichText, page, isCollab}) => {
-    test.skip(!isCollab);
+  test('Undo with collaboration on', async ({
+    isRichText,
+    page,
+    isCollab,
+    browserName,
+  }) => {
+    test.skip(!isCollab || IS_MAC);
 
     await focusEditor(page);
     await page.keyboard.type('hello');
@@ -97,7 +103,6 @@ test.describe('Collaboration', () => {
       focusPath: [1],
     });
 
-    await sleep(1050);
     await toggleCheckList(page);
     await page.keyboard.type('a');
     await page.keyboard.press('Enter');
@@ -181,7 +186,6 @@ test.describe('Collaboration', () => {
       focusPath: [0, 0, 0],
     });
 
-    await sleep(1050);
     await page.keyboard.press('ArrowDown');
     await page.keyboard.type('Some bold text');
 

--- a/packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs
@@ -97,6 +97,7 @@ test.describe('Collaboration', () => {
       focusPath: [1],
     });
 
+    await sleep(1050);
     await toggleCheckList(page);
     await page.keyboard.type('a');
     await page.keyboard.press('Enter');
@@ -180,6 +181,7 @@ test.describe('Collaboration', () => {
       focusPath: [0, 0, 0],
     });
 
+    await sleep(1050);
     await page.keyboard.press('ArrowDown');
     await page.keyboard.type('Some bold text');
 

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -8,7 +8,6 @@
 
 import type {EditorState, NodeKey} from 'lexical';
 
-import {$createOffsetView} from '@lexical/offset';
 import {
   $createParagraphNode,
   $getNodeByKey,
@@ -16,7 +15,6 @@ import {
   $getSelection,
   $isRangeSelection,
   $isTextNode,
-  $setSelection,
 } from 'lexical';
 import invariant from 'shared/invariant';
 import {Text as YText, YEvent, YMapEvent, YTextEvent, YXmlEvent} from 'yjs';
@@ -31,6 +29,7 @@ import {
   syncLocalCursorPosition,
 } from './SyncCursors';
 import {
+  $moveSelectionToPreviousNode,
   doesSelectionNeedRecovering,
   getOrInitCollabNodeFromSharedType,
   syncWithTransaction,
@@ -97,8 +96,6 @@ export function syncYjsChangesToLexical(
 
   editor.update(
     () => {
-      const pendingEditorState: EditorState | null = editor._pendingEditorState;
-
       for (let i = 0; i < events.length; i++) {
         const event = events[i];
         syncEvent(binding, event);
@@ -112,44 +109,15 @@ export function syncYjsChangesToLexical(
       const selection = $getSelection();
 
       if ($isRangeSelection(selection)) {
-        // We can't use Yjs's cursor position here, as it doesn't always
-        // handle selection recovery correctly – especially on elements that
-        // get moved around or split. So instead, we roll our own solution.
         if (doesSelectionNeedRecovering(selection)) {
           const prevSelection = currentEditorState._selection;
 
           if ($isRangeSelection(prevSelection)) {
-            const prevOffsetView = $createOffsetView(
-              editor,
-              0,
-              currentEditorState,
-            );
-            const nextOffsetView = $createOffsetView(
-              editor,
-              0,
-              pendingEditorState,
-            );
-            const [start, end] =
-              prevOffsetView.getOffsetsFromSelection(prevSelection);
-            const nextSelection =
-              start >= 0 && end >= 0
-                ? nextOffsetView.createSelectionFromOffsets(
-                    start,
-                    end,
-                    prevOffsetView,
-                  )
-                : null;
-
-            if (nextSelection !== null) {
-              $setSelection(nextSelection);
-            } else {
-              // Fallback is to use the Yjs cursor position
-              syncLocalCursorPosition(binding, provider);
-
-              if (doesSelectionNeedRecovering(selection)) {
-                // Fallback
-                $getRoot().selectEnd();
-              }
+            syncLocalCursorPosition(binding, provider);
+            if (doesSelectionNeedRecovering(selection)) {
+              // If the selected node is deleted , move the selection to the previous or parent node.
+              const anchorNodeKey = selection.anchor.key;
+              $moveSelectionToPreviousNode(anchorNodeKey, currentEditorState);
             }
           }
 
@@ -174,7 +142,7 @@ export function syncYjsChangesToLexical(
   );
 }
 
-function handleNormalizationMergeConflicts(
+function $handleNormalizationMergeConflicts(
   binding: Binding,
   normalizedNodes: Set<NodeKey>,
 ): void {
@@ -244,7 +212,7 @@ export function syncLexicalUpdateToYjs(
       // when we need to handle normalization merge conflicts.
       if (tags.has('collaboration') || tags.has('historic')) {
         if (normalizedNodes.size > 0) {
-          handleNormalizationMergeConflicts(binding, normalizedNodes);
+          $handleNormalizationMergeConflicts(binding, normalizedNodes);
         }
 
         return;

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -115,7 +115,7 @@ export function syncYjsChangesToLexical(
           if ($isRangeSelection(prevSelection)) {
             syncLocalCursorPosition(binding, provider);
             if (doesSelectionNeedRecovering(selection)) {
-              // If the selected node is deleted , move the selection to the previous or parent node.
+              // If the selected node is deleted, move the selection to the previous or parent node.
               const anchorNodeKey = selection.anchor.key;
               $moveSelectionToPreviousNode(anchorNodeKey, currentEditorState);
             }

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -9,6 +9,7 @@
 import type {Binding, YjsNode} from '.';
 import type {
   DecoratorNode,
+  EditorState,
   ElementNode,
   LexicalNode,
   NodeMap,
@@ -18,6 +19,7 @@ import type {
 
 import {
   $getNodeByKey,
+  $getRoot,
   $isDecoratorNode,
   $isElementNode,
   $isLineBreakNode,
@@ -170,7 +172,7 @@ function getNodeTypeFromSharedType(
   return type;
 }
 
-export function getOrInitCollabNodeFromSharedType(
+export function $getOrInitCollabNodeFromSharedType(
   binding: Binding,
   sharedType: XmlText | YMap<unknown> | XmlElement,
   parent?: CollabElementNode,
@@ -190,7 +192,7 @@ export function getOrInitCollabNodeFromSharedType(
     const sharedParent = sharedType.parent;
     const targetParent =
       parent === undefined && sharedParent !== null
-        ? getOrInitCollabNodeFromSharedType(
+        ? $getOrInitCollabNodeFromSharedType(
             binding,
             sharedParent as XmlText | YMap<unknown> | XmlElement,
           )
@@ -215,6 +217,8 @@ export function getOrInitCollabNodeFromSharedType(
 
   return collabNode;
 }
+/** @deprecated renamed to $getOrInitCollabNodeFromSharedType by @lexical/eslint-plugin rules-of-lexical */
+export const getOrInitCollabNodeFromSharedType = $getOrInitCollabNodeFromSharedType;
 
 export function createLexicalNodeFromCollabNode(
   binding: Binding,
@@ -473,7 +477,7 @@ export function syncWithTransaction(binding: Binding, fn: () => void): void {
   binding.doc.transact(fn, binding);
 }
 
-export function createChildrenArray(
+export function $createChildrenArray(
   element: ElementNode,
   nodeMap: null | NodeMap,
 ): Array<NodeKey> {
@@ -490,6 +494,8 @@ export function createChildrenArray(
   }
   return children;
 }
+/** @deprecated renamed to $createChildrenArray by @lexical/eslint-plugin rules-of-lexical */
+export const createChildrenArray = $createChildrenArray;
 
 export function removeFromParent(node: LexicalNode): void {
   const oldParent = node.getParent();
@@ -539,5 +545,39 @@ export function removeFromParent(node: LexicalNode): void {
     }
     writableParent.__size--;
     writableNode.__parent = null;
+  }
+}
+
+export function $moveSelectionToPreviousNode(
+  anchorNodeKey: string,
+  currentEditorState: EditorState,
+) {
+  const anchorNode = currentEditorState._nodeMap.get(anchorNodeKey);
+  if (!anchorNode) {
+    $getRoot().selectStart();
+    return;
+  }
+  // Get previous node
+  const prevNodeKey = anchorNode.__prev;
+  let prevNode: ElementNode | null = null;
+  if (prevNodeKey) {
+    prevNode = $getNodeByKey(prevNodeKey);
+  }
+
+  // If previous node not found, get parent node
+  if (prevNode === null && anchorNode.__parent !== null) {
+    prevNode = $getNodeByKey(anchorNode.__parent);
+  }
+  if (prevNode === null) {
+    $getRoot().selectStart();
+    return;
+  }
+
+  if (prevNode !== null && prevNode.isAttached()) {
+    prevNode.selectEnd();
+    return;
+  } else {
+    // If the found node is also deleted, select the next one
+    $moveSelectionToPreviousNode(prevNode.__key, currentEditorState);
   }
 }

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -218,7 +218,8 @@ export function $getOrInitCollabNodeFromSharedType(
   return collabNode;
 }
 /** @deprecated renamed to $getOrInitCollabNodeFromSharedType by @lexical/eslint-plugin rules-of-lexical */
-export const getOrInitCollabNodeFromSharedType = $getOrInitCollabNodeFromSharedType;
+export const getOrInitCollabNodeFromSharedType =
+  $getOrInitCollabNodeFromSharedType;
 
 export function createLexicalNodeFromCollabNode(
   binding: Binding,


### PR DESCRIPTION
**Closes:** #6010, #4846

The current logic uses previous selection for calculating new cursor position, which does not work correctly, if the last action includes adding new text.

## Test plan

### Before


![cursor-undo-before](https://github.com/facebook/lexical/assets/47710336/9b899c34-5dea-40ae-8bfc-e39dd29d0a54)


### After

![cursor-undo-after](https://github.com/facebook/lexical/assets/47710336/3a22b842-c773-431b-9324-7837570adbd7)
