### PR TITLE
Bug Fix: Fix issue where selecting a cell then dragging outside of table would not select entire table

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -709,7 +709,7 @@ test.describe.parallel('Selection', () => {
     browserName,
     legacyEvents,
   }) => {
-    test.skip(isPlainText);
+    test.skip(isPlainText || isCollab);
 
     await focusEditor(page);
     await insertTable(page, 1, 2);

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -714,15 +714,15 @@ test.describe.parallel('Selection', () => {
     await focusEditor(page);
     await insertTable(page, 1, 2);
     await moveToEditorEnd(page);
-    const lastCellText = 'Some text';
-    await page.keyboard.type(lastCellText);
+
+    const endParagraphText = 'Some text';
+    await page.keyboard.type(endParagraphText);
 
     const lastCell = page.locator(
       '.PlaygroundEditorTheme__tableCell:last-child',
     );
     await lastCell.click();
-    const cellText = 'Foo';
-    await page.keyboard.type(cellText);
+    await page.keyboard.type('Foo');
 
     const expectedSelection = createHumanReadableSelection({
       anchorOffset: {desc: 'beginning of cell', value: 0},
@@ -731,7 +731,7 @@ test.describe.parallel('Selection', () => {
         {desc: 'first table row', value: 0},
         {desc: 'first cell', value: 0},
       ],
-      focusOffset: {desc: 'full text length', value: lastCellText.length},
+      focusOffset: {desc: 'full text length', value: endParagraphText.length},
       focusPath: [
         {desc: 'index of last paragraph', value: 2},
         {desc: 'index of first span', value: 0},

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -26,6 +26,7 @@ import {
   assertSelection,
   assertTableSelectionCoordinates,
   click,
+  createHumanReadableSelection,
   evaluate,
   expect,
   focusEditor,
@@ -671,26 +672,80 @@ test.describe.parallel('Selection', () => {
     const lastCellText = lastCell.locator('span');
     const tripleClickDelay = 50;
     await lastCellText.click({clickCount: 3, delay: tripleClickDelay});
-    const anchorPath = [1, 0, 1, 0];
 
-    // Only the last cell should be selected, and not the entire docuemnt
-    if (browserName === 'firefox') {
-      // Firefox selects the p > span > #text node
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [...anchorPath, 0, 0],
-        focusOffset: cellText.length,
-        focusPath: [...anchorPath, 0, 0],
-      });
-    } else {
-      // Other browsers select the p
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath,
-        focusOffset: 1,
-        focusPath: anchorPath,
-      });
-    }
+    const expectedSelection = createHumanReadableSelection({
+      anchorOffset: {desc: 'beginning of cell', value: 0},
+      anchorPath: [
+        {desc: 'index of table in root', value: 1},
+        {desc: 'first table row', value: 0},
+        {desc: 'first cell', value: 0},
+        {desc: 'beginning of text', value: 0},
+      ],
+      focusOffset: {desc: 'beginning of text', value: 0},
+      focusPath: [
+        {desc: 'index of table in root', value: 1},
+        {desc: 'first table row', value: 0},
+        {desc: 'first cell', value: 0},
+        {desc: 'beginning of text', value: 0},
+      ],
+    });
+
+    // Only the first cell should be selected, and not the entire document
+    // Ideally the last cell should be selected since that was what was triple-clicked,
+    // but due to the complex selection logic involved, this was the best that could be done.
+    // The goal ultimately was to prevent dangerous whole document selection.
+    // Getting the last cell precisely selected can be done at a later point.
+    await assertSelection(page, expectedSelection);
+  });
+
+  /**
+   * Dragging down from a table cell onto paragraph text below the table should select the entire table
+   * and select the paragraph text below the table.
+   */
+  test('Selecting table cell then dragging to outside of table should select entire table', async ({
+    page,
+    isPlainText,
+    isCollab,
+    browserName,
+    legacyEvents,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+    await insertTable(page, 1, 2);
+    await moveToEditorEnd(page);
+    const lastCellText = 'Some text';
+    await page.keyboard.type(lastCellText);
+
+    const lastCell = page.locator(
+      '.PlaygroundEditorTheme__tableCell:last-child',
+    );
+    await lastCell.click();
+    const cellText = 'Foo';
+    await page.keyboard.type(cellText);
+
+    const expectedSelection = createHumanReadableSelection({
+      anchorOffset: {desc: 'beginning of cell', value: 0},
+      anchorPath: [
+        {desc: 'index of table in root', value: 1},
+        {desc: 'first table row', value: 0},
+        {desc: 'first cell', value: 0},
+      ],
+      focusOffset: {desc: 'full text length', value: lastCellText.length},
+      focusPath: [
+        {desc: 'index of last paragraph', value: 2},
+        {desc: 'index of first span', value: 0},
+        {desc: 'index of text block', value: 0},
+      ],
+    });
+
+    // Move the mouse to the last cell
+    await lastCell.hover();
+    await page.mouse.down();
+    // Move the mouse to the end of the document
+    await page.mouse.move(0, 500);
+
+    await assertSelection(page, expectedSelection);
   });
 
   test('Can persist the text format from the paragraph', async ({

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -755,6 +755,12 @@ test.describe.parallel('Selection', () => {
     await lastCell.click();
     await page.keyboard.type('Foo');
 
+    // Move the mouse to the last cell
+    await lastCell.hover();
+    await page.mouse.down();
+    // Move the mouse to the end of the document
+    await page.mouse.move(500, 500);
+
     const expectedSelection = createHumanReadableSelection(
       'the full table from beginning to the end of the text in the last cell',
       {
@@ -772,13 +778,6 @@ test.describe.parallel('Selection', () => {
         ],
       },
     );
-
-    // Move the mouse to the last cell
-    await lastCell.hover();
-    await page.mouse.down();
-    // Move the mouse to the end of the document
-    await page.mouse.move(0, 500);
-
     await assertSelection(page, expectedSelection);
   });
 

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1317,7 +1317,7 @@ test.describe.parallel('Tables', () => {
 
     await insertTable(page, 2, 2);
 
-    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await click(page, '.PlaygroundEditorTheme__tableCell:first-child');
     await page.keyboard.type('Hello');
 
     await page.keyboard.down('Shift');
@@ -1332,8 +1332,7 @@ test.describe.parallel('Tables', () => {
     await insertSampleImage(page);
     await page.keyboard.type(' <- it works!');
 
-    // Wait for Decorator to mount.
-    await page.waitForTimeout(3000);
+    await waitForSelector(page, '.editor-image img');
 
     await assertHTML(
       page,

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -971,7 +971,7 @@ export async function pressInsertLinkButton(page) {
  * then the cursor is at the 4th character of the 3rd element of the 2nd element of the 1st element.
  *
  * @example
- * const expectedSelection = createHumanReadableSelection({
+ * const expectedSelection = createHumanReadableSelection('the full text of the last cell', {
  *   anchorOffset: {desc: 'beginning of cell', value: 0},
  *   anchorPath: [
  *     {desc: 'index of table in root', value: 1},
@@ -986,7 +986,7 @@ export async function pressInsertLinkButton(page) {
  *   ],
  * });
  */
-export function createHumanReadableSelection(dto) {
+export function createHumanReadableSelection(_overview, dto) {
   return {
     anchorOffset: dto.anchorOffset.value,
     anchorPath: dto.anchorPath.map((p) => p.value),

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -961,3 +961,36 @@ export async function dragDraggableMenuTo(
 export async function pressInsertLinkButton(page) {
   await click(page, '.toolbar-item[aria-label="Insert link"]');
 }
+
+/**
+ * Creates a selection object to assert against that is human readable and self-describing.
+ *
+ * Selections are composed of an anchorPath (the start) and a focusPath (the end).
+ * Once you traverse each path, you use the respective offsets to find the exact location of the cursor.
+ * So offsets are relative to their path. For example, if the anchorPath is [0, 1, 2] and the anchorOffset is 3,
+ * then the cursor is at the 4th character of the 3rd element of the 2nd element of the 1st element.
+ *
+ * @example
+ * const expectedSelection = createHumanReadableSelection({
+ *   anchorOffset: {desc: 'beginning of cell', value: 0},
+ *   anchorPath: [
+ *     {desc: 'index of table in root', value: 1},
+ *     {desc: 'first table row', value: 0},
+ *     {desc: 'first cell', value: 0},
+ *   ],
+ *   focusOffset: {desc: 'full text length', value: lastCellText.length},
+ *   focusPath: [
+ *     {desc: 'index of last paragraph', value: 2},
+ *     {desc: 'index of first span', value: 0},
+ *     {desc: 'index of text block', value: 0},
+ *   ],
+ * });
+ */
+export function createHumanReadableSelection(dto) {
+  return {
+    anchorOffset: dto.anchorOffset.value,
+    anchorPath: dto.anchorPath.map((p) => p.value),
+    focusOffset: dto.focusOffset.value,
+    focusPath: dto.focusPath.map((p) => p.value),
+  };
+}

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -978,7 +978,7 @@ export async function pressInsertLinkButton(page) {
  *     {desc: 'first table row', value: 0},
  *     {desc: 'first cell', value: 0},
  *   ],
- *   focusOffset: {desc: 'full text length', value: lastCellText.length},
+ *   focusOffset: {desc: 'full text length', value: 9},
  *   focusPath: [
  *     {desc: 'index of last paragraph', value: 2},
  *     {desc: 'index of first span', value: 0},

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -764,6 +764,25 @@ export function applyTableHandlers(
                   : lastCell.getChildrenSize(),
                 'element',
               );
+            } else if (isAnchorInside) {
+              const [tableMap] = $computeTableMap(
+                tableNode,
+                anchorCellNode,
+                anchorCellNode,
+              );
+              const firstCell = tableMap[0][0].cell;
+              const lastCell = tableMap[tableMap.length - 1].at(-1)!.cell;
+              /**
+               * If isBackward, set the anchor to be at the end of the table so that when the cursor moves outside of
+               * the table in the backward direction, the entire table will be selected from its end.
+               * Otherwise, if forward, set the anchor to be at the start of the table so that when the focus is dragged
+               * outside th end of the table, it will start from the beginning of the table.
+               */
+              newSelection.anchor.set(
+                isBackward ? lastCell.getKey() : firstCell.getKey(),
+                isBackward ? lastCell.getChildrenSize() : 0,
+                'element',
+              );
             }
             $setSelection(newSelection);
             $addHighlightStyleToTable(editor, tableObserver);


### PR DESCRIPTION
This fixes a [regression](https://github.com/facebook/lexical/pull/6542#issuecomment-2318374970) caused by [this PR](https://github.com/facebook/lexical/pull/6542).

The PR above aimed to solve a destructive issue where triple-clicking in a table could inadvertently select the entire document. The solution caused a regression where dragging out from inside a table wouldn't select the entire table, even though the highlight made it seem like it was selected.

I spent a bit of time trying to fix both the regression and the original triple-click issue but unfortunately had to reach a compromise where I could fix the regression, and fix the triple-click issue, with the compromise that triple-clicking the last cell would end up selecting the first cell (rather than the whole document). That's fine enough for me, so long as the whole document isn't selected, but isn't exactly technically correct.

However I couldn't figure out why the first cell was being selected. The code looks right to me and inspecting the selection before it's made tells me that the last cell should be selected, but for some reason, it's being overriden somewhere to the first cell.

In any case I think this PR represents a suitable compromise and we can either merge it now if it makes sense, or wait to see if someone understands what a fix could look like that addresses both issues.

# Test plan

Tests were added and modified. I also added a utility function with the goal of making it easier to read and work with selection objects. Reading other people's selection objects, especially when reviewing the PR, is very hard to contextualize.

For example, this is hard to understand or conceptualize at first glance:

```js
const expectedSelection = {
  anchorOffset: 0,
  anchorPath: [1, 0, 0],
  focusOffset: 9,
  focusPath: [2, 0, 0],
};
```

You'd have to print out the DOM to really verify what's going on here as a reviewer.

I've created a helper function that allows for self-describing names:

```js
    const expectedSelection = createHumanReadableSelection({
      anchorOffset: {desc: 'beginning of cell', value: 0},
      anchorPath: [
        {desc: 'index of table in root', value: 1},
        {desc: 'first table row', value: 0},
        {desc: 'first cell', value: 0},
      ],
      focusOffset: {desc: 'full text length', value: 9},
      focusPath: [
        {desc: 'index of last paragraph', value: 2},
        {desc: 'index of first span', value: 0},
        {desc: 'index of text block', value: 0},
      ],
    });
```

Not required as part of this PR so I can remove it if it's not helpful.

## Before

https://github.com/user-attachments/assets/5c748a13-054e-4440-8669-75700e923d05

## After

https://github.com/user-attachments/assets/116d7ad8-7fbd-4d24-b54a-189cc1cf2454
