### PR TITLE
[Lexical] #6097 run extended tests on merge_group event

### DIFF
--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -1,6 +1,7 @@
 name: Lexical Tests (Extended)
 
 on:
+  merge_group:
   pull_request:
     types: [labeled, synchronize]
     paths-ignore:
@@ -12,5 +13,5 @@ concurrency:
 
 jobs:
   e2e-tests:
-    if: github.repository_owner == 'facebook' && contains(github.event.pull_request.labels.*.name, 'extended-tests')
+    if: (github.repository_owner == 'facebook' && contains(github.event.pull_request.labels.*.name, 'extended-tests')) || github.event_name == 'merge_group'
     uses: ./.github/workflows/call-e2e-all-tests.yml


### PR DESCRIPTION
- Follow up on #6097  run extended tests on merge group event
- This is to ensure :
   - No branch is merged without running e2e tests successfully
   - e2e tests are run every time on merge not just if a label is added manually by facebook owner.
- will need the Merge Queue settings to be enabled 1st before we we could test this