### PR TITLE
[lexical-examples] Chore: Add DOMExportOutputMap type to the exportMap

### DIFF
--- a/examples/react-rich/package-lock.json
+++ b/examples/react-rich/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@lexical/react-rich-example",
-  "version": "0.15.0",
+  "version": "0.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-rich-example",
-      "version": "0.15.0",
+      "version": "0.20.0",
       "dependencies": {
-        "@lexical/react": "0.15.0",
-        "lexical": "0.15.0",
+        "@lexical/react": "0.20.0",
+        "lexical": "0.20.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -789,38 +789,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.15.0.tgz",
-      "integrity": "sha512-binCltK7KiURQJFogvueYfmDNEKynN/lmZrCLFp2xBjEIajqw4WtOVLJZ33engdqNlvj0JqrxrWxbKG+yvUwrg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.20.0.tgz",
+      "integrity": "sha512-oHmb9kSVHjeFCd2q8VrEXW22doUHMJ6cGXqo7Ican7Ljl4/9OgRWr+cq55yntoSaJfCrRYkTiZCLDejF2ciSiA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.15.0",
-        "@lexical/list": "0.15.0",
-        "@lexical/selection": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/html": "0.20.0",
+        "@lexical/list": "0.20.0",
+        "@lexical/selection": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.15.0.tgz",
-      "integrity": "sha512-n185gjinGhz/M4BW1ayNPYAEgwW4T/NEFl2Wey/O+07W3zvh9k9ai7RjWd0c8Qzqc4DLlqvibvWPebWObQHA4w==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.20.0.tgz",
+      "integrity": "sha512-zFsVGuzIn4CQxEnlW4AG/Hq6cyATVZ4fZTxozE/f5oK4vDPvnY/goRxrzSuAMX73A/HRX3kTEzMDcm4taRM3Mg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0",
         "prismjs": "^1.27.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.15.0.tgz",
-      "integrity": "sha512-kK/IVEiQyqs2DsY4QRYFaFiKQMpaAukAl8PXmNeGTZ7cfFVsP29E4n0/pjY+oxmiRvxbO1s2i14q58nfuhj4VQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.20.0.tgz",
+      "integrity": "sha512-/CnL+Dfpzw4koy2BTdUICkvrCkMIYG8Y73KB/S1Bt5UzJpD+PV300puWJ0NvUvAj24H78r73jxvK2QUG67Tdaw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.15.0",
-        "@lexical/link": "0.15.0",
-        "@lexical/mark": "0.15.0",
-        "@lexical/table": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/html": "0.20.0",
+        "@lexical/link": "0.20.0",
+        "@lexical/mark": "0.20.0",
+        "@lexical/table": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -828,133 +831,145 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.15.0.tgz",
-      "integrity": "sha512-hg2rGmxVJF7wmN6psuKw3EyhcNF7DtOYwUCBpjFZVshzAjsNEBfEnqhiMkSVSlN4+WOfM7LS+B88PTKPcnFGbQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.20.0.tgz",
+      "integrity": "sha512-3DAHF8mSKiPZtXCqu2P8ynSwS3fGXzg4G/V0lXNjBxhmozjzUzWZRWIWtmTlWdEu9GXsoyeM3agcaxyDPJJwkA==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.15.0"
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.15.0.tgz",
-      "integrity": "sha512-EP6KKvS6BY/8Vh1MLQYeOcYaxnvrLsUkvXXr+Fg8N477Us54Ju69pPO563mbWt7/bpnL9Sh0fbk82JtxqPWpSg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.20.0.tgz",
+      "integrity": "sha512-ldOP/d9tA6V9qvLyr3mRYkcYY5ySOHJ2BFOW/jZPxQcj6lWafS8Lk7XdMUpHHDjRpY2Hizsi5MHJkIqFglYXbw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.15.0.tgz",
-      "integrity": "sha512-r+pzR2k/51AL6l8UfXeVe/GWPIeWY1kEOuKx9nsYB9tmAkTF66tTFz33DJIMWBVtAHWN7Dcdv0/yy6q8R6CAUQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.20.0.tgz",
+      "integrity": "sha512-dXtIS31BU6RmLX2KwLAi1EgGl+USeyi+rshh19azACXHPFqONZgPd2t21LOLSFn7C1/W+cSp/kqVDlQVbZUZRA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.15.0.tgz",
-      "integrity": "sha512-x/sfGvibwo8b5Vso4ppqNyS/fVve6Rn+TmvP/0eWOaa0I3aOQ57ulfcK6p/GTe+ZaEi8vW64oZPdi8XDgwSRaA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.20.0.tgz",
+      "integrity": "sha512-ob7QHkEv+mhaZjlurDj90UmEyN9G4rzBPR5QV42PLnu1qMSviMEdI5V3a5/A5aFf/FDDQ+0GAgWBFnA/MEDczQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/selection": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.15.0.tgz",
-      "integrity": "sha512-KBV/zWk5FxqZGNcq3IKGBDCcS4t0uteU1osAIG+pefo4waTkOOgibxxEJDop2QR5wtjkYva3Qp0D8ZyJDMMMlw==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.20.0.tgz",
+      "integrity": "sha512-zicDcfgRZPRFZ8WOZv5er0Aqkde+i7QoFVkLQD4dNLLORjoMSJOISJH6VEdjBl3k7QJTxbfrt+xT5d/ZsAN5GA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.15.0.tgz",
-      "integrity": "sha512-JuF4k7uo4rZFOSZGrmkxo1+sUrwTKNBhhJAiCgtM+6TO90jppxzCFNKur81yPzF1+g4GWLC9gbjzKb52QPb6cQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.20.0.tgz",
+      "integrity": "sha512-ufSse8ui3ooUe0HA/yF/9STrG8wYhIDLMRhELOw80GFCkPJaxs6yRvjfmJooH5IC88rpUJ5XXFFiZKfGxEZLEw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.15.0.tgz",
-      "integrity": "sha512-cdePA98sOJRc4/HHqcOcPBFq4UDwzaFJOK1N1E6XUGcXH1GU8zHtV1ElTgmbsGkyjBRwhR+OqKm9eso1PBOUkg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.20.0.tgz",
+      "integrity": "sha512-1P2izmkgZ4VDp+49rWO1KfWivL5aA30y5kkYbFZ/CS05fgbO7ogMjLSajpz+RN/zzW79v3q4YfikrMgaD23InA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.15.0.tgz",
-      "integrity": "sha512-wu1EP758l452BovDa7i9ZAeWuFj+YY0bc2mNc08nfZ9GqdGMej1JIguY4CwIROCYVizprL9Ocn0avH1uv9b8fA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.20.0.tgz",
+      "integrity": "sha512-ZoGsECejp9z6MEvc8l81b1h1aWbB3sTq6xOFeUTbDL5vKpA67z5CmQQLi0uZWrygrbO9dSE3Q/JGcodUrczxbw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.15.0",
-        "@lexical/link": "0.15.0",
-        "@lexical/list": "0.15.0",
-        "@lexical/rich-text": "0.15.0",
-        "@lexical/text": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/code": "0.20.0",
+        "@lexical/link": "0.20.0",
+        "@lexical/list": "0.20.0",
+        "@lexical/rich-text": "0.20.0",
+        "@lexical/text": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.15.0.tgz",
-      "integrity": "sha512-VO1f3m8+RRdRjuXMtCBhi1COVKRC2LhP8AFYxnFlvbV+Waz9R5xB9pqFFUe4RtyqyTLmOUj6+LtsUFhq+23voQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.20.0.tgz",
+      "integrity": "sha512-VMhxsxxDGnpVw0jgC8UlDf0Q2RHIHbS49uZgs3l9nP+O+G8s3b76Ta4Tb+iJOK2FY6874/TcQMbSuXGhfpQk8A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.15.0"
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.15.0.tgz",
-      "integrity": "sha512-9qKVCvh9Oka+bzR3th+UWdTEeMZXYy1ZxWbjSxefRMgQxzCvqSuVioK/065gPbvGga9EfvgLLLBDXZm8ISbJQA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.20.0.tgz",
+      "integrity": "sha512-z4lElzLm1FVifc7bzBZN4VNKeTuwygpyHQvCJVWXzF2Kbvex43PEYMi8u4A83idVqbmzbyBLASwUJS0voLoPLw==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.15.0"
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.15.0.tgz",
-      "integrity": "sha512-yeK466mXb4xaCCJouGzEHQs59fScHxF8Asq0azNyJmkhQWYrU7WdckHf2xj8ItZFFPyj7lvwKRDYnoy4HQD7Mg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.20.0.tgz",
+      "integrity": "sha512-LvoC+9mm2Im1iO8GgtgaqSfW0T3mIE5GQl1xGxbVNdANmtHmBgRAJn2KfQm1XHZP6zydLRMhZkzC+jfInh2yfQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.15.0",
-        "@lexical/selection": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/clipboard": "0.20.0",
+        "@lexical/selection": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.15.0.tgz",
-      "integrity": "sha512-TWDp/F9cKwjGreLzIdHKlPUeTn275rR6j1VXrBffNwC5ovxWcKLVRg502eY5xvRQH3lkKQpFgIFbJW4KTvhFsQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.20.0.tgz",
+      "integrity": "sha512-5QbN5AFtZ9efXxU/M01ADhUZgthR0e8WKi5K/w5EPpWtYFDPQnUte3rKUjYJ7uwG1iwcvaCpuMbxJjHQ+i6pDQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.15.0",
-        "@lexical/code": "0.15.0",
-        "@lexical/devtools-core": "0.15.0",
-        "@lexical/dragon": "0.15.0",
-        "@lexical/hashtag": "0.15.0",
-        "@lexical/history": "0.15.0",
-        "@lexical/link": "0.15.0",
-        "@lexical/list": "0.15.0",
-        "@lexical/mark": "0.15.0",
-        "@lexical/markdown": "0.15.0",
-        "@lexical/overflow": "0.15.0",
-        "@lexical/plain-text": "0.15.0",
-        "@lexical/rich-text": "0.15.0",
-        "@lexical/selection": "0.15.0",
-        "@lexical/table": "0.15.0",
-        "@lexical/text": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "@lexical/yjs": "0.15.0",
-        "lexical": "0.15.0",
+        "@lexical/clipboard": "0.20.0",
+        "@lexical/code": "0.20.0",
+        "@lexical/devtools-core": "0.20.0",
+        "@lexical/dragon": "0.20.0",
+        "@lexical/hashtag": "0.20.0",
+        "@lexical/history": "0.20.0",
+        "@lexical/link": "0.20.0",
+        "@lexical/list": "0.20.0",
+        "@lexical/mark": "0.20.0",
+        "@lexical/markdown": "0.20.0",
+        "@lexical/overflow": "0.20.0",
+        "@lexical/plain-text": "0.20.0",
+        "@lexical/rich-text": "0.20.0",
+        "@lexical/selection": "0.20.0",
+        "@lexical/table": "0.20.0",
+        "@lexical/text": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "@lexical/yjs": "0.20.0",
+        "lexical": "0.20.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -963,59 +978,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.15.0.tgz",
-      "integrity": "sha512-76tXh/eeEOHl91HpFEXCc/tUiLrsa9RcSyvCzRZahk5zqYvQPXma/AUfRzuSMf2kLwDEoauKAVqNFQcbPhqwpQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.20.0.tgz",
+      "integrity": "sha512-BR1pACdMA+Ymef0f5EN1y+9yP8w7S+9MgmBP1yjr3w4KdqRnfSaGWyxwcHU8eA+zu16QfivpB6501VJ90YeuXw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.15.0",
-        "@lexical/selection": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/clipboard": "0.20.0",
+        "@lexical/selection": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.15.0.tgz",
-      "integrity": "sha512-S+AQC6eJiQYSa5zOPuecN85prCT0Bcb8miOdJaE17Zh+vgdUH5gk9I0tEBeG5T7tkSpq6lFiEqs2FZSfaHflbQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.20.0.tgz",
+      "integrity": "sha512-YnkH5UCMNN/em95or/6uwAV31vcENh1Roj+JOg5KD+gJuA7VGdDCy0vZl/o0+1badXozeZ2VRxXNC6JSK7T4+A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.15.0"
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.15.0.tgz",
-      "integrity": "sha512-3IRBg8IoIHetqKozRQbJQ2aPyG0ziXZ+lc8TOIAGs6METW/wxntaV+rTNrODanKAgvk2iJTIyfFkYjsqS9+VFg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.20.0.tgz",
+      "integrity": "sha512-qHuK2rvQUoQDx62YpvJE3Ev4yK9kjRFo79IDBapxrhoXg/wCGQOjMBzVD3G5PWkhyl/GDnww80GwYjLloQLQzg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/clipboard": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.15.0.tgz",
-      "integrity": "sha512-WsAkAt9T1RH1iDrVuWeoRUeMCOAWar5oSFtnQ4m9vhT/zuf5b8efK87GiqCH00ZAn4DGzOuAfyXlMFqBVCQdkQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.20.0.tgz",
+      "integrity": "sha512-Fu64i5CIlEOlgucSdp9XFqB2XqoRsw4at76n93+6RF4+LgGDnu4nLXQVCVxNmLcGyh2WgczuTpnk5P2mHNAIUA==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.15.0"
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.15.0.tgz",
-      "integrity": "sha512-/6954LDmTcVFgexhy5WOZDa4TxNQOEZNrf8z7TRAFiAQkihcME/GRoq1en5cbXoVNF8jv5AvNyyc7x0MByRJ6A==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.20.0.tgz",
+      "integrity": "sha512-sXIa2nowrNxY8VcjjuxZbJ/HovIql8bmInNaxBR03JAYfqMiL5I5/dYgjOQJV49NJnuR1uTY2GwVxVTXCTFUCw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.15.0",
-        "@lexical/selection": "0.15.0",
-        "@lexical/table": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/list": "0.20.0",
+        "@lexical/selection": "0.20.0",
+        "@lexical/table": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.15.0.tgz",
-      "integrity": "sha512-Rf4AIu620Cq90li6GU58gkzlGRdntHP4ZeZrbJ3ToW7vEEnkW6Wl9/HhO647GG4OL5w46M0iWvx1b1b8xjYT1w==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.20.0.tgz",
+      "integrity": "sha512-TiHNhu2VkhXN69V+fXVS3xjOQ6aLnheQUGwOAhuFkDPL3VLCb0yl2Mgydpayn+3Grwii4ZBHcF7oCC84GiU5bw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/offset": "0.20.0",
+        "@lexical/selection": "0.20.0",
+        "lexical": "0.20.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1556,6 +1579,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -1592,14 +1616,16 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.15.0.tgz",
-      "integrity": "sha512-/7HrPAmtgsc1F+qpv5bFwoQZ6CbH/w3mPPL2AW5P75/QYrqKz4bhvJrc2jozIX0GxtuT/YUYT7w+1sZMtUWbOg=="
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.20.0.tgz",
+      "integrity": "sha512-lJEHLFACXqRf3u/VlIOu9T7MJ51O4la92uOBwiS9Sx+juDK3Nrru5Vgl1aUirV1qK8XEM3h6Org2HcrsrzZ3ZA==",
+      "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.94",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.94.tgz",
-      "integrity": "sha512-hZ3p54jL4Wpu7IOg26uC7dnEWiMyNlUrb9KoG7+xYs45WkQwpVvKFndVq2+pqLYKe1u8Fp3+zAfZHVvTK34PvQ==",
+      "version": "0.2.98",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.98.tgz",
+      "integrity": "sha512-XteTiNO0qEXqqweWx+b21p/fBnNHUA1NwAtJNJek1oPrewEZs2uiT4gWivHKr9GqCjDPAhchz0UQO8NwU3bBNA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -1705,6 +1731,7 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
       "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1948,12 +1975,13 @@
       "dev": true
     },
     "node_modules/yjs": {
-      "version": "13.6.15",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.15.tgz",
-      "integrity": "sha512-moFv4uNYhp8BFxIk3AkpoAnnjts7gwdpiG8RtyFiKbMtxKCS0zVZ5wPaaGpwC3V2N/K8TK8MwtSI3+WO9CHWjQ==",
+      "version": "13.6.20",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.20.tgz",
+      "integrity": "sha512-Z2YZI+SYqK7XdWlloI3lhMiKnCdFCVC4PchpdO+mCYwtiTwncjUbnRK9R1JmkNfdmHyDXuWN3ibJAt0wsqTbLQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "lib0": "^0.2.86"
+        "lib0": "^0.2.98"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -2424,225 +2452,227 @@
       }
     },
     "@lexical/clipboard": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.15.0.tgz",
