### PR TITLE
Add optional selection argument to $getHtmlContent flow type

### DIFF
--- a/packages/lexical-clipboard/flow/LexicalClipboard.js.flow
+++ b/packages/lexical-clipboard/flow/LexicalClipboard.js.flow
@@ -24,7 +24,11 @@ declare export function $insertDataTransferForRichText(
   editor: LexicalEditor,
 ): void;
 
-declare export function $getHtmlContent(editor: LexicalEditor): string | null;
+declare export function $getHtmlContent(
+  editor: LexicalEditor,
+  selection?: BaseSelection,
+): string | null;
+
 declare export function $getLexicalContent(
   editor: LexicalEditor,
 ): string | null;


### PR DESCRIPTION
TSIA -- the implementation has an optional selection argument that defaults to `$getSelection()`

<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

Closes #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*