### PR TITLE
CI: dont cancel other test runs if e2e flaky job fails

### DIFF
--- a/.github/workflows/call-e2e-test.yml
+++ b/.github/workflows/call-e2e-test.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   e2e-test:
     runs-on: ${{ inputs.os }}
+    continue-on-error: ${{ inputs.flaky }}
     if: (inputs.browser != 'webkit' || inputs.os == 'macos-latest') && (inputs.editor-mode != 'rich-text-with-collab' || inputs.events-mode != 'legacy-events')
     env:
       CI: true


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

see https://github.com/facebook/lexical/actions/runs/10090883909/job/27901243336?pr=6458 as example

when a flaky job fails, a cancel signal is sent out to other jobs. the tests in flaky job are likely to fail due to flakiness so we should not let that cancel other job runs.

(also hoping flaky job failures would not fail the overall PR check signal but lets see)

context on flaky job: it should be a non blocking job to isolate known flaky test. it gives clearer signal if a test is failing due to a known flaky test

## Test plan

see how the ci goes.

when one flaky job fail it should not trigger a cancel signal for other jobs