### PR TITLE
[lexical-devtools] Feature: Reflect picker state on inspector button ui

### DIFF
--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
@@ -18,17 +18,11 @@ interface Props {
 }
 
 export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
-  const [isActive, setIsActive] = React.useState(false);
-
   const handleClick = () => {
     const injectedPegasusService = getRPCService<IInjectedPegasusService>(
       'InjectedPegasusService',
       {context: 'window', tabId: tabID},
     );
-
-    if (!isActive) {
-      setIsActive(true);
-    }
 
     injectedPegasusService
       .refreshLexicalEditors()
@@ -36,8 +30,7 @@ export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
       .catch((err) => {
         setErrorMessage(err.message);
         console.error(err);
-      })
-      .finally(() => setIsActive(false));
+      });
   };
 
   return (
@@ -48,8 +41,6 @@ export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
       size="xs"
       onClick={handleClick}
       icon={<Image w={5} src="/inspect.svg" />}
-      isActive={isActive}
-      _active={{bg: 'blue.100'}}
     />
   );
 }

--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
@@ -10,6 +10,7 @@ import {IconButton, Image} from '@chakra-ui/react';
 import {getRPCService} from '@webext-pegasus/rpc';
 import * as React from 'react';
 
+import {useExtensionStore} from '../../../store';
 import {IInjectedPegasusService} from '../../injected/InjectedPegasusService';
 
 interface Props {
@@ -18,6 +19,8 @@ interface Props {
 }
 
 export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
+  const {isSelecting} = useExtensionStore();
+
   const handleClick = () => {
     const injectedPegasusService = getRPCService<IInjectedPegasusService>(
       'InjectedPegasusService',
@@ -41,6 +44,8 @@ export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
       size="xs"
       onClick={handleClick}
       icon={<Image w={5} src="/inspect.svg" />}
+      isActive={isSelecting}
+      _active={{bg: 'blue.100'}}
     />
   );
 }

--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
@@ -20,6 +20,7 @@ interface Props {
 
 export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
   const {isSelecting} = useExtensionStore();
+  const isActive = isSelecting[tabID];
 
   const handleClick = () => {
     const injectedPegasusService = getRPCService<IInjectedPegasusService>(
@@ -44,7 +45,7 @@ export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
       size="xs"
       onClick={handleClick}
       icon={<Image w={5} src="/inspect.svg" />}
-      isActive={isSelecting}
+      isActive={isActive}
       _active={{bg: 'blue.100'}}
     />
   );

--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
   const {isSelecting} = useExtensionStore();
-  const isActive = isSelecting[tabID] ?? false;
+  const isActive = isSelecting[tabID];
 
   const handleClick = () => {
     const injectedPegasusService = getRPCService<IInjectedPegasusService>(

--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
   const {isSelecting} = useExtensionStore();
-  const isActive = isSelecting[tabID];
+  const isActive = isSelecting[tabID] ?? false;
 
   const handleClick = () => {
     const injectedPegasusService = getRPCService<IInjectedPegasusService>(

--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/components/EditorInspectorButton.tsx
@@ -18,11 +18,17 @@ interface Props {
 }
 
 export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
+  const [isActive, setIsActive] = React.useState(false);
+
   const handleClick = () => {
     const injectedPegasusService = getRPCService<IInjectedPegasusService>(
       'InjectedPegasusService',
       {context: 'window', tabId: tabID},
     );
+
+    if (!isActive) {
+      setIsActive(true);
+    }
 
     injectedPegasusService
       .refreshLexicalEditors()
@@ -30,7 +36,8 @@ export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
       .catch((err) => {
         setErrorMessage(err.message);
         console.error(err);
-      });
+      })
+      .finally(() => setIsActive(false));
   };
 
   return (
@@ -41,6 +48,8 @@ export function EditorInspectorButton({tabID, setErrorMessage}: Props) {
       size="xs"
       onClick={handleClick}
       icon={<Image w={5} src="/inspect.svg" />}
+      isActive={isActive}
+      _active={{bg: 'blue.100'}}
     />
   );
 }

--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/main.tsx
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/main.tsx
@@ -17,12 +17,14 @@ import App from './App.tsx';
 const tabID = browser.devtools.inspectedWindow.tabId;
 initPegasusTransport();
 
-extensionStoreReady().then(() =>
-  ReactDOM.createRoot(document.getElementById('root')!).render(
-    <React.StrictMode>
-      <ChakraProvider>
-        <App tabID={tabID} />
-      </ChakraProvider>
-    </React.StrictMode>,
-  ),
-);
+extensionStoreReady()
+  .then((store) => store.getState().initTab(tabID))
+  .then(() =>
+    ReactDOM.createRoot(document.getElementById('root')!).render(
+      <React.StrictMode>
+        <ChakraProvider>
+          <App tabID={tabID} />
+        </ChakraProvider>
+      </React.StrictMode>,
+    ),
+  );

--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/main.tsx
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/main.tsx
@@ -17,14 +17,12 @@ import App from './App.tsx';
 const tabID = browser.devtools.inspectedWindow.tabId;
 initPegasusTransport();
 
-extensionStoreReady()
-  .then((store) => store.getState().initTab(tabID))
-  .then(() =>
-    ReactDOM.createRoot(document.getElementById('root')!).render(
-      <React.StrictMode>
-        <ChakraProvider>
-          <App tabID={tabID} />
-        </ChakraProvider>
-      </React.StrictMode>,
-    ),
-  );
+extensionStoreReady().then(() =>
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <ChakraProvider>
+        <App tabID={tabID} />
+      </ChakraProvider>
+    </React.StrictMode>,
+  ),
+);

--- a/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
+++ b/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
@@ -85,39 +85,42 @@ export class InjectedPegasusService
     editor.setEditorState(deserializeEditorState(editorState));
   }
 
-  toggleEditorPicker(): void {
-    if (this.pickerActive != null) {
-      this.pickerActive?.stop();
-      this.pickerActive = null;
-
-      return;
-    }
-
-    this.pickerActive = new ElementPicker({style: ELEMENT_PICKER_STYLE});
-    this.pickerActive.start({
-      elementFilter: (el) => {
-        let parent: HTMLElement | null = el;
-        while (parent != null && parent.tagName !== 'BODY') {
-          if ('__lexicalEditor' in parent) {
-            return parent;
-          }
-          parent = parent.parentElement;
-        }
-
-        return false;
-      },
-
-      onClick: (el) => {
+  toggleEditorPicker(): Promise<void> {
+    return new Promise((resolve) => {
+      if (this.pickerActive != null) {
         this.pickerActive?.stop();
         this.pickerActive = null;
-        if (isLexicalNode(el)) {
-          this.extensionStore
-            .getState()
-            .setSelectedEditorKey(this.tabID, el.__lexicalEditor.getKey());
-        } else {
-          console.warn('Selected Element is not a Lexical node');
-        }
-      },
+
+        return resolve();
+      }
+
+      this.pickerActive = new ElementPicker({style: ELEMENT_PICKER_STYLE});
+      this.pickerActive.start({
+        elementFilter: (el) => {
+          let parent: HTMLElement | null = el;
+          while (parent != null && parent.tagName !== 'BODY') {
+            if ('__lexicalEditor' in parent) {
+              return parent;
+            }
+            parent = parent.parentElement;
+          }
+
+          return false;
+        },
+
+        onClick: (el) => {
+          this.pickerActive?.stop();
+          this.pickerActive = null;
+          if (isLexicalNode(el)) {
+            this.extensionStore
+              .getState()
+              .setSelectedEditorKey(this.tabID, el.__lexicalEditor.getKey());
+          } else {
+            console.warn('Selected Element is not a Lexical node');
+          }
+          resolve();
+        },
+      });
     });
   }
 }

--- a/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
+++ b/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
@@ -86,18 +86,21 @@ export class InjectedPegasusService
   }
 
   toggleEditorPicker(): void {
-    if (this.pickerActive != null) {
-      this.pickerActive?.stop();
-      this.pickerActive = null;
-
-      return;
+    if (this.pickerActive !== null) {
+      this.deactivatePicker();
+    } else {
+      this.activatePicker();
     }
+  }
+
+  private activatePicker(): void {
+    this.extensionStore.getState().setIsSelecting(true);
 
     this.pickerActive = new ElementPicker({style: ELEMENT_PICKER_STYLE});
     this.pickerActive.start({
       elementFilter: (el) => {
         let parent: HTMLElement | null = el;
-        while (parent != null && parent.tagName !== 'BODY') {
+        while (parent !== null && parent.tagName !== 'BODY') {
           if ('__lexicalEditor' in parent) {
             return parent;
           }
@@ -108,8 +111,7 @@ export class InjectedPegasusService
       },
 
       onClick: (el) => {
-        this.pickerActive?.stop();
-        this.pickerActive = null;
+        this.deactivatePicker();
         if (isLexicalNode(el)) {
           this.extensionStore
             .getState()
@@ -119,5 +121,11 @@ export class InjectedPegasusService
         }
       },
     });
+  }
+
+  private deactivatePicker(): void {
+    this.pickerActive?.stop();
+    this.pickerActive = null;
+    this.extensionStore.getState().setIsSelecting(false);
   }
 }

--- a/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
+++ b/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
@@ -94,7 +94,7 @@ export class InjectedPegasusService
   }
 
   private activatePicker(): void {
-    this.extensionStore.getState().setIsSelecting(true);
+    this.extensionStore.getState().setIsSelecting(this.tabID, true);
 
     this.pickerActive = new ElementPicker({style: ELEMENT_PICKER_STYLE});
     this.pickerActive.start({
@@ -126,6 +126,6 @@ export class InjectedPegasusService
   private deactivatePicker(): void {
     this.pickerActive?.stop();
     this.pickerActive = null;
-    this.extensionStore.getState().setIsSelecting(false);
+    this.extensionStore.getState().setIsSelecting(this.tabID, false);
   }
 }

--- a/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
+++ b/packages/lexical-devtools/src/entrypoints/injected/InjectedPegasusService.ts
@@ -85,42 +85,39 @@ export class InjectedPegasusService
     editor.setEditorState(deserializeEditorState(editorState));
   }
 
-  toggleEditorPicker(): Promise<void> {
-    return new Promise((resolve) => {
-      if (this.pickerActive != null) {
+  toggleEditorPicker(): void {
+    if (this.pickerActive != null) {
+      this.pickerActive?.stop();
+      this.pickerActive = null;
+
+      return;
+    }
+
+    this.pickerActive = new ElementPicker({style: ELEMENT_PICKER_STYLE});
+    this.pickerActive.start({
+      elementFilter: (el) => {
+        let parent: HTMLElement | null = el;
+        while (parent != null && parent.tagName !== 'BODY') {
+          if ('__lexicalEditor' in parent) {
+            return parent;
+          }
+          parent = parent.parentElement;
+        }
+
+        return false;
+      },
+
+      onClick: (el) => {
         this.pickerActive?.stop();
         this.pickerActive = null;
-
-        return resolve();
-      }
-
-      this.pickerActive = new ElementPicker({style: ELEMENT_PICKER_STYLE});
-      this.pickerActive.start({
-        elementFilter: (el) => {
-          let parent: HTMLElement | null = el;
-          while (parent != null && parent.tagName !== 'BODY') {
-            if ('__lexicalEditor' in parent) {
-              return parent;
-            }
-            parent = parent.parentElement;
-          }
-
-          return false;
-        },
-
-        onClick: (el) => {
-          this.pickerActive?.stop();
-          this.pickerActive = null;
-          if (isLexicalNode(el)) {
-            this.extensionStore
-              .getState()
-              .setSelectedEditorKey(this.tabID, el.__lexicalEditor.getKey());
-          } else {
-            console.warn('Selected Element is not a Lexical node');
-          }
-          resolve();
-        },
-      });
+        if (isLexicalNode(el)) {
+          this.extensionStore
+            .getState()
+            .setSelectedEditorKey(this.tabID, el.__lexicalEditor.getKey());
+        } else {
+          console.warn('Selected Element is not a Lexical node');
+        }
+      },
     });
   }
 }

--- a/packages/lexical-devtools/src/store.ts
+++ b/packages/lexical-devtools/src/store.ts
@@ -25,7 +25,6 @@ export interface ExtensionState {
   isSelecting: {
     [tabID: number]: boolean;
   };
-  initTab: (tabID: number) => void;
   markTabAsRestricted: (tabID: number) => void;
   setStatesForTab: (
     id: number,
@@ -37,21 +36,6 @@ export interface ExtensionState {
 
 export const useExtensionStore = create<ExtensionState>()(
   subscribeWithSelector((set) => ({
-    initTab: (tabID: number) =>
-      set((state) => ({
-        isSelecting: {
-          ...state.isSelecting,
-          [tabID]: false,
-        },
-        lexicalState: {
-          ...state.lexicalState,
-          [tabID]: null,
-        },
-        selectedEditorKey: {
-          ...state.selectedEditorKey,
-          [tabID]: null,
-        },
-      })),
     isSelecting: {},
     lexicalState: {},
     markTabAsRestricted: (tabID: number) =>

--- a/packages/lexical-devtools/src/store.ts
+++ b/packages/lexical-devtools/src/store.ts
@@ -25,6 +25,7 @@ export interface ExtensionState {
   isSelecting: {
     [tabID: number]: boolean;
   };
+  initTab: (tabID: number) => void;
   markTabAsRestricted: (tabID: number) => void;
   setStatesForTab: (
     id: number,
@@ -36,6 +37,21 @@ export interface ExtensionState {
 
 export const useExtensionStore = create<ExtensionState>()(
   subscribeWithSelector((set) => ({
+    initTab: (tabID: number) =>
+      set((state) => ({
+        isSelecting: {
+          ...state.isSelecting,
+          [tabID]: false,
+        },
+        lexicalState: {
+          ...state.lexicalState,
+          [tabID]: null,
+        },
+        selectedEditorKey: {
+          ...state.selectedEditorKey,
+          [tabID]: null,
+        },
+      })),
     isSelecting: {},
     lexicalState: {},
     markTabAsRestricted: (tabID: number) =>

--- a/packages/lexical-devtools/src/store.ts
+++ b/packages/lexical-devtools/src/store.ts
@@ -28,10 +28,13 @@ export interface ExtensionState {
     states: {[editorKey: string]: SerializedRawEditorState},
   ) => void;
   setSelectedEditorKey: (tabID: number, editorKey: string | null) => void;
+  isSelecting: boolean;
+  setIsSelecting: (isSelecting: boolean) => void;
 }
 
 export const useExtensionStore = create<ExtensionState>()(
   subscribeWithSelector((set) => ({
+    isSelecting: false,
     lexicalState: {},
     markTabAsRestricted: (tabID: number) =>
       set((state) => ({
@@ -41,6 +44,10 @@ export const useExtensionStore = create<ExtensionState>()(
         },
       })),
     selectedEditorKey: {},
+    setIsSelecting: (isSelecting: boolean) =>
+      set(() => ({
+        isSelecting,
+      })),
     setSelectedEditorKey: (tabID: number, editorKey: string | null) =>
       set((state) => ({
         selectedEditorKey: {

--- a/packages/lexical-devtools/src/store.ts
+++ b/packages/lexical-devtools/src/store.ts
@@ -22,19 +22,21 @@ export interface ExtensionState {
   selectedEditorKey: {
     [tabID: number]: string | null;
   };
+  isSelecting: {
+    [tabID: number]: boolean;
+  };
   markTabAsRestricted: (tabID: number) => void;
   setStatesForTab: (
     id: number,
     states: {[editorKey: string]: SerializedRawEditorState},
   ) => void;
   setSelectedEditorKey: (tabID: number, editorKey: string | null) => void;
-  isSelecting: boolean;
-  setIsSelecting: (isSelecting: boolean) => void;
+  setIsSelecting: (tadID: number, isSelecting: boolean) => void;
 }
 
 export const useExtensionStore = create<ExtensionState>()(
   subscribeWithSelector((set) => ({
-    isSelecting: false,
+    isSelecting: {},
     lexicalState: {},
     markTabAsRestricted: (tabID: number) =>
       set((state) => ({
@@ -44,9 +46,12 @@ export const useExtensionStore = create<ExtensionState>()(
         },
       })),
     selectedEditorKey: {},
-    setIsSelecting: (isSelecting: boolean) =>
-      set(() => ({
-        isSelecting,
+    setIsSelecting: (tabID: number, isSelecting: boolean) =>
+      set((state) => ({
+        isSelecting: {
+          ...state.isSelecting,
+          [tabID]: isSelecting,
+        },
       })),
     setSelectedEditorKey: (tabID: number, editorKey: string | null) =>
       set((state) => ({


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

`EditorInspectorButton` reflects pickerActive state on UI.

**Closes:** #6068

## Test plan

### Before

https://github.com/facebook/lexical/assets/40269597/dec0b200-d955-4c04-8d3a-d04096f583bb


### After


https://github.com/facebook/lexical/assets/40269597/9ec3152e-75be-4722-9257-e6d5eee087f8

