### PR TITLE
CI: fix build failure on astro integration tests

### DIFF
--- a/.github/workflows/call-integration-tests.yml
+++ b/.github/workflows/call-integration-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.18.0]
+        node-version: [20.15.1]
     env:
       CI: true
     steps:


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

This updates node version to the latest LTS `20.15.1` on integrations tests workflow due to the regression in the latest astro `4.11.6`.

Should other tests be updated as well now?

Closes #6413 

## Test plan

run integrations tests