### PR TITLE
[lexical-table] CI: Remerge PR 6200 Resizing table with merged cells

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1753,8 +1753,8 @@ test.describe.parallel('Tables', () => {
       (actualHtml) =>
         // flaky fix: +- 1px for the height assertion
         actualHtml.replace(
-          '<tr style="height: 87px">',
           '<tr style="height: 88px">',
+          '<tr style="height: 87px">',
         ),
     );
   });

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1745,6 +1745,17 @@ test.describe.parallel('Tables', () => {
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
       `,
+      undefined,
+      {
+        ignoreClasses: false,
+        ignoreInlineStyles: false,
+      },
+      (actualHtml) =>
+        // flaky fix: +- 1px for the height assertion
+        actualHtml.replace(
+          '<tr style="height: 87px">',
+          '<tr style="height: 88px">',
+        ),
     );
   });
 

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -41,6 +41,7 @@ import {
   selectCellsFromTableCords,
   selectFromAdditionalStylesDropdown,
   selectFromAlignDropdown,
+  selectorBoundingBox,
   setBackgroundColor,
   test,
   toggleColumnHeader,
@@ -1514,6 +1515,232 @@ test.describe.parallel('Tables', () => {
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test('Resize merged cells width (1)', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    await initialize({isCollab, page});
+    test.skip(isPlainText);
+    if (IS_COLLAB) {
+      // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
+      page.setViewportSize({height: 1000, width: 3000});
+    }
+
+    await focusEditor(page);
+
+    await insertTable(page, 3, 3);
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
+    await mergeTableCells(page);
+    await click(page, 'td:nth-child(3) > .PlaygroundEditorTheme__paragraph');
+    const resizerBoundingBox = await selectorBoundingBox(
+      page,
+      '.TableCellResizer__resizer:first-child',
+    );
+    const x = resizerBoundingBox.x + resizerBoundingBox.width / 2;
+    const y = resizerBoundingBox.y + resizerBoundingBox.height / 2;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + 50, y);
+    await page.mouse.up();
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              colspan="2"
+              rowspan="2">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              style="width: 125px">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 125px">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 125px">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test('Resize merged cells width (2)', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    await initialize({isCollab, page});
+    test.skip(isPlainText);
+    if (IS_COLLAB) {
+      // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
+      page.setViewportSize({height: 1000, width: 3000});
+    }
+
+    await focusEditor(page);
+
+    await insertTable(page, 3, 3);
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
+    await mergeTableCells(page);
+    await page.locator('th').first().click();
+    const resizerBoundingBox = await selectorBoundingBox(
+      page,
+      '.TableCellResizer__resizer:first-child',
+    );
+    const x = resizerBoundingBox.x + resizerBoundingBox.width / 2;
+    const y = resizerBoundingBox.y + resizerBoundingBox.height / 2;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + 50, y);
+    await page.mouse.up();
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              colspan="2"
+              rowspan="2">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              style="width: 125px">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test('Resize merged cells height', async ({page, isPlainText, isCollab}) => {
+    await initialize({isCollab, page});
+    test.skip(isPlainText);
+    if (IS_COLLAB) {
+      // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
+      page.setViewportSize({height: 1000, width: 3000});
+    }
+
+    await focusEditor(page);
+
+    await insertTable(page, 3, 3);
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      true,
+      false,
+    );
+    await mergeTableCells(page);
+    await page.locator('th').first().click();
+    const resizerBoundingBox = await selectorBoundingBox(
+      page,
+      '.TableCellResizer__resizer:nth-child(2)',
+    );
+    const x = resizerBoundingBox.x + resizerBoundingBox.width / 2;
+    const y = resizerBoundingBox.y + resizerBoundingBox.height / 2;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x, y + 50);
+    await page.mouse.up();
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr style="height: 88px">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              colspan="2"
+              rowspan="2">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
           </tr>
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1623,7 +1623,7 @@ test.describe.parallel('Tables', () => {
       false,
     );
     await mergeTableCells(page);
-    await page.locator('th').first().click();
+    await click(page, 'th');
     const resizerBoundingBox = await selectorBoundingBox(
       page,
       '.TableCellResizer__resizer:first-child',
@@ -1696,7 +1696,7 @@ test.describe.parallel('Tables', () => {
       false,
     );
     await mergeTableCells(page);
-    await page.locator('th').first().click();
+    await click(page, 'th');
     const resizerBoundingBox = await selectorBoundingBox(
       page,
       '.TableCellResizer__resizer:nth-child(2)',

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1713,7 +1713,7 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
-          <tr style="height: 88px">
+          <tr style="height: 87px">
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
               colspan="2"

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -215,6 +215,7 @@ export async function assertHTML(
   {ignoreClasses = false, ignoreInlineStyles = false} = {},
   actualHtmlModificationsCallback,
 ) {
+  // test
   if (IS_COLLAB) {
     await Promise.all([
       assertHTMLOnPageOrFrame(

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -215,7 +215,6 @@ export async function assertHTML(
   {ignoreClasses = false, ignoreInlineStyles = false} = {},
   actualHtmlModificationsCallback,
 ) {
-  // test
   if (IS_COLLAB) {
     await Promise.all([
       assertHTMLOnPageOrFrame(
@@ -242,6 +241,7 @@ export async function assertHTML(
       ignoreClasses,
       ignoreInlineStyles,
       'page',
+      actualHtmlModificationsCallback,
     );
   }
 }

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -183,7 +183,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
           }
 
           let height = tableRow.getHeight();
-          if (!height) {
+          if (height === undefined) {
             const rowCells = tableRow.getChildren<TableCellNode>();
             height = Math.min(
               ...rowCells.map(
@@ -206,12 +206,12 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
     activeEditor: LexicalEditor,
   ): number | undefined => {
     const width = cell.getWidth();
-    if (width) {
+    if (width !== undefined) {
       return width;
     }
 
     const domCellNode = activeEditor.getElementByKey(cell.getKey());
-    if (!domCellNode) {
+    if (domCellNode == null) {
       return undefined;
     }
     const computedStyle = getComputedStyle(domCellNode);
@@ -275,7 +275,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
                   tableMap[row][columnIndex + 1].cell)
             ) {
               const width = getCellNodeWidth(cell.cell, editor);
-              if (!width) {
+              if (width === undefined) {
                 continue;
               }
               const newWidth = Math.max(width + widthChange, MIN_COLUMN_WIDTH);

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -34,6 +34,8 @@ export {
   TableRowNode,
 } from './LexicalTableRowNode';
 export type {
+  TableMapType,
+  TableMapValueType,
   TableSelection,
   TableSelectionShape,
 } from './LexicalTableSelection';


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
- the CI for e2e tests signal was missing on https://github.com/facebook/lexical/pull/6200 hence it got reverted in https://github.com/facebook/lexical/pull/6224 when e2e test failed on main
- remerge [[PR](https://github.com/facebook/lexical/pull/6200)](https://github.com/facebook/lexical/pull/6200) with test fix from https://github.com/facebook/lexical/pull/6228

Credits for the fixes goes to @AlexanderReznik , im just helping to remerge the changes



## update: fix the flaky table resize test in collab mode
added a fix for the flaky table resize test in collab mode. sometimes, the height is 87px, sometimes it is 88 px.

using the actual html modification call back introduced in https://github.com/facebook/lexical/pull/6240/commits, accept either 88 or 87 px as html output


Closes #6241

## Test plan
```
npm run start &  npm run test-e2e-chromium
```
  2 flaky
    [chromium] › packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs:109:3 › Clear All Formatting › Should preserve the default styling of hashtags and mentions 
    [chromium] › packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs:1114:3 › TextFormatting › Regression #2523: can toggle format when selecting a TextNode edge followed by a non TextNode;  
  20 skipped
  415 passed (2.7m)

