### PR TITLE
[lexical-markdown] Fix: normalize markdown in $convertFromMarkdownString to comply with CommonMark spec

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -526,7 +526,7 @@ export const LINK: TextMatchTransformer = {
   type: 'text-match',
 };
 
-export function sanitizeMarkdown(input: string): string {
+export function normalizeMarkdown(input: string): string {
   const lines = input.split('\n');
   let inCodeBlock = false;
   const sanitizedLines: string[] = [];

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -158,6 +158,8 @@ const UNORDERED_LIST_REGEX = /^(\s*)[-*+]\s/;
 const CHECK_LIST_REGEX = /^(\s*)(?:-\s)?\s?(\[(\s|x)?\])\s/i;
 const HEADING_REGEX = /^(#{1,6})\s/;
 const QUOTE_REGEX = /^>\s/;
+const CODE_START_REGEX = /^[ \t]*```(\w+)?/;
+const CODE_END_REGEX = /^[ \t]*```$/;
 
 const createBlockNode = (
   createNode: (match: Array<string>) => ElementNode,
@@ -334,9 +336,9 @@ export const CODE: MultilineElementTransformer = {
   },
   regExpEnd: {
     optional: true,
-    regExp: /[ \t]*```$/,
+    regExp: CODE_END_REGEX,
   },
-  regExpStart: /^[ \t]*```(\w+)?/,
+  regExpStart: CODE_START_REGEX,
   replace: (
     rootNode,
     children,
@@ -536,7 +538,7 @@ export function normalizeMarkdown(input: string): string {
     const lastLine = sanitizedLines[sanitizedLines.length - 1];
 
     // Detect the start or end of a code block
-    if (line.includes('```')) {
+    if (CODE_START_REGEX.test(line) || CODE_END_REGEX.test(line)) {
       inCodeBlock = !inCodeBlock;
       sanitizedLines.push(line);
       continue;

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -159,7 +159,7 @@ const CHECK_LIST_REGEX = /^(\s*)(?:-\s)?\s?(\[(\s|x)?\])\s/i;
 const HEADING_REGEX = /^(#{1,6})\s/;
 const QUOTE_REGEX = /^>\s/;
 const CODE_START_REGEX = /^[ \t]*```(\w+)?/;
-const CODE_END_REGEX = /^[ \t]*```$/;
+const CODE_END_REGEX = /[ \t]*```$/;
 
 const createBlockNode = (
   createNode: (match: Array<string>) => ElementNode,

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -318,11 +318,10 @@ export const CODE: MultilineElementTransformer = {
       return null;
     }
     const textContent = node.getTextContent();
-    const removeSingleNewLine = textContent.replace(/(?<!\n)\n(?!\n)/g, '');
     return (
       '```' +
       (node.getLanguage() || '') +
-      (removeSingleNewLine ? '\n' + removeSingleNewLine : '') +
+      (textContent ? '\n' + textContent : '') +
       '\n' +
       '```'
     );

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -153,6 +153,12 @@ export type TextMatchTransformer = Readonly<{
   type: 'text-match';
 }>;
 
+const ORDERED_LIST_REGEX = /^(\s*)(\d{1,})\.\s/;
+const UNORDERED_LIST_REGEX = /^(\s*)[-*+]\s/;
+const CHECK_LIST_REGEX = /^(\s*)(?:-\s)?\s?(\[(\s|x)?\])\s/i;
+const HEADING_REGEX = /^(#{1,6})\s/;
+const QUOTE_REGEX = /^>\s/;
+
 const createBlockNode = (
   createNode: (match: Array<string>) => ElementNode,
 ): ElementTransformer['replace'] => {
@@ -266,7 +272,7 @@ export const HEADING: ElementTransformer = {
     const level = Number(node.getTag().slice(1));
     return '#'.repeat(level) + ' ' + exportChildren(node);
   },
-  regExp: /^(#{1,6})\s/,
+  regExp: HEADING_REGEX,
   replace: createBlockNode((match) => {
     const tag = ('h' + match[1].length) as HeadingTagType;
     return $createHeadingNode(tag);
@@ -288,7 +294,7 @@ export const QUOTE: ElementTransformer = {
     }
     return output.join('\n');
   },
-  regExp: /^>\s/,
+  regExp: QUOTE_REGEX,
   replace: (parentNode, children, _match, isImport) => {
     if (isImport) {
       const previousNode = parentNode.getPreviousSibling();
@@ -399,7 +405,7 @@ export const UNORDERED_LIST: ElementTransformer = {
   export: (node, exportChildren) => {
     return $isListNode(node) ? listExport(node, exportChildren, 0) : null;
   },
-  regExp: /^(\s*)[-*+]\s/,
+  regExp: UNORDERED_LIST_REGEX,
   replace: listReplace('bullet'),
   type: 'element',
 };
@@ -409,7 +415,7 @@ export const CHECK_LIST: ElementTransformer = {
   export: (node, exportChildren) => {
     return $isListNode(node) ? listExport(node, exportChildren, 0) : null;
   },
-  regExp: /^(\s*)(?:-\s)?\s?(\[(\s|x)?\])\s/i,
+  regExp: CHECK_LIST_REGEX,
   replace: listReplace('check'),
   type: 'element',
 };
@@ -419,7 +425,7 @@ export const ORDERED_LIST: ElementTransformer = {
   export: (node, exportChildren) => {
     return $isListNode(node) ? listExport(node, exportChildren, 0) : null;
   },
-  regExp: /^(\s*)(\d{1,})\.\s/,
+  regExp: ORDERED_LIST_REGEX,
   replace: listReplace('number'),
   type: 'element',
 };
@@ -519,3 +525,47 @@ export const LINK: TextMatchTransformer = {
   trigger: ')',
   type: 'text-match',
 };
+
+export function sanitizeMarkdown(input: string): string {
+  const lines = input.split('\n');
+  let inCodeBlock = false;
+  const sanitizedLines: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lastLine = sanitizedLines[sanitizedLines.length - 1];
+
+    // Detect the start or end of a markdown code block
+    if (line.includes('```')) {
+      inCodeBlock = !inCodeBlock;
+      sanitizedLines.push(line);
+      continue;
+    }
+
+    // If we are inside a code block, keep the line unchanged
+    if (inCodeBlock) {
+      sanitizedLines.push(line);
+      continue;
+    }
+
+    // In markdown the concept of "empty paragraphs" does not exist.
+    // Blocks must be separated by an empty line. Non-empty adjacent lines must be merged.
+    if (
+      line === '' ||
+      lastLine === '' ||
+      !lastLine ||
+      HEADING_REGEX.test(lastLine) ||
+      HEADING_REGEX.test(line) ||
+      QUOTE_REGEX.test(line) ||
+      ORDERED_LIST_REGEX.test(line) ||
+      UNORDERED_LIST_REGEX.test(line) ||
+      CHECK_LIST_REGEX.test(line)
+    ) {
+      sanitizedLines.push(line);
+    } else {
+      sanitizedLines[sanitizedLines.length - 1] = lastLine + line;
+    }
+  }
+
+  return sanitizedLines.join('\n');
+}

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -535,7 +535,7 @@ export function sanitizeMarkdown(input: string): string {
     const line = lines[i];
     const lastLine = sanitizedLines[sanitizedLines.length - 1];
 
-    // Detect the start or end of a markdown code block
+    // Detect the start or end of a code block
     if (line.includes('```')) {
       inCodeBlock = !inCodeBlock;
       sanitizedLines.push(line);

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -318,10 +318,11 @@ export const CODE: MultilineElementTransformer = {
       return null;
     }
     const textContent = node.getTextContent();
+    const removeSingleNewLine = textContent.replace(/(?<!\n)\n(?!\n)/g, '');
     return (
       '```' +
       (node.getLanguage() || '') +
-      (textContent ? '\n' + textContent : '') +
+      (removeSingleNewLine ? '\n' + removeSingleNewLine : '') +
       '\n' +
       '```'
     );

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -94,18 +94,35 @@ describe('Markdown', () => {
       md: '###### Hello world',
     },
     {
-      // Multiline paragraphs
-      html: '<p><span style="white-space: pre-wrap;">Hello</span><br><span style="white-space: pre-wrap;">world</span><br><span style="white-space: pre-wrap;">!</span></p>',
+      // Multiline paragraphs: https://spec.commonmark.org/dingus/?text=Hello%0Aworld%0A!
+      html: '<p><span style="white-space: pre-wrap;">Helloworld!</span></p>',
       md: ['Hello', 'world', '!'].join('\n'),
+      skipExport: true,
+    },
+    {
+      // Multiline paragraphs
+      // TO-DO: It would be nice to support also hard line breaks (<br>) as \ or double spaces
+      // See https://spec.commonmark.org/0.31.2/#hard-line-breaks.
+      // Example: '<p><span style="white-space: pre-wrap;">Hello\\\nworld\\\n!</span></p>',
+      html: '<p><span style="white-space: pre-wrap;">Hello<br>world<br>!</span></p>',
+      md: ['Hello', 'world', '!'].join('\n'),
+      skipImport: true,
     },
     {
       html: '<blockquote><span style="white-space: pre-wrap;">Hello</span><br><span style="white-space: pre-wrap;">world!</span></blockquote>',
       md: '> Hello\n> world!',
     },
+    // TO-DO: <br> should be preserved
+    // {
+    //   html: '<ul><li value="1"><span style="white-space: pre-wrap;">Hello</span></li><li value="2"><span style="white-space: pre-wrap;">world<br>!<br>!</span></li></ul>',
+    //   md: '- Hello\n- world<br>!<br>!',
+    //   skipImport: true,
+    // },
     {
-      // Multiline list items
-      html: '<ul><li value="1"><span style="white-space: pre-wrap;">Hello</span></li><li value="2"><span style="white-space: pre-wrap;">world</span><br><span style="white-space: pre-wrap;">!</span><br><span style="white-space: pre-wrap;">!</span></li></ul>',
+      // Multiline list items: https://spec.commonmark.org/dingus/?text=-%20Hello%0A-%20world%0A!%0A!
+      html: '<ul><li value="1"><span style="white-space: pre-wrap;">Hello</span></li><li value="2"><span style="white-space: pre-wrap;">world!!</span></li></ul>',
       md: '- Hello\n- world\n!\n!',
+      skipExport: true,
     },
     {
       html: '<ul><li value="1"><span style="white-space: pre-wrap;">Hello</span></li><li value="2"><span style="white-space: pre-wrap;">world</span></li></ul>',
@@ -275,8 +292,8 @@ describe('Markdown', () => {
       skipExport: true,
     },
     {
-      // Import only: multiline quote will be prefixed with ">" on each line during export
-      html: '<blockquote><span style="white-space: pre-wrap;">Hello</span><br><span style="white-space: pre-wrap;">world</span><br><span style="white-space: pre-wrap;">!</span></blockquote>',
+      // https://spec.commonmark.org/dingus/?text=%3E%20Hello%0Aworld%0A!
+      html: '<blockquote><span style="white-space: pre-wrap;">Helloworld!</span></blockquote>',
       md: '> Hello\nworld\n!',
       skipExport: true,
     },
@@ -299,8 +316,9 @@ describe('Markdown', () => {
     },
     {
       customTransformers: [MDX_HTML_TRANSFORMER],
-      html: '<p><span style="white-space: pre-wrap;">Some HTML in mdx:</span></p><pre spellcheck="false" data-language="MyComponent"><span style="white-space: pre-wrap;">From HTML: Line 1\nSome Text</span></pre>',
+      html: '<p><span style="white-space: pre-wrap;">Some HTML in mdx:</span></p><pre spellcheck="false" data-language="MyComponent"><span style="white-space: pre-wrap;">From HTML: Line 1Some Text</span></pre>',
       md: 'Some HTML in mdx:\n\n<MyComponent>Line 1\nSome Text</MyComponent>',
+      skipExport: true,
     },
   ];
 

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -244,18 +244,6 @@ describe('Markdown', () => {
       md: '```javascript\nCode\n```',
     },
     {
-      html: '<pre spellcheck="false" data-language="javascript" data-highlight-language="javascript"><span style="white-space: pre-wrap;">A[B\nC](https://www.google.com)</span></pre>',
-      md: ['```javascript', 'A[B', 'C](https://www.google.com)', '```'].join(
-        '\n',
-      ),
-      skipExport: true,
-    },
-    {
-      html: '<pre spellcheck="false" data-language="javascript" data-highlight-language="javascript"><span style="white-space: pre-wrap;">A[B\nC](https://www.google.com)</span></pre>',
-      md: ['```javascript', 'A[BC](https://www.google.com)', '```'].join('\n'),
-      skipImport: true,
-    },
-    {
       // Should always preserve language in md but keep data-highlight-language only for supported languages
       html: '<pre spellcheck="false" data-language="unknown"><span style="white-space: pre-wrap;">Code</span></pre>',
       md: '```unknown\nCode\n```',

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -243,6 +243,18 @@ describe('Markdown', () => {
       md: '```javascript\nCode\n```',
     },
     {
+      html: '<pre spellcheck="false" data-language="javascript" data-highlight-language="javascript"><span style="white-space: pre-wrap;">A[B\nC](https://www.google.com)</span></pre>',
+      md: ['```javascript', 'A[B', 'C](https://www.google.com)', '```'].join(
+        '\n',
+      ),
+      skipExport: true,
+    },
+    {
+      html: '<pre spellcheck="false" data-language="javascript" data-highlight-language="javascript"><span style="white-space: pre-wrap;">A[B\nC](https://www.google.com)</span></pre>',
+      md: ['```javascript', 'A[BC](https://www.google.com)', '```'].join('\n'),
+      skipImport: true,
+    },
+    {
       // Should always preserve language in md but keep data-highlight-language only for supported languages
       html: '<pre spellcheck="false" data-language="unknown"><span style="white-space: pre-wrap;">Code</span></pre>',
       md: '```unknown\nCode\n```',

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -22,8 +22,10 @@ import {
   Transformer,
   TRANSFORMERS,
 } from '../..';
-import {MultilineElementTransformer} from '../../MarkdownTransformers';
-import {sanitizeMarkdown} from '../../utils';
+import {
+  MultilineElementTransformer,
+  sanitizeMarkdown,
+} from '../../MarkdownTransformers';
 
 // Matches html within a mdx file
 const MDX_HTML_TRANSFORMER: MultilineElementTransformer = {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -23,6 +23,7 @@ import {
   TRANSFORMERS,
 } from '../..';
 import {MultilineElementTransformer} from '../../MarkdownTransformers';
+import {sanitizeMarkdown} from '../../utils';
 
 // Matches html within a mdx file
 const MDX_HTML_TRANSFORMER: MultilineElementTransformer = {
@@ -418,4 +419,48 @@ describe('Markdown', () => {
       ).toBe(md);
     });
   }
+});
+
+describe('sanitizeMarkdown', () => {
+  it('should combine lines separated by a single \n unless they are in a codeblock', () => {
+    const markdown = `
+1
+2
+
+3
+
+\`\`\`md
+1
+2
+
+3
+\`\`\`
+
+\`\`\`js
+1
+2
+
+3
+\`\`\`
+`;
+    expect(sanitizeMarkdown(markdown)).toBe(`
+12
+
+3
+
+\`\`\`md
+1
+2
+
+3
+\`\`\`
+
+\`\`\`js
+1
+2
+
+3
+\`\`\`
+`);
+  });
 });

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -24,7 +24,7 @@ import {
 } from '../..';
 import {
   MultilineElementTransformer,
-  sanitizeMarkdown,
+  normalizeMarkdown,
 } from '../../MarkdownTransformers';
 
 // Matches html within a mdx file
@@ -429,7 +429,7 @@ describe('Markdown', () => {
   }
 });
 
-describe('sanitizeMarkdown', () => {
+describe('normalizeMarkdown', () => {
   it('should combine lines separated by a single \n unless they are in a codeblock', () => {
     const markdown = `
 1
@@ -451,7 +451,7 @@ describe('sanitizeMarkdown', () => {
 3
 \`\`\`
 `;
-    expect(sanitizeMarkdown(markdown)).toBe(`
+    expect(normalizeMarkdown(markdown)).toBe(`
 12
 
 3

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -33,10 +33,10 @@ import {
   LINK,
   ORDERED_LIST,
   QUOTE,
+  sanitizeMarkdown,
   STRIKETHROUGH,
   UNORDERED_LIST,
 } from './MarkdownTransformers';
-import {sanitizeMarkdown} from './utils';
 
 const ELEMENT_TRANSFORMERS: Array<ElementTransformer> = [
   HEADING,

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -31,9 +31,9 @@ import {
   ITALIC_STAR,
   ITALIC_UNDERSCORE,
   LINK,
+  normalizeMarkdown,
   ORDERED_LIST,
   QUOTE,
-  sanitizeMarkdown,
   STRIKETHROUGH,
   UNORDERED_LIST,
 } from './MarkdownTransformers';
@@ -83,7 +83,7 @@ function $convertFromMarkdownString(
   node?: ElementNode,
   shouldPreserveNewLines = false,
 ): void {
-  const sanitizedMarkdown = sanitizeMarkdown(markdown);
+  const sanitizedMarkdown = normalizeMarkdown(markdown);
   const importMarkdown = createMarkdownImport(
     transformers,
     shouldPreserveNewLines,

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -36,6 +36,7 @@ import {
   STRIKETHROUGH,
   UNORDERED_LIST,
 } from './MarkdownTransformers';
+import {sanitizeMarkdown} from './utils';
 
 const ELEMENT_TRANSFORMERS: Array<ElementTransformer> = [
   HEADING,
@@ -82,11 +83,12 @@ function $convertFromMarkdownString(
   node?: ElementNode,
   shouldPreserveNewLines = false,
 ): void {
+  const sanitizedMarkdown = sanitizeMarkdown(markdown);
   const importMarkdown = createMarkdownImport(
     transformers,
     shouldPreserveNewLines,
   );
-  return importMarkdown(markdown, node);
+  return importMarkdown(sanitizedMarkdown, node);
 }
 
 /**

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -456,37 +456,3 @@ export function isEmptyParagraph(node: LexicalNode): boolean {
       MARKDOWN_EMPTY_LINE_REG_EXP.test(firstChild.getTextContent()))
   );
 }
-
-export function sanitizeMarkdown(input: string): string {
-  const lines = input.split('\n');
-  let inCodeBlock = false;
-  const sanitizedLines: string[] = [];
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-
-    // If we are inside a code block, keep the line unchanged
-    if (inCodeBlock) {
-      sanitizedLines.push(line);
-      continue;
-    }
-
-    // Detect the start or end of a markdown code block
-    if (line.startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
-      sanitizedLines.push(line);
-      continue;
-    }
-
-    // In markdown the concept of "empty paragraphs" does not exist.
-    // Blocks must be separated by an empty line. Non-empty adjacent lines must be merged.
-    const lastLine = sanitizedLines[sanitizedLines.length - 1];
-    if (line === '' || lastLine === '' || !lastLine) {
-      sanitizedLines.push(line);
-    } else {
-      sanitizedLines[sanitizedLines.length - 1] = lastLine + line;
-    }
-  }
-
-  return sanitizedLines.join('\n');
-}

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -456,3 +456,37 @@ export function isEmptyParagraph(node: LexicalNode): boolean {
       MARKDOWN_EMPTY_LINE_REG_EXP.test(firstChild.getTextContent()))
   );
 }
+
+export function sanitizeMarkdown(input: string): string {
+  const lines = input.split('\n');
+  let inCodeBlock = false;
+  const sanitizedLines: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // If we are inside a code block, keep the line unchanged
+    if (inCodeBlock) {
+      sanitizedLines.push(line);
+      continue;
+    }
+
+    // Detect the start or end of a markdown code block
+    if (line.startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      sanitizedLines.push(line);
+      continue;
+    }
+
+    // In markdown the concept of "empty paragraphs" does not exist.
+    // Blocks must be separated by an empty line. Non-empty adjacent lines must be merged.
+    const lastLine = sanitizedLines[sanitizedLines.length - 1];
+    if (line === '' || lastLine === '' || !lastLine) {
+      sanitizedLines.push(line);
+    } else {
+      sanitizedLines[sanitizedLines.length - 1] = lastLine + line;
+    }
+  }
+
+  return sanitizedLines.join('\n');
+}

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -1310,7 +1310,6 @@ const IMPORTED_MARKDOWN_HTML = html`
       bold italic strikethrough
     </strong>
     <span data-lexical-text="true">text,</span>
-    <br />
     <strong
       class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
       data-lexical-text="true">
@@ -1408,9 +1407,7 @@ const IMPORTED_MARKDOWN_HTML = html`
     dir="ltr">
     <span data-lexical-text="true">Blockquotes text goes here</span>
     <br />
-    <span data-lexical-text="true">And second</span>
-    <br />
-    <span data-lexical-text="true">line after</span>
+    <span data-lexical-text="true">And secondline after</span>
   </blockquote>
   <blockquote
     class="PlaygroundEditorTheme__quote PlaygroundEditorTheme__ltr"
@@ -1488,9 +1485,9 @@ const IMPORTED_MARKDOWN_HTML = html`
           class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
           dir="ltr"
           value="1">
-          <span data-lexical-text="true">And can be nested</span>
-          <br />
-          <span data-lexical-text="true">and multiline as well</span>
+          <span data-lexical-text="true">
+            And can be nested and multiline as well
+          </span>
         </li>
       </ol>
     </li>


### PR DESCRIPTION
## Problem

In markdown, the concept of "empty paragraphs" does not exist.
Blocks must be separated by an empty line, and non-empty adjacent lines must be merged.

Let's take this markdown as an example:
```md
one
two

three
```

Currently, it is converted to the following (incorrect):
```html
<p>one<br>two</p>
<p>three</p>
```

When in fact, the correct output should be this ([proof](https://github.com/payloadcms/payload/issues/8049)):
```html
<p>onetwo</p>
<p>three</p>
```

For context, we are trying to import real `mdx` files into Lexical, and because of this issue, the current output contains some errors, such as [this one here](https://github.com/payloadcms/payload/issues/8049).

## Solution

At first I thought it would be enough to remove all single line breaks (`\n`), which were not accompanied by further consecutive line breaks (`\n\n`).

However, the solution was not that easy, as there were some tricky edgecases. To mention just a couple of examples:

- within a code block, no line breaks should be removed ([ref](https://spec.commonmark.org/dingus/?text=one%0Atwo%0A%0Athree%0A%0A%60%60%60%0Aone%0Atwo%0A%0Athree%0A%60%60%60)).
- consecutive heading + paragraph should not be combined, but list-item + "paragraph" should ([ref](https://spec.commonmark.org/dingus/?text=%23%20One%0Atwo%0A%0A-%20three%0Afour)).

That's why I wrote a function called `sanitizeMarkdown` to cover these and all the other cases I found, and which is now run inside `$convertFromMarkdownString`.

A few tests required changes. Since the correct result was not obvious, I left some comments linking to permalinks in the CommonMark playground.

## Future work

If one would like to add a hard line break, there are 3 ways to do so in markdown ([source](https://spec.commonmark.org/0.31.2/#hard-line-breaks)):
1. an html `<br>` tag, 
2. ending the line with two spaces, 
3. or ending the line with `\`.

Right now, the only option that works with Lexical is the first one. I've left a TO-DO comment indicating that it would be nice to support the other 2 in the future.

## Test plan

### Before

https://github.com/user-attachments/assets/8475659c-7636-413d-9547-abbbbb032d31

### After

https://github.com/user-attachments/assets/1665a4ff-ca33-4ecc-a242-d86d1577ed3f


