### PR TITLE
[lexical] Bug Fix: more accurate line break pasting

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -720,6 +720,12 @@ describe('LexicalEventHelpers', () => {
           inputs: [pasteHTML('<ol><li>1</li><li><br /></li><li>3</li></ol>')],
           name: 'only br in a li',
         },
+        {
+          expectedHTML:
+            '<p class="editor-paragraph"><span data-lexical-text="true">1</span></p><p class="editor-paragraph"><span data-lexical-text="true">2</span></p><p class="editor-paragraph"><span data-lexical-text="true">3</span></p>',
+          inputs: [pasteHTML('1<p>2<br /></p>3')],
+          name: 'last br in a block node is ignored',
+        },
       ];
 
       suite.forEach((testUnit, i) => {

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -678,6 +678,12 @@ describe('LexicalEventHelpers', () => {
           ],
           name: 'two lines and br in spans',
         },
+        {
+          expectedHTML:
+            '<ol class="editor-list-ol"><li value="1" class="editor-listitem"><span data-lexical-text="true">1</span></li><li value="2" class="editor-listitem"><br></li><li value="3" class="editor-listitem"><span data-lexical-text="true">3</span></li></ol>',
+          inputs: [pasteHTML('<ol><li>1</li><li><br /></li><li>3</li></ol>')],
+          name: 'only br in a li',
+        },
       ];
 
       suite.forEach((testUnit, i) => {

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -50,7 +50,7 @@ export class LineBreakNode extends LexicalNode {
   static importDOM(): DOMConversionMap | null {
     return {
       br: (node: Node) => {
-        if (isOnlyChildInBlockNode(node)) {
+        if (isOnlyChildInBlockNode(node) || isLastChildInBlockNode(node)) {
           return null;
         }
         return {
@@ -105,6 +105,30 @@ function isOnlyChildInBlockNode(node: Node): boolean {
       ) {
         return true;
       }
+    }
+  }
+  return false;
+}
+
+function isLastChildInBlockNode(node: Node): boolean {
+  const parentElement = node.parentElement;
+  if (parentElement !== null && isBlockDomNode(parentElement)) {
+    // check if node is first child, because only childs dont count
+    const firstChild = parentElement.firstChild!;
+    if (
+      firstChild === node ||
+      (firstChild.nextSibling === node && isWhitespaceDomTextNode(firstChild))
+    ) {
+      return false;
+    }
+
+    // check if its last child
+    const lastChild = parentElement.lastChild!;
+    if (
+      lastChild === node ||
+      (lastChild.previousSibling === node && isWhitespaceDomTextNode(lastChild))
+    ) {
+      return true;
     }
   }
   return false;

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -16,7 +16,7 @@ import type {
 
 import {DOM_TEXT_TYPE} from '../LexicalConstants';
 import {LexicalNode} from '../LexicalNode';
-import {$applyNodeReplacement} from '../LexicalUtils';
+import {$applyNodeReplacement, isBlockDomNode} from '../LexicalUtils';
 
 export type SerializedLineBreakNode = SerializedLexicalNode;
 
@@ -50,7 +50,7 @@ export class LineBreakNode extends LexicalNode {
   static importDOM(): DOMConversionMap | null {
     return {
       br: (node: Node) => {
-        if (isOnlyChildInParagraph(node)) {
+        if (isOnlyChildInBlockNode(node)) {
           return null;
         }
         return {
@@ -89,9 +89,9 @@ export function $isLineBreakNode(
   return node instanceof LineBreakNode;
 }
 
-function isOnlyChildInParagraph(node: Node): boolean {
+function isOnlyChildInBlockNode(node: Node): boolean {
   const parentElement = node.parentElement;
-  if (parentElement !== null && parentElement.tagName === 'P') {
+  if (parentElement !== null && isBlockDomNode(parentElement)) {
     const firstChild = parentElement.firstChild!;
     if (
       firstChild === node ||


### PR DESCRIPTION
Improve br pasting

- ignore only child br in block nodes and not just `<p>`. fixes extra br in `<li>` paste
- ignore last br in block node, since thats what html is doing ([src](https://stackoverflow.com/questions/61907540/when-are-br-elements-ignored-when-within-a-paragraph#:~:text=All%20br%20elements%20at%20the,elements%20has%20to%20be%20ignored.)) 

## Test plan

![Screenshot 2024-07-12 at 3 04 21 PM](https://github.com/user-attachments/assets/afe528b6-4c0e-4436-8e12-33b9afa777c3)

### Before

![Screenshot 2024-07-12 at 3 04 32 PM](https://github.com/user-attachments/assets/5d9f2d25-841e-4ac1-806c-40375be93b2b)



### After

![Screenshot 2024-07-12 at 3 06 30 PM](https://github.com/user-attachments/assets/97a625bc-72f6-4c64-9f05-89839a8f52c4)

---

![Screenshot 2024-07-12 at 3 27 27 PM](https://github.com/user-attachments/assets/5c56c34a-bc74-49d8-ae61-64a0e05ca2a2)

### before
![Screenshot 2024-07-12 at 3 27 45 PM](https://github.com/user-attachments/assets/cf55e53d-c83e-470c-913c-a4cc6003838f)


### after
![Screenshot 2024-07-12 at 3 27 39 PM](https://github.com/user-attachments/assets/af390c29-97a5-41b2-8f5e-1f11245840c6)


