### PR TITLE
Chore: add workflow to auto close stale pr based on label

### DIFF
--- a/.github/workflows/close-stale-pr.yml
+++ b/.github/workflows/close-stale-pr.yml
@@ -1,0 +1,18 @@
+name: Close stale PR
+on:
+  pull_request:
+    types: labeled
+jobs:
+  test-action:
+    if: github.event.label.name == 'stale-pr'
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr close "$NUMBER" --comment "$COMMENT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
+          COMMENT: >
+            Closing this PR due to staleness! If there are new updates, please reopen the PR.

--- a/.github/workflows/close-stale-pr.yml
+++ b/.github/workflows/close-stale-pr.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: labeled
 jobs:
-  test-action:
+  close-pr:
     if: github.event.label.name == 'stale-pr'
     permissions:
       pull-requests: write


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
Spring cleaning since the number of stale PRs are growing



## Test plan

1. add "stale-pr" label
2. this PR closes with a comment

<img width="1012" alt="Screenshot 2024-10-15 at 11 50 39 AM" src="https://github.com/user-attachments/assets/69e6f396-850f-4967-8e37-31ab575eccf5">




