### PR TITLE
Collapsible as div

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1452,7 +1452,7 @@ test.describe('Tables', () => {
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-              <details class="Collapsible__container" open="">
+              <div class="Collapsible__container">
                 <summary class="Collapsible__title">
                   <p class="PlaygroundEditorTheme__paragraph">
                     <span data-lexical-text="true">123</span>
@@ -1466,7 +1466,7 @@ test.describe('Tables', () => {
                   <p class="PlaygroundEditorTheme__paragraph"><br /></p>
                   <p class="PlaygroundEditorTheme__paragraph"><br /></p>
                 </div>
-              </details>
+              </div>
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
             <th
@@ -1489,7 +1489,7 @@ test.describe('Tables', () => {
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-              <details class="Collapsible__container" open="">
+              <div class="Collapsible__container">
                 <summary class="Collapsible__title">
                   <p class="PlaygroundEditorTheme__paragraph">
                     <span data-lexical-text="true">123</span>
@@ -1498,7 +1498,7 @@ test.describe('Tables', () => {
                 <div class="Collapsible__content">
                   <p class="PlaygroundEditorTheme__paragraph"><br /></p>
                 </div>
-              </details>
+              </div>
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
             <th

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1427,6 +1427,7 @@ test.describe('Tables', () => {
     page,
     isPlainText,
     isCollab,
+    browserName,
   }) => {
     await initialize({isCollab, page});
     test.skip(isPlainText);
@@ -1443,6 +1444,13 @@ test.describe('Tables', () => {
     await page.keyboard.press('Enter');
     await page.keyboard.press('Enter');
 
+    const collapsibleOpeningTag =
+      browserName === 'chromium'
+        ? '<div class="Collapsible__container">'
+        : '<details class="Collapsible__container" open="">';
+    const collapsibleClosingTag =
+      browserName === 'chromium' ? '</div>' : '</details>';
+
     await assertHTML(
       page,
       html`
@@ -1452,21 +1460,21 @@ test.describe('Tables', () => {
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-              <div class="Collapsible__container">
-                <summary class="Collapsible__title">
-                  <p class="PlaygroundEditorTheme__paragraph">
-                    <span data-lexical-text="true">123</span>
-                  </p>
-                </summary>
-                <div class="Collapsible__content">
-                  <p class="PlaygroundEditorTheme__paragraph">
-                    <span data-lexical-text="true">123</span>
-                  </p>
-                  <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-                  <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-                  <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-                </div>
+              ${collapsibleOpeningTag}
+              <summary class="Collapsible__title">
+                <p class="PlaygroundEditorTheme__paragraph">
+                  <span data-lexical-text="true">123</span>
+                </p>
+              </summary>
+              <div class="Collapsible__content">
+                <p class="PlaygroundEditorTheme__paragraph">
+                  <span data-lexical-text="true">123</span>
+                </p>
+                <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+                <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+                <p class="PlaygroundEditorTheme__paragraph"><br /></p>
               </div>
+              ${collapsibleClosingTag}
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
             <th
@@ -1489,16 +1497,16 @@ test.describe('Tables', () => {
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-              <div class="Collapsible__container">
-                <summary class="Collapsible__title">
-                  <p class="PlaygroundEditorTheme__paragraph">
-                    <span data-lexical-text="true">123</span>
-                  </p>
-                </summary>
-                <div class="Collapsible__content">
-                  <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-                </div>
+              ${collapsibleOpeningTag}
+              <summary class="Collapsible__title">
+                <p class="PlaygroundEditorTheme__paragraph">
+                  <span data-lexical-text="true">123</span>
+                </p>
+              </summary>
+              <div class="Collapsible__content">
+                <p class="PlaygroundEditorTheme__paragraph"><br /></p>
               </div>
+              ${collapsibleClosingTag}
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
             <th

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1446,7 +1446,7 @@ test.describe('Tables', () => {
 
     const collapsibleOpeningTag =
       browserName === 'chromium'
-        ? '<div class="Collapsible__container">'
+        ? '<div class="Collapsible__container" open>'
         : '<details class="Collapsible__container" open="">';
     const collapsibleClosingTag =
       browserName === 'chromium' ? '</div>' : '</details>';

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1446,7 +1446,7 @@ test.describe('Tables', () => {
 
     const collapsibleOpeningTag =
       browserName === 'chromium'
-        ? '<div class="Collapsible__container" open>'
+        ? '<div class="Collapsible__container" open="">'
         : '<details class="Collapsible__container" open="">';
     const collapsibleClosingTag =
       browserName === 'chromium' ? '</div>' : '</details>';

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -72,9 +72,10 @@ export class CollapsibleContainerNode extends ElementNode {
         'Expected contentDom to be an HTMLElement',
       );
       if (currentOpen) {
-        contentDom.style.removeProperty('display');
+        contentDom.hidden = false;
       } else {
-        contentDom.style.display = 'none';
+        // @ts-expect-error
+        contentDom.hidden = 'until-found';
       }
     }
 

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -62,6 +62,7 @@ export class CollapsibleContainerNode extends ElementNode {
     let dom: HTMLElement;
     if (IS_CHROME) {
       dom = document.createElement('div');
+      dom.setAttribute('open', '');
     } else {
       const detailsDom = document.createElement('details');
       detailsDom.open = this.__open;
@@ -92,8 +93,10 @@ export class CollapsibleContainerNode extends ElementNode {
           'Expected contentDom to be an HTMLElement',
         );
         if (currentOpen) {
+          dom.setAttribute('open', '');
           contentDom.hidden = false;
         } else {
+          dom.removeAttribute('open');
           setDomHiddenUntilFound(contentDom);
         }
       } else {

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -22,6 +22,8 @@ import {
 import {IS_CHROME} from 'shared/environment';
 import invariant from 'shared/invariant';
 
+import {setDomHiddenUntilFound} from './CollapsibleUtils';
+
 type SerializedCollapsibleContainerNode = Spread<
   {
     open: boolean;
@@ -92,8 +94,7 @@ export class CollapsibleContainerNode extends ElementNode {
         if (currentOpen) {
           contentDom.hidden = false;
         } else {
-          // @ts-expect-error
-          contentDom.hidden = 'until-found';
+          setDomHiddenUntilFound(contentDom);
         }
       } else {
         dom.open = this.__open;

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -100,7 +100,7 @@ export class CollapsibleContainerNode extends ElementNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement('div');
+    const element = document.createElement('details');
     element.classList.add('Collapsible__container');
     element.setAttribute('open', this.__open.toString());
     return {element};

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -67,7 +67,10 @@ export class CollapsibleContainerNode extends ElementNode {
     const currentOpen = this.__open;
     if (prevNode.__open !== currentOpen) {
       const contentDom = dom.children[1];
-      invariant(isHTMLElement(contentDom), 'something');
+      invariant(
+        isHTMLElement(contentDom),
+        'Expected contentDom to be an HTMLElement',
+      );
       if (currentOpen) {
         contentDom.style.removeProperty('display');
       } else {

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -12,12 +12,14 @@ import {
   DOMExportOutput,
   EditorConfig,
   ElementNode,
+  isHTMLElement,
   LexicalEditor,
   LexicalNode,
   NodeKey,
   SerializedElementNode,
   Spread,
 } from 'lexical';
+import invariant from 'shared/invariant';
 
 type SerializedCollapsibleContainerNode = Spread<
   {
@@ -53,15 +55,8 @@ export class CollapsibleContainerNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const dom = document.createElement('details');
+    const dom = document.createElement('div');
     dom.classList.add('Collapsible__container');
-    dom.open = this.__open;
-    dom.addEventListener('toggle', () => {
-      const open = editor.getEditorState().read(() => this.getOpen());
-      if (open !== dom.open) {
-        editor.update(() => this.toggleOpen());
-      }
-    });
     return dom;
   }
 
@@ -69,8 +64,15 @@ export class CollapsibleContainerNode extends ElementNode {
     prevNode: CollapsibleContainerNode,
     dom: HTMLDetailsElement,
   ): boolean {
-    if (prevNode.__open !== this.__open) {
-      dom.open = this.__open;
+    const currentOpen = this.__open;
+    if (prevNode.__open !== currentOpen) {
+      const contentDom = dom.children[1];
+      invariant(isHTMLElement(contentDom), 'something');
+      if (currentOpen) {
+        contentDom.style.removeProperty('display');
+      } else {
+        contentDom.style.display = 'none';
+      }
     }
 
     return false;
@@ -95,7 +97,7 @@ export class CollapsibleContainerNode extends ElementNode {
   }
 
   exportDOM(): DOMExportOutput {
-    const element = document.createElement('details');
+    const element = document.createElement('div');
     element.classList.add('Collapsible__container');
     element.setAttribute('open', this.__open.toString());
     return {element};

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
@@ -16,8 +16,9 @@ import {
   LexicalNode,
   SerializedElementNode,
 } from 'lexical';
+import invariant from 'shared/invariant';
 
-import {CollapsibleContainerNode} from './CollapsibleContainerNode';
+import {$isCollapsibleContainerNode} from './CollapsibleContainerNode';
 
 type SerializedCollapsibleContentNode = SerializedElementNode;
 
@@ -43,7 +44,11 @@ export class CollapsibleContentNode extends ElementNode {
     const dom = document.createElement('div');
     dom.classList.add('Collapsible__content');
     editor.getEditorState().read(() => {
-      const containerNode = this.getParentOrThrow<CollapsibleContainerNode>();
+      const containerNode = this.getParentOrThrow();
+      invariant(
+        $isCollapsibleContainerNode(containerNode),
+        'Expected parent node to be a CollapsibleContainerNode',
+      );
       if (!containerNode.__open) {
         dom.style.display = 'none';
       }

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
@@ -12,9 +12,12 @@ import {
   DOMExportOutput,
   EditorConfig,
   ElementNode,
+  LexicalEditor,
   LexicalNode,
   SerializedElementNode,
 } from 'lexical';
+
+import {CollapsibleContainerNode} from './CollapsibleContainerNode';
 
 type SerializedCollapsibleContentNode = SerializedElementNode;
 
@@ -36,9 +39,15 @@ export class CollapsibleContentNode extends ElementNode {
     return new CollapsibleContentNode(node.__key);
   }
 
-  createDOM(config: EditorConfig): HTMLElement {
+  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     const dom = document.createElement('div');
     dom.classList.add('Collapsible__content');
+    editor.getEditorState().read(() => {
+      const containerNode = this.getParentOrThrow<CollapsibleContainerNode>();
+      if (!containerNode.__open) {
+        dom.style.display = 'none';
+      }
+    });
     return dom;
   }
 

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
@@ -50,9 +50,23 @@ export class CollapsibleContentNode extends ElementNode {
         'Expected parent node to be a CollapsibleContainerNode',
       );
       if (!containerNode.__open) {
-        dom.style.display = 'none';
+        // @ts-expect-error
+        dom.hidden = 'until-found';
       }
     });
+    // @ts-expect-error
+    dom.onbeforematch = () => {
+      editor.update(() => {
+        const containerNode = this.getParentOrThrow().getLatest();
+        invariant(
+          $isCollapsibleContainerNode(containerNode),
+          'Expected parent node to be a CollapsibleContainerNode',
+        );
+        if (!containerNode.__open) {
+          containerNode.toggleOpen();
+        }
+      });
+    };
     return dom;
   }
 

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
@@ -20,6 +20,7 @@ import {IS_CHROME} from 'shared/environment';
 import invariant from 'shared/invariant';
 
 import {$isCollapsibleContainerNode} from './CollapsibleContainerNode';
+import {domOnBeforeMatch, setDomHiddenUntilFound} from './CollapsibleUtils';
 
 type SerializedCollapsibleContentNode = SerializedElementNode;
 
@@ -52,12 +53,10 @@ export class CollapsibleContentNode extends ElementNode {
           'Expected parent node to be a CollapsibleContainerNode',
         );
         if (!containerNode.__open) {
-          // @ts-expect-error
-          dom.hidden = 'until-found';
+          setDomHiddenUntilFound(dom);
         }
       });
-      // @ts-expect-error
-      dom.onbeforematch = () => {
+      domOnBeforeMatch(dom, () => {
         editor.update(() => {
           const containerNode = this.getParentOrThrow().getLatest();
           invariant(
@@ -68,7 +67,7 @@ export class CollapsibleContentNode extends ElementNode {
             containerNode.toggleOpen();
           }
         });
-      };
+      });
     }
     return dom;
   }

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
@@ -16,6 +16,7 @@ import {
   LexicalNode,
   SerializedElementNode,
 } from 'lexical';
+import {IS_CHROME} from 'shared/environment';
 import invariant from 'shared/invariant';
 
 import {$isCollapsibleContainerNode} from './CollapsibleContainerNode';
@@ -43,30 +44,32 @@ export class CollapsibleContentNode extends ElementNode {
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     const dom = document.createElement('div');
     dom.classList.add('Collapsible__content');
-    editor.getEditorState().read(() => {
-      const containerNode = this.getParentOrThrow();
-      invariant(
-        $isCollapsibleContainerNode(containerNode),
-        'Expected parent node to be a CollapsibleContainerNode',
-      );
-      if (!containerNode.__open) {
-        // @ts-expect-error
-        dom.hidden = 'until-found';
-      }
-    });
-    // @ts-expect-error
-    dom.onbeforematch = () => {
-      editor.update(() => {
-        const containerNode = this.getParentOrThrow().getLatest();
+    if (IS_CHROME) {
+      editor.getEditorState().read(() => {
+        const containerNode = this.getParentOrThrow();
         invariant(
           $isCollapsibleContainerNode(containerNode),
           'Expected parent node to be a CollapsibleContainerNode',
         );
         if (!containerNode.__open) {
-          containerNode.toggleOpen();
+          // @ts-expect-error
+          dom.hidden = 'until-found';
         }
       });
-    };
+      // @ts-expect-error
+      dom.onbeforematch = () => {
+        editor.update(() => {
+          const containerNode = this.getParentOrThrow().getLatest();
+          invariant(
+            $isCollapsibleContainerNode(containerNode),
+            'Expected parent node to be a CollapsibleContainerNode',
+          );
+          if (!containerNode.__open) {
+            containerNode.toggleOpen();
+          }
+        });
+      };
+    }
     return dom;
   }
 

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
@@ -18,6 +18,7 @@ import {
   RangeSelection,
   SerializedElementNode,
 } from 'lexical';
+import invariant from 'shared/invariant';
 
 import {$isCollapsibleContainerNode} from './CollapsibleContainerNode';
 import {$isCollapsibleContentNode} from './CollapsibleContentNode';
@@ -45,6 +46,16 @@ export class CollapsibleTitleNode extends ElementNode {
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     const dom = document.createElement('summary');
     dom.classList.add('Collapsible__title');
+    dom.addEventListener('click', () => {
+      editor.update(() => {
+        const collapsibleContainer = this.getLatest().getParentOrThrow();
+        invariant(
+          $isCollapsibleContainerNode(collapsibleContainer),
+          'something',
+        );
+        collapsibleContainer.toggleOpen();
+      });
+    });
     return dom;
   }
 

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
@@ -51,7 +51,7 @@ export class CollapsibleTitleNode extends ElementNode {
         const collapsibleContainer = this.getLatest().getParentOrThrow();
         invariant(
           $isCollapsibleContainerNode(collapsibleContainer),
-          'something',
+          'Expected parent node to be a CollapsibleContainerNode',
         );
         collapsibleContainer.toggleOpen();
       });

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
@@ -18,6 +18,7 @@ import {
   RangeSelection,
   SerializedElementNode,
 } from 'lexical';
+import {IS_CHROME} from 'shared/environment';
 import invariant from 'shared/invariant';
 
 import {$isCollapsibleContainerNode} from './CollapsibleContainerNode';
@@ -46,16 +47,18 @@ export class CollapsibleTitleNode extends ElementNode {
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     const dom = document.createElement('summary');
     dom.classList.add('Collapsible__title');
-    dom.addEventListener('click', () => {
-      editor.update(() => {
-        const collapsibleContainer = this.getLatest().getParentOrThrow();
-        invariant(
-          $isCollapsibleContainerNode(collapsibleContainer),
-          'Expected parent node to be a CollapsibleContainerNode',
-        );
-        collapsibleContainer.toggleOpen();
+    if (IS_CHROME) {
+      dom.addEventListener('click', () => {
+        editor.update(() => {
+          const collapsibleContainer = this.getLatest().getParentOrThrow();
+          invariant(
+            $isCollapsibleContainerNode(collapsibleContainer),
+            'Expected parent node to be a CollapsibleContainerNode',
+          );
+          collapsibleContainer.toggleOpen();
+        });
       });
-    });
+    }
     return dom;
   }
 

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleUtils.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleUtils.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export function setDomHiddenUntilFound(dom: HTMLElement): void {
+  // @ts-expect-error
+  dom.hidden = 'until-found';
+}
+
+export function domOnBeforeMatch(dom: HTMLElement, callback: () => void): void {
+  // @ts-expect-error
+  dom.onbeforematch = callback;
+}


### PR DESCRIPTION
_Memorial day pair coding with @ivailop7 👯_

### Why `div` vs the natively supported `details`?

Turns out that `details` is broken on Chrome. More details on the issue https://github.com/facebook/lexical/issues/5582

Selection now works well on Chrome:

https://github.com/facebook/lexical/assets/193447/e5e15246-0ef9-4853-aa5e-df018a9df373

Find still works

https://github.com/facebook/lexical/assets/193447/840b20e1-6a43-42eb-b72c-bb32212d10f2


