### PR TITLE
[Lexical][Gallery] Add tableplugin example to gallery

### DIFF
--- a/packages/lexical-website/src/components/Gallery/pluginList.tsx
+++ b/packages/lexical-website/src/components/Gallery/pluginList.tsx
@@ -32,4 +32,10 @@ export const plugins = (customFields: {
     title: 'Collab RichText',
     uri: 'https://stackblitz.com/github/facebook/lexical/tree/fix/collab_example/examples/react-rich-collab?ctl=0&file=src%2Fmain.tsx&terminalHeight=0&embed=1',
   },
+  {
+    description: 'Learn how to create an editor with Tables',
+    tags: ['opensource', 'favorite'],
+    title: 'Collab RichText',
+    uri: `${customFields.STACKBLITZ_PREFIX}examples/react-table?embed=1&file=src%2Fmain.tsx&terminalHeight=0&ctl=0`,
+  },
 ];

--- a/packages/lexical-website/src/components/Gallery/pluginList.tsx
+++ b/packages/lexical-website/src/components/Gallery/pluginList.tsx
@@ -35,7 +35,7 @@ export const plugins = (customFields: {
   {
     description: 'Learn how to create an editor with Tables',
     tags: ['opensource', 'favorite'],
-    title: 'Collab RichText',
+    title: 'TablePlugin',
     uri: `${customFields.STACKBLITZ_PREFIX}examples/react-table?embed=1&file=src%2Fmain.tsx&terminalHeight=0&ctl=0`,
   },
 ];


### PR DESCRIPTION
## Description

add tablePlugin example to gallery

## Test plan

<img width="954" alt="Screenshot 2024-07-23 at 3 55 26 PM" src="https://github.com/user-attachments/assets/a44fdbc6-b589-45cb-9503-ec538244b299">

<img width="1728" alt="Screenshot 2024-07-23 at 3 56 23 PM" src="https://github.com/user-attachments/assets/c11330a2-2fa0-45ac-b74c-ce26bbf7acfb">



