### PR TITLE
[lexical-code] Bug Fix: Add global type declarations for Prism

### DIFF
--- a/packages/lexical-code/src/CodeHighlighterPrism.ts
+++ b/packages/lexical-code/src/CodeHighlighterPrism.ts
@@ -25,4 +25,11 @@ import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-java';
 import 'prismjs/components/prism-cpp';
 
-export const Prism: typeof import('prismjs') = globalThis.Prism || window.Prism;
+declare global {
+  interface Window {
+    Prism: typeof import('prismjs');
+  }
+}
+
+export const Prism: typeof import('prismjs') =
+  (globalThis as {Prism?: typeof import('prismjs')}).Prism || window.Prism;


### PR DESCRIPTION
## Description

When investigating https://github.com/facebook/lexical/pull/6731#discussion_r1801368555 it was reported that `npm run ci-check` failed locally due to a type error. It's unclear why this failure doesn't also happen in CI, but I was able to reproduce it locally. The root cause probably has something to do with `@types/prismjs` and how the CI installs things?

All this does is add some type annotations to make it pass.

## Test plan

### Before

```
$ npm run tsc

> @lexical/monorepo@0.18.0 tsc
> tsc

packages/lexical-code/src/CodeHighlighterPrism.ts:28:59 - error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.

28 export const Prism: typeof import('prismjs') = globalThis.Prism || window.Prism;
                                                             ~~~~~

packages/lexical-code/src/CodeHighlighterPrism.ts:28:75 - error TS2339: Property 'Prism' does not exist on type 'Window & typeof globalThis'.

28 export const Prism: typeof import('prismjs') = globalThis.Prism || window.Prism;
                                                                             ~~~~~


Found 2 errors in the same file, starting at: packages/lexical-code/src/CodeHighlighterPrism.ts:28
```

### After

```
$ npm run tsc

> @lexical/monorepo@0.18.0 tsc
> tsc
```
