### PR TITLE
[Lexical] add null check for key undefined before calling toLowerCase function

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -772,35 +772,44 @@ export function isTab(
 }
 
 export function isBold(
-  key: string,
+  key: string | null,
   altKey: boolean,
   metaKey: boolean,
   ctrlKey: boolean,
 ): boolean {
   return (
-    key.toLowerCase() === 'b' && !altKey && controlOrMeta(metaKey, ctrlKey)
+    key != null &&
+    key.toLowerCase() === 'b' &&
+    !altKey &&
+    controlOrMeta(metaKey, ctrlKey)
   );
 }
 
 export function isItalic(
-  key: string,
+  key: string | null,
   altKey: boolean,
   metaKey: boolean,
   ctrlKey: boolean,
 ): boolean {
   return (
-    key.toLowerCase() === 'i' && !altKey && controlOrMeta(metaKey, ctrlKey)
+    key != null &&
+    key.toLowerCase() === 'i' &&
+    !altKey &&
+    controlOrMeta(metaKey, ctrlKey)
   );
 }
 
 export function isUnderline(
-  key: string,
+  key: string | null,
   altKey: boolean,
   metaKey: boolean,
   ctrlKey: boolean,
 ): boolean {
   return (
-    key.toLowerCase() === 'u' && !altKey && controlOrMeta(metaKey, ctrlKey)
+    key != null &&
+    key.toLowerCase() === 'u' &&
+    !altKey &&
+    controlOrMeta(metaKey, ctrlKey)
   );
 }
 
@@ -814,9 +823,9 @@ export function isLineBreak(key: string, shiftKey: boolean): boolean {
 
 // Inserts a new line after the selection
 
-export function isOpenLineBreak(key: string, ctrlKey: boolean): boolean {
+export function isOpenLineBreak(key: string | null, ctrlKey: boolean): boolean {
   // 79 = KeyO
-  return IS_APPLE && ctrlKey && key.toLowerCase() === 'o';
+  return IS_APPLE && ctrlKey && key != null && key.toLowerCase() === 'o';
 }
 
 export function isDeleteWordBackward(
@@ -844,7 +853,7 @@ export function isDeleteLineForward(key: string, metaKey: boolean): boolean {
 }
 
 export function isDeleteBackward(
-  key: string,
+  key: string | null,
   altKey: boolean,
   metaKey: boolean,
   ctrlKey: boolean,
@@ -853,7 +862,9 @@ export function isDeleteBackward(
     if (altKey || metaKey) {
       return false;
     }
-    return isBackspace(key) || (key.toLowerCase() === 'h' && ctrlKey);
+    return (
+      isBackspace(key) || (key != null && key.toLowerCase() === 'h' && ctrlKey)
+    );
   }
   if (ctrlKey || altKey || metaKey) {
     return false;
@@ -862,7 +873,7 @@ export function isDeleteBackward(
 }
 
 export function isDeleteForward(
-  key: string,
+  key: string | null,
   ctrlKey: boolean,
   shiftKey: boolean,
   altKey: boolean,
@@ -872,7 +883,9 @@ export function isDeleteForward(
     if (shiftKey || altKey || metaKey) {
       return false;
     }
-    return isDelete(key) || (key.toLowerCase() === 'd' && ctrlKey);
+    return (
+      isDelete(key) || (key != null && key.toLowerCase() === 'd' && ctrlKey)
+    );
   }
   if (ctrlKey || altKey || metaKey) {
     return false;
@@ -881,33 +894,37 @@ export function isDeleteForward(
 }
 
 export function isUndo(
-  key: string,
+  key: string | null,
   shiftKey: boolean,
   metaKey: boolean,
   ctrlKey: boolean,
 ): boolean {
   return (
-    key.toLowerCase() === 'z' && !shiftKey && controlOrMeta(metaKey, ctrlKey)
+    key != null &&
+    key.toLowerCase() === 'z' &&
+    !shiftKey &&
+    controlOrMeta(metaKey, ctrlKey)
   );
 }
 
 export function isRedo(
-  key: string,
+  key: string | null,
   shiftKey: boolean,
   metaKey: boolean,
   ctrlKey: boolean,
 ): boolean {
   if (IS_APPLE) {
-    return key.toLowerCase() === 'z' && metaKey && shiftKey;
+    return key != null && key.toLowerCase() === 'z' && metaKey && shiftKey;
   }
   return (
-    (key.toLowerCase() === 'y' && ctrlKey) ||
-    (key.toLowerCase() === 'z' && ctrlKey && shiftKey)
+    key != null &&
+    ((key.toLowerCase() === 'y' && ctrlKey) ||
+      (key.toLowerCase() === 'z' && ctrlKey && shiftKey))
   );
 }
 
 export function isCopy(
-  key: string,
+  key: string | null,
   shiftKey: boolean,
   metaKey: boolean,
   ctrlKey: boolean,
@@ -915,7 +932,7 @@ export function isCopy(
   if (shiftKey) {
     return false;
   }
-  if (key.toLowerCase() === 'c') {
+  if (key != null && key.toLowerCase() === 'c') {
     return IS_APPLE ? metaKey : ctrlKey;
   }
 
@@ -923,7 +940,7 @@ export function isCopy(
 }
 
 export function isCut(
-  key: string,
+  key: string | null,
   shiftKey: boolean,
   metaKey: boolean,
   ctrlKey: boolean,
@@ -931,7 +948,7 @@ export function isCut(
   if (shiftKey) {
     return false;
   }
-  if (key.toLowerCase() === 'x') {
+  if (key != null && key.toLowerCase() === 'x') {
     return IS_APPLE ? metaKey : ctrlKey;
   }
 
@@ -1032,7 +1049,7 @@ export function isReturn(key: string): boolean {
   return key === 'Enter';
 }
 
-export function isBackspace(key: string): boolean {
+export function isBackspace(key: string | null): boolean {
   return key === 'Backspace';
 }
 
@@ -1040,16 +1057,18 @@ export function isEscape(key: string): boolean {
   return key === 'Escape';
 }
 
-export function isDelete(key: string): boolean {
-  return key === 'Delete';
+export function isDelete(key: string | null): boolean {
+  return key != null && key === 'Delete';
 }
 
 export function isSelectAll(
-  key: string,
+  key: string | null,
   metaKey: boolean,
   ctrlKey: boolean,
 ): boolean {
-  return key.toLowerCase() === 'a' && controlOrMeta(metaKey, ctrlKey);
+  return (
+    key != null && key.toLowerCase() === 'a' && controlOrMeta(metaKey, ctrlKey)
+  );
 }
 
 export function $selectAll(): void {


### PR DESCRIPTION
- add null check for key undefined before calling toLowerCase function
- recently see some crashes related to calling toLowercase on undefined, add null check to avoid errors