### PR TITLE
[lexical-playground] Fix: Poll Option not clickable at some place after checked state

### DIFF
--- a/packages/lexical-playground/src/nodes/PollNode.css
+++ b/packages/lexical-playground/src/nodes/PollNode.css
@@ -105,6 +105,7 @@
   margin: 0;
   transform: rotate(45deg);
   border-width: 0 2px 2px 0;
+  pointer-events: none;
 }
 .PollNode__optionCheckbox {
   border: 0px;


### PR DESCRIPTION

<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
Poll option was not clickable after the checked state due to pseudo after element. Added `pointer-events:none` to let the events pass through the pseudo elements on checkbox change 

Closes #6551 

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*
https://d.pr/i/vHvKcU


### After

https://github.com/user-attachments/assets/87bf261d-9bff-4f5a-a76f-5f48bfd1eae2
