### PR TITLE
[lexical] Bug Fix: Export type EditorUpdateOptions

### DIFF
--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -17,6 +17,7 @@ export type {
   EditorSetOptions,
   EditorThemeClasses,
   EditorThemeClassName,
+  EditorUpdateOptions,
   HTMLConfig,
   Klass,
   KlassConstructor,


### PR DESCRIPTION
## Description

Exports the `EditorUpdateOptions` type which is used in the public API for `LexicalEditor.update`

Closes #6331

## Test plan

### Before

Third party packages couldn't easily reference the `EditorUpdateOptions` type

Workaround:
```ts
import type {LexicalEditor} from 'lexical';
type EditorUpdateOptions = NonNullable<Parameters<LexicalEditor['update']>[1]>;
```

### After

Now they can since it is exported

```ts
import type {EditorUpdateOptions} from 'lexical';
```