### PR TITLE
[lexical-react] Refactor: Ensure disconnect is called after connection is established in useYjsCollaboration

### DIFF
--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -57,9 +57,7 @@ export function useYjsCollaboration(
 ): JSX.Element {
   const isReloadingDoc = useRef(false);
 
-  const connect = useCallback(() => {
-    provider.connect();
-  }, [provider]);
+  const connect = useCallback(() => provider.connect(), [provider]);
 
   const disconnect = useCallback(() => {
     try {
@@ -152,11 +150,14 @@ export function useYjsCollaboration(
         }
       },
     );
-    connect();
+
+    const connectionPromise = connect();
 
     return () => {
       if (isReloadingDoc.current === false) {
-        disconnect();
+        Promise.resolve(connectionPromise).then(() => {
+          disconnect();
+        });
       }
 
       provider.off('sync', onSync);


### PR DESCRIPTION
`connect` can be an asynchronous function, and we don't take this into account when disconnecting, meaning that it is possible to disconnect without completing the connect. 
I think this can lead to various side effects, such as being disconnected but still in the connect state.


In my case, this happened in `React.StrictMode`, which is a bit unusual.

It's a simple code change, so I don't think test code is necessary.