### PR TITLE
[lexical-playground][ExcalidrawNode] Bug Fix: Preserve Excalidraw image dimensions after resizing

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -15,8 +15,6 @@ import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
-  $getSelection,
-  $isNodeSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   KEY_BACKSPACE_COMMAND,
@@ -48,13 +46,13 @@ export default function ExcalidrawComponent({
     useLexicalNodeSelection(nodeKey);
   const [isResizing, setIsResizing] = useState<boolean>(false);
 
-  const onDelete = useCallback(
+  const $onDelete = useCallback(
     (event: KeyboardEvent) => {
-      if (isSelected && $isNodeSelection($getSelection())) {
+      if (isSelected) {
         event.preventDefault();
         editor.update(() => {
           const node = $getNodeByKey(nodeKey);
-          if ($isExcalidrawNode(node)) {
+          if (node) {
             node.remove();
           }
         });
@@ -102,22 +100,22 @@ export default function ExcalidrawComponent({
       ),
       editor.registerCommand(
         KEY_DELETE_COMMAND,
-        onDelete,
+        $onDelete,
         COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         KEY_BACKSPACE_COMMAND,
-        onDelete,
+        $onDelete,
         COMMAND_PRIORITY_LOW,
       ),
     );
-  }, [clearSelection, editor, isSelected, isResizing, onDelete, setSelected]);
+  }, [clearSelection, editor, isSelected, isResizing, $onDelete, setSelected]);
 
   const deleteNode = useCallback(() => {
     setModalOpen(false);
     return editor.update(() => {
       const node = $getNodeByKey(nodeKey);
-      if ($isExcalidrawNode(node)) {
+      if (node) {
         node.remove();
       }
     });
@@ -182,15 +180,15 @@ export default function ExcalidrawComponent({
     appState = {},
   } = useMemo(() => JSON.parse(data), [data]);
 
-  const [width, height] = useMemo(() => {
+  const [initialWidth, initialHeight] = useMemo(() => {
     let nodeWidth: 'inherit' | number = 'inherit';
     let nodeHeight: 'inherit' | number = 'inherit';
 
     editor.getEditorState().read(() => {
       const node = $getNodeByKey(nodeKey);
       if ($isExcalidrawNode(node)) {
-        nodeWidth = node.getWidth(); // Now exists
-        nodeHeight = node.getHeight(); // Now exists
+        nodeWidth = node.getWidth();
+        nodeHeight = node.getHeight();
       }
     });
 
@@ -223,8 +221,8 @@ export default function ExcalidrawComponent({
             elements={elements}
             files={files}
             appState={appState}
-            width={width}
-            height={height}
+            width={initialWidth}
+            height={initialHeight}
           />
           {isSelected && (
             <div

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
@@ -17,6 +17,8 @@ import {useEffect, useState} from 'react';
 
 type ImageType = 'svg' | 'canvas';
 
+type Dimension = 'inherit' | number;
+
 type Props = {
   /**
    * Configures the export setting for SVG/Canvas
@@ -31,17 +33,17 @@ type Props = {
    */
   elements: NonDeleted<ExcalidrawElement>[];
   /**
-   * The Excalidraw elements to be rendered as an image
+   * The Excalidraw files associated with the elements
    */
   files: BinaryFiles;
   /**
    * The height of the image to be rendered
    */
-  height?: number | null;
+  height?: Dimension;
   /**
    * The ref object to be used to render the image
    */
-  imageContainerRef: {current: null | HTMLDivElement};
+  imageContainerRef: React.MutableRefObject<HTMLDivElement | null>;
   /**
    * The type of image to be rendered
    */
@@ -53,7 +55,7 @@ type Props = {
   /**
    * The width of the image to be rendered
    */
-  width?: number | null;
+  width?: Dimension;
 };
 
 // exportToSvg has fonts from excalidraw.com
@@ -85,6 +87,8 @@ export default function ExcalidrawImage({
   imageContainerRef,
   appState,
   rootClassName = null,
+  width = 'inherit',
+  height = 'inherit',
 }: Props): JSX.Element {
   const [Svg, setSvg] = useState<SVGElement | null>(null);
 
@@ -106,10 +110,25 @@ export default function ExcalidrawImage({
     setContent();
   }, [elements, files, appState]);
 
+  const containerStyle: React.CSSProperties = {};
+  if (width !== 'inherit') {
+    containerStyle.width = `${width}px`;
+  }
+  if (height !== 'inherit') {
+    containerStyle.height = `${height}px`;
+  }
+
   return (
     <div
-      ref={imageContainerRef}
+      ref={(node) => {
+        if (node) {
+          if (imageContainerRef) {
+            imageContainerRef.current = node;
+          }
+        }
+      }}
       className={rootClassName ?? ''}
+      style={containerStyle}
       dangerouslySetInnerHTML={{__html: Svg?.outerHTML ?? ''}}
     />
   );

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -35,7 +35,7 @@ export type SerializedExcalidrawNode = Spread<
   SerializedLexicalNode
 >;
 
-function convertExcalidrawElement(
+function $convertExcalidrawElement(
   domNode: HTMLElement,
 ): DOMConversionOutput | null {
   const excalidrawData = domNode.getAttribute('data-lexical-excalidraw-json');
@@ -48,7 +48,7 @@ function convertExcalidrawElement(
     !widthStr || widthStr === 'inherit' ? 'inherit' : parseInt(widthStr, 10);
 
   if (excalidrawData) {
-    const node = new ExcalidrawNode(excalidrawData, width, height);
+    const node = $createExcalidrawNode(excalidrawData, width, height);
     return {
       node,
     };
@@ -139,7 +139,7 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
           return null;
         }
         return {
-          conversion: convertExcalidrawElement,
+          conversion: $convertExcalidrawElement,
           priority: 1,
         };
       },
@@ -174,7 +174,7 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
   }
 
   getWidth(): Dimension {
-    return this.__width;
+    return this.getLatest().__width;
   }
 
   setWidth(width: Dimension): void {
@@ -183,7 +183,7 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
   }
 
   getHeight(): Dimension {
-    return this.__height;
+    return this.getLatest().__height;
   }
 
   setHeight(height: Dimension): void {


### PR DESCRIPTION
## Description
When resizing an Excalidraw image within the Lexical editor, the new dimensions are not preserved after certain editor actions. For example, try moving the cursor just to the left of the image and pressing Enter. This will cause the image to revert to its original size and a mismatch between the resize box and the image.

### Changes Introduced
#### Updating the ExcalidrawNode Class:
1. Updated updateDOM method to ensure than when node is updated the dom reflects the new width and height
2. Update $createExcalidrawNode function to take in data, width, height

#### Modifying the ExcalidrawComponent:
1. Retrieved width and height from the node using the new getter methods.
2. Pass width and height to ExcalidrawImage

#### Updating the ExcalidrawImage Component:
1. Accepted width and height as props.
2. Apply the dimensions to the container's style

## Test plan

### Steps to Reproduce:
1. Insert an Excalidraw image into the editor.
5. Resize the image to make it larger.
6. Move the cursor to the left of the image.
7. Press Enter.

### Before
Observed Behavior: The image shrinks back to its original size, losing the resizing adjustments made by the user.


https://github.com/user-attachments/assets/c1011f32-e071-4083-9e5f-02fd3d4718b7



### After
Observed Behavior: The image retains its resized dimensions, preserving the user's adjustments even after the editor updates.


https://github.com/user-attachments/assets/6712543c-0b0b-4015-a0c5-4010162c5427

