### PR TITLE
[lexical][lexical-playground] Bug Fix: Create line break on paste of content type text/html

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -668,6 +668,16 @@ describe('LexicalEventHelpers', () => {
           ],
           name: 'two lines + two paragraphs separated by an empty paragraph (2)',
         },
+        {
+          expectedHTML:
+            '<p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">line 1</span><br><span data-lexical-text="true">line 2</span></p>',
+          inputs: [
+            pasteHTML(
+              '<p class="p1"><span>line 1</span><span><br></span><span>line 2</span></p>',
+            ),
+          ],
+          name: 'two lines and br in spans',
+        },
       ];
 
       suite.forEach((testUnit, i) => {

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -14,6 +14,7 @@ import type {
   SerializedLexicalNode,
 } from '../LexicalNode';
 
+import {DOM_TEXT_TYPE} from '../LexicalConstants';
 import {LexicalNode} from '../LexicalNode';
 import {$applyNodeReplacement} from '../LexicalUtils';
 
@@ -48,7 +49,10 @@ export class LineBreakNode extends LexicalNode {
 
   static importDOM(): DOMConversionMap | null {
     return {
-      br: () => {
+      br: (node: Node) => {
+        if (isOnlyChild(node)) {
+          return null;
+        }
         return {
           conversion: $convertLineBreakElement,
           priority: 0,
@@ -71,7 +75,7 @@ export class LineBreakNode extends LexicalNode {
   }
 }
 
-function $convertLineBreakElement(): DOMConversionOutput {
+function $convertLineBreakElement(node: Node): DOMConversionOutput {
   return {node: $createLineBreakNode()};
 }
 
@@ -83,4 +87,32 @@ export function $isLineBreakNode(
   node: LexicalNode | null | undefined,
 ): node is LineBreakNode {
   return node instanceof LineBreakNode;
+}
+
+function isOnlyChild(node: Node): boolean {
+  const parentElement = node.parentElement;
+  if (parentElement !== null) {
+    const firstChild = parentElement.firstChild!;
+    if (
+      firstChild === node ||
+      (firstChild.nextSibling === node && isWhitespaceDomTextNode(firstChild))
+    ) {
+      const lastChild = parentElement.lastChild!;
+      if (
+        lastChild === node ||
+        (lastChild.previousSibling === node &&
+          isWhitespaceDomTextNode(lastChild))
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function isWhitespaceDomTextNode(node: Node): boolean {
+  return (
+    node.nodeType === DOM_TEXT_TYPE &&
+    /^( |\t|\r?\n)+$/.test(node.textContent || '')
+  );
 }

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -14,7 +14,6 @@ import type {
   SerializedLexicalNode,
 } from '../LexicalNode';
 
-import {DOM_TEXT_TYPE} from '../LexicalConstants';
 import {LexicalNode} from '../LexicalNode';
 import {$applyNodeReplacement} from '../LexicalUtils';
 
@@ -49,10 +48,7 @@ export class LineBreakNode extends LexicalNode {
 
   static importDOM(): DOMConversionMap | null {
     return {
-      br: (node: Node) => {
-        if (isOnlyChild(node)) {
-          return null;
-        }
+      br: () => {
         return {
           conversion: $convertLineBreakElement,
           priority: 0,
@@ -75,7 +71,7 @@ export class LineBreakNode extends LexicalNode {
   }
 }
 
-function $convertLineBreakElement(node: Node): DOMConversionOutput {
+function $convertLineBreakElement(): DOMConversionOutput {
   return {node: $createLineBreakNode()};
 }
 
@@ -87,32 +83,4 @@ export function $isLineBreakNode(
   node: LexicalNode | null | undefined,
 ): node is LineBreakNode {
   return node instanceof LineBreakNode;
-}
-
-function isOnlyChild(node: Node): boolean {
-  const parentElement = node.parentElement;
-  if (parentElement !== null) {
-    const firstChild = parentElement.firstChild!;
-    if (
-      firstChild === node ||
-      (firstChild.nextSibling === node && isWhitespaceDomTextNode(firstChild))
-    ) {
-      const lastChild = parentElement.lastChild!;
-      if (
-        lastChild === node ||
-        (lastChild.previousSibling === node &&
-          isWhitespaceDomTextNode(lastChild))
-      ) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-function isWhitespaceDomTextNode(node: Node): boolean {
-  return (
-    node.nodeType === DOM_TEXT_TYPE &&
-    /^( |\t|\r?\n)+$/.test(node.textContent || '')
-  );
 }

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -50,7 +50,7 @@ export class LineBreakNode extends LexicalNode {
   static importDOM(): DOMConversionMap | null {
     return {
       br: (node: Node) => {
-        if (isOnlyChild(node)) {
+        if (isOnlyChildInParagraph(node)) {
           return null;
         }
         return {
@@ -89,9 +89,9 @@ export function $isLineBreakNode(
   return node instanceof LineBreakNode;
 }
 
-function isOnlyChild(node: Node): boolean {
+function isOnlyChildInParagraph(node: Node): boolean {
   const parentElement = node.parentElement;
-  if (parentElement !== null) {
+  if (parentElement !== null && parentElement.tagName === 'P') {
     const firstChild = parentElement.firstChild!;
     if (
       firstChild === node ||


### PR DESCRIPTION
## Description

### Current behaviour

On copy past of text with content type `text/html` (e.g. from google docs), line breaks inside of paragraphs are ignored. The HTML looks like this (I removed styling attributes for better overview):

```html
<html>
<body>
    <!--StartFragment-->
    <meta charset="utf-8">
    <b>
    	<br />
        <p dir="ltr">Test1</span><span><br /></span><span>Test2</span></p>
        <p dir="ltr">Test3</span></p>
    </b><br class="Apple-interchange-newline">
    <!--EndFragment-->
</body>
</html>
```

The first line break (before p tag) is recognized correctly.
The second line break (which is embedded between Test1 and Test2 in the first paragraph) gets lost.

### Expected / Fixed behaviour

The line break is inserted correctly, no matter where it was placed.

Closes [#5592](https://github.com/facebook/lexical/issues/5592)

## Test plan

### Before


https://github.com/facebook/lexical/assets/10629407/f1482eec-b412-4308-b441-5d386d82a807


### After


https://github.com/facebook/lexical/assets/10629407/d537a8f3-a04e-4912-9785-3eea963e12e4

