### PR TITLE
[lexical-playground] Fix: `ListMaxIndentLevelPlugin` allows indent beyond maxDepth on paste 

### DIFF
--- a/packages/lexical-playground/src/plugins/ListMaxIndentLevelPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/ListMaxIndentLevelPlugin/index.ts
@@ -16,6 +16,7 @@ import {
   $isRangeSelection,
   COMMAND_PRIORITY_CRITICAL,
   INDENT_CONTENT_COMMAND,
+  PASTE_COMMAND,
 } from 'lexical';
 import {useEffect} from 'react';
 
@@ -77,6 +78,14 @@ export default function ListMaxIndentLevelPlugin({
   useEffect(() => {
     return editor.registerCommand(
       INDENT_CONTENT_COMMAND,
+      () => $shouldPreventIndent(maxDepth),
+      COMMAND_PRIORITY_CRITICAL,
+    );
+  }, [editor, maxDepth]);
+
+  useEffect(() => {
+    return editor.registerCommand(
+      PASTE_COMMAND,
       () => $shouldPreventIndent(maxDepth),
       COMMAND_PRIORITY_CRITICAL,
     );


### PR DESCRIPTION
## Description

The `ListMaxIndentLevelPlugin` restricts the maximum indent level for list items based on the defined `maxDepth`. However, when pasting content with a deeper indent, the plugin doesn't automatically enforce this restriction. This allows the pasted content to exceed the allowed indent level, resulting in a higher indent depth than the set `maxDepth`.

*Added logic to restrict paste behaviour for lists in `ListMaxIndentLevelPlugin`, ensuring that pasted content respects the defined `maxDepth` and prevents exceeding the allowed indent level.*


Closes #[6609](https://github.com/facebook/lexical/pull/6609)

## Test plan

### Before

[maxDepth issue](https://d.pr/v/IRF0rH)


### After

[solved maxDepth issue](https://d.pr/v/zw3uMQ)

Note: The solution restricts pasting beyond indent level 7, ensuring the list structure stays within the defined limit. 
