### PR TITLE
fix: delete horizontal node in table cell node

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1703,11 +1703,12 @@ export class RangeSelection implements BaseSelection {
       if (this.forwardDeletion(anchor, anchorNode, isBackward)) {
         return;
       }
-      if ($isElementNode(anchorNode)) {
-        const childNode = anchorNode.getChildAtIndex(0);
-        if ($isDecoratorNode(childNode) && anchor.offset === 0) {
-          return;
-        }
+      if (
+        anchor.offset === 0 &&
+        $isElementNode(anchorNode) &&
+        $isDecoratorNode(anchorNode.getFirstChild())
+      ) {
+        return;
       }
       // Handle the deletion around decorators.
       const focus = this.focus;

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1704,6 +1704,7 @@ export class RangeSelection implements BaseSelection {
         return;
       }
       if (
+        isBackward &&
         anchor.offset === 0 &&
         $isElementNode(anchorNode) &&
         $isDecoratorNode(anchorNode.getFirstChild())

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1703,7 +1703,12 @@ export class RangeSelection implements BaseSelection {
       if (this.forwardDeletion(anchor, anchorNode, isBackward)) {
         return;
       }
-
+      if ($isElementNode(anchorNode)) {
+        const childNode = anchorNode.getChildAtIndex(0);
+        if ($isDecoratorNode(childNode) && anchor.offset === 0) {
+          return;
+        }
+      }
       // Handle the deletion around decorators.
       const focus = this.focus;
       const possibleNode = $getAdjacentNode(focus, isBackward);


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

fix #6459 

This commit solves the problem of continuing to execute subsequent logic when the first node in the ElementNode is decoratorNode