### PR TITLE
[lexical-eslint-plugin] Fix: Use cjs compatible export from built version

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -239,9 +239,14 @@ async function build(name, inputFile, outputPath, outputFile, isProd, format) {
     // This ensures PrismJS imports get included in the bundle
     treeshake: name !== 'Lexical Code' ? 'smallest' : false,
   };
+  /** @type {import('rollup').OutputOptions} */
   const outputOptions = {
     esModule: false,
-    exports: 'named',
+    exports:
+      // Special case for lexical-eslint-plugin which is written in cjs and
+      // requires a default export. Default exports in all other modules are
+      // deprecated.
+      name === 'Lexical Eslint Plugin' ? 'auto' : 'named',
     externalLiveBindings: false,
     file: outputFile,
     format, // change between es and cjs modules


### PR DESCRIPTION
## Description

Using the @lexical/eslint-plugin as a configuration in an external project is currently difficult in v0.16.0 because eslint won't resolve through a default property when processing "plugin:@lexical/recommended".

This happens because the compiled index.ts wrapper will always produce `exports.default = plugin` where what we want is `module.exports = plugin` due to the rollup/esbuild setting of 'named' exports (which we must use for some other modules which mix default and named exports).

Closes #6251

## Test plan

### Before

Try and add @lexical/eslint-plugin to an external project per the docs https://lexical.dev/docs/packages/lexical-eslint-plugin

```
❯ ./node_modules/.bin/eslint . && echo 0

Oops! Something went wrong! :(

ESLint: 8.57.0

ESLint couldn't find the config "plugin:@lexical/recommended" to extend from. Please check that the name of the config is correct.

The config "plugin:@lexical/recommended" was referenced from the config file in "/Users/bob/src/lexical-builder/packages/eslint-config/library.js".

If you still have problems, please stop by https://eslint.org/chat/help to chat with the team.
```

### After

```
$ ./node_modules/.bin/eslint . && echo $?
0
```