### PR TITLE
[lexical-playground] Bug Fix: Update tooltip for redo button with correct macOS shortcut

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -879,7 +879,7 @@ export default function ToolbarPlugin({
         onClick={() => {
           activeEditor.dispatchCommand(REDO_COMMAND, undefined);
         }}
-        title={IS_APPLE ? 'Redo (⌘Y)' : 'Redo (Ctrl+Y)'}
+        title={IS_APPLE ? 'Redo (⇧⌘Z)' : 'Redo (Ctrl+Y)'}
         type="button"
         className="toolbar-item"
         aria-label="Redo">


### PR DESCRIPTION
## Description

The tooltip previously displayed the wrong keyboard shortcut for redo

Closes #6495

## Test plan

### Before

<img width="159" alt="Screenshot 2024-08-06 at 8 34 29 AM" src="https://github.com/user-attachments/assets/b9a420ad-5fdd-44f9-a5da-37efbb176dda">

### After

<img width="209" alt="Screenshot 2024-08-06 at 8 35 10 AM" src="https://github.com/user-attachments/assets/4d11dd75-7dc9-4e63-b525-aa906c684120">
