### PR TITLE
[lexical-code] Bug Fix: Annotate @lexical/code as having side-effects for Prism

### DIFF
--- a/packages/lexical-code/package.json
+++ b/packages/lexical-code/package.json
@@ -25,7 +25,7 @@
     "@types/prismjs": "^1.26.0"
   },
   "module": "LexicalCode.mjs",
-  "sideEffects": false,
+  "sideEffects": true,
   "exports": {
     ".": {
       "import": {

--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -17,8 +17,6 @@ import type {
   TabNode,
 } from 'lexical';
 
-import './CodeHighlighterPrism';
-
 import {
   addClassNamesToElement,
   removeClassNamesFromElement,
@@ -30,6 +28,7 @@ import {
   TextNode,
 } from 'lexical';
 
+import {Prism} from './CodeHighlighterPrism';
 import {$createCodeNode} from './CodeNode';
 
 export const DEFAULT_CODE_LANGUAGE = 'javascript';
@@ -84,11 +83,11 @@ export function getLanguageFriendlyName(lang: string) {
 export const getDefaultCodeLanguage = (): string => DEFAULT_CODE_LANGUAGE;
 
 export const getCodeLanguages = (): Array<string> =>
-  Object.keys(window.Prism.languages)
+  Object.keys(Prism.languages)
     .filter(
       // Prism has several language helpers mixed into languages object
       // so filtering them out here to get langs list
-      (language) => typeof window.Prism.languages[language] !== 'function',
+      (language) => typeof Prism.languages[language] !== 'function',
     )
     .sort();
 

--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -16,8 +16,6 @@ import type {
   RangeSelection,
 } from 'lexical';
 
-import './CodeHighlighterPrism';
-
 import {mergeRegister} from '@lexical/utils';
 import {
   $createLineBreakNode,
@@ -44,6 +42,7 @@ import {
 } from 'lexical';
 import invariant from 'shared/invariant';
 
+import {Prism} from './CodeHighlighterPrism';
 import {
   $createCodeHighlightNode,
   $isCodeHighlightNode,
@@ -69,10 +68,9 @@ export interface Tokenizer {
 export const PrismTokenizer: Tokenizer = {
   defaultLanguage: DEFAULT_CODE_LANGUAGE,
   tokenize(code: string, language?: string): (string | Token)[] {
-    return window.Prism.tokenize(
+    return Prism.tokenize(
       code,
-      window.Prism.languages[language || ''] ||
-        window.Prism.languages[this.defaultLanguage],
+      Prism.languages[language || ''] || Prism.languages[this.defaultLanguage],
     );
   },
 };

--- a/packages/lexical-code/src/CodeHighlighterPrism.ts
+++ b/packages/lexical-code/src/CodeHighlighterPrism.ts
@@ -24,14 +24,5 @@ import 'prismjs/components/prism-swift';
 import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-java';
 import 'prismjs/components/prism-cpp';
-import {CAN_USE_DOM} from 'shared/canUseDOM';
 
-declare global {
-  interface Window {
-    Prism: typeof import('prismjs');
-  }
-}
-
-export const Prism: typeof import('prismjs') = CAN_USE_DOM
-  ? window.Prism
-  : (global as unknown as {Prism: typeof import('prismjs')}).Prism;
+export const Prism: typeof import('prismjs') = globalThis.Prism || window.Prism;

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package-lock.json
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "lexical-esm-astro-react",
-  "version": "0.0.1",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexical-esm-astro-react",
-      "version": "0.0.1",
+      "version": "0.17.1",
       "dependencies": {
-        "@astrojs/check": "^0.5.9",
+        "@astrojs/check": "^0.9.3",
         "@astrojs/react": "^3.1.0",
-        "@lexical/react": "^0.14.3",
-        "@lexical/utils": "^0.14.3",
+        "@lexical/react": "0.17.1",
+        "@lexical/utils": "0.17.1",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "astro": "^4.5.4",
-        "lexical": "^0.14.3",
+        "lexical": "0.17.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "^5.4.2"
@@ -37,11 +37,11 @@
       }
     },
     "node_modules/@astrojs/check": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.5.10.tgz",
-      "integrity": "sha512-vliHXM9cu/viGeKiksUM4mXfO816ohWtawTl2ADPgTsd4nUMjFiyAl7xFZhF34yy4hq4qf7jvK1F2PlR3b5I5w==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.3.tgz",
+      "integrity": "sha512-I6Dz45bMI5YRbp4yK2LKWsHH3/kkHRGdPGruGkLap6pqxhdcNh7oCgN04Ac+haDfc9ow5BYPGPmEhkwef15GQQ==",
       "dependencies": {
-        "@astrojs/language-server": "^2.8.4",
+        "@astrojs/language-server": "^2.14.1",
         "chokidar": "^3.5.3",
         "fast-glob": "^3.3.1",
         "kleur": "^4.1.5",
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.7.1.tgz",
-      "integrity": "sha512-/POejAYuj8WEw7ZI0J8JBvevjfp9jQ9Wmu/Bg52RiNwGXkMV7JnYpsenVfHvvf1G7R5sXHGKlTcxlQWhoUTiGQ=="
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.10.3.tgz",
+      "integrity": "sha512-bL/O7YBxsFt55YHU021oL+xz+B/9HvGNId3F9xURN16aeqDK9juHGktdkCSXz+U4nqFACq6ZFvWomOzhV+zfPw=="
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.4.0",
@@ -65,25 +65,28 @@
       "integrity": "sha512-6B13lz5n6BrbTqCTwhXjJXuR1sqiX/H6rTxzlXx+lN1NnV4jgnq/KJldCQaUWJzPL5SiWahQyinxAbxQtwgPHA=="
     },
     "node_modules/@astrojs/language-server": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.8.4.tgz",
-      "integrity": "sha512-sJH5vGTBkhgA8+hdhzX78UUp4cFz4Mt7xkEkevD188OS5bDMkaue6hK+dtXWM47mnrXFveXA2u38K7S+5+IRjA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.14.2.tgz",
+      "integrity": "sha512-daUJ/+/2pPF3eGG4tVdXKyw0tabUDrJKwLzU8VTuNhEHIn3VZAIES6VT3+mX0lmKcMiKM8/bjZdfY+fPfmnsMA==",
       "dependencies": {
-        "@astrojs/compiler": "^2.7.0",
+        "@astrojs/compiler": "^2.10.3",
+        "@astrojs/yaml2ts": "^0.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
-        "@volar/kit": "~2.1.5",
-        "@volar/language-core": "~2.1.5",
-        "@volar/language-server": "~2.1.5",
-        "@volar/language-service": "~2.1.5",
-        "@volar/typescript": "~2.1.5",
+        "@volar/kit": "~2.4.0",
+        "@volar/language-core": "~2.4.0",
+        "@volar/language-server": "~2.4.0",
+        "@volar/language-service": "~2.4.0",
+        "@volar/typescript": "~2.4.0",
         "fast-glob": "^3.2.12",
-        "volar-service-css": "0.0.34",
-        "volar-service-emmet": "0.0.34",
-        "volar-service-html": "0.0.34",
-        "volar-service-prettier": "0.0.34",
-        "volar-service-typescript": "0.0.34",
-        "volar-service-typescript-twoslash-queries": "0.0.34",
-        "vscode-html-languageservice": "^5.1.2",
+        "muggle-string": "^0.4.1",
+        "volar-service-css": "0.0.61",
+        "volar-service-emmet": "0.0.61",
+        "volar-service-html": "0.0.61",
+        "volar-service-prettier": "0.0.61",
+        "volar-service-typescript": "0.0.61",
+        "volar-service-typescript-twoslash-queries": "0.0.61",
+        "volar-service-yaml": "0.0.61",
+        "vscode-html-languageservice": "^5.2.0",
         "vscode-uri": "^3.0.8"
       },
       "bin": {
@@ -185,6 +188,14 @@
       ],
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@astrojs/yaml2ts": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.1.tgz",
+      "integrity": "sha512-CBaNwDQJz20E5WxzQh4thLVfhB3JEEGz72wRA+oJp6fQR37QLAqXZJU0mHC+yqMOQ6oj0GfRPJrz6hjf+zm6zA==",
+      "dependencies": {
+        "yaml": "^2.5.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -561,10 +572,37 @@
         "@emmetio/scanner": "^1.0.4"
       }
     },
+    "node_modules/@emmetio/css-parser": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.0.tgz",
+      "integrity": "sha512-z7wkxRSZgrQHXVzObGkXG+Vmj3uRlpM11oCZ9pbaz0nFejvCDmAiNDpY75+wgXOcffKpj4rzGtwGaZxfJKsJxw==",
+      "dependencies": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "node_modules/@emmetio/html-matcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
     "node_modules/@emmetio/scanner": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
       "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="
+    },
+    "node_modules/@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw=="
+    },
+    "node_modules/@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",
@@ -955,154 +993,172 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.14.3.tgz",
-      "integrity": "sha512-kMasHJQCNSSdD6US8XF/GJEZAgdmIUIoqwcV/7Q8jVUICYT53bcr+Rh7RxL+1c7ZpJE2rXg5KTELsUPGjs0uwA==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.17.1.tgz",
+      "integrity": "sha512-OVqnEfWX8XN5xxuMPo6BfgGKHREbz++D5V5ISOiml0Z8fV/TQkdgwqbBJcUdJHGRHWSUwdK7CWGs/VALvVvZyw==",
       "dependencies": {
-        "@lexical/html": "0.14.3",
-        "@lexical/list": "0.14.3",
-        "@lexical/selection": "0.14.3",
-        "@lexical/utils": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/html": "0.17.1",
+        "@lexical/list": "0.17.1",
+        "@lexical/selection": "0.17.1",
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.14.3.tgz",
-      "integrity": "sha512-eBhs+TsJ5z7Vg/0e77bau86lN7R5nqO7effkPNNndn0XV2VSDpjMF+PTj4Cd1peenFlfqVivBr9gdewDrvPQng==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.17.1.tgz",
+      "integrity": "sha512-ZspfTm6g6dN3nAb4G5bPp3SqxzdkB/bjGfa0uRKMU6/eBKtrMUgZsGxt0a8JRZ1eq2TZrQhx+l1ceRoLXii/bQ==",
       "dependencies": {
-        "@lexical/utils": "0.14.3",
-        "lexical": "0.14.3",
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1",
         "prismjs": "^1.27.0"
       }
     },
-    "node_modules/@lexical/dragon": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.14.3.tgz",
-      "integrity": "sha512-GTnt5a5Zs1f3q5Z9tC63VPzCFNAG+37ySHO+mQpVqlTsDmwSeJzFKGZyxq81tZXsKaXQZ4llc9K6I1f/XJoypw==",
+    "node_modules/@lexical/devtools-core": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.17.1.tgz",
+      "integrity": "sha512-SzL1EX9Rt5GptIo87t6nDxAc9TtYtl6DyAPNz/sCltspdd69KQgs23sTRa26/tkNFCS1jziRN7vpN3mlnmm5wA==",
       "dependencies": {
-        "lexical": "0.14.3"
+        "@lexical/html": "0.17.1",
+        "@lexical/link": "0.17.1",
+        "@lexical/mark": "0.17.1",
+        "@lexical/table": "0.17.1",
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1"
+      },
+      "peerDependencies": {
+        "react": ">=17.x",
+        "react-dom": ">=17.x"
+      }
+    },
+    "node_modules/@lexical/dragon": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.17.1.tgz",
+      "integrity": "sha512-lhBRKP7RlhiVCLtF0qiNqmMhEO6cQB43sMe7d4bvuY1G2++oKY/XAJPg6QJZdXRrCGRQ6vZ26QRNhRPmCxL5Ng==",
+      "dependencies": {
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.14.3.tgz",
-      "integrity": "sha512-BlMhegitxNscJyM0QGjnzpt7QQaiftVf80dqfiVGdgFJi9hS4wrYEsPpA7jlsZG5Q46DSw/zMRp3tpHfdU6TCQ==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.17.1.tgz",
+      "integrity": "sha512-XtP0BI8vEewAe7tzq9MC49UPUvuChuNJI/jqFp+ezZlt/RUq0BClQCOPuSlrTJhluvE2rWnUnOnVMk8ILRvggQ==",
       "dependencies": {
-        "@lexical/utils": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.14.3.tgz",
-      "integrity": "sha512-I5Ssaz+uRYsFmqN5WfKCyTkPPV1CTnEQ21vuKp8PVI4hBdlIy5aJdeQXbQhg0BdCtQVSjpm7WRGMk5ATiAXLPw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.17.1.tgz",
+      "integrity": "sha512-OU/ohajz4FXchUhghsWC7xeBPypFe50FCm5OePwo767G7P233IztgRKIng2pTT4zhCPW7S6Mfl53JoFHKehpWA==",
       "dependencies": {
-        "@lexical/utils": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.14.3.tgz",
-      "integrity": "sha512-ID4RdHdOXv2qIg6cqNhbYiqgcV5aEJFAV+zZ14CMpxPlW71tiRlmy/Pp4WqCFgjnZ2GZRq34+kag+cT2H69ILQ==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.17.1.tgz",
+      "integrity": "sha512-yGG+K2DXl7Wn2DpNuZ0Y3uCHJgfHkJN3/MmnFb4jLnH1FoJJiuy7WJb/BRRh9H+6xBJ9v70iv+kttDJ0u1xp5w==",
       "dependencies": {
-        "@lexical/selection": "0.14.3",
-        "@lexical/utils": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/selection": "0.17.1",
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.14.3.tgz",
-      "integrity": "sha512-txhuzcx2OfOtZ/fy9cgauDGW1gi2vSU0iQdde4i0UP2KK4ltioA9eFkjqAacGiPvwJ8w2CZV9q5Ck4DgFAKQ7w==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.17.1.tgz",
+      "integrity": "sha512-qFJEKBesZAtR8kfJfIVXRFXVw6dwcpmGCW7duJbtBRjdLjralOxrlVKyFhW9PEXGhi4Mdq2Ux16YnnDncpORdQ==",
       "dependencies": {
-        "@lexical/utils": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.14.3.tgz",
-      "integrity": "sha512-d9ZiEkZ34DpzBNq2GkedJpXF8sIxSQvHOGhNbVvTuBvgDcCwbmXL0KY4k+xu+jMScRO/3oR7C6YZpZT3GaUO+Q==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.17.1.tgz",
+      "integrity": "sha512-k9ZnmQuBvW+xVUtWJZwoGtiVG2cy+hxzkLGU4jTq1sqxRIoSeGcjvhFAK8JSEj4i21SgkB1FmkWXoYK5kbwtRA==",
       "dependencies": {
-        "@lexical/utils": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.14.3.tgz",
-      "integrity": "sha512-HegYMuiCazmM4XXVUzteA5bOFEiWxeIZSMK98rCV7t5czYlQmgaV5PWIT5/wLnSgrJA6apa02JHLINE9CuUHlw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.17.1.tgz",
+      "integrity": "sha512-V82SSRjvygmV+ZMwVpy5gwgr2ZDrJpl3TvEDO+G5I4SDSjbgvua8hO4dKryqiDVlooxQq9dsou0GrZ9Qtm6rYg==",
       "dependencies": {
-        "@lexical/utils": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.14.3.tgz",
-      "integrity": "sha512-G97Twk0qq5Mkj7S95fFODN6D7nBZsHiXgd2QeCZQ+qbrItEsjEsM0vCtVBELpZzyl700ExfIJCA9eHrq28VNxw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.17.1.tgz",
+      "integrity": "sha512-uexR9snyT54jfQTrbr/GZAtzX+8Oyykr4p1HS0vCVL1KU5MDuP2PoyFfOv3rcfB2TASc+aYiINhU2gSXzwCHNg==",
       "dependencies": {
-        "@lexical/code": "0.14.3",
-        "@lexical/link": "0.14.3",
-        "@lexical/list": "0.14.3",
-        "@lexical/rich-text": "0.14.3",
-        "@lexical/text": "0.14.3",
-        "@lexical/utils": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/code": "0.17.1",
+        "@lexical/link": "0.17.1",
+        "@lexical/list": "0.17.1",
+        "@lexical/rich-text": "0.17.1",
+        "@lexical/text": "0.17.1",
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.14.3.tgz",
-      "integrity": "sha512-xzyHLED9N3VPsLSpxs235W1xnh1xLl0SFqLLN9fkZs4fBLPtoPrzfYjjTMx6KgRPCa96GauAMsAaKn+JWHaD4g==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.17.1.tgz",
+      "integrity": "sha512-fX0ZSIFWwUKAjxf6l21vyXFozJGExKWyWxA+EMuOloNAGotHnAInxep0Mt8t/xcvHs7luuyQUxEPw7YrTJP7aw==",
       "dependencies": {
-        "lexical": "0.14.3"
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.14.3.tgz",
-      "integrity": "sha512-2PabHT5vCtfN1lx2d3j1AW6naGJEcjLyUxEMrPzqNZ8IDGuLbD3uRi/wS8evmFLgKkF5mqRnPPlpwGbqGg+qUw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.17.1.tgz",
+      "integrity": "sha512-oElVDq486R3rO2+Zz0EllXJGpW3tN0tfcH+joZ5h36+URKuNeKddqkJuDRvgSLOr9l8Jhtv3+/YKduPJVKMz6w==",
       "dependencies": {
-        "lexical": "0.14.3"
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.14.3.tgz",
-      "integrity": "sha512-Ct3sQmhc34Iuj0YWT5dlLzTcuCLAMx7uaLKb0lxb7A6bcUBPfC1eBv2KtILZ9eW/GEUCMTqYEnmixTY7vPR9AA==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.17.1.tgz",
+      "integrity": "sha512-CSvi4j1a4ame0OAvOKUCCmn2XrNsWcST4lExGTa9Ei/VIh8IZ+a97h4Uby8T3lqOp10x+oiizYWzY30pb9QaBg==",
       "dependencies": {
-        "@lexical/clipboard": "0.14.3",
-        "@lexical/selection": "0.14.3",
-        "@lexical/utils": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/clipboard": "0.17.1",
+        "@lexical/selection": "0.17.1",
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.14.3.tgz",
-      "integrity": "sha512-sUgF7dStJTYvkS14QzlpB5XJ5p498JDSEBSADRsf0KOJsTINAQhh27vXuS8/I2FH3FanonH/RrLwSildL/FnzA==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.17.1.tgz",
+      "integrity": "sha512-DI4k25tO0E1WyozrjaLgKMOmLjOB7+39MT4eZN9brPlU7g+w0wzdGbTZUPgPmFGIKPK+MSLybCwAJCK97j8HzQ==",
       "dependencies": {
-        "@lexical/clipboard": "0.14.3",
-        "@lexical/code": "0.14.3",
-        "@lexical/dragon": "0.14.3",
-        "@lexical/hashtag": "0.14.3",
-        "@lexical/history": "0.14.3",
-        "@lexical/link": "0.14.3",
-        "@lexical/list": "0.14.3",
-        "@lexical/mark": "0.14.3",
-        "@lexical/markdown": "0.14.3",
-        "@lexical/overflow": "0.14.3",
-        "@lexical/plain-text": "0.14.3",
-        "@lexical/rich-text": "0.14.3",
-        "@lexical/selection": "0.14.3",
-        "@lexical/table": "0.14.3",
-        "@lexical/text": "0.14.3",
-        "@lexical/utils": "0.14.3",
-        "@lexical/yjs": "0.14.3",
-        "lexical": "0.14.3",
+        "@lexical/clipboard": "0.17.1",
+        "@lexical/code": "0.17.1",
+        "@lexical/devtools-core": "0.17.1",
+        "@lexical/dragon": "0.17.1",
+        "@lexical/hashtag": "0.17.1",
+        "@lexical/history": "0.17.1",
+        "@lexical/link": "0.17.1",
+        "@lexical/list": "0.17.1",
+        "@lexical/mark": "0.17.1",
+        "@lexical/markdown": "0.17.1",
+        "@lexical/overflow": "0.17.1",
+        "@lexical/plain-text": "0.17.1",
+        "@lexical/rich-text": "0.17.1",
+        "@lexical/selection": "0.17.1",
+        "@lexical/table": "0.17.1",
+        "@lexical/text": "0.17.1",
+        "@lexical/utils": "0.17.1",
+        "@lexical/yjs": "0.17.1",
+        "lexical": "0.17.1",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -1111,59 +1167,59 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.14.3.tgz",
-      "integrity": "sha512-o8wGvRDyPSRcfb6bauF5lzK5u/kzCW+hAQq0ExM1e8p4GHDb0vwz9DA6NH5D0BPHb2fUgknwClHOoJX95WUA8A==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.17.1.tgz",
+      "integrity": "sha512-T3kvj4P1OpedX9jvxN3WN8NP1Khol6mCW2ScFIRNRz2dsXgyN00thH1Q1J/uyu7aKyGS7rzcY0rb1Pz1qFufqQ==",
       "dependencies": {
-        "@lexical/clipboard": "0.14.3",
-        "@lexical/selection": "0.14.3",
-        "@lexical/utils": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/clipboard": "0.17.1",
+        "@lexical/selection": "0.17.1",
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.14.3.tgz",
-      "integrity": "sha512-43EmqG6flLqFJJNZ7GCxFlx3qXy7osB3AQBgxKTthWtQeBrJPdgacctL1jhO7etTIQWP5C1DExy3opDLVKyDjg==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.17.1.tgz",
+      "integrity": "sha512-qBKVn+lMV2YIoyRELNr1/QssXx/4c0id9NCB/BOuYlG8du5IjviVJquEF56NEv2t0GedDv4BpUwkhXT2QbNAxA==",
       "dependencies": {
-        "lexical": "0.14.3"
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.14.3.tgz",
-      "integrity": "sha512-9btpU2lfAE34ucIqlMu5RiSVlxREXY7Zp+s26oFsXNoNPhW57iND96TrqwYo9FJl/6zXXfvqYxnUEcUD2dLgwQ==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.17.1.tgz",
+      "integrity": "sha512-2fUYPmxhyuMQX3MRvSsNaxbgvwGNJpHaKx1Ldc+PT2MvDZ6ALZkfsxbi0do54Q3i7dOon8/avRp4TuVaCnqvoA==",
       "dependencies": {
-        "@lexical/utils": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/utils": "0.17.1",
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.14.3.tgz",
-      "integrity": "sha512-7+B9KkA37iHTlPqt6GHdfBIoaA9dQfhKrQNP9+422/CO/adCru4S94yNxiHXFq7iCvgucfuFop9M8jOfqLQbBQ==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.17.1.tgz",
+      "integrity": "sha512-zD2pAGXaMfPpT8PeNrx3+n0+jGnQORHyn0NEBO+hnyacKfUq5z5sI6Gebsq5NwH789bRadmJM5LvX5w8fsuv6w==",
       "dependencies": {
-        "lexical": "0.14.3"
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.14.3.tgz",
-      "integrity": "sha512-coqG2AO7QhJCM0xBlYvtETjl0il9u4HQRuc8ye3j8jMfNadVvVVWO3Fodmm/8FTPyJuxIij1Ruma9zqhlAbN6Q==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.17.1.tgz",
+      "integrity": "sha512-jCQER5EsvhLNxKH3qgcpdWj/necUb82Xjp8qWQ3c0tyL07hIRm2tDRA/s9mQmvcP855HEZSmGVmR5SKtkcEAVg==",
       "dependencies": {
-        "@lexical/list": "0.14.3",
-        "@lexical/selection": "0.14.3",
-        "@lexical/table": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/list": "0.17.1",
+        "@lexical/selection": "0.17.1",
+        "@lexical/table": "0.17.1",
+        "lexical": "0.17.1"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.14.3.tgz",
-      "integrity": "sha512-Ju+PQJg4NjQoNzfPlQKa6A71sjgGWj5lL4cbe+4xlNoknfK3NApVeznOi3xAM7rUCr6fPBAjzF9/uwfMXR451g==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.17.1.tgz",
+      "integrity": "sha512-9mn5PDtaH5uLMH6hQ59EAx5FkRzmJJFcVs3E6zSIbtgkG3UASR3CFEfgsLKTjl/GC5NnTGuMck+jXaupDVBhOg==",
       "dependencies": {
-        "@lexical/offset": "0.14.3",
-        "lexical": "0.14.3"
+        "@lexical/offset": "0.17.1",
+        "lexical": "0.17.1"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1536,12 +1592,12 @@
       }
     },
     "node_modules/@volar/kit": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.1.6.tgz",
-      "integrity": "sha512-dSuXChDGM0nSG/0fxqlNfadjpAeeo1P1SJPBQ+pDf8H1XrqeJq5gIhxRTEbiS+dyNIG69ATq1CArkbCif+oxJw==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.5.tgz",
+      "integrity": "sha512-ZzyErW5UiDfiIuJ/lpqc2Kx5PHDGDZ/bPlPJYpRcxlrn8Z8aDhRlsLHkNKcNiH65TmNahk2kbLaiejiqu6BD3A==",
       "dependencies": {
-        "@volar/language-service": "2.1.6",
-        "@volar/typescript": "2.1.6",
+        "@volar/language-service": "2.4.5",
+        "@volar/typescript": "2.4.5",
         "typesafe-path": "^0.2.2",
         "vscode-languageserver-textdocument": "^1.0.11",
         "vscode-uri": "^3.0.8"
@@ -1551,23 +1607,21 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.1.6.tgz",
-      "integrity": "sha512-pAlMCGX/HatBSiDFMdMyqUshkbwWbLxpN/RL7HCQDOo2gYBE+uS+nanosLc1qR6pTQ/U8q00xt8bdrrAFPSC0A==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.5.tgz",
+      "integrity": "sha512-F4tA0DCO5Q1F5mScHmca0umsi2ufKULAnMOVBfMsZdT4myhVl4WdKRwCaKcfOkIEuyrAVvtq1ESBdZ+rSyLVww==",
       "dependencies": {
-        "@volar/source-map": "2.1.6"
+        "@volar/source-map": "2.4.5"
       }
     },
     "node_modules/@volar/language-server": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.1.6.tgz",
-      "integrity": "sha512-0w+FV8ro37hVb3qE4ONo3VbS5kEQXv4H/D2xCePyY5dRw6XnbJAPFNKvoxI9mxHTPonvIG1si5rN9MSGSKtgZQ==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.5.tgz",
+      "integrity": "sha512-l5PswE0JzCtstTlwBUpikeSa3lNUBJhTuWtj9KclZTGi2Uex4RcqGOhTiDsUUtvdv/hEuYCxGq1EdJJPlQsD/g==",
       "dependencies": {
-        "@volar/language-core": "2.1.6",
-        "@volar/language-service": "2.1.6",
-        "@volar/snapshot-document": "2.1.6",
-        "@volar/typescript": "2.1.6",
-        "@vscode/l10n": "^0.0.16",
+        "@volar/language-core": "2.4.5",
+        "@volar/language-service": "2.4.5",
+        "@volar/typescript": "2.4.5",
         "path-browserify": "^1.0.1",
         "request-light": "^0.7.0",
         "vscode-languageserver": "^9.0.1",
@@ -1577,46 +1631,35 @@
       }
     },
     "node_modules/@volar/language-service": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.1.6.tgz",
-      "integrity": "sha512-1OpbbPQ6wUIumwMP5r45y8utVEmvq1n6BC8JHqGKsuFr9RGFIldDBlvA/xuO3MDKhjmmPGPHKb54kg1/YN78ow==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.5.tgz",
+      "integrity": "sha512-xiFlL0aViGg6JhwAXyohPrdlID13uom8WQg6DWYaV8ob8RRy+zoLlBUI8SpQctwlWEO9poyrYK01revijAwkcw==",
       "dependencies": {
-        "@volar/language-core": "2.1.6",
+        "@volar/language-core": "2.4.5",
         "vscode-languageserver-protocol": "^3.17.5",
         "vscode-languageserver-textdocument": "^1.0.11",
         "vscode-uri": "^3.0.8"
       }
     },
-    "node_modules/@volar/snapshot-document": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/snapshot-document/-/snapshot-document-2.1.6.tgz",
-      "integrity": "sha512-YNYk1sCOrGg7VHbZM+1It97q0GWhFxdqIwnxSNFoL0X1LuSRXoCT2DRb/aa1J6aBpPMbKqSFUWHGQEAFUnc4Zw==",
-      "dependencies": {
-        "vscode-languageserver-protocol": "^3.17.5",
-        "vscode-languageserver-textdocument": "^1.0.11"
-      }
-    },
     "node_modules/@volar/source-map": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.1.6.tgz",
-      "integrity": "sha512-TeyH8pHHonRCHYI91J7fWUoxi0zWV8whZTVRlsWHSYfjm58Blalkf9LrZ+pj6OiverPTmrHRkBsG17ScQyWECw==",
-      "dependencies": {
-        "muggle-string": "^0.4.0"
-      }
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.5.tgz",
+      "integrity": "sha512-varwD7RaKE2J/Z+Zu6j3mNNJbNT394qIxXwdvz/4ao/vxOfyClZpSDtLKkwWmecinkOVos5+PWkWraelfMLfpw=="
     },
     "node_modules/@volar/typescript": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.1.6.tgz",
-      "integrity": "sha512-JgPGhORHqXuyC3r6skPmPHIZj4LoMmGlYErFTuPNBq9Nhc9VTv7ctHY7A3jMN3ngKEfRrfnUcwXHztvdSQqNfw==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.5.tgz",
+      "integrity": "sha512-mcT1mHvLljAEtHviVcBuOyAwwMKz1ibXTi5uYtP/pf4XxoAzpdkQ+Br2IC0NPCvLCbjPZmbf3I0udndkfB1CDg==",
       "dependencies": {
-        "@volar/language-core": "2.1.6",
-        "path-browserify": "^1.0.1"
+        "@volar/language-core": "2.4.5",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
       }
     },
     "node_modules/@vscode/emmet-helper": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.9.2.tgz",
-      "integrity": "sha512-MaGuyW+fa13q3aYsluKqclmh62Hgp0BpKIqS66fCxfOaBcVQ1OnMQxRRgQUYnCkxFISAQlkJ0qWWPyXjro1Qrg==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.9.3.tgz",
+      "integrity": "sha512-rB39LHWWPQYYlYfpv9qCoZOVioPCftKXXqrsyqN1mTWZM6dTnONT63Db+03vgrBbHzJN45IrgS/AGxw9iiqfEw==",
       "dependencies": {
         "emmet": "^2.4.3",
         "jsonc-parser": "^2.3.0",
@@ -1631,9 +1674,9 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "node_modules/@vscode/l10n": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.16.tgz",
-      "integrity": "sha512-JT5CvrIYYCrmB+dCana8sUqJEcGB1ZDXNLMQ2+42bW995WmNoenijWMUdZfwmuQUTQcEVVIa2OecZzTYWUW9Cg=="
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -1644,6 +1687,21 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-align": {
@@ -2575,9 +2633,9 @@
       "integrity": "sha512-OGkMXLY7XH6ykHE5ZOVVIMHaGAvvxqw98cswTKB683dntBJre7ufm9wouJ0ExDm0VXhHenU8mREvxIbV5nNoVQ=="
     },
     "node_modules/emmet": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.7.tgz",
-      "integrity": "sha512-O5O5QNqtdlnQM2bmKHtJgyChcrFMgQuulI+WdiOw2NArzprUqqxUW6bgYtKvzKgrsYpuLWalOkdhNP+1jluhCA==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.8.tgz",
+      "integrity": "sha512-wFe/dxsx7oi/M2UJ/3yBu4Fm24Irho6lqut4C1YFaZebCvCCMygoDGC7W6I+8+K8PAjfa/Ojn52UHi8WCdDiRA==",
       "dependencies": {
         "@emmetio/abbreviation": "^2.3.3",
         "@emmetio/css-abbreviation": "^2.1.8"
@@ -2738,6 +2796,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -2758,6 +2821,11 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -3421,6 +3489,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3454,14 +3527,14 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.14.3.tgz",
-      "integrity": "sha512-LaWSKj6OpvJ+bdfQA2AybEzho0YoWfAdRGkuCtPNYd/uf7IHyoEwCFQsIBvWCQF23saDgE1NONR4uiwl6iaJ9g=="
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.17.1.tgz",
+      "integrity": "sha512-72/MhR7jqmyqD10bmJw8gztlCm4KDDT+TPtU4elqXrEvHoO5XENi34YAEUD9gIkPfqSwyLa9mwAX1nKzIr5xEA=="
     },
     "node_modules/lib0": {
-      "version": "0.2.93",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.93.tgz",
-      "integrity": "sha512-M5IKsiFJYulS+8Eal8f+zAqf5ckm1vffW0fFDxfgxJ+uiVopvDdd3PxJmz0GsVi3YNO7QCFSq0nAsiDmNhLj9Q==",
+      "version": "0.2.97",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.97.tgz",
+      "integrity": "sha512-Q4d1ekgvufi9FiHkkL46AhecfNjznSL9MRNoJRQ76gBHS9OqU2ArfQK0FvBpuxgWeJeNI0LVgAYMIpsGeX4gYg==",
       "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -3526,6 +3599,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/log-symbols": {
       "version": "5.1.0",
@@ -5050,6 +5128,21 @@
         "node": ">=8.15"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "optional": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
@@ -5353,6 +5446,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6309,42 +6410,23 @@
       }
     },
     "node_modules/typescript-auto-import-cache": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.2.tgz",
-      "integrity": "sha512-+laqe5SFL1vN62FPOOJSUDTZxtgsoOXjneYOXIpx5rQ4UMiN89NAtJLpqLqyebv9fgQ/IMeeTX+mQyRnwvJzvg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.3.tgz",
+      "integrity": "sha512-ojEC7+Ci1ij9eE6hp8Jl9VUNnsEKzztktP5gtYNRMrTmfXVwA1PITYYAkpxCvvupdSYa/Re51B6KMcv1CTZEUA==",
       "dependencies": {
         "semver": "^7.3.8"
       }
     },
-    "node_modules/typescript-auto-import-cache/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/typescript-auto-import-cache/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/typescript-auto-import-cache/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/ultrahtml": {
       "version": "1.5.3",
@@ -7026,16 +7108,16 @@
       }
     },
     "node_modules/volar-service-css": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.34.tgz",
-      "integrity": "sha512-C7ua0j80ZD7bsgALAz/cA1bykPehoIa5n+3+Ccr+YLpj0fypqw9iLUmGLX11CqzqNCO2XFGe/1eXB/c+SWrF/g==",
+      "version": "0.0.61",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.61.tgz",
+      "integrity": "sha512-Ct9L/w+IB1JU8F4jofcNCGoHy6TF83aiapfZq9A0qYYpq+Kk5dH+ONS+rVZSsuhsunq8UvAuF8Gk6B8IFLfniw==",
       "dependencies": {
-        "vscode-css-languageservice": "^6.2.10",
+        "vscode-css-languageservice": "^6.3.0",
         "vscode-languageserver-textdocument": "^1.0.11",
         "vscode-uri": "^3.0.8"
       },
       "peerDependencies": {
-        "@volar/language-service": "~2.1.0"
+        "@volar/language-service": "~2.4.0"
       },
       "peerDependenciesMeta": {
         "@volar/language-service": {
@@ -7044,15 +7126,17 @@
       }
     },
     "node_modules/volar-service-emmet": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.34.tgz",
-      "integrity": "sha512-ubQvMCmHPp8Ic82LMPkgrp9ot+u2p/RDd0RyT0EykRkZpWsagHUF5HWkVheLfiMyx2rFuWx/+7qZPOgypx6h6g==",
+      "version": "0.0.61",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.61.tgz",
+      "integrity": "sha512-iiYqBxjjcekqrRruw4COQHZME6EZYWVbkHjHDbULpml3g8HGJHzpAMkj9tXNCPxf36A+f1oUYjsvZt36qPg4cg==",
       "dependencies": {
-        "@vscode/emmet-helper": "^2.9.2",
-        "vscode-html-languageservice": "^5.1.0"
+        "@emmetio/css-parser": "^0.4.0",
+        "@emmetio/html-matcher": "^1.3.0",
+        "@vscode/emmet-helper": "^2.9.3",
+        "vscode-uri": "^3.0.8"
       },
       "peerDependencies": {
-        "@volar/language-service": "~2.1.0"
+        "@volar/language-service": "~2.4.0"
       },
       "peerDependenciesMeta": {
         "@volar/language-service": {
@@ -7061,16 +7145,16 @@
       }
     },
     "node_modules/volar-service-html": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.34.tgz",
-      "integrity": "sha512-kMEneea1tQbiRcyKavqdrSVt8zV06t+0/3pGkjO3gV6sikXTNShIDkdtB4Tq9vE2cQdM50TuS7utVV7iysUxHw==",
+      "version": "0.0.61",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.61.tgz",
+      "integrity": "sha512-yFE+YmmgqIL5HI4ORqP++IYb1QaGcv+xBboI0WkCxJJ/M35HZj7f5rbT3eQ24ECLXFbFCFanckwyWJVz5KmN3Q==",
       "dependencies": {
-        "vscode-html-languageservice": "^5.1.0",
+        "vscode-html-languageservice": "^5.3.0",
         "vscode-languageserver-textdocument": "^1.0.11",
         "vscode-uri": "^3.0.8"
       },
       "peerDependencies": {
-        "@volar/language-service": "~2.1.0"
+        "@volar/language-service": "~2.4.0"
       },
       "peerDependenciesMeta": {
         "@volar/language-service": {
@@ -7079,14 +7163,14 @@
       }
     },
     "node_modules/volar-service-prettier": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.34.tgz",
-      "integrity": "sha512-BNfJ8FwfPi1Wm/JkuzNjraOLdtKieGksNT/bDyquygVawv1QUzO2HB1hiMKfZGdcSFG5ZL9R0j7bBfRTfXA2gg==",
+      "version": "0.0.61",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.61.tgz",
+      "integrity": "sha512-F612nql5I0IS8HxXemCGvOR2Uxd4XooIwqYVUvk7WSBxP/+xu1jYvE3QJ7EVpl8Ty3S4SxPXYiYTsG3bi+gzIQ==",
       "dependencies": {
         "vscode-uri": "^3.0.8"
       },
       "peerDependencies": {
-        "@volar/language-service": "~2.1.0",
+        "@volar/language-service": "~2.4.0",
         "prettier": "^2.2 || ^3.0"
       },
       "peerDependenciesMeta": {
@@ -7099,18 +7183,19 @@
       }
     },
     "node_modules/volar-service-typescript": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.34.tgz",
-      "integrity": "sha512-NbAry0w8ZXFgGsflvMwmPDCzgJGx3C+eYxFEbldaumkpTAJiywECWiUbPIOfmEHgpOllUKSnhwtLlWFK4YnfQg==",
+      "version": "0.0.61",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.61.tgz",
+      "integrity": "sha512-4kRHxVbW7wFBHZWRU6yWxTgiKETBDIJNwmJUAWeP0mHaKpnDGj/astdRFKqGFRYVeEYl45lcUPhdJyrzanjsdQ==",
       "dependencies": {
         "path-browserify": "^1.0.1",
-        "semver": "^7.5.4",
-        "typescript-auto-import-cache": "^0.3.1",
+        "semver": "^7.6.2",
+        "typescript-auto-import-cache": "^0.3.3",
         "vscode-languageserver-textdocument": "^1.0.11",
-        "vscode-nls": "^5.2.0"
+        "vscode-nls": "^5.2.0",
+        "vscode-uri": "^3.0.8"
       },
       "peerDependencies": {
-        "@volar/language-service": "~2.1.0"
+        "@volar/language-service": "~2.4.0"
       },
       "peerDependenciesMeta": {
         "@volar/language-service": {
@@ -7119,11 +7204,14 @@
       }
     },
     "node_modules/volar-service-typescript-twoslash-queries": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.34.tgz",
-      "integrity": "sha512-XAY2YtWKUp6ht89gxt3L5Dr46LU45d/VlBkj1KXUwNlinpoWiGN4Nm3B6DRF3VoBThAnQgm4c7WD0S+5yTzh+w==",
+      "version": "0.0.61",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.61.tgz",
+      "integrity": "sha512-99FICGrEF0r1E2tV+SvprHPw9Knyg7BdW2fUch0tf59kG+KG+Tj4tL6tUg+cy8f23O/VXlmsWFMIE+bx1dXPnQ==",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
       "peerDependencies": {
-        "@volar/language-service": "~2.1.0"
+        "@volar/language-service": "~2.4.0"
       },
       "peerDependenciesMeta": {
         "@volar/language-service": {
@@ -7131,24 +7219,10 @@
         }
       }
     },
-    "node_modules/volar-service-typescript/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/volar-service-typescript/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7156,42 +7230,64 @@
         "node": ">=10"
       }
     },
-    "node_modules/volar-service-typescript/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    "node_modules/volar-service-yaml": {
+      "version": "0.0.61",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.61.tgz",
+      "integrity": "sha512-L+gbDiLDQQ1rZUbJ3mf3doDsoQUa8OZM/xdpk/unMg1Vz24Zmi2Ign8GrZyBD7bRoIQDwOH9gdktGDKzRPpUNw==",
+      "dependencies": {
+        "vscode-uri": "^3.0.8",
+        "yaml-language-server": "~1.15.0"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
     },
     "node_modules/vscode-css-languageservice": {
-      "version": "6.2.13",
-      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.13.tgz",
-      "integrity": "sha512-2rKWXfH++Kxd9Z4QuEgd1IF7WmblWWU7DScuyf1YumoGLkY9DW6wF/OTlhOyO2rN63sWHX2dehIpKBbho4ZwvA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.1.tgz",
+      "integrity": "sha512-1BzTBuJfwMc3A0uX4JBdJgoxp74cjj4q2mDJdp49yD/GuAq4X0k5WtK6fNcMYr+FfJ9nqgR6lpfCSZDkARJ5qQ==",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
-        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-languageserver-types": "3.17.5",
         "vscode-uri": "^3.0.8"
       }
     },
-    "node_modules/vscode-css-languageservice/node_modules/@vscode/l10n": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
-      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="
-    },
     "node_modules/vscode-html-languageservice": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.2.0.tgz",
-      "integrity": "sha512-cdNMhyw57/SQzgUUGSIMQ66jikqEN6nBNyhx5YuOyj9310+eY9zw8Q0cXpiKzDX8aHYFewQEXRnigl06j/TVwQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.3.1.tgz",
+      "integrity": "sha512-ysUh4hFeW/WOWz/TO9gm08xigiSsV/FOAZ+DolgJfeLftna54YdmZ4A+lIn46RbdO3/Qv5QHTn1ZGqmrXQhZyA==",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
-        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-languageserver-types": "^3.17.5",
         "vscode-uri": "^3.0.8"
       }
     },
-    "node_modules/vscode-html-languageservice/node_modules/@vscode/l10n": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
-      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
@@ -7222,9 +7318,9 @@
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
-      "integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
@@ -7386,6 +7482,86 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
+    "node_modules/yaml": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/yaml-language-server": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.15.0.tgz",
+      "integrity": "sha512-N47AqBDCMQmh6mBLmI6oqxryHRzi33aPFPsJhYy3VTUGCdLHYjGh4FZzpUjRlphaADBBkDmnkM/++KNIOHi5Rw==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "lodash": "4.17.21",
+        "request-light": "^0.5.7",
+        "vscode-json-languageservice": "4.1.8",
+        "vscode-languageserver": "^7.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2",
+        "yaml": "2.2.2"
+      },
+      "bin": {
+        "yaml-language-server": "bin/yaml-language-server"
+      },
+      "optionalDependencies": {
+        "prettier": "2.8.7"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="
+    },
+    "node_modules/yaml-language-server/node_modules/vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "engines": {
+        "node": ">=8.0.0 || >=10.0.0"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/vscode-languageserver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.16.0"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "dependencies": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+    },
+    "node_modules/yaml-language-server/node_modules/yaml": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -7449,9 +7625,9 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.14",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.14.tgz",
-      "integrity": "sha512-D+7KcUr0j+vBCUSKXXEWfA+bG4UQBviAwP3gYBhkstkgwy5+8diOPMx0iqLIOxNo/HxaREUimZRxqHGAHCL2BQ==",
+      "version": "13.6.19",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.19.tgz",
+      "integrity": "sha512-GNKw4mEUn5yWU2QPHRx8jppxmCm9KzbBhB4qJLUJFiiYD0g/tDVgXQ7aPkyh01YO28kbs2J/BEbWBagjuWyejw==",
       "peer": true,
       "dependencies": {
         "lib0": "^0.2.86"

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package.json
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package.json
@@ -11,7 +11,7 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "@astrojs/check": "^0.5.9",
+    "@astrojs/check": "^0.9.3",
     "@astrojs/react": "^3.1.0",
     "@lexical/react": "0.17.1",
     "@lexical/utils": "0.17.1",
@@ -26,6 +26,5 @@
   "devDependencies": {
     "@playwright/test": "^1.43.1"
   },
-  "sideEffects": false,
-  "exports": {}
+  "sideEffects": false
 }

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/src/env.d.ts
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/src/env.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />


### PR DESCRIPTION
## Description

The change in #6562 appears to have triggered an issue with astro's rollup configuration which will treeshake Prism out of @lexical/code, since it is only an import side-effect. Marking the package.json as having sideEffects is sufficient to fix it.

Note that #6650 currently has this commit included so the integration tests pass, but I made it a separate PR in case we want to review/merge separately.

## Test plan

### Before

Integration tests in #6650 were failing

### After

Integration tests pass