### PR TITLE
fix: bug-6851

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1778,7 +1778,7 @@ export class RangeSelection implements BaseSelection {
         possibleNode.selectStart();
         return;
       }
-      this.modify('extend', isBackward, 'character');
+      this.modify('move', isBackward, 'character');
 
       if (!this.isCollapsed()) {
         const focusNode = focus.type === 'text' ? focus.getNode() : null;


### PR DESCRIPTION
https://github.com/facebook/lexical/issues/6851

update:
in LexicalSelection.ts file, change the native selection move mode from "extend" to "move", cause isCollapsed is true.
at line 1781:
this.modify('extend', isBackward, 'character'); => this.modify('move', isBackward, 'character');