### PR TITLE
[lexical-playground] Bug Fix: Replace empty <img> tags with invisible <span> elements to prevent Safari issue

### DIFF
--- a/packages/lexical-playground/src/ui/KatexRenderer.tsx
+++ b/packages/lexical-playground/src/ui/KatexRenderer.tsx
@@ -41,14 +41,14 @@ export default function KatexRenderer({
     // inner text from Katex. There didn't seem to be any other way of making this work,
     // without having a physical space.
     <>
-      <img src="#" alt="" />
+      <span style={{display: 'inline-block', height: '1px', width: '1px'}} />
       <span
         role="button"
         tabIndex={-1}
         onDoubleClick={onDoubleClick}
         ref={katexElementRef}
       />
-      <img src="#" alt="" />
+      <span style={{display: 'inline-block', height: '1px', width: '1px'}} />
     </>
   );
 }


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

- Current Behavior: Equations display with question marks around them in Safari due to empty <img> tags used for spacing around the KaTeX equation
- Changes: This PR replaces the empty <img> tags with invisible <span> elements for spacing, which resolves the issue in Safari while maintaining functionality across other browsers.

Closes #6824

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*

<img width="1783" alt="Screenshot 2024-11-14 at 11 54 18 PM" src="https://github.com/user-attachments/assets/bd94ac01-3abd-422c-9bdc-355dcb6f3cb7">

### After

*Insert relevant screenshots/recordings/automated-tests*

<img width="1783" alt="image" src="https://github.com/user-attachments/assets/e4869c47-dbf1-426b-a87f-8fbb8428bf34">
