### PR TITLE
[lexical-markdown] Feature Change: Dont trim whitespaces on convertFromMarkdownString

### DIFF
--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -110,8 +110,7 @@ function $importBlocks(
   textFormatTransformersIndex: TextFormatTransformersIndex,
   textMatchTransformers: Array<TextMatchTransformer>,
 ) {
-  const lineTextTrimmed = lineText.trim();
-  const textNode = $createTextNode(lineTextTrimmed);
+  const textNode = $createTextNode(lineText);
   const elementNode = $createParagraphNode();
   elementNode.append(textNode);
   rootNode.append(elementNode);
@@ -135,7 +134,7 @@ function $importBlocks(
   // If no transformer found and we left with original paragraph node
   // can check if its content can be appended to the previous node
   // if it's a paragraph, quote or list
-  if (elementNode.isAttached() && lineTextTrimmed.length > 0) {
+  if (elementNode.isAttached() && lineText.length > 0) {
     const previousNode = elementNode.getPreviousSibling();
     if (
       $isParagraphNode(previousNode) ||


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
Issue #6325 is about inconsistent conversion regarding whitespace trim.

markdown -> string: does not trim whitespace
string -> markdown: trims whitespace

the whitespace trim was introduced in https://github.com/facebook/lexical/pull/2519 , which has a bunch of other markdown improvements.

One goal listed in PR2519 is to make markdown a bit closer to commonmark spec. checking commonmark, it doesnt trim whitespaces on string -> markdown conversion. same behavior for markdown on github. so i guess, it would be more commonmark-ish to not trim whitspaces.

<img width="1055" alt="Screenshot 2024-07-01 at 7 55 10 PM" src="https://github.com/facebook/lexical/assets/19604232/babf79e2-45cf-4be5-8879-7852904157c3">

hi @fantactuka ! May i check with you if theres any dangers to not trim whitespaces?


Closes #6325

## Test plan

### Before


https://github.com/facebook/lexical/assets/19604232/2758640c-c63f-46da-bebe-81fa21c7fef6

string -> markdown: trims whitespace


### After
https://github.com/facebook/lexical/assets/19604232/8bcd47c5-6b29-4a31-af64-ccafd09ac3e7

string -> markdown: does not trim whitespace

---

npm run start & npm run test-e2e-chromium

no failing tests