-      "integrity": "sha512-binCltK7KiURQJFogvueYfmDNEKynN/lmZrCLFp2xBjEIajqw4WtOVLJZ33engdqNlvj0JqrxrWxbKG+yvUwrg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.20.0.tgz",
+      "integrity": "sha512-oHmb9kSVHjeFCd2q8VrEXW22doUHMJ6cGXqo7Ican7Ljl4/9OgRWr+cq55yntoSaJfCrRYkTiZCLDejF2ciSiA==",
       "requires": {
-        "@lexical/html": "0.15.0",
-        "@lexical/list": "0.15.0",
-        "@lexical/selection": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/html": "0.20.0",
+        "@lexical/list": "0.20.0",
+        "@lexical/selection": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/code": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.15.0.tgz",
-      "integrity": "sha512-n185gjinGhz/M4BW1ayNPYAEgwW4T/NEFl2Wey/O+07W3zvh9k9ai7RjWd0c8Qzqc4DLlqvibvWPebWObQHA4w==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.20.0.tgz",
+      "integrity": "sha512-zFsVGuzIn4CQxEnlW4AG/Hq6cyATVZ4fZTxozE/f5oK4vDPvnY/goRxrzSuAMX73A/HRX3kTEzMDcm4taRM3Mg==",
       "requires": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0",
         "prismjs": "^1.27.0"
       }
     },
     "@lexical/devtools-core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.15.0.tgz",
