### PR TITLE
[Lexical] Skip newly added flaky "Resize merged cells height/width" tests for linux/collab/firefox mode

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -34,6 +34,7 @@ import {
   insertTableColumnBefore,
   insertTableRowBelow,
   IS_COLLAB,
+  IS_LINUX,
   LEGACY_EVENTS,
   mergeTableCells,
   pasteFromClipboard,
@@ -1523,11 +1524,16 @@ test.describe.parallel('Tables', () => {
   });
 
   test('Resize merged cells width (1)', async ({
+    browserName,
     page,
     isPlainText,
     isCollab,
   }) => {
     await initialize({isCollab, page});
+    test.fixme(
+      isCollab && IS_LINUX && browserName === 'firefox',
+      'Flaky on Linux + Collab',
+    );
     test.skip(isPlainText);
     if (IS_COLLAB) {
       // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
@@ -1676,9 +1682,15 @@ test.describe.parallel('Tables', () => {
     );
   });
 
-  test('Resize merged cells height', async ({page, isPlainText, isCollab}) => {
+  test('Resize merged cells height', async ({
+    browserName,
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
     await initialize({isCollab, page});
     test.skip(isPlainText);
+    test.fixme(IS_COLLAB && IS_LINUX && browserName === 'firefox');
     if (IS_COLLAB) {
       // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
       page.setViewportSize({height: 1000, width: 3000});


### PR DESCRIPTION
## WHAT

New Table tests around "Resize merged cells height/width" added as part of #6200 , initially reverted due to failures on CI and later re-merged  as part of #6235 are still not very stable and failing occasionally in Linux/Collab/Firefox mode right now in the past runs causing CI failures.

hence disable them in Linux/Collab/Firefox for now.

## WHY
fix unstable CI 

https://github.com/facebook/lexical/actions/runs/9364458870
https://github.com/facebook/lexical/actions/runs/9352693358/job/25755810388?pr=6243


## TEST PLAN

```
Running 42 tests using 4 workers

  ✓  1 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:203:5 › Tables › Can exit tables with the horizontal arrow keys › Can exit the last cell of a non-nested table (1.3s)
  ✓  2 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:159:5 › Tables › Can exit tables with the horizontal arrow keys › Can exit the first cell of a non-nested table (1.4s)
  ✓  3 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:115:3 › Tables › Can type inside of table cell (2.1s)
  ✓  4 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:75:3 › Tables › Can a table be inserted from the toolbar (2.1s)
  ✓  5 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:248:5 › Tables › Can exit tables with the horizontal arrow keys › Can exit the first cell of a nested table into the parent table cell (964ms)
  ✓  6 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:276:5 › Tables › Can exit tables with the horizontal arrow keys › Can exit the last cell of a nested table into the parent table cell (1.1s)
  ✓  7 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:409:3 › Tables › Can type text after a table that is the last node (1.1s)
  ✓  8 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:306:3 › Tables › Can insert a paragraph after a table, that is the last node, with the "Enter" key (1.1s)
  ✓  9 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:466:3 › Tables › Can enter a table from a paragraph underneath via the left arrow key (1.1s)
  ✓  10 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:495:5 › Tables › Can navigate table with keyboard › Can navigate cells horizontally (1.4s)
  ✓  11 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:590:5 › Tables › Can navigate table with keyboard › Can navigate cells vertically (898ms)
  ✓  12 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:661:3 › Tables › Can select cells using Table selection (1.5s)
  ✓  13 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:747:3 › Tables › Can select cells using Table selection via keyboard (976ms)
  ✓  14 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:625:5 › Tables › Can navigate table with keyboard › Should not navigate cells when typeahead menu is open and focused (1.7s)
  ✓  15 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:872:3 › Tables › Can style text using Table selection (1.2s)
  ✓  16 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1103:3 › Tables › Range Selection is corrected when it contains a partial Table. (1.1s)
  ✓  17 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:963:3 › Tables › Can copy + paste (internal) using Table selection (1.3s)
  ✓  18 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1045:3 › Tables › Can clear text using Table selection (1.3s)
  ✓  19 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1155:3 › Tables › Select All when document contains tables adds custom table styles. (1.0s)
  ✓  20 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1238:3 › Tables › Horizontal rule inside cell (1.3s)
  ✓  21 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1429:3 › Tables › Can remove new lines in a collapsible section inside of a table (1.3s)
  ✓  22 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1351:3 › Tables › Grid selection: can backspace lines, backspacing empty cell does not destroy it #3278 (1.7s)
  ✓  23 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1526:3 › Tables › Resize merged cells width (1) (1.3s)
  ✓  24 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1608:3 › Tables › Resize merged cells width (2) (1.1s)
  ✓  25 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1685:3 › Tables › Resize merged cells height (1.0s)
  ✓  26 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1774:3 › Tables › Merge/unmerge cells (1) (1.2s)
  ✓  27 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1861:3 › Tables › Merge/unmerge cells (2) (1.2s)
  ✓  28 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1988:3 › Tables › Merge with content (1.1s)
  ✓  29 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:1270:3 › Tables › Grid selection: can select multiple cells and insert an image (4.5s)
  ✓  30 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2208:3 › Tables › Insert row above (with conflicting merged cell) (1.1s)
  ✓  31 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2271:3 › Tables › Insert column before (with conflicting merged cell) (1.1s)
  ✓  32 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2079:3 › Tables › Select multiple merged cells (selection expands to a rectangle) (1.3s)
  ✓  33 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2331:3 › Tables › Insert column before (with selected cell with rowspan > 1) (1.2s)
  ✓  34 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2386:3 › Tables › Insert column before (with 1+ selected cells in a row) (1.2s)
  ✓  35 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2456:3 › Tables › Delete rows (with conflicting merged cell) (1.3s)
  ✓  36 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2517:3 › Tables › Delete columns (with conflicting merged cell) (1.3s)
  ✓  37 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2578:3 › Tables › Deselect when click outside #3785 #4138 (1.1s)
  ✓  38 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2639:3 › Tables › Cell merge feature disabled (866ms)
  ✓  39 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2739:3 › Tables › Cell background color feature disabled (856ms)
  ✓  40 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2606:3 › Tables › Background color to cell (1.3s)
  ✓  41 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2782:3 › Tables › Add column header after merging cells #4378 (1.1s)
  ✓  42 [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:2876:3 › Tables › Can align text using Table selection (1.2s)

  42 passed (15.5s)

```