### PR TITLE
[lexical][auto-link] Fix auto link crash editor

### DIFF
--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -276,6 +276,16 @@ export class LinkNode extends ElementNode {
       selection.getTextContent().length > 0
     );
   }
+
+  isEmailURI(): boolean {
+    return this.__url.startsWith('mailto:');
+  }
+
+  isWebSiteURI(): boolean {
+    return (
+      this.__url.startsWith('https://') || this.__url.startsWith('http://')
+    );
+  }
 }
 
 function $convertAnchorElement(domNode: Node): DOMConversionOutput {

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -91,8 +91,19 @@ function startsWithSeparator(textContent: string): boolean {
   return isSeparator(textContent[0]);
 }
 
-function startsWithFullStop(textContent: string): boolean {
-  return /^\.[a-zA-Z0-9]{1,}/.test(textContent);
+/**
+ * Check if the text content starts with a fullstop followed by a top-level domain.
+ * Meaning if the text content can be a beginning of a top level domain.
+ * @param textContent
+ * @param isEmail
+ * @returns boolean
+ */
+function startsWithTLD(textContent: string, isEmail: boolean): boolean {
+  if (isEmail) {
+    return /^\.[a-zA-Z]{2,}/.test(textContent);
+  } else {
+    return /^\.[a-zA-Z0-9]{1,}/.test(textContent);
+  }
 }
 
 function isPreviousNodeValid(node: LexicalNode): boolean {
@@ -385,7 +396,8 @@ function handleBadNeighbors(
   if (
     $isAutoLinkNode(previousSibling) &&
     !previousSibling.getIsUnlinked() &&
-    (!startsWithSeparator(text) || startsWithFullStop(text))
+    (!startsWithSeparator(text) ||
+      startsWithTLD(text, previousSibling.isEmailURI()))
   ) {
     previousSibling.append(textNode);
     handleLinkEdit(previousSibling, matchers, onChange);


### PR DESCRIPTION
Fixed bug introduced in https://github.com/facebook/lexical/pull/6146. Improving the way a potential top-level domain is parsed for email autolinks. Adding more e2e tests, apparently the email auto-link use case wasn't covered by tests.

Closes #6430

### Before

https://github.com/user-attachments/assets/41384f51-a2c5-489b-b95d-d2d9e13dce55

### After

https://github.com/user-attachments/assets/bcbfd089-a103-40db-bd50-45a3bc3be3ac

