### PR TITLE
Fix discrete nested updates

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -804,7 +804,10 @@ function processNestedUpdates(
         }
         if (options.discrete) {
           const pendingEditorState = editor._pendingEditorState;
-          invariant(pendingEditorState !== null, 'write soemthing');
+          invariant(
+            pendingEditorState !== null,
+            'Unexpected empty pending editor state on discrete nested update',
+          );
           pendingEditorState._flushSync = true;
         }
 

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -802,6 +802,11 @@ function processNestedUpdates(
         if (options.skipTransforms) {
           skipTransforms = true;
         }
+        if (options.discrete) {
+          const pendingEditorState = editor._pendingEditorState;
+          invariant(pendingEditorState !== null, 'write soemthing');
+          pendingEditorState._flushSync = true;
+        }
 
         if (onUpdate) {
           editor._deferred.push(onUpdate);

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -534,9 +534,11 @@ export function createTestEditor(
   return editor;
 }
 
-export function createTestHeadlessEditor(): LexicalEditor {
+export function createTestHeadlessEditor(
+  editorState?: EditorState,
+): LexicalEditor {
   return createHeadlessEditor({
-    namespace: '',
+    editorState,
     onError: (error) => {
       throw error;
     },


### PR DESCRIPTION
If the `discrete` flag was part of a nested update it was being ignored. Instead, the correct behavior is that this update and the previously computed updates should be flushed.