### PR TITLE
[lexical-playground] Bug Fix: Correct ExcalidrawNode DOM handling for proper resizing

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -110,25 +110,13 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
     const span = document.createElement('span');
     const theme = config.theme;
     const className = theme.image;
-
-    span.style.display = 'inline-block';
-
-    span.style.width =
-      this.__width === 'inherit' ? 'inherit' : `${this.__width}px`;
-    span.style.height =
-      this.__height === 'inherit' ? 'inherit' : `${this.__height}px`;
-
     if (className !== undefined) {
       span.className = className;
     }
     return span;
   }
 
-  updateDOM(prevNode: ExcalidrawNode, dom: HTMLElement): boolean {
-    dom.style.width =
-      this.__width === 'inherit' ? 'inherit' : `${this.__width}px`;
-    dom.style.height =
-      this.__height === 'inherit' ? 'inherit' : `${this.__height}px`;
+  updateDOM(): false {
     return false;
   }
 


### PR DESCRIPTION
## Description
In PR #6634, I made a mistake in how the ExcalidrawNode handles DOM creation and updates. I incorrectly added inline styles for width and height directly in the `createDOM` and `updateDOM` methods.

I am reverting the incorrect changes I made.

## Test plan

### Before
- After the first resize, for subsequence resizes, the handles don't update onDrag and only update on release.

https://github.com/user-attachments/assets/398cf56b-c573-45dd-9949-686ec7834567


### After
- The resize handles work as expected
- The bug from PR #6634 is still fixed

https://github.com/user-attachments/assets/e5c3b8ce-38cf-4ed0-9e49-ec863fa08d9e

