### PR TITLE
[lexical-table] Stop selecting the whole table after pasting cells

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -695,7 +695,6 @@ export function applyTableHandlers(
             newAnchorCellKey,
             newFocusCellKey,
           );
-          $setSelection(newTableSelection);
         }
         return true;
       },

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -66,10 +66,7 @@ import {$isTableCellNode} from './LexicalTableCellNode';
 import {$isTableNode} from './LexicalTableNode';
 import {TableDOMTable, TableObserver} from './LexicalTableObserver';
 import {$isTableRowNode} from './LexicalTableRowNode';
-import {
-  $createTableSelection,
-  $isTableSelection,
-} from './LexicalTableSelection';
+import {$isTableSelection} from './LexicalTableSelection';
 import {$computeTableMap, $getNodeTriplet} from './LexicalTableUtils';
 
 const LEXICAL_ELEMENT_KEY = '__lexicalTableSelection';
@@ -633,8 +630,6 @@ export function applyTableHandlers(
         const toY = Math.max(startY, stopY);
         const gridRowNodes = gridNode.getChildren();
         let newRowIdx = 0;
-        let newAnchorCellKey;
-        let newFocusCellKey;
 
         for (let r = fromY; r <= toY; r++) {
           const currentGridRowNode = gridRowNodes[r];
@@ -666,12 +661,6 @@ export function applyTableHandlers(
               return false;
             }
 
-            if (r === fromY && c === fromX) {
-              newAnchorCellKey = currentGridCellNode.getKey();
-            } else if (r === toY && c === toX) {
-              newFocusCellKey = currentGridCellNode.getKey();
-            }
-
             const originalChildren = currentGridCellNode.getChildren();
             newGridCellNode.getChildren().forEach((child) => {
               if ($isTextNode(child)) {
@@ -687,14 +676,6 @@ export function applyTableHandlers(
           }
 
           newRowIdx++;
-        }
-        if (newAnchorCellKey && newFocusCellKey) {
-          const newTableSelection = $createTableSelection();
-          newTableSelection.set(
-            nodes[0].getKey(),
-            newAnchorCellKey,
-            newFocusCellKey,
-          );
         }
         return true;
       },


### PR DESCRIPTION
Fixes #5656

Upon pasting a cells selection in a table when the target area is not a cells selection inside a table, it would select the whole table after the paste event. It worked correctly (not select the whole table) if the selected area to paste to was a cells selection.

Before:

https://github.com/user-attachments/assets/b6e75f2e-2ede-4da4-8ba4-2839c0b194c3

After:

https://github.com/user-attachments/assets/87d209f3-0feb-4833-a7b1-34193852d1f2

