### PR TITLE
[lexical-markdown] shouldMergeAdjacentLines as an option

### DIFF
--- a/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
+++ b/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
@@ -95,6 +95,7 @@ declare export function $convertFromMarkdownString(
   transformers?: Array<Transformer>,
   node?: ElementNode,
   shouldPreserveNewLines?: boolean,
+  shouldNormalizeMarkdown?: boolean,
 ): void;
 
 // TODO:

--- a/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
+++ b/packages/lexical-markdown/flow/LexicalMarkdown.js.flow
@@ -95,7 +95,7 @@ declare export function $convertFromMarkdownString(
   transformers?: Array<Transformer>,
   node?: ElementNode,
   shouldPreserveNewLines?: boolean,
-  shouldNormalizeMarkdown?: boolean,
+  shouldMergeAdjacentLines?: boolean,
 ): void;
 
 // TODO:

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -532,7 +532,10 @@ export const LINK: TextMatchTransformer = {
   type: 'text-match',
 };
 
-export function normalizeMarkdown(input: string): string {
+export function normalizeMarkdown(
+  input: string,
+  shouldMergeAdjacentLines = true,
+): string {
   const lines = input.split('\n');
   let inCodeBlock = false;
   const sanitizedLines: string[] = [];
@@ -573,7 +576,8 @@ export function normalizeMarkdown(input: string): string {
       UNORDERED_LIST_REGEX.test(line) ||
       CHECK_LIST_REGEX.test(line) ||
       TABLE_ROW_REG_EXP.test(line) ||
-      TABLE_ROW_DIVIDER_REG_EXP.test(line)
+      TABLE_ROW_DIVIDER_REG_EXP.test(line) ||
+      !shouldMergeAdjacentLines
     ) {
       sanitizedLines.push(line);
     } else {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -65,7 +65,7 @@ describe('Markdown', () => {
     skipExport?: true;
     skipImport?: true;
     shouldPreserveNewLines?: true;
-    shouldNormalizeMarkdown?: true | false;
+    shouldMergeAdjacentLines?: true | false;
     customTransformers?: Transformer[];
   }>;
 
@@ -206,13 +206,13 @@ describe('Markdown', () => {
     {
       html: '<p><span style="white-space: pre-wrap;">helloworld</span></p>',
       md: 'hello\nworld',
-      shouldNormalizeMarkdown: true,
+      shouldMergeAdjacentLines: true,
       skipExport: true,
     },
     {
       html: '<p><span style="white-space: pre-wrap;">hello</span><br><span style="white-space: pre-wrap;">world</span></p>',
       md: 'hello\nworld',
-      shouldNormalizeMarkdown: false,
+      shouldMergeAdjacentLines: false,
     },
     {
       html: '<p><span style="white-space: pre-wrap;">hello</span><br><span style="white-space: pre-wrap;">world</span></p>',
@@ -354,7 +354,7 @@ describe('Markdown', () => {
     md,
     skipImport,
     shouldPreserveNewLines,
-    shouldNormalizeMarkdown,
+    shouldMergeAdjacentLines,
     customTransformers,
   } of IMPORT_AND_EXPORT) {
     if (skipImport) {
@@ -384,7 +384,7 @@ describe('Markdown', () => {
             ],
             undefined,
             shouldPreserveNewLines,
-            shouldNormalizeMarkdown,
+            shouldMergeAdjacentLines,
           ),
         {
           discrete: true,

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -207,6 +207,7 @@ describe('Markdown', () => {
       html: '<p><span style="white-space: pre-wrap;">helloworld</span></p>',
       md: 'hello\nworld',
       shouldNormalizeMarkdown: true,
+      skipExport: true,
     },
     {
       html: '<p><span style="white-space: pre-wrap;">hello</span><br><span style="white-space: pre-wrap;">world</span></p>',
@@ -353,6 +354,7 @@ describe('Markdown', () => {
     md,
     skipImport,
     shouldPreserveNewLines,
+    shouldNormalizeMarkdown,
     customTransformers,
   } of IMPORT_AND_EXPORT) {
     if (skipImport) {
@@ -382,6 +384,7 @@ describe('Markdown', () => {
             ],
             undefined,
             shouldPreserveNewLines,
+            shouldNormalizeMarkdown,
           ),
         {
           discrete: true,

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -65,6 +65,7 @@ describe('Markdown', () => {
     skipExport?: true;
     skipImport?: true;
     shouldPreserveNewLines?: true;
+    shouldNormalizeMarkdown?: true | false;
     customTransformers?: Transformer[];
   }>;
 
@@ -201,6 +202,16 @@ describe('Markdown', () => {
     {
       html: '<p><i><em style="white-space: pre-wrap;">Hello </em></i><i><b><strong style="white-space: pre-wrap;">world</strong></b></i><i><em style="white-space: pre-wrap;">!</em></i></p>',
       md: '*Hello **world**!*',
+    },
+    {
+      html: '<p><span style="white-space: pre-wrap;">helloworld</span></p>',
+      md: 'hello\nworld',
+      shouldNormalizeMarkdown: true,
+    },
+    {
+      html: '<p><span style="white-space: pre-wrap;">hello</span><br><span style="white-space: pre-wrap;">world</span></p>',
+      md: 'hello\nworld',
+      shouldNormalizeMarkdown: false,
     },
     {
       html: '<p><span style="white-space: pre-wrap;">hello</span><br><span style="white-space: pre-wrap;">world</span></p>',

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -76,16 +76,15 @@ const TRANSFORMERS: Array<Transformer> = [
 
 /**
  * Renders markdown from a string. The selection is moved to the start after the operation.
+ *
+ *  @param {boolean} [shouldPreserveNewLines] By setting this to true, new lines will be preserved between conversions
+ *  @param {boolean} [shouldNormalizeMarkdown] By setting this to true, adjacent non empty lines will be merged according to commonmark spec: https://spec.commonmark.org/0.24/#example-177
  */
 function $convertFromMarkdownString(
   markdown: string,
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
   shouldPreserveNewLines = false,
-  /**
-   * By setting this to true, adjacent non empty lines will be merged
-   * according to commonmark spec: https://spec.commonmark.org/0.24/#example-177
-   */
   shouldNormalizeMarkdown = true,
 ): void {
   const sanitizedMarkdown =

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -78,19 +78,18 @@ const TRANSFORMERS: Array<Transformer> = [
  * Renders markdown from a string. The selection is moved to the start after the operation.
  *
  *  @param {boolean} [shouldPreserveNewLines] By setting this to true, new lines will be preserved between conversions
- *  @param {boolean} [shouldNormalizeMarkdown] By setting this to true, adjacent non empty lines will be merged according to commonmark spec: https://spec.commonmark.org/0.24/#example-177
+ *  @param {boolean} [shouldMergeAdjacentLines] By setting this to true, adjacent non empty lines will be merged according to commonmark spec: https://spec.commonmark.org/0.24/#example-177. Not applicable if shouldPreserveNewLines = true.
  */
 function $convertFromMarkdownString(
   markdown: string,
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
   shouldPreserveNewLines = false,
-  shouldNormalizeMarkdown = true,
+  shouldMergeAdjacentLines = true,
 ): void {
-  const sanitizedMarkdown =
-    shouldPreserveNewLines || !shouldNormalizeMarkdown
-      ? markdown
-      : normalizeMarkdown(markdown);
+  const sanitizedMarkdown = shouldPreserveNewLines
+    ? markdown
+    : normalizeMarkdown(markdown, shouldMergeAdjacentLines);
   const importMarkdown = createMarkdownImport(
     transformers,
     shouldPreserveNewLines,

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -82,10 +82,16 @@ function $convertFromMarkdownString(
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
   shouldPreserveNewLines = false,
+  /**
+   * By setting this to true, adjacent non empty lines will be merged
+   * according to commonmark spec: https://spec.commonmark.org/0.24/#example-177
+   */
+  shouldNormalizeMarkdown = true,
 ): void {
-  const sanitizedMarkdown = shouldPreserveNewLines
-    ? markdown
-    : normalizeMarkdown(markdown);
+  const sanitizedMarkdown =
+    shouldPreserveNewLines || !shouldNormalizeMarkdown
+      ? markdown
+      : normalizeMarkdown(markdown);
   const importMarkdown = createMarkdownImport(
     transformers,
     shouldPreserveNewLines,


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

normalize markdown was introduced in https://github.com/facebook/lexical/pull/6629 . one of the significant behavior change this introduced is merging adjacent non empty lines, according to commonmark spec: https://spec.commonmark.org/0.24/#example-177

it is a welcomed change since that brings lexical's impl closer to commonmark. However to avoid breaking current callsites, im making the normalizedMarkdown an option default to true, so it is easier to rollback incase this new behavior causes a regression somewhere downstream

ultimately, if there is no known usecase to have shouldMergeAdjacentLines = false, will look to deprecate  shouldMergeAdjacentLines and have it always be true.


## Test plan

shouldMergeAdjacentLines = true






https://github.com/user-attachments/assets/5ec217e7-49a5-4119-b4c2-7466366fce47





---

shouldMergeAdjacentLines = false

https://github.com/user-attachments/assets/1c57abfa-db0c-4a8d-a29c-938764075b2d

added automated tests