### PR TITLE
Fix undo

### DIFF
--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -355,7 +355,10 @@ function reconcileParagraphFormat(element: ElementNode): void {
     subTreeTextFormat !== element.__textFormat &&
     !activeEditorStateReadOnly
   ) {
-    element.setTextFormat(subTreeTextFormat);
+    if (!activeEditorStateReadOnly) {
+      const writableNode = element.getWritable();
+      writableNode.__textFormat = subTreeTextFormat;
+    }
   }
 }
 
@@ -438,13 +441,14 @@ function $reconcileChildrenWithDirection(
   dom: HTMLElement,
 ): void {
   const previousSubTreeDirectionTextContent = subTreeDirectionedTextContent;
+  const previousSubTreeTextFormat = subTreeTextFormat;
   subTreeDirectionedTextContent = '';
   subTreeTextFormat = null;
   $reconcileChildren(prevElement, nextElement, dom);
   reconcileBlockDirection(nextElement, dom);
   reconcileParagraphFormat(nextElement);
   subTreeDirectionedTextContent = previousSubTreeDirectionTextContent;
-  subTreeTextFormat = null;
+  subTreeTextFormat = previousSubTreeTextFormat;
 }
 
 function createChildrenArray(


### PR DESCRIPTION
When doing undo in document where some text had format != 0
Error was thrown:
```
TypeError: Cannot assign to read only property '_cachedNodes' of object '#<RangeSelection>'
    at RangeSelection.setCachedNodes 
    at ParagraphNode.getWritable 
    at ParagraphNode.setTextFormat 
    at reconcileParagraphFormat 
    at $reconcileChildrenWithDirection 
 ```
Basically editorState is readOnly at this point, but we try to write to ParagraphNode when text's format is different from paragraph.
I have copied solution from `reconcileBlockDirection`