### PR TITLE
Prevent initial value fn to be called on rerender

### DIFF
--- a/packages/lexical-react/src/useLexicalSubscription.tsx
+++ b/packages/lexical-react/src/useLexicalSubscription.tsx
@@ -29,8 +29,10 @@ export function useLexicalSubscription<T>(
     () => subscription(editor),
     [editor, subscription],
   );
-  const valueRef = useRef<T>(initializedSubscription.initialValueFn());
-  const [value, setValue] = useState<T>(valueRef.current);
+  const [value, setValue] = useState<T>(() =>
+    initializedSubscription.initialValueFn(),
+  );
+  const valueRef = useRef<T>(value);
   useLayoutEffect(() => {
     const {initialValueFn, subscribe} = initializedSubscription;
     const currentValue = initialValueFn();


### PR DESCRIPTION
We call `initialValueFn` on each re-render, fixing that