### PR TITLE
[lexical-playground] Bug Fix: Use local excalidraw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36908,6 +36908,38 @@
         "vite": "^2"
       }
     },
+    "node_modules/vite-plugin-static-copy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.1.0.tgz",
+      "integrity": "sha512-n8lEOIVM00Y/zronm0RG8RdPyFd0SAAFR0sii3NWmgG3PSCyYMsvUNRQTlb3onp1XeMrKIDwCrPGxthKvqX9OQ==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "fast-glob": "^3.2.11",
+        "fs-extra": "^11.1.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/vite/node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -39137,7 +39169,8 @@
         "@vitejs/plugin-react": "^4.2.1",
         "rollup-plugin-copy": "^3.5.0",
         "vite": "^5.2.11",
-        "vite-plugin-replace": "^0.1.1"
+        "vite-plugin-replace": "^0.1.1",
+        "vite-plugin-static-copy": "^2.1.0"
       }
     },
     "packages/lexical-react": {
@@ -56239,6 +56272,7 @@
         "rollup-plugin-copy": "^3.5.0",
         "vite": "^5.2.11",
         "vite-plugin-replace": "^0.1.1",
+        "vite-plugin-static-copy": "^2.1.0",
         "y-websocket": "^1.5.4",
         "yjs": ">=13.5.42"
       }
@@ -64709,6 +64743,31 @@
       "resolved": "https://registry.npmjs.org/vite-plugin-replace/-/vite-plugin-replace-0.1.1.tgz",
       "integrity": "sha512-v+okl3JNt2pf1jDYijw+WPVt6h9FWa/atTi+qnSFBqmKThLTDhlesx0r3bh+oFPmxRJmis5tNx9HtN6lGFoqWg==",
       "dev": true
+    },
+    "vite-plugin-static-copy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.1.0.tgz",
+      "integrity": "sha512-n8lEOIVM00Y/zronm0RG8RdPyFd0SAAFR0sii3NWmgG3PSCyYMsvUNRQTlb3onp1XeMrKIDwCrPGxthKvqX9OQ==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.3",
+        "fast-glob": "^3.2.11",
+        "fs-extra": "^11.1.0",
+        "picocolors": "^1.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
     },
     "vlq": {
       "version": "1.0.1",

--- a/packages/lexical-playground/package.json
+++ b/packages/lexical-playground/package.json
@@ -45,7 +45,8 @@
     "@vitejs/plugin-react": "^4.2.1",
     "rollup-plugin-copy": "^3.5.0",
     "vite": "^5.2.11",
-    "vite-plugin-replace": "^0.1.1"
+    "vite-plugin-replace": "^0.1.1",
+    "vite-plugin-static-copy": "^2.1.0"
   },
   "sideEffects": false
 }

--- a/packages/lexical-playground/src/setupEnv.ts
+++ b/packages/lexical-playground/src/setupEnv.ts
@@ -30,5 +30,9 @@ export default (() => {
     // @ts-expect-error
     delete window.InputEvent.prototype.getTargetRanges;
   }
+
+  // @ts-ignore
+  window.EXCALIDRAW_ASSET_PATH = process.env.EXCALIDRAW_ASSET_PATH;
+
   return INITIAL_SETTINGS;
 })();

--- a/packages/lexical-playground/vite.config.ts
+++ b/packages/lexical-playground/vite.config.ts
@@ -77,7 +77,7 @@ export default defineConfig(({command}) => {
         presets: [['@babel/preset-react', {runtime: 'automatic'}]],
       }),
       react(),
