### PR TITLE
[lexical-playground][TableCellResizer] Bug Fix: Register event handlers on root element

### DIFF
--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -134,15 +134,19 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
       }, 0);
     };
 
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mousedown', onMouseDown);
-    document.addEventListener('mouseup', onMouseUp);
+    const removeRootListener = editor.registerRootListener((rootElement, prevRootElement) => {
+      rootElement?.addEventListener('mousemove', onMouseMove);
+      rootElement?.addEventListener('mousedown', onMouseDown);
+      rootElement?.addEventListener('mouseup', onMouseUp);
+
+      prevRootElement?.removeEventListener('mousemove', onMouseMove);
+      prevRootElement?.removeEventListener('mousedown', onMouseDown);
+      prevRootElement?.removeEventListener('mouseup', onMouseUp);
+    });
 
     return () => {
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mousedown', onMouseDown);
-      document.removeEventListener('mouseup', onMouseUp);
-    };
+      removeRootListener();
+    }
   }, [activeCell, draggingDirection, editor, resetState]);
 
   const isHeightChanging = (direction: MouseDraggingDirection) => {


### PR DESCRIPTION
The `TableCellResizer` plugin registers mouse events on the document, but if there are multiple editors on the page they all receive events causing the inactive editors to throw `TableCellResizer: Table cell node not found.` errors and leading to the inactive editors becoming unresponsive.

Changed the plugin to register events on the editors root element so that events are only raised and handled by the editor the mouse is over.