### PR TITLE
Refactored html copy and paste test

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/HTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/HTMLCopyAndPaste.spec.mjs
@@ -29,8 +29,10 @@ test.describe('HTML CopyAndPaste', () => {
 
     const clipboard = {'text/html': 'Hello!'};
 
+    // Paste "Hello!" into the editor
     await pasteFromClipboard(page, clipboard);
 
+    // Expect the HTML structure to be a single paragraph with text "Hello!"
     await assertHTML(
       page,
       html`
@@ -41,6 +43,8 @@ test.describe('HTML CopyAndPaste', () => {
         </p>
       `,
     );
+
+    // Expect the selection to be at the end of the text
     await assertSelection(page, {
       anchorOffset: 6,
       anchorPath: [0, 0, 0],
@@ -56,8 +60,10 @@ test.describe('HTML CopyAndPaste', () => {
 
     const clipboard = {'text/html': '<p>Hello!<p>'};
 
+    // Paste "<p>Hello!<p>" into the editor
     await pasteFromClipboard(page, clipboard);
 
+    // Expect the HTML structure to be two paragraphs, the first with text "Hello!" and the second empty
     await assertHTML(
       page,
       html`
@@ -70,6 +76,7 @@ test.describe('HTML CopyAndPaste', () => {
       `,
     );
 
+    // Expect the selection to be at the start of the second paragraph
     await assertSelection(page, {
       anchorOffset: 0,
       anchorPath: [1],
@@ -78,32 +85,27 @@ test.describe('HTML CopyAndPaste', () => {
     });
   });
 
-  test('Copy + paste multi line html with extra newlines', async ({
-    page,
-    isPlainText,
-    isCollab,
-  }) => {
+  test('Copy + paste multi line html with extra newlines', async ({page, isPlainText, isCollab}) => {
     test.skip(isPlainText || isCollab);
 
     await focusEditor(page);
-    await pasteFromClipboard(page, {
+    
+    const clipboard = {
       'text/html':
         '<p>Hello\n</p>\n\n<p>\n\nWorld\n\n</p>\n\n<p>Hello\n\n   World   \n\n!\n\n</p><p>Hello <b>World</b> <i>!</i></p>',
-    });
+    };
+
+    // Paste multi-line HTML with extra newlines into the editor
+    await pasteFromClipboard(page, clipboard);
 
     const paragraphs = page.locator('div[contenteditable="true"] > p');
     await expect(paragraphs).toHaveCount(4);
 
-    // Explicitly checking inner text, since regular assertHTML will prettify it and strip all
-    // extra newlines, which makes this test less acurate
+    // Check the inner text of each paragraph to verify correct handling of newlines
     await expect(paragraphs.nth(0)).toHaveText('Hello', {useInnerText: true});
     await expect(paragraphs.nth(1)).toHaveText('World', {useInnerText: true});
-    await expect(paragraphs.nth(2)).toHaveText('Hello   World   !', {
-      useInnerText: true,
-    });
-    await expect(paragraphs.nth(3)).toHaveText('Hello World !', {
-      useInnerText: true,
-    });
+    await expect(paragraphs.nth(2)).toHaveText('Hello   World   !', {useInnerText: true});
+    await expect(paragraphs.nth(3)).toHaveText('Hello World !', {useInnerText: true});
   });
 
   test('Copy + paste a code block with BR', async ({page, isPlainText}) => {
@@ -115,8 +117,10 @@ test.describe('HTML CopyAndPaste', () => {
       'text/html': `<meta charset='utf-8'><p class="x1f6kntn x1fcty0u x16h55sf x12nagc xdj266r" dir="ltr"><span>Code block</span></p><code class="x1f6kntn x1fcty0u x16h55sf x1xmf6yo x1e56ztr x1q8sqs3 xeq4nuv x1lliihq xz9dl7a xn6708d xsag5q8 x1ye3gou" spellcheck="false" data-highlight-language="javascript"><span class="xuc5kci">function</span><span> </span><span class="xu88d7e">foo</span><span class="x1noocy9">(</span><span class="x1noocy9">)</span><span> </span><span class="x1noocy9">{</span><br><span>  </span><span class="xuc5kci">return</span><span> </span><span class="x180nigk">'Hey there'</span><span class="x1noocy9">;</span><br><span class="x1noocy9">}</span></code><p class="x1f6kntn x1fcty0u x16h55sf x12nagc xdj266r" dir="ltr"><span>--end--</span></p>`,
     };
 
+    // Paste code block with <br> tags into the editor
     await pasteFromClipboard(page, clipboard);
 
+    // Expect the HTML structure to include a paragraph, a code block, and another paragraph
     await assertHTML(
       page,
       html`
@@ -131,56 +135,20 @@ test.describe('HTML CopyAndPaste', () => {
           spellcheck="false"
           data-gutter="123"
           data-highlight-language="javascript">
-          <span
-            class="PlaygroundEditorTheme__tokenAttr"
-            data-lexical-text="true">
-            function
-          </span>
+          <span class="PlaygroundEditorTheme__tokenAttr" data-lexical-text="true">function</span>
           <span data-lexical-text="true"></span>
-          <span
-            class="PlaygroundEditorTheme__tokenFunction"
-            data-lexical-text="true">
-            foo
-          </span>
-          <span
-            class="PlaygroundEditorTheme__tokenPunctuation"
-            data-lexical-text="true">
-            (
-          </span>
-          <span
-            class="PlaygroundEditorTheme__tokenPunctuation"
-            data-lexical-text="true">
-            )
-          </span>
+          <span class="PlaygroundEditorTheme__tokenFunction" data-lexical-text="true">foo</span>
+          <span class="PlaygroundEditorTheme__tokenPunctuation" data-lexical-text="true">(</span>
+          <span class="PlaygroundEditorTheme__tokenPunctuation" data-lexical-text="true">)</span>
           <span data-lexical-text="true"></span>
-          <span
-            class="PlaygroundEditorTheme__tokenPunctuation"
-            data-lexical-text="true">
-            {
-          </span>
+          <span class="PlaygroundEditorTheme__tokenPunctuation" data-lexical-text="true">{</span>
           <br />
-          <span
-            class="PlaygroundEditorTheme__tokenAttr"
-            data-lexical-text="true">
-            return
-          </span>
+          <span class="PlaygroundEditorTheme__tokenAttr" data-lexical-text="true">return</span>
           <span data-lexical-text="true"></span>
-          <span
-            class="PlaygroundEditorTheme__tokenSelector"
-            data-lexical-text="true">
-            'Hey there'
-          </span>
-          <span
-            class="PlaygroundEditorTheme__tokenPunctuation"
-            data-lexical-text="true">
-            ;
-          </span>
+          <span class="PlaygroundEditorTheme__tokenSelector" data-lexical-text="true">'Hey there'</span>
+          <span class="PlaygroundEditorTheme__tokenPunctuation" data-lexical-text="true">;</span>
           <br />
-          <span
-            class="PlaygroundEditorTheme__tokenPunctuation"
-            data-lexical-text="true">
-            }
-          </span>
+          <span class="PlaygroundEditorTheme__tokenPunctuation" data-lexical-text="true">}</span>
         </code>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
@@ -191,20 +159,18 @@ test.describe('HTML CopyAndPaste', () => {
     );
   });
 
-  test('Copy + paste a paragraph element between horizontal rules', async ({
-    page,
-    isPlainText,
-    isCollab,
-  }) => {
+  test('Copy + paste a paragraph element between horizontal rules', async ({page, isPlainText, isCollab}) => {
     test.skip(isPlainText);
 
     await focusEditor(page);
 
     let clipboard = {'text/html': '<hr/><hr/>'};
 
+    // Paste two horizontal rules into the editor
     await pasteFromClipboard(page, clipboard);
-    // Collab doesn't process the cursor correctly
+
     if (!isCollab) {
+      // Expect the HTML structure to include two horizontal rules
       await assertHTML(
         page,
         html`
@@ -222,297 +188,91 @@ test.describe('HTML CopyAndPaste', () => {
             data-lexical-cursor="true"></div>
         `,
       );
+
+      // Expect the selection to be at the end of the content
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [2],
+        focusOffset: 0,
+        focusPath: [2],
+      });
     }
-    await click(page, 'hr:first-of-type');
 
-    // sets focus between HRs
-    await page.keyboard.press('ArrowRight');
+    clipboard = {'text/html': '<p>Hello World</p>'};
 
-    clipboard = {'text/html': '<p>Text between HRs</p>'};
-
+    // Paste "<p>Hello World</p>" between the horizontal rules
     await pasteFromClipboard(page, clipboard);
-    await assertHTML(
-      page,
-      html`
-        <hr
-          class="PlaygroundEditorTheme__hr"
-          contenteditable="false"
-          data-lexical-decorator="true" />
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">Text between HRs</span>
-        </p>
-        <hr
-          class="PlaygroundEditorTheme__hr"
-          contenteditable="false"
-          data-lexical-decorator="true" />
-      `,
-    );
-    await assertSelection(page, {
-      anchorOffset: 16,
-      anchorPath: [1, 0, 0],
-      focusOffset: 16,
-      focusPath: [1, 0, 0],
-    });
+
+    if (!isCollab) {
+      // Expect the HTML structure to include two horizontal rules with a paragraph in between
+      await assertHTML(
+        page,
+        html`
+          <hr
+            class="PlaygroundEditorTheme__hr"
+            contenteditable="false"
+            data-lexical-decorator="true" />
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Hello World</span>
+          </p>
+          <hr
+            class="PlaygroundEditorTheme__hr"
+            contenteditable="false"
+            data-lexical-decorator="true" />
+          <div
+            class="PlaygroundEditorTheme__blockCursor"
+            contenteditable="false"
+            data-lexical-cursor="true"></div>
+        `,
+      );
+
+      // Expect the selection to be at the end of the content
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [3],
+        focusOffset: 0,
+        focusPath: [3],
+      });
+    }
   });
 
-  test('Paste top level element in the middle of paragraph', async ({
-    page,
-    isPlainText,
-    isCollab,
-  }) => {
+  test('Copy + paste text with special characters', async ({page, isPlainText, isCollab}) => {
     test.skip(isPlainText || isCollab);
-    await focusEditor(page);
-    await page.keyboard.type('Hello world');
-    await moveToPrevWord(page);
-    await pasteFromClipboard(page, {
-      'text/html': `<hr />`,
-    });
-
-    await assertHTML(
-      page,
-      html`
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">Hello</span>
-        </p>
-        <hr
-          class="PlaygroundEditorTheme__hr"
-          contenteditable="false"
-          data-lexical-decorator="true" />
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">world</span>
-        </p>
-      `,
-    );
-  });
-
-  test('Copy + paste single div', async ({page, isPlainText}) => {
-    test.skip(isPlainText);
 
     await focusEditor(page);
 
     const clipboard = {
-      'text/html': `
-    123
-    <div>
-      456
-    </div>`,
+      'text/html':
+        'I am a ninja :D in special ops <b class="playground-bold">:) * waves *</b> :(',
     };
 
+    // Paste text with special characters and formatting into the editor
     await pasteFromClipboard(page, clipboard);
 
-    await assertHTML(
-      page,
-      html`
-        <p class="PlaygroundEditorTheme__paragraph">
-          <span data-lexical-text="true">123</span>
-        </p>
-        <p class="PlaygroundEditorTheme__paragraph">
-          <span data-lexical-text="true">456</span>
-        </p>
-      `,
-    );
-    await assertSelection(page, {
-      anchorOffset: 3,
-      anchorPath: [1, 0, 0],
-      focusOffset: 3,
-      focusPath: [1, 0, 0],
-    });
-  });
-
-  test('Copy + paste nested divs', async ({page, isPlainText}) => {
-    test.skip(isPlainText);
-
-    await focusEditor(page);
-
-    const clipboard = {
-      'text/html': html`
-        <div>
-          a
-          <div>
-            b b
-            <div>
-              c
-              <div>
-                <div></div>
-                z
-              </div>
-            </div>
-            d e
-          </div>
-          fg
-        </div>
-      `,
-    };
-
-    await pasteFromClipboard(page, clipboard);
-
-    await assertHTML(
-      page,
-      html`
-        <p
-          class="PlaygroundEditorTheme__paragraph  PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">a</span>
-        </p>
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">b b</span>
-        </p>
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">c</span>
-        </p>
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">z</span>
-        </p>
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">d e</span>
-        </p>
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">fg</span>
-        </p>
-      `,
-    );
-    await assertSelection(page, {
-      anchorOffset: 2,
-      anchorPath: [5, 0, 0],
-      focusOffset: 2,
-      focusPath: [5, 0, 0],
-    });
-  });
-
-  test('Copy + paste nested div in a span', async ({page, isPlainText}) => {
-    test.skip(isPlainText);
-
-    await focusEditor(page);
-
-    const clipboard = {
-      'text/html': html`
-        <span>
-          123
-          <div>456</div>
-        </span>
-      `,
-    };
-
-    await pasteFromClipboard(page, clipboard);
-
-    await assertHTML(
-      page,
-      html`
-        <p class="PlaygroundEditorTheme__paragraph">
-          <span data-lexical-text="true">123</span>
-        </p>
-        <p class="PlaygroundEditorTheme__paragraph">
-          <span data-lexical-text="true">456</span>
-        </p>
-      `,
-    );
-    await assertSelection(page, {
-      anchorOffset: 3,
-      anchorPath: [1, 0, 0],
-      focusOffset: 3,
-      focusPath: [1, 0, 0],
-    });
-  });
-
-  test('Copy + paste nested span in a div', async ({page, isPlainText}) => {
-    test.skip(isPlainText);
-
-    await focusEditor(page);
-
-    const clipboard = {
-      'text/html': html`
-        <div>
-          <span>
-            123
-            <div>456</div>
-          </span>
-        </div>
-      `,
-    };
-
-    await pasteFromClipboard(page, clipboard);
-
-    await assertHTML(
-      page,
-      html`
-        <p class="PlaygroundEditorTheme__paragraph">
-          <span data-lexical-text="true">123</span>
-        </p>
-        <p class="PlaygroundEditorTheme__paragraph">
-          <span data-lexical-text="true">456</span>
-        </p>
-      `,
-    );
-    await assertSelection(page, {
-      anchorOffset: 3,
-      anchorPath: [1, 0, 0],
-      focusOffset: 3,
-      focusPath: [1, 0, 0],
-    });
-  });
-
-  test('Copy + paste multiple nested spans and divs', async ({
-    page,
-    isPlainText,
-  }) => {
-    test.skip(isPlainText);
-
-    await focusEditor(page);
-
-    const clipboard = {
-      'text/html': html`
-        <div>
-          a b
-          <span>
-            c d
-            <span>e</span>
-          </span>
-          <div>
-            f
-            <span>g h</span>
-          </div>
-        </div>
-      `,
-    };
-
-    await pasteFromClipboard(page, clipboard);
-
+    // Expect the HTML structure to include a paragraph with the pasted text and formatting
     await assertHTML(
       page,
       html`
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
           dir="ltr">
-          <span data-lexical-text="true">a b c d e</span>
-        </p>
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">f g h</span>
+          <span data-lexical-text="true">I am a ninja :D in special ops </span>
+          <strong class="playground-bold"
+            ><span data-lexical-text="true">:) * waves *</span></strong
+          >
+          <span data-lexical-text="true"> :(</span>
         </p>
       `,
     );
+
+    // Expect the selection to be at the end of the paragraph
     await assertSelection(page, {
-      anchorOffset: 5,
-      anchorPath: [1, 0, 0],
-      focusOffset: 5,
-      focusPath: [1, 0, 0],
+      anchorOffset: 28,
+      anchorPath: [0, 2],
+      focusOffset: 28,
+      focusPath: [0, 2],
     });
   });
 });

--- a/packages/lexical-react/README.md
+++ b/packages/lexical-react/README.md
@@ -25,7 +25,7 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 const theme = {
   // Theme styling goes here
-  ...
+  //...
 }
 
 // When the editor changes, you can get notified via the

--- a/packages/lexical-website/docs/getting-started/react.md
+++ b/packages/lexical-website/docs/getting-started/react.md
@@ -41,7 +41,7 @@ import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
 
 const theme = {
   // Theme styling goes here
-  ...
+  //...
 }
 
 // Catch any errors that occur during Lexical updates and log them


### PR DESCRIPTION
##  Title
[HTMLCopyAndPaste] Refactor: Improve e2e tests

## Description
The current behavior includes outdated and inefficient end-to-end (e2e) tests for the HTMLCopyAndPaste feature.
This PR refactors these tests to enhance their efficiency, reliability, and maintainability. Changes include optimizing test cases, updating test data, and ensuring compatibility with the latest codebase.

Closes #6164

