### PR TITLE
[Lexical][CI] ignore running unit/integerity/e2e tests on examples folder code

### DIFF
--- a/.github/workflows/after-approval.yml
+++ b/.github/workflows/after-approval.yml
@@ -17,7 +17,7 @@ jobs:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "merge_group"]'
-          paths_ignore: '["packages/lexical-website/**", "packages/*/README.md", ".size-limit.js"]'
+          paths_ignore: '["packages/lexical-website/**", "packages/*/README.md", ".size-limit.js", "examples/**"]'
   e2e-tests:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true' && (github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'extended-tests'))

--- a/.github/workflows/tests-extended.yml
+++ b/.github/workflows/tests-extended.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [labeled, synchronize, reopened]
     paths-ignore:
+      - 'examples/**'
       - 'packages/lexical-website/**'
       - 'packages/*/README.md'
       - '.size-limit.js'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
     paths-ignore:
+      - 'examples/**'
       - 'packages/lexical-website/**'
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
+      - 'examples/**'
       - 'packages/lexical-website/**'
 
 concurrency:


### PR DESCRIPTION
## Description

- ignore running unit/integerity/e2e tests on examples folder code
- examples are not impacting the real package code and shouldn't be triggering running of e2e/unit tests, similar to website