### PR TITLE
[*] Chore: Mark additional tests as flaky from #6535 test runs

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/ListsCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/ListsCopyAndPaste.spec.mjs
@@ -108,183 +108,182 @@ test.describe('Lists CopyAndPaste', () => {
     });
   });
 
-  test('Copy and paste of partial list items into the list', async ({
-    page,
-    isPlainText,
-    isCollab,
-    browserName,
-  }) => {
-    test.skip(isPlainText);
+  test(
+    'Copy and paste of partial list items into the list',
+    {tag: '@flaky'},
+    async ({page, isPlainText, isCollab, browserName}) => {
+      test.skip(isPlainText);
 
-    await focusEditor(page);
+      await focusEditor(page);
 
-    // Add three list items
-    await page.keyboard.type('- one');
-    await page.keyboard.press('Enter');
-    await page.keyboard.type('two');
-    await page.keyboard.press('Enter');
-    await page.keyboard.type('three');
+      // Add three list items
+      await page.keyboard.type('- one');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('two');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('three');
 
-    await page.keyboard.press('Enter');
-    await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
 
-    // Add a paragraph
-    await page.keyboard.type('Some text.');
+      // Add a paragraph
+      await page.keyboard.type('Some text.');
 
-    await assertHTML(
-      page,
-      html`
-        <ul class="PlaygroundEditorTheme__ul">
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="1">
-            <span data-lexical-text="true">one</span>
-          </li>
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="2">
-            <span data-lexical-text="true">two</span>
-          </li>
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="3">
-            <span data-lexical-text="true">three</span>
-          </li>
-        </ul>
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">Some text.</span>
-        </p>
-      `,
-    );
-    await assertSelection(page, {
-      anchorOffset: 10,
-      anchorPath: [1, 0, 0],
-      focusOffset: 10,
-      focusPath: [1, 0, 0],
-    });
+      await assertHTML(
+        page,
+        html`
+          <ul class="PlaygroundEditorTheme__ul">
+            <li
+              class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              value="1">
+              <span data-lexical-text="true">one</span>
+            </li>
+            <li
+              class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              value="2">
+              <span data-lexical-text="true">two</span>
+            </li>
+            <li
+              class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              value="3">
+              <span data-lexical-text="true">three</span>
+            </li>
+          </ul>
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Some text.</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 10,
+        anchorPath: [1, 0, 0],
+        focusOffset: 10,
+        focusPath: [1, 0, 0],
+      });
 
-    await page.keyboard.down('Shift');
-    await moveToLineBeginning(page);
-    await moveLeft(page, 3);
-    await page.keyboard.up('Shift');
+      await page.keyboard.down('Shift');
+      await moveToLineBeginning(page);
+      await moveLeft(page, 3);
+      await page.keyboard.up('Shift');
 
-    await assertSelection(page, {
-      anchorOffset: 10,
-      anchorPath: [1, 0, 0],
-      focusOffset: 3,
-      focusPath: [0, 2, 0, 0],
-    });
+      await assertSelection(page, {
+        anchorOffset: 10,
+        anchorPath: [1, 0, 0],
+        focusOffset: 3,
+        focusPath: [0, 2, 0, 0],
+      });
 
-    // Copy the partial list item and paragraph
-    const clipboard = await copyToClipboard(page);
+      // Copy the partial list item and paragraph
+      const clipboard = await copyToClipboard(page);
 
-    // Select all and remove content
-    await page.keyboard.press('ArrowUp');
-    await page.keyboard.press('ArrowUp');
-    if (!IS_WINDOWS && browserName === 'firefox') {
+      // Select all and remove content
       await page.keyboard.press('ArrowUp');
-    }
-    await moveToLineEnd(page);
+      await page.keyboard.press('ArrowUp');
+      if (!IS_WINDOWS && browserName === 'firefox') {
+        await page.keyboard.press('ArrowUp');
+      }
+      await moveToLineEnd(page);
 
-    await page.keyboard.down('Enter');
+      await page.keyboard.down('Enter');
 
-    await assertHTML(
-      page,
-      html`
-        <ul class="PlaygroundEditorTheme__ul">
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="1">
-            <span data-lexical-text="true">one</span>
-          </li>
-          <li class="PlaygroundEditorTheme__listItem" value="2">
-            <br />
-          </li>
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="3">
-            <span data-lexical-text="true">two</span>
-          </li>
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="4">
-            <span data-lexical-text="true">three</span>
-          </li>
-        </ul>
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">Some text.</span>
-        </p>
-      `,
-    );
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [0, 1],
-      focusOffset: 0,
-      focusPath: [0, 1],
-    });
+      await assertHTML(
+        page,
+        html`
+          <ul class="PlaygroundEditorTheme__ul">
+            <li
+              class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              value="1">
+              <span data-lexical-text="true">one</span>
+            </li>
+            <li class="PlaygroundEditorTheme__listItem" value="2">
+              <br />
+            </li>
+            <li
+              class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              value="3">
+              <span data-lexical-text="true">two</span>
+            </li>
+            <li
+              class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              value="4">
+              <span data-lexical-text="true">three</span>
+            </li>
+          </ul>
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Some text.</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0, 1],
+        focusOffset: 0,
+        focusPath: [0, 1],
+      });
 
-    await pasteFromClipboard(page, clipboard);
+      await pasteFromClipboard(page, clipboard);
 
-    await assertHTML(
-      page,
-      html`
-        <ul class="PlaygroundEditorTheme__ul">
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="1">
-            <span data-lexical-text="true">one</span>
-          </li>
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="2">
-            <span data-lexical-text="true">ee</span>
-          </li>
-        </ul>
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">Some text.</span>
-        </p>
-        <ul class="PlaygroundEditorTheme__ul">
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="1">
-            <span data-lexical-text="true">two</span>
-          </li>
-          <li
-            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
-            dir="ltr"
-            value="2">
-            <span data-lexical-text="true">three</span>
-          </li>
-        </ul>
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">Some text.</span>
-        </p>
-      `,
-    );
-    await assertSelection(page, {
-      anchorOffset: 10,
-      anchorPath: [1, 0, 0],
-      focusOffset: 10,
-      focusPath: [1, 0, 0],
-    });
-  });
+      await assertHTML(
+        page,
+        html`
+          <ul class="PlaygroundEditorTheme__ul">
+            <li
+              class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              value="1">
+              <span data-lexical-text="true">one</span>
+            </li>
+            <li
+              class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              value="2">
+              <span data-lexical-text="true">ee</span>
+            </li>
+          </ul>
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Some text.</span>
+          </p>
+          <ul class="PlaygroundEditorTheme__ul">
+            <li
+              class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              value="1">
+              <span data-lexical-text="true">two</span>
+            </li>
+            <li
+              class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              value="2">
+              <span data-lexical-text="true">three</span>
+            </li>
+          </ul>
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Some text.</span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 10,
+        anchorPath: [1, 0, 0],
+        focusOffset: 10,
+        focusPath: [1, 0, 0],
+      });
+    },
+  );
 
   test('Copy list items and paste back into list', async ({
     page,

--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
@@ -27,131 +27,130 @@ import {
 
 test.describe('HorizontalRule', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-  test('Can create a horizontal rule and move selection around it', async ({
-    page,
-    isCollab,
-    isPlainText,
-    browserName,
-  }) => {
-    test.skip(isPlainText);
-    await focusEditor(page);
+  test(
+    'Can create a horizontal rule and move selection around it',
+    {tag: '@flaky'},
+    async ({page, isCollab, isPlainText, browserName}) => {
+      test.skip(isPlainText);
+      await focusEditor(page);
 
-    await selectFromInsertDropdown(page, '.horizontal-rule');
+      await selectFromInsertDropdown(page, '.horizontal-rule');
 
-    await waitForSelector(page, 'hr');
+      await waitForSelector(page, 'hr');
 
-    await assertHTML(
-      page,
-      html`
-        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-        <hr
-          class="PlaygroundEditorTheme__hr"
-          contenteditable="false"
-          data-lexical-decorator="true" />
-        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-      `,
-    );
-
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [2],
-      focusOffset: 0,
-      focusPath: [2],
-    });
-
-    await page.keyboard.press('ArrowUp');
-
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [0],
-      focusOffset: 0,
-      focusPath: [0],
-    });
-
-    await page.keyboard.press('ArrowRight');
-    await page.keyboard.press('ArrowRight');
-
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [2],
-      focusOffset: 0,
-      focusPath: [2],
-    });
-
-    await page.keyboard.press('ArrowLeft');
-    await page.keyboard.press('ArrowLeft');
-
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [0],
-      focusOffset: 0,
-      focusPath: [0],
-    });
-
-    await page.keyboard.type('Some text');
-
-    await page.keyboard.press('ArrowRight');
-    await page.keyboard.press('ArrowRight');
-
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [2],
-      focusOffset: 0,
-      focusPath: [2],
-    });
-
-    await page.keyboard.type('Some more text');
-
-    await assertHTML(
-      page,
-      html`
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">Some text</span>
-        </p>
-        <hr
-          class="PlaygroundEditorTheme__hr"
-          contenteditable="false"
-          data-lexical-decorator="true" />
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">Some more text</span>
-        </p>
-      `,
-    );
-
-    await moveToLineBeginning(page);
-
-    await page.keyboard.press('ArrowLeft');
-
-    await page.keyboard.press('ArrowLeft');
-
-    await assertSelection(page, {
-      anchorOffset: 1,
-      anchorPath: [0],
-      focusOffset: 1,
-      focusPath: [0],
-    });
-
-    await pressBackspace(page, 10);
-
-    // Collab doesn't process the cursor correctly
-    if (!isCollab) {
       await assertHTML(
         page,
-        '<div class="PlaygroundEditorTheme__blockCursor" contenteditable="false" data-lexical-cursor="true"></div><hr class="PlaygroundEditorTheme__hr" data-lexical-decorator="true" contenteditable="false"><p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">Some more text</span></p>',
+        html`
+          <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+          <hr
+            class="PlaygroundEditorTheme__hr"
+            contenteditable="false"
+            data-lexical-decorator="true" />
+          <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        `,
       );
-    }
 
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [],
-      focusOffset: 0,
-      focusPath: [],
-    });
-  });
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [2],
+        focusOffset: 0,
+        focusPath: [2],
+      });
+
+      await page.keyboard.press('ArrowUp');
+
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0],
+        focusOffset: 0,
+        focusPath: [0],
+      });
+
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('ArrowRight');
+
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [2],
+        focusOffset: 0,
+        focusPath: [2],
+      });
+
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('ArrowLeft');
+
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0],
+        focusOffset: 0,
+        focusPath: [0],
+      });
+
+      await page.keyboard.type('Some text');
+
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('ArrowRight');
+
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [2],
+        focusOffset: 0,
+        focusPath: [2],
+      });
+
+      await page.keyboard.type('Some more text');
+
+      await assertHTML(
+        page,
+        html`
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Some text</span>
+          </p>
+          <hr
+            class="PlaygroundEditorTheme__hr"
+            contenteditable="false"
+            data-lexical-decorator="true" />
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">Some more text</span>
+          </p>
+        `,
+      );
+
+      await moveToLineBeginning(page);
+
+      await page.keyboard.press('ArrowLeft');
+
+      await page.keyboard.press('ArrowLeft');
+
+      await assertSelection(page, {
+        anchorOffset: 1,
+        anchorPath: [0],
+        focusOffset: 1,
+        focusPath: [0],
+      });
+
+      await pressBackspace(page, 10);
+
+      // Collab doesn't process the cursor correctly
+      if (!isCollab) {
+        await assertHTML(
+          page,
+          '<div class="PlaygroundEditorTheme__blockCursor" contenteditable="false" data-lexical-cursor="true"></div><hr class="PlaygroundEditorTheme__hr" data-lexical-decorator="true" contenteditable="false"><p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">Some more text</span></p>',
+        );
+      }
+
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [],
+        focusOffset: 0,
+        focusPath: [],
+      });
+    },
+  );
 
   test('Will add a horizontal rule at the end of a current TextNode and move selection to the new ParagraphNode.', async ({
     page,

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -25,7 +25,6 @@ import {
   focusEditor,
   html,
   initialize,
-  IS_LINUX,
   keyDownCtrlOrMeta,
   keyUpCtrlOrMeta,
   pasteFromClipboard,
@@ -1923,82 +1922,86 @@ test.describe.parallel('Links', () => {
     );
   });
 
-  test('Can handle pressing Enter inside a Link', async ({page}) => {
-    await focusEditor(page);
-    await page.keyboard.type('Hello awesome');
-    await selectAll(page);
-    await click(page, '.link');
-    await click(page, '.link-confirm');
-    await page.keyboard.press('ArrowRight');
-    await page.keyboard.type('world');
+  test(
+    'Can handle pressing Enter inside a Link',
+    {tag: '@flaky'},
+    async ({page}) => {
+      await focusEditor(page);
+      await page.keyboard.type('Hello awesome');
+      await selectAll(page);
+      await click(page, '.link');
+      await click(page, '.link-confirm');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.type('world');
 
-    await moveToLineBeginning(page);
-    await moveRight(page, 6);
+      await moveToLineBeginning(page);
+      await moveRight(page, 6);
 
-    await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
 
-    await assertHTML(
-      page,
-      html`
-        <p dir="ltr">
-          <a dir="ltr" href="https://" rel="noreferrer">
-            <span data-lexical-text="true">Hello</span>
-          </a>
-        </p>
-        <p dir="ltr">
-          <a dir="ltr" href="https://" rel="noreferrer">
-            <span data-lexical-text="true">awesome</span>
-          </a>
-          <span data-lexical-text="true">world</span>
-        </p>
-      `,
-      undefined,
-      {ignoreClasses: true},
-    );
-  });
+      await assertHTML(
+        page,
+        html`
+          <p dir="ltr">
+            <a dir="ltr" href="https://" rel="noreferrer">
+              <span data-lexical-text="true">Hello</span>
+            </a>
+          </p>
+          <p dir="ltr">
+            <a dir="ltr" href="https://" rel="noreferrer">
+              <span data-lexical-text="true">awesome</span>
+            </a>
+            <span data-lexical-text="true">world</span>
+          </p>
+        `,
+        undefined,
+        {ignoreClasses: true},
+      );
+    },
+  );
 
-  test('Can handle pressing Enter inside a Link containing multiple TextNodes', async ({
-    page,
-    isCollab,
-  }) => {
-    test.fixme(isCollab && IS_LINUX, 'Flaky on Linux + Collab');
-    await focusEditor(page);
-    await page.keyboard.type('Hello ');
-    await toggleBold(page);
-    await page.keyboard.type('awe');
-    await toggleBold(page);
-    await page.keyboard.type('some');
-    await selectAll(page);
-    await click(page, '.link');
-    await click(page, '.link-confirm');
-    await page.keyboard.press('ArrowRight');
-    await page.keyboard.type(' world');
+  test(
+    'Can handle pressing Enter inside a Link containing multiple TextNodes',
+    {tag: '@flaky'},
+    async ({page, isCollab}) => {
+      await focusEditor(page);
+      await page.keyboard.type('Hello ');
+      await toggleBold(page);
+      await page.keyboard.type('awe');
+      await toggleBold(page);
+      await page.keyboard.type('some');
+      await selectAll(page);
+      await click(page, '.link');
+      await click(page, '.link-confirm');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.type(' world');
 
-    await moveToLineBeginning(page);
-    await moveRight(page, 6);
+      await moveToLineBeginning(page);
+      await moveRight(page, 6);
 
-    await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
 
-    await assertHTML(
-      page,
-      html`
-        <p dir="ltr">
-          <a dir="ltr" href="https://" rel="noreferrer">
-            <span data-lexical-text="true">Hello</span>
-          </a>
-        </p>
-        <p dir="ltr">
-          <a dir="ltr" href="https://" rel="noreferrer">
-            <strong data-lexical-text="true">awe</strong>
-            <span data-lexical-text="true">some</span>
-          </a>
-          <span data-lexical-text="true">world</span>
-        </p>
-      `,
-      undefined,
-      {ignoreClasses: true},
-    );
-  });
+      await assertHTML(
+        page,
+        html`
+          <p dir="ltr">
+            <a dir="ltr" href="https://" rel="noreferrer">
+              <span data-lexical-text="true">Hello</span>
+            </a>
+          </p>
+          <p dir="ltr">
+            <a dir="ltr" href="https://" rel="noreferrer">
+              <strong data-lexical-text="true">awe</strong>
+              <span data-lexical-text="true">some</span>
+            </a>
+            <span data-lexical-text="true">world</span>
+          </p>
+        `,
+        undefined,
+        {ignoreClasses: true},
+      );
+    },
+  );
 
   test(
     'Can handle pressing Enter at the beginning of a Link',

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -874,30 +874,28 @@ test.describe.parallel('Selection', () => {
     });
   });
 
-  test('shift+arrowdown into a table, when the table is the last node, selects the whole table', async ({
-    page,
-    isPlainText,
-    isCollab,
-    browserName,
-    legacyEvents,
-  }) => {
-    test.skip(isPlainText);
-    test.fixme(browserName === 'chromium' && legacyEvents);
-    await focusEditor(page);
-    await insertTable(page, 2, 2);
-    await moveToEditorEnd(page);
-    await deleteBackward(page);
-    await moveToEditorBeginning(page);
-    await page.keyboard.down('Shift');
-    await page.keyboard.press('ArrowDown');
-    await page.keyboard.up('Shift');
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [0],
-      focusOffset: 1,
-      focusPath: [1, 1, 1],
-    });
-  });
+  test(
+    'shift+arrowdown into a table, when the table is the last node, selects the whole table',
+    {tag: '@flaky'},
+    async ({page, isPlainText, isCollab, browserName, legacyEvents}) => {
+      test.skip(isPlainText);
+      test.fixme(browserName === 'chromium' && legacyEvents);
+      await focusEditor(page);
+      await insertTable(page, 2, 2);
+      await moveToEditorEnd(page);
+      await deleteBackward(page);
+      await moveToEditorBeginning(page);
+      await page.keyboard.down('Shift');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.up('Shift');
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [0],
+        focusOffset: 1,
+        focusPath: [1, 1, 1],
+      });
+    },
+  );
 
   test('shift+arrowup into a table, when the table is the first node, selects the whole table', async ({
     page,
@@ -924,37 +922,35 @@ test.describe.parallel('Selection', () => {
     });
   });
 
-  test('shift+arrowdown into a table, when the table is the only node, selects the whole table', async ({
-    page,
-    isPlainText,
-    isCollab,
-    legacyEvents,
-    browserName,
-  }) => {
-    test.skip(isPlainText);
-    test.fixme(browserName === 'chromium' && legacyEvents);
-    await focusEditor(page);
-    await insertTable(page, 2, 2);
-    await moveToEditorBeginning(page);
-    await deleteBackward(page);
-    await moveToEditorEnd(page);
-    await deleteBackward(page);
-    await moveToEditorBeginning(page);
-    await moveUp(page, 1);
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [],
-      focusOffset: 0,
-      focusPath: [],
-    });
-    await page.keyboard.down('Shift');
-    await page.keyboard.press('ArrowDown');
-    await page.keyboard.up('Shift');
-    await assertTableSelectionCoordinates(page, {
-      anchor: {x: 0, y: 0},
-      focus: {x: 1, y: 1},
-    });
-  });
+  test(
+    'shift+arrowdown into a table, when the table is the only node, selects the whole table',
+    {tag: '@flaky'},
+    async ({page, isPlainText, isCollab, legacyEvents, browserName}) => {
+      test.skip(isPlainText);
+      test.fixme(browserName === 'chromium' && legacyEvents);
+      await focusEditor(page);
+      await insertTable(page, 2, 2);
+      await moveToEditorBeginning(page);
+      await deleteBackward(page);
+      await moveToEditorEnd(page);
+      await deleteBackward(page);
+      await moveToEditorBeginning(page);
+      await moveUp(page, 1);
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [],
+        focusOffset: 0,
+        focusPath: [],
+      });
+      await page.keyboard.down('Shift');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.up('Shift');
+      await assertTableSelectionCoordinates(page, {
+        anchor: {x: 0, y: 0},
+        focus: {x: 1, y: 1},
+      });
+    },
+  );
 
   test('shift+arrowup into a table, when the table is the only node, selects the whole table', async ({
     page,

--- a/packages/lexical-playground/__tests__/e2e/Tab.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tab.spec.mjs
@@ -17,71 +17,75 @@ import {
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 test.describe('Tab', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-  test(`can tab + IME`, async ({page, isPlainText, browserName}) => {
-    // CDP session is only available in Chromium
-    test.skip(
-      isPlainText || browserName === 'firefox' || browserName === 'webkit',
-    );
+  test(
+    `can tab + IME`,
+    {tag: '@flaky'},
+    async ({page, isPlainText, browserName}) => {
+      // CDP session is only available in Chromium
+      test.skip(
+        isPlainText || browserName === 'firefox' || browserName === 'webkit',
+      );
 
-    const client = await page.context().newCDPSession(page);
-    async function imeType() {
-      // await page.keyboard.imeSetComposition('ｓ', 1, 1);
-      await client.send('Input.imeSetComposition', {
-        selectionStart: 1,
-        selectionEnd: 1,
-        text: 'ｓ',
-      });
-      // await page.keyboard.imeSetComposition('す', 1, 1);
-      await client.send('Input.imeSetComposition', {
-        selectionStart: 1,
-        selectionEnd: 1,
-        text: 'す',
-      });
-      // await page.keyboard.imeSetComposition('すｓ', 2, 2);
-      await client.send('Input.imeSetComposition', {
-        selectionStart: 2,
-        selectionEnd: 2,
-        text: 'すｓ',
-      });
-      // await page.keyboard.imeSetComposition('すｓｈ', 3, 3);
-      await client.send('Input.imeSetComposition', {
-        selectionStart: 3,
-        selectionEnd: 3,
-        text: 'すｓｈ',
-      });
-      // await page.keyboard.imeSetComposition('すし', 2, 2);
-      await client.send('Input.imeSetComposition', {
-        selectionStart: 2,
-        selectionEnd: 2,
-        text: 'すし',
-      });
-      // await page.keyboard.insertText('すし');
-      await client.send('Input.insertText', {
-        text: 'すし',
-      });
-      await page.keyboard.type(' ');
-    }
-    await focusEditor(page);
-    // Indent
-    await page.keyboard.press('Tab');
-    await imeType();
-    await page.keyboard.press('Tab');
-    await imeType();
+      const client = await page.context().newCDPSession(page);
+      async function imeType() {
+        // await page.keyboard.imeSetComposition('ｓ', 1, 1);
+        await client.send('Input.imeSetComposition', {
+          selectionStart: 1,
+          selectionEnd: 1,
+          text: 'ｓ',
+        });
+        // await page.keyboard.imeSetComposition('す', 1, 1);
+        await client.send('Input.imeSetComposition', {
+          selectionStart: 1,
+          selectionEnd: 1,
+          text: 'す',
+        });
+        // await page.keyboard.imeSetComposition('すｓ', 2, 2);
+        await client.send('Input.imeSetComposition', {
+          selectionStart: 2,
+          selectionEnd: 2,
+          text: 'すｓ',
+        });
+        // await page.keyboard.imeSetComposition('すｓｈ', 3, 3);
+        await client.send('Input.imeSetComposition', {
+          selectionStart: 3,
+          selectionEnd: 3,
+          text: 'すｓｈ',
+        });
+        // await page.keyboard.imeSetComposition('すし', 2, 2);
+        await client.send('Input.imeSetComposition', {
+          selectionStart: 2,
+          selectionEnd: 2,
+          text: 'すし',
+        });
+        // await page.keyboard.insertText('すし');
+        await client.send('Input.insertText', {
+          text: 'すし',
+        });
+        await page.keyboard.type(' ');
+      }
+      await focusEditor(page);
+      // Indent
+      await page.keyboard.press('Tab');
+      await imeType();
+      await page.keyboard.press('Tab');
+      await imeType();
 
-    await assertHTML(
-      page,
-      html`
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent PlaygroundEditorTheme__ltr"
-          dir="ltr"
-          style="padding-inline-start: calc(40px)">
-          <span data-lexical-text="true">すし</span>
-          <span data-lexical-text="true"></span>
-          <span data-lexical-text="true">すし</span>
-        </p>
-      `,
-    );
-  });
+      await assertHTML(
+        page,
+        html`
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__indent PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            style="padding-inline-start: calc(40px)">
+            <span data-lexical-text="true">すし</span>
+            <span data-lexical-text="true"></span>
+            <span data-lexical-text="true">すし</span>
+          </p>
+        `,
+      );
+    },
+  );
 
   test('can tab inside code block #4399', async ({page, isPlainText}) => {
     test.skip(isPlainText);

--- a/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs
@@ -1111,23 +1111,48 @@ test.describe.parallel('TextFormatting', () => {
     expect(isButtonActiveStatusDisplayedCorrectly).toBe(true);
   });
 
-  test('Regression #2523: can toggle format when selecting a TextNode edge followed by a non TextNode; ', async ({
-    page,
-    isCollab,
-    isPlainText,
-  }) => {
-    test.skip(isPlainText);
-    await focusEditor(page);
+  test(
+    'Regression #2523: can toggle format when selecting a TextNode edge followed by a non TextNode; ',
+    {tag: '@flaky'},
+    async ({page, isCollab, isPlainText}) => {
+      test.skip(isPlainText);
+      await focusEditor(page);
 
-    await page.keyboard.type('A');
-    await insertSampleImage(page);
-    await page.keyboard.type('BC');
+      await page.keyboard.type('A');
+      await insertSampleImage(page);
+      await page.keyboard.type('BC');
 
-    await moveLeft(page, 1);
-    await selectCharacters(page, 'left', 2);
+      await moveLeft(page, 1);
+      await selectCharacters(page, 'left', 2);
 
-    if (!isCollab) {
-      await waitForSelector(page, '.editor-image img');
+      if (!isCollab) {
+        await waitForSelector(page, '.editor-image img');
+        await assertHTML(
+          page,
+          html`
+            <p
+              class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+              dir="ltr">
+              <span data-lexical-text="true">A</span>
+              <span
+                class="editor-image"
+                contenteditable="false"
+                data-lexical-decorator="true">
+                <div draggable="false">
+                  <img
+                    class="focused"
+                    alt="Yellow flower in tilt shift lens"
+                    draggable="false"
+                    src="${SAMPLE_IMAGE_URL}"
+                    style="height: inherit; max-width: 500px; width: inherit" />
+                </div>
+              </span>
+              <span data-lexical-text="true">BC</span>
+            </p>
+          `,
+        );
+      }
+      await toggleBold(page);
       await assertHTML(
         page,
         html`
@@ -1141,7 +1166,35 @@ test.describe.parallel('TextFormatting', () => {
               data-lexical-decorator="true">
               <div draggable="false">
                 <img
-                  class="focused"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="${SAMPLE_IMAGE_URL}"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+            </span>
+            <strong
+              class="PlaygroundEditorTheme__textBold"
+              data-lexical-text="true">
+              B
+            </strong>
+            <span data-lexical-text="true">C</span>
+          </p>
+        `,
+      );
+      await toggleBold(page);
+      await assertHTML(
+        page,
+        html`
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true">A</span>
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="false">
+                <img
                   alt="Yellow flower in tilt shift lens"
                   draggable="false"
                   src="${SAMPLE_IMAGE_URL}"
@@ -1152,61 +1205,8 @@ test.describe.parallel('TextFormatting', () => {
           </p>
         `,
       );
-    }
-    await toggleBold(page);
-    await assertHTML(
-      page,
-      html`
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">A</span>
-          <span
-            class="editor-image"
-            contenteditable="false"
-            data-lexical-decorator="true">
-            <div draggable="false">
-              <img
-                alt="Yellow flower in tilt shift lens"
-                draggable="false"
-                src="${SAMPLE_IMAGE_URL}"
-                style="height: inherit; max-width: 500px; width: inherit" />
-            </div>
-          </span>
-          <strong
-            class="PlaygroundEditorTheme__textBold"
-            data-lexical-text="true">
-            B
-          </strong>
-          <span data-lexical-text="true">C</span>
-        </p>
-      `,
-    );
-    await toggleBold(page);
-    await assertHTML(
-      page,
-      html`
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">A</span>
-          <span
-            class="editor-image"
-            contenteditable="false"
-            data-lexical-decorator="true">
-            <div draggable="false">
-              <img
-                alt="Yellow flower in tilt shift lens"
-                draggable="false"
-                src="${SAMPLE_IMAGE_URL}"
-                style="height: inherit; max-width: 500px; width: inherit" />
-            </div>
-          </span>
-          <span data-lexical-text="true">BC</span>
-        </p>
-      `,
-    );
-  });
+    },
+  );
 
   test('Multiline selection format ignores new lines', async ({
     page,

--- a/packages/lexical-playground/__tests__/regression/429-swapping-emoji.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/429-swapping-emoji.spec.mjs
@@ -18,42 +18,91 @@ import {
 
 test.describe('Regression test #429', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
-  test(`Can add new lines before the line with emoji`, async ({
-    isRichText,
-    page,
-  }) => {
-    await focusEditor(page);
-    await page.keyboard.type(':) or :(');
-    await assertHTML(
-      page,
-      html`
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span class="emoji happysmile" data-lexical-text="true">
-            <span class="emoji-inner">🙂</span>
-          </span>
-          <span data-lexical-text="true">or</span>
-          <span class="emoji unhappysmile" data-lexical-text="true">
-            <span class="emoji-inner">🙁</span>
-          </span>
-        </p>
-      `,
-    );
-    await assertSelection(page, {
-      anchorOffset: 2,
-      anchorPath: [0, 2, 0, 0],
-      focusOffset: 2,
-      focusPath: [0, 2, 0, 0],
-    });
-
-    await moveLeft(page, 6);
-    await page.keyboard.press('Enter');
-    if (isRichText) {
+  test(
+    `Can add new lines before the line with emoji`,
+    {tag: '@flaky'},
+    async ({isRichText, page}) => {
+      await focusEditor(page);
+      await page.keyboard.type(':) or :(');
       await assertHTML(
         page,
         html`
-          <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span class="emoji happysmile" data-lexical-text="true">
+              <span class="emoji-inner">🙂</span>
+            </span>
+            <span data-lexical-text="true">or</span>
+            <span class="emoji unhappysmile" data-lexical-text="true">
+              <span class="emoji-inner">🙁</span>
+            </span>
+          </p>
+        `,
+      );
+      await assertSelection(page, {
+        anchorOffset: 2,
+        anchorPath: [0, 2, 0, 0],
+        focusOffset: 2,
+        focusPath: [0, 2, 0, 0],
+      });
+
+      await moveLeft(page, 6);
+      await page.keyboard.press('Enter');
+      if (isRichText) {
+        await assertHTML(
+          page,
+          html`
+            <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            <p
+              class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+              dir="ltr">
+              <span class="emoji happysmile" data-lexical-text="true">
+                <span class="emoji-inner">🙂</span>
+              </span>
+              <span data-lexical-text="true">or</span>
+              <span class="emoji unhappysmile" data-lexical-text="true">
+                <span class="emoji-inner">🙁</span>
+              </span>
+            </p>
+          `,
+        );
+        await assertSelection(page, {
+          anchorOffset: 0,
+          anchorPath: [1, 0, 0, 0],
+          focusOffset: 0,
+          focusPath: [1, 0, 0, 0],
+        });
+      } else {
+        await assertHTML(
+          page,
+          html`
+            <p
+              class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+              dir="ltr">
+              <br />
+              <span class="emoji happysmile" data-lexical-text="true">
+                <span class="emoji-inner">🙂</span>
+              </span>
+              <span data-lexical-text="true">or</span>
+              <span class="emoji unhappysmile" data-lexical-text="true">
+                <span class="emoji-inner">🙁</span>
+              </span>
+            </p>
+          `,
+        );
+        await assertSelection(page, {
+          anchorOffset: 0,
+          anchorPath: [0, 1, 0, 0],
+          focusOffset: 0,
+          focusPath: [0, 1, 0, 0],
+        });
+      }
+
+      await page.keyboard.press('Backspace');
+      await assertHTML(
+        page,
+        html`
           <p
             class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
             dir="ltr">
@@ -69,58 +118,10 @@ test.describe('Regression test #429', () => {
       );
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [1, 0, 0, 0],
+        anchorPath: [0, 0, 0, 0],
         focusOffset: 0,
-        focusPath: [1, 0, 0, 0],
+        focusPath: [0, 0, 0, 0],
       });
-    } else {
-      await assertHTML(
-        page,
-        html`
-          <p
-            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-            dir="ltr">
-            <br />
-            <span class="emoji happysmile" data-lexical-text="true">
-              <span class="emoji-inner">🙂</span>
-            </span>
-            <span data-lexical-text="true">or</span>
-            <span class="emoji unhappysmile" data-lexical-text="true">
-              <span class="emoji-inner">🙁</span>
-            </span>
-          </p>
-        `,
-      );
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [0, 1, 0, 0],
-        focusOffset: 0,
-        focusPath: [0, 1, 0, 0],
-      });
-    }
-
-    await page.keyboard.press('Backspace');
-    await assertHTML(
-      page,
-      html`
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span class="emoji happysmile" data-lexical-text="true">
-            <span class="emoji-inner">🙂</span>
-          </span>
-          <span data-lexical-text="true">or</span>
-          <span class="emoji unhappysmile" data-lexical-text="true">
-            <span class="emoji-inner">🙁</span>
-          </span>
-        </p>
-      `,
-    );
-    await assertSelection(page, {
-      anchorOffset: 0,
-      anchorPath: [0, 0, 0, 0],
-      focusOffset: 0,
-      focusPath: [0, 0, 0, 0],
-    });
-  });
+    },
+  );
 });


