### PR TITLE
[lexical-playground] Bug Fix: Track Resizing Actions for Excalidraw in History Stack

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -31,9 +31,13 @@ import ExcalidrawImage from './ExcalidrawImage';
 export default function ExcalidrawComponent({
   nodeKey,
   data,
+  width,
+  height,
 }: {
   data: string;
   nodeKey: NodeKey;
+  width: 'inherit' | number;
+  height: 'inherit' | number;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
   const [isModalOpen, setModalOpen] = useState<boolean>(
@@ -180,20 +184,9 @@ export default function ExcalidrawComponent({
     appState = {},
   } = useMemo(() => JSON.parse(data), [data]);
 
-  const [initialWidth, initialHeight] = useMemo(() => {
-    let nodeWidth: 'inherit' | number = 'inherit';
-    let nodeHeight: 'inherit' | number = 'inherit';
-
-    editor.getEditorState().read(() => {
-      const node = $getNodeByKey(nodeKey);
-      if ($isExcalidrawNode(node)) {
-        nodeWidth = node.getWidth();
-        nodeHeight = node.getHeight();
-      }
-    });
-
-    return [nodeWidth, nodeHeight];
-  }, [editor, nodeKey]);
+  const [currentWidth, currentHeight] = useMemo(() => {
+    return [width, height];
+  }, [width, height]);
 
   const closeModal = useCallback(() => {
     setModalOpen(false);
@@ -233,8 +226,8 @@ export default function ExcalidrawComponent({
             elements={elements}
             files={files}
             appState={appState}
-            width={initialWidth}
-            height={initialHeight}
+            width={currentWidth}
+            height={currentHeight}
           />
           {isSelected && (
             <div

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -184,10 +184,6 @@ export default function ExcalidrawComponent({
     appState = {},
   } = useMemo(() => JSON.parse(data), [data]);
 
-  const [currentWidth, currentHeight] = useMemo(() => {
-    return [width, height];
-  }, [width, height]);
-
   const closeModal = useCallback(() => {
     setModalOpen(false);
     if (elements.length === 0) {
@@ -226,8 +222,8 @@ export default function ExcalidrawComponent({
             elements={elements}
             files={files}
             appState={appState}
-            width={currentWidth}
-            height={currentHeight}
+            width={width}
+            height={height}
           />
           {isSelected && (
             <div

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -181,7 +181,12 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
   decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {
     return (
       <Suspense fallback={null}>
-        <ExcalidrawComponent nodeKey={this.getKey()} data={this.__data} />
+        <ExcalidrawComponent
+          nodeKey={this.getKey()}
+          data={this.__data}
+          width={this.__width}
+          height={this.__height}
+        />
       </Suspense>
     );
   }


### PR DESCRIPTION
## Description
### Current Behaviour
Excalidraw resizing actions are not tracked. My understanding of this is that because the component is fetching width and height from the editor state rather than receiving them as props, React didn't detect the changes to width and height, preventing the component from rerendering on resizing. And as a result, Lexical did not record these transactions in its history stack.

### Changes Introduced
I am now passing in the width and height properties as props into ExcalidrawComponent, similar to what is done in ImageNode. And I got rid of useMemo.

### Before

https://github.com/user-attachments/assets/4d120470-4ef1-4a87-9400-fd8de21c4d7b


### After

https://github.com/user-attachments/assets/5b8b8741-a7ee-4722-a400-8038e192293e


Tested in collab mode as well.
