### PR TITLE
Fixed Uncommented Code in Getting Started with React Docs

### DIFF
--- a/packages/lexical-website/docs/getting-started/react.md
+++ b/packages/lexical-website/docs/getting-started/react.md
@@ -41,7 +41,7 @@ import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
 
 const theme = {
   // Theme styling goes here
-  ...
+  //...
 }
 
 // Catch any errors that occur during Lexical updates and log them


### PR DESCRIPTION

Title:
[lexical-docs] Bug Fix: Uncommented Code in Getting Started with React Docs

Description

The current behavior includes uncommented code sections in the "Getting Started with React" documentation on the Lexical website, which can lead to confusion and potential errors for users following the guide.

This pull request addresses the issue by commenting out the placeholder code sections to ensure the code snippet is clear and functional.

Closes #6142 

## Test plan

### Before

![Screenshot 2024-05-25 003133](https://github.com/facebook/lexical/assets/123353022/d0105e20-8c70-42cf-bb02-c995971a2291)




### After

![Screenshot 2024-05-25 003249](https://github.com/facebook/lexical/assets/123353022/1d6fba9b-ef97-4e3d-843b-614cbef52224)

