### PR TITLE
[lexical-markdown] Bug Fix: add missing shouldPreserveNewLines to markdown flow

### DIFF
--- a/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
+++ b/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
@@ -69,6 +69,7 @@ declare export function $convertFromMarkdownString(
   markdown: string,
   transformers?: Array<Transformer>,
   node?: ElementNode,
+  shouldPreserveNewLines?: boolean,
 ): void;
 
 // TODO:
@@ -76,6 +77,7 @@ declare export function $convertFromMarkdownString(
 declare export function $convertToMarkdownString(
   transformers?: Array<Transformer>,
   node?: ElementNode,
+  shouldPreserveNewLines?: boolean,
 ): string;
 
 declare export var BOLD_ITALIC_STAR: TextFormatTransformer;


### PR DESCRIPTION
followup to https://github.com/facebook/lexical/pull/6020 , which introduces shouldPreserveNewLines flag . update the flow file to be in sync