### PR TITLE
[Lexical][Size-Checks] Measure both cjs/esm builds for regression checks

### DIFF
--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - 'packages/lexical-website/**'
       - 'packages/*/README.md'
+      - '.size-limit.js'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -37,10 +37,11 @@ const getAliasType = (type) =>
     packagesManager.getPublicPackages().flatMap((pkg) =>
       pkg.getNormalizedNpmModuleExportEntries().map(([k, v]) => {
         switch (type) {
-          case 'development':
-            return [k, pkg.resolve('dist', v.require.development)];
-          case 'production':
-            return [k, pkg.resolve('dist', v.require.production)];
+          case 'esm':
+            return [
+              k,
+              pkg.resolve('dist', v.require.default.replace('.js', '.mjs')),
+            ];
           default:
             return [k, pkg.resolve('dist', v.require.default)];
         }
@@ -52,7 +53,7 @@ const modifyWebpackConfigForType = (config, alias) =>
   Object.assign(config, {resolve: {alias}});
 
 function sizeLimitConfig(pkg) {
-  return ['development', 'production'].map((type) => {
+  return ['cjs', 'esm'].map((type) => {
     const aliasType = getAliasType(type);
     return {
       path:
@@ -72,9 +73,9 @@ function sizeLimitConfig(pkg) {
 /**
  * These are the packages that were measured previously in #3600
  * We could consider adding more packages and/or also measuring
- * other build combinations such as esbuild/webpack, mjs/cjs etc.
+ * other build combinations such as esbuild/webpack.
  *
- * The current configuration measures only: webpack + cjs + dev/prod.
+ * The current configuration measures only: webpack + esm/cjs.
  *
  */
 module.exports = [

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -32,47 +32,54 @@ const path = require('node:path');
  * as that is what was measured previously in #3600.
  */
 const {packagesManager} = require('./scripts/shared/packagesManager');
-const alias = Object.fromEntries(
-  packagesManager
-    .getPublicPackages()
-    .flatMap((pkg) =>
-      pkg
-        .getNormalizedNpmModuleExportEntries()
-        .map(([k, v]) => [k, pkg.resolve('dist', v.require.default)]),
+const getAliasType = (type) =>
+  Object.fromEntries(
+    packagesManager.getPublicPackages().flatMap((pkg) =>
+      pkg.getNormalizedNpmModuleExportEntries().map(([k, v]) => {
+        switch (type) {
+          case 'development':
+            return [k, pkg.resolve('dist', v.require.development)];
+          case 'production':
+            return [k, pkg.resolve('dist', v.require.production)];
+          default:
+            return [k, pkg.resolve('dist', v.require.default)];
+        }
+      }),
     ),
-);
+  );
 
-const extendConfig = {resolve: {alias}};
-const modifyWebpackConfig = (config) => Object.assign(config, extendConfig);
+const modifyWebpackConfigForType = (config, alias) =>
+  Object.assign(config, {resolve: {alias}});
 
 function sizeLimitConfig(pkg) {
-  return {
-    path:
-      alias[pkg] != null
-        ? alias[pkg]
-        : Object.keys(alias)
-            .filter((k) => k.startsWith(pkg))
-            .map((k) => alias[k]),
-    modifyWebpackConfig,
-    running: false,
-    name: pkg,
-  };
+  return ['development', 'production'].map((type) => {
+    const aliasType = getAliasType(type);
+    return {
+      path:
+        aliasType[pkg] != null
+          ? aliasType[pkg]
+          : Object.keys(aliasType)
+              .filter((k) => k.startsWith(pkg))
+              .map((k) => aliasType[k]),
+      modifyWebpackConfig: (config) =>
+        modifyWebpackConfigForType(config, aliasType),
+      running: false,
+      name: pkg + ' - ' + type,
+    };
+  });
 }
 
 /**
  * These are the packages that were measured previously in #3600
  * We could consider adding more packages and/or also measuring
- * other build combinations such as esbuild/webpack, mjs/cjs, dev/prod, etc.
+ * other build combinations such as esbuild/webpack, mjs/cjs etc.
  *
- * The current configuration measures only: webpack + cjs + prod.
+ * The current configuration measures only: webpack + cjs + dev/prod.
  *
- * In order to also measure dev, we would want to change the size script in
- * package.json to run build-release instead of build-prod so both
- * dev and prod artifacts would be available.
  */
 module.exports = [
   'lexical',
   '@lexical/rich-text',
   '@lexical/plain-text',
   '@lexical/react',
-].map(sizeLimitConfig);
+].flatMap(sizeLimitConfig);

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "postversion": "git checkout -b ${npm_package_version}__release && npm run update-version && npm install && npm run update-packages && npm run extract-codes && npm run update-changelog && git add -A && git commit -m v${npm_package_version} && git tag -a v${npm_package_version} -m v${npm_package_version}",
     "publish-extension": "npm run zip -w @lexical/devtools && npm run publish -w @lexical/devtools",
     "release": "npm run prepare-release && node ./scripts/npm/release.js",
-    "size": "npm run build-prod -- --release && size-limit"
+    "size": "npm run build-prod && size-limit"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "postversion": "git checkout -b ${npm_package_version}__release && npm run update-version && npm install && npm run update-packages && npm run extract-codes && npm run update-changelog && git add -A && git commit -m v${npm_package_version} && git tag -a v${npm_package_version} -m v${npm_package_version}",
     "publish-extension": "npm run zip -w @lexical/devtools && npm run publish -w @lexical/devtools",
     "release": "npm run prepare-release && node ./scripts/npm/release.js",
-    "size": "npm run build-prod && size-limit"
+    "size": "npm run build-prod -- --release && size-limit"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",


### PR DESCRIPTION
## WHAT

follow up on #6137 

- Measure both cjs/esm build combinations for size checks
- Also ignore size-limit file from triggering extended tests run
## WHY
- Current regression checks meaure only cjs checks, enhance to check both cjs/esm changes.
- Not needed to run e2e tests for size-limit workflow updates

## Test
```
sahejk@sahejk-mbp lexical % npx size-limit
✔ Adding to empty webpack project
✔ Running JS in headless Chrome
  
  lexical - cjs
  Size:         22.5 kB with all dependencies, minified and brotlied
  Loading time: 440 ms  on slow 3G
  
  lexical - esm
  Size:         22.97 kB with all dependencies, minified and brotlied
  Loading time: 449 ms   on slow 3G
  
  @lexical/rich-text - cjs
  Size:         33.25 kB with all dependencies, minified and brotlied
  Loading time: 650 ms   on slow 3G
  
  @lexical/rich-text - esm
  Size:         23.05 kB with all dependencies, minified and brotlied
  Loading time: 451 ms   on slow 3G
  
  @lexical/plain-text - cjs
  Size:         33.21 kB with all dependencies, minified and brotlied
  Loading time: 649 ms   on slow 3G
  
  @lexical/plain-text - esm
  Size:         225 B with all dependencies, minified and brotlied
  Loading time: 10 ms on slow 3G
  
  @lexical/react - cjs
  Size:         150.4 kB with all dependencies, minified and brotlied
  Loading time: 3 s      on slow 3G
  
  @lexical/react - esm
  Size:         83.86 kB with all dependencies, minified and brotlied
  Loading time: 1.7 s    on slow 3G
  
sahejk@sahejk-mbp lexical % 
```