### PR TITLE
Revert "[lexical-playground][lexical-poll] Bug Fix: Fixes undefined context inside Poll add option"

### DIFF
--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -91,7 +91,7 @@ export class PollNode extends DecoratorNode<JSX.Element> {
       serializedNode.question,
       serializedNode.options,
     );
-    serializedNode.options.forEach((option) => node.addOption(option));
+    serializedNode.options.forEach(node.addOption);
     return node;
   }
 


### PR DESCRIPTION
Reverts facebook/lexical#6361 Sorry, didn't see the CLA wasn't signed. Apologies. Reverting.