### PR TITLE
[*] Feature: Check undeclared dependencies in build

### DIFF
--- a/packages/lexical-yjs/package.json
+++ b/packages/lexical-yjs/package.json
@@ -16,6 +16,7 @@
   "types": "index.d.ts",
   "dependencies": {
     "@lexical/offset": "0.17.1",
+    "@lexical/selection": "0.17.1",
     "lexical": "0.17.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Description

It's easy to add inter-package dependencies in the monorepo that can cause problems for npm users.

Closes #6572

## Test plan

### Before

Packages could have undeclared inter-package dependencies that go unchecked

### After

The build fails when these inter-package dependencies are not declared

```
❯ npm run build

> @lexical/monorepo@0.17.1 build
> node scripts/build.js

Error: packages/lexical-yjs/src/SyncCursors.ts has an undeclared dependency in its import of @lexical/selection.
Add the following to the dependencies in packages/lexical-yjs/package.json: "@lexical/selection": "0.17.1"
```