### PR TITLE
[lexical-table] Fix table cell format for selection within cell

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -38,6 +38,7 @@ import {
   $getSelection,
   $isDecoratorNode,
   $isElementNode,
+  $isNodeSelection,
   $isRangeSelection,
   $isRootOrShadowRoot,
   $isTextNode,
@@ -460,17 +461,15 @@ export function applyTableHandlers(
       (formatType) => {
         const selection = $getSelection();
         if (
-          $isSelectionInTable(selection, tableNode) &&
-          selection!.getNodes().length === 1 &&
-          $isTextNode(selection!.getNodes()[0])
+          $isSelectionInTable(selection, tableNode) ||
+          $isNodeSelection(selection)
         ) {
-          const tableCellNode = $findMatchingParent(
-            selection!.getNodes()[0],
-            $isTableCellNode,
-          );
-          if (tableCellNode) {
-            tableCellNode.setFormat(formatType);
-          }
+          selection!.getNodes().forEach((node) => {
+            const tableCellNode = $findMatchingParent(node, $isTableCellNode);
+            if (tableCellNode) {
+              tableCellNode.setFormat(formatType);
+            }
+          });
           return false;
         }
 

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -460,6 +460,21 @@ export function applyTableHandlers(
       (formatType) => {
         const selection = $getSelection();
         if (
+          $isSelectionInTable(selection, tableNode) &&
+          selection!.getNodes().length === 1 &&
+          $isTextNode(selection!.getNodes()[0])
+        ) {
+          const tableCellNode = $findMatchingParent(
+            selection!.getNodes()[0],
+            $isTableCellNode,
+          );
+          if (tableCellNode) {
+            tableCellNode.setFormat(formatType);
+          }
+          return false;
+        }
+
+        if (
           !$isTableSelection(selection) ||
           !$isSelectionInTable(selection, tableNode)
         ) {


### PR DESCRIPTION
Currently, the TableCellNode tracks the format of the paragraph inside. This is applied correctly when selection is via table selection (range selection including a table, whole table selection, cells selection). 

There is a collection of cases if it's selection within the table cell, since the table cell is not selected the format doesn't propagate to the parent TableCellNode correctly and things get out of sync. This fixes those cases.

Before:

https://github.com/user-attachments/assets/bb1feffc-ab08-4232-9e86-3735eca43335

After:

Things are in sync

https://github.com/user-attachments/assets/fb459ff0-0898-4c81-a2e4-a001f796d86a

