### PR TITLE
[lexical-playground] CI: fix flaky MaxLength emoji e2e test

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/MaxLength.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/MaxLength.spec.mjs
@@ -79,7 +79,7 @@ test.describe('MaxLength', () => {
     await pasteFromClipboard(page, {
       'text/plain': 'lorem ipsum dolor sit amet, consectetur adipiscing elit',
     });
-    await pressBackspace(page, 1, STANDARD_KEYPRESS_DELAY_MS);
+    await pressBackspace(page, 1);
 
     await assertHTML(
       page,
@@ -105,7 +105,7 @@ test.describe('MaxLength', () => {
       `,
     );
 
-    await pressBackspace(page, 1, STANDARD_KEYPRESS_DELAY_MS);
+    await pressBackspace(page, 1);
     await page.keyboard.type('💏');
 
     await assertHTML(

--- a/packages/lexical-playground/__tests__/e2e/MaxLength.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/MaxLength.spec.mjs
@@ -79,7 +79,7 @@ test.describe('MaxLength', () => {
     await pasteFromClipboard(page, {
       'text/plain': 'lorem ipsum dolor sit amet, consectetur adipiscing elit',
     });
-    await pressBackspace(page, 1);
+    await pressBackspace(page);
 
     await assertHTML(
       page,
@@ -105,7 +105,7 @@ test.describe('MaxLength', () => {
       `,
     );
 
-    await pressBackspace(page, 1);
+    await pressBackspace(page);
     await page.keyboard.type('💏');
 
     await assertHTML(

--- a/packages/lexical-playground/__tests__/e2e/MaxLength.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/MaxLength.spec.mjs
@@ -7,6 +7,10 @@
  */
 
 import {
+  pressBackspace,
+  STANDARD_KEYPRESS_DELAY_MS,
+} from '../keyboardShortcuts/index.mjs';
+import {
   assertHTML,
   assertSelection,
   clearEditor,
@@ -75,7 +79,7 @@ test.describe('MaxLength', () => {
     await pasteFromClipboard(page, {
       'text/plain': 'lorem ipsum dolor sit amet, consectetur adipiscing elit',
     });
-    await page.keyboard.press('Backspace');
+    await pressBackspace(page, 1, STANDARD_KEYPRESS_DELAY_MS);
 
     await assertHTML(
       page,
@@ -88,7 +92,7 @@ test.describe('MaxLength', () => {
       `,
     );
 
-    await page.keyboard.type('💏');
+    await page.keyboard.type('💏', {delay: STANDARD_KEYPRESS_DELAY_MS});
 
     await assertHTML(
       page,
@@ -101,7 +105,7 @@ test.describe('MaxLength', () => {
       `,
     );
 
-    await page.keyboard.press('Backspace');
+    await pressBackspace(page, 1, STANDARD_KEYPRESS_DELAY_MS);
     await page.keyboard.type('💏');
 
     await assertHTML(


### PR DESCRIPTION

## Description
`&nbsp;` appears randomly thus making test flaky, add keypress delays when typing to prevent that

## Test plan

add `--reporter=html --repeat-each=10` to "test-e2e-collab-firefox": "cross-env E2E_BROWSER=firefox E2E_EDITOR_MODE=rich-text-with-collab playwright test --project=\"firefox\"", in build script

then run `npm run start & npm run test-e2e-collab-firefox`

### Before

![Screenshot 2024-06-05 at 6 29 26 PM](https://github.com/facebook/lexical/assets/19604232/dd705576-153c-4ef9-9c23-388b77c9d516)



### After
```
npm run start & npm run cross-env E2E_BROWSER=firefox E2E_EDITOR_MODE=rich-text-with-collab playwright test --project="firefox" --reporter=html --repeat-each=10


> @lexical/monorepo@0.16.0 test-e2e-collab-firefox
> cross-env E2E_BROWSER=firefox E2E_EDITOR_MODE=rich-text-with-collab playwright test --project="firefox" --reporter=html --repeat-each=10


> @lexical/monorepo@0.16.0 start
> cross-env NODE_ENV=development concurrently "npm:collab" "npm run dev --prefix packages/lexical-playground"

[collab] 
[collab] > @lexical/monorepo@0.16.0 collab
[collab] > cross-env HOST=localhost PORT=1234 npx y-websocket-server
[collab] 
[1] 
[1] > lexical-playground@0.16.0 dev
[1] > vite --host --port 3000
[1] 

Running 10 tests using 4 workers
[4/10] [firefox] › packages/lexical-playground/__tests__/e2e/MaxLength.spec.mjs:77:8 › MaxLength › can restrict emojis on boundaries
[1] 
[1]   VITE v5.2.11  ready in 620 ms
[1] 
[1]   ➜  Local:   http://localhost:3000/
[1]   ➜  Network: http://172.19.82.250:3000/
  Slow test file: [firefox] › packages/lexical-playground/__tests__/e2e/MaxLength.spec.mjs (53.0s)
  Consider splitting slow test files to speed up parallel execution
  10 passed (19.9s)