### PR TITLE
[lexical-selection] Fix __language in null

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1360,7 +1360,7 @@ export class RangeSelection implements BaseSelection {
 
     // CASE 1: insert inside a code block
     if ($isElementNode(firstBlock) && '__language' in firstBlock) {
-      if ('__language' in nodes[0]) {
+      if (nodes[0] && '__language' in nodes[0]) {
         this.insertText(nodes[0].getTextContent());
       } else {
         const index = $removeTextAndSplitBlock(this);

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1359,7 +1359,11 @@ export class RangeSelection implements BaseSelection {
     const last = nodes[nodes.length - 1]!;
 
     // CASE 1: insert inside a code block
-    if ($isElementNode(firstBlock) && '__language' in firstBlock) {
+    if (
+      firstBlock &&
+      $isElementNode(firstBlock) &&
+      '__language' in firstBlock
+    ) {
       if (nodes[0] && '__language' in nodes[0]) {
         this.insertText(nodes[0].getTextContent());
       } else {


### PR DESCRIPTION
5th highest error we are observing is: 'Cannot use 'in' operator to search for __language in null'
Not being able to reproduce, but confident the below should address this error in particular, since it seems like the only place in the code base we call '__language'