### PR TITLE
docs: fix typo in editor.registerCommand() usage

### DIFF
--- a/packages/lexical-website/docs/intro.md
+++ b/packages/lexical-website/docs/intro.md
@@ -132,5 +132,5 @@ unregisterListener();
 
 Commands are the communication system used to wire everything together in Lexical. Custom commands can be created using `createCommand()` and
 dispatched to an editor using `editor.dispatchCommand(command, payload)`. Lexical dispatches commands internally when key presses are triggered
-and when other important signals occur. Commands can also be handled using `editor.registerCommand(handler, priority)`, and incoming commands are
+and when other important signals occur. Commands can also be handled using `editor.registerCommand(command, handler, priority)`, and incoming commands are
 propagated through all handlers by priority until a handler stops the propagation (in a similar way to event propagation in the browser).


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

Closes #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*