### PR TITLE
Hide Table Add Buttons on KeyDown

### DIFF
--- a/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
@@ -131,18 +131,25 @@ function TableHoverActionsContainer({
     250,
   );
 
+  const hideButtons = () => {
+    setShownColumn(false);
+    setShownRow(false);
+  };
+
   useEffect(() => {
     if (!shouldListenMouseMove) {
       return;
     }
 
     document.addEventListener('mousemove', debouncedOnMouseMove);
+    document.addEventListener('keydown', hideButtons);
 
     return () => {
       setShownRow(false);
       setShownColumn(false);
       debouncedOnMouseMove.cancel();
       document.removeEventListener('mousemove', debouncedOnMouseMove);
+      document.removeEventListener('keydown', hideButtons);
     };
   }, [shouldListenMouseMove, debouncedOnMouseMove]);
 

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -317,30 +317,6 @@ export function applyTableHandlers(
   const $deleteCellHandler = (event: KeyboardEvent): boolean => {
     const selection = $getSelection();
 
-    if (!$isSelectionInTable(selection, tableNode)) {
-      const nodes = selection ? selection.getNodes() : null;
-      if (nodes) {
-        const table = nodes.find(
-          (node) =>
-            $isTableNode(node) && node.getKey() === tableObserver.tableNodeKey,
-        );
-        if ($isTableNode(table)) {
-          const parentNode = table.getParent();
-          if (!parentNode) {
-            return false;
-          }
-          const nextNode = table.getNextSibling() || table.getPreviousSibling();
-          table.remove();
-          if (nextNode) {
-            nextNode.selectStart();
-          } else {
-            parentNode.selectStart();
-          }
-        }
-      }
-      return true;
-    }
-
     if ($isTableSelection(selection)) {
       event.preventDefault();
       event.stopPropagation();
@@ -358,6 +334,34 @@ export function applyTableHandlers(
       }
     }
 
+    if (!$isSelectionInTable(selection, tableNode)) {
+      const nodes = selection ? selection.getNodes() : null;
+      if (nodes) {
+        for (const node of nodes) {
+          // const table = nodes.find(
+          //   (node) =>
+          //     $isTableNode(node) && node.getKey() === tableObserver.tableNodeKey,
+          // );
+
+          if ($isTableNode(node)) {
+            const parentNode = node.getParent();
+            if (!parentNode) {
+              return false;
+            }
+            const nextNode = node.getNextSibling() || node.getPreviousSibling();
+            node.remove();
+            if (nextNode) {
+              nextNode.selectStart();
+            } else {
+              parentNode.selectStart();
+            }
+          } else {
+            node.remove();
+          }
+        }
+      }
+      return true;
+    }
     return false;
   };
 

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -317,23 +317,6 @@ export function applyTableHandlers(
   const $deleteCellHandler = (event: KeyboardEvent): boolean => {
     const selection = $getSelection();
 
-    if ($isTableSelection(selection)) {
-      event.preventDefault();
-      event.stopPropagation();
-      tableObserver.clearText();
-
-      return true;
-    } else if ($isRangeSelection(selection)) {
-      const tableCellNode = $findMatchingParent(
-        selection.anchor.getNode(),
-        (n) => $isTableCellNode(n),
-      );
-
-      if (!$isTableCellNode(tableCellNode)) {
-        return false;
-      }
-    }
-
     if (!$isSelectionInTable(selection, tableNode)) {
       const nodes = selection ? selection.getNodes() : null;
       if (nodes) {
@@ -361,6 +344,23 @@ export function applyTableHandlers(
         }
       }
       return true;
+    }
+
+    if ($isTableSelection(selection)) {
+      event.preventDefault();
+      event.stopPropagation();
+      tableObserver.clearText();
+
+      return true;
+    } else if ($isRangeSelection(selection)) {
+      const tableCellNode = $findMatchingParent(
+        selection.anchor.getNode(),
+        (n) => $isTableCellNode(n),
+      );
+
+      if (!$isTableCellNode(tableCellNode)) {
+        return false;
+      }
     }
     return false;
   };

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -320,26 +320,21 @@ export function applyTableHandlers(
     if (!$isSelectionInTable(selection, tableNode)) {
       const nodes = selection ? selection.getNodes() : null;
       if (nodes) {
-        for (const node of nodes) {
-          // const table = nodes.find(
-          //   (node) =>
-          //     $isTableNode(node) && node.getKey() === tableObserver.tableNodeKey,
-          // );
-
-          if ($isTableNode(node)) {
-            const parentNode = node.getParent();
-            if (!parentNode) {
-              return false;
-            }
-            const nextNode = node.getNextSibling() || node.getPreviousSibling();
-            node.remove();
-            if (nextNode) {
-              nextNode.selectStart();
-            } else {
-              parentNode.selectStart();
-            }
+        const table = nodes.find(
+          (node) =>
+            $isTableNode(node) && node.getKey() === tableObserver.tableNodeKey,
+        );
+        if ($isTableNode(table)) {
+          const parentNode = table.getParent();
+          if (!parentNode) {
+            return false;
+          }
+          const nextNode = table.getNextSibling() || table.getPreviousSibling();
+          table.remove();
+          if (nextNode) {
+            nextNode.selectStart();
           } else {
-            node.remove();
+            parentNode.selectStart();
           }
         }
       }
@@ -362,6 +357,7 @@ export function applyTableHandlers(
         return false;
       }
     }
+
     return false;
   };
 


### PR DESCRIPTION
Hide the table hover add buttons when the user starts typing, to prevent the button overlap.

Before:

https://github.com/user-attachments/assets/1fcbe68b-9c67-415f-a399-801c06505a26

After:

https://github.com/user-attachments/assets/2a939d15-cab4-4b96-a11f-935ca473740c

