### PR TITLE
[lexical-react][lexical-playground] Bug Fix: Workaround for yjs disconnect race in React StrictMode

### DIFF
--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -155,9 +155,18 @@ export function useYjsCollaboration(
 
     return () => {
       if (isReloadingDoc.current === false) {
-        Promise.resolve(connectionPromise).then(() => {
+        if (connectionPromise) {
+          connectionPromise.then(disconnect);
+        } else {
+          // Workaround for race condition in StrictMode. It's possible there
+          // is a different race for the above case where connect returns a
+          // promise, but we don't have an example of that in-repo.
+          // It's possible that there is a similar issue with
+          // TOGGLE_CONNECT_COMMAND below when the provider connect returns a
+          // promise.
+          // https://github.com/facebook/lexical/issues/6640
           disconnect();
-        });
+        }
       }
 
       provider.off('sync', onSync);
@@ -198,18 +207,16 @@ export function useYjsCollaboration(
     return editor.registerCommand(
       TOGGLE_CONNECT_COMMAND,
       (payload) => {
-        if (connect !== undefined && disconnect !== undefined) {
-          const shouldConnect = payload;
+        const shouldConnect = payload;
 
-          if (shouldConnect) {
-            // eslint-disable-next-line no-console
-            console.log('Collaboration connected!');
-            connect();
-          } else {
-            // eslint-disable-next-line no-console
-            console.log('Collaboration disconnected!');
-            disconnect();
-          }
+        if (shouldConnect) {
+          // eslint-disable-next-line no-console
+          console.log('Collaboration connected!');
+          connect();
+        } else {
+          // eslint-disable-next-line no-console
+          console.log('Collaboration disconnected!');
+          disconnect();
         }
 
         return true;


### PR DESCRIPTION
## Description

The PR in #6619 created a regression for local collab development by introducing a timing change in when disconnect was called. When reviewing the PR I didn't think it caused an issue because the deployed playground and CI tests worked fine, but when running the playground locally with vite dev mode it does cause an issue. 

https://github.com/facebook/lexical/pull/6619#discussion_r1754903692

Closes #6640

## Test plan

### Before

```
npm run start
npm run test-e2e-chromium # from another terminal
```

All tests fail.

Can also reproduce collab not working at http://localhost:3000/split/?isCollab=true

Note that this only happens when running locally with vite dev, it does not cause any problems in CI or in production.

### After

It all works as expected.
