### PR TITLE
Bug Fix: Fix issue where triple-clicking a cell would dangerously select entire document

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -648,6 +648,38 @@ test.describe.parallel('Selection', () => {
     );
   });
 
+  test('Triple-clicking last cell in table should not select entire document', async ({
+    page,
+    isPlainText,
+    isCollab,
+    browserName,
+    legacyEvents,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await page.keyboard.type('Line1');
+    await insertTable(page, 1, 2);
+
+    const lastCell = page.locator(
+      '.PlaygroundEditorTheme__tableCell:last-child',
+    );
+    await lastCell.click();
+    await page.keyboard.type('Foo');
+
+    const lastCellText = lastCell.locator('span');
+    const tripleClickDelay = 50;
+    await lastCellText.click({clickCount: 3, delay: tripleClickDelay});
+
+    // Only the last cell should be selected, and not the entire docuemnt
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [1, 0, 1, 0],
+      focusOffset: 1,
+      focusPath: [1, 0, 1, 0],
+    });
+  });
+
   test('Can persist the text format from the paragraph', async ({
     page,
     isPlainText,

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -764,14 +764,6 @@ export function applyTableHandlers(
                   : lastCell.getChildrenSize(),
                 'element',
               );
-            } else {
-              newSelection.anchor.set(
-                tableNode.getParentOrThrow().getKey(),
-                isBackward
-                  ? tableNode.getIndexWithinParent() + 1
-                  : tableNode.getIndexWithinParent(),
-                'element',
-              );
             }
             $setSelection(newSelection);
             $addHighlightStyleToTable(editor, tableObserver);


### PR DESCRIPTION
## Description
Triple-clicking may seem esoteric at first but it's a relatively common interaction for quickly selecting whole blocks. For example, triple clicking a paragraph selects the entire paragraph (at least on macOS).

We were seeing a strange issue for some of our users: their entire document would go missing. When we worked with some of these users, we found that previous revisions of their doc showed that it consisted of only a single large table.

After it happened to one of our team members, we found that it was very easy, particularly on mobile, to accidentally select the entire table while trying to tap a single cell to edit. It's my theory that when tapping very rapidly on mobile, a triple-click event gets processed.

Nonetheless, it's easy to replicate this issue on desktop in the playground:

1. Create a table of any size
2. Write some text in the last cell
3. Triple click on the text in the last cell

**Result**: **entire** document get highlighted. One keystroke at this point is all it would take to wipe your entire document.

**Expected result**: only the text in the cell gets highlighted.

In my opinion the code responsible seems relatively dangerous: reaching out to the parent to grab some more nodes for selection. And in fact the issue that the original code was added to address does not seem to be affected by the removal of this code, as evidenced by the passing of the test added in that commit: https://github.com/facebook/lexical/commit/2b2a4f61b6b0c66721fd22e2c7900d0e4c3114d5

It's also my opinion that for large open source projects like this, tests should be the ultimate way of determining what stays and what goes. At some point there will no longer be anyone involved in the project who has all the historical context necessary to determine whether a change is harmful or beneficial, and its up to the tests to defend each change.

In this case, the removal of this code does not harm anyones tests, and improve the usecase mentioned above.

## Test plan

A test was added that fails without the fix. Without the fix, the test would fail because the entire document would be highlighted.

### Before

https://github.com/user-attachments/assets/a3bacdd1-1a75-492a-ace9-89c3600d7954

### After

https://github.com/user-attachments/assets/1c2a3251-42e6-4969-b6ee-43883f5e0390