### PR TITLE
[lexical-react] Bug Fix: Use automatic jsx runtime with react/jsx-runtime -> react alias in www

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -72,6 +72,8 @@ const wwwMappings = {
   'prismjs/components/prism-swift': 'prism-swift',
   'prismjs/components/prism-typescript': 'prism-typescript',
   'react-dom': 'ReactDOMComet',
+  // The react entrypoint in fb includes the jsx runtime
+  'react/jsx-runtime': 'react',
 };
 
 /**
@@ -192,7 +194,7 @@ async function build(name, inputFile, outputPath, outputFile, isProd, format) {
               tsconfig: path.resolve('./tsconfig.build.json'),
             },
           ],
-          ['@babel/preset-react', {runtime: isWWW ? 'classic' : 'automatic'}],
+          ['@babel/preset-react', {runtime: 'automatic'}],
         ],
       }),
       {


### PR DESCRIPTION
## Description

Changes www builds to use automatic jsx runtime with the react/jsx-runtime module aliased to react.

As far as I can tell react's [index.fb.js](https://github.com/facebook/react/blob/c325aec1ee5ae970ea70efc9b19574aa0e72c9a1/packages/react/index.fb.js#L60) is used as the module's entrypoint for fb builds and it includes the JSX runtime (Fragment is already present in the react module).

This should solve the problems that #6134 and #6140 are trying to work around in a more systematic and future-compatible way.

## Test plan

Someone with access to intern will have to do a sync and make sure that this does indeed work.