### PR TITLE
[lexical-rich-text][lexical-plain-text] workaround for Korean IME issue on iOS

### DIFF
--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -274,6 +274,12 @@ export function registerPlainText(editor: LexicalEditor): () => void {
           return false;
         }
 
+        // Exception handling for iOS native behavior instead of Lexical's behavior when using Korean on iOS devices.
+        // more details - https://github.com/facebook/lexical/issues/5841
+        if (IS_IOS && navigator.language === 'ko-KR') {
+          return false;
+        }
+
         event.preventDefault();
         return editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
       },

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -878,7 +878,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
 
         // Exception handling for iOS native behavior instead of Lexical's behavior when using Korean on iOS devices.
         // more details - https://github.com/facebook/lexical/issues/5841
-        if (navigator.language === 'ko-KR' && IS_IOS) {
+        if (IS_IOS && navigator.language === 'ko-KR') {
           return false;
         }
         event.preventDefault();

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -871,6 +871,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
         ) {
           const element = $getNearestBlockElementAncestorOrThrow(anchorNode);
           if (element.getIndent() > 0) {
+            event.preventDefault();
             return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
           }
         }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -863,14 +863,14 @@ export function registerRichText(editor: LexicalEditor): () => void {
 
         // Exception handling for iOS native behavior instead of Lexical's behavior when using Korean on iOS devices.
         // On other devices, if you backspace during composing, you get a keyCode of 229 (composing state), but on iOS, the behavior is different: it outputs a keyCode of 8 and appends the remnants of the composing character to the previous character.
-         if (
+        if (
           event.keyCode === 8 &&
           navigator.language === 'ko-KR' &&
           /iPad|iPhone|iPod/.test(navigator.userAgent)
         ) {
           return false;
         }
-        
+
         event.preventDefault();
         const {anchor} = selection;
         const anchorNode = anchor.getNode();

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -863,8 +863,12 @@ export function registerRichText(editor: LexicalEditor): () => void {
 
         // Exception handling for iOS native behavior instead of Lexical's behavior when using Korean on iOS devices.
         // On other devices, if you backspace during composing, you get a keyCode of 229 (composing state), but on iOS, the behavior is different: it outputs a keyCode of 8 and appends the remnants of the composing character to the previous character.
-        if (event.keyCode === 8 && navigator.language === 'ko-KR' && /iPad|iPhone|iPod/.test(navigator.userAgent)) {
-          return false
+         if (
+          event.keyCode === 8 &&
+          navigator.language === 'ko-KR' &&
+          /iPad|iPhone|iPod/.test(navigator.userAgent)
+        ) {
+          return false;
         }
         
         event.preventDefault();

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -860,6 +860,13 @@ export function registerRichText(editor: LexicalEditor): () => void {
         if (!$isRangeSelection(selection)) {
           return false;
         }
+
+        // Exception handling for iOS native behavior instead of Lexical's behavior when using Korean on iOS devices.
+        // On other devices, if you backspace during composing, you get a keyCode of 229 (composing state), but on iOS, the behavior is different: it outputs a keyCode of 8 and appends the remnants of the composing character to the previous character.
+        if (event.keyCode === 8 && navigator.language === 'ko-KR' && /iPad|iPhone|iPod/.test(navigator.userAgent)) {
+          return false
+        }
+        
         event.preventDefault();
         const {anchor} = selection;
         const anchorNode = anchor.getNode();

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -861,17 +861,6 @@ export function registerRichText(editor: LexicalEditor): () => void {
           return false;
         }
 
-        // Exception handling for iOS native behavior instead of Lexical's behavior when using Korean on iOS devices.
-        // On other devices, if you backspace during composing, you get a keyCode of 229 (composing state), but on iOS, the behavior is different: it outputs a keyCode of 8 and appends the remnants of the composing character to the previous character.
-        if (
-          event.keyCode === 8 &&
-          navigator.language === 'ko-KR' &&
-          /iPad|iPhone|iPod/.test(navigator.userAgent)
-        ) {
-          return false;
-        }
-
-        event.preventDefault();
         const {anchor} = selection;
         const anchorNode = anchor.getNode();
 
@@ -885,6 +874,14 @@ export function registerRichText(editor: LexicalEditor): () => void {
             return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
           }
         }
+
+        // Exception handling for iOS native behavior instead of Lexical's behavior when using Korean on iOS devices.
+        // more details - https://github.com/facebook/lexical/issues/5841
+        if (navigator.language === 'ko-KR' && IS_IOS) {
+          return false;
+        }
+        event.preventDefault();
+
         return editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
       },
       COMMAND_PRIORITY_EDITOR,


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

related to #5841, #3305.
based on #4814,

- adds follow-up commits to resolve side effect caused by blocking `isCollapsed` handling.
- adds same workaround to plain text plugin.

while we don't have `e2e-ios` tests, I checked the fix without `if (navigator.language === 'ko-KR' && IS_IOS)` passed tests on my local.

please include @Deadintegral as a co-author since it contains his work. 

Closes #4814

## Test plan

### Before

https://github.com/user-attachments/assets/c9483f3c-a8b9-4aa9-96b3-663d46d3d2e9

### After

https://github.com/user-attachments/assets/c294d341-bac4-4bed-af6a-15e094e33372