-      "integrity": "sha512-kK/IVEiQyqs2DsY4QRYFaFiKQMpaAukAl8PXmNeGTZ7cfFVsP29E4n0/pjY+oxmiRvxbO1s2i14q58nfuhj4VQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.20.0.tgz",
+      "integrity": "sha512-/CnL+Dfpzw4koy2BTdUICkvrCkMIYG8Y73KB/S1Bt5UzJpD+PV300puWJ0NvUvAj24H78r73jxvK2QUG67Tdaw==",
       "requires": {
-        "@lexical/html": "0.15.0",
-        "@lexical/link": "0.15.0",
-        "@lexical/mark": "0.15.0",
-        "@lexical/table": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/html": "0.20.0",
+        "@lexical/link": "0.20.0",
+        "@lexical/mark": "0.20.0",
+        "@lexical/table": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/dragon": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.15.0.tgz",
-      "integrity": "sha512-hg2rGmxVJF7wmN6psuKw3EyhcNF7DtOYwUCBpjFZVshzAjsNEBfEnqhiMkSVSlN4+WOfM7LS+B88PTKPcnFGbQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.20.0.tgz",
+      "integrity": "sha512-3DAHF8mSKiPZtXCqu2P8ynSwS3fGXzg4G/V0lXNjBxhmozjzUzWZRWIWtmTlWdEu9GXsoyeM3agcaxyDPJJwkA==",
       "requires": {
-        "lexical": "0.15.0"
+        "lexical": "0.20.0"
       }
     },
     "@lexical/hashtag": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.15.0.tgz",
