### PR TITLE
[lexical-playground] Table Hover Action Buttons

### DIFF
--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -63,6 +63,7 @@ import SpeechToTextPlugin from './plugins/SpeechToTextPlugin';
 import TabFocusPlugin from './plugins/TabFocusPlugin';
 import TableCellActionMenuPlugin from './plugins/TableActionMenuPlugin';
 import TableCellResizer from './plugins/TableCellResizer';
+import TableHoverActionsPlugin from './plugins/TableHoverActionsPlugin';
 import TableOfContentsPlugin from './plugins/TableOfContentsPlugin';
 import ToolbarPlugin from './plugins/ToolbarPlugin';
 import TreeViewPlugin from './plugins/TreeViewPlugin';
@@ -185,6 +186,7 @@ export default function Editor(): JSX.Element {
               hasCellBackgroundColor={tableCellBackgroundColor}
             />
             <TableCellResizer />
+            <TableHoverActionsPlugin />
             <ImagesPlugin />
             <InlineImagePlugin />
             <LinkPlugin />

--- a/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
@@ -102,7 +102,7 @@ function TableHoverActionsContainer({
           right: tableElemRight,
           bottom: tableElemBottom,
           height: tableElemHeight,
-        } = tableDOMElement.getBoundingClientRect();
+        } = (tableDOMElement as HTMLTableElement).getBoundingClientRect();
 
         const {y: editorElemY} = anchorElem.getBoundingClientRect();
 
@@ -167,16 +167,18 @@ function TableHoverActionsContainer({
 
   const insertAction = (insertRow: boolean) => {
     editor.update(() => {
-      const maybeTableCell = $getNearestNodeFromDOMNode(
-        tableDOMNodeRef.current,
-      );
-      maybeTableCell?.selectEnd();
-      if (insertRow) {
-        $insertTableRow__EXPERIMENTAL();
-        setShownRow(false);
-      } else {
-        $insertTableColumn__EXPERIMENTAL();
-        setShownColumn(false);
+      if (tableDOMNodeRef.current) {
+        const maybeTableNode = $getNearestNodeFromDOMNode(
+          tableDOMNodeRef.current,
+        );
+        maybeTableNode?.selectEnd();
+        if (insertRow) {
+          $insertTableRow__EXPERIMENTAL();
+          setShownRow(false);
+        } else {
+          $insertTableColumn__EXPERIMENTAL();
+          setShownColumn(false);
+        }
       }
     });
   };

--- a/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {
+  $getTableColumnIndexFromTableCellNode,
+  $getTableRowIndexFromTableCellNode,
+  $insertTableColumn__EXPERIMENTAL,
+  $insertTableRow__EXPERIMENTAL,
+  $isTableCellNode,
+$isTableNode, TableNode,
+  TableRowNode} from '@lexical/table';
+import {$findMatchingParent} from '@lexical/utils';
+import {$getNearestNodeFromDOMNode} from 'lexical';
+import {useEffect, useRef, useState} from 'react';
+import * as React from 'react';
+import {createPortal} from 'react-dom';
+
+import {useDebounce} from '../CodeActionMenuPlugin/utils';
+
+function TableHoverActionsContainer({
+  anchorElem,
+}: {
+  anchorElem: HTMLElement;
+}): JSX.Element {
+  const [editor] = useLexicalComposerContext();
+
+  const [isShownRow, setShownRow] = useState<boolean>(false);
+  const [isShownColumn, setShownColumn] = useState<boolean>(false);
+  const [shouldListenMouseMove, setShouldListenMouseMove] =
+    useState<boolean>(false);
+  const [position, setPosition] = useState({});
+  const codeSetRef = useRef<Set<string>>(new Set());
+  const codeDOMNodeRef = useRef<HTMLElement | null>(null);
+
+  const debouncedOnMouseMove = useDebounce(
+    (event: MouseEvent) => {
+      const {codeDOMNode, isOutside} = getMouseInfo(event);
+      if (isOutside) {
+        setShownRow(false);
+        setShownColumn(false);
+        return;
+      }
+
+      if (!codeDOMNode) {
+        return;
+      }
+
+      codeDOMNodeRef.current = codeDOMNode;
+
+      let hoveredRowNode: TableNode | null = null;
+      let hoveredColumnNode: TableNode | null = null;
+      let tableDOMElement;
+      editor.update(() => {
+        const maybeTableCell = $getNearestNodeFromDOMNode(codeDOMNode);
+
+        if ($isTableCellNode(maybeTableCell)) {
+          const table = $findMatchingParent(maybeTableCell, (node) =>
+            $isTableNode(node),
+          );
+          if (!table) {
+            return;
+          }
+          tableDOMElement = editor.getElementByKey(table?.getKey());
+
+          const rowCount = (table as TableNode).getChildrenSize();
+          const colCount = (
+            (table as TableNode).getChildAtIndex(0) as TableRowNode
+          )?.getChildrenSize();
+
+          const rowIndex = $getTableRowIndexFromTableCellNode(maybeTableCell);
+          const colIndex =
+            $getTableColumnIndexFromTableCellNode(maybeTableCell);
+
+          if (rowIndex === rowCount - 1) {
+            hoveredRowNode = maybeTableCell;
+          } else if (colIndex === colCount - 1) {
+            hoveredColumnNode = maybeTableCell;
+          } else {
+            setShownRow(false);
+            setShownColumn(false);
+            hoveredRowNode = null;
+          }
+        }
+      });
+
+      const {
+        width: editorElemWidth,
+        y: editorElemY,
+        x: editorElemX,
+        right: editorElemRight,
+        bottom: editorElemBottom,
+        height: editorElemHeight,
+      } = tableDOMElement.getBoundingClientRect();
+      if (hoveredRowNode) {
+        setShownRow(true);
+        setPosition({
+          left: editorElemX,
+          top: editorElemBottom + 5,
+          width: editorElemWidth,
+        });
+      } else if (hoveredColumnNode) {
+        setShownColumn(true);
+        setPosition({
+          height: editorElemHeight,
+          left: editorElemRight + 5,
+          top: editorElemY,
+        });
+      }
+
+      // const {clientX, clientY} = event;
+      // const isOverAddColumnButton =
+      //   clientX > editorElemX + editorElemWidth &&
+      //   clientX < editorElemX + editorElemWidth + 25;
+      // const isOverAddRowButton =
+      //   clientY > editorElemY + editorElemHeight &&
+      //   clientY < editorElemY + editorElemHeight + 25;
+      // setShownColumn(isOverAddColumnButton);
+      // setShownRow(isOverAddRowButton);
+    },
+    50,
+    250,
+  );
+
+  useEffect(() => {
+    if (!shouldListenMouseMove) {
+      return;
+    }
+
+    document.addEventListener('mousemove', debouncedOnMouseMove);
+
+    return () => {
+      setShownRow(false);
+      setShownColumn(false);
+      debouncedOnMouseMove.cancel();
+      document.removeEventListener('mousemove', debouncedOnMouseMove);
+    };
+  }, [shouldListenMouseMove, debouncedOnMouseMove]);
+
+  editor.registerMutationListener(TableNode, (mutations) => {
+    editor.getEditorState().read(() => {
+      for (const [key, type] of mutations) {
+        switch (type) {
+          case 'created':
+            codeSetRef.current.add(key);
+            setShouldListenMouseMove(codeSetRef.current.size > 0);
+            break;
+
+          case 'destroyed':
+            codeSetRef.current.delete(key);
+            setShouldListenMouseMove(codeSetRef.current.size > 0);
+            break;
+
+          default:
+            break;
+        }
+      }
+    });
+  });
+
+  const insertActionRowOrColumn = (insertRow: boolean) => {
+    editor.update(() => {
+      if (insertRow) {
+        $insertTableRow__EXPERIMENTAL();
+      } else {
+        $insertTableColumn__EXPERIMENTAL();
+      }
+    });
+  };
+
+  return (
+    <>
+      {isShownRow || isShownColumn ? (
+        <button
+          className={
+            isShownRow
+              ? 'PlaygroundEditorTheme__tableAddRows'
+              : 'PlaygroundEditorTheme__tableAddColumns'
+          }
+          style={{...position}}
+          onClick={() => insertActionRowOrColumn(isShownRow)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function getMouseInfo(event: MouseEvent): {
+  codeDOMNode: HTMLElement | null;
+  isOutside: boolean;
+} {
+  const target = event.target;
+
+  if (target && target instanceof HTMLElement) {
+    const codeDOMNode = target.closest<HTMLElement>(
+      'td.PlaygroundEditorTheme__tableCell, th.PlaygroundEditorTheme__tableCell',
+    );
+    const isOutside = !(
+      codeDOMNode ||
+      target.closest<HTMLElement>('div.code-action-menu-container')
+    );
+
+    return {codeDOMNode, isOutside};
+  } else {
+    return {codeDOMNode: null, isOutside: true};
+  }
+}
+
+export default function TableHoverActionsPlugin({
+  anchorElem = document.body,
+}: {
+  anchorElem?: HTMLElement;
+}): React.ReactPortal | null {
+  return createPortal(
+    <TableHoverActionsContainer anchorElem={anchorElem} />,
+    anchorElem,
+  );
+}

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -183,11 +183,8 @@
 }
 .PlaygroundEditorTheme__tableAddColumns {
   position: absolute;
-  top: 0;
-  width: 20px;
   background-color: #eee;
   height: 100%;
-  right: -25px;
   animation: table-controls 0.2s ease;
   border: 0;
   cursor: pointer;
@@ -212,11 +209,8 @@
 }
 .PlaygroundEditorTheme__tableAddRows {
   position: absolute;
-  bottom: -25px;
   width: calc(100% - 25px);
   background-color: #eee;
-  height: 20px;
-  left: 0;
   animation: table-controls 0.2s ease;
   border: 0;
   cursor: pointer;

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -123,7 +123,7 @@
   overflow-x: scroll;
   table-layout: fixed;
   width: max-content;
-  margin: 30px 0;
+  margin: 0px 25px 30px 0px;
 }
 .PlaygroundEditorTheme__tableSelection *::selection {
   background-color: transparent;
@@ -206,7 +206,8 @@
   height: 100%;
   opacity: 0.4;
 }
-.PlaygroundEditorTheme__tableAddColumns:hover {
+.PlaygroundEditorTheme__tableAddColumns:hover,
+.PlaygroundEditorTheme__tableAddRows:hover {
   background-color: #c9dbf0;
 }
 .PlaygroundEditorTheme__tableAddRows {
@@ -233,9 +234,6 @@
   width: 100%;
   height: 100%;
   opacity: 0.4;
-}
-.PlaygroundEditorTheme__tableAddRows:hover {
-  background-color: #c9dbf0;
 }
 @keyframes table-controls {
   0% {

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.ts
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.ts
@@ -91,8 +91,6 @@ const theme: EditorThemeClasses = {
   quote: 'PlaygroundEditorTheme__quote',
   rtl: 'PlaygroundEditorTheme__rtl',
   table: 'PlaygroundEditorTheme__table',
-  tableAddColumns: 'PlaygroundEditorTheme__tableAddColumns',
-  tableAddRows: 'PlaygroundEditorTheme__tableAddRows',
   tableCell: 'PlaygroundEditorTheme__tableCell',
   tableCellActionButton: 'PlaygroundEditorTheme__tableCellActionButton',
   tableCellActionButtonContainer:


### PR DESCRIPTION
Recreate the Experimental Table Hover Action Buttons for the Classic Table as a standalone playground plugin.
Clean up some of the remnants from the original implementation that was deleted a year ago.

https://github.com/facebook/lexical/assets/7893468/cf12e22b-687d-4988-a2f5-2ec251178b9c