### PR TITLE
[lexical-utils] Bug Fix: Add missing Flow type declarations

### DIFF
--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -94,3 +94,20 @@ declare export function $splitNode(
   node: ElementNode,
   offset: number,
 ): [ElementNode | null, ElementNode];
+
+//new
+
+declare export function $getNextRightPreorderNode(
+  startingNode: LexicalNode,
+): LexicalNode | null;
+declare export function calculateZoomLevel(element: Element | null): number;
+declare export function $isEditorIsNestedEditor(editor: LexicalEditor): boolean;
+declare export function objectKlassEquals<T>(
+  object: mixed,
+  objectClass: Class<T>,
+): boolean;
+declare export function $filter<T>(
+  nodes: Array<LexicalNode>,
+  filterFn: (node: LexicalNode) => null | T,
+): Array<T>;
+declare export function $insertFirst(parent: ElementNode, node: LexicalNode): void;

--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -48,6 +48,9 @@ declare export function $getNextSiblingOrParentSibling(
   node: LexicalNode,
 ): null | [LexicalNode, number];
 declare export function $getDepth(node: LexicalNode): number;
+declare export function $getNextRightPreorderNode(
+  startingNode: LexicalNode,
+): LexicalNode | null;
 declare export function $getNearestNodeOfType<T: LexicalNode>(
   node: LexicalNode,
   klass: Class<T>,
@@ -90,24 +93,23 @@ declare export function $wrapNodeInElement(
   createElementNode: () => ElementNode,
 ): ElementNode;
 
+declare export function objectKlassEquals<T>(
+  object: mixed,
+  objectClass: Class<T>,
+): boolean;
+
+declare export function $filter<T>(
+  nodes: Array<LexicalNode>,
+  filterFn: (node: LexicalNode) => null | T,
+): Array<T>;
+
+declare export function $insertFirst(parent: ElementNode, node: LexicalNode): void;
+
 declare export function $splitNode(
   node: ElementNode,
   offset: number,
 ): [ElementNode | null, ElementNode];
 
-//new
-
-declare export function $getNextRightPreorderNode(
-  startingNode: LexicalNode,
-): LexicalNode | null;
 declare export function calculateZoomLevel(element: Element | null): number;
+
 declare export function $isEditorIsNestedEditor(editor: LexicalEditor): boolean;
-declare export function objectKlassEquals<T>(
-  object: mixed,
-  objectClass: Class<T>,
-): boolean;
-declare export function $filter<T>(
-  nodes: Array<LexicalNode>,
-  filterFn: (node: LexicalNode) => null | T,
-): Array<T>;
-declare export function $insertFirst(parent: ElementNode, node: LexicalNode): void;


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
The `calculateZoomLevel` function, along with several other utility functions, is missing Flow type declarations in `LexicalUtils.js.flow`. This causes Flow to throw missing-export errors, requiring `$FlowFixMe` comments to suppress the errors.

This pull request adds type declarations to `LexicalUtils.js.flow` for the following functions:

	•	calculateZoomLevel
	•	$getNextRightPreorderNode
	•	$isEditorIsNestedEditor
	•	objectKlassEquals
	•	$filter
	•	$insertFirst

Closes #6823

## Test plan

### Before

Before the fix, the following import:
```javascript
import { calculateZoomLevel } from "@lexical/utils";
```
would case this error when running with Flow
```
Cannot import calculateZoomLevel because there is no calculateZoomLevel export in
@lexical/utils. [missing-export]

     // @flow
     
     import { calculateZoomLevel } from "@lexical/utils";
```

### After
With the changes described above, there are no errors when trying to run the code and all functions work as intended.

