### PR TITLE
[lexical] Chore: Add export of DOMExportOutputMap from lexical

### DIFF
--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -42,6 +42,7 @@ export type {
   DOMConversionMap,
   DOMConversionOutput,
   DOMExportOutput,
+  DOMExportOutputMap,
   LexicalNode,
   NodeKey,
   NodeMap,


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

In the current setup, the `DOMExportOutputMap` type is not exported from the Lexical core, making it challenging for developers to define custom export configurations in the `html` property of `CreateEditorArgs` without re-creating this type from scratch. This process can lead to redundant code and a higher risk of type errors, particularly for configurations that customize DOM export logic.

This PR exports `DOMExportOutputMap` directly from the Lexical core, allowing developers to use this type immediately in any html.export configurations, which:

1. Reduces redundant type definitions.
2. Improves code readability and reusability.
3. Enhances type safety for custom DOM export setups.

Closes #6802

## Test plan

### Before
Developers needed to manually define `DOMExportOutputMap`, increasing the risk of type errors and inconsistencies in custom export configurations.

### After

With `DOMExportOutputMap` now directly accessible from the Lexical core, developers can import and use the type immediately, resulting in cleaner and more robust custom export setups.
