### PR TITLE
Revert "[lexical-plaintext] Feature: add escape key handler"

### DIFF
--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -37,7 +37,6 @@ import {
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
   KEY_ENTER_COMMAND,
-  KEY_ESCAPE_COMMAND,
   PASTE_COMMAND,
   REMOVE_TEXT_COMMAND,
   SELECT_ALL_COMMAND,
@@ -322,18 +321,6 @@ export function registerPlainText(editor: LexicalEditor): () => void {
         }
 
         return editor.dispatchCommand(INSERT_LINE_BREAK_COMMAND, false);
-      },
-      COMMAND_PRIORITY_EDITOR,
-    ),
-    editor.registerCommand(
-      KEY_ESCAPE_COMMAND,
-      () => {
-        const selection = $getSelection();
-        if (!$isRangeSelection(selection)) {
-          return false;
-        }
-        editor.blur();
-        return true;
       },
       COMMAND_PRIORITY_EDITOR,
     ),


### PR DESCRIPTION
Reverts facebook/lexical#5991

This was actually an unintended breaking change that prevented "close on Esc" and [other use cases](https://github.com/facebook/lexical/pull/5991#issuecomment-2132094564) from working correctly.