### PR TITLE
[lexical] Bug Fix: getCachedTypeToNodeMap should handle a empty and writable EditorState

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -903,7 +903,7 @@ export class LexicalEditor {
     klass: Klass<LexicalNode>,
   ): void {
     const prevEditorState = this._editorState;
-    const nodeMap = getCachedTypeToNodeMap(this._editorState).get(
+    const nodeMap = getCachedTypeToNodeMap(prevEditorState).get(
       klass.getType(),
     );
     if (!nodeMap) {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1710,9 +1710,15 @@ export type TypeToNodeMap = Map<string, NodeMap>;
  * Compute a cached Map of node type to nodes for a frozen EditorState
  */
 const cachedNodeMaps = new WeakMap<EditorState, TypeToNodeMap>();
+const EMPTY_TYPE_TO_NODE_MAP: TypeToNodeMap = new Map();
 export function getCachedTypeToNodeMap(
   editorState: EditorState,
 ): TypeToNodeMap {
+  // If this is a new Editor it may have a writable this._editorState
+  // with only a 'root' entry.
+  if (!editorState._readOnly && editorState.isEmpty()) {
+    return EMPTY_TYPE_TO_NODE_MAP;
+  }
   invariant(
     editorState._readOnly,
     'getCachedTypeToNodeMap called with a writable EditorState',

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -35,6 +35,7 @@ import {
   COMMAND_PRIORITY_EDITOR,
   COMMAND_PRIORITY_LOW,
   createCommand,
+  createEditor,
   EditorState,
   ElementNode,
   type Klass,
@@ -1807,7 +1808,14 @@ describe('LexicalEditor tests', () => {
     expect(textNodeMutation2[0].get(textNodeKeys[1])).toBe('destroyed');
     expect(textNodeMutation2[0].get(textNodeKeys[2])).toBe('destroyed');
   });
-
+  it('mutation listener on newly initialized editor', async () => {
+    editor = createEditor();
+    const textNodeMutations = jest.fn();
+    editor.registerMutationListener(TextNode, textNodeMutations, {
+      skipInitialization: false,
+    });
+    expect(textNodeMutations.mock.calls.length).toBe(0);
+  });
   it('mutation listener with setEditorState', async () => {
     init();
 


### PR DESCRIPTION
## Description

Follow-up to #6357

When an editor is still initializing the this._editorState may be writable but will only have the 'root' entry. We need to special case this to prevent an exception if a mutation listener with initialization is registered before the first reconciliation.

## Test plan

The unit test covers this case and will fail without the change