### PR TITLE
[lexical] Feature: Add onUpdate function during update with $onUpdate (correct baselline)

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -844,6 +844,7 @@ declare export function $isParagraphNode(
 export type EventHandler = (event: Event, editor: LexicalEditor) => void;
 declare export function $hasUpdateTag(tag: string): boolean;
 declare export function $addUpdateTag(tag: string): void;
+declare export function $onUpdate(updateFn: () => void): void;
 declare export function $getNearestNodeFromDOMNode(
   startingDOM: Node,
 ): LexicalNode | null;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1314,6 +1314,19 @@ export function $addUpdateTag(tag: string): void {
   editor._updateTags.add(tag);
 }
 
+/**
+ * Add a function to run after the current update. This will run after any
+ * `onUpdate` function already supplied to `editor.update()`, as well as any
+ * functions added with previous calls to `$onUpdate`.
+ *
+ * @param updateFn The function to run after the current update.
+ */
+export function $onUpdate(updateFn: () => void): void {
+  errorOnReadOnly();
+  const editor = getActiveEditor();
+  editor._deferred.push(updateFn);
+}
+
 export function $maybeMoveChildrenSelectionToParent(
   parentNode: LexicalNode,
 ): BaseSelection | null {

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -23,6 +23,7 @@ import {
 } from 'lexical';
 
 import {
+  $onUpdate,
   emptyFunction,
   generateRandomKey,
   getCachedTypeToNodeMap,
@@ -239,6 +240,43 @@ describe('LexicalUtils tests', () => {
         expect(currentParagraphKeys).toEqual(
           expect.arrayContaining(paragraphKeys),
         );
+      });
+    });
+
+    describe('$onUpdate', () => {
+      test('added fn runs after update, original onUpdate, and prior calls to $onUpdate', () => {
+        const {editor} = testEnv;
+        const runs: string[] = [];
+
+        editor.update(
+          () => {
+            $getRoot().append(
+              $createParagraphNode().append($createTextNode('foo')),
+            );
+            $onUpdate(() => {
+              runs.push('second');
+            });
+            $onUpdate(() => {
+              runs.push('third');
+            });
+          },
+          {
+            onUpdate: () => {
+              runs.push('first');
+            },
+          },
+        );
+
+        // Flush pending updates
+        editor.read(() => {});
+
+        expect(runs).toEqual(['first', 'second', 'third']);
+      });
+
+      test('adding fn throws outside update', () => {
+        expect(() => {
+          $onUpdate(() => {});
+        }).toThrow();
       });
     });
 

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -172,6 +172,7 @@ export {
   $isRootOrShadowRoot,
   $isTokenOrSegmented,
   $nodesOfType,
+  $onUpdate,
   $selectAll,
   $setCompositionKey,
   $setSelection,


### PR DESCRIPTION
## Description

Adds `$onUpdate(fn)` to allow an in-progress update/command to append a function to the `_deferred` stack.

Closes #6767

## Test plan

### Before

This functionality did not exist. Calling `editor.update` with an `onUpdate` function was the only way to perform an action after an update.

### After

Performing an update such as:

```ts
editor.update(() => {
  // perform updates
  $onUpdate(() => {
    console.log('second onUpdate);
  });
}, {
  onUpdate: () => {
    console.log('first onUpdate');
  }
});
```

would emit `first onUpdate`, followed by `second onUpdate`, once the updates were flushed. This is essentially what the unit test does.

<img width="637" alt="Successful unit test results" src="https://github.com/user-attachments/assets/3aacd3a6-b923-4f94-93ac-3f722794403b">
