### PR TITLE
[Lexical][Tables] Follow up on #6267 handle multi column delete crash on forward selection at end of the table

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -2620,6 +2620,55 @@ test.describe.parallel('Tables', () => {
     );
   });
 
+  test('Delete columns forward at end of table', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    await initialize({isCollab, page});
+    test.skip(isPlainText);
+    if (IS_COLLAB) {
+      // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
+      page.setViewportSize({height: 1000, width: 3000});
+    }
+
+    await focusEditor(page);
+
+    await insertTable(page, 2, 4);
+
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 1},
+      {x: 3, y: 1},
+      false,
+      false,
+    );
+
+    await deleteTableColumns(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
   test('Deselect when click outside #3785 #4138', async ({
     page,
     isPlainText,

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -636,7 +636,10 @@ export function $deleteTableColumn__EXPERIMENTAL(): void {
     const {cell} = nextColumn;
     $moveSelectionToCell(cell);
   } else {
-    const previousRow = focusRowMap[focusStartColumn - 1];
+    const previousRow =
+      focusStartColumn < anchorStartColumn
+        ? focusRowMap[focusStartColumn - 1]
+        : focusRowMap[anchorStartColumn - 1];
     const {cell} = previousRow;
     $moveSelectionToCell(cell);
   }


### PR DESCRIPTION
## What
fix crash on forward column deletion at the end of the table

## Why
currently backward multiple column deletion **at the end of the table** works, forward multiple column deletion crashes, add handling for the same.


## Before

https://github.com/facebook/lexical/assets/163521239/4b04bdbf-8f44-4e38-97af-1b35cb2b8f33



## After


https://github.com/facebook/lexical/assets/163521239/0904b649-cd2b-4c61-8077-2845eb44f2d0


