### PR TITLE
[lexical-table] Bug Fix: Fix down arrow key handling in TableObserver

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -782,8 +782,14 @@ export function applyTableHandlers(
             const firstCell = firstRow.getFirstChild();
             if (
               $isTableCellNode(firstCell) &&
-              !$findMatchingParent(anchorCell, (node) => node.is(firstCell))
+              tableNode.is(
+                $findMatchingParent(
+                  anchorCell,
+                  (node) => node.is(tableNode) || node.is(firstCell),
+                ),
+              )
             ) {
+              // The selection moved to the table, but not in the first cell
               firstCell.selectStart();
               return true;
             }


### PR DESCRIPTION
## Description

The firefox workaround for down arrow key navigation introduced in #6759 was missing a table check, so it did not work correctly when multiple tables are present.


## Test plan

### Before

https://github.com/facebook/lexical/pull/6759#issuecomment-2478582679

![chrome-capture-2024-11-15](https://github.com/user-attachments/assets/aaf8a590-e826-4ea0-a202-77c7a8ec3d1d)

### After

https://github.com/user-attachments/assets/6b6815fb-30e0-4549-aac1-27349f360098

