### PR TITLE
[lexical-react] Fix(lexical-react): ContentEditable props type rename

### DIFF
--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -29,6 +29,15 @@ export type ContentEditableProps = Omit<ElementProps, 'editor'> &
       }
   );
 
+  /**
+ * @deprecated This type has been renamed to `ContentEditableProps` to provide a clearer and more descriptive name.
+ * For backward compatibility, this type is still exported as `Props`, but it is recommended to migrate to using `ContentEditableProps` instead.
+ *
+ * @note This alias is maintained for compatibility purposes but may be removed in future versions.
+ * Please update your codebase to use `ContentEditableProps` to ensure long-term maintainability.
+ */ 
+export type Props = ContentEditableProps  
+
 export const ContentEditable = forwardRef(ContentEditableImpl);
 
 function ContentEditableImpl(

--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -29,14 +29,14 @@ export type ContentEditableProps = Omit<ElementProps, 'editor'> &
       }
   );
 
-  /**
+/**
  * @deprecated This type has been renamed to `ContentEditableProps` to provide a clearer and more descriptive name.
  * For backward compatibility, this type is still exported as `Props`, but it is recommended to migrate to using `ContentEditableProps` instead.
  *
  * @note This alias is maintained for compatibility purposes but may be removed in future versions.
  * Please update your codebase to use `ContentEditableProps` to ensure long-term maintainability.
- */ 
-export type Props = ContentEditableProps  
+ */
+export type Props = ContentEditableProps;
 
 export const ContentEditable = forwardRef(ContentEditableImpl);
 

--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -15,7 +15,7 @@ import {forwardRef, Ref, useLayoutEffect, useState} from 'react';
 import {ContentEditableElement} from './shared/LexicalContentEditableElement';
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 
-export type Props = Omit<ElementProps, 'editor'> &
+export type ContentEditableProps = Omit<ElementProps, 'editor'> &
   (
     | {
         'aria-placeholder'?: void;
@@ -32,7 +32,7 @@ export type Props = Omit<ElementProps, 'editor'> &
 export const ContentEditable = forwardRef(ContentEditableImpl);
 
 function ContentEditableImpl(
-  props: Props,
+  props: ContentEditableProps,
   ref: Ref<HTMLDivElement>,
 ): JSX.Element {
   const {placeholder, ...rest} = props;


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
The name of the type seems too generic, so I suggest renaming it to:

Like the link below
https://github.com/facebook/lexical/blob/main/packages/lexical-react/src/LexicalTablePlugin.ts