### PR TITLE
[lexical] Bug Fix: TextNode in token mode should not be split by removeText

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1117,6 +1117,17 @@ export class RangeSelection implements BaseSelection {
     let lastNode = lastPoint.getNode();
     const firstBlock = $getAncestor(firstNode, INTERNAL_$isBlock);
     const lastBlock = $getAncestor(lastNode, INTERNAL_$isBlock);
+    // If a token is partially selected then move the selection to cover the whole selection
+    if (
+      $isTextNode(firstNode) &&
+      firstNode.isToken() &&
+      firstPoint.offset < firstNode.getTextContentSize()
+    ) {
+      firstPoint.offset = 0;
+    }
+    if (lastPoint.offset > 0 && $isTextNode(lastNode) && lastNode.isToken()) {
+      lastPoint.offset = lastNode.getTextContentSize();
+    }
 
     selectedNodes.forEach((node) => {
       if (


### PR DESCRIPTION
## Description

The #6456 removeText rewrite introduced a regression in token mode behavior where it behaved too similarly to segmented nodes, it would be split and replaced with a plain TextNode instead of being deleted in full. This takes the simple approach of just expanding the selection outwards if the focus or anchor node contains any content from a token node.

Closes #6687

## Test plan

### Before

There were no tests to show that token TextNode should be deleted in full by removeText

### After

Now there are tests that cover removeText behavior for token TextNode
