### PR TITLE
[lexical] Chore: Add more helpful invariants to $applyNodeReplacement

### DIFF
--- a/packages/lexical-website/docs/concepts/node-replacement.md
+++ b/packages/lexical-website/docs/concepts/node-replacement.md
@@ -16,7 +16,8 @@ const editorConfig = {
             replace: ParagraphNode,
             with: (node: ParagraphNode) => {
                 return new CustomParagraphNode();
-            }
+            },
+            withKlass: CustomParagraphNode,
         }
     ]
 }

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -295,7 +295,11 @@ const initialConfig: InitialConfigType = {
     onError: (error: any) => console.log(error),
     nodes: [
       ExtendedTextNode,
-      { replace: TextNode, with: (node: TextNode) => new ExtendedTextNode(node.__text) },
+      {
+        replace: TextNode,
+        with: (node: TextNode) => new ExtendedTextNode(node.__text),
+        withKlass: ExtendedTextNode,
+      },
       ListNode,
       ListItemNode,
     ]
@@ -306,6 +310,7 @@ and create a new Extended Text Node plugin
 
 ```js
 import {
+  $applyNodeReplacement,
   $isTextNode,
   DOMConversion,
   DOMConversionMap,
@@ -378,7 +383,7 @@ export class ExtendedTextNode extends TextNode {
 }
 
 export function $createExtendedTextNode(text: string): ExtendedTextNode {
-	return new ExtendedTextNode(text);
+  return $applyNodeReplacement(new ExtendedTextNode(text));
 }
 
 export function $isExtendedTextNode(node: LexicalNode | null | undefined): node is ExtendedTextNode {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1405,9 +1405,7 @@ export function $copyNode<T extends LexicalNode>(node: T): T {
   return copy;
 }
 
-export function $applyNodeReplacement<N extends LexicalNode>(
-  node: LexicalNode,
-): N {
+export function $applyNodeReplacement<N extends LexicalNode>(node: N): N {
   const editor = getActiveEditor();
   const nodeType = node.constructor.getType();
   const registeredNode = editor._nodes.get(nodeType);
@@ -1417,29 +1415,43 @@ export function $applyNodeReplacement<N extends LexicalNode>(
     node.constructor.name,
     nodeType,
   );
-  const replaceFunc = registeredNode.replace;
-  if (replaceFunc !== null) {
-    const replacementNode = replaceFunc(node);
+  const {replace, replaceWithKlass} = registeredNode;
+  if (replace !== null) {
+    const replacementNode = replace(node);
+    const replacementNodeKlass = replacementNode.constructor;
+    if (replaceWithKlass !== null) {
+      invariant(
+        replacementNode instanceof replaceWithKlass,
+        '$applyNodeReplacement failed. Expected replacement node to be an instance of %s with type %s but returned %s with type %s from original node %s with type %s',
+        replaceWithKlass.name,
+        replaceWithKlass.getType(),
+        replacementNodeKlass.name,
+        replacementNodeKlass.getType(),
+        node.constructor.name,
+        nodeType,
+      );
+    } else {
+      invariant(
+        replacementNode instanceof node.constructor &&
+          replacementNodeKlass !== node.constructor,
+        '$applyNodeReplacement failed. Ensure replacement node %s with type %s is a subclass of the original node %s with type %s.',
+        replacementNodeKlass.name,
+        replacementNodeKlass.getType(),
+        node.constructor.name,
+        nodeType,
+      );
+    }
     invariant(
-      replacementNode instanceof node.constructor,
-      '$applyNodeReplacement failed. Ensure replacement node %s with type %s is a subclass of the original node %s with type %s.',
-      replacementNode.constructor.name,
-      replacementNode.getType(),
-      node.constructor.name,
-      nodeType,
-    );
-    invariant(
-      replacementNode.constructor === node.constructor ||
-        replacementNode.__key !== node.__key,
+      replacementNode.__key !== node.__key,
       '$applyNodeReplacement failed. Ensure that the key argument is *not* used in your replace function (from node %s with type %s to node %s with type %s), Node keys must never be re-used except by the static clone method.',
       node.constructor.name,
       nodeType,
-      replacementNode.constructor.name,
-      replacementNode.getType(),
+      replacementNodeKlass.name,
+      replacementNodeKlass.getType(),
     );
     return replacementNode as N;
   }
-  return node as N;
+  return node;
 }
 
 export function errorOnInsertTextNodeOnRoot(

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1411,22 +1411,33 @@ export function $applyNodeReplacement<N extends LexicalNode>(
   const editor = getActiveEditor();
   const nodeType = node.constructor.getType();
   const registeredNode = editor._nodes.get(nodeType);
-  if (registeredNode === undefined) {
-    invariant(
-      false,
-      '$initializeNode failed. Ensure node has been registered to the editor. You can do this by passing the node class via the "nodes" array in the editor config.',
-    );
-  }
+  invariant(
+    registeredNode !== undefined,
+    '$applyNodeReplacement node %s with type %s must be registered to the editor. You can do this by passing the node class via the "nodes" array in the editor config.',
+    node.constructor.name,
+    nodeType,
+  );
   const replaceFunc = registeredNode.replace;
   if (replaceFunc !== null) {
-    const replacementNode = replaceFunc(node) as N;
-    if (!(replacementNode instanceof node.constructor)) {
-      invariant(
-        false,
-        '$initializeNode failed. Ensure replacement node is a subclass of the original node.',
-      );
-    }
-    return replacementNode;
+    const replacementNode = replaceFunc(node);
+    invariant(
+      replacementNode instanceof node.constructor,
+      '$applyNodeReplacement failed. Ensure replacement node %s with type %s is a subclass of the original node %s with type %s.',
+      replacementNode.constructor.name,
+      replacementNode.getType(),
+      node.constructor.name,
+      nodeType,
+    );
+    invariant(
+      replacementNode.constructor === node.constructor ||
+        replacementNode.__key !== node.__key,
+      '$applyNodeReplacement failed. Ensure that the key argument is *not* used in your replace function (from node %s with type %s to node %s with type %s), Node keys must never be re-used except by the static clone method.',
+      node.constructor.name,
+      nodeType,
+      replacementNode.constructor.name,
+      replacementNode.getType(),
+    );
+    return replacementNode as N;
   }
   return node as N;
 }

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -7,24 +7,29 @@
  */
 
 import {
+  $applyNodeReplacement,
+  $createParagraphNode,
+  $createTextNode,
   $getNodeByKey,
   $getRoot,
   $isTokenOrSegmented,
   $nodesOfType,
+  createEditor,
+  isSelectionWithinEditor,
+  ParagraphNode,
+  resetRandomKey,
+  SerializedTextNode,
+  TextNode,
+} from 'lexical';
+
+import {
   emptyFunction,
   generateRandomKey,
   getCachedTypeToNodeMap,
   getTextDirection,
   isArray,
-  isSelectionWithinEditor,
-  resetRandomKey,
   scheduleMicroTask,
 } from '../../LexicalUtils';
-import {
-  $createParagraphNode,
-  ParagraphNode,
-} from '../../nodes/LexicalParagraphNode';
-import {$createTextNode, TextNode} from '../../nodes/LexicalTextNode';
 import {initializeUnitTest} from '../utils';
 
 describe('LexicalUtils tests', () => {
@@ -288,6 +293,286 @@ describe('LexicalUtils tests', () => {
       expect(
         [...textMap.values()].map((node) => (node as TextNode).__text),
       ).toEqual(expect.arrayContaining(['a', 'b']));
+    });
+  });
+});
+describe('$applyNodeReplacement', () => {
+  class ExtendedTextNode extends TextNode {
+    static getType() {
+      return 'extended-text';
+    }
+    static clone(node: ExtendedTextNode): ExtendedTextNode {
+      return new ExtendedTextNode(node.__text, node.getKey());
+    }
+    exportJSON(): SerializedTextNode {
+      return {...super.exportJSON(), type: this.getType()};
+    }
+    initWithTextNode(node: TextNode): this {
+      this.__text = node.__text;
+      TextNode.prototype.afterCloneFrom.call(this, node);
+      return this;
+    }
+    initWithJSON(serializedNode: SerializedTextNode): this {
+      this.setTextContent(serializedNode.text);
+      this.setFormat(serializedNode.format);
+      this.setDetail(serializedNode.detail);
+      this.setMode(serializedNode.mode);
+      this.setStyle(serializedNode.style);
+      return this;
+    }
+    static importJSON(serializedNode: SerializedTextNode): ExtendedTextNode {
+      return $createExtendedTextNode().initWithJSON(serializedNode);
+    }
+  }
+  class ExtendedExtendedTextNode extends ExtendedTextNode {
+    static getType() {
+      return 'extended-extended-text';
+    }
+    static clone(node: ExtendedExtendedTextNode): ExtendedExtendedTextNode {
+      return new ExtendedExtendedTextNode(node.__text, node.getKey());
+    }
+    initWithExtendedTextNode(node: ExtendedTextNode): this {
+      return this.initWithTextNode(node);
+    }
+    static importJSON(
+      serializedNode: SerializedTextNode,
+    ): ExtendedExtendedTextNode {
+      return $createExtendedExtendedTextNode().initWithJSON(serializedNode);
+    }
+    exportJSON(): SerializedTextNode {
+      return {...super.exportJSON(), type: this.getType()};
+    }
+  }
+  function $createExtendedTextNode(text: string = '') {
+    return $applyNodeReplacement(new ExtendedTextNode(text));
+  }
+  function $createExtendedExtendedTextNode(text: string = '') {
+    return $applyNodeReplacement(new ExtendedExtendedTextNode(text));
+  }
+  test('validates replace node configuration', () => {
+    const editor = createEditor({
+      nodes: [
+        {
+          replace: TextNode,
+          with: (node) => $createExtendedTextNode().initWithTextNode(node),
+        },
+      ],
+      onError(err) {
+        throw err;
+      },
+    });
+    expect(() => {
+      editor.update(
+        () => {
+          $getRoot()
+            .clear()
+            .append($createParagraphNode().append($createTextNode('text')));
+        },
+        {discrete: true},
+      );
+    }).toThrow(
+      'Attempted to create node ExtendedTextNode that was not configured to be used on the editor',
+    );
+  });
+  test('validates replace node type withKlass', () => {
+    const editor = createEditor({
+      nodes: [
+        {
+          replace: TextNode,
+          with: (node) => node,
+          withKlass: ExtendedTextNode,
+        },
+      ],
+      onError(err) {
+        throw err;
+      },
+    });
+    expect(() => {
+      editor.update(
+        () => {
+          $getRoot()
+            .clear()
+            .append($createParagraphNode().append($createTextNode('text')));
+        },
+        {discrete: true},
+      );
+    }).toThrow(
+      '$applyNodeReplacement failed. Expected replacement node to be an instance of ExtendedTextNode with type extended-text but returned TextNode with type text from original node TextNode with type text',
+    );
+  });
+  test('validates replace node type change', () => {
+    const editor = createEditor({
+      nodes: [
+        {
+          replace: TextNode,
+          with: (node: TextNode) => new TextNode(node.__text),
+        },
+      ],
+      onError(err) {
+        throw err;
+      },
+    });
+    expect(() => {
+      editor.update(
+        () => {
+          $getRoot()
+            .clear()
+            .append($createParagraphNode().append($createTextNode('text')));
+        },
+        {discrete: true},
+      );
+    }).toThrow(
+      '$applyNodeReplacement failed. Ensure replacement node TextNode with type text is a subclass of the original node TextNode with type text',
+    );
+  });
+  test('validates replace node key change', () => {
+    const editor = createEditor({
+      nodes: [
+        {
+          replace: TextNode,
+          with: (node: TextNode) =>
+            new ExtendedTextNode(node.__text, node.getKey()),
+        },
+      ],
+      onError(err) {
+        throw err;
+      },
+    });
+    expect(() => {
+      editor.update(
+        () => {
+          $getRoot()
+            .clear()
+            .append($createParagraphNode().append($createTextNode('text')));
+        },
+        {discrete: true},
+      );
+    }).toThrow(
+      'Lexical node with constructor ExtendedTextNode attempted to re-use key from node in active editor state with constructor TextNode. Keys must not be re-used when the type is changed.',
+    );
+  });
+  test('validates replace node configuration withKlass', () => {
+    const editor = createEditor({
+      nodes: [
+        {
+          replace: TextNode,
+          with: (node) => $createExtendedTextNode().initWithTextNode(node),
+          withKlass: ExtendedTextNode,
+        },
+      ],
+      onError(err) {
+        throw err;
+      },
+    });
+    expect(() => {
+      editor.update(
+        () => {
+          $getRoot()
+            .clear()
+            .append($createParagraphNode().append($createTextNode('text')));
+        },
+        {discrete: true},
+      );
+    }).toThrow(
+      'Attempted to create node ExtendedTextNode that was not configured to be used on the editor',
+    );
+  });
+  test('validates nested replace node configuration', () => {
+    const editor = createEditor({
+      nodes: [
+        ExtendedTextNode,
+        {
+          replace: ExtendedTextNode,
+          with: (node) =>
+            $createExtendedExtendedTextNode().initWithExtendedTextNode(node),
+        },
+      ],
+      onError(err) {
+        throw err;
+      },
+    });
+    expect(() => {
+      editor.update(
+        () => {
+          $getRoot()
+            .clear()
+            .append(
+              $createParagraphNode().append($createExtendedTextNode('text')),
+            );
+        },
+        {discrete: true},
+      );
+    }).toThrow(
+      'Attempted to create node ExtendedExtendedTextNode that was not configured to be used on the editor',
+    );
+  });
+  test('validates nested replace node configuration withKlass', () => {
+    const editor = createEditor({
+      nodes: [
+        ExtendedTextNode,
+        {
+          replace: TextNode,
+          with: (node) => $createExtendedTextNode().initWithTextNode(node),
+          withKlass: ExtendedTextNode,
+        },
+        {
+          replace: ExtendedTextNode,
+          with: (node) =>
+            $createExtendedExtendedTextNode().initWithExtendedTextNode(node),
+          withKlass: ExtendedExtendedTextNode,
+        },
+      ],
+      onError(err) {
+        throw err;
+      },
+    });
+    expect(() => {
+      editor.update(
+        () => {
+          $getRoot()
+            .clear()
+            .append($createParagraphNode().append($createTextNode('text')));
+        },
+        {discrete: true},
+      );
+    }).toThrow(
+      'Attempted to create node ExtendedExtendedTextNode that was not configured to be used on the editor',
+    );
+  });
+  test('nested replace node configuration works', () => {
+    const editor = createEditor({
+      nodes: [
+        ExtendedTextNode,
+        ExtendedExtendedTextNode,
+        {
+          replace: TextNode,
+          with: (node) => $createExtendedTextNode().initWithTextNode(node),
+          withKlass: ExtendedTextNode,
+        },
+        {
+          replace: ExtendedTextNode,
+          with: (node) =>
+            $createExtendedExtendedTextNode().initWithExtendedTextNode(node),
+          withKlass: ExtendedExtendedTextNode,
+        },
+      ],
+      onError(err) {
+        throw err;
+      },
+    });
+    editor.update(
+      () => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTextNode('text')));
+      },
+      {discrete: true},
+    );
+    editor.read(() => {
+      const textNodes = $getRoot().getAllTextNodes();
+      expect(textNodes).toHaveLength(1);
+      expect(textNodes[0].constructor).toBe(ExtendedExtendedTextNode);
+      expect(textNodes[0].getTextContent()).toBe('text');
     });
   });
 });


### PR DESCRIPTION
## Description

Specifying the key argument incorrectly in a replacement function is a common mistake. This PR adds a helpful invariant and improves the error messages in the existing invariants for `$applyNodeReplacement`.

## Test plan

### Before

It was possible to write code that behaves incorrectly in subtle ways without a clear error message if you wrote a replacement function that preserved a node's `__key` incorrectly, e.g. https://discord.com/channels/953974421008293909/1278046226100654243

### After

Invariants will throw an error early if this type of mistake is made with enough information to fix it.