### PR TITLE
[lexical-table][lexical-playground] Bug Fix: Fix merged cell related edge cases

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1889,9 +1889,10 @@ test.describe.parallel('Tables', () => {
                 <span data-lexical-text="true">second</span>
               </p>
             </th>
-            <td class="PlaygroundEditorTheme__tableCell">
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-            </td>
+            </th>
           </tr>
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
@@ -2233,6 +2234,139 @@ test.describe.parallel('Tables', () => {
             <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test('Merge multiple merged cells and then unmerge', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    await initialize({isCollab, page});
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    await insertTable(page, 3, 3);
+
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+    await moveDown(page, 1);
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 0, y: 1},
+      true,
+      true,
+    );
+    await mergeTableCells(page);
+
+    await moveRight(page, 1);
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 0},
+      {x: 2, y: 0},
+      true,
+      true,
+    );
+    await mergeTableCells(page);
+
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 1, y: 0},
+      true,
+      true,
+    );
+    await mergeTableCells(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
+              colspan="3"
+              rowspan="2">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr><br /></tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 0},
+      {x: 0, y: 0},
+      true,
+      true,
+    );
+    await unmergeTableCell(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
           </tr>
           <tr>
             <th

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -665,91 +665,93 @@ test.describe.parallel('Tables', () => {
     });
   });
 
