### PR TITLE
[lexical-playground] Fix Table Hover Actions Noclick Bug

### DIFF
--- a/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
@@ -107,6 +107,7 @@ function TableHoverActionsContainer({
         const {y: editorElemY} = anchorElem.getBoundingClientRect();
 
         if (hoveredRowNode) {
+          setShownColumn(false);
           setShownRow(true);
           setPosition({
             height: BUTTON_WIDTH_PX,
@@ -116,6 +117,7 @@ function TableHoverActionsContainer({
           });
         } else if (hoveredColumnNode) {
           setShownColumn(true);
+          setShownRow(false);
           setPosition({
             height: tableElemHeight,
             left: tableElemRight + 5,


### PR DESCRIPTION
Had an annoying bug in the Table Hover Actions plugin, where when one hovers over one of the buttons but then clicks the other one, the state was not correct. Fixed.

Before:

https://github.com/facebook/lexical/assets/7893468/2e7f6948-2bf0-4122-ac4f-7ad5374166ef

After: 

https://github.com/facebook/lexical/assets/7893468/5b74cee0-ba2b-407c-b6d9-24803c79403a