-      "integrity": "sha512-EP6KKvS6BY/8Vh1MLQYeOcYaxnvrLsUkvXXr+Fg8N477Us54Ju69pPO563mbWt7/bpnL9Sh0fbk82JtxqPWpSg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.20.0.tgz",
+      "integrity": "sha512-ldOP/d9tA6V9qvLyr3mRYkcYY5ySOHJ2BFOW/jZPxQcj6lWafS8Lk7XdMUpHHDjRpY2Hizsi5MHJkIqFglYXbw==",
       "requires": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/history": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.15.0.tgz",
-      "integrity": "sha512-r+pzR2k/51AL6l8UfXeVe/GWPIeWY1kEOuKx9nsYB9tmAkTF66tTFz33DJIMWBVtAHWN7Dcdv0/yy6q8R6CAUQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.20.0.tgz",
+      "integrity": "sha512-dXtIS31BU6RmLX2KwLAi1EgGl+USeyi+rshh19azACXHPFqONZgPd2t21LOLSFn7C1/W+cSp/kqVDlQVbZUZRA==",
       "requires": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/html": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.15.0.tgz",
-      "integrity": "sha512-x/sfGvibwo8b5Vso4ppqNyS/fVve6Rn+TmvP/0eWOaa0I3aOQ57ulfcK6p/GTe+ZaEi8vW64oZPdi8XDgwSRaA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.20.0.tgz",
+      "integrity": "sha512-ob7QHkEv+mhaZjlurDj90UmEyN9G4rzBPR5QV42PLnu1qMSviMEdI5V3a5/A5aFf/FDDQ+0GAgWBFnA/MEDczQ==",
       "requires": {
-        "@lexical/selection": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/selection": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/link": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.15.0.tgz",
-      "integrity": "sha512-KBV/zWk5FxqZGNcq3IKGBDCcS4t0uteU1osAIG+pefo4waTkOOgibxxEJDop2QR5wtjkYva3Qp0D8ZyJDMMMlw==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.20.0.tgz",
+      "integrity": "sha512-zicDcfgRZPRFZ8WOZv5er0Aqkde+i7QoFVkLQD4dNLLORjoMSJOISJH6VEdjBl3k7QJTxbfrt+xT5d/ZsAN5GA==",
       "requires": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/list": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.15.0.tgz",
-      "integrity": "sha512-JuF4k7uo4rZFOSZGrmkxo1+sUrwTKNBhhJAiCgtM+6TO90jppxzCFNKur81yPzF1+g4GWLC9gbjzKb52QPb6cQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.20.0.tgz",
+      "integrity": "sha512-ufSse8ui3ooUe0HA/yF/9STrG8wYhIDLMRhELOw80GFCkPJaxs6yRvjfmJooH5IC88rpUJ5XXFFiZKfGxEZLEw==",
       "requires": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/mark": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.15.0.tgz",
-      "integrity": "sha512-cdePA98sOJRc4/HHqcOcPBFq4UDwzaFJOK1N1E6XUGcXH1GU8zHtV1ElTgmbsGkyjBRwhR+OqKm9eso1PBOUkg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.20.0.tgz",
+      "integrity": "sha512-1P2izmkgZ4VDp+49rWO1KfWivL5aA30y5kkYbFZ/CS05fgbO7ogMjLSajpz+RN/zzW79v3q4YfikrMgaD23InA==",
       "requires": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/markdown": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.15.0.tgz",
-      "integrity": "sha512-wu1EP758l452BovDa7i9ZAeWuFj+YY0bc2mNc08nfZ9GqdGMej1JIguY4CwIROCYVizprL9Ocn0avH1uv9b8fA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.20.0.tgz",
+      "integrity": "sha512-ZoGsECejp9z6MEvc8l81b1h1aWbB3sTq6xOFeUTbDL5vKpA67z5CmQQLi0uZWrygrbO9dSE3Q/JGcodUrczxbw==",
       "requires": {
-        "@lexical/code": "0.15.0",
-        "@lexical/link": "0.15.0",
-        "@lexical/list": "0.15.0",
-        "@lexical/rich-text": "0.15.0",
-        "@lexical/text": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/code": "0.20.0",
+        "@lexical/link": "0.20.0",
+        "@lexical/list": "0.20.0",
+        "@lexical/rich-text": "0.20.0",
+        "@lexical/text": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/offset": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.15.0.tgz",
-      "integrity": "sha512-VO1f3m8+RRdRjuXMtCBhi1COVKRC2LhP8AFYxnFlvbV+Waz9R5xB9pqFFUe4RtyqyTLmOUj6+LtsUFhq+23voQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.20.0.tgz",
+      "integrity": "sha512-VMhxsxxDGnpVw0jgC8UlDf0Q2RHIHbS49uZgs3l9nP+O+G8s3b76Ta4Tb+iJOK2FY6874/TcQMbSuXGhfpQk8A==",
       "requires": {
-        "lexical": "0.15.0"
+        "lexical": "0.20.0"
       }
     },
     "@lexical/overflow": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.15.0.tgz",
-      "integrity": "sha512-9qKVCvh9Oka+bzR3th+UWdTEeMZXYy1ZxWbjSxefRMgQxzCvqSuVioK/065gPbvGga9EfvgLLLBDXZm8ISbJQA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.20.0.tgz",
+      "integrity": "sha512-z4lElzLm1FVifc7bzBZN4VNKeTuwygpyHQvCJVWXzF2Kbvex43PEYMi8u4A83idVqbmzbyBLASwUJS0voLoPLw==",
       "requires": {
-        "lexical": "0.15.0"
+        "lexical": "0.20.0"
       }
     },
     "@lexical/plain-text": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.15.0.tgz",
