### PR TITLE
[lexical-markdown]: Refactor: allows omitting certain properties from TextMatchTransformers, adds jsdocs

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -111,6 +111,10 @@ function exportChildren(
 
   mainLoop: for (const child of children) {
     for (const transformer of textMatchTransformers) {
+      if (!transformer.export) {
+        continue;
+      }
+
       const result = transformer.export(
         child,
         (parentNode) =>

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -359,6 +359,9 @@ function importTextMatchTransformers(
 
   mainLoop: while (textNode) {
     for (const transformer of textMatchTransformers) {
+      if (!transformer.replace || !transformer.importRegExp) {
+        continue;
+      }
       const match = textNode.getTextContent().match(transformer.importRegExp);
 
       if (!match) {

--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -158,6 +158,9 @@ function runTextMatchTransformers(
   }
 
   for (const transformer of transformers) {
+    if (!transformer.replace || !transformer.regExp) {
+      continue;
+    }
     const match = textContent.match(transformer.regExp);
 
     if (match === null) {
@@ -389,11 +392,11 @@ export function registerMarkdownShortcuts(
   transformers: Array<Transformer> = TRANSFORMERS,
 ): () => void {
   const byType = transformersByType(transformers);
-  const textFormatTransformersIndex = indexBy(
+  const textFormatTransformersByTrigger = indexBy(
     byType.textFormat,
     ({tag}) => tag[tag.length - 1],
   );
-  const textMatchTransformersIndex = indexBy(
+  const textMatchTransformersByTrigger = indexBy(
     byType.textMatch,
     ({trigger}) => trigger,
   );
@@ -449,7 +452,7 @@ export function registerMarkdownShortcuts(
       runTextMatchTransformers(
         anchorNode,
         anchorOffset,
-        textMatchTransformersIndex,
+        textMatchTransformersByTrigger,
       )
     ) {
       return;
@@ -458,7 +461,7 @@ export function registerMarkdownShortcuts(
     $runTextFormatTransformers(
       anchorNode,
       anchorOffset,
-      textFormatTransformersIndex,
+      textFormatTransformersByTrigger,
     );
   };
 

--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -139,17 +139,33 @@ export type TextFormatTransformer = Readonly<{
 
 export type TextMatchTransformer = Readonly<{
   dependencies: Array<Klass<LexicalNode>>;
-  export: (
+  /**
+   * Determines how a node should be exported to markdown
+   */
+  export?: (
     node: LexicalNode,
     // eslint-disable-next-line no-shadow
     exportChildren: (node: ElementNode) => string,
     // eslint-disable-next-line no-shadow
     exportFormat: (node: TextNode, textContent: string) => string,
   ) => string | null;
-  importRegExp: RegExp;
+  /**
+   * This regex determines what text is matched during markdown imports
+   */
+  importRegExp?: RegExp;
+  /**
+   * This regex determines what text is matched for markdown shortcuts while typing in the editor
+   */
   regExp: RegExp;
-  replace: (node: TextNode, match: RegExpMatchArray) => void;
-  trigger: string;
+  /**
+   * Determines how the matched markdown text should be transformed into a node during the markdown import process
+   */
+  replace?: (node: TextNode, match: RegExpMatchArray) => void;
+  /**
+   * Single character that allows the transformer to trigger when typed in the editor. This does not affect markdown imports outside of the markdown shortcut plugin.
+   * If the trigger is matched, the `regExp` will be used to match the text in the second step.
+   */
+  trigger?: string;
   type: 'text-match';
 }>;
 

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -405,12 +405,16 @@ function codeBlockExport(node: LexicalNode) {
 
 export function indexBy<T>(
   list: Array<T>,
-  callback: (arg0: T) => string,
+  callback: (arg0: T) => string | undefined,
 ): Readonly<Record<string, Array<T>>> {
   const index: Record<string, Array<T>> = {};
 
   for (const item of list) {
     const key = callback(item);
+
+    if (!key) {
+      continue;
+    }
 
     if (index[key]) {
       index[key].push(item);


### PR DESCRIPTION
In my project, I have a `TextMatchTransformer` that I use solely for  node => markdown string exports. For markdown string => node imports I'm using Multiline markdown transformers.

In order to accommodate this without having to pass fake stub properties to the `TextMatchTransformer`, this PR makes all properties optional.

Also added some much-needed JSDocs for this interface