### PR TITLE
fix: preserve custom fields in Lexical-Yjs sync

### DIFF
--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -502,6 +502,7 @@ export function syncLexicalSelectionToYjs(
     color,
     focusing,
     awarenessData,
+    ...customFields
   } = localState;
   let anchorPos = null;
   let focusPos = null;
@@ -531,6 +532,7 @@ export function syncLexicalSelectionToYjs(
       focusPos,
       focusing,
       name,
+      ...customFields,
     });
   }
 }

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -502,7 +502,6 @@ export function syncLexicalSelectionToYjs(
     color,
     focusing,
     awarenessData,
-    ...customFields
   } = localState;
   let anchorPos = null;
   let focusPos = null;
@@ -526,13 +525,13 @@ export function syncLexicalSelectionToYjs(
     shouldUpdatePosition(currentFocusPos, focusPos)
   ) {
     awareness.setLocalState({
+      ...localState,
       anchorPos,
       awarenessData,
       color,
       focusPos,
       focusing,
       name,
-      ...customFields,
     });
   }
 }

--- a/packages/lexical-yjs/src/index.ts
+++ b/packages/lexical-yjs/src/index.ts
@@ -20,6 +20,7 @@ export type UserState = {
   focusPos: null | RelativePosition;
   name: string;
   awarenessData: object;
+  [key: string]: unknown;
 };
 export const CONNECTED_COMMAND: LexicalCommand<boolean> =
   createCommand('CONNECTED_COMMAND');


### PR DESCRIPTION
When syncing Lexical selection to Yjs, custom fields in the local state were being dropped. This commit ensures all custom fields are preserved during the sync process, maintaining data integrity in collaborative editing scenarios.

Updated syncLexicalSelectionToYjs to include ...customFields Ensures backwards compatibility with existing implementations Improves reliability of custom data persistence in collaboration

prev [PR](https://github.com/facebook/lexical/pull/6683) where ProviderAwareness  type was extended with `setLocalStateField ` 