### PR TITLE
[lexical] Feature: Add version identifier to LexicalEditor constructor

### DIFF
--- a/packages/lexical-devtools-core/src/generateContent.ts
+++ b/packages/lexical-devtools-core/src/generateContent.ts
@@ -161,8 +161,8 @@ export function generateContent(
   } else {
     res += '\n  └ None dispatched.';
   }
-
-  res += '\n\n editor:';
+  const {version} = editor.constructor;
+  res += `\n\n editor${version ? ` (v${version})` : ''}:`;
   res += `\n  └ namespace ${editorConfig.namespace}`;
   if (compositionKey !== null) {
     res += `\n  └ compositionKey ${compositionKey}`;

--- a/packages/lexical-devtools/src/utils/isLexicalNode.ts
+++ b/packages/lexical-devtools/src/utils/isLexicalNode.ts
@@ -6,10 +6,12 @@
  *
  */
 
+import {getEditorPropertyFromDOMNode} from 'lexical';
+
 import {LexicalHTMLElement} from '../types';
 
 export function isLexicalNode(
   node: LexicalHTMLElement | Element,
 ): node is LexicalHTMLElement {
-  return (node as LexicalHTMLElement).__lexicalEditor !== undefined;
+  return getEditorPropertyFromDOMNode(node) !== undefined;
 }

--- a/packages/lexical-playground/vite.config.ts
+++ b/packages/lexical-playground/vite.config.ts
@@ -52,6 +52,10 @@ export default defineConfig(({command}) => {
             from: /__DEV__/g,
             to: 'true',
           },
+          {
+            from: 'process.env.LEXICAL_VERSION',
+            to: JSON.stringify(`${process.env.npm_package_version}+git`),
+          },
         ],
       }),
       babel({

--- a/packages/lexical-playground/vite.prod.config.ts
+++ b/packages/lexical-playground/vite.prod.config.ts
@@ -53,6 +53,10 @@ export default defineConfig({
           from: /__DEV__/g,
           to: 'false',
         },
+        {
+          from: 'process.env.LEXICAL_VERSION',
+          to: JSON.stringify(`${process.env.npm_package_version}+git`),
+        },
       ],
     }),
     babel({

--- a/packages/lexical-react/src/LexicalCheckListPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCheckListPlugin.tsx
@@ -28,6 +28,7 @@ import {
   $isElementNode,
   $isRangeSelection,
   COMMAND_PRIORITY_LOW,
+  getNearestEditorFromDOMNode,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_UP_COMMAND,
@@ -199,20 +200,20 @@ function handleCheckItemEvent(event: PointerEvent, callback: () => void) {
 
 function handleClick(event: Event) {
   handleCheckItemEvent(event as PointerEvent, () => {
-    const domNode = event.target as HTMLElement;
-    const editor = findEditor(domNode);
+    if (event.target instanceof HTMLElement) {
+      const domNode = event.target;
+      const editor = getNearestEditorFromDOMNode(domNode);
 
-    if (editor != null && editor.isEditable()) {
-      editor.update(() => {
-        if (event.target) {
+      if (editor != null && editor.isEditable()) {
+        editor.update(() => {
           const node = $getNearestNodeFromDOMNode(domNode);
 
           if ($isListItemNode(node)) {
             domNode.focus();
             node.toggleChecked();
           }
-        }
-      });
+        });
+      }
     }
   });
 }
@@ -222,22 +223,6 @@ function handlePointerDown(event: PointerEvent) {
     // Prevents caret moving when clicking on check mark
     event.preventDefault();
   });
-}
-
-function findEditor(target: Node) {
-  let node: ParentNode | Node | null = target;
-
-  while (node) {
-    // @ts-ignore internal field
-    if (node.__lexicalEditor) {
-      // @ts-ignore internal field
-      return node.__lexicalEditor;
-    }
-
-    node = node.parentNode;
-  }
-
-  return null;
 }
 
 function getActiveCheckListItem(): HTMLElement | null {

--- a/packages/lexical-website/docs/concepts/listeners.md
+++ b/packages/lexical-website/docs/concepts/listeners.md
@@ -84,7 +84,7 @@ handle external UI state and UI features relating to specific types of node.
 If any existing nodes are in the DOM, and skipInitialization is not true, the listener
 will be called immediately with an updateTag of 'registerMutationListener' where all
 nodes have the 'created' NodeMutation. This can be controlled with the skipInitialization option
-(default is currently true for backwards compatibility in 0.16.x but will change to false in 0.17.0).
+(default is currently true for backwards compatibility in 0.17.x but will change to false in 0.18.0).
 
 ```js
 const removeMutationListener = editor.registerMutationListener(

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -562,6 +562,9 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
 export class LexicalEditor {
   ['constructor']!: KlassConstructor<typeof LexicalEditor>;
 
+  /** The version with build identifiers for this editor (since 0.17.1) */
+  static version: string | undefined;
+
   /** @internal */
   _headless: boolean;
   /** @internal */
@@ -1284,3 +1287,5 @@ export class LexicalEditor {
     };
   }
 }
+
+LexicalEditor.version = process.env.LEXICAL_VERSION;

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -94,6 +94,7 @@ import {
   getAnchorTextFromDOM,
   getDOMSelection,
   getDOMTextNode,
+  getEditorPropertyFromDOMNode,
   getEditorsToPropagate,
   getNearestEditorFromDOMNode,
   getWindow,
@@ -111,6 +112,7 @@ import {
   isEscape,
   isFirefoxClipboardEvents,
   isItalic,
+  isLexicalEditor,
   isLineBreak,
   isModifier,
   isMoveBackward,
@@ -1329,13 +1331,17 @@ export function removeRootElementEvents(rootElement: HTMLElement): void {
     doc.removeEventListener('selectionchange', onDocumentSelectionChange);
   }
 
-  // @ts-expect-error: internal field
-  const editor: LexicalEditor | null | undefined = rootElement.__lexicalEditor;
+  const editor = getEditorPropertyFromDOMNode(rootElement);
 
-  if (editor !== null && editor !== undefined) {
+  if (isLexicalEditor(editor)) {
     cleanActiveNestedEditorsMap(editor);
     // @ts-expect-error: internal field
     rootElement.__lexicalEditor = null;
+  } else if (editor) {
+    invariant(
+      false,
+      'Attempted to remove event handlers from a node that does not belong to this build of Lexical',
+    );
   }
 
   const removeHandles = getRootElementRemoveHandles(rootElement);

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -6,16 +6,6 @@
  *
  */
 
-import type {
-  CommandPayloadType,
-  EditorUpdateOptions,
-  LexicalCommand,
-  LexicalEditor,
-  Listener,
-  MutatedNodes,
-  RegisteredNodes,
-  Transform,
-} from './LexicalEditor';
 import type {SerializedEditorState} from './LexicalEditorState';
 import type {LexicalNode, SerializedLexicalNode} from './LexicalNode';
 
@@ -23,7 +13,17 @@ import invariant from 'shared/invariant';
 
 import {$isElementNode, $isTextNode, SELECTION_CHANGE_COMMAND} from '.';
 import {FULL_RECONCILE, NO_DIRTY_NODES} from './LexicalConstants';
-import {resetEditor} from './LexicalEditor';
+import {
+  CommandPayloadType,
+  EditorUpdateOptions,
+  LexicalCommand,
+  LexicalEditor,
+  Listener,
+  MutatedNodes,
+  RegisteredNodes,
+  resetEditor,
+  Transform,
+} from './LexicalEditor';
 import {
   cloneEditorState,
   createEmptyEditorState,
@@ -47,9 +47,11 @@ import {
 import {
   $getCompositionKey,
   getDOMSelection,
+  getEditorPropertyFromDOMNode,
   getEditorStateTextContent,
   getEditorsToPropagate,
   getRegisteredNodeOrThrow,
+  isLexicalEditor,
   removeDOMBlockCursorElement,
   scheduleMicroTask,
   updateDOMBlockCursorElement,
@@ -96,7 +98,8 @@ export function getActiveEditorState(): EditorState {
       'Unable to find an active editor state. ' +
         'State helpers or node methods can only be used ' +
         'synchronously during the callback of ' +
-        'editor.update(), editor.read(), or editorState.read().',
+        'editor.update(), editor.read(), or editorState.read().%s',
+      collectBuildInformation(),
     );
   }
 
@@ -110,11 +113,53 @@ export function getActiveEditor(): LexicalEditor {
       'Unable to find an active editor. ' +
         'This method can only be used ' +
         'synchronously during the callback of ' +
-        'editor.update() or editor.read().',
+        'editor.update() or editor.read().%s',
+      collectBuildInformation(),
     );
   }
-
   return activeEditor;
+}
+
+function collectBuildInformation(): string {
+  if (__DEV__) {
+    let compatibleEditors = 0;
+    const incompatibleEditors = new Set<string>();
+    const thisVersion = LexicalEditor.version;
+    if (typeof window !== 'undefined') {
+      for (const node of document.querySelectorAll('[contenteditable]')) {
+        const editor = getEditorPropertyFromDOMNode(node);
+        if (isLexicalEditor(editor)) {
+          compatibleEditors += 1;
+        } else if (editor) {
+          const constructor =
+            editor.constructor as typeof editor['constructor'] &
+              Record<string, unknown>;
+          let version =
+            typeof constructor.version === 'string'
+              ? constructor.version
+              : '<0.17.1';
+          if (version === thisVersion) {
+            version +=
+              ' (separately built, likely a bundler configuration issue)';
+          }
+          incompatibleEditors.add(version);
+        }
+      }
+    }
+    const output = [
+      ` Detected on the page: ${compatibleEditors} compatible editor(s) with version ${thisVersion}`,
+    ];
+    if (incompatibleEditors.size > 0) {
+      output.push(
+        ` and incompatible editors with versions ${Array.from(
+          incompatibleEditors,
+        ).join(', ')}`,
+      );
+    }
+    return output.join('');
+  } else {
+    return '';
+  }
 }
 
 export function internalGetActiveEditor(): LexicalEditor | null {

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -121,45 +121,36 @@ export function getActiveEditor(): LexicalEditor {
 }
 
 function collectBuildInformation(): string {
-  if (__DEV__) {
-    let compatibleEditors = 0;
-    const incompatibleEditors = new Set<string>();
-    const thisVersion = LexicalEditor.version;
-    if (typeof window !== 'undefined') {
-      for (const node of document.querySelectorAll('[contenteditable]')) {
-        const editor = getEditorPropertyFromDOMNode(node);
-        if (isLexicalEditor(editor)) {
-          compatibleEditors += 1;
-        } else if (editor) {
-          const constructor =
+  let compatibleEditors = 0;
+  const incompatibleEditors = new Set<string>();
+  const thisVersion = LexicalEditor.version;
+  if (typeof window !== 'undefined') {
+    for (const node of document.querySelectorAll('[contenteditable]')) {
+      const editor = getEditorPropertyFromDOMNode(node);
+      if (isLexicalEditor(editor)) {
+        compatibleEditors++;
+      } else if (editor) {
+        let version = String(
+          (
             editor.constructor as typeof editor['constructor'] &
-              Record<string, unknown>;
-          let version =
-            typeof constructor.version === 'string'
-              ? constructor.version
-              : '<0.17.1';
-          if (version === thisVersion) {
-            version +=
-              ' (separately built, likely a bundler configuration issue)';
-          }
-          incompatibleEditors.add(version);
+              Record<string, unknown>
+          ).version || '<0.17.1',
+        );
+        if (version === thisVersion) {
+          version +=
+            ' (separately built, likely a bundler configuration issue)';
         }
+        incompatibleEditors.add(version);
       }
     }
-    const output = [
-      ` Detected on the page: ${compatibleEditors} compatible editor(s) with version ${thisVersion}`,
-    ];
-    if (incompatibleEditors.size > 0) {
-      output.push(
-        ` and incompatible editors with versions ${Array.from(
-          incompatibleEditors,
-        ).join(', ')}`,
-      );
-    }
-    return output.join('');
-  } else {
-    return '';
   }
+  let output = ` Detected on the page: ${compatibleEditors} compatible editor(s) with version ${thisVersion}`;
+  if (incompatibleEditors.size) {
+    output += ` and incompatible editors with versions ${Array.from(
+      incompatibleEditors,
+    ).join(', ')}`;
+  }
+  return output;
 }
 
 export function internalGetActiveEditor(): LexicalEditor | null {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -149,14 +149,22 @@ export function isSelectionWithinEditor(
   }
 }
 
+/**
+ * @returns true if the given argument is a LexicalEditor instance from this build of Lexical
+ */
+export function isLexicalEditor(editor: unknown): editor is LexicalEditor {
+  // Check instanceof to prevent issues with multiple embedded Lexical installations
+  return editor instanceof LexicalEditor;
+}
+
 export function getNearestEditorFromDOMNode(
   node: Node | null,
 ): LexicalEditor | null {
   let currentNode = node;
   while (currentNode != null) {
     // @ts-expect-error: internal field
-    const editor: LexicalEditor = currentNode.__lexicalEditor;
-    if (editor != null) {
+    const editor: unknown = currentNode.__lexicalEditor;
+    if (isLexicalEditor(editor)) {
       return editor;
     }
     currentNode = getParentElement(currentNode);

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -123,8 +123,7 @@ export function isSelectionCapturedInDecoratorInput(anchorDOM: Node): boolean {
     (nodeName === 'INPUT' ||
       nodeName === 'TEXTAREA' ||
       (activeElement.contentEditable === 'true' &&
-        // @ts-ignore internal field
-        activeElement.__lexicalEditor == null))
+        getEditorPropertyFromDOMNode(activeElement) == null))
   );
 }
 
@@ -162,14 +161,19 @@ export function getNearestEditorFromDOMNode(
 ): LexicalEditor | null {
   let currentNode = node;
   while (currentNode != null) {
-    // @ts-expect-error: internal field
-    const editor: unknown = currentNode.__lexicalEditor;
+    const editor = getEditorPropertyFromDOMNode(currentNode);
     if (isLexicalEditor(editor)) {
       return editor;
     }
     currentNode = getParentElement(currentNode);
   }
   return null;
+}
+
+/** @internal */
+export function getEditorPropertyFromDOMNode(node: Node | null): unknown {
+  // @ts-expect-error: internal field
+  return node ? node.__lexicalEditor : null;
 }
 
 export function getTextDirection(text: string): 'ltr' | 'rtl' | null {

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -176,6 +176,7 @@ export {
   $setCompositionKey,
   $setSelection,
   $splitNode,
+  getEditorPropertyFromDOMNode,
   getNearestEditorFromDOMNode,
   isBlockDomNode,
   isHTMLAnchorElement,

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -181,6 +181,7 @@ export {
   isHTMLAnchorElement,
   isHTMLElement,
   isInlineDomNode,
+  isLexicalEditor,
   isSelectionCapturedInDecoratorInput,
   isSelectionWithinEditor,
   resetRandomKey,

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package.json
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package.json
@@ -1,29 +1,31 @@
 {
   "name": "lexical-esm-astro-react",
   "type": "module",
-  "version": "0.0.1",
+  "version": "0.17.0",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
-    "astro": "astro",	
+    "astro": "astro",
     "test": "playwright test"
   },
   "dependencies": {
     "@astrojs/check": "^0.5.9",
     "@astrojs/react": "^3.1.0",
-    "@lexical/react": "^0.14.3",
-    "@lexical/utils": "^0.14.3",
+    "@lexical/react": "0.17.0",
+    "@lexical/utils": "0.17.0",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "astro": "^4.5.4",
-    "lexical": "^0.14.3",
+    "lexical": "0.17.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.4.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.43.1"
-  }
+  },
+  "sideEffects": false,
+  "exports": {}
 }

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package.json
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package.json
@@ -26,6 +26,5 @@
   "devDependencies": {
     "@playwright/test": "^1.43.1"
   },
-  "sideEffects": false,
-  "exports": {}
+  "sideEffects": false
 }

--- a/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/package.json
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lexical-esm-nextjs",
-  "version": "0.1.0",
+  "version": "0.17.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -9,9 +9,9 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "@lexical/plain-text": "^0.14.5",
-    "@lexical/react": "^0.14.5",
-    "lexical": "^0.14.5",
+    "@lexical/plain-text": "0.17.0",
+    "@lexical/react": "0.17.0",
+    "lexical": "0.17.0",
     "next": "^14.2.1",
     "react": "^18",
     "react-dom": "^18"

--- a/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/package.json
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/package.json
@@ -1,32 +1,31 @@
 {
-	"name": "lexical-sveltekit-vanilla-js",
-	"version": "0.0.1",
-	"private": true,
-	"scripts": {
-		"dev": "vite dev",
-		"build": "vite build",
-		"preview": "vite preview",
-		"test": "playwright test"
-	},
-	"devDependencies": {
-		"@playwright/test": "^1.28.1",
-		"@sveltejs/adapter-auto": "^3.0.0",
-		"@sveltejs/adapter-node": "^5.0.1",
-		"@sveltejs/adapter-static": "^3.0.1",
-		"@sveltejs/kit": "^2.0.0",
-		"@sveltejs/vite-plugin-svelte": "^3.0.0",
-		"lexical": "^0.14.5",
-		"@lexical/dragon": "^0.14.5",
-		"@lexical/history": "^0.14.5",
-		"@lexical/rich-text": "^0.14.5",
-		"@lexical/utils": "^0.14.5",
-		"prettier": "^3.1.1",
-		"prettier-plugin-svelte": "^3.1.2",
-		"svelte": "^4.2.7",
-		"tslib": "^2.4.1",
-		"typescript": "^5.0.0",
-		"vite": "^5.1.7"
-	},
-	"type": "module",
-	"dependencies": {}
+  "name": "lexical-sveltekit-vanilla-js",
+  "version": "0.17.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@lexical/dragon": "0.17.0",
+    "@lexical/history": "0.17.0",
+    "@lexical/rich-text": "0.17.0",
+    "@lexical/utils": "0.17.0",
+    "@playwright/test": "^1.28.1",
+    "@sveltejs/adapter-auto": "^3.0.0",
+    "@sveltejs/adapter-node": "^5.0.1",
+    "@sveltejs/adapter-static": "^3.0.1",
+    "@sveltejs/kit": "^2.0.0",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
+    "lexical": "0.17.0",
+    "prettier": "^3.1.1",
+    "prettier-plugin-svelte": "^3.1.2",
+    "svelte": "^4.2.7",
+    "tslib": "^2.4.1",
+    "typescript": "^5.0.0",
+    "vite": "^5.1.7"
+  },
+  "type": "module"
 }

--- a/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/tests/test.ts
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/tests/test.ts
@@ -17,3 +17,14 @@ test('index page has expected h1 and lexical state', async ({ page }) => {
 		/"text": "Welcome to the Vanilla JS Lexical Demo!"/
 	);
 });
+
+test('lexical editor has an accessible numeric version', async ({ page }) => {
+	await page.goto('/');
+	await expect(
+		page.getByRole('heading', { name: 'SvelteKit Lexical Basic - Vanilla JS' })
+	).toBeVisible();
+	expect(await page.evaluate(() =>
+		// @ts-expect-error
+		document.querySelector('[contenteditable]')!.__lexicalEditor.constructor.version
+	)).toMatch(/^\d+\.\d+\.\d+/);
+});

--- a/scripts/__tests__/integration/setup.js
+++ b/scripts/__tests__/integration/setup.js
@@ -28,6 +28,9 @@ module.exports = async function (globalConfig, projectConfig) {
         ),
     );
   if (!needsBuild) {
+    console.log(
+      '\nWARNING: Running integration tests with cached build artifacts from a previous `npm run prepare-release`.',
+    );
     return;
   }
   await exec('npm run prepare-release');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -125,9 +125,18 @@ function getExtension(format) {
  * @param {string} outputFile
  * @param {boolean} isProd
  * @param {'cjs'|'esm'} format
+ * @param {string} version
  * @returns {Promise<Array<string>>} the exports of the built module
  */
-async function build(name, inputFile, outputPath, outputFile, isProd, format) {
+async function build(
+  name,
+  inputFile,
+  outputPath,
+  outputFile,
+  isProd,
+  format,
+  version,
+) {
   const extensions = ['.js', '.jsx', '.ts', '.tsx'];
   const inputOptions = {
     external(modulePath, src) {
@@ -214,6 +223,9 @@ async function build(name, inputFile, outputPath, outputFile, isProd, format) {
             __DEV__: isProd ? 'false' : 'true',
             delimiters: ['', ''],
             preventAssignment: true,
+            'process.env.LEXICAL_VERSION': JSON.stringify(
+              `${version}+${isProd ? 'prod' : 'dev'}.${format}`,
+            ),
           },
           isWWW && strictWWWMappings,
         ),
@@ -393,6 +405,7 @@ async function buildAll() {
   for (const pkg of packagesManager.getPublicPackages()) {
     const {name, sourcePath, outputPath, packageName, modules} =
       pkg.getPackageBuildDefinition();
+    const {version} = pkg.packageJson;
     for (const module of modules) {
       for (const format of formats) {
         const {sourceFileName, outputFileName} = module;
@@ -408,6 +421,7 @@ async function buildAll() {
           ),
           isProduction,
           format,
+          version,
         );
 
         if (isRelease) {
@@ -421,6 +435,7 @@ async function buildAll() {
             ),
             false,
             format,
+            version,
           );
           buildForkModules(outputPath, outputFileName, format, exports);
         }

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -47,7 +47,10 @@ function updatePackage(pkg) {
 function updateVersion() {
   packagesManager.getPackages().forEach(updatePackage);
   glob
-    .sync('./examples/*/package.json')
+    .sync([
+      './examples/*/package.json',
+      './scripts/__tests__/integration/fixtures/*/package.json',
+    ])
     .forEach((packageJsonPath) =>
       updatePackage(new PackageMetadata(packageJsonPath)),
     );


### PR DESCRIPTION
## Description

New `LexicalEditor.version` static to help users diagnose installation issues.

Also refactors other `__lexicalEditor` code to avoid conflicts with multiple lexical builds on the page (RE #6481)

Inspecting the lexical editor's version can be done as follows (example assumes exactly one editor on the page):

```
> document.querySelector('[contenteditable]').__lexicalEditor.constructor.version
'0.17.0+dev.esm'
```

It does not have support for coming up with special build identifiers for the versions of lexical we build in CI and for the website that do not correspond to npm versions.

Closes #6145
Closes #5996

## Test plan

There's an integration test that checks to make sure the version is set and accessible from the editor instance

### Before

```
> oldLexical.createEditor().constructor.version
undefined
> lexical.createEditor().constructor.version
'0.17.0+dev.esm'
```

### After

Using https://lexical-playground-git-fork-etrepum-version-a6c103-fbopensource.vercel.app/esm/

<img width="520" alt="Screenshot 2024-08-03 at 4 08 56 PM" src="https://github.com/user-attachments/assets/409f4dde-8b97-42d9-a759-7cda45a31cea">
