### PR TITLE
[lexical-playground] CI: skip flaky e2e tests identified by playwright

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
@@ -109,6 +109,7 @@ test.describe('Clear All Formatting', () => {
   test(`Should preserve the default styling of hashtags and mentions`, async ({
     page,
   }) => {
+    test.fixme(true, 'Flaky');
     await focusEditor(page);
 
     await page.keyboard.type('#facebook testing');

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -1117,6 +1117,7 @@ test.describe('TextFormatting', () => {
     isPlainText,
   }) => {
     test.skip(isPlainText);
+    test.fixme(true, 'Flaky');
     await focusEditor(page);
 
     await page.keyboard.type('A');


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
reduce noisy signal + save resources otherwise used to run flaky e2e tests

closes #6241

## Test plan
```
npm run start &  npm run test-e2e-chromium
```

### Before

 > Consider splitting slow test files to speed up parallel execution
  2 flaky
    [chromium] › packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs:109:3 › Clear All Formatting › Should preserve the default styling of hashtags and mentions 
    [chromium] › packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs:1114:3 › TextFormatting › Regression #2523: can toggle format when selecting a TextNode edge followed by a non TextNode;  
  20 skipped


### After

 > Consider splitting slow test files to speed up parallel execution
  22 skipped
  412 passed (2.2m)