-      "integrity": "sha512-yeK466mXb4xaCCJouGzEHQs59fScHxF8Asq0azNyJmkhQWYrU7WdckHf2xj8ItZFFPyj7lvwKRDYnoy4HQD7Mg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.20.0.tgz",
+      "integrity": "sha512-LvoC+9mm2Im1iO8GgtgaqSfW0T3mIE5GQl1xGxbVNdANmtHmBgRAJn2KfQm1XHZP6zydLRMhZkzC+jfInh2yfQ==",
       "requires": {
-        "@lexical/clipboard": "0.15.0",
-        "@lexical/selection": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/clipboard": "0.20.0",
+        "@lexical/selection": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/react": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.15.0.tgz",
-      "integrity": "sha512-TWDp/F9cKwjGreLzIdHKlPUeTn275rR6j1VXrBffNwC5ovxWcKLVRg502eY5xvRQH3lkKQpFgIFbJW4KTvhFsQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.20.0.tgz",
+      "integrity": "sha512-5QbN5AFtZ9efXxU/M01ADhUZgthR0e8WKi5K/w5EPpWtYFDPQnUte3rKUjYJ7uwG1iwcvaCpuMbxJjHQ+i6pDQ==",
       "requires": {
-        "@lexical/clipboard": "0.15.0",
-        "@lexical/code": "0.15.0",
-        "@lexical/devtools-core": "0.15.0",
-        "@lexical/dragon": "0.15.0",
-        "@lexical/hashtag": "0.15.0",
-        "@lexical/history": "0.15.0",
-        "@lexical/link": "0.15.0",
-        "@lexical/list": "0.15.0",
-        "@lexical/mark": "0.15.0",
-        "@lexical/markdown": "0.15.0",
-        "@lexical/overflow": "0.15.0",
-        "@lexical/plain-text": "0.15.0",
-        "@lexical/rich-text": "0.15.0",
-        "@lexical/selection": "0.15.0",
-        "@lexical/table": "0.15.0",
-        "@lexical/text": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "@lexical/yjs": "0.15.0",
-        "lexical": "0.15.0",
+        "@lexical/clipboard": "0.20.0",
+        "@lexical/code": "0.20.0",
+        "@lexical/devtools-core": "0.20.0",
+        "@lexical/dragon": "0.20.0",
+        "@lexical/hashtag": "0.20.0",
+        "@lexical/history": "0.20.0",
+        "@lexical/link": "0.20.0",
+        "@lexical/list": "0.20.0",
+        "@lexical/mark": "0.20.0",
+        "@lexical/markdown": "0.20.0",
+        "@lexical/overflow": "0.20.0",
+        "@lexical/plain-text": "0.20.0",
+        "@lexical/rich-text": "0.20.0",
+        "@lexical/selection": "0.20.0",
+        "@lexical/table": "0.20.0",
+        "@lexical/text": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "@lexical/yjs": "0.20.0",
+        "lexical": "0.20.0",
         "react-error-boundary": "^3.1.4"
       }
     },
     "@lexical/rich-text": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.15.0.tgz",
