### PR TITLE
Expose getStyleObjectFromCss in @lexical/selection

### DIFF
--- a/packages/lexical-selection/flow/LexicalSelection.js.flow
+++ b/packages/lexical-selection/flow/LexicalSelection.js.flow
@@ -20,7 +20,7 @@ declare export function $cloneWithProperties<T: LexicalNode>(node: T): T;
 declare export function getStyleObjectFromCSS(css: string): {
   [string]: string,
 };
-declare export funciton getCSSFromStyleObject(styles: Record<string, string>): string;
+declare export function getCSSFromStyleObject(styles: Record<string, string>): string;
 declare export function $patchStyleText(
   selection: BaseSelection,
   patch: {

--- a/packages/lexical-selection/flow/LexicalSelection.js.flow
+++ b/packages/lexical-selection/flow/LexicalSelection.js.flow
@@ -20,6 +20,7 @@ declare export function $cloneWithProperties<T: LexicalNode>(node: T): T;
 declare export function getStyleObjectFromCSS(css: string): {
   [string]: string,
 };
+declare export funciton getCSSFromStyleObject(styles: Record<string, string>): string;
 declare export function $patchStyleText(
   selection: BaseSelection,
   patch: {

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -27,7 +27,7 @@ import {
   createDOMRange,
   createRectsFromDOMRange,
   getCSSFromStyleObject,
-  getStyleObjectFromCSS
+  getStyleObjectFromCSS,
 } from './utils';
 
 export {
@@ -54,4 +54,9 @@ export {
   $wrapNodes,
 };
 
-export {createDOMRange, createRectsFromDOMRange, getCSSFromStyleObject, getStyleObjectFromCSS};
+export {
+  createDOMRange,
+  createRectsFromDOMRange,
+  getCSSFromStyleObject,
+  getStyleObjectFromCSS,
+};

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -26,7 +26,8 @@ import {
 import {
   createDOMRange,
   createRectsFromDOMRange,
-  getStyleObjectFromCSS,
+  getCSSFromStyleObject,
+  getStyleObjectFromCSS
 } from './utils';
 
 export {
@@ -53,4 +54,4 @@ export {
   $wrapNodes,
 };
 
-export {createDOMRange, createRectsFromDOMRange, getStyleObjectFromCSS};
+export {createDOMRange, createRectsFromDOMRange, getCSSFromStyleObject, getStyleObjectFromCSS};


### PR DESCRIPTION
### Problem
There is a need to use `getCSSFromStyleObject` together with `getStyleObjectFromCSS` in order to change a specific style that is applied to a node with `setStyle`. 

`getStyleObjectFromCSS` is available in the @lexical/selection package but not `getCSSFromStyleObject` even though the function exists in the utils file. 

This PR is simply exposing this function that already exists.