### PR TITLE
[Lexical][CI] Add more ||ism in e2e tests to decrease overall run time

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -35,7 +35,7 @@ test.beforeEach(({isPlainText}) => {
   test.skip(isPlainText);
 });
 
-test.describe('Links', () => {
+test.describe.parallel('Links', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
   test(`Can convert a text node into a link`, async ({page}) => {
     await focusEditor(page);

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -68,7 +68,7 @@ test.beforeEach(({isPlainText}) => {
   test.skip(isPlainText);
 });
 
-test.describe('Nested List', () => {
+test.describe.parallel('Nested List', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
 
   test(`Can create a list and partially copy some content out of it`, async ({

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -49,7 +49,7 @@ async function checkHTMLExpectationsIncludingUndoRedo(
   await assertHTML(page, forwardHTML);
 }
 
-test.describe('Markdown', () => {
+test.describe.parallel('Markdown', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
   const triggersAndExpectations = [
     {
@@ -374,7 +374,7 @@ async function assertMarkdownImportExport(
   await assertHTML(page, expectedHTML);
 }
 
-test.describe('Markdown', () => {
+test.describe.parallel('Markdown', () => {
   test.beforeEach(({isCollab, isPlainText, page}) => {
     test.skip(isPlainText);
     return initialize({isCollab, page});

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -46,7 +46,7 @@ import {
   YOUTUBE_SAMPLE_URL,
 } from '../utils/index.mjs';
 
-test.describe('Selection', () => {
+test.describe.parallel('Selection', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
   test('does not focus the editor on load', async ({page}) => {
     const editorHasFocus = async () =>

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -69,7 +69,7 @@ async function fillTablePartiallyWithText(page) {
   await page.keyboard.press('c');
 }
 
-test.describe('Tables', () => {
+test.describe.parallel('Tables', () => {
   test(`Can a table be inserted from the toolbar`, async ({
     page,
     isPlainText,
@@ -152,7 +152,8 @@ test.describe('Tables', () => {
     );
   });
 
-  test.describe(`Can exit tables with the horizontal arrow keys`, () => {
+  test.describe
+    .parallel(`Can exit tables with the horizontal arrow keys`, () => {
     test(`Can exit the first cell of a non-nested table`, async ({
       page,
       isPlainText,
@@ -488,7 +489,7 @@ test.describe('Tables', () => {
     });
   });
 
-  test.describe(`Can navigate table with keyboard`, () => {
+  test.describe.parallel(`Can navigate table with keyboard`, () => {
     test(`Can navigate cells horizontally`, async ({
       page,
       isPlainText,

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -32,7 +32,7 @@ import {
   waitForSelector,
 } from '../utils/index.mjs';
 
-test.describe('TextFormatting', () => {
+test.describe.parallel('TextFormatting', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
   test(`Can create bold text using the shortcut`, async ({
     page,

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -48,5 +48,6 @@ const config = {
         timeout: 120 * 1000,
       }
     : undefined,
+  workers: 4,
 };
 module.exports = config;


### PR DESCRIPTION
## WHAT 
- Add ||ism in slow test files by changing test.describe to test.describe.parallel 
- Add ||ism in workers - in CI we were using just 1 worker while in local dev machines we use 4 workers, change to 4 workers in CI as well to make the tests run faster

https://playwright.dev/docs/test-parallel


## WHY
- Lower the running time for github workflows related to e2e tests and hence lower the spend

## Test Plan

Before: https://github.com/facebook/lexical/actions/runs/9342978263/usage?pr=6198 
~6h 


After:   https://github.com/facebook/lexical/actions/runs/9344275667/usage?pr=6237
~3h 45min