### PR TITLE
feat: allow disable flush mutations

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -620,6 +620,8 @@ export class LexicalEditor {
   /** @internal */
   _editable: boolean;
   /** @internal */
+  _disableFlushMutations: boolean = false;
+  /** @internal */
   _blockCursorElement: null | HTMLDivElement;
 
   /** @internal */

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -11,6 +11,7 @@ import type {LexicalEditor} from './LexicalEditor';
 import type {BaseSelection} from './LexicalSelection';
 
 import {IS_FIREFOX} from 'shared/environment';
+import warnOnlyOnce from 'shared/warnOnlyOnce';
 
 import {
   $getSelection,
@@ -116,7 +117,10 @@ export function $flushMutations(
   isProcessingMutations = true;
   const shouldFlushTextMutations =
     performance.now() - lastTextEntryTimeStamp > TEXT_MUTATION_VARIANCE;
-
+  if (editor._disableFlushMutations) {
+    warnOnlyOnce('flush mutation disabled');
+    return;
+  }
   try {
     updateEditor(editor, () => {
       const selection = $getSelection() || getLastSelection(editor);


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
i would like to stop flush Mutation when rendering read-only html with lexcial, after render, i wnat to update dom with dom api not with lexical. i.e  user might update bg color, add  stuff to html...etc. 

basically, once rendered, ditch lexical. 


*Describe the changes in this pull request*

Closes #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*