### PR TITLE
[lexical][lexical-selection] Bug Fix: Respect mode when patching text style

### DIFF
--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -30,6 +30,7 @@ import {
   LexicalNode,
   ParagraphNode,
   RangeSelection,
+  TextModeType,
   TextNode,
 } from 'lexical';
 import {
@@ -3076,6 +3077,52 @@ describe('$patchStyleText', () => {
       expect(color).toEqual('');
     });
   });
+
+  test.each<TextModeType>(['token', 'segmented'])(
+    'can update style of text node that is in %s mode',
+    async (mode) => {
+      const editor = createTestEditor();
+
+      const element = document.createElement('div');
+      editor.setRootElement(element);
+
+      await editor.update(() => {
+        const root = $getRoot();
+
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
+
+        const text = $createTextNode('first').setFormat('bold');
+        paragraph.append(text);
+
+        const textInMode = $createTextNode('second').setMode(mode);
+        paragraph.append(textInMode);
+
+        $setAnchorPoint({
+          key: text.getKey(),
+          offset: 'fir'.length,
+          type: 'text',
+        });
+
+        $setFocusPoint({
+          key: textInMode.getKey(),
+          offset: 'sec'.length,
+          type: 'text',
+        });
+
+        const selection = $getSelection();
+        $patchStyleText(selection!, {'font-size': '15px'});
+      });
+
+      expect(element.innerHTML).toBe(
+        '<p dir="ltr">' +
+          '<strong data-lexical-text="true">fir</strong>' +
+          '<strong style="font-size: 15px;" data-lexical-text="true">st</strong>' +
+          '<span style="font-size: 15px;" data-lexical-text="true">second</span>' +
+          '</p>',
+      );
+    },
+  );
 
   test('preserve backward selection when changing style of 2 different text nodes', async () => {
     const editor = createTestEditor();

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -15,6 +15,7 @@ import {
   $isRangeSelection,
   $isRootNode,
   $isTextNode,
+  $isTokenOrSegmented,
   BaseSelection,
   ElementNode,
   LexicalEditor,
@@ -404,8 +405,11 @@ export function $patchStyleText(
         return;
       }
 
-      // The entire node is selected, so just format it
-      if (startOffset === 0 && endOffset === firstNodeTextLength) {
+      // The entire node is selected or a token/segment, so just format it
+      if (
+        $isTokenOrSegmented(firstNode) ||
+        (startOffset === 0 && endOffset === firstNodeTextLength)
+      ) {
         $patchStyle(firstNode, patch);
         firstNode.select(startOffset, endOffset);
       } else {
@@ -423,8 +427,8 @@ export function $patchStyleText(
       startOffset < firstNode.getTextContentSize() &&
       firstNode.canHaveFormat()
     ) {
-      if (startOffset !== 0) {
-        // the entire first node isn't selected, so split it
+      if (startOffset !== 0 && !$isTokenOrSegmented(firstNode)) {
+        // the entire first node isn't selected and it isn't a token or segmented, so split it
         firstNode = firstNode.splitText(startOffset)[1];
         startOffset = 0;
         if (isBefore) {
@@ -449,8 +453,8 @@ export function $patchStyleText(
         endOffset = lastNodeTextLength;
       }
 
-      // if the entire last node isn't selected, split it
-      if (endOffset !== lastNodeTextLength) {
+      // if the entire last node isn't selected and it isn't a token or segmented, split it
+      if (endOffset !== lastNodeTextLength && !$isTokenOrSegmented(lastNode)) {
         [lastNode] = lastNode.splitText(endOffset);
       }
 

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -169,6 +169,7 @@ export {
   $isInlineElementOrDecoratorNode,
   $isLeafNode,
   $isRootOrShadowRoot,
+  $isTokenOrSegmented,
   $nodesOfType,
   $selectAll,
   $setCompositionKey,


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
There is an issue in Lexical where token and segmented text nodes are not correctly handled during text styling operations. This results in improper formatting / node splitting, leading to unexpected behaviour.

After some debugging, I saw that it is handled correctly in the `RangeSelection` class, but not in the helper method used to patch the text style.
https://github.com/facebook/lexical/blob/2c90ee08e6cb9a073ed4cb7a9fca3c8f273d9f47/packages/lexical/src/LexicalSelection.ts#L1136-L1182

Closes #6427 <!-- issue number -->

1. Added `$isTokenOrSegmented` to the list of exported utilities.
2. Updated `$patchStyleText` function: Adjusted logic to prevent splitting of token/segmented nodes