### PR DESCRIPTION
## Description

We still have a lot of tests that are flaky, which is a considerable burden on contributions and reviewing them. This is just the ones that flaked in #6535 on this particular run https://github.com/facebook/lexical/actions/runs/10481362302/job/29033662935

## Test plan

### Before

```
 9 flaky
    [chromium] › packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/ListsCopyAndPaste.spec.mjs:111:3 › Lists CopyAndPaste › Copy and paste of partial list items into the list 
    [chromium] › packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs:30:3 › HorizontalRule › Can create a horizontal rule and move selection around it 
    [chromium] › packages/lexical-playground/__tests__/e2e/Links.spec.mjs:1926:3 › Links › Can handle pressing Enter inside a Link 
    [chromium] › packages/lexical-playground/__tests__/e2e/Links.spec.mjs:1960:3 › Links › Can handle pressing Enter inside a Link containing multiple TextNodes 
    [chromium] › packages/lexical-playground/__tests__/e2e/Selection.spec.mjs:877:3 › Selection › shift+arrowdown into a table, when the table is the last node, selects the whole table 
    [chromium] › packages/lexical-playground/__tests__/e2e/Selection.spec.mjs:927:3 › Selection › shift+arrowdown into a table, when the table is the only node, selects the whole table 
    [chromium] › packages/lexical-playground/__tests__/e2e/Tab.spec.mjs:20:3 › Tab › can tab + IME ─
    [chromium] › packages/lexical-playground/__tests__/e2e/TextFormatting.spec.mjs:1114:3 › TextFormatting › Regression #2523: can toggle format when selecting a TextNode edge followed by a non TextNode;  
    [chromium] › packages/lexical-playground/__tests__/regression/429-swapping-emoji.spec.mjs:21:3 › Regression test #429 › Can add new lines before the line with emoji 
```

### After

These 9 tests are tagged `@flaky`