### PR TITLE
[lexical-selection] Fix lost autolink styling

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -770,6 +770,7 @@ export class RangeSelection implements BaseSelection {
       ) {
         nextSibling = $createTextNode();
         nextSibling.setFormat(format);
+        nextSibling.setStyle(style);
         if (!firstNodeParent.canInsertTextAfter()) {
           firstNodeParent.insertAfter(nextSibling);
         } else {


### PR DESCRIPTION
Fix bug related to a lost autolink styling. Right away after autolink is created during the user input, the following symbols are inserted without a proper style. This PR fixes that by keeping the style of the newly inserted text node.

## Description

Closes #6155

## Test plan
1. Open https://playground.lexical.dev/
2. Clear the editor
3. Set font size to anything other than the default 15
4. Start typing "www.github.com"
5. See an autolink is created with proper styles.

### Before

See https://github.com/facebook/lexical/issues/6155


### After

https://github.com/facebook/lexical/assets/5062807/ba07fa54-37d6-45d6-90e6-9ab2e315910f




