### PR TITLE
[lexical-table] Return inserted node from `$insertTableRow__EXPERIMENTAL` and `$insertTableColumn__EXPERIMENTAL`

### DIFF
--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -237,11 +237,11 @@ declare export function $deleteTableColumn(
 
 declare export function $insertTableRow__EXPERIMENTAL(
   insertAfter: boolean,
-): TableRowNode | void;
+): TableRowNode | null;
 
 declare export function $insertTableColumn__EXPERIMENTAL(
   insertAfter: boolean,
-): void;
+): TableCellNode | null;
 
 declare export function $deleteTableRow__EXPERIMENTAL(): void;
 

--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -237,7 +237,7 @@ declare export function $deleteTableColumn(
 
 declare export function $insertTableRow__EXPERIMENTAL(
   insertAfter: boolean,
-): TableRowNode | undefined;
+): TableRowNode | void;
 
 declare export function $insertTableColumn__EXPERIMENTAL(
   insertAfter: boolean,

--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -237,7 +237,7 @@ declare export function $deleteTableColumn(
 
 declare export function $insertTableRow__EXPERIMENTAL(
   insertAfter: boolean,
-): void;
+): TableRowNode | undefined;
 
 declare export function $insertTableColumn__EXPERIMENTAL(
   insertAfter: boolean,

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -245,7 +245,14 @@ const getHeaderState = (
   return TableCellHeaderStates.NO_STATUS;
 };
 
-export function $insertTableRow__EXPERIMENTAL(insertAfter = true): void {
+/**
+ * Inserts a table row before or after the current focus cell node,
+ * taking into account any spans. If successful, returns the
+ * inserted table row node.
+ */
+export function $insertTableRow__EXPERIMENTAL(
+  insertAfter = true,
+): TableRowNode | undefined {
   const selection = $getSelection();
   invariant(
     $isRangeSelection(selection) || $isTableSelection(selection),
@@ -256,6 +263,7 @@ export function $insertTableRow__EXPERIMENTAL(insertAfter = true): void {
   const [gridMap, focusCellMap] = $computeTableMap(grid, focusCell, focusCell);
   const columnCount = gridMap[0].length;
   const {startRow: focusStartRow} = focusCellMap;
+  let insertedRow: TableRowNode | undefined = undefined;
   if (insertAfter) {
     const focusEndRow = focusStartRow + focusCell.__rowSpan - 1;
     const focusEndRowMap = gridMap[focusEndRow];
@@ -284,6 +292,7 @@ export function $insertTableRow__EXPERIMENTAL(insertAfter = true): void {
       'focusEndRow is not a TableRowNode',
     );
     focusEndRowNode.insertAfter(newRow);
+    insertedRow = newRow;
   } else {
     const focusStartRowMap = gridMap[focusStartRow];
     const newRow = $createTableRowNode();
@@ -311,7 +320,9 @@ export function $insertTableRow__EXPERIMENTAL(insertAfter = true): void {
       'focusEndRow is not a TableRowNode',
     );
     focusStartRowNode.insertBefore(newRow);
+    insertedRow = newRow;
   }
+  return insertedRow;
 }
 
 export function $insertTableColumn(

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -252,7 +252,7 @@ const getHeaderState = (
  */
 export function $insertTableRow__EXPERIMENTAL(
   insertAfter = true,
-): TableRowNode | undefined {
+): TableRowNode | null {
   const selection = $getSelection();
   invariant(
     $isRangeSelection(selection) || $isTableSelection(selection),
@@ -263,7 +263,7 @@ export function $insertTableRow__EXPERIMENTAL(
   const [gridMap, focusCellMap] = $computeTableMap(grid, focusCell, focusCell);
   const columnCount = gridMap[0].length;
   const {startRow: focusStartRow} = focusCellMap;
-  let insertedRow: TableRowNode | undefined = undefined;
+  let insertedRow: TableRowNode | null = null;
   if (insertAfter) {
     const focusEndRow = focusStartRow + focusCell.__rowSpan - 1;
     const focusEndRowMap = gridMap[focusEndRow];
@@ -384,7 +384,14 @@ export function $insertTableColumn(
   return tableNode;
 }
 
-export function $insertTableColumn__EXPERIMENTAL(insertAfter = true): void {
+/**
+ * Inserts a column before or after the current focus cell node,
+ * taking into account any spans. If successful, returns the
+ * first inserted cell node.
+ */
+export function $insertTableColumn__EXPERIMENTAL(
+  insertAfter = true,
+): TableCellNode | null {
   const selection = $getSelection();
   invariant(
     $isRangeSelection(selection) || $isTableSelection(selection),
@@ -490,6 +497,7 @@ export function $insertTableColumn__EXPERIMENTAL(insertAfter = true): void {
     newColWidths.splice(columnIndex, 0, newWidth);
     grid.setColWidths(newColWidths);
   }
+  return firstInsertedCell;
 }
 
 export function $deleteTableColumn(


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

Currently, the `$insertTableRow__EXPERIMENTAL` function doesn't return anything, so if you want to insert a table row using it and do something with the inserted row, you'll have to do all the calculations again to find the inserted row.
With this PR, the function will return the inserted row node if it was successful and undefined if not. This removes the need for rewriting all the logic regarding spans just to find the inserted row.
Also returns the first inserted cell from `$insertTableColumn__EXPERIMENTAL`