### PR TITLE
Bug Fix: Insert paragraph at table's edge inside a collapsible

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -1655,9 +1655,19 @@ function $getTableEdgeCursorPosition(
   selection: RangeSelection,
   tableNode: TableNode,
 ) {
+  const tableNodeParent = tableNode.getParent();
+  if (!tableNodeParent) {
+    return undefined;
+  }
+
+  const tableNodeParentDOM = editor.getElementByKey(tableNodeParent.getKey());
+  if (!tableNodeParentDOM) {
+    return undefined;
+  }
+
   // TODO: Add support for nested tables
   const domSelection = window.getSelection();
-  if (!domSelection || domSelection.anchorNode !== editor.getRootElement()) {
+  if (!domSelection || domSelection.anchorNode !== tableNodeParentDOM) {
     return undefined;
   }
 


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
The current logic for checking if a selection is at a table's edge fails when the table is inside a collapsible section, as it compares against the root element. This PR fixes the issue by comparing against the table's parent element instead.

**Closes:** #6157 

## Test plan

### Before


[screencast-playground.lexical.dev-2024.05.21-10_16_24.webm](https://github.com/facebook/lexical/assets/88986106/b3dc740d-20b2-4b61-b21c-40cb4533d9bc)


### After


[screencast-localhost_3002-2024.05.21-10_18_35.webm](https://github.com/facebook/lexical/assets/88986106/bf3d5705-1a27-4c65-8c1f-71ac38503144)

