### PR TITLE
[lexical-react][lexical-dev-tools-core] Bug Fix: TreeView selection indicator

### DIFF
--- a/packages/lexical-devtools-core/src/generateContent.ts
+++ b/packages/lexical-devtools-core/src/generateContent.ts
@@ -445,7 +445,7 @@ function $printSelectedCharsLine({
   ];
   const unselectedChars = Array(start + 1).fill(' ');
   const selectedChars = Array(end - start).fill(SYMBOLS.selectedChar);
-  const paddingLength = typeDisplay.length + 3; // 2 for the spaces around + 1 for the double quote.
+  const paddingLength = typeDisplay.length + 2; // 1 for the space after + 1 for the double quote.
 
   const nodePrintSpaces = Array(nodeKeyDisplay.length + paddingLength).fill(
     ' ',


### PR DESCRIPTION
## Description

- When debugging using TreeView, the selection indicator under the text in debug TreeView pane below the editor is 1 position too far to the right.
- This PR fixes this bug. See the screenshots below.
- fix after PR #6180 - sorry I didn't notice this issue with that PR.

## Test plan

Tested in the Lexical Playground.

### Before

![Lexical TreeView selection before](https://github.com/facebook/lexical/assets/5582153/dd9d78d2-a9d8-4ff1-b21e-3bdad60a8a2a)

### After

![Lexical TreeView selection after](https://github.com/facebook/lexical/assets/5582153/cdc59f03-cd70-44ed-8dfb-5eecc9720b8f)