### PR TITLE
[lexical] Bug Fix: removeText for token text nodes

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1130,14 +1130,15 @@ export class RangeSelection implements BaseSelection {
     });
 
     const fixText = (node: TextNode, del: number) => {
-      if (node.getTextContent() === '') {
+      if (node.getTextContent() === '' || (del !== 0 && node.isToken())) {
         node.remove();
-      } else if (del !== 0 && $isTokenOrSegmented(node)) {
+      } else if (del !== 0 && node.isSegmented()) {
         const textNode = $createTextNode(node.getTextContent());
         textNode.setFormat(node.getFormat());
         textNode.setStyle(node.getStyle());
         return node.replace(textNode);
       }
+      return node;
     };
     if (firstNode === lastNode && $isTextNode(firstNode)) {
       const del = Math.abs(focus.offset - anchor.offset);
@@ -1148,11 +1149,11 @@ export class RangeSelection implements BaseSelection {
     if ($isTextNode(firstNode)) {
       const del = firstNode.getTextContentSize() - firstPoint.offset;
       firstNode.spliceText(firstPoint.offset, del, '');
-      firstNode = fixText(firstNode, del) || firstNode;
+      firstNode = fixText(firstNode, del);
     }
     if ($isTextNode(lastNode)) {
       lastNode.spliceText(0, lastPoint.offset, '');
-      lastNode = fixText(lastNode, lastPoint.offset) || lastNode;
+      lastNode = fixText(lastNode, lastPoint.offset);
     }
     if (firstNode.isAttached() && $isTextNode(firstNode)) {
       firstNode.selectEnd();


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

This PR fixes an issue where text nodes in token mode were not being deleted properly when partially removed. According to the documentation, token nodes should be immutable and should be deleted as a whole. However, the current behaviour allowed partial deletion of the text within a token node, resulting in an unexpected mutation into a non-token node.

<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

1. In `fixText` added another condition treating a `token` node similiar to an empty text node, effectively removing the node.
2. Consistent Return: `fixText` now always returns a node, eliminating the need for the || operator in assignments like firstNode = fixText(firstNode, del) || firstNode;. This simplifies the code and prevents potential undefined errors.

Closes #6687

## Test plan

### Before

![CleanShot 2024-10-01 at 18 28 12](https://github.com/user-attachments/assets/5c2ec8f2-9d03-4d54-93e3-a7bc3d8b39b7)

### After

![CleanShot 2024-10-01 at 18 27 14](https://github.com/user-attachments/assets/235f9ce4-6fb4-4364-a3f0-f7725ebc308c)
