### PR TITLE
[lexical] surface more error details in reconciler

### DIFF
--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -340,7 +340,18 @@ function reconcileElementTerminatingLineBreak(
       const element = dom.__lexicalLineBreak;
 
       if (element != null) {
-        dom.removeChild(element);
+        try {
+          dom.removeChild(element);
+        } catch (error) {
+          if (typeof error === 'object' && error != null) {
+            const msg = `${error.toString()} Parent: ${dom.tagName}, child: ${
+              element.tagName
+            }.`;
+            throw new Error(msg);
+          } else {
+            throw error;
+          }
+        }
       }
 
       // @ts-expect-error: internal field
@@ -501,7 +512,22 @@ function $reconcileChildren(
     } else {
       const lastDOM = getPrevElementByKeyOrThrow(prevFirstChildKey);
       const replacementDOM = $createNode(nextFrstChildKey, null, null);
-      dom.replaceChild(replacementDOM, lastDOM);
+      try {
+        dom.replaceChild(replacementDOM, lastDOM);
+      } catch (error) {
+        if (typeof error === 'object' && error != null) {
+          const msg = `${error.toString()} Parent: ${
+            dom.tagName
+          }, new child: {tag: ${
+            replacementDOM.tagName
+          } key: ${nextFrstChildKey}}, old child: {tag: ${
+            lastDOM.tagName
+          }, key: ${prevFirstChildKey}}.`;
+          throw new Error(msg);
+        } else {
+          throw error;
+        }
+      }
       destroyNode(prevFirstChildKey, null);
     }
     const nextChildNode = activeNextNodeMap.get(nextFrstChildKey);


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

since 25 jul, observing a high number of `The node to be replaced/removed is not a child of this node` errors, at the following 2 lines where im adding logging. These errors spiked on 6 Aug but have since died down (on its own) to ~ 2 errors a daily

i've not been able to reproduce those errors so surfacing more details in the error msg to get more clues

i made sure to only surface privacy safe details in the error

fix attempt: https://github.com/facebook/lexical/pull/6513

## Test plan


<img width="776" alt="Screenshot 2024-08-12 at 12 14 54 PM" src="https://github.com/user-attachments/assets/65bd49a4-094f-4505-a761-d22db00f60e7">

threw a new error there to emulate the error. 

to trigger that line, replace an entire paragraph node, eg. pasting over the entire paragraph node 

<img width="982" alt="Screenshot 2024-08-12 at 12 40 25 PM" src="https://github.com/user-attachments/assets/761440e4-36ef-4901-ae42-107d44993410">



