### PR TITLE
Fix issue where cmd/ctrl + left arrow after a tab character would cause exception

### DIFF
--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -96,15 +96,16 @@ export function getStartOfCodeInLine(
   while (true) {
     if (nodeOffset === 0) {
       node = node.getPreviousSibling();
-      if (node === null) {
+      if (
+        node === null ||
+        !(
+          $isCodeHighlightNode(node) ||
+          $isTabNode(node) ||
+          $isLineBreakNode(node)
+        )
+      ) {
         break;
       }
-      invariant(
-        $isCodeHighlightNode(node) ||
-          $isTabNode(node) ||
-          $isLineBreakNode(node),
-        'Expected a valid Code Node: CodeHighlightNode, TabNode, LineBreakNode',
-      );
       if ($isLineBreakNode(node)) {
         last = {
           node,

--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -96,16 +96,15 @@ export function getStartOfCodeInLine(
   while (true) {
     if (nodeOffset === 0) {
       node = node.getPreviousSibling();
-      if (
-        node === null ||
-        !(
-          $isCodeHighlightNode(node) ||
-          $isTabNode(node) ||
-          $isLineBreakNode(node)
-        )
-      ) {
+      if (node === null) {
         break;
       }
+      invariant(
+        $isCodeHighlightNode(node) ||
+          $isTabNode(node) ||
+          $isLineBreakNode(node),
+        'Expected a valid Code Node: CodeHighlightNode, TabNode, LineBreakNode',
+      );
       if ($isLineBreakNode(node)) {
         last = {
           node,
@@ -774,7 +773,9 @@ function $handleMoveTo(
   const focusNode = focus.getNode();
   const isMoveToStart = type === MOVE_TO_START;
 
+  // Ensure the selection is within the codeblock
   if (
+    !$isSelectionInCode(selection) ||
     !($isCodeHighlightNode(anchorNode) || $isTabNode(anchorNode)) ||
     !($isCodeHighlightNode(focusNode) || $isTabNode(focusNode))
   ) {

--- a/packages/lexical-playground/__tests__/e2e/Tab.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tab.spec.mjs
@@ -8,9 +8,11 @@
 
 import {
   assertHTML,
+  assertSelection,
   focusEditor,
   html,
   initialize,
+  keyDownCtrlOrMeta,
   test,
 } from '../utils/index.mjs';
 
@@ -113,6 +115,33 @@ test.describe('Tab', () => {
         </code>
       `,
     );
+  });
+
+  test('can go to start of line after a tab character', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+
+    await page.keyboard.type('Foo');
+    await page.keyboard.press('Tab');
+
+    page.on('pageerror', (error) => {
+      throw new Error(`Uncaught exception: ${error.message}`);
+    });
+
+    // Press ctrl + left arrow key to go to start of line
+    await keyDownCtrlOrMeta(page);
+    await page.keyboard.press('ArrowLeft');
+
+    // ensure cursor is now at beginning of line
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0, 0, 0],
+      focusOffset: 0,
+      focusPath: [0, 0, 0],
+    });
   });
 });
 /* eslint-enable sort-keys-fix/sort-keys-fix */


### PR DESCRIPTION
Steps to replicate:

1. Type `Foo` in editor
2. Press Tab key on keyboard
3. Press cmd/ctrl + left arrow to go to start of line (note: left arrow and _not_ backspace)

Result:

> Uncaught Error: Expected a valid Code Node: CodeHighlightNode, TabNode, LineBreakNode

(In prod environments: `A lexical error occurred Error: Minified Lexical error #167; visit https://lexical.dev/docs/error?code=167`)

In our application, we show a blocking modal whenever a Lexical editor exception is caught, so that the user does not corrupt their document, particularly in a collaborative context, where we do not want to sync up corrupt state to other users.

It's not clear why the [getStartOfCodeInLine](https://github.com/facebook/lexical/blob/main/packages/lexical-code/src/CodeHighlighter.ts#L80) function requires this condition to be true:

```
          $isCodeHighlightNode(node) ||
          $isTabNode(node) ||
          $isLineBreakNode(node)
```

since if you start at the end of the tab character with the text `Foo [tab]`, the function will initially be called with offset 1 and the tab node as the first param. The first if condition in the while loop will resolve to false and then decrement the offset to 0. The next iteration of the while loop will then enter into the `if (nodeOffset === 0)` branch, at which point `node.getPreviousSibling()` will get the Text node to the left of the tab node, which will not satisfy the condition of being a code highlight, tab, or line break node, causing the exception.

It seems to me that we can instead safely break in this case.

@zurfyx is the original author via https://github.com/facebook/lexical/pull/4436 so perhaps he can shed additional insight.

# Tests

An e2e test was added, although it's a bit redundant since the code that throws has been removed, so this test will likely never fail unless the exception is re-added. Perhaps a unit test might make more sense but I haven't gotten acquainted with that side of the project yet. The test does presently fail however without the fix.

## Before

https://github.com/user-attachments/assets/3723b8cf-4961-4646-bfd6-1c8cda5a0d57

## After

https://github.com/user-attachments/assets/6ea4e641-f457-4a2d-a273-25f43646ffb0
