### PR TITLE
[lexical] Bug Fix: mutation listener set for original node should work with the replaced node

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -445,13 +445,23 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
         replace = options.with;
         replaceWithKlass = options.withKlass || null;
       }
-      // Ensure custom nodes implement required methods.
+      // Ensure custom nodes implement required methods and replaceWithKlass is instance of base klass.
       if (__DEV__) {
         // ArtificialNode__DO_NOT_USE can get renamed, so we use the type
         const nodeType =
           Object.prototype.hasOwnProperty.call(klass, 'getType') &&
           klass.getType();
         const name = klass.name;
+
+        if (replaceWithKlass) {
+          invariant(
+            replaceWithKlass.prototype instanceof klass,
+            "%s doesn't extend the %s",
+            replaceWithKlass.name,
+            name,
+          );
+        }
+
         if (
           name !== 'RootNode' &&
           nodeType !== 'root' &&

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -833,8 +833,24 @@ export class LexicalEditor {
       );
     }
 
+    let klassToMutate = klass;
+    const replaceKlass = registeredNode.replaceWithKlass;
+    if (replaceKlass) {
+      klassToMutate = replaceKlass;
+      const registeredReplaceNode = this._nodes.get(replaceKlass.getType());
+
+      if (registeredReplaceNode === undefined) {
+        invariant(
+          false,
+          'Node %s has not been registered. Ensure node has been passed to createEditor.',
+          replaceKlass.name,
+        );
+      }
+    }
+
     const mutations = this._listeners.mutation;
-    mutations.set(listener, klass);
+    mutations.set(listener, klassToMutate);
+
     return () => {
       mutations.delete(listener);
     };

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -823,7 +823,7 @@ export class LexicalEditor {
     klass: Klass<LexicalNode>,
     listener: MutationListener,
   ): () => void {
-    const registeredNode = this._nodes.get(klass.getType());
+    let registeredNode = this._nodes.get(klass.getType());
 
     if (registeredNode === undefined) {
       invariant(
@@ -834,12 +834,14 @@ export class LexicalEditor {
     }
 
     let klassToMutate = klass;
-    const replaceKlass = registeredNode.replaceWithKlass;
-    if (replaceKlass) {
-      klassToMutate = replaceKlass;
-      const registeredReplaceNode = this._nodes.get(replaceKlass.getType());
 
-      if (registeredReplaceNode === undefined) {
+    let replaceKlass: Klass<LexicalNode> | null = null;
+    while ((replaceKlass = registeredNode.replaceWithKlass)) {
+      klassToMutate = replaceKlass;
+
+      registeredNode = this._nodes.get(replaceKlass.getType());
+
+      if (registeredNode === undefined) {
         invariant(
           false,
           'Node %s has not been registered. Ensure node has been passed to createEditor.',


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

Based on the https://github.com/facebook/lexical/pull/6089 (this one adds tests)

Closes #4498

## Test plan

see tests!