### PR TITLE
Bug Fix: Add check for `DecoratorNode` for horizontal table navigation.

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -32,6 +32,7 @@ import {
   $getNearestNodeFromDOMNode,
   $getPreviousSelection,
   $getSelection,
+  $isDecoratorNode,
   $isElementNode,
   $isRangeSelection,
   $isTextNode,
@@ -1356,6 +1357,11 @@ function $handleArrowKey(
       const anchorOffset = anchor.offset;
       const anchorNode = anchor.getNode();
       if (!anchorNode) {
+        return false;
+      }
+
+      const selectedNodes = selection.getNodes();
+      if (selectedNodes.length === 1 && $isDecoratorNode(selectedNodes[0])) {
         return false;
       }
 


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
Pressing the left-arrow key in the first table cell with a decorator node or the right-arrow key in the last table cell with a decorator node previously moved the selection outside the table instead of selecting the node.

Added a check for `DecoratorNode` when moving horizontally through a table.

**Closes:** #6128 

## Test plan

### Before

https://www.loom.com/share/98a1761d09574eb895290b80bfcf85ef?sid=134ed533-67b9-42da-bf2d-06d12bb053a8

https://www.loom.com/share/9a2d3376839b4c48b0a672a0ee0207c3?sid=6b6d2918-d603-4974-a314-17063571c492

### After

https://www.loom.com/share/269473b64fbb4c7eb34f5aca0a9d1ee5?sid=bdaa7cad-ecc8-4841-a844-932b8e72621c