### PR TITLE
[WIP] Feature: Apply indent value from theme on exporting paragraphNode

### DIFF
--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -190,7 +190,9 @@ function $convertParagraphElement(element: HTMLElement): DOMConversionOutput {
   const node = $createParagraphNode();
   if (element.style) {
     node.setFormat(element.style.textAlign as ElementFormatType);
-    const indent = parseInt(element.style.textIndent, 10) / 20;
+
+    //  TODO: leverage theme indent class or default 40 ?
+    const indent = parseInt(element.style.textIndent, 10) / 40;
     if (indent > 0) {
       node.setIndent(indent);
     }
@@ -224,7 +226,7 @@ function setElementIndent(
   }
 
   const indentationBaseValue =
-    global.window
+    window
       .getComputedStyle(dom)
       .getPropertyValue('--lexical-indent-base-value') || DEFAULT_INDENT_VALUE;
 
@@ -232,6 +234,6 @@ function setElementIndent(
     // padding-inline-start is not widely supported in email HTML, but
     // Lexical Reconciler uses padding-inline-start. Using text-indent instead.
     'text-indent',
-    `calc(${indent} * ${indentationBaseValue})`,
+    `${indent * parseInt(indentationBaseValue, 10)}px`,
   );
 }

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -120,11 +120,7 @@ export class ParagraphNode extends ElementNode {
         element.dir = direction;
       }
       const indent = this.getIndent();
-      if (indent > 0) {
-        // padding-inline-start is not widely supported in email HTML, but
-        // Lexical Reconciler uses padding-inline-start. Using text-indent instead.
-        element.style.textIndent = `${indent * 20}px`;
-      }
+      setElementIndent(element, indent, editor._config.theme.indent);
     }
 
     return {
@@ -210,4 +206,34 @@ export function $isParagraphNode(
   node: LexicalNode | null | undefined,
 ): node is ParagraphNode {
   return node instanceof ParagraphNode;
+}
+
+const DEFAULT_INDENT_VALUE = '40px';
+
+function setElementIndent(
+  dom: HTMLElement,
+  indent: number,
+  indentClassName?: string,
+): void {
+  if (typeof indentClassName === 'string') {
+    const elementHasClassName = dom.classList.contains(indentClassName);
+
+    if (indent > 0 && !elementHasClassName) {
+      dom.classList.add(indentClassName);
+    } else if (indent < 1 && elementHasClassName) {
+      dom.classList.remove(indentClassName);
+    }
+  }
+
+  const indentationBaseValue =
+    global.window
+      .getComputedStyle(dom)
+      .getPropertyValue('--lexical-indent-base-value') || DEFAULT_INDENT_VALUE;
+
+  dom.style.setProperty(
+    // padding-inline-start is not widely supported in email HTML, but
+    // Lexical Reconciler uses padding-inline-start. Using text-indent instead.
+    'text-indent',
+    indent === 0 ? '' : `calc(${indent} * ${indentationBaseValue})`,
+  );
 }

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -215,14 +215,12 @@ function setElementIndent(
   indent: number,
   indentClassName?: string,
 ): void {
-  if (typeof indentClassName === 'string') {
-    const elementHasClassName = dom.classList.contains(indentClassName);
+  if (indent < 1) {
+    return;
+  }
 
-    if (indent > 0 && !elementHasClassName) {
-      dom.classList.add(indentClassName);
-    } else if (indent < 1 && elementHasClassName) {
-      dom.classList.remove(indentClassName);
-    }
+  if (typeof indentClassName === 'string') {
+    dom.classList.add(indentClassName);
   }
 
   const indentationBaseValue =
@@ -234,6 +232,6 @@ function setElementIndent(
     // padding-inline-start is not widely supported in email HTML, but
     // Lexical Reconciler uses padding-inline-start. Using text-indent instead.
     'text-indent',
-    indent === 0 ? '' : `calc(${indent} * ${indentationBaseValue})`,
+    `calc(${indent} * ${indentationBaseValue})`,
   );
 }


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

Now, `exportDOM` of `paragraphNode` applies indent value that is configured from theme and also has indent class.
So we get more similar html generated to dom created by reconciler.

**Closes:** #6082

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*