### PR TITLE
[Lexical][CI] Fix issues in after_approval workflow

### DIFF
--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -29,7 +29,7 @@ jobs:
     if: always()
     steps:
       - name: Flaky test notice PR comment
-        if: (${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} && (needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'))
+        if: (needs.e2e-tests.result == 'failure' && ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }}) || (needs.e2e-tests.result == 'cancelled' && ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }})
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |

--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -23,26 +23,6 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true' && (github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'extended-tests'))
     uses: ./.github/workflows/call-e2e-all-tests.yml
 
-  is_pr_from_facebook:
-    if: ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo PR from facebook branch
-        run: |
-          echo "PR from facebbook branch ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} "
-
-  flaky-test-notice:
-    needs: [e2e-tests, is_pr_from_facebook]
-    runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name != 'facebook/lexical' }} && always()
-    steps:
-      - name: Flaky test notice PR comment
-        if: needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            E2E tests failed on [this run](https://github.com/facebook/lexical/actions/runs/${{ github.run_id }}). Please check if the failure is due to a flaky test. Visit the [Flaky Test Tracker](https://github.com/facebook/lexical/discussions/6289) for known flaky tests, and record the failed test run there if its a flaky failure.
-
   integration-tests:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true' && (github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'extended-tests'))

--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -34,7 +34,7 @@ jobs:
   flaky-test-notice:
     needs: [e2e-tests, is_pr_from_facebook]
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ github.event.pull_request.head.repo.full_name != 'facebook/lexical' }} && always()
     steps:
       - name: Flaky test notice PR comment
         if: needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'

--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -29,7 +29,7 @@ jobs:
     if: always()
     steps:
       - name: Flaky test notice PR comment
-        if: ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} && (needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled')
+        if: (${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} && (needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'))
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |

--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   pre_job:
+    if: (github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'extended-tests'))
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -13,26 +14,14 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          concurrent_skipping: 'always'
+          concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "merge_group"]'
-          paths-ignore: '["packages/lexical-website/**", "packages/*/README.md", ".size-limit.js"]'
+          paths_ignore: '["packages/lexical-website/**", "packages/*/README.md", ".size-limit.js"]'
   e2e-tests:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true' && (github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'extended-tests'))
     uses: ./.github/workflows/call-e2e-all-tests.yml
-
-  flaky-test-notice:
-    needs: e2e-tests
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - name: Flaky test notice PR comment
-        if: needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            E2E tests failed on [this run](https://github.com/facebook/lexical/actions/runs/${{ github.run_id }}). Please check if the failure is due to a flaky test. Visit the [Flaky Test Tracker](https://github.com/facebook/lexical/discussions/6289) for known flaky tests, and record the failed test run there if its a flaky failure.
 
   integration-tests:
     needs: pre_job

--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -23,6 +23,18 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true' && (github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'extended-tests'))
     uses: ./.github/workflows/call-e2e-all-tests.yml
 
+  flaky-test-notice:
+    needs: e2e-tests
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} && always()
+    steps:
+      - name: Flaky test notice PR comment
+        if: needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            E2E tests failed on [this run](https://github.com/facebook/lexical/actions/runs/${{ github.run_id }}). Please check if the failure is due to a flaky test. Visit the [Flaky Test Tracker](https://github.com/facebook/lexical/discussions/6289) for known flaky tests, and record the failed test run there if its a flaky failure.
+
   integration-tests:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true' && (github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'extended-tests'))

--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -23,13 +23,21 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true' && (github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'extended-tests'))
     uses: ./.github/workflows/call-e2e-all-tests.yml
 
+  is_pr_from_facebook:
+    if: ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo PR from facebook branch
+        run: |
+          echo "PR from facebbook branch ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} "
+
   flaky-test-notice:
-    needs: e2e-tests
+    needs: [e2e-tests, is_pr_from_facebook]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Flaky test notice PR comment
-        if: (needs.e2e-tests.result == 'failure' && ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }}) || (needs.e2e-tests.result == 'cancelled' && ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }})
+        if: needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |

--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -26,10 +26,10 @@ jobs:
   flaky-test-notice:
     needs: e2e-tests
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} && always()
+    if: always()
     steps:
       - name: Flaky test notice PR comment
-        if: needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'
+        if: ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} && (needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled')
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |

--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -20,10 +20,10 @@ jobs:
   flaky-test-notice:
     needs: e2e-tests
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} && always()
+    if: always()
     steps:
       - name: Flaky test notice PR comment
