### PR TITLE
[lexical-list] Bug Fix: Handle appending inline element nodes in ListNode.append

### DIFF
--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -200,8 +200,12 @@ export class ListNode extends ElementNode {
         if ($isListNode(currentNode)) {
           listItemNode.append(currentNode);
         } else if ($isElementNode(currentNode)) {
-          const textNode = $createTextNode(currentNode.getTextContent());
-          listItemNode.append(textNode);
+          if (currentNode.isInline()) {
+            listItemNode.append(currentNode);
+          } else {
+            const textNode = $createTextNode(currentNode.getTextContent());
+            listItemNode.append(textNode);
+          }
         } else {
           listItemNode.append(currentNode);
         }


### PR DESCRIPTION
Currently, `ListNode.append` will always convert an element node into a text node, even if the element node is inline and can be appended as a whole which can end up removing formatting and unwrapping things like links.

While this is rarely hit, since most of the code in the lexical codebase accounts for appending to a child list item instead of the list directly, I think it still makes sense for this to be correct.