### PR TITLE
[Lexical][Gallery] add option to add gallery content in Meta Intern only

### DIFF
--- a/packages/lexical-website/docusaurus.config.js
+++ b/packages/lexical-website/docusaurus.config.js
@@ -405,6 +405,13 @@ const config = {
             label: 'iOS',
             position: 'left',
           },
+          process.env.FB_INTERNAL
+            ? {
+                label: 'Gallery',
+                position: 'left',
+                to: '/gallery',
+              }
+            : null,
           {
             href: GITHUB_REPO_URL,
             label: 'GitHub',
@@ -415,7 +422,7 @@ const config = {
             label: 'iOS GitHub',
             position: 'right',
           },
-        ],
+        ].filter((item) => item != null),
         logo: {
           alt: 'Lexical',
           src: 'img/logo.svg',

--- a/packages/lexical-website/src/components/GalleryPage.js
+++ b/packages/lexical-website/src/components/GalleryPage.js
@@ -19,7 +19,7 @@ function GalleryImpl() {
   useEffect(() => {
     try {
       if (process.env.FB_INTERNAL) {
-        import('../../InternGalleryPage').then(setInternGallery);
+        import('../../../InternGalleryPage').then(setInternGallery);
       }
     } catch (e) {
       throw e;

--- a/packages/lexical-website/src/components/GalleryPage.js
+++ b/packages/lexical-website/src/components/GalleryPage.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import {useEffect, useState} from 'react';
+
+export default function GalleryPage() {
+  return <BrowserOnly>{() => <GalleryImpl />}</BrowserOnly>;
+}
+
+function GalleryImpl() {
+  const [internGallery, setInternGallery] = useState(null);
+
+  useEffect(() => {
+    try {
+      if (process.env.FB_INTERNAL) {
+        import('../../InternGalleryPage').then(setInternGallery);
+      }
+    } catch (e) {
+      throw e;
+    }
+  }, []);
+  return internGallery != null ? internGallery.InternGalleryPage() : <></>;
+}

--- a/packages/lexical-website/src/pages/gallery.md
+++ b/packages/lexical-website/src/pages/gallery.md
@@ -1,0 +1,9 @@
+---
+id: gallery
+title: Gallery
+---
+import { FBInternOnly } from 'docusaurus-plugin-internaldocs-fb/internal';
+import GalleryPage from '@site/src/components/GalleryPage';
+
+# Gallery (WIP)
+<GalleryPage/>


### PR DESCRIPTION
## WHAT 
-  add option to add gallery content in Meta Intern only

## WHY
- Building a prototype for UI Gallery in Meta intern 1st before starting in Open Source.


## Test Plan

> Meta Build

<img width="1175" alt="Screenshot 2024-06-18 at 4 03 55 PM" src="https://github.com/facebook/lexical/assets/163521239/5805def4-e19c-44e0-bd94-5e3628c903f8">


> Lexical Build remains Not impacted 

https://lexical-git-lexicalgallerywip-fbopensource.vercel.app/