-  test(`Can select cells using Table selection`, async ({
-    page,
-    isPlainText,
-    isCollab,
-  }) => {
-    await initialize({isCollab, page});
-    test.skip(isPlainText);
+  test(
+    `Can select cells using Table selection`,
+    {
+      tag: '@flaky',
+    },
+    async ({page, isPlainText, isCollab}) => {
+      await initialize({isCollab, page});
+      test.skip(isPlainText);
 
-    await focusEditor(page);
-    await insertTable(page, 2, 3);
+      await focusEditor(page);
+      await insertTable(page, 2, 3);
 
-    await fillTablePartiallyWithText(page);
-    await selectCellsFromTableCords(
-      page,
-      {x: 0, y: 0},
-      {x: 1, y: 1},
-      true,
-      false,
-    );
+      await fillTablePartiallyWithText(page);
+      await selectCellsFromTableCords(
+        page,
+        {x: 0, y: 0},
+        {x: 1, y: 1},
+        true,
+        false,
+      );
 
-    await assertHTML(
-      page,
-      html`
-        <p><br /></p>
-        <table>
-          <tr>
-            <th
-              style="background-color: rgb(172, 206, 247); caret-color: transparent">
-              <p dir="ltr"><span data-lexical-text="true">a</span></p>
-            </th>
-            <th
-              style="background-color: rgb(172, 206, 247); caret-color: transparent">
-              <p dir="ltr"><span data-lexical-text="true">bb</span></p>
-            </th>
-            <th>
-              <p dir="ltr"><span data-lexical-text="true">cc</span></p>
-            </th>
-          </tr>
-          <tr>
-            <th
-              style="background-color: rgb(172, 206, 247); caret-color: transparent">
-              <p dir="ltr"><span data-lexical-text="true">d</span></p>
-            </th>
-            <td
-              style="background-color: rgb(172, 206, 247); caret-color: transparent">
-              <p dir="ltr"><span data-lexical-text="true">e</span></p>
-            </td>
-            <td>
-              <p dir="ltr"><span data-lexical-text="true">f</span></p>
-            </td>
-          </tr>
-        </table>
-        <p><br /></p>
-      `,
-      html`
-        <p><br /></p>
-        <table>
-          <tr>
-            <th>
-              <p dir="ltr"><span data-lexical-text="true">a</span></p>
-            </th>
-            <th>
-              <p dir="ltr"><span data-lexical-text="true">bb</span></p>
-            </th>
-            <th>
-              <p dir="ltr"><span data-lexical-text="true">cc</span></p>
-            </th>
-          </tr>
-          <tr>
-            <th>
-              <p dir="ltr"><span data-lexical-text="true">d</span></p>
-            </th>
-            <td>
-              <p dir="ltr"><span data-lexical-text="true">e</span></p>
-            </td>
-            <td>
-              <p dir="ltr"><span data-lexical-text="true">f</span></p>
-            </td>
-          </tr>
-        </table>
-        <p><br /></p>
-      `,
-      {ignoreClasses: true},
-    );
-  });
+      await assertHTML(
+        page,
+        html`
+          <p><br /></p>
+          <table>
+            <tr>
+              <th
+                style="background-color: rgb(172, 206, 247); caret-color: transparent">
+                <p dir="ltr"><span data-lexical-text="true">a</span></p>
+              </th>
+              <th
+                style="background-color: rgb(172, 206, 247); caret-color: transparent">
+                <p dir="ltr"><span data-lexical-text="true">bb</span></p>
+              </th>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+              </th>
+            </tr>
+            <tr>
+              <th
+                style="background-color: rgb(172, 206, 247); caret-color: transparent">
+                <p dir="ltr"><span data-lexical-text="true">d</span></p>
+              </th>
+              <td
+                style="background-color: rgb(172, 206, 247); caret-color: transparent">
+                <p dir="ltr"><span data-lexical-text="true">e</span></p>
+              </td>
+              <td>
+                <p dir="ltr"><span data-lexical-text="true">f</span></p>
+              </td>
+            </tr>
+          </table>
+          <p><br /></p>
+        `,
+        html`
+          <p><br /></p>
+          <table>
+            <tr>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">a</span></p>
+              </th>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">bb</span></p>
+              </th>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">cc</span></p>
+              </th>
+            </tr>
+            <tr>
+              <th>
+                <p dir="ltr"><span data-lexical-text="true">d</span></p>
+              </th>
+              <td>
+                <p dir="ltr"><span data-lexical-text="true">e</span></p>
+              </td>
+              <td>
+                <p dir="ltr"><span data-lexical-text="true">f</span></p>
+              </td>
+            </tr>
+          </table>
+          <p><br /></p>
+        `,
+        {ignoreClasses: true},
+      );
+    },
+  );
 
   test(`Can select cells using Table selection via keyboard`, async ({
     page,

--- a/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
+++ b/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
@@ -212,7 +212,10 @@ export const TABLE: ElementTransformer = {
         if (!$isTableCellNode(cell)) {
           return;
         }
-        cell.toggleHeaderStyle(TableCellHeaderStates.ROW);
+        cell.setHeaderStyles(
+          TableCellHeaderStates.ROW,
+          TableCellHeaderStates.ROW,
+        );
       });
 
       // Remove line

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -407,12 +407,14 @@ function TableActionMenu({
         throw new Error('Expected table row');
       }
 
+      const newStyle =
+        tableCellNode.getHeaderStyles() ^ TableCellHeaderStates.ROW;
       tableRow.getChildren().forEach((tableCell) => {
         if (!$isTableCellNode(tableCell)) {
           throw new Error('Expected table cell');
         }
 
-        tableCell.toggleHeaderStyle(TableCellHeaderStates.ROW);
+        tableCell.setHeaderStyles(newStyle, TableCellHeaderStates.ROW);
       });
 
       clearTableSelection();
@@ -436,6 +438,8 @@ function TableActionMenu({
         throw new Error('Expected table cell to be inside of table row.');
       }
 
+      const newStyle =
+        tableCellNode.getHeaderStyles() ^ TableCellHeaderStates.COLUMN;
       for (let r = 0; r < tableRows.length; r++) {
         const tableRow = tableRows[r];
 
@@ -455,7 +459,7 @@ function TableActionMenu({
           throw new Error('Expected table cell');
         }
 
-        tableCell.toggleHeaderStyle(TableCellHeaderStates.COLUMN);
+        tableCell.setHeaderStyles(newStyle, TableCellHeaderStates.COLUMN);
       }
       clearTableSelection();
       onClose();

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -43,7 +43,6 @@ import {
 import * as React from 'react';
 import {ReactPortal, useCallback, useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
-import invariant from 'shared/invariant';
 
 import useModal from '../../hooks/useModal';
 import ColorPicker from '../../ui/ColorPicker';
@@ -57,48 +56,6 @@ function computeSelectionCount(selection: TableSelection): {
     columns: selectionShape.toX - selectionShape.fromX + 1,
     rows: selectionShape.toY - selectionShape.fromY + 1,
   };
-}
-
-// This is important when merging cells as there is no good way to re-merge weird shapes (a result
-// of selecting merged cells and non-merged)
-function isTableSelectionRectangular(selection: TableSelection): boolean {
-  const nodes = selection.getNodes();
-  const currentRows: Array<number> = [];
-  let currentRow = null;
-  let expectedColumns = null;
-  let currentColumns = 0;
-  for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i];
-    if ($isTableCellNode(node)) {
-      const row = node.getParentOrThrow();
-      invariant(
-        $isTableRowNode(row),
-        'Expected CellNode to have a RowNode parent',
-      );
-      if (currentRow !== row) {
-        if (expectedColumns !== null && currentColumns !== expectedColumns) {
-          return false;
-        }
-        if (currentRow !== null) {
-          expectedColumns = currentColumns;
-        }
-        currentRow = row;
-        currentColumns = 0;
-      }
-      const colSpan = node.__colSpan;
-      for (let j = 0; j < colSpan; j++) {
-        if (currentRows[currentColumns + j] === undefined) {
-          currentRows[currentColumns + j] = 0;
-        }
-        currentRows[currentColumns + j] += node.__rowSpan;
-      }
-      currentColumns += colSpan;
-    }
-  }
-  return (
-    (expectedColumns === null || currentColumns === expectedColumns) &&
-    currentRows.every((v) => v === currentRows[0])
-  );
 }
 
 function $canUnmerge(): boolean {
@@ -208,9 +165,7 @@ function TableActionMenu({
         const currentSelectionCounts = computeSelectionCount(selection);
         updateSelectionCounts(computeSelectionCount(selection));
         setCanMergeCells(
-          isTableSelectionRectangular(selection) &&
-            (currentSelectionCounts.columns > 1 ||
-              currentSelectionCounts.rows > 1),
+          currentSelectionCounts.columns > 1 || currentSelectionCounts.rows > 1,
         );
       }
       // Unmerge cell

--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -62,12 +62,12 @@ declare export class TableCellNode extends ElementNode {
   getRowSpan(): number;
   setRowSpan(rowSpan: number): this;
   getTag(): string;
-  setHeaderStyles(headerState: TableCellHeaderState): TableCellHeaderState;
+  setHeaderStyles(headerState: TableCellHeaderState, mask?: TableCellHeaderState): TableCellNode;
   getHeaderStyles(): TableCellHeaderState;
-  setWidth(width: number): ?number;
+  setWidth(width: number): TableCellNode;
   getWidth(): ?number;
   getBackgroundColor(): null | string;
-  setBackgroundColor(newBackgroundColor: null | string): void;
+  setBackgroundColor(newBackgroundColor: null | string): TableCellNode;
   toggleHeaderStyle(headerState: TableCellHeaderState): TableCellNode;
   hasHeader(): boolean;
   updateDOM(prevNode: TableCellNode): boolean;

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -69,15 +69,18 @@ export class TableCellNode extends ElementNode {
   }
 
   static clone(node: TableCellNode): TableCellNode {
-    const cellNode = new TableCellNode(
+    return new TableCellNode(
       node.__headerState,
       node.__colSpan,
       node.__width,
       node.__key,
     );
-    cellNode.__rowSpan = node.__rowSpan;
-    cellNode.__backgroundColor = node.__backgroundColor;
-    return cellNode;
+  }
+
+  afterCloneFrom(node: this): void {
+    super.afterCloneFrom(node);
+    this.__rowSpan = node.__rowSpan;
+    this.__backgroundColor = node.__backgroundColor;
   }
 
   static importDOM(): DOMConversionMap | null {
@@ -96,14 +99,13 @@ export class TableCellNode extends ElementNode {
   static importJSON(serializedNode: SerializedTableCellNode): TableCellNode {
     const colSpan = serializedNode.colSpan || 1;
     const rowSpan = serializedNode.rowSpan || 1;
-    const cellNode = $createTableCellNode(
+    return $createTableCellNode(
       serializedNode.headerState,
       colSpan,
       serializedNode.width || undefined,
-    );
-    cellNode.__rowSpan = rowSpan;
-    cellNode.__backgroundColor = serializedNode.backgroundColor || null;
-    return cellNode;
+    )
+      .setRowSpan(rowSpan)
+      .setBackgroundColor(serializedNode.backgroundColor || null);
   }
 
   constructor(
@@ -190,41 +192,46 @@ export class TableCellNode extends ElementNode {
   }
 
   getColSpan(): number {
-    return this.__colSpan;
+    return this.getLatest().__colSpan;
   }
 
   setColSpan(colSpan: number): this {
-    this.getWritable().__colSpan = colSpan;
-    return this;
+    const self = this.getWritable();
+    self.__colSpan = colSpan;
+    return self;
   }
 
   getRowSpan(): number {
-    return this.__rowSpan;
+    return this.getLatest().__rowSpan;
   }
 
   setRowSpan(rowSpan: number): this {
-    this.getWritable().__rowSpan = rowSpan;
-    return this;
+    const self = this.getWritable();
+    self.__rowSpan = rowSpan;
+    return self;
   }
 
   getTag(): string {
     return this.hasHeader() ? 'th' : 'td';
   }
 
-  setHeaderStyles(headerState: TableCellHeaderState): TableCellHeaderState {
+  setHeaderStyles(
+    headerState: TableCellHeaderState,
+    mask: TableCellHeaderState = TableCellHeaderStates.BOTH,
+  ): this {
     const self = this.getWritable();
-    self.__headerState = headerState;
-    return this.__headerState;
+    self.__headerState = (headerState & mask) | (self.__headerState & ~mask);
+    return self;
   }
 
   getHeaderStyles(): TableCellHeaderState {
     return this.getLatest().__headerState;
   }
 
-  setWidth(width: number): number | null | undefined {
+  setWidth(width: number): this {
     const self = this.getWritable();
     self.__width = width;
-    return this.__width;
+    return self;
   }
 
   getWidth(): number | undefined {
@@ -235,11 +242,13 @@ export class TableCellNode extends ElementNode {
     return this.getLatest().__backgroundColor;
   }
 
-  setBackgroundColor(newBackgroundColor: null | string): void {
-    this.getWritable().__backgroundColor = newBackgroundColor;
+  setBackgroundColor(newBackgroundColor: null | string): this {
+    const self = this.getWritable();
+    self.__backgroundColor = newBackgroundColor;
+    return self;
   }
 
-  toggleHeaderStyle(headerStateToToggle: TableCellHeaderState): TableCellNode {
+  toggleHeaderStyle(headerStateToToggle: TableCellHeaderState): this {
     const self = this.getWritable();
 
     if ((self.__headerState & headerStateToToggle) === headerStateToToggle) {

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -557,7 +557,7 @@ export function $deleteTableRow__EXPERIMENTAL(): void {
     const rowNode = grid.getChildAtIndex(row);
     invariant(
       $isTableRowNode(rowNode),
-      'Expected GridNode childAtIndex(%s) to be RowNode',
+      'Expected TableNode childAtIndex(%s) to be RowNode',
       String(row),
     );
     rowNode.remove();
@@ -673,19 +673,43 @@ export function $unmergeCell(): void {
   const [cell, row, grid] = $getNodeTriplet(anchor);
   const colSpan = cell.__colSpan;
   const rowSpan = cell.__rowSpan;
+  if (colSpan === 1 && rowSpan === 1) {
+    return;
+  }
+  const [map, cellMap] = $computeTableMap(grid, cell, cell);
+  const {startColumn, startRow} = cellMap;
+  // Create a heuristic for what the style of the unmerged cells should be
+  // based on whether every row or column already had that state before the
+  // unmerge.
+  const baseColStyle = cell.__headerState & TableCellHeaderStates.COLUMN;
+  const colStyles = Array.from({length: colSpan}, (_v, i) => {
+    let colStyle = baseColStyle;
+    for (let rowIdx = 0; colStyle !== 0 && rowIdx < map.length; rowIdx++) {
+      colStyle &= map[rowIdx][i + startColumn].cell.__headerState;
+    }
+    return colStyle;
+  });
+  const baseRowStyle = cell.__headerState & TableCellHeaderStates.ROW;
+  const rowStyles = Array.from({length: rowSpan}, (_v, i) => {
+    let rowStyle = baseRowStyle;
+    for (let colIdx = 0; rowStyle !== 0 && colIdx < map[0].length; colIdx++) {
+      rowStyle &= map[i + startRow][colIdx].cell.__headerState;
+    }
+    return rowStyle;
+  });
+
   if (colSpan > 1) {
     for (let i = 1; i < colSpan; i++) {
       cell.insertAfter(
-        $createTableCellNode(TableCellHeaderStates.NO_STATUS).append(
+        $createTableCellNode(colStyles[i] | rowStyles[0]).append(
           $createParagraphNode(),
         ),
       );
     }
     cell.setColSpan(1);
   }
+
   if (rowSpan > 1) {
-    const [map, cellMap] = $computeTableMap(grid, cell, cell);
-    const {startColumn, startRow} = cellMap;
     let currentRowNode;
     for (let i = 1; i < rowSpan; i++) {
       const currentRow = startRow + i;
@@ -707,18 +731,18 @@ export function $unmergeCell(): void {
         }
       }
       if (insertAfterCell === null) {
-        for (let j = 0; j < colSpan; j++) {
+        for (let j = colSpan - 1; j >= 0; j--) {
           $insertFirst(
             currentRowNode,
-            $createTableCellNode(TableCellHeaderStates.NO_STATUS).append(
+            $createTableCellNode(colStyles[j] | rowStyles[i]).append(
               $createParagraphNode(),
             ),
           );
         }
       } else {
-        for (let j = 0; j < colSpan; j++) {
+        for (let j = colSpan - 1; j >= 0; j--) {
           insertAfterCell.insertAfter(
-            $createTableCellNode(TableCellHeaderStates.NO_STATUS).append(
+            $createTableCellNode(colStyles[j] | rowStyles[i]).append(
               $createParagraphNode(),
             ),
           );
@@ -739,8 +763,8 @@ export function $computeTableMap(
     cellA,
     cellB,
   );
-  invariant(cellAValue !== null, 'Anchor not found in Grid');
-  invariant(cellBValue !== null, 'Focus not found in Grid');
+  invariant(cellAValue !== null, 'Anchor not found in Table');
+  invariant(cellBValue !== null, 'Focus not found in Table');
   return [tableMap, cellAValue, cellBValue];
 }
 
@@ -784,7 +808,7 @@ export function $computeTableMapSkipCellCheck(
     const row = gridChildren[i];
     invariant(
       $isTableRowNode(row),
-      'Expected GridNode children to be TableRowNode',
+      'Expected TableNode children to be TableRowNode',
     );
     const rowChildren = row.getChildren();
     let j = 0;
@@ -832,7 +856,7 @@ export function $getNodeTriplet(
   const grid = row.getParent();
   invariant(
     $isTableNode(grid),
-    'Expected TableRowNode to have a parent GridNode',
+    'Expected TableRowNode to have a parent TableNode',
   );
   return [cell, row, grid];
 }


### PR DESCRIPTION
## Description

* Ensure that `TableSelection.getNodes` returns each node at most once, which fixes logic errors in merge code when the "first cell" shows up multiple times due to merge
* Account for `colSpan` and `rowSpan` in `TableSelection.getShape`
* Fix some inconsistencies with the implementation of `TableCellNode`
* Use a heuristic for setting table cell styles when unmerging cells
* Add a mask for TableCellNode.setHeaderStyles so that the row or column style can be explicitly set without affecting the other setting
* Remove restriction on merging "weird shapes" of table cells, all selections are rectangular and can be merged
* Workaround in `$computeTableMapSkipCellCheck` for non-rectangular tables with rowSpan below the last `<tr>` in the table. Someone who cares more about these edge cases with what is essentially a bad input should put some more work into this though, since there are likely still other edge cases. The `TableMapType` and its associated functions (e.g. `$computeTableMap`) really should get tossed, it's not a good abstraction and it can't represent a non-rectangular table, but because the types are fully transparent it can't be fixed in-place in a backwards compatible way.

/cc @ivailop7 

Closes #6599
Closes #4470
Closes #5853
Closes #6605
Closes #6584

## Test plan

* Use [localhost playground URL](http://localhost:3000/#doc=H4sIAAAAAAAAE-2ZTUsDMRCG_8t7DmWztlZzFTwLexQP6WZsF2OyTKetpfS_S7_AFly0KBaZUwjhTYZnkueSFSg0krkSLwS3Aucsm7GeNDEwJbjHo8mTQWiYamlygkuzGA2eM796gQMMmhQoCVxhIMuW4NB69mP27QQGc-LpNmgNhN7kfp8sdtNKlnETwdp8XsGf1_b9Y8SPItUU48kxI1-_jDnPUrjLMfNhszrHqvUJrjSYkA90aM-VAefFbs12Mfp3JOwJCasklEQniTPr4Lw4KuPLJvp3eE_lU-pF25MolISS6CSh8vlhvCoffXJKQkmohlXDF0FCn5ySUBKqYdXwBV00JaEklMRva_jMfbpcfrGd2H6HHRW-Noh-KpWfU4Czw3Jw3e8Pbvq3w9Jgmmdcb3IP0S93nfqYRtGzw57F-h3XpvuXdxsAAA) or [playground URL](https://playground.lexical.dev/#doc=H4sIAAAAAAAAE-2ZTUsDMRCG_8t7DmWztlZzFTwLexQP6WZsF2OyTKetpfS_S7_AFly0KBaZUwjhTYZnkueSFSg0krkSLwS3Aucsm7GeNDEwJbjHo8mTQWiYamlygkuzGA2eM796gQMMmhQoCVxhIMuW4NB69mP27QQGc-LpNmgNhN7kfp8sdtNKlnETwdp8XsGf1_b9Y8SPItUU48kxI1-_jDnPUrjLMfNhszrHqvUJrjSYkA90aM-VAefFbs12Mfp3JOwJCasklEQniTPr4Lw4KuPLJvp3eE_lU-pF25MolISS6CSh8vlhvCoffXJKQkmohlXDF0FCn5ySUBKqYdXwBV00JaEklMRva_jMfbpcfrGd2H6HHRW-Noh-KpWfU4Czw3Jw3e8Pbvq3w9Jgmmdcb3IP0S93nfqYRtGzw57F-h3XpvuXdxsAAA)  and merge the top two cells that are already merged
* Unmerge cells

### Before

* Prior to this PR it will throw an exception

### After

* The merge executes with the correct colSpan/rowSpan (from two cells with colSpan=2 and rowSpan=1 to one cell with colSpan=2 and rowSpan=1)
* The unmerge results in 4 cells with colSpan=1, rowSpan=1