### PR TITLE
[lexical-table] Bug Fix: Enable observer updates on table elements attributes change

### DIFF
--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -151,6 +151,7 @@ export class TableObserver {
 
       this.table = getTable(tableElement);
       observer.observe(tableElement, {
+        attributes: true,
         childList: true,
         subtree: true,
       });


### PR DESCRIPTION
## Description

Now table observer doesn't listen to table DOM element attibutes updates. So when attempting to extend table node with features that require table element attibute updates (for example adding/remoing classes to table element) it won't re-render table.

This change will enable observer to listen to attibutes changes as well as to changes in children.

Closes #6410

## Details on the topic

Here's documentation about mutation observer: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe

[attributes](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe#attributes) is set to `false` by default and setting it to `true` will watch for changes to the value of attributes on the node or nodes being monitored.

In case we can't enable all attibutes, it should be possible to upgrade table creation payload to include attribute names filter to enable monitoring only specified attributes for those who needs it by passing names to [attributeFilter](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe#attributefilter)

## Test plan

No new tests seem to be needed. All unit tests and e2e tests pass. No changes to existing table functionality.