### PR TITLE
[Lexical] Attempt to fix after approval workflow

### DIFF
--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   label-pr:
-    if: github.event.review.state == 'commented' && !contains(github.event.pull_request.labels.*.name, 'extended-tests')
+    if: github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'extended-tests')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,6 +25,6 @@ jobs:
         run: |
           echo "Adding label 'extended-tests' to PR $NUMBER"
           gh pr edit "$NUMBER" --add-label "extended-tests" || (echo "Failed to add label" && exit 1)
-  # e2e-tests:
-  #   needs: label-pr
-  #   uses: ./.github/workflows/call-e2e-all-tests.yml
+  e2e-tests:
+    needs: label-pr
+    uses: ./.github/workflows/call-e2e-all-tests.yml

--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -24,6 +24,3 @@ jobs:
         run: |
           echo "Adding label 'extended-tests' to PR $NUMBER"
           gh pr edit "$NUMBER" --add-label "extended-tests" || (echo "Failed to add label" && exit 1)
-  e2e-tests:
-    needs: label-pr
-    uses: ./.github/workflows/call-e2e-all-tests.yml

--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -3,10 +3,6 @@ name: After Approval
 on:
   pull_request_review:
     types: [submitted]
-  pull_request_target:
-    types: [review_requested, opened, reopened, synchronize]
-    branches:
-      - 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,11 +10,13 @@ concurrency:
 
 jobs:
   label-pr:
-    if: github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'extended-tests')
+    if: github.event.review.state == 'commented' && !contains(github.event.pull_request.labels.*.name, 'extended-tests')
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
       - name: Add label for extended tests
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -27,6 +25,6 @@ jobs:
         run: |
           echo "Adding label 'extended-tests' to PR $NUMBER"
           gh pr edit "$NUMBER" --add-label "extended-tests" || (echo "Failed to add label" && exit 1)
-  e2e-tests:
-    needs: label-pr
-    uses: ./.github/workflows/call-e2e-all-tests.yml
+  # e2e-tests:
+  #   needs: label-pr
+  #   uses: ./.github/workflows/call-e2e-all-tests.yml

--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -16,10 +16,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
       - name: Add label for extended tests
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ADD_LABEL_PAT }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.pull_request.number }}
         run: |


### PR DESCRIPTION
- #6136  adds ```pull_request_target``` action but it doesn't get triggered on approve so its not helpful right now to use as is, hence could be removed to avoid confusions.

using my fine grain access PAT to trigger the workflow for add label
- it only has read/write access to PR and
- read access to content

Test Plan
- tested in https://github.com/facebook/lexical/pull/6168

TODO
- will replace my PAT with lexical-bot PAT once setup is done