### PR TITLE
Remove noisy running time signal mentioned in #6137

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,6 +1,5 @@
 name: 'Bundles'
 on:
-  pull_request:
   pull_request_target:
     branches:
       - main

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,8 +1,7 @@
 name: 'Bundles'
 on:
-  pull_request_target:
-    branches:
-      - main
+  pull_request:
+
 jobs:
   size-limit:
     runs-on: ubuntu-latest

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,7 +1,8 @@
 name: 'Bundles'
 on:
-  pull_request:
-
+  pull_request_target:
+    branches:
+      - main
 jobs:
   size-limit:
     runs-on: ubuntu-latest

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -49,6 +49,7 @@ function sizeLimitConfig(pkg) {
   return {
     path: alias[pkg],
     modifyWebpackConfig,
+    running: false,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "postversion": "git checkout -b ${npm_package_version}__release && npm run update-version && npm install && npm run update-packages && npm run extract-codes && npm run update-changelog && git add -A && git commit -m v${npm_package_version} && git tag -a v${npm_package_version} -m v${npm_package_version}",
     "publish-extension": "npm run zip -w @lexical/devtools && npm run publish -w @lexical/devtools",
     "release": "npm run prepare-release && node ./scripts/npm/release.js",
-    "size": "npm run build && size-limit"
+    "size": "npm run build-prod && size-limit"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "postversion": "git checkout -b ${npm_package_version}__release && npm run update-version && npm install && npm run update-packages && npm run extract-codes && npm run update-changelog && git add -A && git commit -m v${npm_package_version} && git tag -a v${npm_package_version} -m v${npm_package_version}",
     "publish-extension": "npm run zip -w @lexical/devtools && npm run publish -w @lexical/devtools",
     "release": "npm run prepare-release && node ./scripts/npm/release.js",
-    "size": "npm run build-prod && size-limit"
+    "size": "npm run build && size-limit"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",


### PR DESCRIPTION
## WHAT
- Remove noisy running time signal mentioned in #6137 for now, as its NOT useful
- Remove duplicate triggers for pull-request-target and pull-request


## NOTE: 
the given PR workflow "comments" updated to have "running-time" as we are using pull-request-target instead of pull-request, it runs workflow against main branch not current branch. Tested the change locally using pull-request workflow trigger and updated the screenshot below

Before:
<img width="854" alt="Screenshot 2024-05-30 at 11 52 35 AM" src="https://github.com/facebook/lexical/assets/163521239/c46ed685-6d2d-4117-a8f1-00b2d362d8e8">

After:

<img width="975" alt="Screenshot 2024-05-30 at 11 46 25 AM" src="https://github.com/facebook/lexical/assets/163521239/6c220fd5-58a4-4783-a6e7-b6cb5e333708">


