### PR TITLE
[Lexical] Fix missing meta copyright headers in files 

### DIFF
--- a/packages/lexical-devtools/safari-xcode/Lexical Developer Tools/Lexical Developer Tools Extension/SafariWebExtensionHandler.swift
+++ b/packages/lexical-devtools/safari-xcode/Lexical Developer Tools/Lexical Developer Tools Extension/SafariWebExtensionHandler.swift
@@ -1,9 +1,10 @@
-//
-//  SafariWebExtensionHandler.swift
-//  Lexical Developer Tools Extension
-//
-//  Created by Vladlen Fedosov on 5/14/24.
-//
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
 
 import SafariServices
 import os.log

--- a/packages/lexical-devtools/safari-xcode/Lexical Developer Tools/Lexical Developer Tools/AppDelegate.swift
+++ b/packages/lexical-devtools/safari-xcode/Lexical Developer Tools/Lexical Developer Tools/AppDelegate.swift
@@ -1,9 +1,10 @@
-//
-//  AppDelegate.swift
-//  Lexical Developer Tools
-//
-//  Created by Vladlen Fedosov on 5/14/24.
-//
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
 
 import Cocoa
 

--- a/packages/lexical-devtools/safari-xcode/Lexical Developer Tools/Lexical Developer Tools/Resources/Style.css
+++ b/packages/lexical-devtools/safari-xcode/Lexical Developer Tools/Lexical Developer Tools/Resources/Style.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 * {
   -webkit-user-select: none;
   -webkit-user-drag: none;

--- a/packages/lexical-devtools/safari-xcode/Lexical Developer Tools/Lexical Developer Tools/ViewController.swift
+++ b/packages/lexical-devtools/safari-xcode/Lexical Developer Tools/Lexical Developer Tools/ViewController.swift
@@ -1,9 +1,10 @@
-//
-//  ViewController.swift
-//  Lexical Developer Tools
-//
-//  Created by Vladlen Fedosov on 5/14/24.
-//
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
 
 import Cocoa
 import SafariServices

--- a/packages/lexical-devtools/src/entrypoints/devtools-panel/App.css
+++ b/packages/lexical-devtools/src/entrypoints/devtools-panel/App.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 pre {
   line-height: 1.1;
   background: #222;

--- a/packages/lexical-devtools/src/entrypoints/popup/style.css
+++ b/packages/lexical-devtools/src/entrypoints/popup/style.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/packages/lexical-playground/src/nodes/PageBreakNode/index.css
+++ b/packages/lexical-playground/src/nodes/PageBreakNode/index.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 /* @import url('assets/styles/variables.css'); */
 
 [type='page-break'] {

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 .code-action-menu-container {
   height: 35.8px;
   font-size: 10px;

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 .floating-text-format-popup {
   display: flex;
   background: #fff;

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 .table-of-contents .heading2 {
   margin-left: 10px;
 }

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 .font-size-input {
   font-weight: bold;
   font-size: 14px;

--- a/packages/lexical-playground/src/ui/Dialog.css
+++ b/packages/lexical-playground/src/ui/Dialog.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 .DialogActions {
   display: flex;
   flex-direction: row;

--- a/packages/lexical-playground/src/ui/Select.css
+++ b/packages/lexical-playground/src/ui/Select.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 select {
   appearance: none;
   -webkit-appearance: none;

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/astro.config.mjs
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/astro.config.mjs
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import { defineConfig } from "astro/config";
 
 import react from "@astrojs/react";

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/playwright.config.ts
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/playwright.config.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/tests/test.ts
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/tests/test.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import { expect, test } from '@playwright/test';
 
 test('index page has expected h1 and lexical state', async ({ page }) => {

--- a/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/app/layout.tsx
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/app/layout.tsx
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import type { Metadata } from "next";
 import "./styles.css";
 

--- a/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/app/page.tsx
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/app/page.tsx
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import EditorUseClient from "./EditorUseClient";
 
 export const dynamic = 'force-dynamic';

--- a/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/next.config.mjs
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/next.config.mjs
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {ignoreDuringBuilds: true},

--- a/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/playwright.config.ts
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/playwright.config.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {

--- a/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/postcss.config.js
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/postcss.config.js
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 module.exports = {
   plugins: {
     tailwindcss: {},

--- a/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/tailwind.config.ts
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/tailwind.config.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import type { Config } from "tailwindcss";
 
 const config: Config = {

--- a/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/tests/test.ts
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/tests/test.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import { expect, test } from '@playwright/test';
 
 test('index page has expected h1 and lexical state', async ({ page }) => {

--- a/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/playwright.config.ts
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/playwright.config.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {

--- a/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/src/app.d.ts
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/src/app.d.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {

--- a/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/svelte.config.js
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/svelte.config.js
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 // import adapter from '@sveltejs/adapter-auto';
 import adapter from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';

--- a/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/tests/test.ts
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/tests/test.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import { expect, test } from '@playwright/test';
 
 test('index page has expected h1 and lexical state', async ({ page }) => {

--- a/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/vite.config.ts
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/vite.config.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import { sveltekit } from '@sveltejs/kit/vite';
 
 export default {


### PR DESCRIPTION
## What

Fix ```missing  copyright headers in source file``` issue generated via the Automated Meta Open Source Checks script

## Why
Every project specific source file must contain a doc block with an appropriate copyright header. Unrelated files must be listed as exceptions in the Copyright Headers Exceptions page in the repo dashboard.
A copyright header clearly indicates that the code is owned by Meta. Every open source file must start with a comment containing "Meta Platforms, Inc. and affiliates"

## TODO 
check how to auto include more paths to .eslintrc for copyright headers
 https://github.com/facebook/lexical/blob/96bdfb1c859d4d38a19064063bf89958b646ab54/.eslintrc.js