### PR TITLE
[lexical-link] Bug Fix: Removing a link from descendants

### DIFF
--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -18,7 +18,11 @@ import type {
   SerializedElementNode,
 } from 'lexical';
 
-import {addClassNamesToElement, isHTMLAnchorElement} from '@lexical/utils';
+import {
+  $findMatchingParent,
+  addClassNamesToElement,
+  isHTMLAnchorElement,
+} from '@lexical/utils';
 import {
   $applyNodeReplacement,
   $getSelection,
@@ -495,16 +499,20 @@ export function $toggleLink(
   if (url === null) {
     // Remove LinkNodes
     nodes.forEach((node) => {
-      const parent = node.getParent();
+      const parentLink = $findMatchingParent(
+        node,
+        (parent): parent is LinkNode =>
+          !$isAutoLinkNode(parent) && $isLinkNode(parent),
+      );
 
-      if (!$isAutoLinkNode(parent) && $isLinkNode(parent)) {
-        const children = parent.getChildren();
+      if (parentLink) {
+        const children = parentLink.getChildren();
 
         for (let i = 0; i < children.length; i++) {
-          parent.insertBefore(children[i]);
+          parentLink.insertBefore(children[i]);
         }
 
-        parent.remove();
+        parentLink.remove();
       }
     });
   } else {


### PR DESCRIPTION
## Description

At the moment it is possible to delete LinkNode only when children are TextNode. But if there is another node inside the link above the text, deletion will not work.

With this PR I fix this behavior and show how it works using the MarkNode example (via adding a comment) in lexical-playground

## Test plan

### Before

https://github.com/user-attachments/assets/669a5ed9-926d-477c-9f7b-14c2a72d6577

### After

https://github.com/user-attachments/assets/6a56895c-2b08-4862-8787-ba0cef492d2d
