### PR TITLE
[Lexica][CI] run extended tests for safari in mac-os and chrome/firefox in linux/windows

### DIFF
--- a/.github/workflows/call-e2e-all-tests.yml
+++ b/.github/workflows/call-e2e-all-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.18.0]
-        browser: ['chromium', 'firefox', 'webkit']
+        browser: ['webkit']
         editor-mode: ['rich-text', 'plain-text']
         events-mode: ['modern-events']
     uses: ./.github/workflows/call-e2e-test.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.18.0]
-        browser: ['chromium', 'firefox', 'webkit']
+        browser: ['webkit']
     uses: ./.github/workflows/call-e2e-test.yml
     with:
       os: 'macos-latest'
@@ -94,7 +94,7 @@ jobs:
   prod:
     strategy:
       matrix:
-        os: ['macos-latest']
+        os: ['ubuntu-latest']
         node-version: [18.18.0]
         browser: ['chromium']
         editor-mode: ['rich-text']
@@ -111,7 +111,7 @@ jobs:
   collab-prod:
     strategy:
       matrix:
-        os: ['macos-latest']
+        os: ['ubuntu-latest']
         node-version: [18.18.0]
         browser: ['chromium']
         editor-mode: ['rich-text-with-collab']
@@ -134,7 +134,7 @@ jobs:
         prod: [false]
     uses: ./.github/workflows/call-e2e-test.yml
     with:
-      os: 'macos-latest'
+      os: 'ubuntu-latest'
       browser: 'chromium'
       node-version: 18.18.0
       events-mode: 'modern-events'
@@ -151,7 +151,7 @@ jobs:
         events-mode: ['modern-events']
     uses: ./.github/workflows/call-e2e-test.yml
     with:
-      os: 'macos-latest'
+      os: 'ubuntu-latest'
       flaky: true
       node-version: ${{ matrix.node-version }}
       browser: ${{ matrix.browser }}

--- a/.github/workflows/call-e2e-all-tests.yml
+++ b/.github/workflows/call-e2e-all-tests.yml
@@ -4,12 +4,27 @@ on:
   workflow_call:
 
 jobs:
-  mac:
+  mac-rich:
+    strategy:
+      matrix:
+        node-version: [18.18.0]
+        browser: ['webkit', 'chromium', 'firefox']
+        editor-mode: ['rich-text']
+        events-mode: ['modern-events']
+    uses: ./.github/workflows/call-e2e-test.yml
+    with:
+      os: 'macos-latest'
+      node-version: ${{ matrix.node-version }}
+      browser: ${{ matrix.browser }}
+      editor-mode: ${{ matrix.editor-mode }}
+      events-mode: ${{ matrix.events-mode }}
+
+  mac-plain:
     strategy:
       matrix:
         node-version: [18.18.0]
         browser: ['webkit']
-        editor-mode: ['rich-text', 'plain-text']
+        editor-mode: ['plain-text']
         events-mode: ['modern-events']
     uses: ./.github/workflows/call-e2e-test.yml
     with:


### PR DESCRIPTION
## Description
- run extended tests for safari in mac-os and chrome/firefox in linux/windows
- follow up on suggestion in discord 
https://discord.com/channels/953974421008293909/1179904979587301387/1266354720356827170

- run only safari tests in mac-os
- for tests like react-beta, etc which are only run in mac-os/chrome change to ubuntu/chrome

![image](https://github.com/user-attachments/assets/bdf3d79a-abc4-4e44-921b-dabe3991f2c3)
