### PR TITLE
Upgrade vite version to address vulnerabilities detected by the Open …

### DIFF
--- a/examples/react-rich-collab/package.json
+++ b/examples/react-rich-collab/package.json
@@ -28,6 +28,6 @@
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",
     "typescript": "^5.2.2",
-    "vite": "^5.1.4"
+    "vite": "^5.1.7"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5370,9 +5370,9 @@
       }
     },
     "node_modules/@excalidraw/excalidraw": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.17.0.tgz",
-      "integrity": "sha512-NzP22v5xMqxYW27ZtTHhiGFe7kE8NeBk45aoeM/mDSkXiOXPDH+PcvwzHRN/Ei+Vj/0sTPHxejn8bZyRWKGjXg==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.17.6.tgz",
+      "integrity": "sha512-fyCl+zG/Z5yhHDh5Fq2ZGmphcrALmuOdtITm8gN4d8w4ntnaopTXcTfnAAaU3VleDC6LhTkoLOTG6P5kgREiIg==",
       "peerDependencies": {
         "react": "^17.0.2 || ^18.2.0",
         "react-dom": "^17.0.2 || ^18.2.0"
@@ -19815,15 +19815,15 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.15.6",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.15.6.tgz",
-      "integrity": "sha512-UpzJy4yrnqnhXvRPhjEuLA4lcPn6eRngixW7Q3TJErjg3Aw2PuLFBzTkdUb89UtumxjhHTqL3a5GDGETMSwgJA==",
+      "version": "0.16.10",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.10.tgz",
+      "integrity": "sha512-ZiqaC04tp2O5utMsl2TEZTXxa6WSC4yo0fv5ML++D3QZv/vx2Mct0mTlRx3O+uUkjfuAgOkzsCmq5MiUEsDDdA==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
       ],
       "dependencies": {
-        "commander": "^8.0.0"
+        "commander": "^8.3.0"
       },
       "bin": {
         "katex": "cli.js"
@@ -33338,7 +33338,7 @@
         "@lexical/selection": "0.16.0",
         "@lexical/table": "0.16.0",
         "@lexical/utils": "0.16.0",
-        "katex": "^0.15.2",
+        "katex": "^0.16.10",
         "lexical": "0.16.0",
         "lodash-es": "^4.17.21",
         "prettier": "^2.3.2",
@@ -37256,9 +37256,9 @@
       "dev": true
     },
     "@excalidraw/excalidraw": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.17.0.tgz",
-      "integrity": "sha512-NzP22v5xMqxYW27ZtTHhiGFe7kE8NeBk45aoeM/mDSkXiOXPDH+PcvwzHRN/Ei+Vj/0sTPHxejn8bZyRWKGjXg=="
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.17.6.tgz",
+      "integrity": "sha512-fyCl+zG/Z5yhHDh5Fq2ZGmphcrALmuOdtITm8gN4d8w4ntnaopTXcTfnAAaU3VleDC6LhTkoLOTG6P5kgREiIg=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",
@@ -47842,11 +47842,11 @@
       }
     },
     "katex": {
-      "version": "0.15.6",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.15.6.tgz",
-      "integrity": "sha512-UpzJy4yrnqnhXvRPhjEuLA4lcPn6eRngixW7Q3TJErjg3Aw2PuLFBzTkdUb89UtumxjhHTqL3a5GDGETMSwgJA==",
+      "version": "0.16.10",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.10.tgz",
+      "integrity": "sha512-ZiqaC04tp2O5utMsl2TEZTXxa6WSC4yo0fv5ML++D3QZv/vx2Mct0mTlRx3O+uUkjfuAgOkzsCmq5MiUEsDDdA==",
       "requires": {
-        "commander": "^8.0.0"
+        "commander": "^8.3.0"
       }
     },
     "keyv": {
@@ -48083,7 +48083,7 @@
         "@rollup/plugin-commonjs": "^25.0.7",
         "@types/lodash-es": "^4.14.182",
         "@vitejs/plugin-react": "^4.2.1",
-        "katex": "^0.15.2",
+        "katex": "^0.16.10",
         "lexical": "0.16.0",
         "lodash-es": "^4.17.21",
         "prettier": "^2.3.2",

--- a/packages/lexical-playground/package.json
+++ b/packages/lexical-playground/package.json
@@ -26,7 +26,7 @@
     "@lexical/selection": "0.16.0",
     "@lexical/table": "0.16.0",
     "@lexical/utils": "0.16.0",
-    "katex": "^0.15.2",
+    "katex": "^0.16.10",
     "lexical": "0.16.0",
     "lodash-es": "^4.17.21",
     "prettier": "^2.3.2",


### PR DESCRIPTION
## WHAT 

Upgrate vite version in scripts/tests/integration/fixtures/lexical-esm-sveltekit-vanilla-js


## WHY

Task raised by Meta Open source bot

GitHub has identified a security vulnerability in a package dependency defined in the repository, [facebook/lexical](https://github.com/facebook/lexical).

Package Dependency
Repository: [facebook/lexical](https://github.com/facebook/lexical)
Manifest file: [scripts/tests/integration/fixtures/lexical-esm-sveltekit-vanilla-js/package-lock.json](https://github.com/facebook/lexical/blob/main/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/package-lock.json)
Package name: [vite](https://npmjs.com/package/vite)
Affected versions: >= 5.1.0, <= 5.1.6
Fixed in version: 5.1.7
Severity: MODERATE

References
https://github.com/vitejs/vite/security/advisories/GHSA-8jhw-289h-jh2g
https://github.com/vitejs/vite/commit/011bbca350e447d1b499d242804ce62738c12bc0
https://github.com/vitejs/vite/commit/5a056dd2fc80dbafed033062fe6aaf4717309f48
https://github.com/vitejs/vite/commit/89c7c645f09d16a38f146ef4a1528f218e844d67
https://github.com/vitejs/vite/commit/96a7f3a41ef2f9351c46f3ab12489bb4efa03cc9
https://github.com/vitejs/vite/commit/ba5269cca81de3f5fbb0f49d58a1c55688043258
https://github.com/vitejs/vite/commit/d2db33f7d4b96750b35370c70dd2c35ec3b9b649
https://nvd.nist.gov/vuln/detail/CVE-2024-31207
https://github.com/advisories/GHSA-8jhw-289h-jh2g