-      ...viteCopyExcalidrawAssets('dev'),
+      ...viteCopyExcalidrawAssets(),
       viteCopyEsm(),
       commonjs({
         // This is required for React 19 (at least 19.0.0-beta-26f2496093-20240514)

--- a/packages/lexical-playground/vite.config.ts
+++ b/packages/lexical-playground/vite.config.ts
@@ -15,6 +15,7 @@ import {replaceCodePlugin} from 'vite-plugin-replace';
 
 import moduleResolution from '../shared/viteModuleResolution';
 import viteCopyEsm from './viteCopyEsm';
+import viteCopyExcalidrawAssets from './viteCopyExcalidrawAssets';
 
 const require = createRequire(import.meta.url);
 
@@ -76,6 +77,7 @@ export default defineConfig(({command}) => {
         presets: [['@babel/preset-react', {runtime: 'automatic'}]],
       }),
       react(),
+      ...viteCopyExcalidrawAssets('dev'),
       viteCopyEsm(),
       commonjs({
         // This is required for React 19 (at least 19.0.0-beta-26f2496093-20240514)

--- a/packages/lexical-playground/vite.prod.config.ts
+++ b/packages/lexical-playground/vite.prod.config.ts
@@ -14,6 +14,7 @@ import {replaceCodePlugin} from 'vite-plugin-replace';
 
 import moduleResolution from '../shared/viteModuleResolution';
 import viteCopyEsm from './viteCopyEsm';
+import viteCopyExcalidrawAssets from './viteCopyExcalidrawAssets';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -69,6 +70,7 @@ export default defineConfig({
       presets: [['@babel/preset-react', {runtime: 'automatic'}]],
     }),
     react(),
+    ...viteCopyExcalidrawAssets('prod'),
     viteCopyEsm(),
     commonjs({
       // This is required for React 19 (at least 19.0.0-beta-26f2496093-20240514)

--- a/packages/lexical-playground/vite.prod.config.ts
+++ b/packages/lexical-playground/vite.prod.config.ts
@@ -70,7 +70,7 @@ export default defineConfig({
       presets: [['@babel/preset-react', {runtime: 'automatic'}]],
     }),
     react(),
-    ...viteCopyExcalidrawAssets('prod'),
+    ...viteCopyExcalidrawAssets(),
     viteCopyEsm(),
     commonjs({
       // This is required for React 19 (at least 19.0.0-beta-26f2496093-20240514)

--- a/packages/lexical-playground/viteCopyExcalidrawAssets.ts
+++ b/packages/lexical-playground/viteCopyExcalidrawAssets.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import type {Plugin} from 'vite';
+
+import {createRequire} from 'node:module';
+import * as path from 'node:path';
+import {Target, viteStaticCopy} from 'vite-plugin-static-copy';
+
+const require = createRequire(import.meta.url);
+
+export default function viteCopyExcalidrawAssets(): Plugin[] {
+  const targets: Target[] = [
+    'excalidraw-assets',
+    'excalidraw-assets-dev',
+  ].flatMap((assetDir) => {
+    const srcDir = path.join(
+      require.resolve('@excalidraw/excalidraw'),
+      '..',
+      'dist',
+      assetDir,
+    );
+    return [
+      {
+        dest: `${assetDir}/`,
+        src: [path.join(srcDir, '*.js'), path.join(srcDir, '*.woff2')],
+      },
+      {
+        dest: `${assetDir}/locales/`,
+        src: [path.join(srcDir, 'locales', '*.js')],
+      },
+    ];
+  });
+  return [
+    {
+      config() {
+        return {
+          define: {
+            'process.env.EXCALIDRAW_ASSET_PATH': JSON.stringify('/'),
+          },
+        };
+      },
+      name: 'viteCopyExcalidrawAssets',
+    },
+    ...viteStaticCopy({
+      targets,
+    }),
+  ];
+}

--- a/packages/lexical-playground/viteCopyExcalidrawAssets.ts
+++ b/packages/lexical-playground/viteCopyExcalidrawAssets.ts
@@ -8,7 +8,6 @@
 import type {Plugin} from 'vite';
 
 import {createRequire} from 'node:module';
-import * as path from 'node:path';
 import {Target, viteStaticCopy} from 'vite-plugin-static-copy';
 
 const require = createRequire(import.meta.url);
@@ -18,20 +17,17 @@ export default function viteCopyExcalidrawAssets(): Plugin[] {
     'excalidraw-assets',
     'excalidraw-assets-dev',
   ].flatMap((assetDir) => {
-    const srcDir = path.join(
-      require.resolve('@excalidraw/excalidraw'),
-      '..',
-      'dist',
-      assetDir,
-    );
+    const srcDir = `${require.resolve(
+      '@excalidraw/excalidraw',
+    )}/../dist/${assetDir}`;
     return [
       {
         dest: `${assetDir}/`,
-        src: [path.join(srcDir, '*.js'), path.join(srcDir, '*.woff2')],
+        src: [`${srcDir}/*.js`, `${srcDir}/*.woff2`],
       },
       {
         dest: `${assetDir}/locales/`,
-        src: [path.join(srcDir, 'locales', '*.js')],
+        src: [`${srcDir}/locales/*.js`],
       },
     ];
   });

--- a/packages/lexical-playground/viteCopyExcalidrawAssets.ts
+++ b/packages/lexical-playground/viteCopyExcalidrawAssets.ts
@@ -8,6 +8,8 @@
 import type {Plugin} from 'vite';
 
 import {createRequire} from 'node:module';
+import * as path from 'node:path';
+import {normalizePath} from 'vite';
 import {Target, viteStaticCopy} from 'vite-plugin-static-copy';
 
 const require = createRequire(import.meta.url);
@@ -17,17 +19,22 @@ export default function viteCopyExcalidrawAssets(): Plugin[] {
     'excalidraw-assets',
     'excalidraw-assets-dev',
   ].flatMap((assetDir) => {
-    const srcDir = `${require.resolve(
-      '@excalidraw/excalidraw',
-    )}/../dist/${assetDir}`;
+    const srcDir = path.join(
+      require.resolve('@excalidraw/excalidraw'),
+      '..',
+      'dist',
+      assetDir,
+    );
     return [
       {
         dest: `${assetDir}/`,
-        src: [`${srcDir}/*.js`, `${srcDir}/*.woff2`],
+        src: [path.join(srcDir, '*.js'), path.join(srcDir, '*.woff2')].map(
+          normalizePath,
+        ),
       },
       {
         dest: `${assetDir}/locales/`,
-        src: [`${srcDir}/locales/*.js`],
+        src: [path.join(srcDir, 'locales', '*.js')].map(normalizePath),
       },
     ];
   });

--- a/packages/shared/viteModuleResolution.ts
+++ b/packages/shared/viteModuleResolution.ts
@@ -11,6 +11,7 @@ import type {
   NpmModuleExportEntry,
   PackageMetadata,
 } from '../../scripts/shared/PackageMetadata';
+import type {Alias} from 'vite';
 
 import * as fs from 'node:fs';
 import {createRequire} from 'node:module';
@@ -81,7 +82,7 @@ const distModuleResolution = (environment: 'development' | 'production') => {
 
 export default function moduleResolution(
   environment: 'source' | 'development' | 'production',
-) {
+): Alias[] {
   return environment === 'source'
     ? sourceModuleResolution()
     : distModuleResolution(environment);


### PR DESCRIPTION
## Description

Excalidraw is configured by default to load its assets from a public CDN (unpkg). This adds additional latency to local development and the test suite, particularly when working with an unstable connection.

Removing this third party connection should also speed up our CI and make it slightly more reliable.

I can thank the current atmospheric river in SF combined with wireless internet to tracking this one down 🌧️ 

## Test plan

### Before

<details>
<summary>Open network inspector to find assets loaded from unpkg.com in the playground</summary>

![Screenshot 2024-11-22 at 18 15 38](https://github.com/user-attachments/assets/0d2b6a12-1a6d-49bd-bfe4-3292eb8706be)
</details>

### After

<details>
<summary>No assets loaded from unpkg.com in the playground build for this PR</summary>

![Screenshot 2024-11-22 at 18 32 47](https://github.com/user-attachments/assets/8a3dbde3-e8de-46fd-9034-acafd4df9e9e)
</details>