### PR TITLE
[lexical-playground] Bug Fix: Fix table row/column index when resizing merged cells

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1690,7 +1690,8 @@ test.describe.parallel('Tables', () => {
               <th
                 class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
                 colspan="2"
-                rowspan="2">
+                rowspan="2"
+                style="width: 217px">
                 <p class="PlaygroundEditorTheme__paragraph"><br /></p>
               </th>
               <th
@@ -1705,11 +1706,10 @@ test.describe.parallel('Tables', () => {
             </tr>
             <tr>
               <th
-                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
-                style="width: 125px">
+                class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
                 <p class="PlaygroundEditorTheme__paragraph"><br /></p>
               </th>
-              <td class="PlaygroundEditorTheme__tableCell">
+              <td class="PlaygroundEditorTheme__tableCell" style="width: 125px">
                 <p class="PlaygroundEditorTheme__paragraph"><br /></p>
               </td>
               <td class="PlaygroundEditorTheme__tableCell">
@@ -1766,7 +1766,7 @@ test.describe.parallel('Tables', () => {
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
         <table class="PlaygroundEditorTheme__table">
-          <tr style="height: 87px">
+          <tr>
             <th
               class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader"
               colspan="2"
@@ -1778,7 +1778,7 @@ test.describe.parallel('Tables', () => {
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </th>
           </tr>
-          <tr>
+          <tr style="height: 87px">
             <td class="PlaygroundEditorTheme__tableCell">
               <p class="PlaygroundEditorTheme__paragraph"><br /></p>
             </td>

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -173,7 +173,9 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
           const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
 
           const tableRowIndex =
-            $getTableRowIndexFromTableCellNode(tableCellNode);
+            $getTableRowIndexFromTableCellNode(tableCellNode) +
+            tableCellNode.getRowSpan() -
+            1;
 
           const tableRows = tableNode.getChildren();
 

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -242,7 +242,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
     for (let row = 0; row < tableMap.length; row++) {
       for (let column = 0; column < tableMap[row].length; column++) {
         if (tableMap[row][column].cell === tableCellNode) {
-          return column;
+          return column + tableCellNode.getColSpan() - 1;
         }
       }
     }


### PR DESCRIPTION
## Description
When table cells are merged (either vertically or horizontally) and you try to resize them, it resizes the row or column of the top/left cell.

Update the index to account for colspan and rowspan so the correct column/row is resized.

Closes #6623

## Test plan

### Before

https://github.com/user-attachments/assets/75333ad5-c0fa-4800-b3c6-25d932d8b8df

### After

https://github.com/user-attachments/assets/473d6d33-f467-4e16-afbb-8bc947367c7d


