### PR TITLE
[Lexical] Fix #6221  delete multiple column table crash 

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -2575,6 +2575,51 @@ test.describe.parallel('Tables', () => {
     );
   });
 
+  test('Delete columns backward', async ({page, isPlainText, isCollab}) => {
+    await initialize({isCollab, page});
+    test.skip(isPlainText);
+    if (IS_COLLAB) {
+      // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
+      page.setViewportSize({height: 1000, width: 3000});
+    }
+
+    await focusEditor(page);
+
+    await insertTable(page, 2, 4);
+
+    await selectCellsFromTableCords(
+      page,
+      {x: 3, y: 1},
+      {x: 1, y: 1},
+      false,
+      false,
+    );
+
+    await deleteTableColumns(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
   test('Deselect when click outside #3785 #4138', async ({
     page,
     isPlainText,

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -628,7 +628,10 @@ export function $deleteTableColumn__EXPERIMENTAL(): void {
     }
   }
   const focusRowMap = gridMap[focusStartRow];
-  const nextColumn = focusRowMap[anchorStartColumn + anchorCell.__colSpan];
+  const nextColumn =
+    anchorStartColumn > focusStartColumn
+      ? focusRowMap[anchorStartColumn + anchorCell.__colSpan]
+      : focusRowMap[focusStartColumn + focusCell.__colSpan];
   if (nextColumn !== undefined) {
     const {cell} = nextColumn;
     $moveSelectionToCell(cell);

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -628,7 +628,7 @@ export function $deleteTableColumn__EXPERIMENTAL(): void {
     }
   }
   const focusRowMap = gridMap[focusStartRow];
-  const nextColumn = focusRowMap[focusStartColumn + focusCell.__colSpan];
+  const nextColumn = focusRowMap[anchorStartColumn + anchorCell.__colSpan];
   if (nextColumn !== undefined) {
     const {cell} = nextColumn;
     $moveSelectionToCell(cell);


### PR DESCRIPTION
## What
fix crash on backward column deletion

## Why
currently forward multiple column deletion works, backward multiple column deletion crashes, add handling for the same.

Before:

#6221

After:

https://github.com/facebook/lexical/assets/163521239/0ed169c8-eacd-473d-ac70-63470a1cd695



Closes #6221 