### PR TITLE
[lexical-playground] Feature: Store lexical editor on the window for quick inspection

### DIFF
--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -48,6 +48,7 @@ import ExcalidrawPlugin from './plugins/ExcalidrawPlugin';
 import FigmaPlugin from './plugins/FigmaPlugin';
 import FloatingLinkEditorPlugin from './plugins/FloatingLinkEditorPlugin';
 import FloatingTextFormatToolbarPlugin from './plugins/FloatingTextFormatToolbarPlugin';
+import GlobalInspectPlugin from './plugins/GlobalInspectPlugin';
 import ImagesPlugin from './plugins/ImagesPlugin';
 import InlineImagePlugin from './plugins/InlineImagePlugin';
 import KeywordsPlugin from './plugins/KeywordsPlugin';
@@ -142,7 +143,7 @@ export default function Editor(): JSX.Element {
         <ComponentPickerPlugin />
         <EmojiPickerPlugin />
         <AutoEmbedPlugin />
-
+        <GlobalInspectPlugin />
         <MentionsPlugin />
         <EmojisPlugin />
         <HashtagPlugin />

--- a/packages/lexical-playground/src/plugins/GlobalInspectPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/GlobalInspectPlugin/index.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useEffect} from 'react';
+
+export default function GlobalInspectPlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).lexicalEditor = editor;
+    // eslint-disable-next-line no-console
+    console.log('Lexical editor is now available as `lexicalEditor`');
+
+    return () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (window as any).lexicalEditor;
+    };
+  }, [editor]);
+
+  return null;
+}


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

I've frequently found myself hunting through React Dev Tools to find the editor in state and store it on a global so that I can dig into the internals.

This would save me a few clicks 😅

## Test plan

Tested locally in dev mode.