### PR TITLE
[test][Lexical][CI] Increase workers to 6 to improve run time

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -48,6 +48,6 @@ const config = {
         timeout: 120 * 1000,
       }
     : undefined,
-  workers: 4,
+  workers: 6,
 };
 module.exports = config;


### PR DESCRIPTION
## What
Increase workers to 6 to improve run time

## Why
- locally doing this does give a performance boost in overall run time for firefox tests