### PR TITLE
[lexical-dev-tools-core] Feature: Index tree view cmds

### DIFF
--- a/packages/lexical-devtools-core/src/generateContent.ts
+++ b/packages/lexical-devtools-core/src/generateContent.ts
@@ -28,8 +28,9 @@ import {
   $isParagraphNode,
   $isRangeSelection,
   $isTextNode,
-  LexicalCommand,
 } from 'lexical';
+
+import {LexicalCommandLog} from './useLexicalCommandsLog';
 
 const NON_SINGLE_WIDTH_CHARS_REPLACEMENT: Readonly<Record<string, string>> =
   Object.freeze({
@@ -86,7 +87,7 @@ const MODE_PREDICATES = [
 
 export function generateContent(
   editor: LexicalEditor,
-  commandsLog: ReadonlyArray<LexicalCommand<unknown> & {payload: unknown}>,
+  commandsLog: LexicalCommandLog,
   exportDOM: boolean,
   obfuscateText: boolean = false,
 ): string {
@@ -148,8 +149,8 @@ export function generateContent(
   res += '\n\n commands:';
 
   if (commandsLog.length) {
-    for (const {type, payload} of commandsLog) {
-      res += `\n  └ { type: ${type}, payload: ${
+    for (const {index, type, payload} of commandsLog) {
+      res += `\n  └ ${index}. { type: ${type}, payload: ${
         payload instanceof Event ? payload.constructor.name : payload
       } }`;
     }

--- a/packages/lexical-devtools-core/src/useLexicalCommandsLog.ts
+++ b/packages/lexical-devtools-core/src/useLexicalCommandsLog.ts
@@ -12,7 +12,7 @@ import {COMMAND_PRIORITY_CRITICAL, LexicalCommand} from 'lexical';
 import {useEffect, useMemo, useState} from 'react';
 
 export type LexicalCommandLog = ReadonlyArray<
-  LexicalCommand<unknown> & {payload: unknown}
+  {index: number} & LexicalCommand<unknown> & {payload: unknown}
 >;
 
 export function registerLexicalCommandLogger(

--- a/packages/lexical-devtools-core/src/useLexicalCommandsLog.ts
+++ b/packages/lexical-devtools-core/src/useLexicalCommandsLog.ts
@@ -22,15 +22,17 @@ export function registerLexicalCommandLogger(
   ) => void,
 ): () => void {
   const unregisterCommandListeners = new Set<() => void>();
-
+  let i = 0;
   for (const [command] of editor._commands) {
     unregisterCommandListeners.add(
       editor.registerCommand(
         command,
         (payload) => {
           setLoggedCommands((state) => {
+            i += 1;
             const newState = [...state];
             newState.push({
+              index: i,
               payload,
               type: command.type ? command.type : 'UNKNOWN',
             });


### PR DESCRIPTION
## Description
I always get confused which way the commands list is flowing in the debug view, so adding an index to show that clearly

it also helps show that commands listed are jumped if > 10 commands get updated in the list

## Test plan

### Before


https://github.com/facebook/lexical/assets/19604232/003f0876-027c-40ba-9b21-188f816712bc

^ not clear which direction commands are flowing


### After


https://github.com/facebook/lexical/assets/19604232/7a04cab5-13f9-4af7-a0b7-27f4c444b7b1

^ with index the list is clearer

