### PR TITLE
[lexical-playground] Bug Fix: Disable equation editing in read-only mode

### DIFF
--- a/packages/lexical-playground/src/nodes/EquationComponent.tsx
+++ b/packages/lexical-playground/src/nodes/EquationComponent.tsx
@@ -7,6 +7,7 @@
  */
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
@@ -37,6 +38,7 @@ export default function EquationComponent({
   nodeKey,
 }: EquationComponentProps): JSX.Element {
   const [editor] = useLexicalComposerContext();
+  const isEditable = useLexicalEditable();
   const [equationValue, setEquationValue] = useState(equation);
   const [showEquationEditor, setShowEquationEditor] = useState<boolean>(false);
   const inputRef = useRef(null);
@@ -64,6 +66,9 @@ export default function EquationComponent({
   }, [showEquationEditor, equation, equationValue]);
 
   useEffect(() => {
+    if (!isEditable) {
+      return;
+    }
     if (showEquationEditor) {
       return mergeRegister(
         editor.registerCommand(
@@ -107,11 +112,11 @@ export default function EquationComponent({
         }
       });
     }
-  }, [editor, nodeKey, onHide, showEquationEditor]);
+  }, [editor, nodeKey, onHide, showEquationEditor, isEditable]);
 
   return (
     <>
-      {showEquationEditor ? (
+      {showEquationEditor && isEditable ? (
         <EquationEditor
           equation={equationValue}
           setEquation={setEquationValue}
@@ -123,7 +128,11 @@ export default function EquationComponent({
           <KatexRenderer
             equation={equationValue}
             inline={inline}
-            onDoubleClick={() => setShowEquationEditor(true)}
+            onDoubleClick={() => {
+              if (isEditable) {
+                setShowEquationEditor(true);
+              }
+            }}
           />
         </ErrorBoundary>
       )}


### PR DESCRIPTION
## Description
Currently, the equation component allows editing equations even in read-only mode. 

### Changes Introduced in this PR
- Prevent double clicking from showing the equation editor in read-only mode.
- Adjust event handlers that open the equation editor or handle selection changes to be disabled when in read-only mode

### Before

https://github.com/user-attachments/assets/0090223c-f251-41b8-a276-7750e551b2fa



### After


https://github.com/user-attachments/assets/67f22f04-4fac-4293-bf14-114e03f009b6


