### PR TITLE
Revert "[lexical-react] Bug Fix: checklist cannot be toggled in sub-e…

### DIFF
--- a/packages/lexical-react/src/LexicalCheckListPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCheckListPlugin.tsx
@@ -215,7 +215,6 @@ function handleClick(event: Event) {
       });
     }
   });
-  event.stopPropagation(); // Prevents potential parent-editor listeners from firing, causing the checkbox toggle to be undone
 }
 
 function handlePointerDown(event: PointerEvent) {
@@ -223,7 +222,6 @@ function handlePointerDown(event: PointerEvent) {
     // Prevents caret moving when clicking on check mark
     event.preventDefault();
   });
-  event.stopPropagation();
 }
 
 function findEditor(target: Node) {


### PR DESCRIPTION
…ditors (#6216)"

This reverts commit 35efa43b88362676bf6e3bd5b5d5045387aa3c22.

---

While `event.stopPropagation()` might be correct, it is currently being triggered for every single click on the editor, the scope needs to be revised.