### PR TITLE
[lexical] check for child nodes before removing/replacing in reconciler

### DIFF
--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -340,7 +340,9 @@ function reconcileElementTerminatingLineBreak(
       const element = dom.__lexicalLineBreak;
 
       if (element != null) {
-        dom.removeChild(element);
+        if (dom.hasChildNodes()) {
+          dom.removeChild(element);
+        }
       }
 
       // @ts-expect-error: internal field
@@ -501,7 +503,9 @@ function $reconcileChildren(
     } else {
       const lastDOM = getPrevElementByKeyOrThrow(prevFirstChildKey);
       const replacementDOM = $createNode(nextFrstChildKey, null, null);
-      dom.replaceChild(replacementDOM, lastDOM);
+      if (dom.hasChildNodes()) {
+        dom.replaceChild(replacementDOM, lastDOM);
+      }
       destroyNode(prevFirstChildKey, null);
     }
     const nextChildNode = activeNextNodeMap.get(nextFrstChildKey);

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -72,7 +72,7 @@ function destroyNode(key: NodeKey, parentDOM: null | HTMLElement): void {
 
   if (parentDOM !== null) {
     const dom = getPrevElementByKeyOrThrow(key);
-    if (dom.parentNode === parentDOM) {
+    if (dom.parentNode === parentDOM && parentDOM.hasChildNodes()) {
       parentDOM.removeChild(dom);
     }
   }


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
See https://github.com/facebook/lexical/pull/6511 for context

tldr theres lots of The node to be replaced/removed is not a child of this node errors which i cant reproduce. but hope this fix will help resolve (some) of the errors

a more thorough way is to check if the child to be remove actually exists but i think that means iterating through the dom tree which is time consuming, so settling for this quick check

another option is do try catch for `The node to be replaced/removed is not a child of this node` error and move on but im not sure if such an approach would have side effects



## Test plan

tested no regressions to the reconciler. tested by pasting over an entire para node


