### PR TITLE
[*] Fix: Resolve Windows regression caused by upgrading glob

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@
 **/dist/**
 **/build/**
 **/npm/**
+!scripts/npm/**
 **/.output/**
 **/.browser-profiles/**
 **/__tests__/integration/fixtures/**

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -17,7 +17,7 @@ import {selectAll} from '../keyboardShortcuts/index.mjs';
 function findAsset(pattern) {
   const prefix = 'packages/lexical-playground/build';
   const resolvedPattern = `${prefix}/assets/${pattern}`;
-  for (const fn of glob.sync(resolvedPattern)) {
+  for (const fn of glob.sync(resolvedPattern, {windowsPathsNoEscape: true})) {
     return fn.slice(prefix.length);
   }
   throw new Error(`Missing asset at ${resolvedPattern}`);

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -18,7 +18,7 @@ function findAsset(pattern) {
   const prefix = 'packages/lexical-playground/build';
   const resolvedPattern = `${prefix}/assets/${pattern}`;
   for (const fn of glob.sync(resolvedPattern, {windowsPathsNoEscape: true})) {
-    return fn.replace('\\', '/').slice(prefix.length);
+    return fn.replaceAll('\\', '/').slice(prefix.length);
   }
   throw new Error(`Missing asset at ${resolvedPattern}`);
 }

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -18,7 +18,7 @@ function findAsset(pattern) {
   const prefix = 'packages/lexical-playground/build';
   const resolvedPattern = `${prefix}/assets/${pattern}`;
   for (const fn of glob.sync(resolvedPattern, {windowsPathsNoEscape: true})) {
-    return fn.slice(prefix.length);
+    return fn.replace('\\', '/').slice(prefix.length);
   }
   throw new Error(`Missing asset at ${resolvedPattern}`);
 }

--- a/packages/lexical-website/plugins/package-docs/index.js
+++ b/packages/lexical-website/plugins/package-docs/index.js
@@ -36,9 +36,13 @@ module.exports = async function (context, options) {
     loadContent: () => {
       fs.mkdirSync(options.targetDir, {recursive: true});
       const oldTargets = new Set(
-        glob.sync(path.resolve(options.targetDir, '*.md')),
+        glob.sync(path.resolve(options.targetDir, '*.md'), {
+          windowsPathsNoEscape: true,
+        }),
       );
-      for (const srcPath of glob.sync(`${options.baseDir}/*/README.md`)) {
+      for (const srcPath of glob.sync(`${options.baseDir}/*/README.md`, {
+        windowsPathsNoEscape: true,
+      })) {
         const jsonPath = path.resolve(path.dirname(srcPath), 'package.json');
         if (!fs.existsSync(jsonPath)) {
           continue;

--- a/scripts/__tests__/integration/prepare-release.test.js
+++ b/scripts/__tests__/integration/prepare-release.test.js
@@ -27,5 +27,7 @@ describe('prepare-release tests', () => {
   }
 });
 ['examples', 'scripts/__tests__/integration/fixtures']
-  .flatMap((packagesDir) => glob.sync(`${packagesDir}/*/package.json`))
+  .flatMap((packagesDir) =>
+    glob.sync(`${packagesDir}/*/package.json`, {windowsPathsNoEscape: true}),
+  )
   .forEach((exampleJsonPath) => describeExample(exampleJsonPath));

--- a/scripts/__tests__/unit/build.test.js
+++ b/scripts/__tests__/unit/build.test.js
@@ -38,7 +38,11 @@ describe('public package.json audits (`npm run update-packages` to fix most issu
         });
       }
       it('has *.flow types', () => {
-        expect(glob.sync(pkg.resolve('flow', '*.flow'))).not.toEqual([]);
+        expect(
+          glob.sync(pkg.resolve('flow', '*.flow'), {
+            windowsPathsNoEscape: true,
+          }),
+        ).not.toEqual([]);
       });
       it('uses the expected directory/npm naming convention', () => {
         expect(npmName.replace(/^@/, '').replace('/', '-')).toBe(
@@ -118,7 +122,11 @@ describe('www public package audits (`npm run update-packages` to fix most issue
     const wwwEntrypoint = `${npmToWwwName(npmName)}.js`;
     describe(npmName, () => {
       it('has *.flow types', () => {
-        expect(glob.sync(pkg.resolve('flow', '*.flow'))).not.toEqual([]);
+        expect(
+          glob.sync(pkg.resolve('flow', '*.flow'), {
+            windowsPathsNoEscape: true,
+          }),
+        ).not.toEqual([]);
       });
       // Only worry about the entrypoint stub if it has a single module export
       if (pkg.getExportedNpmModuleNames().every((name) => name === npmName)) {

--- a/scripts/npm/prepare-release.js
+++ b/scripts/npm/prepare-release.js
@@ -31,7 +31,9 @@ function preparePackage(pkg) {
   fs.removeSync(pkg.resolve('npm'));
   fs.ensureDirSync(pkg.resolve('npm'));
   fs.copySync(pkg.resolve('dist'), pkg.resolve('npm'));
-  const flowSources = glob.sync(pkg.resolve('flow', '*.flow'));
+  const flowSources = glob.sync(pkg.resolve('flow', '*.flow'), {
+    windowsPathsNoEscape: true,
+  });
   if (flowSources.length === 0) {
     console.error(
       `Missing Flow type definitions for package ${pkg.getDirectoryName()}`,

--- a/scripts/override-react.js
+++ b/scripts/override-react.js
@@ -19,7 +19,10 @@ async function main() {
     throw new Error('USAGE: node ./scripts/override-react --version=beta');
   }
   const packages = ['react', 'react-dom'];
-  ['package.json', ...glob.sync('./packages/*/package.json')].forEach((fn) => {
+  [
+    'package.json',
+    ...glob.sync('./packages/*/package.json', {windowsPathsNoEscape: true}),
+  ].forEach((fn) => {
     const json = fs.readJsonSync(fn);
     const isRoot = fn === 'package.json';
     let didUpdate = isRoot;

--- a/scripts/shared/packagesManager.js
+++ b/scripts/shared/packagesManager.js
@@ -129,5 +129,6 @@ exports.packagesManager = new PackagesManager(
       path.dirname(path.dirname(__dirname)),
       'packages/*/package.json',
     ),
+    {windowsPathsNoEscape: true},
   ),
 );

