### PR TITLE
[lexical-playground] CI: fix flaky headings e2e test

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Headings/HeadingsEnterAtEnd.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Headings/HeadingsEnterAtEnd.spec.mjs
@@ -46,7 +46,7 @@ test(`Headings - stays as a heading when you press enter in the middle of a head
 
   await moveToEditorBeginning(page);
 
-  await moveRight(page, 5);
+  await moveRight(page, 5, 500);
 
   await page.keyboard.press('Enter');
 


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
test failing at random because enter key is pressed too soon after the last move right key press. add a 500 ms delay to fix that

Closes #6241

## Test plan

 npm run start & npm run test-e2e-collab-chromium  

### Before

```
    - Expected  - 2
    + Received  + 2

      <h1 class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr" dir="ltr">
    -   <span data-lexical-text="true">Welco</span>
    +   <span data-lexical-text="true">Welc</span>
      </h1>
      <h1 class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr" dir="ltr">
    -   <span data-lexical-text="true">me to the playground</span>
    +   <span data-lexical-text="true">ome to the playground</span>
      </h1>

  1 failed
    [chromium] › packages/lexical-playground/__tests__/e2e/Headings/HeadingsEnterAtEnd.spec.mjs:22:6 › Headings - stays as a heading when you press enter in the middle of a heading 
```


### After

  ✓  1 …adings/HeadingsEnterAtEnd.spec.mjs:22:6 › Headings - stays as a heading when you press enter in the middle of a heading (4.4s)

