### PR TITLE
[lexical-playground] CI: skip flaky collab e2e test 

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -1963,7 +1963,7 @@ test.describe('Links', () => {
     page,
     isCollab,
   }) => {
-    test.fixme(isCollab && IS_MAC && IS_LINUX, 'Flaky on Collab, Mac + Linux');
+    test.fixme(isCollab && (IS_MAC || IS_LINUX), 'Flaky on Collab, Mac/Linux');
     await focusEditor(page);
     await page.keyboard.type('Hello ');
     await toggleBold(page);

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -25,6 +25,7 @@ import {
   html,
   initialize,
   IS_LINUX,
+  IS_MAC,
   keyDownCtrlOrMeta,
   keyUpCtrlOrMeta,
   pasteFromClipboard,
@@ -428,7 +429,9 @@ test.describe('Links', () => {
 
   test(`Can create a link with some text after, insert paragraph, then backspace, it should merge correctly`, async ({
     page,
+    isCollab,
   }) => {
+    test.fixme(isCollab, 'Flaky on Collab');
     await focusEditor(page);
     await page.keyboard.type(' abc def ');
     await moveLeft(page, 5);
@@ -1960,7 +1963,7 @@ test.describe('Links', () => {
     page,
     isCollab,
   }) => {
-    test.fixme(isCollab && IS_LINUX, 'Flaky on Linux + Collab');
+    test.fixme(isCollab && IS_MAC && IS_LINUX, 'Flaky on Collab, Mac + Linux');
     await focusEditor(page);
     await page.keyboard.type('Hello ');
     await toggleBold(page);

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -1433,7 +1433,9 @@ test.describe('Nested List', () => {
 
   test('remove list breaks when selection in empty nested list item 2', async ({
     page,
+    isCollab,
   }) => {
+    test.fixme(isCollab, 'Flaky on Collab');
     await focusEditor(page);
     await page.keyboard.type('Hello World');
     await page.keyboard.press('Enter');

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -474,8 +474,13 @@ test.describe('Selection', () => {
     );
   });
 
-  test('Can delete sibling elements forward', async ({page, isPlainText}) => {
+  test('Can delete sibling elements forward', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
     test.skip(isPlainText);
+    test.fixme(isCollab, 'Flaky on Collab');
 
     await focusEditor(page);
     await page.keyboard.press('Enter');

--- a/packages/lexical-playground/__tests__/e2e/TextEntry.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextEntry.spec.mjs
@@ -121,8 +121,11 @@ test.describe('TextEntry', () => {
   test(`Can insert a paragraph between two text nodes`, async ({
     page,
     isPlainText,
+    isCollab,
   }) => {
     test.skip(isPlainText);
+    test.fixme(isCollab, 'Flaky on Collab');
+
     await focusEditor(page);
     await page.keyboard.type('Hello ');
     await toggleBold(page);


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
eg. https://github.com/facebook/lexical/actions/runs/9322462619/job/25663598465

^ flaky collab tests failing on ci signal

disable flaky collab tests so we dont waste resources running them + reduce noise in the ci


Closes #6241

## Test plan
```
npm run test-e2e-collab-chromium   
```

run this until all flaky test skipped

>  Consider splitting slow test files to speed up parallel execution
  73 skipped
  361 passed (3.7m)