### PR TITLE
[Lexical][CI] Remove measuring running time as its not giving any meaningful info

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -49,6 +49,7 @@ function sizeLimitConfig(pkg) {
   return {
     path: alias[pkg],
     modifyWebpackConfig,
+    running: false,
   };
 }
 


### PR DESCRIPTION
Remove measuring running time as its not giving any meaningful info when running size-limit workflow