### PR TITLE
[lexical-yjs] Bug Fix: Add missing setLocalStateField method to ProviderAwareness type

### DIFF
--- a/packages/lexical-react/src/__tests__/unit/LexicalCollaborationPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalCollaborationPlugin.test.tsx
@@ -53,6 +53,7 @@ describe(`LexicalCollaborationPlugin`, () => {
             off: () => {},
             on: () => {},
             setLocalState: () => {},
+            setLocalStateField: () => {},
           },
           connect: () => {},
           disconnect: () => {},

--- a/packages/lexical-react/src/__tests__/unit/utils.tsx
+++ b/packages/lexical-react/src/__tests__/unit/utils.tsx
@@ -82,6 +82,7 @@ export class Client implements Provider {
     off(): void;
     on(): void;
     setLocalState: (state: UserState) => void;
+    setLocalStateField: (field: string, value: unknown) => void;
   };
 
   constructor(id: Client['_id'], connection: Client['_connection']) {
@@ -104,6 +105,9 @@ export class Client implements Provider {
 
       setLocalState: (state) => {
         this._awarenessState = state;
+      },
+      setLocalStateField: (field: string, value: unknown) => {
+        // TODO
       },
     };
   }

--- a/packages/lexical-yjs/src/index.ts
+++ b/packages/lexical-yjs/src/index.ts
@@ -32,6 +32,7 @@ export type ProviderAwareness = {
   off: (type: 'update', cb: () => void) => void;
   on: (type: 'update', cb: () => void) => void;
   setLocalState: (arg0: UserState) => void;
+  setLocalStateField: (field: string, value: unknown) => void;
 };
 declare interface Provider {
   awareness: ProviderAwareness;


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

The current type definition doesn't include the `setLocalStateField` method, which can lead to TypeScript errors when using this method and prevents proper code completion in IDEs. This change improves type safety and developer experience when working with the `lexical-yjs` package.

This PR adds the missing `setLocalStateField` method to the `ProviderAwareness` type in the `lexical-yjs` package([ref](https://github.com/yjs/y-protocols/blob/master/awareness.js#L141)). This method is present in the actual implementation of awareness providers but was not reflected in the TypeScript type definition.


## Test plan

### Before

--

### After

--