### PR TITLE
[lexical] Refactor: [RFC] LexicalNode.afterCloneFrom to simplify clone implementation

### DIFF
--- a/packages/lexical-website/docs/concepts/nodes.md
+++ b/packages/lexical-website/docs/concepts/nodes.md
@@ -111,6 +111,8 @@ class MyCustomNode extends SomeOtherNode {
   }
 
   static clone(node: MyCustomNode): MyCustomNode {
+    // If any state needs to be set after construction, it should be
+    // done by overriding the `afterCloneFrom` instance method.
     return new MyCustomNode(node.__foo, node.__key);
   }
 

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -365,10 +365,7 @@ export class ExtendedTextNode extends TextNode {
   }
 
   isSimpleText() {
-    return (
-      (this.__type === 'text' || this.__type === 'extended-text') &&
-      this.__mode === 0
-    );
+    return this.__type === 'extended-text' && this.__mode === 0;
   }
 
   exportJSON(): SerializedTextNode {

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -205,6 +205,16 @@ export class LexicalNode {
     );
   }
 
+  /**
+   * Perform any state updates on the clone of prevNode that are not already
+   * handled by the constructor call in the static clone method.
+   */
+  afterCloneFrom(prevNode: this) {
+    this.__parent = prevNode.__parent;
+    this.__next = prevNode.__next;
+    this.__prev = prevNode.__prev;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static importDOM?: () => DOMConversionMap<any> | null;
 

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -207,7 +207,53 @@ export class LexicalNode {
 
   /**
    * Perform any state updates on the clone of prevNode that are not already
-   * handled by the constructor call in the static clone method.
+   * handled by the constructor call in the static clone method. If you have
+   * state to update in your clone that is not handled directly by the
+   * constructor, it is advisable to override this method but it is required
+   * to include a call to `super.afterCloneFrom(prevNode)` in your
+   * implementation. This is only intended to be called by
+   * {@link $cloneWithProperties} function or via a super call.
+   *
+   * @example
+   * ```ts
+   * class ClassesTextNode extends TextNode {
+   *   // Not shown: static getType, static importJSON, exportJSON, createDOM, updateDOM
+   *   __classes = new Set<string>();
+   *   static clone(node: ClassesTextNode): ClassesTextNode {
+   *     // The inherited TextNode constructor is used here, so
+   *     // classes is not set by this method.
+   *     return new ClassesTextNode(node.__text, node.__key);
+   *   }
+   *   afterCloneFrom(node: this): void {
+   *     // This calls TextNode.afterCloneFrom and LexicalNode.afterCloneFrom
+   *     // for necessary state updates
+   *     super.afterCloneFrom(node);
+   *     this.__addClasses(node.__classes);
+   *   }
+   *   // This method is a private implementation detail, it is not
+   *   // suitable for the public API because it does not call getWritable
+   *   __addClasses(classNames: Iterable<string>): this {
+   *     for (const className of classNames) {
+   *       this.__classes.add(className);
+   *     }
+   *     return this;
+   *   }
+   *   addClass(...classNames: string[]): this {
+   *     return this.getWritable().__addClasses(classNames);
+   *   }
+   *   removeClass(...classNames: string[]): this {
+   *     const node = this.getWritable();
+   *     for (const className of classNames) {
+   *       this.__classes.delete(className);
+   *     }
+   *     return this;
+   *   }
+   *   getClasses(): Set<string> {
+   *     return this.getLatest().__classes;
+   *   }
+   * }
+   * ```
+   *
    */
   afterCloneFrom(prevNode: this) {
     this.__parent = prevNode.__parent;
@@ -713,8 +759,9 @@ export class LexicalNode {
   }
 
   /**
-   * Returns a mutable version of the node. Will throw an error if
-   * called outside of a Lexical Editor {@link LexicalEditor.update} callback.
+   * Returns a mutable version of the node using {@link $cloneWithProperties}
+   * if necessary. Will throw an error if called outside of a Lexical Editor
+   * {@link LexicalEditor.update} callback.
    *
    */
   getWritable(): this {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1752,8 +1752,13 @@ export function getCachedTypeToNodeMap(
 }
 
 /**
- * Returns a clone of a node with the same key and parent/next/prev pointers and other
- * properties that are not set by the KlassConstructor.clone (format, style, etc.).
+ * Returns a clone of a node using `node.constructor.clone()` followed by
+ * `clone.afterCloneFrom(node)`. The resulting clone must have the same key,
+ * parent/next/prev pointers, and other properties that are not set by
+ * `node.constructor.clone` (format, style, etc.). This is primarily used by
+ * {@link LexicalNode.getWritable} to create a writable version of an
+ * existing node. The clone is the same logical node as the original node,
+ * do not try and use this function to duplicate or copy an existing node.
  *
  * Does not mutate the EditorState.
  * @param node - The node to be cloned.

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -41,7 +41,6 @@ import {
   $isDecoratorNode,
   $isElementNode,
   $isLineBreakNode,
-  $isParagraphNode,
   $isRangeSelection,
   $isRootNode,
   $isTextNode,
@@ -1763,31 +1762,19 @@ export function getCachedTypeToNodeMap(
 export function $cloneWithProperties<T extends LexicalNode>(latestNode: T): T {
   const constructor = latestNode.constructor;
   const mutableNode = constructor.clone(latestNode) as T;
-  mutableNode.__parent = latestNode.__parent;
-  mutableNode.__next = latestNode.__next;
-  mutableNode.__prev = latestNode.__prev;
-  if ($isElementNode(latestNode) && $isElementNode(mutableNode)) {
-    if ($isParagraphNode(latestNode) && $isParagraphNode(mutableNode)) {
-      mutableNode.__textFormat = latestNode.__textFormat;
-      mutableNode.__textStyle = latestNode.__textStyle;
-    }
-    mutableNode.__first = latestNode.__first;
-    mutableNode.__last = latestNode.__last;
-    mutableNode.__size = latestNode.__size;
-    mutableNode.__indent = latestNode.__indent;
-    mutableNode.__format = latestNode.__format;
-    mutableNode.__style = latestNode.__style;
-    mutableNode.__dir = latestNode.__dir;
-  } else if ($isTextNode(latestNode) && $isTextNode(mutableNode)) {
-    mutableNode.__format = latestNode.__format;
-    mutableNode.__style = latestNode.__style;
-    mutableNode.__mode = latestNode.__mode;
-    mutableNode.__detail = latestNode.__detail;
-  }
+  mutableNode.afterCloneFrom(latestNode);
   if (__DEV__) {
     invariant(
       mutableNode.__key === latestNode.__key,
       "$cloneWithProperties: %s.clone(node) (with type '%s') did not return a node with the same key, make sure to specify node.__key as the last argument to the constructor",
+      constructor.name,
+      constructor.getType(),
+    );
+    invariant(
+      mutableNode.__parent === latestNode.__parent &&
+        mutableNode.__next === latestNode.__next &&
+        mutableNode.__prev === latestNode.__prev,
+      "$cloneWithProperties: %s.clone(node) (with type '%s') overrided afterCloneFrom but did not call super.afterCloneFrom(prevNode)",
       constructor.name,
       constructor.getType(),
     );

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -7,18 +7,20 @@
  */
 
 import {
+  $createRangeSelection,
   $getRoot,
   $getSelection,
   $isDecoratorNode,
   $isElementNode,
   $isRangeSelection,
+  createEditor,
   DecoratorNode,
   ElementNode,
   ParagraphNode,
+  SerializedTextNode,
   TextNode,
 } from 'lexical';
 
-import {$createRangeSelection} from '../..';
 import {LexicalNode} from '../../LexicalNode';
 import {$createParagraphNode} from '../../nodes/LexicalParagraphNode';
 import {$createTextNode} from '../../nodes/LexicalTextNode';
@@ -146,6 +148,75 @@ describe('LexicalNode tests', () => {
 
           expect(() => LexicalNode.clone(node)).toThrow();
         });
+      });
+      test('LexicalNode.afterCloneFrom()', () => {
+        class VersionedTextNode extends TextNode {
+          // ['constructor']!: KlassConstructor<typeof VersionedTextNode>;
+          __version = 0;
+          static getType(): 'vtext' {
+            return 'vtext';
+          }
+          static clone(node: VersionedTextNode): VersionedTextNode {
+            return new VersionedTextNode(node.__text, node.__key);
+          }
+          static importJSON(node: SerializedTextNode): VersionedTextNode {
+            throw new Error('Not implemented');
+          }
+          exportJSON(): SerializedTextNode {
+            throw new Error('Not implemented');
+          }
+          afterCloneFrom(node: this): void {
+            super.afterCloneFrom(node);
+            this.__version = node.__version + 1;
+          }
+        }
+        const editor = createEditor({
+          nodes: [VersionedTextNode],
+          onError(err) {
+            throw err;
+          },
+        });
+        let versionedTextNode: VersionedTextNode;
+
+        editor.update(
+          () => {
+            versionedTextNode = new VersionedTextNode('test');
+            $getRoot().append($createParagraphNode().append(versionedTextNode));
+            expect(versionedTextNode.__version).toEqual(0);
+          },
+          {discrete: true},
+        );
+        editor.update(
+          () => {
+            expect(versionedTextNode.getLatest().__version).toEqual(0);
+            expect(
+              versionedTextNode.setTextContent('update').setMode('token')
+                .__version,
+            ).toEqual(1);
+          },
+          {discrete: true},
+        );
+        editor.update(
+          () => {
+            let latest = versionedTextNode.getLatest();
+            expect(versionedTextNode.__version).toEqual(0);
+            expect(versionedTextNode.__mode).toEqual(0);
+            expect(versionedTextNode.getMode()).toEqual('token');
+            expect(latest.__version).toEqual(1);
+            expect(latest.__mode).toEqual(1);
+            latest = latest.setTextContent('another update');
+            expect(latest.__version).toEqual(2);
+            expect(latest.getWritable().__version).toEqual(2);
+            expect(
+              versionedTextNode.getLatest().getWritable().__version,
+            ).toEqual(2);
+            expect(versionedTextNode.getLatest().__version).toEqual(2);
+            expect(versionedTextNode.__mode).toEqual(0);
+            expect(versionedTextNode.getLatest().__mode).toEqual(1);
+            expect(versionedTextNode.getMode()).toEqual('token');
+          },
+          {discrete: true},
+        );
       });
 
       test('LexicalNode.getType()', async () => {

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -93,6 +93,17 @@ export class ElementNode extends LexicalNode {
     this.__dir = null;
   }
 
+  afterCloneFrom(prevNode: this) {
+    super.afterCloneFrom(prevNode);
+    this.__first = prevNode.__first;
+    this.__last = prevNode.__last;
+    this.__size = prevNode.__size;
+    this.__indent = prevNode.__indent;
+    this.__format = prevNode.__format;
+    this.__style = prevNode.__style;
+    this.__dir = prevNode.__dir;
+  }
+
   getFormat(): number {
     const self = this.getLatest();
     return self.__format;

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -90,6 +90,12 @@ export class ParagraphNode extends ElementNode {
     return new ParagraphNode(node.__key);
   }
 
+  afterCloneFrom(prevNode: this) {
+    super.afterCloneFrom(prevNode);
+    this.__textFormat = prevNode.__textFormat;
+    this.__textStyle = prevNode.__textStyle;
+  }
+
   // View
 
   createDOM(config: EditorConfig): HTMLElement {

--- a/packages/lexical/src/nodes/LexicalTabNode.ts
+++ b/packages/lexical/src/nodes/LexicalTabNode.ts
@@ -29,12 +29,13 @@ export class TabNode extends TextNode {
   }
 
   static clone(node: TabNode): TabNode {
-    const newNode = new TabNode(node.__key);
+    return new TabNode(node.__key);
+  }
+
+  afterCloneFrom(prevNode: this): void {
+    super.afterCloneFrom(prevNode);
     // TabNode __text can be either '\t' or ''. insertText will remove the empty Node
-    newNode.__text = node.__text;
-    newNode.__format = node.__format;
-    newNode.__style = node.__style;
-    return newNode;
+    this.__text = prevNode.__text;
   }
 
   constructor(key?: NodeKey) {

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -303,6 +303,14 @@ export class TextNode extends LexicalNode {
     return new TextNode(node.__text, node.__key);
   }
 
+  afterCloneFrom(prevNode: this): void {
+    super.afterCloneFrom(prevNode);
+    this.__format = prevNode.__format;
+    this.__style = prevNode.__style;
+    this.__mode = prevNode.__mode;
+    this.__detail = prevNode.__detail;
+  }
+
   constructor(text: string, key?: NodeKey) {
     super(key);
     this.__text = text;


### PR DESCRIPTION
## Description

The code path for cloning lexical nodes is a bit weird with some branching for different node types and no extensibility. We can clean it up by moving that part of the clone process to an instance method.

Unlike #3920 this does not try and make a generic clone method, the boilerplate is still there – but all for good reason. It's at least 2-3x faster to have the boilerplate than to use `Object.create`, `Object.assign`, etc. presumably due to JIT de-optimization reasons. Using the constructor in this way (the status quo) also prevents sharing of mutable objects that could happen unintentionally with a shallow clone of all properties.

This changes the `$cloneWithProperties` function to first call `latestNode.constructor.clone(latestNode)`, then call `mutableNode.afterCloneFrom(latestNode)` to handle all of the post-construction state updates. This means the `clone` static method can "simply" call the constructor and any other update to the node can be done in `afterCloneFrom` in the correct order (super first) rather than have it happen later in a way where users have no visibility or control over the process.

The change is entirely backwards compatible, other than reserving a new name on the API.

## Test plan

Will write additional docs and tests if this is deemed to be a worthwhile endeavor.
