### PR TITLE
[Lexical] Chore: Update default skipInitialization to false for registerMutationListener

### DIFF
--- a/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {ParagraphNode, TextNode} from 'lexical';
+import {$createLinkNode, $isLinkNode, LinkNode} from '@lexical/link';
+import {$getRoot, ParagraphNode, TextNode} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 
 import {
@@ -257,6 +258,45 @@ describe('LexicalListNode tests', () => {
         expect(listNode.append(...nodesToAppend)).toBe(listNode);
         expect($isListItemNode(listNode.getFirstChild())).toBe(true);
         expect(listNode.getFirstChild()?.getTextContent()).toBe('Hello');
+      });
+    });
+
+    test('ListNode.append() should wrap an InlineNode in a ListItemNode without converting it to TextNode', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const listNode = $createListNode('bullet', 1);
+        const linkNode = $createLinkNode('https://lexical.dev/');
+
+        listNode.append(linkNode);
+
+        const root = $getRoot();
+        root.append(listNode);
+      });
+
+      editor.read(() => {
+        const root = $getRoot();
+
+        const listNode = root.getFirstChild();
+        expect(listNode).not.toBeNull();
+        expect($isListNode(listNode)).toBe(true);
+
+        if ($isListNode(listNode)) {
+          const firstChild = listNode.getFirstChild();
+          expect($isListItemNode(firstChild)).toBe(true);
+
+          if ($isListItemNode(firstChild)) {
+            const wrappedNode = firstChild?.getFirstChild();
+            expect(wrappedNode).not.toBeNull();
+            expect($isLinkNode(wrappedNode)).toBe(true);
+
+            expect((wrappedNode as LinkNode).getURL()).toBe(
+              'https://lexical.dev/',
+            );
+          } else {
+            expect($isListItemNode(firstChild)).toBe(true);
+          }
+        }
       });
     });
 

--- a/packages/lexical-website/docs/concepts/listeners.md
+++ b/packages/lexical-website/docs/concepts/listeners.md
@@ -84,7 +84,7 @@ handle external UI state and UI features relating to specific types of node.
 If any existing nodes are in the DOM, and skipInitialization is not true, the listener
 will be called immediately with an updateTag of 'registerMutationListener' where all
 nodes have the 'created' NodeMutation. This can be controlled with the skipInitialization option
-(The default was previously true for backwards compatibility with <= 0.16.1 but has been changed to false as of 0.21.0).
+(whose default was previously true for backwards compatibility with &lt;=0.16.1 but has been changed to false as of 0.21.0).
 
 ```js
 const removeMutationListener = editor.registerMutationListener(

--- a/packages/lexical-website/docs/concepts/listeners.md
+++ b/packages/lexical-website/docs/concepts/listeners.md
@@ -84,7 +84,7 @@ handle external UI state and UI features relating to specific types of node.
 If any existing nodes are in the DOM, and skipInitialization is not true, the listener
 will be called immediately with an updateTag of 'registerMutationListener' where all
 nodes have the 'created' NodeMutation. This can be controlled with the skipInitialization option
-(default is currently true for backwards compatibility in 0.17.x but will change to false in 0.18.0).
+(The default was previously true for backwards compatibility with <= 0.16.1 but has been changed to false as of 0.21.0).
 
 ```js
 const removeMutationListener = editor.registerMutationListener(

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -844,7 +844,7 @@ export class LexicalEditor {
    * If any existing nodes are in the DOM, and skipInitialization is not true, the listener
    * will be called immediately with an updateTag of 'registerMutationListener' where all
    * nodes have the 'created' NodeMutation. This can be controlled with the skipInitialization option
-   * (The default was previously true for backwards compatibility with <= 0.16.1 but has been changed to false as of 0.21.0).
+   * (whose default was previously true for backwards compatibility with &lt;=0.16.1 but has been changed to false as of 0.21.0).
    *
    * @param klass - The class of the node that you want to listen to mutations on.
    * @param listener - The logic you want to run when the node is mutated.

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -216,13 +216,13 @@ export interface MutationListenerOptions {
   /**
    * Skip the initial call of the listener with pre-existing DOM nodes.
    *
-   * The default is currently true for backwards compatibility with <= 0.16.1
-   * but this default is expected to change to false in 0.17.0.
+   * The default was previously true for backwards compatibility with <= 0.16.1
+   * but this default has been changed to false as of 0.21.0.
    */
   skipInitialization?: boolean;
 }
 
-const DEFAULT_SKIP_INITIALIZATION = true;
+const DEFAULT_SKIP_INITIALIZATION = false;
 
 export type UpdateListener = (arg0: {
   dirtyElements: Map<NodeKey, IntentionallyMarkedAsDirtyElement>;
@@ -844,7 +844,7 @@ export class LexicalEditor {
    * If any existing nodes are in the DOM, and skipInitialization is not true, the listener
    * will be called immediately with an updateTag of 'registerMutationListener' where all
    * nodes have the 'created' NodeMutation. This can be controlled with the skipInitialization option
-   * (default is currently true for backwards compatibility in 0.16.x but will change to false in 0.17.0).
+   * (The default was previously true for backwards compatibility with <= 0.16.1 but has been changed to false as of 0.21.0).
    *
    * @param klass - The class of the node that you want to listen to mutations on.
    * @param listener - The logic you want to run when the node is mutated.


### PR DESCRIPTION

## Description
The default value for the `skipInitialization` option in `registerMutationListener` was deprecated in #6357 and was intended to change to `false`. This PR updates the default (`DEFAULT_SKIP_INITIALIZATION`) and corresponding comments/docs to reflect the correct value - False.

Closes #6846 

