### PR TITLE
Remove 'legacy-events' from mac & linux e2e matrix

### DIFF
--- a/.github/workflows/call-e2e-all-tests.yml
+++ b/.github/workflows/call-e2e-all-tests.yml
@@ -10,7 +10,7 @@ jobs:
         node-version: [18.18.0]
         browser: ['chromium', 'firefox', 'webkit']
         editor-mode: ['rich-text', 'plain-text']
-        events-mode: ['legacy-events', 'modern-events']
+        events-mode: ['modern-events']
     uses: ./.github/workflows/call-e2e-test.yml
     with:
       os: 'macos-latest'
@@ -25,7 +25,7 @@ jobs:
         node-version: [18.18.0]
         browser: ['chromium', 'firefox']
         editor-mode: ['rich-text', 'plain-text']
-        events-mode: ['legacy-events', 'modern-events']
+        events-mode: ['modern-events']
     uses: ./.github/workflows/call-e2e-test.yml
     with:
       os: 'ubuntu-latest'
@@ -41,6 +41,9 @@ jobs:
         browser: ['chromium', 'firefox']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['legacy-events', 'modern-events']
+        exclude:
+          - events-mode: 'legacy-events'
+            browser: 'firefox'
     uses: ./.github/workflows/call-e2e-test.yml
     with:
       os: 'windows-latest'


### PR DESCRIPTION
## Description

Remove `legacy-events` from the e2e test matrix for all OS and browsers except `chromium` on `windows`. I think this removes 12 e2e test runs.

The `legacy-events` version of e2e tests was [adding in Oct 2021](https://github.com/facebook/lexical/pull/750) and tests for when `beforeinput` is not available. But the browser support for that event is quite broad these days, mostly in line with the lowest versions of Chrome Meta supports (in practice) internally. So the need to test not-`beforeinput` doesn't appear to be significant. I thought we'd keep chromium-windows for now, because Windows is the only OS where we see the oldest versions of Chrome (where `beforeinput` is not supported) being used.

<img width="781" alt="image" src="https://github.com/facebook/lexical/assets/239676/ff18af17-4618-4abe-8b9b-fa019a2bf423">