### PR TITLE
[lexical] Bug Fix: Fix decorator selection regression with short-circuiting

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -295,27 +295,16 @@ export class LexicalNode {
 
       const parentNode = this.getParent();
       if ($isDecoratorNode(this) && this.isInline() && parentNode) {
-        const {anchor, focus} = targetSelection;
-
-        if (anchor.isBefore(focus)) {
-          const anchorNode = anchor.getNode() as ElementNode;
-          const isAnchorPointToLast =
-            anchor.offset === anchorNode.getChildrenSize();
-          const isAnchorNodeIsParent = anchorNode.is(parentNode);
-          const isLastChild = anchorNode.getLastChildOrThrow().is(this);
-
-          if (isAnchorPointToLast && isAnchorNodeIsParent && isLastChild) {
-            return false;
-          }
-        } else {
-          const focusNode = focus.getNode() as ElementNode;
-          const isFocusPointToLast =
-            focus.offset === focusNode.getChildrenSize();
-          const isFocusNodeIsParent = focusNode.is(parentNode);
-          const isLastChild = focusNode.getLastChildOrThrow().is(this);
-          if (isFocusPointToLast && isFocusNodeIsParent && isLastChild) {
-            return false;
-          }
+        const firstPoint = targetSelection.isBackward()
+          ? targetSelection.focus
+          : targetSelection.anchor;
+        const firstElement = firstPoint.getNode() as ElementNode;
+        if (
+          firstPoint.offset === firstElement.getChildrenSize() &&
+          firstElement.is(parentNode) &&
+          firstElement.getLastChildOrThrow().is(this)
+        ) {
+          return false;
         }
       }
     }

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -12,9 +12,13 @@ import {
   $isDecoratorNode,
   $isElementNode,
   $isRangeSelection,
+  $setSelection,
   DecoratorNode,
   ElementNode,
+  LexicalEditor,
+  NodeKey,
   ParagraphNode,
+  RangeSelection,
   TextNode,
 } from 'lexical';
 
@@ -304,54 +308,165 @@ describe('LexicalNode tests', () => {
         await Promise.resolve().then();
       });
 
-      test('LexicalNode.isSelected(): with inline decorator node', async () => {
-        const {editor} = testEnv;
+      describe('LexicalNode.isSelected(): with inline decorator node', () => {
+        let editor: LexicalEditor;
         let paragraphNode1: ParagraphNode;
         let paragraphNode2: ParagraphNode;
+        let paragraphNode3: ParagraphNode;
         let inlineDecoratorNode: InlineDecoratorNode;
-
-        editor.update(() => {
-          paragraphNode1 = $createParagraphNode();
-          paragraphNode2 = $createParagraphNode();
-          inlineDecoratorNode = new InlineDecoratorNode();
-          paragraphNode1.append(inlineDecoratorNode);
-          $getRoot().append(paragraphNode1, paragraphNode2);
-          paragraphNode1.selectEnd();
-          const selection = $getSelection();
-
-          if ($isRangeSelection(selection)) {
-            expect(selection.anchor.getNode().is(paragraphNode1)).toBe(true);
-          }
+        let names: Record<NodeKey, string>;
+        beforeEach(() => {
+          editor = testEnv.editor;
+          editor.update(() => {
+            inlineDecoratorNode = new InlineDecoratorNode();
+            paragraphNode1 = $createParagraphNode();
+            paragraphNode2 = $createParagraphNode().append(inlineDecoratorNode);
+            paragraphNode3 = $createParagraphNode();
+            names = {
+              [inlineDecoratorNode.getKey()]: 'd',
+              [paragraphNode1.getKey()]: 'p1',
+              [paragraphNode2.getKey()]: 'p2',
+              [paragraphNode3.getKey()]: 'p3',
+            };
+            $getRoot()
+              .clear()
+              .append(paragraphNode1, paragraphNode2, paragraphNode3);
+          });
         });
-
-        editor.update(() => {
-          const selection = $getSelection();
-          if ($isRangeSelection(selection)) {
-            expect(selection.anchor.key).toBe(paragraphNode1.getKey());
-
-            selection.focus.set(paragraphNode2.getKey(), 1, 'element');
-          }
-        });
-
-        await Promise.resolve().then();
-
-        editor.getEditorState().read(() => {
-          expect(inlineDecoratorNode.isSelected()).toBe(false);
-        });
-
-        editor.update(() => {
-          const selection = $getSelection();
-          if ($isRangeSelection(selection)) {
-            selection.anchor.set(paragraphNode2.getKey(), 0, 'element');
-            selection.focus.set(paragraphNode1.getKey(), 1, 'element');
-          }
-        });
-
-        await Promise.resolve().then();
-
-        editor.getEditorState().read(() => {
-          expect(inlineDecoratorNode.isSelected()).toBe(false);
-        });
+        const cases: {
+          label: string;
+          isSelected: boolean;
+          update: () => void;
+        }[] = [
+          {
+            isSelected: true,
+            label: 'whole editor',
+            update() {
+              $getRoot().select(0);
+            },
+          },
+          {
+            isSelected: true,
+            label: 'containing paragraph',
+            update() {
+              paragraphNode2.select(0);
+            },
+          },
+          {
+            isSelected: true,
+            label: 'before and containing',
+            update() {
+              paragraphNode2
+                .select(0)
+                .anchor.set(paragraphNode1.getKey(), 0, 'element');
+            },
+          },
+          {
+            isSelected: true,
+            label: 'containing and after',
+            update() {
+              paragraphNode2
+                .select(0)
+                .focus.set(paragraphNode3.getKey(), 0, 'element');
+            },
+          },
+          {
+            isSelected: true,
+            label: 'before and after',
+            update() {
+              paragraphNode1
+                .select(0)
+                .focus.set(paragraphNode3.getKey(), 0, 'element');
+            },
+          },
+          {
+            isSelected: false,
+            label: 'collapsed before',
+            update() {
+              paragraphNode2.select(0, 0);
+            },
+          },
+          {
+            isSelected: false,
+            label: 'in another element',
+            update() {
+              paragraphNode1.select(0);
+            },
+          },
+          {
+            isSelected: false,
+            label: 'before',
+            update() {
+              paragraphNode1
+                .select(0)
+                .focus.set(paragraphNode2.getKey(), 0, 'element');
+            },
+          },
+          {
+            isSelected: false,
+            label: 'collapsed after',
+            update() {
+              paragraphNode2.selectEnd();
+            },
+          },
+          {
+            isSelected: false,
+            label: 'after',
+            update() {
+              paragraphNode3
+                .select(0)
+                .anchor.set(
+                  paragraphNode2.getKey(),
+                  paragraphNode2.getChildrenSize(),
+                  'element',
+                );
+            },
+          },
+        ];
+        for (const {label, isSelected, update} of cases) {
+          test(`${isSelected ? 'is' : "isn't"} selected ${label}`, () => {
+            editor.update(update);
+            const $verify = () => {
+              const selection = $getSelection() as RangeSelection;
+              expect($isRangeSelection(selection)).toBe(true);
+              const dbg = [selection.anchor, selection.focus]
+                .map(
+                  (point) =>
+                    `(${names[point.key] || point.key}:${point.offset})`,
+                )
+                .join(' ');
+              const nodes = `[${selection
+                .getNodes()
+                .map((k) => names[k.__key] || k.__key)
+                .join(',')}]`;
+              expect([dbg, nodes, inlineDecoratorNode.isSelected()]).toEqual([
+                dbg,
+                nodes,
+                isSelected,
+              ]);
+            };
+            editor.read($verify);
+            editor.update(() => {
+              const selection = $getSelection();
+              if ($isRangeSelection(selection)) {
+                const backwards = $createRangeSelection();
+                backwards.anchor.set(
+                  selection.focus.key,
+                  selection.focus.offset,
+                  selection.focus.type,
+                );
+                backwards.focus.set(
+                  selection.anchor.key,
+                  selection.anchor.offset,
+                  selection.anchor.type,
+                );
+                $setSelection(backwards);
+              }
+              expect($isRangeSelection(selection)).toBe(true);
+            });
+            editor.read($verify);
+          });
+        }
       });
 
       test('LexicalNode.getKey()', async () => {


### PR DESCRIPTION
## Description

The fix in #5948 introduced a crashing regression because the logic doesn't short-circuit when an empty element is encountered.

Closes #6506

## Test plan

### Before

Crash happens after these conditions:

* Clear playground
* Insert blank line (creating empty paragraph node)
* Insert image (in a second paragraph)
* Select all

[sample url - must select all after clicking this](https://playground.lexical.dev/#doc=H4sIAAAAAAAAE72Qy2rDMBBF_-WuRaIkpC7aFroOuNBF6WKwJpZAtoQ0zoPgfy-J05Jm1ULpahiYM_dwT2DrJeZaSBjmhByjnGfjfLCZe5i3b8u7gvWZG_Gxh-mHEBS2MXckMICC7y33AqMV5JgYBokytZmSg8KOc7mACwXhgzxfST2ttRzDGcGo7gwoyAsfrhkNpSn-9AP73wtfnty6juOo4Ni3brrr6PDqrTiYtdYKxcX906fSlkJhhZIbGDiRVMx8nnxThm6WXJRY5kut8RXmO2r5rpn99FyP_1T2n1SkEKhITTu2MItquVo-VOtV9VhVCiUOuTlzm0DHNseht7c09GxRzTTGD_nMaJKOAgAA)

<details>
<summary>
example exception
</summary>

```
Error rendering tree: Expected node 47 to have a last child.

Stack:
Error: Expected node 47 to have a last child.
    at Il.getLastChildOrThrow (https://playground.lexical.dev/assets/main-CGFr7rm0.js:51:28219)
    at _a.isSelected (https://playground.lexical.dev/assets/main-CGFr7rm0.js:45:5077)
    at https://playground.lexical.dev/assets/main-CGFr7rm0.js:347:106
    at https://playground.lexical.dev/assets/main-CGFr7rm0.js:362:162
    at Array.forEach (<anonymous>)
    at MC (https://playground.lexical.dev/assets/main-CGFr7rm0.js:362:146)
    at https://playground.lexical.dev/assets/main-CGFr7rm0.js:362:224
    at Array.forEach (<anonymous>)
    at MC (https://playground.lexical.dev/assets/main-CGFr7rm0.js:362:146)
    at https://playground.lexical.dev/assets/main-CGFr7rm0.js:347:42
```
</details>

### After

Doesn't crash, has more test coverage
