### PR TITLE
#6768 fix to avoid infinite markdown shortcut matchers run

### DIFF
--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -480,10 +480,13 @@ export function registerMarkdownShortcuts(
       const selection = editorState.read($getSelection);
       const prevSelection = prevEditorState.read($getSelection);
 
+      // We expect selection to be a collapsed range and not match previous one (as we want
+      // to trigger transforms only as user types)
       if (
         !$isRangeSelection(prevSelection) ||
         !$isRangeSelection(selection) ||
-        !selection.isCollapsed()
+        !selection.isCollapsed() ||
+        selection.is(prevSelection)
       ) {
         return;
       }

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -595,6 +595,16 @@ test.describe.parallel('Markdown', () => {
       `,
       text: 'hello [world](https://www.test.com)!',
     },
+    {
+      html: html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">10:20:30😄</span>
+        </p>
+      `,
+      text: '10:20:30:smile:',
+    },
   ];
 
   const NESTED_TEXT_FORMAT_SHORTCUTS = [

--- a/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
+++ b/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts
@@ -100,7 +100,7 @@ export const EMOJI: TextMatchTransformer = {
   dependencies: [],
   export: () => null,
   importRegExp: /:([a-z0-9_]+):/,
-  regExp: /:([a-z0-9_]+):/,
+  regExp: /:([a-z0-9_]+):$/,
   replace: (textNode, [, name]) => {
     const emoji = emojiList.find((e) => e.aliases.includes(name))?.emoji;
     if (emoji) {


### PR DESCRIPTION
Issue #6768 happens because of emoji markdown shortcut. It has conditional replacement which was not really supported for shortcuts:

https://github.com/facebook/lexical/blob/07ca5c83c2f512734976504ef9fae5d39b6072ae/packages/lexical-playground/src/plugins/MarkdownTransformers/index.ts#L105-L108

1. Quick option is to disable it from list of shortcut transformers: 

https://github.com/facebook/lexical/blob/07ca5c83c2f512734976504ef9fae5d39b6072ae/packages/lexical-playground/src/plugins/MarkdownShortcutPlugin/index.tsx#L15

2. Another alternative would be to update emoji RegExp to match exact emoji names and instead of having `:([a-Z0-9]):` it'd be `:(smile|sad|happy|...|joy):`. The problem is that with current emoji-list that regex is 23kb long.

3. Enable conditional replacement (this PR). The reason it ran infinitely is because once we find match we call `textNode.splitText(matchOffset)` to extract text node that should be replaced:

https://github.com/facebook/lexical/blob/07ca5c83c2f512734976504ef9fae5d39b6072ae/packages/lexical-markdown/src/MarkdownShortcuts.ts#L174-L181

Even if we don't replace anything, it still causes full update cycle which triggers another transformers run. One thing is whether we should even call update cycle for unused result of `.splitText` (cc @zurfyx) given split nodes will reconcile back to a single text node. But on top of it, we don't really need to run any shortcuts logic if selection itself hasn't changed as we only suppose to do it when user types (i.e. selection moves).

Another (more minor) issue was in emoji regex that should ensure we only attempt to run matcher against end of node's text

### Test plan

Tests + sanity check

```
npm run test-e2e-chromium -- Markdown
✓ 52 passed (28.5s)
```