### PR TITLE
[lexical-table] Bug Fix: Add @lexical/clipboard as a direct dependency of @lexical/table

### DIFF
--- a/packages/lexical-table/package.json
+++ b/packages/lexical-table/package.json
@@ -12,6 +12,7 @@
   "main": "LexicalTable.js",
   "types": "index.d.ts",
   "dependencies": {
+    "@lexical/clipboard": "0.17.1",
     "@lexical/utils": "0.17.1",
     "lexical": "0.17.1"
   },


### PR DESCRIPTION
## Description

0.17.1 added a @lexical/clipboard dependency in @lexical/table but it was not declared in package.json

Closes #6569

## Test plan

### Before

Undeclared dependencies in @lexical/table could potentially cause a package manager to generate an incorrect lockfile

### After

It should no longer be possible for that error to occur