### PR TITLE
Fix clear rootElement on React

### DIFF
--- a/packages/lexical-react/src/shared/LexicalContentEditableElement.tsx
+++ b/packages/lexical-react/src/shared/LexicalContentEditableElement.tsx
@@ -60,6 +60,8 @@ export function ContentEditableElement({
         rootElement.ownerDocument.defaultView
       ) {
         editor.setRootElement(rootElement);
+      } else {
+        editor.setRootElement(null);
       }
     },
     [editor],

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -8,6 +8,7 @@
 
 import {$createLinkNode} from '@lexical/link';
 import {$createListItemNode, $createListNode} from '@lexical/list';
+import {AutoFocusPlugin} from '@lexical/react/LexicalAutoFocusPlugin';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
@@ -187,6 +188,7 @@ describe('LexicalSelection tests', () => {
           />
           <HistoryPlugin />
           <TestPlugin />
+          <AutoFocusPlugin />
         </TestComposer>
       );
     }
@@ -195,7 +197,6 @@ describe('LexicalSelection tests', () => {
       reactRoot.render(<TestBase />);
       await Promise.resolve().then();
     });
-    editor!.getRootElement()!.focus();
 
     await Promise.resolve().then();
     // Focus first element
@@ -2269,7 +2270,7 @@ describe('LexicalSelection tests', () => {
     });
 
     it('adjust offset for inline elements text formatting', async () => {
-      init();
+      await init();
 
       await editor!.update(() => {
         const root = $getRoot();

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -755,7 +755,6 @@ export class LexicalEditor {
     listener(this._rootElement, null);
     listenerSetOrMap.add(listener);
     return () => {
-      listener(null, this._rootElement);
       listenerSetOrMap.delete(listener);
     };
   }

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -972,7 +972,7 @@ describe('LexicalEditor tests', () => {
           [editor] = useLexicalComposerContext();
 
           useEffect(() => {
-            editor.registerRootListener(listener);
+            return editor.registerRootListener(listener);
           }, []);
 
           return null;
@@ -1011,7 +1011,7 @@ describe('LexicalEditor tests', () => {
         await Promise.resolve().then();
       });
 
-      expect(listener).toHaveBeenCalledTimes(3);
+      expect(listener).toHaveBeenCalledTimes(4);
       expect(container.innerHTML).toBe(
         '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p><br></p></div>',
       );


### PR DESCRIPTION
When we introduced the `if` condition in https://github.com/facebook/lexical/pull/5070 we missed the `null` case.