-      "integrity": "sha512-76tXh/eeEOHl91HpFEXCc/tUiLrsa9RcSyvCzRZahk5zqYvQPXma/AUfRzuSMf2kLwDEoauKAVqNFQcbPhqwpQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.20.0.tgz",
+      "integrity": "sha512-BR1pACdMA+Ymef0f5EN1y+9yP8w7S+9MgmBP1yjr3w4KdqRnfSaGWyxwcHU8eA+zu16QfivpB6501VJ90YeuXw==",
       "requires": {
-        "@lexical/clipboard": "0.15.0",
-        "@lexical/selection": "0.15.0",
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/clipboard": "0.20.0",
+        "@lexical/selection": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/selection": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.15.0.tgz",
-      "integrity": "sha512-S+AQC6eJiQYSa5zOPuecN85prCT0Bcb8miOdJaE17Zh+vgdUH5gk9I0tEBeG5T7tkSpq6lFiEqs2FZSfaHflbQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.20.0.tgz",
+      "integrity": "sha512-YnkH5UCMNN/em95or/6uwAV31vcENh1Roj+JOg5KD+gJuA7VGdDCy0vZl/o0+1badXozeZ2VRxXNC6JSK7T4+A==",
       "requires": {
-        "lexical": "0.15.0"
+        "lexical": "0.20.0"
       }
     },
     "@lexical/table": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.15.0.tgz",