--- a/scripts/update-tsconfig.js
+++ b/scripts/update-tsconfig.js
@@ -60,6 +60,7 @@ async function updateTsconfig({
       testPaths.push([`${pkg.getNpmName()}/src`, [resolveRelative('src')]]);
       for (const fn of glob.sync(
         pkg.resolve('src', '__tests__', 'utils', '*.{ts,tsx,mjs,jsx}'),
+        {windowsPathsNoEscape: true},
       )) {
         testPaths.push([
           `${pkg.getNpmName()}/src/__tests__/utils`,

--- a/scripts/validate-tsc-types.js
+++ b/scripts/validate-tsc-types.js
@@ -29,7 +29,7 @@ const diagnosticsHost = {
  */
 function validateTscTypes() {
   const dtsFilesPattern = './.ts-temp/packages/{lexical,lexical-*}/**/*.d.ts';
-  const dtsFiles = glob.sync(dtsFilesPattern);
+  const dtsFiles = glob.sync(dtsFilesPattern, {windowsPathsNoEscape: true});
   if (dtsFiles.length === 0) {
     console.error(
       `Missing ${dtsFilesPattern}, \`npm run build-prod\` or \`npm run build-release\` first`,

--- a/scripts/www/rewriteImports.js
+++ b/scripts/www/rewriteImports.js
@@ -22,7 +22,9 @@ const transformFlowFileContents = require('./transformFlowFileContents');
 // for each package so they can easily be copied to www.
 async function rewriteImports() {
   for (const pkg of packagesManager.getPackages()) {
-    for (const flowFile of glob.sync(pkg.resolve('flow', '*.flow'))) {
+    for (const flowFile of glob.sync(pkg.resolve('flow', '*.flow'), {
+      windowsPathsNoEscape: true,
+    })) {
       const data = fs.readFileSync(flowFile, 'utf8');
       const result = await transformFlowFileContents(data);
       fs.writeFileSync(


### PR DESCRIPTION
## Description

Upgrading glob in #6215 changed its behavior on Windows, since it now expects you to specify paths that use '/' as the path separator so that '\\' can be used for escaping glob characters unless the windowsPathsNoEscape option is specified which disables escaping of glob characters (a feature we do not use).

Hopefully #6198 works and lands soon so that this type of regression can be avoided in the future

## Test Plan

Please add the extended-tests label to this PR so that we can confirm that it works before merging

### Before

Windows e2e tests failed

### After

Windows e2e tests should succeed
