### PR TITLE
Grammar Issue - Repeated Word

### DIFF
--- a/packages/lexical-website/docs/intro.md
+++ b/packages/lexical-website/docs/intro.md
@@ -81,7 +81,7 @@ Node Transforms and Command Listeners are called with an implicit `editor.update
 
 It is permitted to do nested updates, or nested reads, but an update should not be nested in a read
 or vice versa. For example, `editor.update(() => editor.update(() => {...}))` is allowed. It is permitted
-to nest nest an `editor.read` at the end of an `editor.update`, but this will immediately flush the update
+to nest an `editor.read` at the end of an `editor.update`, but this will immediately flush the update
 and any additional update in that callback will throw an error.
 
 All Lexical Nodes are dependent on the associated Editor State. With few exceptions, you should only call methods


### PR DESCRIPTION
The word 'nest' shows twice in this sentence and one should be removed:

from: nest nest 
to: nest

<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

Closes #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*