### PR TITLE
[examples] Chore: Use named export of LexicalErrorBoundary in the examples

### DIFF
--- a/examples/react-plain-text/src/App.tsx
+++ b/examples/react-plain-text/src/App.tsx
@@ -8,7 +8,7 @@
 import {AutoFocusPlugin} from '@lexical/react/LexicalAutoFocusPlugin';
 import {LexicalComposer} from '@lexical/react/LexicalComposer';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
-import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
+import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
 

--- a/examples/react-rich/src/App.tsx
+++ b/examples/react-rich/src/App.tsx
@@ -8,7 +8,7 @@
 import {AutoFocusPlugin} from '@lexical/react/LexicalAutoFocusPlugin';
 import {LexicalComposer} from '@lexical/react/LexicalComposer';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
-import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
+import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
 


### PR DESCRIPTION
## Description

Looks like #6088 missed rewriting two default imports of LexicalErrorBoundary in the react examples (or there was a regression?)

See also #6253

## Test plan

The react-plain-text and react-rich examples should still work.