### PR TITLE
[lexical] Bug Fix: DOM Clobbering Gadget found in rollup bundled scripts that leads to XSS

### DIFF
--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package-lock.json
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "lexical-esm-astro-react",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexical-esm-astro-react",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "dependencies": {
         "@astrojs/check": "^0.9.3",
         "@astrojs/react": "^3.1.0",
-        "@lexical/react": "0.17.1",
-        "@lexical/utils": "0.17.1",
+        "@lexical/react": "0.18.0",
+        "@lexical/utils": "0.18.0",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "astro": "^4.5.4",
-        "lexical": "0.17.1",
+        "lexical": "0.18.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "^5.4.2"
@@ -993,38 +993,38 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.17.1.tgz",
-      "integrity": "sha512-OVqnEfWX8XN5xxuMPo6BfgGKHREbz++D5V5ISOiml0Z8fV/TQkdgwqbBJcUdJHGRHWSUwdK7CWGs/VALvVvZyw==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.18.0.tgz",
+      "integrity": "sha512-ybc+hx14wj0n2ZjdOkLcZ02MRB3UprXjpLDXlByFIuVcZpUxVcp3NzA0UBPOKXYKvdt0bmgjnAsFWM5OSbwS0w==",
       "dependencies": {
-        "@lexical/html": "0.17.1",
-        "@lexical/list": "0.17.1",
-        "@lexical/selection": "0.17.1",
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/html": "0.18.0",
+        "@lexical/list": "0.18.0",
+        "@lexical/selection": "0.18.0",
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.17.1.tgz",
-      "integrity": "sha512-ZspfTm6g6dN3nAb4G5bPp3SqxzdkB/bjGfa0uRKMU6/eBKtrMUgZsGxt0a8JRZ1eq2TZrQhx+l1ceRoLXii/bQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.18.0.tgz",
+      "integrity": "sha512-VB8fRHIrB8QTqyZUvGBMVWP2tpKe3ArOjPdWAqgrS8MVFldqUhuTHcW+XJFkVxcEBYCXynNT29YRYtQhfQ+vDQ==",
       "dependencies": {
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1",
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0",
         "prismjs": "^1.27.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.17.1.tgz",
-      "integrity": "sha512-SzL1EX9Rt5GptIo87t6nDxAc9TtYtl6DyAPNz/sCltspdd69KQgs23sTRa26/tkNFCS1jziRN7vpN3mlnmm5wA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.18.0.tgz",
+      "integrity": "sha512-gVgtEkLwGjz1frOmDpFJzDPFxPgAcC9n5ZaaZWHo5GLcptnQmkuLm1t+UInQWujXhFmcyJzfiqDaMJ8EIcb2Ww==",
       "dependencies": {
-        "@lexical/html": "0.17.1",
-        "@lexical/link": "0.17.1",
-        "@lexical/mark": "0.17.1",
-        "@lexical/table": "0.17.1",
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/html": "0.18.0",
+        "@lexical/link": "0.18.0",
+        "@lexical/mark": "0.18.0",
+        "@lexical/table": "0.18.0",
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -1032,133 +1032,133 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.17.1.tgz",
-      "integrity": "sha512-lhBRKP7RlhiVCLtF0qiNqmMhEO6cQB43sMe7d4bvuY1G2++oKY/XAJPg6QJZdXRrCGRQ6vZ26QRNhRPmCxL5Ng==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.18.0.tgz",
+      "integrity": "sha512-toD/y2/TgtG+eFVKXf65kDk/Mv02FwgmcGH18nyAabZnO1TLBaMYPkGFdTTZ8hVmQxqIu9nZuLWUbdIBMs8UWw==",
       "dependencies": {
-        "lexical": "0.17.1"
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.17.1.tgz",
-      "integrity": "sha512-XtP0BI8vEewAe7tzq9MC49UPUvuChuNJI/jqFp+ezZlt/RUq0BClQCOPuSlrTJhluvE2rWnUnOnVMk8ILRvggQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.18.0.tgz",
+      "integrity": "sha512-bm+Sv7keguVYbUY0ngd+iAv2Owd3dePzdVkzkmw9Al8GPXkE5ll8fjq6Xjw2u3OVhf+9pTnesIo/AS7H+h0exw==",
       "dependencies": {
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.17.1.tgz",
-      "integrity": "sha512-OU/ohajz4FXchUhghsWC7xeBPypFe50FCm5OePwo767G7P233IztgRKIng2pTT4zhCPW7S6Mfl53JoFHKehpWA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.18.0.tgz",
+      "integrity": "sha512-c87J4ke1Sae03coElJay2Ikac/4OcA2OmhtNbt2gAi/XBtcsP4mPuz1yZfZf9XIe+weekObgjinvZekQ2AFw0g==",
       "dependencies": {
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.17.1.tgz",
-      "integrity": "sha512-yGG+K2DXl7Wn2DpNuZ0Y3uCHJgfHkJN3/MmnFb4jLnH1FoJJiuy7WJb/BRRh9H+6xBJ9v70iv+kttDJ0u1xp5w==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.18.0.tgz",
+      "integrity": "sha512-8lhba1DFnnobXgYm4Rk5Gr2tZedD4Gl6A/NKCt7whO/CET63vT3UnK2ggcVVgtIJG530Cv0bdZoJbJu5DauI5w==",
       "dependencies": {
-        "@lexical/selection": "0.17.1",
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/selection": "0.18.0",
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.17.1.tgz",
-      "integrity": "sha512-qFJEKBesZAtR8kfJfIVXRFXVw6dwcpmGCW7duJbtBRjdLjralOxrlVKyFhW9PEXGhi4Mdq2Ux16YnnDncpORdQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.18.0.tgz",
+      "integrity": "sha512-GCYcbNTSTwJk0lr+GMc8nn6Meq44BZs3QL2d1B0skpZAspd8yI53sRS6HDy5P+jW5P0dzyZr/XJAU4U+7zsEEg==",
       "dependencies": {
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.17.1.tgz",
-      "integrity": "sha512-k9ZnmQuBvW+xVUtWJZwoGtiVG2cy+hxzkLGU4jTq1sqxRIoSeGcjvhFAK8JSEj4i21SgkB1FmkWXoYK5kbwtRA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.18.0.tgz",
+      "integrity": "sha512-DEWs9Scbg3+STZeE2O0OoG8SWnKnxQccObBzyeHRjn4GAN6JA7lgcAzfrdgp0fNWTbMM/ku876MmXKGnqhvg9Q==",
       "dependencies": {
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.17.1.tgz",
-      "integrity": "sha512-V82SSRjvygmV+ZMwVpy5gwgr2ZDrJpl3TvEDO+G5I4SDSjbgvua8hO4dKryqiDVlooxQq9dsou0GrZ9Qtm6rYg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.18.0.tgz",
+      "integrity": "sha512-QA4YWfTP5WWnCnoH/RmfcsSZyhhd7oeFWDpfP7S8Bbmhz6kiPwGcsVr+uRQBBT56AqEX167xX2rX8JR6FiYZqA==",
       "dependencies": {
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.17.1.tgz",
-      "integrity": "sha512-uexR9snyT54jfQTrbr/GZAtzX+8Oyykr4p1HS0vCVL1KU5MDuP2PoyFfOv3rcfB2TASc+aYiINhU2gSXzwCHNg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.18.0.tgz",
+      "integrity": "sha512-uSWwcK8eJw5C+waEhU5WoX8W+JxNZbKuFnZwsn5nsp+iQgqMj4qY6g0yJub4sq8vvh6jjl4vVXhXTq2up9aykw==",
       "dependencies": {
-        "@lexical/code": "0.17.1",
-        "@lexical/link": "0.17.1",
-        "@lexical/list": "0.17.1",
-        "@lexical/rich-text": "0.17.1",
-        "@lexical/text": "0.17.1",
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/code": "0.18.0",
+        "@lexical/link": "0.18.0",
+        "@lexical/list": "0.18.0",
+        "@lexical/rich-text": "0.18.0",
+        "@lexical/text": "0.18.0",
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.17.1.tgz",
-      "integrity": "sha512-fX0ZSIFWwUKAjxf6l21vyXFozJGExKWyWxA+EMuOloNAGotHnAInxep0Mt8t/xcvHs7luuyQUxEPw7YrTJP7aw==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.18.0.tgz",
+      "integrity": "sha512-KGlboyLSxQAH5PMOlJmyvHlbYXZneVnKiHpfyBV5IUX5kuyB/eZbQEYcJP9saekfQ5Xb1FWXWmsZEo+sWtrrZA==",
       "dependencies": {
-        "lexical": "0.17.1"
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.17.1.tgz",
-      "integrity": "sha512-oElVDq486R3rO2+Zz0EllXJGpW3tN0tfcH+joZ5h36+URKuNeKddqkJuDRvgSLOr9l8Jhtv3+/YKduPJVKMz6w==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.18.0.tgz",
+      "integrity": "sha512-3ATTwttVgZtVLq60ZUWbpbXBbpuMa3PZD5CxSP3nulviL+2I4phvacV4WUN+8wMeq+PGmuarl+cYfrFL02ii3g==",
       "dependencies": {
-        "lexical": "0.17.1"
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.17.1.tgz",
-      "integrity": "sha512-CSvi4j1a4ame0OAvOKUCCmn2XrNsWcST4lExGTa9Ei/VIh8IZ+a97h4Uby8T3lqOp10x+oiizYWzY30pb9QaBg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.18.0.tgz",
+      "integrity": "sha512-L6yQpiwW0ZacY1oNwvRBxSuW2TZaUcveZLheJc8JzGcZoVxzII/CAbLZG8691VbNuKsbOURiNXZIsgwujKmo4Q==",
       "dependencies": {
-        "@lexical/clipboard": "0.17.1",
-        "@lexical/selection": "0.17.1",
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/clipboard": "0.18.0",
+        "@lexical/selection": "0.18.0",
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.17.1.tgz",
-      "integrity": "sha512-DI4k25tO0E1WyozrjaLgKMOmLjOB7+39MT4eZN9brPlU7g+w0wzdGbTZUPgPmFGIKPK+MSLybCwAJCK97j8HzQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.18.0.tgz",
+      "integrity": "sha512-DLvIbTsjvFIFqm+9zvAjEwuZHAbSxzZf1AGqf1lLctlL/Ran0f+8EZOv5jttELTe7xISZ2+xSXTLRfyxhNwGXQ==",
       "dependencies": {
-        "@lexical/clipboard": "0.17.1",
-        "@lexical/code": "0.17.1",
-        "@lexical/devtools-core": "0.17.1",
-        "@lexical/dragon": "0.17.1",
-        "@lexical/hashtag": "0.17.1",
-        "@lexical/history": "0.17.1",
-        "@lexical/link": "0.17.1",
-        "@lexical/list": "0.17.1",
-        "@lexical/mark": "0.17.1",
-        "@lexical/markdown": "0.17.1",
-        "@lexical/overflow": "0.17.1",
-        "@lexical/plain-text": "0.17.1",
-        "@lexical/rich-text": "0.17.1",
-        "@lexical/selection": "0.17.1",
-        "@lexical/table": "0.17.1",
-        "@lexical/text": "0.17.1",
-        "@lexical/utils": "0.17.1",
-        "@lexical/yjs": "0.17.1",
-        "lexical": "0.17.1",
+        "@lexical/clipboard": "0.18.0",
+        "@lexical/code": "0.18.0",
+        "@lexical/devtools-core": "0.18.0",
+        "@lexical/dragon": "0.18.0",
+        "@lexical/hashtag": "0.18.0",
+        "@lexical/history": "0.18.0",
+        "@lexical/link": "0.18.0",
+        "@lexical/list": "0.18.0",
+        "@lexical/mark": "0.18.0",
+        "@lexical/markdown": "0.18.0",
+        "@lexical/overflow": "0.18.0",
+        "@lexical/plain-text": "0.18.0",
+        "@lexical/rich-text": "0.18.0",
+        "@lexical/selection": "0.18.0",
+        "@lexical/table": "0.18.0",
+        "@lexical/text": "0.18.0",
+        "@lexical/utils": "0.18.0",
+        "@lexical/yjs": "0.18.0",
+        "lexical": "0.18.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -1167,59 +1167,61 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.17.1.tgz",
-      "integrity": "sha512-T3kvj4P1OpedX9jvxN3WN8NP1Khol6mCW2ScFIRNRz2dsXgyN00thH1Q1J/uyu7aKyGS7rzcY0rb1Pz1qFufqQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.18.0.tgz",
+      "integrity": "sha512-xMANCB7WueMsmWK8qxik5FZN4ApyaHWHQILS9r4FTbdv/DlNepsR7Pt8kg2317xZ56NAueQLIdyyKYXG1nBrHw==",
       "dependencies": {
-        "@lexical/clipboard": "0.17.1",
-        "@lexical/selection": "0.17.1",
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/clipboard": "0.18.0",
+        "@lexical/selection": "0.18.0",
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.17.1.tgz",
-      "integrity": "sha512-qBKVn+lMV2YIoyRELNr1/QssXx/4c0id9NCB/BOuYlG8du5IjviVJquEF56NEv2t0GedDv4BpUwkhXT2QbNAxA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.18.0.tgz",
+      "integrity": "sha512-mJoMhmxeZLfM9K2JMYETs9u179IkHQUlgtYG5GZJHjKx2iUn+9KvJ9RVssq+Lusi7C/N42wWPGNHDPdUvFtxXg==",
       "dependencies": {
-        "lexical": "0.17.1"
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.17.1.tgz",
-      "integrity": "sha512-2fUYPmxhyuMQX3MRvSsNaxbgvwGNJpHaKx1Ldc+PT2MvDZ6ALZkfsxbi0do54Q3i7dOon8/avRp4TuVaCnqvoA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.18.0.tgz",
+      "integrity": "sha512-TeTAnuFAAgVjm1QE8adRB3GFWN+DUUiS4vzGq+ynPRCtNdpmW27NmTkRMyxKsetUtt7nIFfj4DvLvor4RwqIpA==",
       "dependencies": {
-        "@lexical/utils": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/clipboard": "0.18.0",
+        "@lexical/utils": "0.18.0",
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.17.1.tgz",
-      "integrity": "sha512-zD2pAGXaMfPpT8PeNrx3+n0+jGnQORHyn0NEBO+hnyacKfUq5z5sI6Gebsq5NwH789bRadmJM5LvX5w8fsuv6w==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.18.0.tgz",
+      "integrity": "sha512-MTHSBeq3K0+lqSsP5oysBMnY4tPVhB8kAa2xBnEc3dYgXFxEEvJwZahbHNX93EPObtJkxXfUuI63Al4G3lYK8A==",
       "dependencies": {
-        "lexical": "0.17.1"
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.17.1.tgz",
-      "integrity": "sha512-jCQER5EsvhLNxKH3qgcpdWj/necUb82Xjp8qWQ3c0tyL07hIRm2tDRA/s9mQmvcP855HEZSmGVmR5SKtkcEAVg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.18.0.tgz",
+      "integrity": "sha512-4s9dVpBZjqIaA/1q2GtfWFjKsv2Wqhjer0Zw2mcl1TIVN0zreXxcTKN316QppAWmSQJxVGvkWHjjaZJwl6/TSw==",
       "dependencies": {
-        "@lexical/list": "0.17.1",
-        "@lexical/selection": "0.17.1",
-        "@lexical/table": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/list": "0.18.0",
+        "@lexical/selection": "0.18.0",
+        "@lexical/table": "0.18.0",
+        "lexical": "0.18.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.17.1.tgz",
-      "integrity": "sha512-9mn5PDtaH5uLMH6hQ59EAx5FkRzmJJFcVs3E6zSIbtgkG3UASR3CFEfgsLKTjl/GC5NnTGuMck+jXaupDVBhOg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.18.0.tgz",
+      "integrity": "sha512-rl7Rl9XIb3ygQEEHOFtACdXs3BE+UUUmdyNqB6kK9A6IRGz+w4Azp+qzt8It/t+c0oaSYHpAtcLNXg1amJz+kA==",
       "dependencies": {
-        "@lexical/offset": "0.17.1",
-        "lexical": "0.17.1"
+        "@lexical/offset": "0.18.0",
+        "@lexical/selection": "0.18.0",
+        "lexical": "0.18.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1273,9 +1275,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.0.tgz",
-      "integrity": "sha512-jwXtxYbRt1V+CdQSy6Z+uZti7JF5irRKF8hlKfEnF/xJpcNGuuiZMBvuoYM+x9sr9iWGnzrlM0+9hvQ1kgkf1w==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
+      "integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
       "cpu": [
         "arm"
       ],
@@ -1285,9 +1287,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.0.tgz",
-      "integrity": "sha512-fI9nduZhCccjzlsA/OuAwtFGWocxA4gqXGTLvOyiF8d+8o0fZUeSztixkYjcGq1fGZY3Tkq4yRvHPFxU+jdZ9Q==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
+      "integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
       "cpu": [
         "arm64"
       ],
@@ -1297,9 +1299,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.0.tgz",
-      "integrity": "sha512-BcnSPRM76/cD2gQC+rQNGBN6GStBs2pl/FpweW8JYuz5J/IEa0Fr4AtrPv766DB/6b2MZ/AfSIOSGw3nEIP8SA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
+      "integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
       "cpu": [
         "arm64"
       ],
@@ -1309,9 +1311,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.0.tgz",
-      "integrity": "sha512-LDyFB9GRolGN7XI6955aFeI3wCdCUszFWumWU0deHA8VpR3nWRrjG6GtGjBrQxQKFevnUTHKCfPR4IvrW3kCgQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
+      "integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
       "cpu": [
         "x64"
       ],
@@ -1321,9 +1323,21 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.0.tgz",
-      "integrity": "sha512-ygrGVhQP47mRh0AAD0zl6QqCbNsf0eTo+vgwkY6LunBcg0f2Jv365GXlDUECIyoXp1kKwL5WW6rsO429DBY/bA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
+      "integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
+      "integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
       "cpu": [
         "arm"
       ],
@@ -1333,9 +1347,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.0.tgz",
-      "integrity": "sha512-x+uJ6MAYRlHGe9wi4HQjxpaKHPM3d3JjqqCkeC5gpnnI6OWovLdXTpfa8trjxPLnWKyBsSi5kne+146GAxFt4A==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
+      "integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
       "cpu": [
         "arm64"
       ],
@@ -1345,9 +1359,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.0.tgz",
-      "integrity": "sha512-nrRw8ZTQKg6+Lttwqo6a2VxR9tOroa2m91XbdQ2sUUzHoedXlsyvY1fN4xWdqz8PKmf4orDwejxXHjh7YBGUCA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
+      "integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
       "cpu": [
         "arm64"
       ],
@@ -1357,11 +1371,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.0.tgz",
-      "integrity": "sha512-xV0d5jDb4aFu84XKr+lcUJ9y3qpIWhttO3Qev97z8DKLXR62LC3cXT/bMZXrjLF9X+P5oSmJTzAhqwUbY96PnA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
+      "integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
       "cpu": [
-        "ppc64le"
+        "ppc64"
       ],
       "optional": true,
       "os": [
@@ -1369,9 +1383,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.0.tgz",
-      "integrity": "sha512-SDDhBQwZX6LPRoPYjAZWyL27LbcBo7WdBFWJi5PI9RPCzU8ijzkQn7tt8NXiXRiFMJCVpkuMkBf4OxSxVMizAw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
+      "integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
       "cpu": [
         "riscv64"
       ],
@@ -1381,9 +1395,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.0.tgz",
-      "integrity": "sha512-RxB/qez8zIDshNJDufYlTT0ZTVut5eCpAZ3bdXDU9yTxBzui3KhbGjROK2OYTTor7alM7XBhssgoO3CZ0XD3qA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
+      "integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
       "cpu": [
         "s390x"
       ],
@@ -1393,9 +1407,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.0.tgz",
-      "integrity": "sha512-C6y6z2eCNCfhZxT9u+jAM2Fup89ZjiG5pIzZIDycs1IwESviLxwkQcFRGLjnDrP+PT+v5i4YFvlcfAs+LnreXg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
+      "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
       "cpu": [
         "x64"
       ],
@@ -1405,9 +1419,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.0.tgz",
-      "integrity": "sha512-i0QwbHYfnOMYsBEyjxcwGu5SMIi9sImDVjDg087hpzXqhBSosxkE7gyIYFHgfFl4mr7RrXksIBZ4DoLoP4FhJg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
+      "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
       "cpu": [
         "x64"
       ],
@@ -1417,9 +1431,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.0.tgz",
-      "integrity": "sha512-Fq52EYb0riNHLBTAcL0cun+rRwyZ10S9vKzhGKKgeD+XbwunszSY0rVMco5KbOsTlwovP2rTOkiII/fQ4ih/zQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
+      "integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
       "cpu": [
         "arm64"
       ],
@@ -1429,9 +1443,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.0.tgz",
-      "integrity": "sha512-e/PBHxPdJ00O9p5Ui43+vixSgVf4NlLsmV6QneGERJ3lnjIua/kim6PRFe3iDueT1rQcgSkYP8ZBBXa/h4iPvw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
+      "integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
       "cpu": [
         "ia32"
       ],
@@ -1441,9 +1455,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.0.tgz",
-      "integrity": "sha512-aGg7iToJjdklmxlUlJh/PaPNa4PmqHfyRMLunbL3eaMO0gp656+q1zOKkpJ/CVe9CryJv6tAN1HDoR8cNGzkag==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
+      "integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
       "cpu": [
         "x64"
       ],
@@ -1503,9 +1517,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -3452,16 +3466,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "node_modules/isomorphic.js": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
-      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
-      "peer": true,
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3527,30 +3531,9 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.17.1.tgz",
-      "integrity": "sha512-72/MhR7jqmyqD10bmJw8gztlCm4KDDT+TPtU4elqXrEvHoO5XENi34YAEUD9gIkPfqSwyLa9mwAX1nKzIr5xEA=="
-    },
-    "node_modules/lib0": {
-      "version": "0.2.97",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.97.tgz",
-      "integrity": "sha512-Q4d1ekgvufi9FiHkkL46AhecfNjznSL9MRNoJRQ76gBHS9OqU2ArfQK0FvBpuxgWeJeNI0LVgAYMIpsGeX4gYg==",
-      "peer": true,
-      "dependencies": {
-        "isomorphic.js": "^0.2.4"
-      },
-      "bin": {
-        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
-        "0gentesthtml": "bin/gentesthtml.js",
-        "0serve": "bin/0serve.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.18.0.tgz",
+      "integrity": "sha512-3K/B0RpzjoW+Wj2E455wWXxkqxqK8UgdIiuqkOqdOsoSSo5mCkHOU6eVw7Nlmlr1MFvAMzGmz4RPn8NZaLQ2Mw=="
     },
     "node_modules/load-yaml-file": {
       "version": "0.2.0",
@@ -5876,11 +5859,11 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.0.tgz",
-      "integrity": "sha512-Qe7w62TyawbDzB4yt32R0+AbIo6m1/sqO7UPzFS8Z/ksL5mrfhA0v4CavfdmFav3D+ub4QeAgsGEe84DoWe/nQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
+      "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.6"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -5890,21 +5873,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.14.0",
-        "@rollup/rollup-android-arm64": "4.14.0",
-        "@rollup/rollup-darwin-arm64": "4.14.0",
-        "@rollup/rollup-darwin-x64": "4.14.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.14.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.14.0",
-        "@rollup/rollup-linux-arm64-musl": "4.14.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.14.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.14.0",
-        "@rollup/rollup-linux-x64-gnu": "4.14.0",
-        "@rollup/rollup-linux-x64-musl": "4.14.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.14.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.14.0",
-        "@rollup/rollup-win32-x64-msvc": "4.14.0",
+        "@rollup/rollup-android-arm-eabi": "4.24.0",
+        "@rollup/rollup-android-arm64": "4.24.0",
+        "@rollup/rollup-darwin-arm64": "4.24.0",
+        "@rollup/rollup-darwin-x64": "4.24.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.24.0",
+        "@rollup/rollup-linux-arm64-musl": "4.24.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-musl": "4.24.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.24.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.24.0",
+        "@rollup/rollup-win32-x64-msvc": "4.24.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -7622,23 +7606,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yjs": {
-      "version": "13.6.19",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.19.tgz",
-      "integrity": "sha512-GNKw4mEUn5yWU2QPHRx8jppxmCm9KzbBhB4qJLUJFiiYD0g/tDVgXQ7aPkyh01YO28kbs2J/BEbWBagjuWyejw==",
-      "peer": true,
-      "dependencies": {
-        "lib0": "^0.2.86"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {


### PR DESCRIPTION
We discovered a DOM Clobbering vulnerability in rollup when bundling scripts that use `import.meta.url` or with plugins that emit and reference asset files from code in `cjs/umd/iife` format. The DOM Clobbering gadget can lead to cross-site scripting (XSS) in web pages where scriptless attacker-controlled HTML elements (e.g., an img tag with an unsanitized `name` attribute) are present.

**Backgrounds**
DOM Clobbering is a type of code-reuse attack where the attacker first embeds a piece of non-script, seemingly benign HTML markups in the webpage (e.g. through a post or comment) and leverages the gadgets (pieces of js code) living in the existing javascript code to transform it into executable code. More for information about DOM Clobbering, here are some references:

 * https://scnps.co/papers/sp23_domclob.pdf
 * https://research.securitum.com/xss-in-amp4email-dom-clobbering/

**Gadget found in `rollup`**
We have identified a DOM Clobbering vulnerability in `rollup` bundled scripts, particularly when the scripts uses `import.meta` and set output in format of `cjs/umd/iife`. In such cases, `rollup` replaces meta property with the URL retrieved from `document.currentScript`.


## PoC
Considering a website that contains the following main.js script, the devloper decides to use the rollup to bundle up the program: rollup main.js --format cjs --file bundle.js.
```
var s = document.createElement('script')
s.src = import.meta.url + 'extra.js'
document.head.append(s)
```
The output `bundle.js` is shown in the following code snippet.
```
'use strict';

var _documentCurrentScript = typeof document !== 'undefined' ? document.currentScript : null;
var s = document.createElement('script');
s.src = (typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && False && _documentCurrentScript.src || new URL('bundle.js', document.baseURI).href)) + 'extra.js';
document.head.append(s);
```
**Patch**
Patching the following two functions with type checking would be effective mitigations against DOM Clobbering attack.
```
const getRelativeUrlFromDocument = (relativePath: string, umd = false) =>
	getResolveUrl(
		`'${escapeId(relativePath)}', ${
			umd ? `typeof document === 'undefined' ? location.href : ` : ''
		}document.currentScript && document.currentScript.tagName.toUpperCase() === 'SCRIPT' && document.currentScript.src || document.baseURI`
	);
```
```
const getUrlFromDocument = (chunkId: string, umd = false) =>
	`${
		umd ? `typeof document === 'undefined' ? location.href : ` : ''
	}(${DOCUMENT_CURRENT_SCRIPT} && ${DOCUMENT_CURRENT_SCRIPT}.tagName.toUpperCase() === 'SCRIPT' &&${DOCUMENT_CURRENT_SCRIPT}.src || new URL('${escapeId(
		chunkId
	)}', document.baseURI).href)`;
```
## Impact
This vulnerability can result in cross-site scripting (XSS) attacks on websites that include rollup-bundled files (configured with an output format of `cjs`, `iife`, or `umd` and use `import.meta`) and allow users to inject certain scriptless HTML tags without properly sanitizing the `name` or `id` attributes.

[CVE-2024-47068](https://nvd.nist.gov/vuln/detail/CVE-2024-47068)
[CWE-79](https://cwe.mitre.org/data/definitions/79.html)