### PR TITLE
[lexical-playground][lexical-poll] Bug Fix: Fixes undefined context inside Poll add option

### DIFF
--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -91,7 +91,7 @@ export class PollNode extends DecoratorNode<JSX.Element> {
       serializedNode.question,
       serializedNode.options,
     );
-    serializedNode.options.forEach(node.addOption);
+    serializedNode.options.forEach((option) => node.addOption(option));
     return node;
   }
 


### PR DESCRIPTION
When lexical parse PollNode, you get error `Cannot get getWritable of undefined`.
The reason is that `this` is equal to undefined because of passing addOption function as an argument.

## Test plan
Add a poll to initial state
Get error on init, no poll content inside