### PR TITLE
[lexical-react]: Fix incorrect addition of empty cells on table paste

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
@@ -572,4 +572,154 @@ test.describe('HTML Tables CopyAndPaste', () => {
       `,
     );
   });
+
+  test('Copy + paste table with merged cells and unequal number of cells in rows', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    const clipboard = {
+      'text/html': html`
+        123
+        <table>
+          <tr>
+            <td colspan="2">
+              <p>
+                <span>1</span>
+              </p>
+            </td>
+            <td>
+              <p>
+                <span>2</span>
+              </p>
+            </td>
+            <td>
+              <p>
+                <span>3</span>
+              </p>
+            </td>
+            <td>
+              <p>
+                <span>4</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td rowspan="4">
+              <p>
+                <span>7</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>
+                <span>8</span>
+              </p>
+            </td>
+            <td rowspan="2">
+              <p>
+                <span>9</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>
+                <span>0</span>
+              </p>
+            </td>
+          </tr>
+        </table>
+      `,
+    };
+
+    await pasteFromClipboard(page, clipboard);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span data-lexical-text="true">123</span>
+        </p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell" colspan="2">
+              <p class="PlaygroundEditorTheme__paragraph">
+                <span data-lexical-text="true">1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph">
+                <span data-lexical-text="true">2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph">
+                <span data-lexical-text="true">3</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph">
+                <span data-lexical-text="true">4</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell" rowspan="4">
+              <p class="PlaygroundEditorTheme__paragraph">
+                <span data-lexical-text="true">7</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph">
+                <span data-lexical-text="true">8</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" rowspan="2">
+              <p class="PlaygroundEditorTheme__paragraph">
+                <span data-lexical-text="true">9</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph">
+                <span data-lexical-text="true">0</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+      `,
+    );
+  });
 });

--- a/packages/lexical-react/src/LexicalTablePlugin.ts
+++ b/packages/lexical-react/src/LexicalTablePlugin.ts
@@ -88,20 +88,18 @@ export function TablePlugin({
           return Math.max(curLength, row.length);
         }, 0);
         for (let i = 0; i < gridMap.length; ++i) {
-          const rowLength = gridMap[i].length;
+          const row = gridMap[i].filter((cell) => cell);
+          const rowLength = row.length;
           if (rowLength === maxRowLength) {
             continue;
           }
-          const lastCellMap = gridMap[i][rowLength - 1];
-          const lastRowCell = lastCellMap.cell;
+          const rowNode: TableRowNode | null = node.getChildAtIndex(i);
           for (let j = rowLength; j < maxRowLength; ++j) {
             // TODO: inherit header state from another header or body
             const newCell = $createTableCellNode(0);
             newCell.append($createParagraphNode());
-            if (lastRowCell !== null) {
-              lastRowCell.insertAfter(newCell);
-            } else {
-              $insertFirst(lastRowCell, newCell);
+            if (rowNode) {
+              rowNode.append(newCell);
             }
           }
         }

--- a/packages/lexical-react/src/LexicalTablePlugin.ts
+++ b/packages/lexical-react/src/LexicalTablePlugin.ts
@@ -87,20 +87,21 @@ export function TablePlugin({
         const maxRowLength = gridMap.reduce((curLength, row) => {
           return Math.max(curLength, row.length);
         }, 0);
+        const rowNodes = node.getChildren();
         for (let i = 0; i < gridMap.length; ++i) {
-          const row = gridMap[i].filter((cell) => cell);
-          const rowLength = row.length;
-          if (rowLength === maxRowLength) {
+          const rowLength = gridMap[i].reduce(
+            (acc, cell) => (cell ? 1 + acc : acc),
+            0,
+          );
+          const rowNode = rowNodes[i];
+          if (rowLength === maxRowLength || !rowNode) {
             continue;
           }
-          const rowNode: TableRowNode | null = node.getChildAtIndex(i);
           for (let j = rowLength; j < maxRowLength; ++j) {
             // TODO: inherit header state from another header or body
             const newCell = $createTableCellNode(0);
             newCell.append($createParagraphNode());
-            if (rowNode) {
-              rowNode.append(newCell);
-            }
+            rowNode.append(newCell);
           }
         }
       }),

--- a/packages/lexical-react/src/LexicalTablePlugin.ts
+++ b/packages/lexical-react/src/LexicalTablePlugin.ts
@@ -89,19 +89,22 @@ export function TablePlugin({
         }, 0);
         const rowNodes = node.getChildren();
         for (let i = 0; i < gridMap.length; ++i) {
+          const rowNode = rowNodes[i];
+          if (!rowNode) {
+            continue;
+          }
           const rowLength = gridMap[i].reduce(
             (acc, cell) => (cell ? 1 + acc : acc),
             0,
           );
-          const rowNode = rowNodes[i];
-          if (rowLength === maxRowLength || !rowNode) {
+          if (rowLength === maxRowLength) {
             continue;
           }
           for (let j = rowLength; j < maxRowLength; ++j) {
             // TODO: inherit header state from another header or body
             const newCell = $createTableCellNode(0);
             newCell.append($createParagraphNode());
-            rowNode.append(newCell);
+            (rowNode as TableRowNode).append(newCell);
           }
         }
       }),


### PR DESCRIPTION
This PR fixes the issue with empty cells getting incorrectly added to a table upon paste.

## Before
When a table with rows with unequal sizes and merged cells is pasted, we add the empty cells in the wrong row.
For example, a table like this: 
![image](https://github.com/user-attachments/assets/59dc6538-381a-4c9c-ada2-1e69a2312f71)


![table-transform-before](https://github.com/user-attachments/assets/1605ad58-f336-4dc9-aa70-184c14c6033a)

## After
Empty cells are now added to the correct row.

![table-transform-after](https://github.com/user-attachments/assets/d2becaa0-b7c1-4e83-a035-2baa14a7ade6)
