### PR TITLE
[lexical] Feature:  customElements judgment when destroyNode

### DIFF
--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -72,7 +72,7 @@ function destroyNode(key: NodeKey, parentDOM: null | HTMLElement): void {
 
   if (parentDOM !== null) {
     const dom = getPrevElementByKeyOrThrow(key);
-    if (dom.parentNode === parentDOM) {
+    if (dom.parentNode === parentDOM || isCustomElementChild(dom, parentDOM)) {
       parentDOM.removeChild(dom);
     }
   }
@@ -940,4 +940,17 @@ function getPrevElementByKeyOrThrow(key: NodeKey): HTMLElement {
   }
 
   return element;
+}
+
+function isCustomElementChild(dom: HTMLElement, parentDOM: HTMLElement) {
+  if (!parentDOM.tagName.includes('-')) {
+    return false;
+  }
+  for (let i = 0, l = parentDOM.children.length; i < l; i++) {
+    const child = parentDOM.children.item(i);
+    if (dom === child) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
## Description
I define customElement, it include multiple elements，like:
```typescript
class FTable extends HTMLElement {
  sectionEle: HTMLDivElement
  tableEle: HTMLTableElement
  tableBodyEle: HTMLTableSectionElement
  constructor() {
    super()
    this.sectionEle = document.createElement('div')
    this.sectionEle.className = 'c-editor-doc-table-section'
    this.tableEle = document.createElement('table')
    this.tableEle.className = 'c-editor-doc-table'
    this.tableBodyEle = document.createElement('tbody')
    this.tableEle.append(this.tableBodyEle)
    this.sectionEle.append(this.tableEle)
  }
  connectedCallback() {
    this.append(this.sectionEle)
  }
  appendChild<T extends Node>(node: T): T {
    this.tableBodyEle.appendChild(node)
    return node
  }
  insertBefore<T extends Node>(node: T, child: Node | null): T {
    this.tableBodyEle.insertBefore(node, child === this.sectionEle ? this.tableBodyEle.childNodes[0] : child)
    return node
  }
  removeChild<T extends Node>(child: T): T {
    this.tableBodyEle.removeChild(child)
    return child
  }
  get children() {
    return this.tableBodyEle.children
  }
}

window.customElements.define('f-table', FTable)
```

create node, like:
```typescript
class TableNode extends ElementNode {
  ...
  createDOM(config: EditorConfig): HTMLElement {
    const element = document.createElement('f-table')
    return element
  }
  ...
}
```

now, cant destroyNode TableNode's children Element.
because TableNode's children Element's parentNode not equal to the customElement
```typescript
if (dom.parentNode === parentDOM) {
  parentDOM.removeChild(dom);
}
```

## Test plan

### Before

if (dom.parentNode === parentDOM) {
  parentDOM.removeChild(dom);
}


### After

modification  the customElement's children and add isCustomElementChild judgment
```typescript
if (dom.parentNode === parentDOM || isCustomElementChild(dom, parentDOM)) {
  parentDOM.removeChild(dom);
}
```