### PR TITLE
[lexical-markdown] set shouldMergeAdjacentLines default to be false 

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -550,7 +550,7 @@ export const LINK: TextMatchTransformer = {
 
 export function normalizeMarkdown(
   input: string,
-  shouldMergeAdjacentLines = true,
+  shouldMergeAdjacentLines = false,
 ): string {
   const lines = input.split('\n');
   let inCodeBlock = false;

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -524,7 +524,7 @@ E3
 | --- | --- |
 | c | d |
 `;
-    expect(normalizeMarkdown(markdown)).toBe(markdown);
+    expect(normalizeMarkdown(markdown, true)).toBe(markdown);
   });
 });
 
@@ -602,6 +602,6 @@ E3
 | --- | --- |
 | c | d |
 `;
-    expect(normalizeMarkdown(markdown)).toBe(markdown);
+    expect(normalizeMarkdown(markdown, false)).toBe(markdown);
   });
 });

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -100,6 +100,7 @@ describe('Markdown', () => {
       // Multiline paragraphs: https://spec.commonmark.org/dingus/?text=Hello%0Aworld%0A!
       html: '<p><span style="white-space: pre-wrap;">Helloworld!</span></p>',
       md: ['Hello', 'world', '!'].join('\n'),
+      shouldMergeAdjacentLines: true,
       skipExport: true,
     },
     {
@@ -125,6 +126,7 @@ describe('Markdown', () => {
       // Multiline list items: https://spec.commonmark.org/dingus/?text=-%20Hello%0A-%20world%0A!%0A!
       html: '<ul><li value="1"><span style="white-space: pre-wrap;">Hello</span></li><li value="2"><span style="white-space: pre-wrap;">world!!</span></li></ul>',
       md: '- Hello\n- world\n!\n!',
+      shouldMergeAdjacentLines: true,
       skipExport: true,
     },
     {
@@ -314,6 +316,7 @@ describe('Markdown', () => {
       // https://spec.commonmark.org/dingus/?text=%3E%20Hello%0Aworld%0A!
       html: '<blockquote><span style="white-space: pre-wrap;">Helloworld!</span></blockquote>',
       md: '> Hello\nworld\n!',
+      shouldMergeAdjacentLines: true,
       skipExport: true,
     },
     {
@@ -332,11 +335,13 @@ describe('Markdown', () => {
       customTransformers: [MDX_HTML_TRANSFORMER],
       html: '<p><span style="white-space: pre-wrap;">Some HTML in mdx:</span></p><pre spellcheck="false" data-language="MyComponent"><span style="white-space: pre-wrap;">From HTML: Some Text</span></pre>',
       md: 'Some HTML in mdx:\n\n<MyComponent>Some Text</MyComponent>',
+      shouldMergeAdjacentLines: true,
     },
     {
       customTransformers: [MDX_HTML_TRANSFORMER],
       html: '<p><span style="white-space: pre-wrap;">Some HTML in mdx:</span></p><pre spellcheck="false" data-language="MyComponent"><span style="white-space: pre-wrap;">From HTML: Line 1Some Text</span></pre>',
       md: 'Some HTML in mdx:\n\n<MyComponent>Line 1\nSome Text</MyComponent>',
+      shouldMergeAdjacentLines: true,
       skipExport: true,
     },
   ];
@@ -448,7 +453,7 @@ describe('Markdown', () => {
   }
 });
 
-describe('normalizeMarkdown', () => {
+describe('normalizeMarkdown - shouldMergeAdjacentLines', () => {
   it('should combine lines separated by a single \n unless they are in a codeblock', () => {
     const markdown = `
 A1
@@ -482,7 +487,7 @@ E2
 
 E3
 `;
-    expect(normalizeMarkdown(markdown)).toBe(`
+    expect(normalizeMarkdown(markdown, true)).toBe(`
 A1A2
 
 A3

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -453,7 +453,7 @@ describe('Markdown', () => {
   }
 });
 
-describe('normalizeMarkdown - shouldMergeAdjacentLines', () => {
+describe('normalizeMarkdown - shouldMergeAdjacentLines = true', () => {
   it('should combine lines separated by a single \n unless they are in a codeblock', () => {
     const markdown = `
 A1
@@ -513,6 +513,84 @@ D3
 \`\`\`single line code\`\`\`
 
 E1E2
+
+E3
+`);
+  });
+
+  it('tables', () => {
+    const markdown = `
+| a | b |
+| --- | --- |
+| c | d |
+`;
+    expect(normalizeMarkdown(markdown)).toBe(markdown);
+  });
+});
+
+describe('normalizeMarkdown - shouldMergeAdjacentLines = false', () => {
+  it('should not combine lines separated by a single \n', () => {
+    const markdown = `
+A1
+A2
+
+A3
+
+\`\`\`md
+B1
+B2
+
+B3
+\`\`\`
+
+C1
+C2
+
+C3
+
+\`\`\`js
+D1
+D2
+
+D3
+\`\`\`
+
+\`\`\`single line code\`\`\`
+
+E1
+E2
+
+E3
+`;
+    expect(normalizeMarkdown(markdown, false)).toBe(`
+A1
+A2
+
+A3
+
+\`\`\`md
+B1
+B2
+
+B3
+\`\`\`
+
+C1
+C2
+
+C3
+
+\`\`\`js
+D1
+D2
+
+D3
+\`\`\`
+
+\`\`\`single line code\`\`\`
+
+E1
+E2
 
 E3
 `);

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -85,7 +85,7 @@ function $convertFromMarkdownString(
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
   shouldPreserveNewLines = false,
-  shouldMergeAdjacentLines = true,
+  shouldMergeAdjacentLines = false,
 ): void {
   const sanitizedMarkdown = shouldPreserveNewLines
     ? markdown

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -1310,6 +1310,7 @@ const IMPORTED_MARKDOWN_HTML = html`
       bold italic strikethrough
     </strong>
     <span data-lexical-text="true">text,</span>
+    <br />
     <strong
       class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__textStrikethrough"
       data-lexical-text="true">
@@ -1407,7 +1408,9 @@ const IMPORTED_MARKDOWN_HTML = html`
     dir="ltr">
     <span data-lexical-text="true">Blockquotes text goes here</span>
     <br />
-    <span data-lexical-text="true">And secondline after</span>
+    <span data-lexical-text="true">And second</span>
+    <br />
+    <span data-lexical-text="true">line after</span>
   </blockquote>
   <blockquote
     class="PlaygroundEditorTheme__quote PlaygroundEditorTheme__ltr"
@@ -1485,9 +1488,9 @@ const IMPORTED_MARKDOWN_HTML = html`
           class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
           dir="ltr"
           value="1">
-          <span data-lexical-text="true">
-            And can be nested and multiline as well
-          </span>
+          <span data-lexical-text="true">And can be nested</span>
+          <br />
+          <span data-lexical-text="true">and multiline as well</span>
         </li>
       </ol>
     </li>


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
For backwards compatibility, setting default shouldMergeAdjacentLines = false to not introduce breaking change from the previous npm release. 

Github Flavoured Markdown has the same behavior as shouldMergeAdjacentLines = false:


https://github.com/user-attachments/assets/c3dabbf7-d666-44dc-a586-2d03c0a01cec



## Test plan

npm run test-unit
npm run test-e2e-chromium
