### PR TITLE
Bug Fix; Fix context menu pasting supporting lexical format to maintain style

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -136,7 +136,7 @@ export function $insertDataTransferForRichText(
 ): void {
   const lexicalString =
     dataTransfer.getData('application/x-lexical-editor') ||
-    dataTransfer.getData('application/x-lexical/editor');
+    dataTransfer.getData('web application/x-lexical-editor');
   if (lexicalString) {
     try {
       const payload = JSON.parse(lexicalString);

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -523,13 +523,12 @@ const clipboardDataFunctions = [
  */
 export function $getClipboardDataFromSelection(
   selection: BaseSelection | null = $getSelection(),
-  editor: LexicalEditor = $getEditor(),
 ): LexicalClipboardData {
   const clipboardData: LexicalClipboardData = {
     'text/plain': selection ? selection.getTextContent() : '',
-    'web application/x-lexical-editor': $getLexicalContent(editor, selection),
   };
   if (selection) {
+    const editor = $getEditor();
     for (const [mimeType, $editorFn] of clipboardDataFunctions) {
       const v = $editorFn(editor, selection);
       if (v !== null) {

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -39,7 +39,7 @@ export interface LexicalClipboardData {
   'text/html'?: string | undefined;
   'application/x-lexical-editor'?: string | undefined;
   'text/plain': string;
-  'web application/x-lexical-editor'?: string | null;
+  'web application/x-lexical-editor'?: string | undefined;
 }
 
 /**


### PR DESCRIPTION


## Description
clipboard API doesnt support "application/x-lexical-editor" type which is causing pasting through context menu to lose orignal style of copied text
Trying to register application/x-lexical-format in the but $onPasteForRichText is only storing text/html and text/plain
*Describe the changes in this pull request*

Closes #6720  (attempts to)
 see video for more info

https://github.com/user-attachments/assets/bdba1daf-18e1-460b-8d8f-fde5264c8ecb




## Test plan
TBD
### Before




### After
TBD
