### PR TITLE
[lexical-core][code-node] Bug Fix: Adding an empty paragraph before code node

### DIFF
--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -21,6 +21,7 @@ import './CodeHighlighterPrism';
 import {mergeRegister} from '@lexical/utils';
 import {
   $createLineBreakNode,
+  $createParagraphNode,
   $createTabNode,
   $createTextNode,
   $getNodeByKey,
@@ -28,6 +29,7 @@ import {
   $insertNodes,
   $isLineBreakNode,
   $isRangeSelection,
+  $isRootNode,
   $isTabNode,
   $isTextNode,
   COMMAND_PRIORITY_LOW,
@@ -666,7 +668,16 @@ function $handleShiftLines(
       ) {
         const codeNodeSibling = codeNode.getPreviousSibling();
         if (codeNodeSibling === null) {
-          codeNode.selectPrevious();
+          const parent = codeNode.getParent();
+          if ($isRootNode(parent)) {
+            // No previous siblings and the parent node is RootNode,
+            // adding an empty paragraph and select it.
+            const emptyP = $createParagraphNode();
+            codeNode.insertBefore(emptyP);
+            emptyP.select();
+          } else {
+            codeNode.selectPrevious();
+          }
           event.preventDefault();
           return true;
         }


### PR DESCRIPTION
## Description
Adding an empty paragraph before a code node when a user clicks Arrow Up from the code block and there are no other nodes before the code node.

**Closes:** #5968

## Test plan

### Before

https://github.com/facebook/lexical/assets/5062807/395ad864-807f-4a3e-ab3e-e2dc933c04dd


### After


https://github.com/facebook/lexical/assets/5062807/428af10e-d3c0-41fb-843b-404bb974a990



