### PR TITLE
[Lexical][Gallery] Add description in the card, option to render preview card at run time if no image

### DIFF
--- a/packages/lexical-website/src/components/Gallery/Card.js
+++ b/packages/lexical-website/src/components/Gallery/Card.js
@@ -28,7 +28,8 @@ function Card({item}) {
     <li key={item.title} className="card shadow--md">
       <a href={item.uri} target="_blank">
         <div className={clsx('card__image', styles.showcaseCardImage)}>
-          <img src={image} alt={item.title} />
+          {item.renderPreview == null && <img src={image} alt={item.title} />}
+          {item.renderPreview != null && item.renderPreview()}
         </div>
       </a>
       <div className="card__body">

--- a/packages/lexical-website/src/components/Gallery/pluginList.js
+++ b/packages/lexical-website/src/components/Gallery/pluginList.js
@@ -8,7 +8,13 @@
 
 export const plugins = (customFields) => [
   {
+    description: 'Learn how to create an editor with Emojis',
     title: 'EmojiPlugin',
     uri: `${customFields.STACKBLITZ_PREFIX}examples/vanilla-js-plugin?embed=1&file=src%2Femoji-plugin%2FEmojiPlugin.ts&terminalHeight=0&ctl=0`,
+  },
+  {
+    description: 'Learn how to create an editor with RichText',
+    title: 'Collab RichText',
+    uri: 'https://stackblitz.com/github/facebook/lexical/tree/fix/collab_example/examples/react-rich-collab?ctl=0&file=src%2Fmain.tsx&terminalHeight=0&embed=1',
   },
 ];

--- a/packages/lexical-website/src/components/Gallery/pluginList.js
+++ b/packages/lexical-website/src/components/Gallery/pluginList.js
@@ -13,7 +13,7 @@ export const plugins = (customFields) => [
     uri: `${customFields.STACKBLITZ_PREFIX}examples/vanilla-js-plugin?embed=1&file=src%2Femoji-plugin%2FEmojiPlugin.ts&terminalHeight=0&ctl=0`,
   },
   {
-    description: 'Learn how to create an editor with RichText',
+    description: 'Learn how to create an editor with Real Time Collaboration',
     title: 'Collab RichText',
     uri: 'https://stackblitz.com/github/facebook/lexical/tree/fix/collab_example/examples/react-rich-collab?ctl=0&file=src%2Fmain.tsx&terminalHeight=0&embed=1',
   },

--- a/packages/lexical-website/src/components/Gallery/styles.module.css
+++ b/packages/lexical-website/src/components/Gallery/styles.module.css
@@ -7,7 +7,7 @@
 
 .cardList {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(310px, 1fr));
   gap: 24px;
 }
 
@@ -28,7 +28,7 @@ html[data-theme='dark'] .showcaseFavorite {
 
 .showcaseCardImage {
   overflow: hidden;
-  height: 150px;
+  height: 240px;
   border-bottom: 2px solid var(--ifm-color-emphasis-200);
 }
 


### PR DESCRIPTION
## Description
- Add description in the gallery card, 
- Add option in plugin list config to render preview card at run time if no image
- Add collab example

## Test plan
<img width="1494" alt="Screenshot 2024-07-04 at 7 42 58 PM" src="https://github.com/facebook/lexical/assets/163521239/4a561b51-fcdd-4de1-b1b0-c42ffc0a9e1c">

