### PR TITLE
[lexical-table]  Bug: Table formatting and styling not persisting for empty cells

### DIFF
--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -357,12 +357,7 @@ export class TableObserver {
       const anchor = formatSelection.anchor;
       const focus = formatSelection.focus;
 
-      const cellNodes: Array<TableCellNode> = [];
-      for (const node of selection.getNodes()) {
-        if ($isTableCellNode(node)) {
-          cellNodes.push(node);
-        }
-      }
+      const cellNodes = selection.getNodes().filter($isTableCellNode);
       const paragraph = cellNodes[0].getFirstChild();
       const alignFormatWith = $isParagraphNode(paragraph)
         ? paragraph.getFormatFlags(type, null)

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -21,12 +21,13 @@ import {
   $getRoot,
   $getSelection,
   $isElementNode,
+  $isParagraphNode,
   $setSelection,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import invariant from 'shared/invariant';
 
-import {$isTableCellNode} from './LexicalTableCellNode';
+import {$isTableCellNode, TableCellNode} from './LexicalTableCellNode';
 import {$isTableNode} from './LexicalTableNode';
 import {
   $createTableSelection,
@@ -356,12 +357,21 @@ export class TableObserver {
       const anchor = formatSelection.anchor;
       const focus = formatSelection.focus;
 
-      selection.getNodes().forEach((cellNode) => {
-        if ($isTableCellNode(cellNode)) {
-          anchor.set(cellNode.getKey(), 0, 'element');
-          focus.set(cellNode.getKey(), cellNode.getChildrenSize(), 'element');
-          formatSelection.formatText(type);
+      const cellNodes: Array<TableCellNode> = [];
+      for (const node of selection.getNodes()) {
+        if ($isTableCellNode(node)) {
+          cellNodes.push(node);
         }
+      }
+      const paragraph = cellNodes[0].getFirstChild();
+      const alignFormatWith = $isParagraphNode(paragraph)
+        ? paragraph.getFormatFlags(type, null)
+        : null;
+
+      cellNodes.forEach((cellNode: TableCellNode) => {
+        anchor.set(cellNode.getKey(), 0, 'element');
+        focus.set(cellNode.getKey(), cellNode.getChildrenSize(), 'element');
+        formatSelection.formatText(type, alignFormatWith);
       });
 
       $setSelection(selection);

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -357,7 +357,7 @@ export class TableObserver {
       const focus = formatSelection.focus;
 
       selection.getNodes().forEach((cellNode) => {
-        if ($isTableCellNode(cellNode) && cellNode.getTextContentSize() !== 0) {
+        if ($isTableCellNode(cellNode)) {
           anchor.set(cellNode.getKey(), 0, 'element');
           focus.set(cellNode.getKey(), cellNode.getChildrenSize(), 'element');
           formatSelection.formatText(type);

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1174,8 +1174,12 @@ export class RangeSelection implements BaseSelection {
    * merging nodes as necessary.
    *
    * @param formatType the format type to apply to the nodes in the Selection.
+   * @param alignWithFormat a 32-bit integer representing formatting flags to align with.
    */
-  formatText(formatType: TextFormatType): void {
+  formatText(
+    formatType: TextFormatType,
+    alignWithFormat: number | null = null,
+  ): void {
     if (this.isCollapsed()) {
       this.toggleFormat(formatType);
       // When changing format, we should stop composition
@@ -1230,7 +1234,10 @@ export class RangeSelection implements BaseSelection {
       return;
     }
 
-    const firstNextFormat = firstNode.getFormatFlags(formatType, null);
+    const firstNextFormat = firstNode.getFormatFlags(
+      formatType,
+      alignWithFormat,
+    );
 
     const lastIndex = selectedTextNodesLength - 1;
     let lastNode = selectedTextNodes[lastIndex];

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -21,6 +21,7 @@ import {
   $isDecoratorNode,
   $isElementNode,
   $isLineBreakNode,
+  $isParagraphNode,
   $isRootNode,
   $isTextNode,
   $setSelection,
@@ -1189,6 +1190,13 @@ export class RangeSelection implements BaseSelection {
         selectedTextNodes.push(selectedNode);
       }
     }
+
+    selectedNodes.forEach((node) => {
+      if ($isParagraphNode(node)) {
+        const newFormat = node.getFormatFlags(formatType, null);
+        node.setTextFormat(newFormat);
+      }
+    });
 
     const selectedTextNodesLength = selectedTextNodes.length;
     if (selectedTextNodesLength === 0) {

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1195,13 +1195,6 @@ export class RangeSelection implements BaseSelection {
       }
     }
 
-    selectedNodes.forEach((node) => {
-      if ($isParagraphNode(node)) {
-        const newFormat = node.getFormatFlags(formatType, null);
-        node.setTextFormat(newFormat);
-      }
-    });
-
     const selectedTextNodesLength = selectedTextNodes.length;
     if (selectedTextNodesLength === 0) {
       this.toggleFormat(formatType);
@@ -1238,6 +1231,12 @@ export class RangeSelection implements BaseSelection {
       formatType,
       alignWithFormat,
     );
+    selectedNodes.forEach((node) => {
+      if ($isParagraphNode(node)) {
+        const newFormat = node.getFormatFlags(formatType, firstNextFormat);
+        node.setTextFormat(newFormat);
+      }
+    });
 
     const lastIndex = selectedTextNodesLength - 1;
     let lastNode = selectedTextNodes[lastIndex];

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -30,6 +30,7 @@ import {
   $applyNodeReplacement,
   getCachedClassNameArray,
   isHTMLElement,
+  toggleTextFormatType,
 } from '../LexicalUtils';
 import {ElementNode} from './LexicalElementNode';
 import {$isTextNode, TextFormatType} from './LexicalTextNode';
@@ -73,6 +74,17 @@ export class ParagraphNode extends ElementNode {
   hasTextFormat(type: TextFormatType): boolean {
     const formatFlag = TEXT_TYPE_TO_FORMAT[type];
     return (this.getTextFormat() & formatFlag) !== 0;
+  }
+
+  /**
+   * Returns the format flags applied to the node as a 32-bit integer.
+   *
+   * @returns a number representing the TextFormatTypes applied to the node.
+   */
+  getFormatFlags(type: TextFormatType, alignWithFormat: null | number): number {
+    const self = this.getLatest();
+    const format = self.__textFormat;
+    return toggleTextFormatType(format, type, alignWithFormat);
   }
 
   getTextStyle(): string {


### PR DESCRIPTION
## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Apply format change to empty paragraphs. Before it was only applied to text nodes*

Closes #[6583](https://github.com/facebook/lexical/issues/6583)

## Test plan

### Before
Formatting is not applied to empty paragraphs
![table-bug-before](https://github.com/user-attachments/assets/f36efd48-6888-41ab-b769-b039d3a10510)

### After
Formatting is applied to empty paragraphs
![table-bug-after](https://github.com/user-attachments/assets/d443b500-63e2-4a8d-8744-013c6cab669d)
