### PR TITLE
Refactor import paths in LexicalEditorState

### DIFF
--- a/packages/lexical/src/LexicalEditorState.ts
+++ b/packages/lexical/src/LexicalEditorState.ts
@@ -14,7 +14,6 @@ import type {SerializedRootNode} from './nodes/LexicalRootNode';
 
 import invariant from 'shared/invariant';
 
-
 import {readEditorState} from './LexicalUpdates';
 import {$getRoot} from './LexicalUtils';
 import {$isElementNode} from './nodes/LexicalElementNode';

--- a/packages/lexical/src/LexicalEditorState.ts
+++ b/packages/lexical/src/LexicalEditorState.ts
@@ -9,13 +9,15 @@
 import type {LexicalEditor} from './LexicalEditor';
 import type {LexicalNode, NodeMap, SerializedLexicalNode} from './LexicalNode';
 import type {BaseSelection} from './LexicalSelection';
+import type {SerializedElementNode} from './nodes/LexicalElementNode';
 import type {SerializedRootNode} from './nodes/LexicalRootNode';
 
 import invariant from 'shared/invariant';
 
-import {$isElementNode, SerializedElementNode} from '.';
+
 import {readEditorState} from './LexicalUpdates';
 import {$getRoot} from './LexicalUtils';
+import {$isElementNode} from './nodes/LexicalElementNode';
 import {$createRootNode} from './nodes/LexicalRootNode';
 
 export interface SerializedEditorState<


### PR DESCRIPTION
[lexical] Refactor: Change import paths syntax in LexicalEditorState

Description

The current behavior implements not consistent import approaches which can lead to confusion.

This pull request addresses the issue by using consistent import syntax to make it easier to understand
which module is from where imported.
