### PR TITLE
Revert "Fix OverflowNode configuration"

### DIFF
--- a/packages/lexical-overflow/src/index.ts
+++ b/packages/lexical-overflow/src/index.ts
@@ -69,15 +69,7 @@ export class OverflowNode extends ElementNode {
     return parent.insertNewAfter(selection, restoreSelection);
   }
 
-  canBeEmpty(): false {
-    return false;
-  }
-
-  isInline(): true {
-    return true;
-  }
-
-  excludeFromCopy(): true {
+  excludeFromCopy(): boolean {
     return true;
   }
 }


### PR DESCRIPTION
Reverts facebook/lexical#6027

OverflowNode causes problems with LineBreakNode with this configuration change, causes the tests to fail in plain text mode (the insertion point always ends up *before* the trailing LineBreakNode) but the same strange behavior comes up if you press shift-return to insert a LineBreakNode into a ParagraphNode in rich text mode. I think we will need to revisit #6027 with additional tests.

Closes #6534

/cc @zurfyx @ivailop7 