### PR TITLE
[lexical-devtools] Chore: Safari App Store review fixes

### DIFF
--- a/packages/lexical-devtools/safari-xcode/Lexical Developer Tools/Lexical Developer Tools/ViewController.swift
+++ b/packages/lexical-devtools/safari-xcode/Lexical Developer Tools/Lexical Developer Tools/ViewController.swift
@@ -9,7 +9,7 @@ import Cocoa
 import SafariServices
 import WebKit
 
-let extensionBundleIdentifier = "dev.lexical.Lexical-Developer-Tools.Extension"
+let extensionBundleIdentifier = "com.epam.lexical.developerTools.safariExt"
 
 class ViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHandler {
 

--- a/packages/lexical-website/docs/getting-started/devtools.md
+++ b/packages/lexical-website/docs/getting-started/devtools.md
@@ -4,6 +4,8 @@ sidebar_label: "Developer Tools"
 
 # Lexical Developer Tools
 
+## Extension
+
 The easiest way to debug websites built with Lexical is to install the Lexical Developer Tools browser extension. It is available for several popular browsers:
 
 
@@ -21,3 +23,12 @@ The easiest way to debug websites built with Lexical is to install the Lexical D
 Now, if you visit a website built with Lexical (such as [https://playground.lexical.dev/](https://playground.lexical.dev/)), you will see the _Lexical_ panel in your browser Inspector window.
 
 <img src="/img/docs/devtools-demo.png" width="460" alt="Lexical Developer Tools Demo screenshot">
+
+## Extension Support
+
+Feel free to reach out to us for support, or just to chat, at <a href="mailto:EPAM-lexical-support@epam.com">EPAM-lexical-support@epam.com</a> or via our [community channels](/community).
+
+Legal information:
+
+- <a href="https://opensource.facebook.com/legal/privacy/" rel="noreferrer noopener" target="_blank">Meta Open Source - Privacy Policy</a>
+- <a href="https://opensource.facebook.com/legal/terms/" rel="noreferrer noopener" target="_blank">Meta Open Source - Terms of Use</a>


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

- Fix: When clicked on ”Quit and Open Safari Extensions Preferences”, it quits the app but did not launch Safari Extensions Preferences Panel.
- Added devtools extension specific support section to Lexical website as per Apple's requirements

## Test plan

See website preview