### PR TITLE
[lexical-playground] Bug Fix: fix comment timestamps

### DIFF
--- a/packages/lexical-playground/src/commenting/index.ts
+++ b/packages/lexical-playground/src/commenting/index.ts
@@ -56,7 +56,10 @@ export function createComment(
     content,
     deleted: deleted === undefined ? false : deleted,
     id: id === undefined ? createUID() : id,
-    timeStamp: timeStamp === undefined ? performance.now() : timeStamp,
+    timeStamp:
+      timeStamp === undefined
+        ? performance.timeOrigin + performance.now()
+        : timeStamp,
     type: 'comment',
   };
 }

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -466,7 +466,9 @@ function CommentsPanelListComment({
   rtf: Intl.RelativeTimeFormat;
   thread?: Thread;
 }): JSX.Element {
-  const seconds = Math.round((comment.timeStamp - performance.now()) / 1000);
+  const seconds = Math.round(
+    (comment.timeStamp - (performance.timeOrigin + performance.now())) / 1000,
+  );
   const minutes = Math.round(seconds / 60);
   const [modal, showModal] = useModal();
 


### PR DESCRIPTION
## Description

When adding collaborative comments in the playground, the comment timestamps are now consistent even in different window contexts.

Closes #6554

## Test plan

Follow the reproduction steps in issue #6554 and see that the comment timestamps are now the same.

### Before

Comment timestamps are inconsistent in different window contexts.

### After

Comment timestamps are the same in different window contexts.

## Note

There are other uses of `performance.now()` in this repo that might need to be reviewed.