### PR TITLE
Fix test results CI path on Windows

### DIFF
--- a/.github/workflows/call-e2e-test.yml
+++ b/.github/workflows/call-e2e-test.yml
@@ -24,7 +24,7 @@ jobs:
       E2E_EVENTS_MODE: ${{ inputs.events-mode }}
       OVERRIDE_REACT_VERSION: ${{ inputs.override-react-version }}
       cache_playwright_path: ${{ inputs.os == 'macos-latest' && '~/Library/Caches/ms-playwright' || inputs.os == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\ms-playwright' || '~/.cache/ms-playwright' }}
-      test_results_path: ${{ inputs.os == 'windows-latest' && '~/.npm/_logs/' || 'test-results/' }}
+      test_results_path: 'test-results/'
       test_script: test-e2e-${{ inputs.editor-mode == 'rich-text-with-collab' && 'collab-' || '' }}${{ inputs.prod && 'prod-' || '' }}ci-${{ inputs.browser }} ${{ inputs.flaky && '-- -- --grep "@flaky"' || '-- -- --grep-invert "@flaky"' }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Playwright test results on Windows are not being uploaded to GitHub artifacts when a test fails.

```
Run actions/upload-artifact@v4
Warning: No files were found with the provided path: ~/.npm/_logs/. No artifacts will be uploaded.
```

It was refactored here: https://github.com/facebook/lexical/pull/6029

You can see examples of failed tests not uploading the .webm files here:

- https://github.com/facebook/lexical/actions/runs/10533193071/job/29188769482#step:11:96
- https://github.com/facebook/lexical/actions/runs/10668949805/job/29569803459?pr=6579#step:11:19

The playwright run log shows it's saving the video to `test-results/` and not `~/.npm/_logs/`

    attachment #1: video (video/webm) ──────────────────────────────────────────────────────────────
    test-results\e2e-Selection-Selection-Se-61a62--should-select-entire-table-chromium-retry1\video.webm

Video results do get uploaded correctly on non-Windows failures.

Ultimately I can't be sure this is the correct fix since I imagine I don't have permission to run modified workflows, but hoping to open this up to someone that may know better what's going on (cc @etrepum).
