### PR TITLE
Restore registerRootListener null call

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -768,6 +768,7 @@ export class LexicalEditor {
     listener(this._rootElement, null);
     listenerSetOrMap.add(listener);
     return () => {
+      listener(null, this._rootElement);
       listenerSetOrMap.delete(listener);
     };
   }

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1138,7 +1138,7 @@ describe('LexicalEditor tests', () => {
         await Promise.resolve().then();
       });
 
-      expect(listener).toHaveBeenCalledTimes(4);
+      expect(listener).toHaveBeenCalledTimes(5);
       expect(container.innerHTML).toBe(
         '<div contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p><br></p></div>',
       );


### PR DESCRIPTION
Restores the null call I removed in #6389, unfortunately it's a breaking change. Products are using this to do the teardown. For example:

```
if (prevElement !== null) {
    prevElement.removeEventListener('click', handleClick);
    prevElement.removeEventListener('pointerdown', handlePointerDown);
  }
```

We may need to introduce a new function/signature and always migrate to it. If we were to mimic React this would be intuitive and wouldn't need to return a fake `null` `rootElement`:

```
registerRootListener(prevElement, nextElement) {
  
  return () => {
    if (prevElement !== null) {
      prevElement.removeEventListener(...);
  }
```