### PR TITLE
[lexical-table] Fix cut for pure text within cell

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -396,8 +396,10 @@ export function applyTableHandlers(
             $deleteCellHandler(event);
             return true;
           } else if ($isRangeSelection(selection)) {
-            $deleteCellHandler(event);
-            selection.removeText();
+            editor.update(() => {
+              $deleteCellHandler(event);
+              selection.removeText();
+            });
             return true;
           }
         }


### PR DESCRIPTION
Broke 'Cut' for pure text from within a table cell

Before: 

https://github.com/user-attachments/assets/ab143d1e-39d7-420c-a41c-a344a4aa3117

After:
Pastes correctly