### PR TITLE
[lexical-table] Bug Fix: Selection in tables with merged cells

### DIFF
--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -162,7 +162,9 @@ export class TableNode extends ElementNode {
       return null;
     }
 
-    const cell = row[x];
+    const index = x < row.length ? x : row.length - 1;
+
+    const cell = row[index];
 
     if (cell == null) {
       return null;


### PR DESCRIPTION
## Description
Quickfix for #6515
As described in the issue currently changing the selection using the arrow keys can throw an error that crashes the editor.
(Error: `Uncaught Error: Node at cords not TableCellNode.`)


<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

- Closes #6515
- Closes #6519 (duplicate)

This quickfix works quite well for merged cells at the end of a row (most common cases imo)

For merged cells at the beginning or the middle of a row this simple approach creates some unexpected cursor jumps. But instead of crashing the user can be easily adapt the position and the editor won't break.
(For a full fix the positions would need to consider the colspan everywhere in the table plugin, that would be a bigger refactoring I guess).

I did check where this function is used and did some manual testing and did not encounter unwanted side effects, but this is also my first glance inside the lexical codebase :)
Fingers crossed.


## Test plan

### Before
![before](https://github.com/user-attachments/assets/a1624604-7164-429f-ae28-62932400f044)


### After
![after](https://github.com/user-attachments/assets/a0479e61-92d1-4729-bed9-7c2293b018e2)
