### PR TITLE
Replace 'await' with 'async' in lexical-headless/README.md

### DIFF
--- a/packages/lexical-headless/README.md
+++ b/packages/lexical-headless/README.md
@@ -35,7 +35,7 @@ you can convert lexical editor state to markdown on server:
 const { createHeadlessEditor } = require('@lexical/headless');
 const { $convertToMarkdownString, TRANSFORMERS } = require('@lexical/markdown');
 
-app.get('article/:id/markdown', await (req, res) => {
+app.get('article/:id/markdown', async (req, res) => {
   const editor = createHeadlessEditor({
     nodes: [],
     onError: () => {},


### PR DESCRIPTION

## Description
This is a minor change. I have updated the @lexical/headless/README.md document to replace 'await' with 'async'.

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*