### PR TITLE
Fix: Aria attributes for ContentEditable are ignored

### DIFF
--- a/packages/lexical-react/src/shared/LexicalContentEditableElement.tsx
+++ b/packages/lexical-react/src/shared/LexicalContentEditableElement.tsx
@@ -88,7 +88,6 @@ function ContentEditableElementImpl(
 
   return (
     <div
-      {...rest}
       aria-activedescendant={isEditable ? ariaActiveDescendant : undefined}
       aria-autocomplete={isEditable ? ariaAutoComplete : 'none'}
       aria-controls={isEditable ? ariaControls : undefined}
@@ -118,6 +117,7 @@ function ContentEditableElementImpl(
       spellCheck={spellCheck}
       style={style}
       tabIndex={tabIndex}
+      {...rest}
     />
   );
 }


### PR DESCRIPTION

## Description
Fix Aria attributes for ContentEditable element

Closes #6789

## Test plan

### Before

When adding aria-labelledby to the ContentEditable it is not visible in the dom.

```
<ContentEditable
className={'ContentEditable__root'}
aria-labelledby='TEST'
/>

```

### After

The aria-labelledby is visible in the the dom. you can check it out by inspecting element in browser DevTools to verify the ARIA attributes...


## TODO
Write a unit test to verify the attributes are properly rendered in the DOM