### PR TITLE
[Lexical] Fix meta sync build failing due to recent changes in LexicalErrorBoundary.tsx

### DIFF
--- a/packages/lexical-react/src/LexicalErrorBoundary.tsx
+++ b/packages/lexical-react/src/LexicalErrorBoundary.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import * as React from 'react';
 import {ErrorBoundary as ReactErrorBoundary} from 'react-error-boundary';
 
 export type LexicalErrorBoundaryProps = {


### PR DESCRIPTION
- #6088 removes 

> import * as React from 'react'; 

from LexicalErrorBoundary.tsx 

- but in generated file LexicalErrorBoundary.dev.js / LexicalErrorBoundary.prod.js  this import was needed,
-  would need further investigation whats going wrong, but this should fix the WWW sync causing some e2e tests to fail with the issue replicable on trying the steps manually as well

<img width="629" alt="Screenshot 2024-05-20 at 12 19 39 PM" src="https://github.com/facebook/lexical/assets/163521239/c557d727-8840-4de7-b35a-70cfec2299ae">

