### PR TITLE
[lexical-playground] Bug Fix: empty code block not focused

### DIFF
--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -183,11 +183,12 @@ export default function ActionsPlugin({
           undefined, //node
           shouldPreserveNewLinesInMarkdown,
         );
-        root
-          .clear()
-          .append(
-            $createCodeNode('markdown').append($createTextNode(markdown)),
-          );
+        const codeNode = $createCodeNode('markdown');
+        codeNode.append($createTextNode(markdown));
+        root.clear().append(codeNode);
+        if (markdown.length === 0) {
+          codeNode.select();
+        }
       }
     });
   }, [editor, shouldPreserveNewLinesInMarkdown]);
@@ -218,6 +219,7 @@ export default function ActionsPlugin({
         aria-label="Import editor state from JSON">
         <i className="import" />
       </button>
+
       <button
         className="action-button export"
         onClick={() =>


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
when converting an empty editor to markdown codeblock, the codeblock isnt focused and typing puts chars into the editor root instead of the codeblock. does not happen if codeblock is not empty

## Test plan

### Before


https://github.com/user-attachments/assets/72495357-304f-45a2-b79b-4f3b28be998d




### After


https://github.com/user-attachments/assets/ce9b595f-ae45-48fb-88ba-ad9ef2ee8b8d

