### PR TITLE
[*] Fix: size-limit report for esm modules

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -50,6 +50,7 @@ function sizeLimitConfig(pkg) {
   return ['require', 'import'].map((type) => {
     const aliasType = getAliasType(type);
     return {
+      import: '*',
       path:
         aliasType[pkg] != null
           ? aliasType[pkg]


### PR DESCRIPTION
## Description

For some reason the default configuration of size-limit for @lexical/plain-text caused nearly the whole module to be tree shaken, so nothing of interest was measured. This makes sure to test the full size of every package we are measuring.

Closes #6233

## Test plan

### Before

size-limit would report a 225 bytes for @lexical/plain-text esm

```
  @lexical/plain-text - esm
  Size:         225 B with all dependencies, minified and brotlied
  Loading time: 10 ms on slow 3G
```

### After

size-limit should report a meaningful number for @lexical/plain-text esm

```
  @lexical/plain-text - esm
  Size:         24.44 kB with all dependencies, minified and brotlied
  Loading time: 478 ms   on slow 3G
```