-      "integrity": "sha512-3IRBg8IoIHetqKozRQbJQ2aPyG0ziXZ+lc8TOIAGs6METW/wxntaV+rTNrODanKAgvk2iJTIyfFkYjsqS9+VFg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.20.0.tgz",
+      "integrity": "sha512-qHuK2rvQUoQDx62YpvJE3Ev4yK9kjRFo79IDBapxrhoXg/wCGQOjMBzVD3G5PWkhyl/GDnww80GwYjLloQLQzg==",
       "requires": {
-        "@lexical/utils": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/clipboard": "0.20.0",
+        "@lexical/utils": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/text": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.15.0.tgz",
-      "integrity": "sha512-WsAkAt9T1RH1iDrVuWeoRUeMCOAWar5oSFtnQ4m9vhT/zuf5b8efK87GiqCH00ZAn4DGzOuAfyXlMFqBVCQdkQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.20.0.tgz",
+      "integrity": "sha512-Fu64i5CIlEOlgucSdp9XFqB2XqoRsw4at76n93+6RF4+LgGDnu4nLXQVCVxNmLcGyh2WgczuTpnk5P2mHNAIUA==",
       "requires": {
-        "lexical": "0.15.0"
+        "lexical": "0.20.0"
       }
     },
     "@lexical/utils": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.15.0.tgz",
-      "integrity": "sha512-/6954LDmTcVFgexhy5WOZDa4TxNQOEZNrf8z7TRAFiAQkihcME/GRoq1en5cbXoVNF8jv5AvNyyc7x0MByRJ6A==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.20.0.tgz",
+      "integrity": "sha512-sXIa2nowrNxY8VcjjuxZbJ/HovIql8bmInNaxBR03JAYfqMiL5I5/dYgjOQJV49NJnuR1uTY2GwVxVTXCTFUCw==",
       "requires": {
-        "@lexical/list": "0.15.0",
-        "@lexical/selection": "0.15.0",
-        "@lexical/table": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/list": "0.20.0",
+        "@lexical/selection": "0.20.0",
+        "@lexical/table": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@lexical/yjs": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.15.0.tgz",
-      "integrity": "sha512-Rf4AIu620Cq90li6GU58gkzlGRdntHP4ZeZrbJ3ToW7vEEnkW6Wl9/HhO647GG4OL5w46M0iWvx1b1b8xjYT1w==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.20.0.tgz",
+      "integrity": "sha512-TiHNhu2VkhXN69V+fXVS3xjOQ6aLnheQUGwOAhuFkDPL3VLCb0yl2Mgydpayn+3Grwii4ZBHcF7oCC84GiU5bw==",
       "requires": {
-        "@lexical/offset": "0.15.0",
-        "lexical": "0.15.0"
+        "@lexical/offset": "0.20.0",
+        "@lexical/selection": "0.20.0",
+        "lexical": "0.20.0"
       }
     },
     "@rollup/rollup-android-arm-eabi": {
@@ -3021,14 +3051,14 @@
       "dev": true
     },
     "lexical": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.15.0.tgz",
