### PR TITLE
Remove emojis from emoticons plugins

### DIFF
--- a/packages/lexical-playground/src/plugins/EmojisPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/EmojisPlugin/index.ts
@@ -19,10 +19,6 @@ const emojis: Map<string, [string, string]> = new Map([
   [':D', ['emoji veryhappysmile', '😀']],
   [':(', ['emoji unhappysmile', '🙁']],
   ['<3', ['emoji heart', '❤']],
-  ['🙂', ['emoji happysmile', '🙂']],
-  ['😀', ['emoji veryhappysmile', '😀']],
-  ['🙁', ['emoji unhappysmile', '🙁']],
-  ['❤', ['emoji heart', '❤']],
 ]);
 
 function $findAndTransformEmoji(node: TextNode): null | TextNode {


### PR DESCRIPTION
This logic for just 4 emojis doesn't bring any value and the `slice(i, i + 2)` is unintentionally cutting emojis in half


https://github.com/facebook/lexical/assets/193447/2aecb625-476a-45c3-905a-80c7ab12b5c0

