### PR TITLE
[Lexical] Fix broken sync due to deprecation of ReactDOMComet to ReactDOM

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -71,7 +71,7 @@ const wwwMappings = {
   'prismjs/components/prism-sql': 'prism-sql',
   'prismjs/components/prism-swift': 'prism-swift',
   'prismjs/components/prism-typescript': 'prism-typescript',
-  'react-dom': 'ReactDOMComet',
+  'react-dom': 'ReactDOM',
   // The react entrypoint in fb includes the jsx runtime
   'react/jsx-runtime': 'react',
 };


### PR DESCRIPTION
## WHAT
replace mapping for react-dom to ReactDOM from ReactDOMComet

## WHY
ReactDOMComet was deprecated 5 days ago to ReactDOM in Meta intern builds