### PR TITLE
Chore: change className props in TreeView component to optional

### DIFF
--- a/packages/lexical-devtools-core/src/TreeView.tsx
+++ b/packages/lexical-devtools-core/src/TreeView.tsx
@@ -17,12 +17,12 @@ export const TreeView = forwardRef<
   HTMLPreElement,
   {
     editorState: EditorState;
-    treeTypeButtonClassName: string;
-    timeTravelButtonClassName: string;
-    timeTravelPanelButtonClassName: string;
-    timeTravelPanelClassName: string;
-    timeTravelPanelSliderClassName: string;
-    viewClassName: string;
+    treeTypeButtonClassName?: string;
+    timeTravelButtonClassName?: string;
+    timeTravelPanelButtonClassName?: string;
+    timeTravelPanelClassName?: string;
+    timeTravelPanelSliderClassName?: string;
+    viewClassName?: string;
     generateContent: (exportDOM: boolean) => Promise<string>;
     setEditorState: (state: EditorState, options?: EditorSetOptions) => void;
     setEditorReadOnly: (isReadonly: boolean) => void;

--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -29,12 +29,12 @@ export function TreeView({
   customPrintNode,
 }: {
   editor: LexicalEditor;
-  treeTypeButtonClassName: string;
-  timeTravelButtonClassName: string;
-  timeTravelPanelButtonClassName: string;
-  timeTravelPanelClassName: string;
-  timeTravelPanelSliderClassName: string;
-  viewClassName: string;
+  treeTypeButtonClassName?: string;
+  timeTravelButtonClassName?: string;
+  timeTravelPanelButtonClassName?: string;
+  timeTravelPanelClassName?: string;
+  timeTravelPanelSliderClassName?: string;
+  viewClassName?: string;
   customPrintNode?: CustomPrintNodeFn;
 }): JSX.Element {
   const treeElementRef = React.createRef<HTMLPreElement>();


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

The `<TreeView />` component is primarily intended for debugging, but currently, all of its props are required. It would be more convenient if the className prop were optional.
