### PR TITLE
[lexical-table][lexical-playground] Feature: Add column widths to TableNode

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
@@ -43,6 +43,11 @@ test.describe('HTML Tables CopyAndPaste', () => {
       page,
       html`
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
@@ -113,6 +118,11 @@ test.describe('HTML Tables CopyAndPaste', () => {
       page,
       html`
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
@@ -191,6 +201,11 @@ test.describe('HTML Tables CopyAndPaste', () => {
       page,
       html`
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr style="height: 21px">
             <td class="PlaygroundEditorTheme__tableCell">
               <p
@@ -277,6 +292,12 @@ test.describe('HTML Tables CopyAndPaste', () => {
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table
           class="PlaygroundEditorTheme__table PlaygroundEditorTheme__tableSelection">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
@@ -388,6 +409,12 @@ test.describe('HTML Tables CopyAndPaste', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -531,6 +558,10 @@ test.describe('HTML Tables CopyAndPaste', () => {
           <span data-lexical-text="true">123</span>
         </p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph">
@@ -646,6 +677,13 @@ test.describe('HTML Tables CopyAndPaste', () => {
           <span data-lexical-text="true">123</span>
         </p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <td class="PlaygroundEditorTheme__tableCell" colspan="2">
               <p class="PlaygroundEditorTheme__paragraph">

--- a/packages/lexical-playground/__tests__/e2e/Indentation.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Indentation.spec.mjs
@@ -106,6 +106,9 @@ test.describe('Identation', () => {
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table
           class="PlaygroundEditorTheme__table PlaygroundEditorTheme__tableSelection">
+          <colgroup>
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
@@ -188,6 +191,9 @@ test.describe('Identation', () => {
         </p>
         <table
           class="PlaygroundEditorTheme__table PlaygroundEditorTheme__tableSelection">
+          <colgroup>
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
@@ -281,6 +287,9 @@ test.describe('Identation', () => {
         </p>
         <table
           class="PlaygroundEditorTheme__table PlaygroundEditorTheme__tableSelection">
+          <colgroup>
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
@@ -368,6 +377,9 @@ test.describe('Identation', () => {
         </p>
         <table
           class="PlaygroundEditorTheme__table PlaygroundEditorTheme__tableSelection">
+          <colgroup>
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
@@ -445,6 +457,9 @@ test.describe('Identation', () => {
         <p class="PlaygroundEditorTheme__paragraph" style=""><br /></p>
         <table
           class="PlaygroundEditorTheme__table PlaygroundEditorTheme__tableSelection">
+          <colgroup>
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -715,14 +715,14 @@ test.describe.parallel('Selection', () => {
           anchorOffset: {desc: 'beginning of cell', value: 0},
           anchorPath: [
             {desc: 'index of table in root', value: 1},
-            {desc: 'first table row', value: 0},
+            {desc: 'first table row', value: 1},
             {desc: 'first cell', value: 0},
             {desc: 'beginning of text', value: 0},
           ],
           focusOffset: {desc: 'beginning of text', value: 0},
           focusPath: [
             {desc: 'index of table in root', value: 1},
-            {desc: 'first table row', value: 0},
+            {desc: 'first table row', value: 1},
             {desc: 'first cell', value: 0},
             {desc: 'beginning of text', value: 0},
           ],
@@ -771,7 +771,7 @@ test.describe.parallel('Selection', () => {
         anchorOffset: {desc: 'beginning of cell', value: 0},
         anchorPath: [
           {desc: 'index of table in root', value: 1},
-          {desc: 'first table row', value: 0},
+          {desc: 'first table row', value: 1},
           {desc: 'first cell', value: 0},
         ],
         focusOffset: {desc: 'full text length', value: endParagraphText.length},

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -685,7 +685,7 @@ test.describe.parallel('Selection', () => {
           anchorOffset: {desc: 'beginning of cell', value: 0},
           anchorPath: [
             {desc: 'index of table in root', value: 1},
-            {desc: 'first table row', value: 0},
+            {desc: 'first table row', value: 1},
             {desc: 'second cell', value: 1},
             {desc: 'first paragraph', value: 0},
             {desc: 'first span', value: 0},
@@ -694,7 +694,7 @@ test.describe.parallel('Selection', () => {
           focusOffset: {desc: 'full text length', value: cellText.length},
           focusPath: [
             {desc: 'index of table in root', value: 1},
-            {desc: 'first table row', value: 0},
+            {desc: 'first table row', value: 1},
             {desc: 'second cell', value: 1},
             {desc: 'first paragraph', value: 0},
             {desc: 'first span', value: 0},
@@ -1029,7 +1029,7 @@ test.describe.parallel('Selection', () => {
         anchorOffset: 0,
         anchorPath: [0],
         focusOffset: 1,
-        focusPath: [1, 1, 1],
+        focusPath: [1, 2, 1],
       });
     },
   );
@@ -1052,7 +1052,7 @@ test.describe.parallel('Selection', () => {
         anchorOffset: 0,
         anchorPath: [1],
         focusOffset: 1,
-        focusPath: [0, 0, 0],
+        focusPath: [0, 1, 0],
       });
     },
   );

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -399,6 +399,10 @@ test.describe.parallel('Selection', () => {
           <span data-lexical-text="true">abc</span>
         </p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -2371,6 +2371,11 @@ test.describe.parallel('Tables', () => {
         html`
           <p class="PlaygroundEditorTheme__paragraph"><br /></p>
           <table class="PlaygroundEditorTheme__table">
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th
                 class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
@@ -3448,6 +3453,11 @@ test.describe.parallel('Tables', () => {
         html`
           <p><br /></p>
           <table>
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th style="text-align: center">
                 <p dir="ltr" style="text-align: center">

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -90,6 +90,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p><br /></p>
         <table>
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th>
               <p><br /></p>
@@ -132,6 +136,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p><br /></p>
         <table>
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th>
               <p dir="ltr"><span data-lexical-text="true">abc</span></p>
@@ -344,6 +352,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p><br /></p>
         <table>
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th>
               <p><br /></p>
@@ -389,6 +401,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p><br /></p>
         <table>
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th>
               <p><br /></p>
@@ -446,6 +462,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p><br /></p>
         <table>
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th>
               <p><br /></p>
@@ -515,6 +535,10 @@ test.describe.parallel('Tables', () => {
         html`
           <p><br /></p>
           <table>
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th>
                 <p><br /></p>
@@ -691,6 +715,11 @@ test.describe.parallel('Tables', () => {
         html`
           <p><br /></p>
           <table>
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th
                 style="background-color: rgb(172, 206, 247); caret-color: transparent">
@@ -723,6 +752,11 @@ test.describe.parallel('Tables', () => {
         html`
           <p><br /></p>
           <table>
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th>
                 <p dir="ltr"><span data-lexical-text="true">a</span></p>
@@ -775,7 +809,7 @@ test.describe.parallel('Tables', () => {
     }
 
     const firstRowFirstColumnCellBoundingBox = await p.locator(
-      'table:first-of-type > tr:nth-child(1) > th:nth-child(1)',
+      'table:first-of-type > :nth-match(tr, 1) > th:nth-child(1)',
     );
 
     // Focus on inside the iFrame or the boundingBox() below returns null.
@@ -795,6 +829,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p><br /></p>
         <table>
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               style="background-color: rgb(172, 206, 247); caret-color: transparent">
@@ -838,6 +877,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p><br /></p>
         <table>
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th>
               <p dir="ltr"><span data-lexical-text="true">a</span></p>
@@ -909,6 +953,11 @@ test.describe.parallel('Tables', () => {
         html`
           <p><br /></p>
           <table>
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th
                 style="background-color: rgb(172, 206, 247); caret-color: transparent">
@@ -941,6 +990,11 @@ test.describe.parallel('Tables', () => {
         html`
           <p><br /></p>
           <table>
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th>
                 <p dir="ltr"><strong data-lexical-text="true">a</strong></p>
@@ -1006,6 +1060,10 @@ test.describe.parallel('Tables', () => {
         page,
         html`
           <table>
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th>
                 <p dir="ltr"><span data-lexical-text="true">a</span></p>
@@ -1024,6 +1082,11 @@ test.describe.parallel('Tables', () => {
             </tr>
           </table>
           <table>
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th>
                 <p dir="ltr"><span data-lexical-text="true">a</span></p>
@@ -1084,6 +1147,11 @@ test.describe.parallel('Tables', () => {
         html`
           <p><br /></p>
           <table>
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th>
                 <p><br /></p>
@@ -1136,6 +1204,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p><br /></p>
         <table>
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               style="background-color: rgb(172, 206, 247); caret-color: transparent">
@@ -1152,6 +1224,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p><br /></p>
         <table>
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th>
               <p><br /></p>
@@ -1187,6 +1263,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p dir="ltr"><span data-lexical-text="true">Hello World</span></p>
         <table>
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               style="background-color: rgb(172, 206, 247); caret-color: transparent">
@@ -1221,6 +1302,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p dir="ltr"><span data-lexical-text="true">Hello World</span></p>
         <table>
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th>
               <p><br /></p>
@@ -1288,6 +1374,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p><br /></p>
         <table>
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th>
               <p><span data-lexical-text="true">123</span></p>
@@ -1341,6 +1431,10 @@ test.describe.parallel('Tables', () => {
         html`
           <p class="PlaygroundEditorTheme__paragraph"><br /></p>
           <table class="PlaygroundEditorTheme__table">
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th
                 class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -1411,6 +1505,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -1445,6 +1543,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -1498,6 +1600,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -1535,6 +1641,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -1608,6 +1718,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 142px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
@@ -1616,13 +1731,12 @@ test.describe.parallel('Tables', () => {
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
             <th
-              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-              style="width: 125px">
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
           </tr>
           <tr>
-            <td class="PlaygroundEditorTheme__tableCell" style="width: 125px">
+            <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>
           </tr>
@@ -1634,7 +1748,7 @@ test.describe.parallel('Tables', () => {
             <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell" style="width: 125px">
+            <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>
           </tr>
@@ -1686,12 +1800,16 @@ test.describe.parallel('Tables', () => {
         html`
           <p class="PlaygroundEditorTheme__paragraph"><br /></p>
           <table class="PlaygroundEditorTheme__table">
+            <colgroup>
+              <col style="width: 142px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th
                 class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
                 colspan="2"
-                rowspan="2"
-                style="width: 217px">
+                rowspan="2">
                 <p class="PlaygroundEditorTheme__paragraph"><br /></p>
               </th>
               <th
@@ -1709,7 +1827,7 @@ test.describe.parallel('Tables', () => {
                 class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
                 <p class="PlaygroundEditorTheme__paragraph"><br /></p>
               </th>
-              <td class="PlaygroundEditorTheme__tableCell" style="width: 125px">
+              <td class="PlaygroundEditorTheme__tableCell">
                 <p class="PlaygroundEditorTheme__paragraph"><br /></p>
               </td>
               <td class="PlaygroundEditorTheme__tableCell">
@@ -1766,6 +1884,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
@@ -1842,6 +1965,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -1873,6 +2001,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -1932,6 +2065,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -1983,6 +2121,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -2069,6 +2212,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -2174,6 +2322,11 @@ test.describe.parallel('Tables', () => {
           <p class="PlaygroundEditorTheme__paragraph"><br /></p>
           <table
             class="PlaygroundEditorTheme__table PlaygroundEditorTheme__tableSelection">
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th
                 class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
@@ -2305,6 +2458,11 @@ test.describe.parallel('Tables', () => {
         html`
           <p class="PlaygroundEditorTheme__paragraph"><br /></p>
           <table class="PlaygroundEditorTheme__table">
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th
                 class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
@@ -2345,6 +2503,11 @@ test.describe.parallel('Tables', () => {
         html`
           <p class="PlaygroundEditorTheme__paragraph"><br /></p>
           <table class="PlaygroundEditorTheme__table">
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th
                 class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -2426,6 +2589,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -2490,6 +2657,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
@@ -2547,6 +2719,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -2601,6 +2777,12 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -2681,6 +2863,10 @@ test.describe.parallel('Tables', () => {
         html`
           <p class="PlaygroundEditorTheme__paragraph"><br /></p>
           <table class="PlaygroundEditorTheme__table">
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th
                 class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -2743,6 +2929,10 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -2796,6 +2986,9 @@ test.describe.parallel('Tables', () => {
         html`
           <p class="PlaygroundEditorTheme__paragraph"><br /></p>
           <table class="PlaygroundEditorTheme__table">
+            <colgroup>
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th
                 class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -2846,6 +3039,9 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -2912,6 +3108,9 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
@@ -2969,6 +3168,11 @@ test.describe.parallel('Tables', () => {
       page,
       html`
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
@@ -3054,6 +3258,9 @@ test.describe.parallel('Tables', () => {
       page,
       html`
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
@@ -3104,6 +3311,12 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -3190,6 +3403,11 @@ test.describe.parallel('Tables', () => {
         html`
           <p><br /></p>
           <table>
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th
                 style="background-color: rgb(172, 206, 247); caret-color: transparent; text-align: center">
@@ -3297,6 +3515,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -3374,6 +3597,11 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -179,9 +179,9 @@ test.describe.parallel('Tables', () => {
 
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [1, 0, 0, 0],
+        anchorPath: [1, 1, 0, 0],
         focusOffset: 0,
-        focusPath: [1, 0, 0, 0],
+        focusPath: [1, 1, 0, 0],
       });
 
       await moveLeft(page, 1);
@@ -196,17 +196,17 @@ test.describe.parallel('Tables', () => {
       await page.keyboard.type('ab');
       await assertSelection(page, {
         anchorOffset: 2,
-        anchorPath: [1, 0, 0, 0, 0, 0],
+        anchorPath: [1, 1, 0, 0, 0, 0],
         focusOffset: 2,
-        focusPath: [1, 0, 0, 0, 0, 0],
+        focusPath: [1, 1, 0, 0, 0, 0],
       });
 
       await moveRight(page, 3);
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [1, 1, 1, 0],
+        anchorPath: [1, 2, 1, 0],
         focusOffset: 0,
-        focusPath: [1, 1, 1, 0],
+        focusPath: [1, 2, 1, 0],
       });
     });
 
@@ -224,9 +224,9 @@ test.describe.parallel('Tables', () => {
       await moveRight(page, 3);
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [1, 1, 1, 0],
+        anchorPath: [1, 2, 1, 0],
         focusOffset: 0,
-        focusPath: [1, 1, 1, 0],
+        focusPath: [1, 2, 1, 0],
       });
 
       await moveRight(page, 1);
@@ -241,9 +241,9 @@ test.describe.parallel('Tables', () => {
       await page.keyboard.type('ab');
       await assertSelection(page, {
         anchorOffset: 2,
-        anchorPath: [1, 1, 1, 0, 0, 0],
+        anchorPath: [1, 2, 1, 0, 0, 0],
         focusOffset: 2,
-        focusPath: [1, 1, 1, 0, 0, 0],
+        focusPath: [1, 2, 1, 0, 0, 0],
       });
 
       await moveRight(page, 3);
@@ -269,17 +269,17 @@ test.describe.parallel('Tables', () => {
 
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [1, 0, 0, 1, 0, 0, 0],
+        anchorPath: [1, 1, 0, 1, 1, 0, 0],
         focusOffset: 0,
-        focusPath: [1, 0, 0, 1, 0, 0, 0],
+        focusPath: [1, 1, 0, 1, 1, 0, 0],
       });
 
       await moveLeft(page, 1);
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [1, 0, 0, 0],
+        anchorPath: [1, 1, 0, 0],
         focusOffset: 0,
-        focusPath: [1, 0, 0, 0],
+        focusPath: [1, 1, 0, 0],
       });
     });
 
@@ -298,17 +298,17 @@ test.describe.parallel('Tables', () => {
       await moveRight(page, 3);
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [1, 0, 0, 1, 1, 1, 0],
+        anchorPath: [1, 1, 0, 1, 2, 1, 0],
         focusOffset: 0,
-        focusPath: [1, 0, 0, 1, 1, 1, 0],
+        focusPath: [1, 1, 0, 1, 2, 1, 0],
       });
 
       await moveRight(page, 1);
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [1, 0, 0, 2],
+        anchorPath: [1, 1, 0, 2],
         focusOffset: 0,
-        focusPath: [1, 0, 0, 2],
+        focusPath: [1, 1, 0, 2],
       });
     });
   });
@@ -343,9 +343,9 @@ test.describe.parallel('Tables', () => {
     await deleteBackward(page);
     await assertSelection(page, {
       anchorOffset: 0,
-      anchorPath: [1, 1, 1, 0],
+      anchorPath: [1, 2, 1, 0],
       focusOffset: 0,
-      focusPath: [1, 1, 1, 0],
+      focusPath: [1, 2, 1, 0],
     });
     await assertHTML(
       page,
@@ -512,9 +512,9 @@ test.describe.parallel('Tables', () => {
     await moveLeft(page, 1);
     await assertSelection(page, {
       anchorOffset: 0,
-      anchorPath: [1, 1, 1, 0],
+      anchorPath: [1, 2, 1, 0],
       focusOffset: 0,
-      focusPath: [1, 1, 1, 0],
+      focusPath: [1, 2, 1, 0],
     });
   });
 
@@ -564,22 +564,6 @@ test.describe.parallel('Tables', () => {
 
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [1, 0, 0, 0],
-        focusOffset: 0,
-        focusPath: [1, 0, 0, 0],
-      });
-
-      await moveRight(page, 1);
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [1, 0, 1, 0],
-        focusOffset: 0,
-        focusPath: [1, 0, 1, 0],
-      });
-
-      await moveRight(page, 1);
-      await assertSelection(page, {
-        anchorOffset: 0,
         anchorPath: [1, 1, 0, 0],
         focusOffset: 0,
         focusPath: [1, 1, 0, 0],
@@ -593,28 +577,44 @@ test.describe.parallel('Tables', () => {
         focusPath: [1, 1, 1, 0],
       });
 
+      await moveRight(page, 1);
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [1, 2, 0, 0],
+        focusOffset: 0,
+        focusPath: [1, 2, 0, 0],
+      });
+
+      await moveRight(page, 1);
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [1, 2, 1, 0],
+        focusOffset: 0,
+        focusPath: [1, 2, 1, 0],
+      });
+
+      await moveLeft(page, 1);
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [1, 2, 0, 0],
+        focusOffset: 0,
+        focusPath: [1, 2, 0, 0],
+      });
+
+      await moveLeft(page, 1);
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [1, 1, 1, 0],
+        focusOffset: 0,
+        focusPath: [1, 1, 1, 0],
+      });
+
       await moveLeft(page, 1);
       await assertSelection(page, {
         anchorOffset: 0,
         anchorPath: [1, 1, 0, 0],
         focusOffset: 0,
         focusPath: [1, 1, 0, 0],
-      });
-
-      await moveLeft(page, 1);
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [1, 0, 1, 0],
-        focusOffset: 0,
-        focusPath: [1, 0, 1, 0],
-      });
-
-      await moveLeft(page, 1);
-      await assertSelection(page, {
-        anchorOffset: 0,
-        anchorPath: [1, 0, 0, 0],
-        focusOffset: 0,
-        focusPath: [1, 0, 0, 0],
       });
     });
 
@@ -631,25 +631,25 @@ test.describe.parallel('Tables', () => {
 
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [1, 0, 0, 0],
-        focusOffset: 0,
-        focusPath: [1, 0, 0, 0],
-      });
-
-      await moveDown(page, 1);
-      await assertSelection(page, {
-        anchorOffset: 0,
         anchorPath: [1, 1, 0, 0],
         focusOffset: 0,
         focusPath: [1, 1, 0, 0],
       });
 
+      await moveDown(page, 1);
+      await assertSelection(page, {
+        anchorOffset: 0,
+        anchorPath: [1, 2, 0, 0],
+        focusOffset: 0,
+        focusPath: [1, 2, 0, 0],
+      });
+
       await moveUp(page, 1);
       await assertSelection(page, {
         anchorOffset: 0,
-        anchorPath: [1, 0, 0, 0],
+        anchorPath: [1, 1, 0, 0],
         focusOffset: 0,
-        focusPath: [1, 0, 0, 0],
+        focusPath: [1, 1, 0, 0],
       });
     });
 
@@ -667,9 +667,9 @@ test.describe.parallel('Tables', () => {
       await page.keyboard.type('@A');
       await assertSelection(page, {
         anchorOffset: 2,
-        anchorPath: [1, 0, 0, 0, 0, 0],
+        anchorPath: [1, 1, 0, 0, 0, 0],
         focusOffset: 2,
-        focusPath: [1, 0, 0, 0, 0, 0],
+        focusPath: [1, 1, 0, 0, 0, 0],
       });
 
       await waitForSelector(page, `#typeahead-menu ul li:first-child.selected`);
@@ -677,9 +677,9 @@ test.describe.parallel('Tables', () => {
       await moveDown(page, 1);
       await assertSelection(page, {
         anchorOffset: 2,
-        anchorPath: [1, 0, 0, 0, 0, 0],
+        anchorPath: [1, 1, 0, 0, 0, 0],
         focusOffset: 2,
-        focusPath: [1, 0, 0, 0, 0, 0],
+        focusPath: [1, 1, 0, 0, 0, 0],
       });
 
       await waitForSelector(

--- a/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Toolbar.spec.mjs
@@ -157,6 +157,13 @@ test.describe('Toolbar', () => {
             <br />
           </p>
           <table>
+            <colgroup>
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+              <col style="width: 92px" />
+            </colgroup>
             <tr>
               <th>
                 <p><br /></p>

--- a/packages/lexical-playground/__tests__/regression/4661-insert-column-selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/4661-insert-column-selection.spec.mjs
@@ -48,6 +48,12 @@ test.describe('Regression test #4661', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
@@ -86,6 +92,7 @@ test.describe('Regression test #4661', () => {
       `,
     );
   });
+
   test('inserting 2 columns after inserts after selection', async ({
     page,
     isPlainText,
@@ -113,6 +120,12 @@ test.describe('Regression test #4661', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
           <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -826,12 +826,12 @@ export async function selectCellsFromTableCords(
   }
 
   const firstRowFirstColumnCell = await leftFrame.locator(
-    `table:first-of-type > tr:nth-child(${firstCords.y + 1}) > ${
+    `table:first-of-type > :nth-match(tr, ${firstCords.y + 1}) > ${
       isFirstHeader ? 'th' : 'td'
     }:nth-child(${firstCords.x + 1})`,
   );
   const secondRowSecondCell = await leftFrame.locator(
-    `table:first-of-type > tr:nth-child(${secondCords.y + 1}) > ${
+    `table:first-of-type > :nth-match(tr, ${secondCords.y + 1}) > ${
       isSecondHeader ? 'th' : 'td'
     }:nth-child(${secondCords.x + 1})`,
   );

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -43,7 +43,7 @@ type MousePosition = {
 type MouseDraggingDirection = 'right' | 'bottom';
 
 const MIN_ROW_HEIGHT = 33;
-const MIN_COLUMN_WIDTH = 75;
+const MIN_COLUMN_WIDTH = 92;
 
 function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
   const targetRef = useRef<HTMLElement | null>(null);

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -233,7 +233,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
     for (let row = 0; row < tableMap.length; row++) {
       for (let column = 0; column < tableMap[row].length; column++) {
         if (tableMap[row][column].cell === tableCellNode) {
-          return column + tableCellNode.getColSpan() - 1;
+          return column;
         }
       }
     }

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -270,9 +270,10 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
           if (width === undefined) {
             return;
           }
+          const newColWidths = [...colWidths];
           const newWidth = Math.max(width + widthChange, MIN_COLUMN_WIDTH);
-          colWidths[columnIndex] = newWidth;
-          tableNode.setColWidths(colWidths);
+          newColWidths[columnIndex] = newWidth;
+          tableNode.setColWidths(newColWidths);
         },
         {tag: 'skip-scroll-into-view'},
       );

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -5,12 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import type {
-  TableCellNode,
-  TableDOMCell,
-  TableMapType,
-  TableMapValueType,
-} from '@lexical/table';
+import type {TableCellNode, TableDOMCell, TableMapType} from '@lexical/table';
 import type {LexicalEditor} from 'lexical';
 
 import './index.css';
@@ -24,6 +19,7 @@ import {
   $isTableCellNode,
   $isTableRowNode,
   getDOMCellFromTarget,
+  TableNode,
 } from '@lexical/table';
 import {calculateZoomLevel} from '@lexical/utils';
 import {$getNearestNodeFromDOMNode} from 'lexical';
@@ -47,7 +43,7 @@ type MousePosition = {
 type MouseDraggingDirection = 'right' | 'bottom';
 
 const MIN_ROW_HEIGHT = 33;
-const MIN_COLUMN_WIDTH = 50;
+const MIN_COLUMN_WIDTH = 75;
 
 function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
   const targetRef = useRef<HTMLElement | null>(null);
@@ -74,6 +70,20 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
   const isMouseDownOnEvent = (event: MouseEvent) => {
     return (event.buttons & 1) === 1;
   };
+
+  useEffect(() => {
+    return editor.registerNodeTransform(TableNode, (tableNode) => {
+      if (tableNode.getColWidths()) {
+        return tableNode;
+      }
+
+      const numColumns = tableNode.getColumnCount();
+      const columnWidth = MIN_COLUMN_WIDTH;
+
+      tableNode.setColWidths(Array(numColumns).fill(columnWidth));
+      return tableNode;
+    });
+  }, [editor]);
 
   useEffect(() => {
     const onMouseMove = (event: MouseEvent) => {
@@ -208,27 +218,6 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
     [activeCell, editor],
   );
 
-  const getCellNodeWidth = (
-    cell: TableCellNode,
-    activeEditor: LexicalEditor,
-  ): number | undefined => {
-    const width = cell.getWidth();
-    if (width !== undefined) {
-      return width;
-    }
-
-    const domCellNode = activeEditor.getElementByKey(cell.getKey());
-    if (domCellNode == null) {
-      return undefined;
-    }
-    const computedStyle = getComputedStyle(domCellNode);
-    return (
-      domCellNode.clientWidth -
-      parseFloat(computedStyle.paddingLeft) -
-      parseFloat(computedStyle.paddingRight)
-    );
-  };
-
   const getCellNodeHeight = (
     cell: TableCellNode,
     activeEditor: LexicalEditor,
@@ -273,22 +262,17 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
             throw new Error('TableCellResizer: Table column not found.');
           }
 
-          for (let row = 0; row < tableMap.length; row++) {
-            const cell: TableMapValueType = tableMap[row][columnIndex];
-            if (
-              cell.startRow === row &&
-              (columnIndex === tableMap[row].length - 1 ||
-                tableMap[row][columnIndex].cell !==
-                  tableMap[row][columnIndex + 1].cell)
-            ) {
-              const width = getCellNodeWidth(cell.cell, editor);
-              if (width === undefined) {
-                continue;
-              }
-              const newWidth = Math.max(width + widthChange, MIN_COLUMN_WIDTH);
-              cell.cell.setWidth(newWidth);
-            }
+          const colWidths = tableNode.getColWidths();
+          if (!colWidths) {
+            return;
           }
+          const width = colWidths[columnIndex];
+          if (width === undefined) {
+            return;
+          }
+          const newWidth = Math.max(width + widthChange, MIN_COLUMN_WIDTH);
+          colWidths[columnIndex] = newWidth;
+          tableNode.setColWidths(colWidths);
         },
         {tag: 'skip-scroll-into-view'},
       );

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -122,7 +122,7 @@
   overflow-y: scroll;
   overflow-x: scroll;
   table-layout: fixed;
-  width: max-content;
+  width: fit-content;
   margin: 0px 25px 30px 0px;
 }
 .PlaygroundEditorTheme__tableRowStriping tr:nth-child(even) {
@@ -137,7 +137,6 @@
 .PlaygroundEditorTheme__tableCell {
   border: 1px solid #bbb;
   width: 75px;
-  min-width: 75px;
   vertical-align: top;
   text-align: start;
   padding: 6px 8px;

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -36,7 +36,7 @@ import {getTable} from './LexicalTableSelectionHelpers';
 
 export type SerializedTableNode = Spread<
   {
-    colWidths?: number[];
+    colWidths?: readonly number[];
     rowStriping?: boolean;
   },
   SerializedElementNode
@@ -82,7 +82,7 @@ function setRowStriping(
 export class TableNode extends ElementNode {
   /** @internal */
   __rowStriping: boolean;
-  __colWidths?: number[];
+  __colWidths?: readonly number[];
 
   static getType(): string {
     return 'table';
@@ -95,7 +95,7 @@ export class TableNode extends ElementNode {
 
   setColWidths(colWidths: number[]) {
     const self = this.getWritable();
-    self.__colWidths = colWidths;
+    self.__colWidths = Object.freeze(colWidths);
     return self;
   }
 
@@ -121,6 +121,7 @@ export class TableNode extends ElementNode {
   static importJSON(serializedNode: SerializedTableNode): TableNode {
     const tableNode = $createTableNode();
     tableNode.__rowStriping = serializedNode.rowStriping || false;
+    tableNode.__colWidths = Object.freeze(serializedNode.colWidths);
     return tableNode;
   }
 

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -96,14 +96,16 @@ export class TableNode extends ElementNode {
   setColWidths(colWidths: number[]) {
     const self = this.getWritable();
     self.__colWidths = colWidths;
+    return self;
   }
 
   static clone(node: TableNode): TableNode {
-    return new TableNode(node.__colWidths, node.__key);
+    return new TableNode(node.__key);
   }
 
   afterCloneFrom(prevNode: this) {
     super.afterCloneFrom(prevNode);
+    this.__colWidths = prevNode.__colWidths;
     this.__rowStriping = prevNode.__rowStriping;
   }
 
@@ -117,15 +119,14 @@ export class TableNode extends ElementNode {
   }
 
   static importJSON(serializedNode: SerializedTableNode): TableNode {
-    const tableNode = $createTableNode(serializedNode.colWidths);
+    const tableNode = $createTableNode();
     tableNode.__rowStriping = serializedNode.rowStriping || false;
     return tableNode;
   }
 
-  constructor(colWidths?: number[], key?: NodeKey) {
+  constructor(key?: NodeKey) {
     super(key);
     this.__rowStriping = false;
-    this.__colWidths = colWidths;
   }
 
   exportJSON(): SerializedTableNode {
@@ -358,8 +359,8 @@ export function $convertTableElement(
   return {node: tableNode};
 }
 
-export function $createTableNode(colWidths?: number[]): TableNode {
-  return $applyNodeReplacement(new TableNode(colWidths));
+export function $createTableNode(): TableNode {
+  return $applyNodeReplacement(new TableNode());
 }
 
 export function $isTableNode(

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -46,7 +46,7 @@ function updateColgroup(
   dom: HTMLElement,
   config: EditorConfig,
   colCount: number,
-  colWidths?: number[],
+  colWidths?: number[] | readonly number[],
 ) {
   const colGroup = dom.querySelector('colgroup');
   if (!colGroup) {
@@ -82,20 +82,21 @@ function setRowStriping(
 export class TableNode extends ElementNode {
   /** @internal */
   __rowStriping: boolean;
-  __colWidths?: readonly number[];
+  __colWidths?: number[] | readonly number[];
 
   static getType(): string {
     return 'table';
   }
 
-  getColWidths() {
+  getColWidths(): number[] | readonly number[] | undefined {
     const self = this.getLatest();
     return self.__colWidths;
   }
 
-  setColWidths(colWidths: number[]) {
+  setColWidths(colWidths: readonly number[]): this {
     const self = this.getWritable();
-    self.__colWidths = Object.freeze(colWidths);
+    // NOTE: Node properties should be immutable. Freeze to prevent accidental mutation.
+    self.__colWidths = __DEV__ ? Object.freeze(colWidths) : colWidths;
     return self;
   }
 
@@ -121,7 +122,7 @@ export class TableNode extends ElementNode {
   static importJSON(serializedNode: SerializedTableNode): TableNode {
     const tableNode = $createTableNode();
     tableNode.__rowStriping = serializedNode.rowStriping || false;
-    tableNode.__colWidths = Object.freeze(serializedNode.colWidths);
+    tableNode.__colWidths = serializedNode.colWidths;
     return tableNode;
   }
 

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -1014,7 +1014,7 @@ export function getTable(tableElement: HTMLElement): TableDOMTable {
     domRows,
     rows: 0,
   };
-  let currentNode = tableElement.firstChild;
+  let currentNode = tableElement.querySelector('tr') as ChildNode | null;
   let x = 0;
   let y = 0;
   domRows.length = 0;

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -471,6 +471,13 @@ export function $insertTableColumn__EXPERIMENTAL(insertAfter = true): void {
   if (firstInsertedCell !== null) {
     $moveSelectionToCell(firstInsertedCell);
   }
+  const colWidths = grid.getColWidths();
+  if (colWidths) {
+    const columnIndex = insertAfterColumn < 0 ? 0 : insertAfterColumn;
+    const newWidth = colWidths[columnIndex];
+    colWidths.splice(columnIndex, 0, newWidth);
+    grid.setColWidths(colWidths);
+  }
 }
 
 export function $deleteTableColumn(
@@ -642,6 +649,11 @@ export function $deleteTableColumn__EXPERIMENTAL(): void {
         : focusRowMap[anchorStartColumn - 1];
     const {cell} = previousRow;
     $moveSelectionToCell(cell);
+  }
+  const colWidths = grid.getColWidths();
+  if (colWidths) {
+    colWidths.splice(startColumn, selectedColumnCount);
+    grid.setColWidths(colWidths);
   }
 }
 

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -473,10 +473,11 @@ export function $insertTableColumn__EXPERIMENTAL(insertAfter = true): void {
   }
   const colWidths = grid.getColWidths();
   if (colWidths) {
+    const newColWidths = [...colWidths];
     const columnIndex = insertAfterColumn < 0 ? 0 : insertAfterColumn;
-    const newWidth = colWidths[columnIndex];
-    colWidths.splice(columnIndex, 0, newWidth);
-    grid.setColWidths(colWidths);
+    const newWidth = newColWidths[columnIndex];
+    newColWidths.splice(columnIndex, 0, newWidth);
+    grid.setColWidths(newColWidths);
   }
 }
 
@@ -652,8 +653,9 @@ export function $deleteTableColumn__EXPERIMENTAL(): void {
   }
   const colWidths = grid.getColWidths();
   if (colWidths) {
-    colWidths.splice(startColumn, selectedColumnCount);
-    grid.setColWidths(colWidths);
+    const newColWidths = [...colWidths];
+    newColWidths.splice(startColumn, selectedColumnCount);
+    grid.setColWidths(newColWidths);
   }
 }
 

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -102,7 +102,7 @@ describe('LexicalTableNode tests', () => {
           const tableNode = $createTableNode();
 
           expect(tableNode.createDOM(editorConfig).outerHTML).toBe(
-            `<table class="${editorConfig.theme.table}"></table>`,
+            `<table class="${editorConfig.theme.table}"><colgroup></colgroup></table>`,
           );
         });
       });
@@ -126,7 +126,7 @@ describe('LexicalTableNode tests', () => {
         // Make sure paragraph is inserted inside empty cells
         const emptyCell = '<td><p><br></p></td>';
         expect(testEnv.innerHTML).toBe(
-          `<table><tr><td><p dir="ltr"><span data-lexical-text="true">Hello there</span></p></td><td><p dir="ltr"><span data-lexical-text="true">General Kenobi!</span></p></td></tr><tr><td><p dir="ltr"><span data-lexical-text="true">Lexical is nice</span></p></td>${emptyCell}</tr></table>`,
+          `<table><colgroup><col><col></colgroup><tr><td><p dir="ltr"><span data-lexical-text="true">Hello there</span></p></td><td><p dir="ltr"><span data-lexical-text="true">General Kenobi!</span></p></td></tr><tr><td><p dir="ltr"><span data-lexical-text="true">Lexical is nice</span></p></td>${emptyCell}</tr></table>`,
         );
       });
 
@@ -147,7 +147,7 @@ describe('LexicalTableNode tests', () => {
           $insertDataTransferForRichText(dataTransfer, selection, editor);
         });
         expect(testEnv.innerHTML).toBe(
-          `<table><tr style="height: 21px;"><td><p dir="ltr"><strong data-lexical-text="true">Surface</strong></p></td><td><p dir="ltr"><em data-lexical-text="true">MWP_WORK_LS_COMPOSER</em></p></td><td><p style="text-align: right;"><span data-lexical-text="true">77349</span></p></td></tr><tr style="height: 21px;"><td><p dir="ltr"><span data-lexical-text="true">Lexical</span></p></td><td><p dir="ltr"><span data-lexical-text="true">XDS_RICH_TEXT_AREA</span></p></td><td><p dir="ltr"><span data-lexical-text="true">sdvd </span><strong data-lexical-text="true">sdfvsfs</strong></p></td></tr></table>`,
+          `<table><colgroup><col><col><col></colgroup><tr style="height: 21px;"><td><p dir="ltr"><strong data-lexical-text="true">Surface</strong></p></td><td><p dir="ltr"><em data-lexical-text="true">MWP_WORK_LS_COMPOSER</em></p></td><td><p style="text-align: right;"><span data-lexical-text="true">77349</span></p></td></tr><tr style="height: 21px;"><td><p dir="ltr"><span data-lexical-text="true">Lexical</span></p></td><td><p dir="ltr"><span data-lexical-text="true">XDS_RICH_TEXT_AREA</span></p></td><td><p dir="ltr"><span data-lexical-text="true">sdvd </span><strong data-lexical-text="true">sdfvsfs</strong></p></td></tr></table>`,
         );
       });
 
@@ -292,7 +292,7 @@ describe('LexicalTableNode tests', () => {
         });
 
         expect(testEnv.innerHTML).toBe(
-          `<p><br></p><table><tr><th><p><br></p></th><th><p><br></p></th><th><p><br></p></th><th><p><br></p></th></tr><tr><th><p><br></p></th><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><th><p><br></p></th><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><th><p><br></p></th><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></table>`,
+          `<p><br></p><table><colgroup><col><col><col><col></colgroup><tr><th><p><br></p></th><th><p><br></p></th><th><p><br></p></th><th><p><br></p></th></tr><tr><th><p><br></p></th><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><th><p><br></p></th><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><th><p><br></p></th><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></table>`,
         );
       });
 
@@ -366,7 +366,7 @@ describe('LexicalTableNode tests', () => {
           const root = $getRoot();
           const table = root.getLastChild<TableNode>();
           expect(table!.createDOM(editorConfig).outerHTML).toBe(
-            `<table class="${editorConfig.theme.table} ${editorConfig.theme.tableRowStriping}" data-lexical-row-striping="true"></table>`,
+            `<table class="${editorConfig.theme.table} ${editorConfig.theme.tableRowStriping}" data-lexical-row-striping="true"><colgroup><col><col><col><col></colgroup></table>`,
           );
         });
 
@@ -382,7 +382,7 @@ describe('LexicalTableNode tests', () => {
           const root = $getRoot();
           const table = root.getLastChild<TableNode>();
           expect(table!.createDOM(editorConfig).outerHTML).toBe(
-            `<table class="${editorConfig.theme.table}"></table>`,
+            `<table class="${editorConfig.theme.table}"><colgroup><col><col><col><col></colgroup></table>`,
           );
         });
       });


### PR DESCRIPTION
## Description

This PR adds an optional `colWidths` property to TableNode, which renders a `<colgroup>` element within tables. 

Defining the column widths has 2 main advantages:
1. We can simplify table resizing logic, particularly around merged cell cases.
2. It enables better control of tables with the style `table-layout: fixed`

If using `table-layout: fixed`, you must set a table width. Lexical playground uses `max-content` which masks some issues. If you want to truncate text within the table, the best way is to change the table width to `fit-content` (and add css to truncate). 

However, without a `<col>` element, a table with layout `fixed` will use the first row to determine column widths for the rest of the table. If there are merged cells in the first row, this makes it impossible to correctly size (and resize) columns in the remaining rows.

Adding `colWidths` to TableNode is the cleanest way to enable the ability to truncate text in tables and simplify resizing.

### Changes
- Add optional `colWidth` to TableNode (an array of pixel width numbers)
- Update `createDOM` to render `<colgroup>` and `<col>` elements with widths, if `colWidths` is set.
- Update playground `TableCellResizerPlugin` to get and set `colWidths` for better resizing

Closes #6623 #6624 (resize bugs)

Now it is also possible to truncate text in cells. This was not possible before and is the main motivation for this PR

## Test plan

Since this changes the output of TableNode, it breaks many tests that expect specific HTML. I will update tests if maintainers are open to this approach.

### Demo
🔉 narrated
https://github.com/user-attachments/assets/aa7902f2-df6f-4975-b83c-2a28e7f086c5


