### PR TITLE
[lexical] Bug Fix: Allow getTopLevelElement to return a DecoratorNode

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -386,8 +386,8 @@ declare export class LexicalNode {
   getIndexWithinParent(): number;
   getParent<T: ElementNode>(): T | null;
   getParentOrThrow<T: ElementNode>(): T;
-  getTopLevelElement(): ElementNode | null;
-  getTopLevelElementOrThrow(): ElementNode;
+  getTopLevelElement(): DecoratorNode<mixed> | ElementNode | null;
+  getTopLevelElementOrThrow(): DecoratorNode<mixed> | ElementNode;
   getParents<T: ElementNode>(): Array<T>;
   getParentKeys(): Array<NodeKey>;
   getPreviousSibling<T: LexicalNode>(): T | null;
@@ -589,6 +589,8 @@ declare export class TextNode extends LexicalNode {
   static getType(): string;
   static clone(node: $FlowFixMe): TextNode;
   constructor(text: string, key?: NodeKey): void;
+  getTopLevelElement(): ElementNode | null;
+  getTopLevelElementOrThrow(): ElementNode;
   getFormat(): number;
   getStyle(): string;
   isComposing(): boolean;
@@ -724,6 +726,8 @@ declare export class ElementNode extends LexicalNode {
   __indent: number;
   __dir: 'ltr' | 'rtl' | null;
   constructor(key?: NodeKey): void;
+  getTopLevelElement(): ElementNode | null;
+  getTopLevelElementOrThrow(): ElementNode;
   getFormat(): number;
   getFormatType(): ElementFormatType;
   getIndent(): number;
@@ -790,6 +794,10 @@ declare export function $isElementNode(
 
 declare export class DecoratorNode<X> extends LexicalNode {
   constructor(key?: NodeKey): void;
+  // Not sure how to get flow to agree that the DecoratorNode<mixed> is compatible with this,
+  // so we have a less precise type than in TS
+  // getTopLevelElement(): this | ElementNode | null;
+  // getTopLevelElementOrThrow(): this | ElementNode;
   decorate(editor: LexicalEditor, config: EditorConfig): X;
   isIsolated(): boolean;
   isInline(): boolean;

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -19,6 +19,7 @@ import {
   $isElementNode,
   $isRootNode,
   $isTextNode,
+  type DecoratorNode,
   ElementNode,
 } from '.';
 import {
@@ -376,14 +377,14 @@ export class LexicalNode {
    * non-root ancestor of this node, or null if none is found. See {@link lexical!$isRootOrShadowRoot}
    * for more information on which Elements comprise "roots".
    */
-  getTopLevelElement(): ElementNode | null {
+  getTopLevelElement(): ElementNode | DecoratorNode<unknown> | null {
     let node: ElementNode | this | null = this;
     while (node !== null) {
       const parent: ElementNode | null = node.getParent();
       if ($isRootOrShadowRoot(parent)) {
         invariant(
-          $isElementNode(node),
-          'Children of root nodes must be elements',
+          $isElementNode(node) || (node === this && $isDecoratorNode(node)),
+          'Children of root nodes must be elements or decorators',
         );
         return node;
       }
@@ -397,7 +398,7 @@ export class LexicalNode {
    * non-root ancestor of this node, or throws if none is found. See {@link lexical!$isRootOrShadowRoot}
    * for more information on which Elements comprise "roots".
    */
-  getTopLevelElementOrThrow(): ElementNode {
+  getTopLevelElementOrThrow(): ElementNode | DecoratorNode<unknown> {
     const parent = this.getTopLevelElement();
     if (parent === null) {
       invariant(

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -9,8 +9,11 @@
 import {
   $getRoot,
   $getSelection,
+  $isDecoratorNode,
+  $isElementNode,
   $isRangeSelection,
   DecoratorNode,
+  ElementNode,
   ParagraphNode,
   TextNode,
 } from 'lexical';
@@ -400,6 +403,30 @@ describe('LexicalNode tests', () => {
           expect(paragraphNode.getTopLevelElement()).toBe(paragraphNode);
         });
         expect(() => textNode.getTopLevelElement()).toThrow();
+        await editor.update(() => {
+          const node = new InlineDecoratorNode();
+          expect(node.getTopLevelElement()).toBe(null);
+          $getRoot().append(node);
+          expect(node.getTopLevelElement()).toBe(node);
+        });
+        editor.getEditorState().read(() => {
+          const elementNodes: ElementNode[] = [];
+          const decoratorNodes: DecoratorNode<unknown>[] = [];
+          for (const child of $getRoot().getChildren()) {
+            expect(child.getTopLevelElement()).toBe(child);
+            if ($isElementNode(child)) {
+              elementNodes.push(child);
+            } else if ($isDecoratorNode(child)) {
+              decoratorNodes.push(child);
+            } else {
+              throw new Error(
+                'Expecting all children to be ElementNode or DecoratorNode',
+              );
+            }
+          }
+          expect(decoratorNodes).toHaveLength(1);
+          expect(elementNodes).toHaveLength(1);
+        });
       });
 
       test('LexicalNode.getTopLevelElementOrThrow()', async () => {
@@ -415,6 +442,12 @@ describe('LexicalNode tests', () => {
           expect(paragraphNode.getTopLevelElementOrThrow()).toBe(paragraphNode);
         });
         expect(() => textNode.getTopLevelElementOrThrow()).toThrow();
+        await editor.update(() => {
+          const node = new InlineDecoratorNode();
+          expect(() => node.getTopLevelElementOrThrow()).toThrow();
+          $getRoot().append(node);
+          expect(node.getTopLevelElementOrThrow()).toBe(node);
+        });
       });
 
       test('LexicalNode.getParents()', async () => {

--- a/packages/lexical/src/nodes/LexicalDecoratorNode.ts
+++ b/packages/lexical/src/nodes/LexicalDecoratorNode.ts
@@ -8,13 +8,21 @@
 
 import type {KlassConstructor, LexicalEditor} from '../LexicalEditor';
 import type {NodeKey} from '../LexicalNode';
+import type {ElementNode} from './LexicalElementNode';
 
 import {EditorConfig} from 'lexical';
 import invariant from 'shared/invariant';
 
 import {LexicalNode} from '../LexicalNode';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export interface DecoratorNode<T> {
+  getTopLevelElement(): ElementNode | this | null;
+  getTopLevelElementOrThrow(): ElementNode | this;
+}
+
 /** @noInheritDoc */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class DecoratorNode<T> extends LexicalNode {
   ['constructor']!: KlassConstructor<typeof DecoratorNode<T>>;
   constructor(key?: NodeKey) {

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -57,7 +57,14 @@ export type ElementFormatType =
   | 'justify'
   | '';
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ElementNode {
+  getTopLevelElement(): ElementNode | null;
+  getTopLevelElementOrThrow(): ElementNode;
+}
+
 /** @noInheritDoc */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ElementNode extends LexicalNode {
   ['constructor']!: KlassConstructor<typeof ElementNode>;
   /** @internal */

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -21,6 +21,7 @@ import type {
   SerializedLexicalNode,
 } from '../LexicalNode';
 import type {BaseSelection, RangeSelection} from '../LexicalSelection';
+import type {ElementNode} from './LexicalElementNode';
 
 import {IS_FIREFOX} from 'shared/environment';
 import invariant from 'shared/invariant';
@@ -274,7 +275,14 @@ function wrapElementWith(
   return el;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface TextNode {
+  getTopLevelElement(): ElementNode | null;
+  getTopLevelElementOrThrow(): ElementNode;
+}
+
 /** @noInheritDoc */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class TextNode extends LexicalNode {
   ['constructor']!: KlassConstructor<typeof TextNode>;
   __text: string;


### PR DESCRIPTION
## Description

Allows `getTopLevelElement` to return a `DecoratorNode` from `LexicalNode`, and uses declaration merging to return a more specific type when called from an `ElementNode`, `TextNode`, or `DecoratorNode`. I couldn't get it to work in a "cleaner" way than declaration merging.

With TypeScript I was able to get the type to be exactly `this | ElementNode | null` for `DecoratorNode.getTopLevelElement` but with Flow it's just `DecoratorNode<mixed> | ElementNode | null`. Flow claimed that `DecoratorNode<mixed>` wasn't compatible with `DecoratorNode<T>` but it really should be in return position like that, and I don't have enough recent flow experience to track down why or if it's possible to get it to return the more precise result.

This PR also applies the fix at the value and type level to `getTopLevelElementOrThrow`.

Closes #6451

## Test plan

### Before

See #6451

### After

Unit test coverage is included