### PR TITLE
[lexical-utils] Fix: mergeRegister should call cleanup functions in reverse order

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/mergeRegister.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/mergeRegister.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {mergeRegister} from '@lexical/utils';
+
+describe('mergeRegister', () => {
+  it('calls all of the clean-up functions', () => {
+    const cleanup = jest.fn();
+    mergeRegister(cleanup, cleanup)();
+    expect(cleanup).toHaveBeenCalledTimes(2);
+  });
+  it('calls the clean-up functions in reverse order', () => {
+    const cleanup = jest.fn();
+    mergeRegister(cleanup.bind(null, 1), cleanup.bind(null, 2))();
+    expect(cleanup.mock.calls.map(([v]) => v)).toEqual([2, 1]);
+  });
+});

--- a/packages/lexical-utils/src/mergeRegister.ts
+++ b/packages/lexical-utils/src/mergeRegister.ts
@@ -25,13 +25,20 @@ type Func = () => void;
  * In this case, useEffect is returning the function returned by mergeRegister as a cleanup
  * function to be executed after either the useEffect runs again (due to one of its dependencies
  * updating) or the component it resides in unmounts.
- * Note the functions don't neccesarily need to be in an array as all arguements
+ * Note the functions don't neccesarily need to be in an array as all arguments
  * are considered to be the func argument and spread from there.
- * @param func - An array of functions meant to be executed by the returned function.
- * @returns the function which executes all the passed register command functions.
+ * The order of cleanup is the reverse of the argument order. Generally it is
+ * expected that the first "acquire" will be "released" last (LIFO order),
+ * because a later step may have some dependency on an earlier one.
+ * @param func - An array of cleanup functions meant to be executed by the returned function.
+ * @returns the function which executes all the passed cleanup functions.
  */
 export default function mergeRegister(...func: Array<Func>): () => void {
   return () => {
-    func.forEach((f) => f());
+    for (let i = func.length - 1; i >= 0; i--) {
+      func[i]();
+    }
+    // Clean up the references and make future calls a no-op
+    func.length = 0;
   };
 }


### PR DESCRIPTION
## Description

While it doesn't ever matter for the typical use case of `mergeRegister` (calling cleanup functions from Lexical listeners), semantically the mergeRegister cleanup functions should be called in reverse order (LIFO) in case there are any inter-dependencies.

For example, in `mergeRegister(A,B,C)`, logically C can have access to A when it is "acquired" so it should also have access to A when it's "released" so C must be cleaned up before A.

There should be no observable difference to most users, because there are generally no ordering or interdependency requirements. If a user did have ordering dependencies they have probably already written their own version that does it "correctly" since it is simple to do and a lot less awkward than something like `mergeRegister(...[A,B,C].reverse())`.

It does add a few bytes to the size of the function, but it should be a little more performant in runtime (using a for loop instead of Array.prototype.forEach) and possibly free memory earlier since it eagerly cleans up the array now as well.

## Test plan

### Before

`mergeRegister(a, b)()` calls `{ a(); b() }`

### After

`mergeRegister(a, b)()` calls `{ b(); a(); }`

There are now unit tests for this function.
