### PR TITLE
[lexical-playground] Fix: the placement of the fontSize button in the ToolbarPlugin  and hide the vertical scroll (Bug Fix)

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1447,6 +1447,7 @@ button.action-button:disabled {
   position: sticky;
   top: 0;
   z-index: 2;
+  overflow-y: hidden; /* disable vertical scroll*/
 }
 
 button.toolbar-item {

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.css
@@ -12,11 +12,11 @@
   color: #777;
   border-radius: 5px;
   border-color: grey;
-  height: 21px;
-  margin-top: 5px;
+  height: 15px;
   padding: 2px 4px;
   text-align: center;
   width: 20px;
+  align-self: center;
 }
 
 .font-size-input:disabled {


### PR DESCRIPTION
This pr aims to fix #6785 

## Description
The changes I made aims to fix the hidden fontsize button when you resizing the browser tab(to a smaller size) of the lexical playground, 

## Before

![Screenshot 2024-11-01 101424](https://github.com/user-attachments/assets/bbbbabeb-8317-4121-a737-1c00692a6774)


## After Fix
![Screenshot 2024-11-01 105702](https://github.com/user-attachments/assets/d1ad2a13-ea62-4d31-9653-1522b240aede)


Closes #6785 

