### PR TITLE
fix empty line issue

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -30,7 +30,7 @@ import {isEmptyParagraph, transformersByType} from './utils';
  */
 export function createMarkdownExport(
   transformers: Array<Transformer>,
-  shouldPreserveNewLines: boolean = false,
+  shouldPreserveNewLines: boolean = true,
 ): (node?: ElementNode) => string {
   const byType = transformersByType(transformers);
   const elementTransformers = [...byType.multilineElement, ...byType.element];

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -46,7 +46,7 @@ type TextFormatTransformersIndex = Readonly<{
  */
 export function createMarkdownImport(
   transformers: Array<Transformer>,
-  shouldPreserveNewLines = false,
+  shouldPreserveNewLines = true,
 ): (markdownString: string, node?: ElementNode) => void {
   const byType = transformersByType(transformers);
   const textFormatTransformersIndex = createTextFormatTransformersIndex(

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -84,8 +84,8 @@ function $convertFromMarkdownString(
   markdown: string,
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
-  shouldPreserveNewLines = false,
-  shouldMergeAdjacentLines = false,
+  shouldPreserveNewLines = true,
+  shouldMergeAdjacentLines = true,
 ): void {
   const sanitizedMarkdown = shouldPreserveNewLines
     ? markdown
@@ -103,7 +103,7 @@ function $convertFromMarkdownString(
 function $convertToMarkdownString(
   transformers: Array<Transformer> = TRANSFORMERS,
   node?: ElementNode,
-  shouldPreserveNewLines: boolean = false,
+  shouldPreserveNewLines: boolean = true,
 ): string {
   const exportMarkdown = createMarkdownExport(
     transformers,

--- a/packages/lexical-playground/src/appSettings.ts
+++ b/packages/lexical-playground/src/appSettings.ts
@@ -22,7 +22,7 @@ export const DEFAULT_SETTINGS = {
   isMaxLength: false,
   isRichText: true,
   measureTypingPerf: false,
-  shouldPreserveNewLinesInMarkdown: false,
+  shouldPreserveNewLinesInMarkdown: true,
   shouldUseLexicalContextMenu: false,
   showNestedEditorTreeView: false,
   showTableOfContents: false,


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
Currently, empty lines on markdown disappear when the markdown button is toggled.
This pull request aim to ensure empty lines are maintained upon toggling markdown. 
I realised that setting a variable called `shouldPreserveNewLines`  to true across all instances it was used seemed to fix the issue.

Closes #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*