### PR TITLE
[lexical-list] Bug Fix: handle non-integer numbers in setIndent

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -357,10 +357,9 @@ export class ListItemNode extends ElementNode {
   }
 
   setIndent(indent: number): this {
-    invariant(
-      typeof indent === 'number' && indent > -1,
-      'Invalid indent value.',
-    );
+    invariant(typeof indent === 'number', 'Invalid indent value.');
+    indent = Math.floor(indent)
+    invariant(indent >= 0, 'Indent value must be non-negative.');
     let currentIndent = this.getIndent();
     while (currentIndent !== indent) {
       if (currentIndent < indent) {


### PR DESCRIPTION
## Description

Handles non-integer numbers in `ListItemNode.setIndent` to prevent infinite loop.

Closes #6521

## Test plan