-      "integrity": "sha512-/7HrPAmtgsc1F+qpv5bFwoQZ6CbH/w3mPPL2AW5P75/QYrqKz4bhvJrc2jozIX0GxtuT/YUYT7w+1sZMtUWbOg=="
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.20.0.tgz",
+      "integrity": "sha512-lJEHLFACXqRf3u/VlIOu9T7MJ51O4la92uOBwiS9Sx+juDK3Nrru5Vgl1aUirV1qK8XEM3h6Org2HcrsrzZ3ZA=="
     },
     "lib0": {
-      "version": "0.2.94",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.94.tgz",
-      "integrity": "sha512-hZ3p54jL4Wpu7IOg26uC7dnEWiMyNlUrb9KoG7+xYs45WkQwpVvKFndVq2+pqLYKe1u8Fp3+zAfZHVvTK34PvQ==",
+      "version": "0.2.98",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.98.tgz",
+      "integrity": "sha512-XteTiNO0qEXqqweWx+b21p/fBnNHUA1NwAtJNJek1oPrewEZs2uiT4gWivHKr9GqCjDPAhchz0UQO8NwU3bBNA==",
       "peer": true,
       "requires": {
         "isomorphic.js": "^0.2.4"
@@ -3223,12 +3253,12 @@
       "dev": true
     },
     "yjs": {
-      "version": "13.6.15",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.15.tgz",
-      "integrity": "sha512-moFv4uNYhp8BFxIk3AkpoAnnjts7gwdpiG8RtyFiKbMtxKCS0zVZ5wPaaGpwC3V2N/K8TK8MwtSI3+WO9CHWjQ==",
+      "version": "13.6.20",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.20.tgz",
+      "integrity": "sha512-Z2YZI+SYqK7XdWlloI3lhMiKnCdFCVC4PchpdO+mCYwtiTwncjUbnRK9R1JmkNfdmHyDXuWN3ibJAt0wsqTbLQ==",
       "peer": true,
       "requires": {
-        "lib0": "^0.2.86"
+        "lib0": "^0.2.98"
       }
     }
   }

--- a/examples/react-rich/src/App.tsx
+++ b/examples/react-rich/src/App.tsx
@@ -16,6 +16,7 @@ import {
   $isTextNode,
   DOMConversionMap,
   DOMExportOutput,
+  DOMExportOutputMap,
   Klass,
   LexicalEditor,
   LexicalNode,
@@ -53,7 +54,7 @@ const removeStylesExportDOM = (
   return output;
 };
 
-const exportMap = new Map<
+const exportMap: DOMExportOutputMap = new Map<
   Klass<LexicalNode>,
   (editor: LexicalEditor, target: LexicalNode) => DOMExportOutput
 >([

--- a/examples/react-rich/src/App.tsx
+++ b/examples/react-rich/src/App.tsx
@@ -54,7 +54,10 @@ const removeStylesExportDOM = (
   return output;
 };
 
-const exportMap: DOMExportOutputMap = new Map([
+const exportMap: DOMExportOutputMap = new Map<
+  Klass<LexicalNode>,
+  (editor: LexicalEditor, target: LexicalNode) => DOMExportOutput
+>([
   [ParagraphNode, removeStylesExportDOM],
   [TextNode, removeStylesExportDOM],
 ]);

--- a/examples/react-rich/src/App.tsx
+++ b/examples/react-rich/src/App.tsx
@@ -54,10 +54,7 @@ const removeStylesExportDOM = (
   return output;
 };
 
-const exportMap: DOMExportOutputMap = new Map<
-  Klass<LexicalNode>,
-  (editor: LexicalEditor, target: LexicalNode) => DOMExportOutput
->([
+const exportMap: DOMExportOutputMap = new Map([
   [ParagraphNode, removeStylesExportDOM],
   [TextNode, removeStylesExportDOM],
 ]);


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

To use the html export configuration in LexicalComposer, users must manually create a custom type definition for DOMExportOutputMap. This is due to the type not being available for direct import from the Lexical core.

Closes #6825 

## Test plan

DOMExportOutputMap should be directly exportable from the Lexical core, enabling users to import it without needing to define custom types for common configurations.
