### PR TITLE
Fix splitText when detached

### DIFF
--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -935,7 +935,7 @@ export class TextNode extends LexicalNode {
       return [self];
     }
     const firstPart = parts[0];
-    const parent = self.getParentOrThrow();
+    const parent = self.getParent();
     let writableNode;
     const format = self.getFormat();
     const style = self.getStyle();
@@ -1005,23 +1005,25 @@ export class TextNode extends LexicalNode {
     }
 
     // Insert the nodes into the parent's children
-    internalMarkSiblingsAsDirty(this);
-    const writableParent = parent.getWritable();
-    const insertionIndex = this.getIndexWithinParent();
-    if (hasReplacedSelf) {
-      writableParent.splice(insertionIndex, 0, splitNodes);
-      this.remove();
-    } else {
-      writableParent.splice(insertionIndex, 1, splitNodes);
-    }
+    if (parent !== null) {
+      internalMarkSiblingsAsDirty(this);
+      const writableParent = parent.getWritable();
+      const insertionIndex = this.getIndexWithinParent();
+      if (hasReplacedSelf) {
+        writableParent.splice(insertionIndex, 0, splitNodes);
+        this.remove();
+      } else {
+        writableParent.splice(insertionIndex, 1, splitNodes);
+      }
 
-    if ($isRangeSelection(selection)) {
-      $updateElementSelectionOnCreateDeleteNode(
-        selection,
-        parent,
-        insertionIndex,
-        partsLength - 1,
-      );
+      if ($isRangeSelection(selection)) {
+        $updateElementSelectionOnCreateDeleteNode(
+          selection,
+          parent,
+          insertionIndex,
+          partsLength - 1,
+        );
+      }
     }
 
     return splitNodes;

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -582,6 +582,18 @@ describe('LexicalTextNode tests', () => {
         });
       },
     );
+
+    test('with detached parent', async () => {
+      await update(() => {
+        const textNode = $createTextNode('foo');
+        const splits = textNode.splitText(1, 2);
+        expect(splits.map((split) => split.getTextContent())).toEqual([
+          'f',
+          'o',
+          'o',
+        ]);
+      });
+    });
   });
 
   describe('createDOM()', () => {


### PR DESCRIPTION
When `splitText` is run on a Node with no parent it crashes. I don't see any obvious reason why this function should only work on attached nodes and there are some valid cases when you'd want to attach the resulting nodes later and leverage `splitText` to preserve the styling and format.