-        if: needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'
+        if: ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} && (needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled')
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |

--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -17,6 +17,18 @@ jobs:
     if: github.repository_owner == 'facebook' && contains(github.event.pull_request.labels.*.name, 'extended-tests')
     uses: ./.github/workflows/call-e2e-all-tests.yml
 
+  flaky-test-notice:
+    needs: e2e-tests
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} && always()
+    steps:
+      - name: Flaky test notice PR comment
+        if: needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            E2E tests failed on [this run](https://github.com/facebook/lexical/actions/runs/${{ github.run_id }}). Please check if the failure is due to a flaky test. Visit the [Flaky Test Tracker](https://github.com/facebook/lexical/discussions/6289) for known flaky tests, and record the failed test run there if its a flaky failure.
+
   integration-tests:
     if: github.repository_owner == 'facebook' && contains(github.event.pull_request.labels.*.name, 'extended-tests')
     uses: ./.github/workflows/call-integration-tests.yml

--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -17,13 +17,21 @@ jobs:
     if: github.repository_owner == 'facebook' && contains(github.event.pull_request.labels.*.name, 'extended-tests')
     uses: ./.github/workflows/call-e2e-all-tests.yml
 
+  is_pr_from_facebook:
+    if: ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo PR from facebook branch
+        run: |
+          echo "PR from facebbook branch ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} "
+
   flaky-test-notice:
-    needs: e2e-tests
+    needs: [e2e-tests, is_pr_from_facebook]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Flaky test notice PR comment
-        if: (${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} && (needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'))
+        if: needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |

--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -17,18 +17,6 @@ jobs:
     if: github.repository_owner == 'facebook' && contains(github.event.pull_request.labels.*.name, 'extended-tests')
     uses: ./.github/workflows/call-e2e-all-tests.yml
 
-  flaky-test-notice:
-    needs: e2e-tests
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - name: Flaky test notice PR comment
-        if: needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            E2E tests failed on [this run](https://github.com/facebook/lexical/actions/runs/${{ github.run_id }}). Please check if the failure is due to a flaky test. Visit the [Flaky Test Tracker](https://github.com/facebook/lexical/discussions/6289) for known flaky tests, and record the failed test run there if its a flaky failure.
-
   integration-tests:
     if: github.repository_owner == 'facebook' && contains(github.event.pull_request.labels.*.name, 'extended-tests')
     uses: ./.github/workflows/call-integration-tests.yml

--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -23,7 +23,7 @@ jobs:
     if: always()
     steps:
       - name: Flaky test notice PR comment
-        if: ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} && (needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled')
+        if: (${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} && (needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'))
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |

--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -17,26 +17,6 @@ jobs:
     if: github.repository_owner == 'facebook' && contains(github.event.pull_request.labels.*.name, 'extended-tests')
     uses: ./.github/workflows/call-e2e-all-tests.yml
 
-  is_pr_from_facebook:
-    if: ${{ github.event.pull_request.head.repo.full_name != 'facebook/lexical' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo PR from facebook branch
-        run: |
-          echo "PR from facebbook branch ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }} "
-
-  flaky-test-notice:
-    needs: [e2e-tests, is_pr_from_facebook]
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - name: Flaky test notice PR comment
-        if: needs.e2e-tests.result == 'failure' || needs.e2e-tests.result == 'cancelled'
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            E2E tests failed on [this run](https://github.com/facebook/lexical/actions/runs/${{ github.run_id }}). Please check if the failure is due to a flaky test. Visit the [Flaky Test Tracker](https://github.com/facebook/lexical/discussions/6289) for known flaky tests, and record the failed test run there if its a flaky failure.
-
   integration-tests:
     if: github.repository_owner == 'facebook' && contains(github.event.pull_request.labels.*.name, 'extended-tests')
     uses: ./.github/workflows/call-integration-tests.yml

--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/call-e2e-all-tests.yml
 
   is_pr_from_facebook:
-    if: ${{ github.event.pull_request.head.repo.full_name == 'facebook/lexical' }}
+    if: ${{ github.event.pull_request.head.repo.full_name != 'facebook/lexical' }}
     runs-on: ubuntu-latest
     steps:
       - name: Echo PR from facebook branch


### PR DESCRIPTION
## WHAT
Fix some issues in Lexical CI job  after observing past runs :
- path-ignore for e2e tests not working due to warning on wrong keyword, should be replaced by path_ignore 
<img width="1342" alt="Screenshot 2024-06-14 at 11 05 57 AM" src="https://github.com/facebook/lexical/assets/163521239/ca7f38dd-1f00-4c64-97f2-16776ba5e01b">

- flaky-test notice not working on "PRs from forks"
https://github.com/facebook/lexical/actions/runs/9506494216/job/26204471038?pr=6274

- concurrent-workflow skipping all concurrent workflows running on multiple PRs rather just for the PR in focus, - change settings from 'always' to "same_content_newer".



## Test plan

#6308