### PR TITLE
Remove surplus argument of shared invariant function

### DIFF
--- a/packages/shared/src/invariant.ts
+++ b/packages/shared/src/invariant.ts
@@ -11,8 +11,7 @@
 // in flow itself, so we can't name it anything else.
 export default function invariant(
   cond?: boolean,
-  message?: string,
-  ...args: string[]
+  message?: string
 ): asserts cond {
   if (cond) {
     return;


### PR DESCRIPTION

[shared] Refactor: Remove surplus invariant function argument

I started to analyze the source code of Lexical in order to advance my skills as a developer and also to get familiar with the project to be able to contribute to it, since it is amazing to me. This is my fist time to actually try to PR in the open source community, so please tell me If I am done something wrong. In the code analyzing, I found an unused function argument in the shared function "invariant", so I deleted it. 