### PR TITLE
[lexical-history][lexical-selection][lexical-react] Fix: #6409 TextNode change detection

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -256,7 +256,7 @@ function $appendNodesToJSON(
   let target = currentNode;
 
   if (selection !== null) {
-    let clone = $cloneWithProperties<LexicalNode>(currentNode);
+    let clone = $cloneWithProperties(currentNode);
     clone =
       $isTextNode(clone) && selection !== null
         ? $sliceSelectedTextNodeContent(selection, clone)
@@ -267,11 +267,11 @@ function $appendNodesToJSON(
 
   const serializedNode = exportNodeToJSON(target);
 
-  // TODO: TextNode calls getTextContent() (NOT node.__text) within it's exportJSON method
+  // TODO: TextNode calls getTextContent() (NOT node.__text) within its exportJSON method
   // which uses getLatest() to get the text from the original node with the same key.
   // This is a deeper issue with the word "clone" here, it's still a reference to the
   // same node as far as the LexicalEditor is concerned since it shares a key.
-  // We need a way to create a clone of a Node in memory with it's own key, but
+  // We need a way to create a clone of a Node in memory with its own key, but
   // until then this hack will work for the selected text extract use case.
   if ($isTextNode(target)) {
     const text = target.__text;

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -7,13 +7,10 @@
  */
 
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
-import {
-  $addNodeStyle,
-  $cloneWithProperties,
-  $sliceSelectedTextNodeContent,
-} from '@lexical/selection';
+import {$addNodeStyle, $sliceSelectedTextNodeContent} from '@lexical/selection';
 import {objectKlassEquals} from '@lexical/utils';
 import {
+  $cloneWithProperties,
   $createTabNode,
   $getRoot,
   $getSelection,

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -193,25 +193,26 @@ function isTextNodeUnchanged(
 
   const prevSelection = prevEditorState._selection;
   const nextSelection = nextEditorState._selection;
-  let isDeletingLine = false;
+  const isDeletingLine =
+    $isRangeSelection(prevSelection) &&
+    $isRangeSelection(nextSelection) &&
+    prevSelection.anchor.type === 'element' &&
+    prevSelection.focus.type === 'element' &&
+    nextSelection.anchor.type === 'text' &&
+    nextSelection.focus.type === 'text';
 
-  if ($isRangeSelection(prevSelection) && $isRangeSelection(nextSelection)) {
-    isDeletingLine =
-      prevSelection.anchor.type === 'element' &&
-      prevSelection.focus.type === 'element' &&
-      nextSelection.anchor.type === 'text' &&
-      nextSelection.focus.type === 'text';
-  }
-
-  if (!isDeletingLine && $isTextNode(prevNode) && $isTextNode(nextNode)) {
+  if (
+    !isDeletingLine &&
+    $isTextNode(prevNode) &&
+    $isTextNode(nextNode) &&
+    prevNode.__parent === nextNode.__parent
+  ) {
+    // This has the assumption that object key order won't change if the
+    // content did not change, which should normally be safe given
+    // the manner in which nodes and exportJSON are typically implemented.
     return (
-      prevNode.__type === nextNode.__type &&
-      prevNode.__text === nextNode.__text &&
-      prevNode.__mode === nextNode.__mode &&
-      prevNode.__detail === nextNode.__detail &&
-      prevNode.__style === nextNode.__style &&
-      prevNode.__format === nextNode.__format &&
-      prevNode.__parent === nextNode.__parent
+      JSON.stringify(prevEditorState.read(() => prevNode.exportJSON())) ===
+      JSON.stringify(nextEditorState.read(() => nextNode.exportJSON()))
     );
   }
   return false;

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -103,7 +103,7 @@ function $appendNodesToHTML(
   let target = currentNode;
 
   if (selection !== null) {
-    let clone = $cloneWithProperties<LexicalNode>(currentNode);
+    let clone = $cloneWithProperties(currentNode);
     clone =
       $isTextNode(clone) && selection !== null
         ? $sliceSelectedTextNodeContent(selection, clone)

--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -16,12 +16,10 @@ import type {
   LexicalNode,
 } from 'lexical';
 
-import {
-  $cloneWithProperties,
-  $sliceSelectedTextNodeContent,
-} from '@lexical/selection';
+import {$sliceSelectedTextNodeContent} from '@lexical/selection';
 import {isBlockDomNode, isHTMLElement} from '@lexical/utils';
 import {
+  $cloneWithProperties,
   $createLineBreakNode,
   $createParagraphNode,
   $getRoot,

--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -15,7 +15,6 @@ import {forwardRef, Ref, useLayoutEffect, useState} from 'react';
 import {ContentEditableElement} from './shared/LexicalContentEditableElement';
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 
-/* eslint-disable @typescript-eslint/ban-types */
 export type Props = Omit<ElementProps, 'editor'> & {
   editor__DEPRECATED?: LexicalEditor;
 } & (
@@ -30,8 +29,6 @@ export type Props = Omit<ElementProps, 'editor'> & {
           | JSX.Element;
       }
   );
-
-/* eslint-enable @typescript-eslint/ban-types */
 
 export const ContentEditable = forwardRef(ContentEditableImpl);
 

--- a/packages/lexical-react/src/LexicalHistoryPlugin.ts
+++ b/packages/lexical-react/src/LexicalHistoryPlugin.ts
@@ -17,13 +17,15 @@ export {createEmptyHistoryState} from '@lexical/history';
 export type {HistoryState};
 
 export function HistoryPlugin({
+  delay,
   externalHistoryState,
 }: {
+  delay?: number;
   externalHistoryState?: HistoryState;
 }): null {
   const [editor] = useLexicalComposerContext();
 
-  useHistory(editor, externalHistoryState);
+  useHistory(editor, externalHistoryState, delay);
 
   return null;
 }

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -2272,42 +2272,44 @@ describe('LexicalSelection tests', () => {
     it('adjust offset for inline elements text formatting', async () => {
       await init();
 
-      await editor!.update(() => {
-        const root = $getRoot();
+      await ReactTestUtils.act(async () => {
+        await editor!.update(() => {
+          const root = $getRoot();
 
-        const text1 = $createTextNode('--');
-        const text2 = $createTextNode('abc');
-        const text3 = $createTextNode('--');
+          const text1 = $createTextNode('--');
+          const text2 = $createTextNode('abc');
+          const text3 = $createTextNode('--');
 
-        root.append(
-          $createParagraphNode().append(
-            text1,
-            $createLinkNode('https://lexical.dev').append(text2),
-            text3,
-          ),
-        );
+          root.append(
+            $createParagraphNode().append(
+              text1,
+              $createLinkNode('https://lexical.dev').append(text2),
+              text3,
+            ),
+          );
 
-        $setAnchorPoint({
-          key: text1.getKey(),
-          offset: 2,
-          type: 'text',
+          $setAnchorPoint({
+            key: text1.getKey(),
+            offset: 2,
+            type: 'text',
+          });
+
+          $setFocusPoint({
+            key: text3.getKey(),
+            offset: 0,
+            type: 'text',
+          });
+
+          const selection = $getSelection();
+
+          if (!$isRangeSelection(selection)) {
+            return;
+          }
+
+          selection.formatText('bold');
+
+          expect(text2.hasFormat('bold')).toBe(true);
         });
-
-        $setFocusPoint({
-          key: text3.getKey(),
-          offset: 0,
-          type: 'text',
-        });
-
-        const selection = $getSelection();
-
-        if (!$isRangeSelection(selection)) {
-          return;
-        }
-
-        selection.formatText('bold');
-
-        expect(text2.hasFormat('bold')).toBe(true);
       });
     });
   });

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -8,7 +8,6 @@
 
 import {
   $addNodeStyle,
-  $cloneWithProperties,
   $isAtNodeEnd,
   $patchStyleText,
   $sliceSelectedTextNodeContent,
@@ -31,8 +30,10 @@ import {
 } from './utils';
 
 export {
+  /** @deprecated moved to the lexical package */ $cloneWithProperties,
+} from 'lexical';
+export {
   $addNodeStyle,
-  $cloneWithProperties,
   $isAtNodeEnd,
   $patchStyleText,
   $sliceSelectedTextNodeContent,

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -36,37 +36,35 @@ import {
 function $updateElementNodeProperties<T extends ElementNode>(
   target: T,
   source: ElementNode,
-): T {
+): void {
   target.__first = source.__first;
   target.__last = source.__last;
   target.__size = source.__size;
   target.__format = source.__format;
   target.__indent = source.__indent;
   target.__dir = source.__dir;
-  return target;
 }
 
 function $updateTextNodeProperties<T extends TextNode>(
   target: T,
   source: TextNode,
-): T {
+): void {
   target.__format = source.__format;
   target.__style = source.__style;
   target.__mode = source.__mode;
   target.__detail = source.__detail;
-  return target;
 }
 
 function $updateParagraphNodeProperties<T extends ParagraphNode>(
   target: T,
   source: ParagraphNode,
-): T {
+): void {
   target.__textFormat = source.__textFormat;
-  return target;
 }
 
 /**
- * Returns a copy of a node, but generates a new key for the copy.
+ * Returns a clone of a node with the same key and parent/next/prev pointers and other
+ * properties that are not set by the KlassConstructor.clone (format, style, etc.).
  * @param node - The node to be cloned.
  * @returns The clone of the node.
  */
@@ -79,16 +77,14 @@ export function $cloneWithProperties<T extends LexicalNode>(node: T): T {
   clone.__prev = node.__prev;
 
   if ($isElementNode(node) && $isElementNode(clone)) {
-    return $updateElementNodeProperties(clone, node);
+    $updateElementNodeProperties(clone, node);
+    if ($isParagraphNode(node) && $isParagraphNode(clone)) {
+      $updateParagraphNodeProperties(clone, node);
+    }
+  } else if ($isTextNode(node) && $isTextNode(clone)) {
+    $updateTextNodeProperties(clone, node);
   }
 
-  if ($isTextNode(node) && $isTextNode(clone)) {
-    return $updateTextNodeProperties(clone, node);
-  }
-
-  if ($isParagraphNode(node) && $isParagraphNode(clone)) {
-    return $updateParagraphNodeProperties(clone, node);
-  }
   return clone;
 }
 

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -11,15 +11,12 @@ import {
   $getNodeByKey,
   $getPreviousSelection,
   $isElementNode,
-  $isParagraphNode,
   $isRangeSelection,
   $isRootNode,
   $isTextNode,
   BaseSelection,
-  ElementNode,
   LexicalEditor,
   LexicalNode,
-  ParagraphNode,
   Point,
   RangeSelection,
   TextNode,
@@ -32,61 +29,6 @@ import {
   getStyleObjectFromCSS,
   getStyleObjectFromRawCSS,
 } from './utils';
-
-function $updateElementNodeProperties<T extends ElementNode>(
-  target: T,
-  source: ElementNode,
-): void {
-  target.__first = source.__first;
-  target.__last = source.__last;
-  target.__size = source.__size;
-  target.__format = source.__format;
-  target.__indent = source.__indent;
-  target.__dir = source.__dir;
-}
-
-function $updateTextNodeProperties<T extends TextNode>(
-  target: T,
-  source: TextNode,
-): void {
-  target.__format = source.__format;
-  target.__style = source.__style;
-  target.__mode = source.__mode;
-  target.__detail = source.__detail;
-}
-
-function $updateParagraphNodeProperties<T extends ParagraphNode>(
-  target: T,
-  source: ParagraphNode,
-): void {
-  target.__textFormat = source.__textFormat;
-}
-
-/**
- * Returns a clone of a node with the same key and parent/next/prev pointers and other
- * properties that are not set by the KlassConstructor.clone (format, style, etc.).
- * @param node - The node to be cloned.
- * @returns The clone of the node.
- */
-export function $cloneWithProperties<T extends LexicalNode>(node: T): T {
-  const constructor = node.constructor;
-  // @ts-expect-error
-  const clone: T = constructor.clone(node);
-  clone.__parent = node.__parent;
-  clone.__next = node.__next;
-  clone.__prev = node.__prev;
-
-  if ($isElementNode(node) && $isElementNode(clone)) {
-    $updateElementNodeProperties(clone, node);
-    if ($isParagraphNode(node) && $isParagraphNode(clone)) {
-      $updateParagraphNodeProperties(clone, node);
-    }
-  } else if ($isTextNode(node) && $isTextNode(clone)) {
-    $updateTextNodeProperties(clone, node);
-  }
-
-  return clone;
-}
 
 /**
  * Generally used to append text content to HTML and JSON. Grabs the text content and "slices"

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import {$cloneWithProperties} from '@lexical/selection';
 import {
+  $cloneWithProperties,
   $createParagraphNode,
   $getPreviousSelection,
   $getRoot,
@@ -446,12 +446,7 @@ export function $restoreEditorState(
   const activeEditorState = editor._pendingEditorState;
 
   for (const [key, node] of editorState._nodeMap) {
-    const clone = $cloneWithProperties(node);
-    if ($isTextNode(clone)) {
-      invariant($isTextNode(node), 'Expected node be a TextNode');
-      clone.__text = node.__text;
-    }
-    nodeMap.set(key, clone);
+    nodeMap.set(key, $cloneWithProperties(node));
   }
 
   if (activeEditorState) {

--- a/packages/lexical-website/src/components/Gallery/utils.tsx
+++ b/packages/lexical-website/src/components/Gallery/utils.tsx
@@ -51,6 +51,6 @@ export function useFilteredExamples(examples: Array<Example>) {
         searchName,
         tags,
       }),
-    [examples, searchName],
+    [examples, searchName, tags],
   );
 }

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -862,6 +862,7 @@ declare export function $hasAncestor(
   child: LexicalNode,
   targetNode: LexicalNode,
 ): boolean;
+declare export function $cloneWithProperties<T: LexicalNode>(node: T): T;
 declare export function $copyNode(
   node: ElementNode,
   offset: number,

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -16,7 +16,6 @@ import invariant from 'shared/invariant';
 import {
   $createParagraphNode,
   $isElementNode,
-  $isParagraphNode,
   $isRootNode,
   $isTextNode,
   ElementNode,
@@ -35,6 +34,7 @@ import {
   getActiveEditorState,
 } from './LexicalUpdates';
 import {
+  $cloneWithProperties,
   $getCompositionKey,
   $getNodeByKey,
   $isRootOrShadowRoot,
@@ -686,7 +686,6 @@ export class LexicalNode {
     const key = this.__key;
     // Ensure we get the latest node from pending state
     const latestNode = this.getLatest();
-    const parent = latestNode.__parent;
     const cloneNotNeeded = editor._cloneNotNeeded;
     const selection = $getSelection();
     if (selection !== null) {
@@ -697,34 +696,12 @@ export class LexicalNode {
       internalMarkNodeAsDirty(latestNode);
       return latestNode;
     }
-    const constructor = latestNode.constructor;
-    const mutableNode = constructor.clone(latestNode);
-    mutableNode.__parent = parent;
-    mutableNode.__next = latestNode.__next;
-    mutableNode.__prev = latestNode.__prev;
-    if ($isElementNode(latestNode) && $isElementNode(mutableNode)) {
-      if ($isParagraphNode(latestNode) && $isParagraphNode(mutableNode)) {
-        mutableNode.__textFormat = latestNode.__textFormat;
-      }
-      mutableNode.__first = latestNode.__first;
-      mutableNode.__last = latestNode.__last;
-      mutableNode.__size = latestNode.__size;
-      mutableNode.__indent = latestNode.__indent;
-      mutableNode.__format = latestNode.__format;
-      mutableNode.__dir = latestNode.__dir;
-    } else if ($isTextNode(latestNode) && $isTextNode(mutableNode)) {
-      mutableNode.__format = latestNode.__format;
-      mutableNode.__style = latestNode.__style;
-      mutableNode.__mode = latestNode.__mode;
-      mutableNode.__detail = latestNode.__detail;
-    }
+    const mutableNode = $cloneWithProperties(latestNode);
     cloneNotNeeded.add(key);
-    mutableNode.__key = key;
     internalMarkNodeAsDirty(mutableNode);
     // Update reference in node map
     nodeMap.set(key, mutableNode);
 
-    // @ts-expect-error
     return mutableNode;
   }
 

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1764,11 +1764,13 @@ export function $cloneWithProperties<T extends LexicalNode>(latestNode: T): T {
     mutableNode.__mode = latestNode.__mode;
     mutableNode.__detail = latestNode.__detail;
   }
-  invariant(
-    mutableNode.__key === latestNode.__key,
-    "$cloneWithProperties: %s.clone(node) (with type '%s') did not return a node with the same key, make sure to specify node.__key as the last argument to the constructor",
-    constructor.name,
-    constructor.getType(),
-  );
+  if (__DEV__) {
+    invariant(
+      mutableNode.__key === latestNode.__key,
+      "$cloneWithProperties: %s.clone(node) (with type '%s') did not return a node with the same key, make sure to specify node.__key as the last argument to the constructor",
+      constructor.name,
+      constructor.getType(),
+    );
+  }
   return mutableNode;
 }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -41,6 +41,7 @@ import {
   $isDecoratorNode,
   $isElementNode,
   $isLineBreakNode,
+  $isParagraphNode,
   $isRangeSelection,
   $isRootNode,
   $isTextNode,
@@ -1381,10 +1382,15 @@ export function $isRootOrShadowRoot(
   return $isRootNode(node) || ($isElementNode(node) && node.isShadowRoot());
 }
 
+/**
+ * Returns a shallow clone of node with a new key
+ *
+ * @param node - The node to be copied.
+ * @returns The copy of the node.
+ */
 export function $copyNode<T extends LexicalNode>(node: T): T {
-  const copy = node.constructor.clone(node);
+  const copy = node.constructor.clone(node) as T;
   $setNodeKey(copy, null);
-  // @ts-expect-error
   return copy;
 }
 
@@ -1726,4 +1732,43 @@ export function getCachedTypeToNodeMap(
     }
   }
   return typeToNodeMap;
+}
+
+/**
+ * Returns a clone of a node with the same key and parent/next/prev pointers and other
+ * properties that are not set by the KlassConstructor.clone (format, style, etc.).
+ *
+ * Does not mutate the EditorState.
+ * @param node - The node to be cloned.
+ * @returns The clone of the node.
+ */
+export function $cloneWithProperties<T extends LexicalNode>(latestNode: T): T {
+  const constructor = latestNode.constructor;
+  const mutableNode = constructor.clone(latestNode) as T;
+  mutableNode.__parent = latestNode.__parent;
+  mutableNode.__next = latestNode.__next;
+  mutableNode.__prev = latestNode.__prev;
+  if ($isElementNode(latestNode) && $isElementNode(mutableNode)) {
+    if ($isParagraphNode(latestNode) && $isParagraphNode(mutableNode)) {
+      mutableNode.__textFormat = latestNode.__textFormat;
+    }
+    mutableNode.__first = latestNode.__first;
+    mutableNode.__last = latestNode.__last;
+    mutableNode.__size = latestNode.__size;
+    mutableNode.__indent = latestNode.__indent;
+    mutableNode.__format = latestNode.__format;
+    mutableNode.__dir = latestNode.__dir;
+  } else if ($isTextNode(latestNode) && $isTextNode(mutableNode)) {
+    mutableNode.__format = latestNode.__format;
+    mutableNode.__style = latestNode.__style;
+    mutableNode.__mode = latestNode.__mode;
+    mutableNode.__detail = latestNode.__detail;
+  }
+  invariant(
+    mutableNode.__key === latestNode.__key,
+    "$cloneWithProperties: %s.clone(node) (with type '%s') did not return a node with the same key, make sure to specify node.__key as the last argument to the constructor",
+    constructor.name,
+    constructor.getType(),
+  );
+  return mutableNode;
 }

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -156,6 +156,7 @@ export {$parseSerializedNode, isCurrentlyReadOnlyMode} from './LexicalUpdates';
 export {
   $addUpdateTag,
   $applyNodeReplacement,
+  $cloneWithProperties,
   $copyNode,
   $getAdjacentNode,
   $getEditor,


### PR DESCRIPTION
## Description

* Targeted fix for lexical-history's `TextNode` change detection when only one text leaf is dirty but unchanged
* Add delay option to HistoryPlugin
* Fix `$cloneWithProperties` - the previous implementation did not correctly handle `__textFormat` from `ParagraphNode`. Also updated the very incorrect doc string.
* Clean up lint and test warning issues elsewhere
* Move `$cloneWithProperties` to the lexical package because the correct implementation was already inlined in `LexicalNode.getWritable()`

A more general fix may be possible, it's unclear whether this hack is really necessary for MaxLengthPlugin but other text node transforms may have similar issues so removing the hack could be backwards incompatible.

Closes #6409

## Test plan

### Before

History's TextNode change detection did not work correctly for subclasses where only properties that did not exist on TextNode changed.

### After

The tests show that the behavior is consistent with expectations