### PR TITLE
[lexical-react] remove editor__DEPRECATED that has been deprecated for two years

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,3 +14,4 @@
 .ts-temp
 **/.docusaurus
 /playwright-report
+test-results

--- a/.prettierignore
+++ b/.prettierignore
@@ -23,3 +23,4 @@ flow-typed
 .prettierignore
 **/.docusaurus
 /playwright-report
+test-results

--- a/packages/lexical-react/flow/LexicalComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalComposer.js.flow
@@ -23,7 +23,6 @@ export type InitialEditorStateType =
   | ((editor: LexicalEditor) => void);
 
 export type InitialConfigType = $ReadOnly<{
-  editor__DEPRECATED?: LexicalEditor | null,
   editable?: boolean,
   namespace: string,
   nodes?: $ReadOnlyArray<Class<LexicalNode> | LexicalNodeReplacement>,

--- a/packages/lexical-react/flow/LexicalContentEditable.js.flow
+++ b/packages/lexical-react/flow/LexicalContentEditable.js.flow
@@ -53,7 +53,6 @@ export type PlaceholderProps =
 
 export type Props = $ReadOnly<{
   ...HTMLDivElementDOMProps,
-  editor__DEPRECATED?: LexicalEditor;
   ariaActiveDescendant?: string,
   ariaAutoComplete?: string,
   ariaControls?: string,

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -39,7 +39,6 @@ export type InitialEditorStateType =
   | ((editor: LexicalEditor) => void);
 
 export type InitialConfigType = Readonly<{
-  editor__DEPRECATED?: LexicalEditor | null;
   namespace: string;
   nodes?: ReadonlyArray<Klass<LexicalNode> | LexicalNodeReplacement>;
   onError: (error: Error, editor: LexicalEditor) => void;
@@ -59,7 +58,6 @@ export function LexicalComposer({initialConfig, children}: Props): JSX.Element {
       const {
         theme,
         namespace,
-        editor__DEPRECATED: initialEditor,
         nodes,
         onError,
         editorState: initialEditorState,
@@ -71,21 +69,15 @@ export function LexicalComposer({initialConfig, children}: Props): JSX.Element {
         theme,
       );
 
-      let editor = initialEditor || null;
-
-      if (editor === null) {
-        const newEditor = createEditor({
-          editable: initialConfig.editable,
-          html,
-          namespace,
-          nodes,
-          onError: (error) => onError(error, newEditor),
-          theme,
-        });
-        initializeEditor(newEditor, initialEditorState);
-
-        editor = newEditor;
-      }
+      const editor = createEditor({
+        editable: initialConfig.editable,
+        html,
+        namespace,
+        nodes,
+        onError: (error) => onError(error, editor),
+        theme,
+      });
+      initializeEditor(editor, initialEditorState);
 
       return [editor, context];
     },

--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -15,9 +15,8 @@ import {forwardRef, Ref, useLayoutEffect, useState} from 'react';
 import {ContentEditableElement} from './shared/LexicalContentEditableElement';
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 
-export type Props = Omit<ElementProps, 'editor'> & {
-  editor__DEPRECATED?: LexicalEditor;
-} & (
+export type Props = Omit<ElementProps, 'editor'> &
+  (
     | {
         'aria-placeholder'?: void;
         placeholder?: null;
@@ -36,10 +35,8 @@ function ContentEditableImpl(
   props: Props,
   ref: Ref<HTMLDivElement>,
 ): JSX.Element {
-  const {placeholder, editor__DEPRECATED, ...rest} = props;
-  // editor__DEPRECATED will always be defined for non MLC surfaces
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const editor = editor__DEPRECATED || useLexicalComposerContext()[0];
+  const {placeholder, ...rest} = props;
+  const [editor] = useLexicalComposerContext();
 
   return (
     <>


### PR DESCRIPTION
## Description

The `editor__DEPRECATED` prop has been deprecated for two years (#1407), this PR removes it.

## Test plan

There were no tests for this feature, and its absence does not need new tests.
