### PR TITLE
[Lexical] Fix size limit workflow git hub action bot not able to create comment for PRs from fork

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,6 +1,6 @@
 name: 'Bundles'
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
 jobs:

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,5 +1,6 @@
 name: 'Bundles'
 on:
+  pull_request:
   pull_request_target:
     branches:
       - main


### PR DESCRIPTION
- Fix size limit workflow git hub action bot not able to create comment for PRs from fork
- Follow React Native Repo example : https://github.com/facebook/react-native/blob/044aadbaf6830b21aab821804dc5a7989010022e/.github/workflows/danger_pr.yml#L4

Fixes #6131 
