### PR TITLE
[lexical-table] Fix table selection paste as plain text

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -336,7 +336,7 @@ export class TableSelection implements BaseSelection {
     for (let i = 0; i < nodes.length; i++) {
       const node: TableCellNode = nodes[i];
       const row = node.__parent;
-      const nextRow = nodes[i + 1 < nodes.length ? i + 1 : 0].__parent;
+      const nextRow = (nodes[i + 1] || {}).__parent;
       textContent +=
         (node.getTextContent() || ' ') + (nextRow !== row ? '\n' : '\t');
     }

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -331,10 +331,10 @@ export class TableSelection implements BaseSelection {
   }
 
   getTextContent(): string {
-    const nodes = this.getNodes();
+    const nodes = this.getNodes().filter((node) => $isTableCellNode(node));
     let textContent = '';
     for (let i = 0; i < nodes.length; i++) {
-      textContent += nodes[i].getTextContent();
+      textContent += nodes[i].getTextContent() + '\n';
     }
     return textContent;
   }

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -334,7 +334,11 @@ export class TableSelection implements BaseSelection {
     const nodes = this.getNodes().filter((node) => $isTableCellNode(node));
     let textContent = '';
     for (let i = 0; i < nodes.length; i++) {
-      textContent += nodes[i].getTextContent() + '\n';
+      const node: TableCellNode = nodes[i];
+      const row = node.__parent;
+      const nextRow = nodes[i + 1 < nodes.length ? i + 1 : 0].__parent;
+      textContent +=
+        (node.getTextContent() || ' ') + (nextRow !== row ? '\n' : '\t');
     }
     return textContent;
   }

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -337,8 +337,7 @@ export class TableSelection implements BaseSelection {
       const node = nodes[i];
       const row = node.__parent;
       const nextRow = (nodes[i + 1] || {}).__parent;
-      textContent +=
-        (node.getTextContent() || ' ') + (nextRow !== row ? '\n' : '\t');
+      textContent += node.getTextContent() + (nextRow !== row ? '\n' : '\t');
     }
     return textContent;
   }

--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -334,7 +334,7 @@ export class TableSelection implements BaseSelection {
     const nodes = this.getNodes().filter((node) => $isTableCellNode(node));
     let textContent = '';
     for (let i = 0; i < nodes.length; i++) {
-      const node: TableCellNode = nodes[i];
+      const node = nodes[i];
       const row = node.__parent;
       const nextRow = (nodes[i + 1] || {}).__parent;
       textContent +=

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -294,6 +294,56 @@ describe('LexicalTableNode tests', () => {
           `<p><br></p><table><tr><th><p><br></p></th><th><p><br></p></th><th><p><br></p></th><th><p><br></p></th></tr><tr><th><p><br></p></th><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><th><p><br></p></th><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><th><p><br></p></th><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></table>`,
         );
       });
+
+      test('Table plain text output validation', async () => {
+        const {editor} = testEnv;
+
+        await editor.update(() => {
+          const root = $getRoot();
+          const table = $createTableNodeWithDimensions(4, 4, true);
+          root.append(table);
+        });
+        await editor.update(() => {
+          const root = $getRoot();
+          const table = root.getLastChild<TableNode>();
+          if (table) {
+            const DOMTable = $getElementForTableNode(editor, table);
+            if (DOMTable) {
+              table
+                ?.getCellNodeFromCords(0, 0, DOMTable)
+                ?.getLastChild<ParagraphNode>()
+                ?.append($createTextNode('1'));
+              table
+                ?.getCellNodeFromCords(1, 0, DOMTable)
+                ?.getLastChild<ParagraphNode>()
+                ?.append($createTextNode(''));
+              table
+                ?.getCellNodeFromCords(2, 0, DOMTable)
+                ?.getLastChild<ParagraphNode>()
+                ?.append($createTextNode('2'));
+              table
+                ?.getCellNodeFromCords(0, 1, DOMTable)
+                ?.getLastChild<ParagraphNode>()
+                ?.append($createTextNode('3'));
+              table
+                ?.getCellNodeFromCords(1, 1, DOMTable)
+                ?.getLastChild<ParagraphNode>()
+                ?.append($createTextNode('4'));
+              table
+                ?.getCellNodeFromCords(2, 1, DOMTable)
+                ?.getLastChild<ParagraphNode>()
+                ?.append($createTextNode(''));
+              const selection = $createTableSelection();
+              selection.set(
+                table.__key,
+                table?.getCellNodeFromCords(0, 0, DOMTable)?.__key || '',
+                table?.getCellNodeFromCords(2, 1, DOMTable)?.__key || '',
+              );
+              expect(selection.getTextContent()).toBe(`1\t\t2\n3\t4\t\n`);
+            }
+          }
+        });
+      });
     },
     undefined,
     <TablePlugin />,


### PR DESCRIPTION
Fixes #6541

Before:
Double pasting incorrectly, since it was reading all nodes - rows and cells.

https://github.com/user-attachments/assets/8ddb613e-1a6b-4985-8052-ff51b9b20982

After:
Pasting correctly, since reading only cells.

https://github.com/user-attachments/assets/c1484903-388a-4f96-86f7-fb97322cd8cc

