### PR TITLE
[lexical-website] Breaking change: Upgrading `docusaurus-plugin-typedoc`

### DIFF
--- a/packages/lexical-website/docusaurus.config.js
+++ b/packages/lexical-website/docusaurus.config.js
@@ -191,6 +191,7 @@ const docusaurusPluginTypedocConfig = {
     './src/plugins/lexical-typedoc-plugin-no-inherit',
     './src/plugins/lexical-typedoc-plugin-module-name',
     'typedoc-plugin-rename-defaults',
+    'typedoc-plugin-frontmatter',
   ],
   sidebar: {
     autoConfiguration: false,

--- a/packages/lexical-website/package.json
+++ b/packages/lexical-website/package.json
@@ -21,11 +21,12 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@vercel/analytics": "^1.0.1",
     "docusaurus-plugin-internaldocs-fb": "1.18.2",
-    "docusaurus-plugin-typedoc": "^0.22.0",
+    "docusaurus-plugin-typedoc": "^1.0.5",
     "fs-extra": "^10.0.0",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "typedoc-plugin-frontmatter": "^1.0.0",
     "typedoc-plugin-markdown": "^3.17.1",
     "typedoc-plugin-rename-defaults": "^0.7.0",
     "unist-util-visit": "^5.0.0"
@@ -34,7 +35,7 @@
     "buffer": "^6.0.3",
     "prettier-plugin-tailwindcss": "^0.4.1",
     "tailwindcss": "^3.3.3",
-    "typedoc": "^0.25.12",
+    "typedoc": "^0.26.10",
     "typescript": "^5.4.5",
     "webpack": "^5.76.0"
   },


### PR DESCRIPTION
## Description
This pull request addresses issue #6072 by updating the version of `docusaurus-plugin-typedoc`. 
I refered this [change log](https://github.com/typedoc2md/typedoc-plugin-markdown/blob/main/packages/docusaurus-plugin-typedoc/CHANGELOG.md). Since it includes relevant modules, additional updates are required in other modules as well.

## Changes Made
* `docusaurus-plugin-typedoc` version changed from `0.22.0` -> `1.0.5`
* `typedoc` version changed from `0.25.12` -> `0.26.10`
* `typedoc-plugin-frontmatter` plugin is added in `docusaurus.config.js`

## Test plan

### Before
Documents under `./packages/lexical-website/docs/api` and `./packages/lexical-website/docs/packages` are generated successfully.
![Screenshot 2024-10-30 at 11 18 49](https://github.com/user-attachments/assets/7bb2ca6a-3f16-49a5-8570-49b6ce7fd6dd)

### After
Delete `./packages/lexical-website/docs/api` and `./packages/lexical-website/docs/packages` folders and run 
```
npm run build
```
under `lexical-website` folder to confirm the documents are successfully generated.

## Issue still need to be fixed
There’s an issue with updating below.
https://github.com/facebook/lexical/blob/e96ee55b749c0fed8ac03d49044dd5594f0bc32e/packages/lexical-website/sidebars.js#L23-L25
When I 
- delete`./packages/lexical-website/docs/api`
- go to `./packages/lexical-website` folder 
- run command `npm run build`

the files are not automatically regenerated.
I documented this problem on the #6072 page, but I haven’t been able to resolve it since I’m unsure who is responsible for it.

I also reached out to the `typedoc-plugin-markdown` module repository for help with modifying the code [here](https://github.com/typedoc2md/typedoc-plugin-markdown/issues/707), but I’m not certain how to implement a fix.

Any assistance with this would be greatly appreciated.