### PR TITLE
[lexical-mark] Bug Fix: Stop MarkNode __ids array deep copy in clone

### DIFF
--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -39,7 +39,7 @@ export class MarkNode extends ElementNode {
   }
 
   static clone(node: MarkNode): MarkNode {
-    return new MarkNode(Array.from(node.__ids), node.__key);
+    return new MarkNode(node.__ids, node.__key);
   }
 
   static importDOM(): null {
@@ -118,7 +118,7 @@ export class MarkNode extends ElementNode {
   addID(id: string): void {
     const self = this.getWritable();
     if ($isMarkNode(self)) {
-      const ids = self.__ids;
+      const ids = Array.from(self.__ids);
       self.__ids = ids;
       for (let i = 0; i < ids.length; i++) {
         // If we already have it, don't add again
@@ -133,7 +133,7 @@ export class MarkNode extends ElementNode {
   deleteID(id: string): void {
     const self = this.getWritable();
     if ($isMarkNode(self)) {
-      const ids = self.__ids;
+      const ids = Array.from(self.__ids);
       self.__ids = ids;
       for (let i = 0; i < ids.length; i++) {
         if (id === ids[i]) {

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -32,7 +32,7 @@ export type SerializedMarkNode = Spread<
 /** @noInheritDoc */
 export class MarkNode extends ElementNode {
   /** @internal */
-  __ids: Array<string>;
+  __ids: readonly string[];
 
   static getType(): string {
     return 'mark';
@@ -57,13 +57,13 @@ export class MarkNode extends ElementNode {
   exportJSON(): SerializedMarkNode {
     return {
       ...super.exportJSON(),
-      ids: this.getIDs(),
+      ids: Array.from(this.getIDs()),
       type: 'mark',
       version: 1,
     };
   }
 
-  constructor(ids: Array<string>, key?: NodeKey) {
+  constructor(ids: readonly string[], key?: NodeKey) {
     super(key);
     this.__ids = ids || [];
   }
@@ -112,7 +112,7 @@ export class MarkNode extends ElementNode {
 
   getIDs(): Array<string> {
     const self = this.getLatest();
-    return $isMarkNode(self) ? self.__ids : [];
+    return $isMarkNode(self) ? Array.from(self.__ids) : [];
   }
 
   addID(id: string): void {
@@ -197,7 +197,7 @@ export class MarkNode extends ElementNode {
   }
 }
 
-export function $createMarkNode(ids: Array<string>): MarkNode {
+export function $createMarkNode(ids: readonly string[]): MarkNode {
   return $applyNodeReplacement(new MarkNode(ids));
 }
 


### PR DESCRIPTION
## Description

In this PR creation of a new `__ids` array is avoided in the clone function of the MarkNode, and the cloned MarkNode will have the same reference to` __ids` array of the original node. This has made an issue in the `syncPropertiesFromYjs` function where we [compare](https://github.com/facebook/lexical/blob/76f8569211780ee7e913176d99d23eddd1cd3b6c/packages/lexical-yjs/src/Utils.ts#L282C5-L282C35
) the old and new nodes' properties, and only make an update to ydoc if the properties are changed. In the case MarkNodes, because the clone function deep-copies the `__ids` array the property comparison detects a change, despite the arrays being identical.

The fix is keeping the same `__ids` array in the cloned node, and only creating new `__ids` array when the array is modified.
