### PR TITLE
Revert "[@lexical/playground] fix: block cursor show horizontal"

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1753,8 +1753,8 @@ button.item.dropdown-item-active i {
   display: block;
   position: absolute;
   top: -2px;
-  height: 18px;
-  border-left: 1px solid black;
+  width: 20px;
+  border-top: 1px solid black;
   animation: CursorBlink 1.1s steps(2, start) infinite;
 }
 


### PR DESCRIPTION
Reverts facebook/lexical#6486
RE #6459

The horizontal cursor is desired in cases where the selection would otherwise be visually ambiguous. This can be reproduced by clearing the editor, creating a table node, selecting before the table node, and pressing up to get a selection at the root node.

Before revert:

https://github.com/user-attachments/assets/5ffdc126-0d8b-47c3-8c94-6d3ad9473b88

After revert:

https://github.com/user-attachments/assets/16c41142-26e2-47ab-9235-1a4d4e61d748

