### PR TITLE
[lexical-html] Feature: support pasting empty block nodes

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -299,9 +299,9 @@ function $createNodesFromDOM(
       // up to the same level as it.
       lexicalNodes = lexicalNodes.concat(childLexicalNodes);
     } else {
-      if (isBlockDomNode(node)) {
-        // Empty block dom node that hasnt been converted, we replace it with a linebreak
-        lexicalNodes = lexicalNodes.concat($createLineBreakNode());
+      if (isBlockDomNode(node) && isDomNodeMiddleChild(node)) {
+        // Empty block dom node that hasnt been converted, we replace it with a linebreak if its a middle child
+        //lexicalNodes = lexicalNodes.concat($createLineBreakNode());
       }
     }
   } else {
@@ -365,4 +365,8 @@ function $unwrapArtificalNodes(
     }
     node.remove();
   }
+}
+
+function isDomNodeMiddleChild(node: Node): boolean {
+  return node.nextSibling != null && node.previousSibling != null;
 }

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -301,7 +301,7 @@ function $createNodesFromDOM(
     } else {
       if (isBlockDomNode(node) && isDomNodeMiddleChild(node)) {
         // Empty block dom node that hasnt been converted, we replace it with a linebreak if its a middle child
-        //lexicalNodes = lexicalNodes.concat($createLineBreakNode());
+        lexicalNodes = lexicalNodes.concat($createLineBreakNode());
       }
     }
   } else {

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -294,9 +294,16 @@ function $createNodesFromDOM(
   }
 
   if (currentLexicalNode == null) {
-    // If it hasn't been converted to a LexicalNode, we hoist its children
-    // up to the same level as it.
-    lexicalNodes = lexicalNodes.concat(childLexicalNodes);
+    if (childLexicalNodes.length > 0) {
+      // If it hasn't been converted to a LexicalNode, we hoist its children
+      // up to the same level as it.
+      lexicalNodes = lexicalNodes.concat(childLexicalNodes);
+    } else {
+      if (isBlockDomNode(node)) {
+        // Empty block dom node that hasnt been converted, we replace it with a linebreak
+        lexicalNodes = lexicalNodes.concat($createLineBreakNode());
+      }
+    }
   } else {
     if ($isElementNode(currentLexicalNode)) {
       // If the current node is a ElementNode after conversion,

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -31,6 +31,7 @@ import {
   $isTextNode,
   ArtificialNode__DO_NOT_USE,
   ElementNode,
+  isInlineDomNode,
 } from 'lexical';
 
 /**
@@ -299,8 +300,8 @@ function $createNodesFromDOM(
       // up to the same level as it.
       lexicalNodes = lexicalNodes.concat(childLexicalNodes);
     } else {
-      if (isBlockDomNode(node) && isDomNodeMiddleChild(node)) {
-        // Empty block dom node that hasnt been converted, we replace it with a linebreak if its a middle child
+      if (isBlockDomNode(node) && isDomNodeBetweenTwoInlineNodes(node)) {
+        // Empty block dom node that hasnt been converted, we replace it with a linebreak if its between inline nodes
         lexicalNodes = lexicalNodes.concat($createLineBreakNode());
       }
     }
@@ -367,6 +368,11 @@ function $unwrapArtificalNodes(
   }
 }
 
-function isDomNodeMiddleChild(node: Node): boolean {
-  return node.nextSibling != null && node.previousSibling != null;
+function isDomNodeBetweenTwoInlineNodes(node: Node): boolean {
+  if (node.nextSibling == null || node.previousSibling == null) {
+    return false;
+  }
+  return (
+    isInlineDomNode(node.nextSibling) && isInlineDomNode(node.previousSibling)
+  );
 }

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -680,8 +680,10 @@ describe('LexicalEventHelpers', () => {
         },
         {
           expectedHTML:
-            '<ol class="editor-list-ol"><li value="1" class="editor-listitem"><span data-lexical-text="true">1</span><br><span data-lexical-text="true">2</span></li><li value="2" class="editor-listitem"><br></li></ol>',
-          inputs: [pasteHTML('<ol><li>1<div></div>2</li><li></li></ol>')],
+            '<ol class="editor-list-ol"><li value="1" class="editor-listitem"><span data-lexical-text="true">1</span><br><span data-lexical-text="true">2</span></li><li value="2" class="editor-listitem"><br></li><li value="3" class="editor-listitem"><span data-lexical-text="true">3</span></li></ol>',
+          inputs: [
+            pasteHTML('<ol><li>1<div></div>2</li><li></li><li>3</li></ol>'),
+          ],
           name: 'empty block node in li behaves like a line break',
         },
         {

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -678,6 +678,16 @@ describe('LexicalEventHelpers', () => {
           ],
           name: 'two lines and br in spans',
         },
+        {
+          expectedHTML: '<ol><li>1<div></div>2</li><li></li></ol>',
+          inputs: [pasteHTML('npm3</li></ol>')],
+          name: 'empty block node behaves like a line break',
+        },
+        {
+          expectedHTML: '<div>1<text></text>2</div>',
+          inputs: [pasteHTML('npm3</li></ol>')],
+          name: 'empty inline node does not behave like a line break',
+        },
       ];
 
       suite.forEach((testUnit, i) => {

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -700,6 +700,12 @@ describe('LexicalEventHelpers', () => {
         },
         {
           expectedHTML:
+            '<p class="editor-paragraph"><span data-lexical-text="true">1</span></p><p class="editor-paragraph"><span data-lexical-text="true">2</span></p>',
+          inputs: [pasteHTML('<div><div>1</div><div></div><div>2</div></div>')],
+          name: 'empty block node between non inline siblings does not behave like a line break',
+        },
+        {
+          expectedHTML:
             '<p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">a</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">b b</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">c</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">z</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">d e</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">fg</span></p>',
           inputs: [
             pasteHTML(

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -679,13 +679,21 @@ describe('LexicalEventHelpers', () => {
           name: 'two lines and br in spans',
         },
         {
-          expectedHTML: '<ol><li>1<div></div>2</li><li></li></ol>',
-          inputs: [pasteHTML('npm3</li></ol>')],
-          name: 'empty block node behaves like a line break',
+          expectedHTML:
+            '<ol class="editor-list-ol"><li value="1" class="editor-listitem"><span data-lexical-text="true">1</span><br><span data-lexical-text="true">2</span></li><li value="2" class="editor-listitem"><br></li></ol>',
+          inputs: [pasteHTML('<ol><li>1<div></div>2</li><li></li></ol>')],
+          name: 'empty block node in li behaves like a line break',
         },
         {
-          expectedHTML: '<div>1<text></text>2</div>',
-          inputs: [pasteHTML('npm3</li></ol>')],
+          expectedHTML:
+            '<p class="editor-paragraph"><span data-lexical-text="true">1</span><br><span data-lexical-text="true">2</span></p>',
+          inputs: [pasteHTML('<div>1<div></div>2</div>')],
+          name: 'empty block node in div behaves like a line break',
+        },
+        {
+          expectedHTML:
+            '<p class="editor-paragraph"><span data-lexical-text="true">12</span></p>',
+          inputs: [pasteHTML('<div>1<text></text>2</div>')],
           name: 'empty inline node does not behave like a line break',
         },
       ];

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -696,6 +696,16 @@ describe('LexicalEventHelpers', () => {
           inputs: [pasteHTML('<div>1<text></text>2</div>')],
           name: 'empty inline node does not behave like a line break',
         },
+        {
+          expectedHTML:
+            '<p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">a</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">b b</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">c</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">z</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">d e</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">fg</span></p>',
+          inputs: [
+            pasteHTML(
+              `<div>a<div>b b<div>c<div><div></div>z</div>d e</div>fg</div>`,
+            ),
+          ],
+          name: 'nested divs',
+        },
       ];
 
       suite.forEach((testUnit, i) => {

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -701,7 +701,7 @@ describe('LexicalEventHelpers', () => {
             '<p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">a</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">b b</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">c</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">z</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">d e</span></p><p class="editor-paragraph" dir="ltr"><span data-lexical-text="true">fg</span></p>',
           inputs: [
             pasteHTML(
-              `<div>a<div>b b<div>c<div><div></div>z</div>d e</div>fg</div>`,
+              `<div>a<div>b b<div>c<div><div></div>z</div></div>d e</div>fg</div>`,
             ),
           ],
           name: 'nested divs',

--- a/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
+++ b/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
@@ -52,25 +52,6 @@ describe('HTMLCopyAndPaste tests', () => {
             </div>`,
         },
         {
-          expectedHTML: `<p dir="ltr"><span data-lexical-text="true">a</span></p><p dir="ltr"><span data-lexical-text="true">b b</span></p><p dir="ltr"><span data-lexical-text="true">c</span></p><p dir="ltr"><span data-lexical-text="true">z </span></p><p dir="ltr"><span data-lexical-text="true">d e </span></p><p dir="ltr"><span data-lexical-text="true">fg</span></p>`,
-          name: 'nested divs',
-          pastedHTML: `<div>
-            a
-            <div>
-              b b
-              <div>
-                c
-                <div>
-                  <div></div>
-                  z
-                </div>
-              </div>
-              d e
-            </div>
-            fg
-          </div>`,
-        },
-        {
           expectedHTML: `<p dir="ltr"><span data-lexical-text="true">a b c d e</span></p><p dir="ltr"><span data-lexical-text="true">f g h</span></p>`,
           name: 'multiple nested spans and divs',
           pastedHTML: `<div>


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
An empty block node (eg. `<div></div>`) in between 2 inline nodes in html places the next inline node on the next line, acting as a linebreak. lexical currently doesnt handle pasting empty block nodes, so there is a missing line break where the empty block node should be.

see test plan for demo.

test cases are added as unit tests 

## Test plan
```
<div>
  1
  <div></div>
  2
</div>
```
![Screenshot 2024-07-12 at 11 56 58 AM](https://github.com/user-attachments/assets/31a1f7f9-13d7-459b-8ce6-d8dcb3bd3196)


### Before

![Screenshot 2024-07-12 at 11 56 48 AM](https://github.com/user-attachments/assets/1be32700-feb4-4d71-b6ea-4fd9dd8fdf7b)




### After

![Screenshot 2024-07-12 at 11 58 12 AM](https://github.com/user-attachments/assets/97fcfa89-12b3-4018-af3d-7084e6ff587f)

---

```
<ol>
  <li>1
    <div></div>
    2
  </li>
  <li>
  </li>
  <li>3</li>
</ol>
```
![Screenshot 2024-07-12 at 12 05 57 PM](https://github.com/user-attachments/assets/c532e40b-fb4a-4cb9-908b-0d39fc9af67e)


### Before

![Screenshot 2024-07-12 at 12 09 06 PM](https://github.com/user-attachments/assets/4d5f2155-a73a-4cb4-83a7-2f185e6d62bb)


### After

![Screenshot 2024-07-12 at 12 09 00 PM](https://github.com/user-attachments/assets/c6e5e955-365b-4162-82b7-6e3ea57f0361)