### PR TITLE
[lexical-react] menu positioning: Unrevert PR6510 but with gating

### DIFF
--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -482,6 +482,7 @@ export function useMenuAnchorRef(
   setResolution: (r: MenuResolution | null) => void,
   className?: string,
   parent: HTMLElement = document.body,
+  shouldIncludePageYOffset: boolean = true,
 ): MutableRefObject<HTMLElement> {
   const [editor] = useLexicalComposerContext();
   const anchorElementRef = useRef<HTMLElement>(document.createElement('div'));
@@ -495,7 +496,10 @@ export function useMenuAnchorRef(
       const {left, top, width, height} = resolution.getRect();
       const anchorHeight = anchorElementRef.current.offsetHeight; // use to position under anchor
       containerDiv.style.top = `${
-        top + window.pageYOffset + anchorHeight + 3
+        top +
+        anchorHeight +
+        3 +
+        (shouldIncludePageYOffset ? window.pageYOffset : 0)
       }px`;
       containerDiv.style.left = `${left + window.pageXOffset}px`;
       containerDiv.style.height = `${height}px`;
@@ -519,7 +523,10 @@ export function useMenuAnchorRef(
           top - rootElementRect.top > menuHeight + height
         ) {
           containerDiv.style.top = `${
-            top - menuHeight + window.pageYOffset - height
+            top -
+            menuHeight -
+            height +
+            (shouldIncludePageYOffset ? window.pageYOffset : 0)
           }px`;
         }
       }

--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -482,7 +482,7 @@ export function useMenuAnchorRef(
   setResolution: (r: MenuResolution | null) => void,
   className?: string,
   parent: HTMLElement = document.body,
-  shouldIncludePageYOffset: boolean = true,
+  shouldIncludePageYOffset__EXPERIMENTAL: boolean = true,
 ): MutableRefObject<HTMLElement> {
   const [editor] = useLexicalComposerContext();
   const anchorElementRef = useRef<HTMLElement>(document.createElement('div'));
@@ -499,7 +499,7 @@ export function useMenuAnchorRef(
         top +
         anchorHeight +
         3 +
-        (shouldIncludePageYOffset ? window.pageYOffset : 0)
+        (shouldIncludePageYOffset__EXPERIMENTAL ? window.pageYOffset : 0)
       }px`;
       containerDiv.style.left = `${left + window.pageXOffset}px`;
       containerDiv.style.height = `${height}px`;
@@ -526,7 +526,7 @@ export function useMenuAnchorRef(
             top -
             menuHeight -
             height +
-            (shouldIncludePageYOffset ? window.pageYOffset : 0)
+            (shouldIncludePageYOffset__EXPERIMENTAL ? window.pageYOffset : 0)
           }px`;
         }
       }
@@ -545,7 +545,13 @@ export function useMenuAnchorRef(
       anchorElementRef.current = containerDiv;
       rootElement.setAttribute('aria-controls', 'typeahead-menu');
     }
-  }, [editor, resolution, className, parent]);
+  }, [
+    editor,
+    resolution,
+    shouldIncludePageYOffset__EXPERIMENTAL,
+    className,
+    parent,
+  ]);
 
   useEffect(() => {
     const rootElement = editor.getRootElement();


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
https://github.com/facebook/lexical/pull/6510 is correct but it broke implementations internally

hence it got reverted to mitigate the internal emergency: https://github.com/facebook/lexical/pull/6558

here, https://github.com/facebook/lexical/pull/6510 is reintroduced but gated behind the shouldIncludePageYOffset option to aid investigations internally and to fix internal to be compatible 

## Test plan

shouldIncludePageYOffset = true


https://github.com/user-attachments/assets/8721cc41-3486-4b0b-83c3-008b3ec4c173





---
shouldIncludePageYOffset = false

https://github.com/user-attachments/assets/db950846-7989-4489-9a33-36ef59cd0ceb