### PR TITLE
[lexical-playground] CI: standardise key press delay

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Headings/HeadingsEnterAtEnd.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Headings/HeadingsEnterAtEnd.spec.mjs
@@ -9,6 +9,7 @@
 import {
   moveRight,
   moveToEditorBeginning,
+  STANDARD_KEYPRESS_DELAY_MS,
 } from '../../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
@@ -46,7 +47,7 @@ test(`Headings - stays as a heading when you press enter in the middle of a head
 
   await moveToEditorBeginning(page);
 
-  await moveRight(page, 5, 500);
+  await moveRight(page, 5, STANDARD_KEYPRESS_DELAY_MS);
 
   await page.keyboard.press('Enter');
 

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -14,6 +14,7 @@ import {
   moveToLineEnd,
   selectAll,
   selectCharacters,
+  STANDARD_KEYPRESS_DELAY_MS,
   toggleBold,
 } from '../keyboardShortcuts/index.mjs';
 import {
@@ -2042,7 +2043,7 @@ test.describe.parallel('Links', () => {
     await page.keyboard.press('ArrowRight');
     await page.keyboard.type(' world');
 
-    await moveLeft(page, 6, 100);
+    await moveLeft(page, 6, STANDARD_KEYPRESS_DELAY_MS);
 
     await page.keyboard.press('Enter');
 

--- a/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
+++ b/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
@@ -18,6 +18,8 @@ import {
   sleep,
 } from '../utils/index.mjs';
 
+export const STANDARD_KEYPRESS_DELAY_MS = 100;
+
 export async function moveToLineBeginning(page) {
   if (IS_MAC) {
     await keyDownCtrlOrMeta(page);

--- a/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
+++ b/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
@@ -18,6 +18,9 @@ import {
   sleep,
 } from '../utils/index.mjs';
 
+/**
+ * A delay value that is short enough yet not too short such that keypresses override each other.
+ */
 export const STANDARD_KEYPRESS_DELAY_MS = 100;
 
 export async function moveToLineBeginning(page) {


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
credits to @Sahejkm for pointing out that 100ms is workable as a delay https://github.com/facebook/lexical/pull/6245/files#r1625266582

introducing `const STANDARD_KEYPRESS_DELAY_MS`

- setting 100ms as a standard keypress delay const, so it can be reused and developers dont need to waste time through trial an error to find an optimal delay value
- the goal of this standard delay is to provide a delay value that is short enough yet not too short such that keypresses still override each other thus leading to flakiness
- this standard should work for most test cases. if there are outliers, a custom value can be passed as the delay instead
- open to adjusting this standard value overtime  

Closes #<!-- issue number -->

## Test plan
npm run start & npm run test-e2e-collab-chromium 

```
  Slow test file: [chromium] › packages/lexical-playground/__tests__/e2e/Mentions.spec.mjs (19.9s)
  Consider splitting slow test files to speed up parallel execution
  1 flaky
    [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1269:3 › Tables › Grid selection: can select multiple cells and insert an image 
  66 skipped
  370 passed (3.9m)
```
tests using the 100ms delay not in flaky list