### PR TITLE
[*] Chore: Disable react-beta test job for now

### DIFF
--- a/.github/workflows/call-e2e-all-tests.yml
+++ b/.github/workflows/call-e2e-all-tests.yml
@@ -140,22 +140,23 @@ jobs:
       editor-mode: ${{ matrix.editor-mode }}
       events-mode: ${{ matrix.events-mode }}
 
-  react-beta:
-    strategy:
-      matrix:
-        # Currently using a single combination for every-patch e2e tests of
-        # react beta to reduce cost impact
-        editor-mode: ['rich-text']
-        prod: [false]
-    uses: ./.github/workflows/call-e2e-test.yml
-    with:
-      os: 'ubuntu-latest'
-      browser: 'chromium'
-      node-version: 18.18.0
-      events-mode: 'modern-events'
-      editor-mode: ${{ matrix.editor-mode }}
-      prod: ${{ matrix.prod }}
-      override-react-version: beta
+  # This has been stalling in GitHub CI for unknown reasons, disable for now
+  # react-beta:
+  #   strategy:
+  #     matrix:
+  #       # Currently using a single combination for every-patch e2e tests of
+  #       # react beta to reduce cost impact
+  #       editor-mode: ['rich-text']
+  #       prod: [false]
+  #   uses: ./.github/workflows/call-e2e-test.yml
+  #   with:
+  #     os: 'ubuntu-latest'
+  #     browser: 'chromium'
+  #     node-version: 18.18.0
+  #     events-mode: 'modern-events'
+  #     editor-mode: ${{ matrix.editor-mode }}
+  #     prod: ${{ matrix.prod }}
+  #     override-react-version: beta
 
   flaky:
     strategy:


### PR DESCRIPTION
## Description

The react-beta CI job has been stalling on some PRs. It's not really feasible to do much debugging on the GitHub Actions runners and it passes locally so I'm not really sure what else to do about it. We got most of the value from it already, I don't think it will matter much until there's another set of major changes in React.

## Test plan

### Before

react-beta job intermittently runs for over an hour and times out

### After

react-beta job no longer runs