### PR TITLE
[lexical][TextNode] Feature: improve supporting multiple format on importDOM of TextNode

### DIFF
--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -1313,22 +1313,25 @@ function applyTextFormatFromStyle(
     if (!$isTextNode(lexicalNode)) {
       return lexicalNode;
     }
-    if (hasBoldFontWeight) {
+    if (hasBoldFontWeight && !lexicalNode.hasFormat('bold')) {
       lexicalNode.toggleFormat('bold');
     }
-    if (hasLinethroughTextDecoration) {
+    if (
+      hasLinethroughTextDecoration &&
+      !lexicalNode.hasFormat('strikethrough')
+    ) {
       lexicalNode.toggleFormat('strikethrough');
     }
-    if (hasItalicFontStyle) {
+    if (hasItalicFontStyle && !lexicalNode.hasFormat('italic')) {
       lexicalNode.toggleFormat('italic');
     }
-    if (hasUnderlineTextDecoration) {
+    if (hasUnderlineTextDecoration && !lexicalNode.hasFormat('underline')) {
       lexicalNode.toggleFormat('underline');
     }
-    if (verticalAlign === 'sub') {
+    if (verticalAlign === 'sub' && !lexicalNode.hasFormat('subscript')) {
       lexicalNode.toggleFormat('subscript');
     }
-    if (verticalAlign === 'super') {
+    if (verticalAlign === 'super' && !lexicalNode.hasFormat('superscript')) {
       lexicalNode.toggleFormat('superscript');
     }
 

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -1260,6 +1260,17 @@ function findTextInLine(text: Text, forward: boolean): null | Text {
   }
 }
 
+const nodeNameToTextFormat: Record<string, TextFormatType> = {
+  code: 'code',
+  em: 'italic',
+  i: 'italic',
+  s: 'strikethrough',
+  strong: 'bold',
+  sub: 'subscript',
+  sup: 'superscript',
+  u: 'underline',
+};
+
 function convertTextFormatElement(domNode: Node): DOMConversionOutput {
   const format = nodeNameToTextFormat[domNode.nodeName.toLowerCase()];
   if (format === undefined) {
@@ -1280,17 +1291,6 @@ export function $isTextNode(
 ): node is TextNode {
   return node instanceof TextNode;
 }
-
-const nodeNameToTextFormat: Record<string, TextFormatType> = {
-  code: 'code',
-  em: 'italic',
-  i: 'italic',
-  s: 'strikethrough',
-  strong: 'bold',
-  sub: 'subscript',
-  sup: 'superscript',
-  u: 'underline',
-};
 
 function applyTextFormatFromStyle(
   style: CSSStyleDeclaration,


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

Currently, when importing textNode from outside sources (or read-only mode), `convertTextFormatElement` function is utilized for `i`, `em`, `strong`, ... 

However, this doesn't reflect their textFormat by style attributes unlike the handling of `span` in `convertSpanElement`.

So this PR extracts some logic from `convertSpanElement` and applies it to `convertTextFormatElement`.

## Test plan

### Before

https://github.com/facebook/lexical/assets/40269597/e389e072-a5f1-4731-82b2-1dd9ba9f60dd


### After

https://github.com/facebook/lexical/assets/40269597/4ab55ca5-75a9-4ad0-8230-f5994b2af59c

