### PR TITLE
[lexical-playground] Bug Fix: Disable table hover actions in read-only mode

### DIFF
--- a/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
@@ -46,9 +46,6 @@ function TableHoverActionsContainer({
 
   const debouncedOnMouseMove = useDebounce(
     (event: MouseEvent) => {
-      if (!isEditable) {
-        return;
-      }
       const {isOutside, tableDOMNode} = getMouseInfo(event);
 
       if (isOutside) {
@@ -156,9 +153,6 @@ function TableHoverActionsContainer({
       editor.registerMutationListener(
         TableNode,
         (mutations) => {
-          if (!isEditable) {
-            return;
-          }
           editor.getEditorState().read(() => {
             for (const [key, type] of mutations) {
               switch (type) {
@@ -181,12 +175,9 @@ function TableHoverActionsContainer({
         {skipInitialization: false},
       ),
     );
-  }, [editor, isEditable]);
+  }, [editor]);
 
   const insertAction = (insertRow: boolean) => {
-    if (!isEditable) {
-      return;
-    }
     editor.update(() => {
       if (tableDOMNodeRef.current) {
         const maybeTableNode = $getNearestNodeFromDOMNode(


### PR DESCRIPTION
## Description
Currently, the table hover actions allows users to add new rows and columns by hovering over the edges of the table, even when the editor is in read-only mode. Specifically the problems are: hover buttons are visible, interactions with the buttons are allowed, and the event handlers are active all while in read-only mode.

### Changes Introduced in this PR
- The hover buttons for adding rows and columns are hidden when the editor is in read-only mode and users cannot trigger hover actions in read-only mode.
- Disabled event listeners in read-only mode
- The `TableHoverActionsContainer` component returns null when the editor is not editable

### Before

https://github.com/user-attachments/assets/392cd48f-b507-4fc0-afc7-b61ad712cf20



### After


https://github.com/user-attachments/assets/f327a4a2-ccbe-4494-9b1f-5f7efff822d5

