### PR TITLE
[lexical-playground] Bug Fix: Disable image and inline focusing, adding caption and editing in read-only mode

### DIFF
--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -26,6 +26,7 @@ import {HashtagPlugin} from '@lexical/react/LexicalHashtagPlugin';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {LexicalNestedComposer} from '@lexical/react/LexicalNestedComposer';
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {mergeRegister} from '@lexical/utils';
 import {
@@ -171,6 +172,7 @@ export default function ImageComponent({
   const [selection, setSelection] = useState<BaseSelection | null>(null);
   const activeEditorRef = useRef<LexicalEditor | null>(null);
   const [isLoadError, setIsLoadError] = useState<boolean>(false);
+  const isEditable = useLexicalEditable();
 
   const $onDelete = useCallback(
     (payload: KeyboardEvent) => {
@@ -398,7 +400,7 @@ export default function ImageComponent({
   } = useSettings();
 
   const draggable = isSelected && $isNodeSelection(selection) && !isResizing;
-  const isFocused = isSelected || isResizing;
+  const isFocused = (isSelected || isResizing) && isEditable;
   return (
     <Suspense fallback={null}>
       <>

--- a/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageComponent.tsx
@@ -15,6 +15,7 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
 import {LexicalNestedComposer} from '@lexical/react/LexicalNestedComposer';
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {mergeRegister} from '@lexical/utils';
 import {
@@ -200,6 +201,7 @@ export default function InlineImageComponent({
   const [editor] = useLexicalComposerContext();
   const [selection, setSelection] = useState<BaseSelection | null>(null);
   const activeEditorRef = useRef<LexicalEditor | null>(null);
+  const isEditable = useLexicalEditable();
 
   const $onDelete = useCallback(
     (payload: KeyboardEvent) => {
@@ -352,25 +354,27 @@ export default function InlineImageComponent({
   ]);
 
   const draggable = isSelected && $isNodeSelection(selection);
-  const isFocused = isSelected;
+  const isFocused = isSelected && isEditable;
   return (
     <Suspense fallback={null}>
       <>
         <span draggable={draggable}>
-          <button
-            className="image-edit-button"
-            ref={buttonRef}
-            onClick={() => {
-              showModal('Update Inline Image', (onClose) => (
-                <UpdateInlineImageDialog
-                  activeEditor={editor}
-                  nodeKey={nodeKey}
-                  onClose={onClose}
-                />
-              ));
-            }}>
-            Edit
-          </button>
+          {isEditable && (
+            <button
+              className="image-edit-button"
+              ref={buttonRef}
+              onClick={() => {
+                showModal('Update Inline Image', (onClose) => (
+                  <UpdateInlineImageDialog
+                    activeEditor={editor}
+                    nodeKey={nodeKey}
+                    onClose={onClose}
+                  />
+                ));
+              }}>
+              Edit
+            </button>
+          )}
           <LazyImage
             className={
               isFocused


### PR DESCRIPTION
## Description
Currently, the image and inline image components can still be focused in read-only mode, and the buttons to add caption and edit are still shown.

### Changes Introduced In this PR
- Prevent focusing on images in read-only mode
- Hide interactive elements in read-only mode

### Before

https://github.com/user-attachments/assets/973b7731-450d-44ae-bef9-e41454ac749f



### After

https://github.com/user-attachments/assets/797d7057-6d3c-45fc-aace-2e42c2d2adda


