### PR TITLE
[lexical-yjs] Bug Fix: Fix text duplication bug in collaborative editors

### DIFF
--- a/packages/lexical-react/src/__tests__/unit/utils.tsx
+++ b/packages/lexical-react/src/__tests__/unit/utils.tsx
@@ -27,11 +27,13 @@ function Editor({
   provider,
   setEditor,
   awarenessData,
+  shouldBootstrapCollab = true,
 }: {
   doc: Y.Doc;
   provider: Provider;
   setEditor: (editor: LexicalEditor) => void;
   awarenessData?: object | undefined;
+  shouldBootstrapCollab?: boolean;
 }) {
   const context = useCollaborationContext();
 
@@ -48,7 +50,7 @@ function Editor({
       <CollaborationPlugin
         id="main"
         providerFactory={() => provider}
-        shouldBootstrap={true}
+        shouldBootstrap={shouldBootstrapCollab}
         awarenessData={awarenessData}
       />
       <RichTextPlugin
@@ -148,7 +150,11 @@ export class Client implements Provider {
     this._connected = false;
   }
 
-  start(rootContainer: Container, awarenessData?: object) {
+  start(
+    rootContainer: Container,
+    awarenessData?: object,
+    shouldBootstrapCollab = true,
+  ) {
     const container = document.createElement('div');
     const reactRoot = createRoot(container);
     this._container = container;
@@ -171,6 +177,7 @@ export class Client implements Provider {
             doc={this._doc}
             setEditor={(editor) => (this._editor = editor)}
             awarenessData={awarenessData}
+            shouldBootstrapCollab={shouldBootstrapCollab}
           />
         </LexicalComposer>,
       );

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -104,7 +104,13 @@ export function useYjsCollaboration(
       const origin = transaction.origin;
       if (origin !== binding) {
         const isFromUndoManger = origin instanceof UndoManager;
-        syncYjsChangesToLexical(binding, provider, events, isFromUndoManger);
+        syncYjsChangesToLexical(
+          binding,
+          provider,
+          events,
+          isFromUndoManger,
+          shouldBootstrap,
+        );
       }
     };
 

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -100,11 +100,6 @@ export function syncYjsChangesToLexical(
         const event = events[i];
         $syncEvent(binding, event);
       }
-      // If there was a collision on the top level paragraph
-      // we need to re-add a paragraph
-      if ($getRoot().getChildrenSize() === 0) {
-        $getRoot().append($createParagraphNode());
-      }
 
       const selection = $getSelection();
 
@@ -135,6 +130,13 @@ export function syncYjsChangesToLexical(
     {
       onUpdate: () => {
         syncCursorPositions(binding, provider);
+        editor.update(() => {
+          // If there was a collision on the top level paragraph
+          // we need to re-add a paragraph
+          if ($getRoot().getChildrenSize() === 0) {
+            $getRoot().append($createParagraphNode());
+          }
+        });
       },
       skipTransforms: true,
       tag: isFromUndoManger ? 'historic' : 'collaboration',

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -126,17 +126,15 @@ export function syncYjsChangesToLexical(
           $syncLocalCursorPosition(binding, provider);
         }
       }
+      // If there was a collision on the top level paragraph
+      // we need to re-add a paragraph
+      if ($getRoot().getChildrenSize() === 0) {
+        $getRoot().append($createParagraphNode());
+      }
     },
     {
       onUpdate: () => {
         syncCursorPositions(binding, provider);
-        editor.update(() => {
-          // If there was a collision on the top level paragraph
-          // we need to re-add a paragraph
-          if ($getRoot().getChildrenSize() === 0) {
-            $getRoot().append($createParagraphNode());
-          }
-        });
       },
       skipTransforms: true,
       tag: isFromUndoManger ? 'historic' : 'collaboration',

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -83,6 +83,7 @@ export function syncYjsChangesToLexical(
   provider: Provider,
   events: Array<YEvent<YText>>,
   isFromUndoManger: boolean,
+  shouldBootstrap: boolean,
 ): void {
   const editor = binding.editor;
   const currentEditorState = editor._editorState;
@@ -99,6 +100,15 @@ export function syncYjsChangesToLexical(
       for (let i = 0; i < events.length; i++) {
         const event = events[i];
         $syncEvent(binding, event);
+      }
+      // Only re-add paragraph if shouldBootstrap is true,
+      // as otherwise it will break the yjs tree
+      if (shouldBootstrap === true) {
+        // If there was a collision on the top level paragraph
+        // we need to re-add a paragraph
+        if ($getRoot().getChildrenSize() === 0) {
+          $getRoot().append($createParagraphNode());
+        }
       }
 
       const selection = $getSelection();
@@ -125,11 +135,6 @@ export function syncYjsChangesToLexical(
         } else {
           $syncLocalCursorPosition(binding, provider);
         }
-      }
-      // If there was a collision on the top level paragraph
-      // we need to re-add a paragraph
-      if ($getRoot().getChildrenSize() === 0) {
-        $getRoot().append($createParagraphNode());
       }
     },
     {


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

When using collaboration with `shouldBootstrap` set to false, you start with an empty root. A paragraph is added when the user actually starts typing.

However, it is possible to undo the creation of this initial paragraph. A new empty paragraph is indeed created, but that is not correctly reflected in the Yjs tree. This causes a de-sync of the Lexical and Yjs trees, which then depending on what the user does can lead to either broken sync (some of the changes going missing) or text duplication (seen in the video below)

This issue has also been reported by other users in the Discord: https://discord.com/channels/953974421008293909/1240637271594762270/1240637271594762270

We noticed in our testing that even though the `syncYjsChangesToLexical` function creates a new paragraph if the root gets empty, the timing of the creation seems to be incorrect in a way where the Yjs tree won't be updated properly. Moving this logic to another `editor.update()` call in the `onUpdate` callback fixes this.

### Steps to replicate

1. Have collaborative editor with `shouldBootstrap` set to false, so that you start with an empty root. There needs to be persistence of the Ydoc for this to happen
2. Make sure this is a new doc
3. Type a word and then undo it
4. Type something else, and press Enter to add a new paragraph
5. Select all and then type something else again
6. Reload the page

## Test plan

### Before


https://github.com/facebook/lexical/assets/8348101/c057b399-6cf2-4b38-b1e1-b796d7afc5c8


### After


https://github.com/facebook/lexical/assets/8348101/73f4c953-5bf3-4c7b-acab-7527617b8359

