### PR TITLE
Feature: Deprecate $nodesOfType function

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1148,7 +1148,9 @@ export function setMutatedNode(
     mutatedNodesByType.set(nodeKey, isMove ? 'updated' : mutation);
   }
 }
-
+/**
+ * @deprecated Use registerMutationListener instead.
+ */
 export function $nodesOfType<T extends LexicalNode>(klass: Klass<T>): Array<T> {
   const klassType = klass.getType();
   const editorState = getActiveEditorState();


### PR DESCRIPTION

## Description
The $nodesOfType function was used to fix a problem with registerMutationListener. After the changes in #6357, registerMutationListener works fine, so $nodesOfType is no longer needed and caused bugs

This PR adds a **feature** to mark `$nodesOfType` as **deprecated**. It suggests using `registerMutationListener` instead. The goal is to remove old code and avoid bugs that can happen when using `$nodesOfType`.

Closes #6847



