### PR TITLE
[lexical-playground][lexical-table] Bug Fix: Fix `Shift`+ `Down Arrow` regression for table sequence.

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -1346,8 +1346,8 @@ function $handleArrowKey(
         event.shiftKey &&
         (direction === 'up' || direction === 'down')
       ) {
-        const anchorNode = selection.anchor.getNode();
-        if ($isRootOrShadowRoot(anchorNode)) {
+        const focusNode = selection.focus.getNode();
+        if ($isRootOrShadowRoot(focusNode)) {
           const selectedNode = selection.getNodes()[0];
           if (selectedNode) {
             const tableCellNode = $findMatchingParent(
@@ -1387,17 +1387,17 @@ function $handleArrowKey(
           }
           return false;
         } else {
-          const anchorParentNode = $findMatchingParent(
-            anchorNode,
+          const focusParentNode = $findMatchingParent(
+            focusNode,
             (n) => $isElementNode(n) && !n.isInline(),
           );
-          if (!anchorParentNode) {
+          if (!focusParentNode) {
             return false;
           }
           const sibling =
             direction === 'down'
-              ? anchorParentNode.getNextSibling()
-              : anchorParentNode.getPreviousSibling();
+              ? focusParentNode.getNextSibling()
+              : focusParentNode.getPreviousSibling();
           if (
             $isTableNode(sibling) &&
             tableObserver.tableNodeKey === sibling.getKey()


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

Fixes an issue where Shift + Down Arrow selects only the first table in a table sequence. The fix ensures that the selection extends to include the next table(s) in sequence.

### Before

Shift + Down Arrow selects only the first table.

https://www.loom.com/share/05d1f521688f48098dc4aa63eb4060f0?sid=46796142-ba1f-45f8-aef9-ff9a0ec44074

### After

Shift + Down Arrow includes the next table in the selection.

https://www.loom.com/share/b01ca74cfb6940e78fc321dbe794a67e?sid=c45fd210-7b36-48d4-b9c5-d13e794a8dbb

