### PR TITLE
Fix Bug: If you add Mentions and your Lexical composer is inside Scrollable area, it auto hides #6277

### DIFF
--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -191,7 +191,9 @@ function isTriggerVisibleInNearestScrollContainer(
 ): boolean {
   const tRect = targetElement.getBoundingClientRect();
   const cRect = containerElement.getBoundingClientRect();
-  return tRect.top > cRect.top && tRect.top < cRect.bottom;
+  return (tRect.top >= cRect.top && tRect.top < cRect.bottom) ||
+                              (tRect.bottom > cRect.top && tRect.bottom <= cRect.bottom) ||
+                              (tRect.top < cRect.top && tRect.bottom > cRect.bottom);
 }
 
 // Reposition the menu on scroll, window resize, and element resize.


### PR DESCRIPTION
Hi,

This PR fixes the Bug reported here: https://github.com/facebook/lexical/issues/6277

It compares only top part of component, but it should also consider bottom part of the component