### PR TITLE
[lexical-utils] Bug Fix: Add feature detection to calculateZoomLevel

### DIFF
--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -660,7 +660,7 @@ function needsManualZoom(): boolean {
     document.body.appendChild(div);
     const noZoom = div.getBoundingClientRect();
     div.style.setProperty('zoom', '2');
-    NEEDS_MANUAL_ZOOM = div.getBoundingClientRect().width > noZoom.width;
+    NEEDS_MANUAL_ZOOM = div.getBoundingClientRect().width === noZoom.width;
     document.body.removeChild(div);
   }
   return NEEDS_MANUAL_ZOOM;

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -647,19 +647,38 @@ export function $insertFirst(parent: ElementNode, node: LexicalNode): void {
   }
 }
 
+let NEEDS_MANUAL_ZOOM = IS_FIREFOX || !CAN_USE_DOM ? false : undefined;
+function needsManualZoom(): boolean {
+  if (NEEDS_MANUAL_ZOOM === undefined) {
+    // If the browser implements standardized CSS zoom, then the client rect
+    // will be wider after zoom is applied
+    // https://chromestatus.com/feature/5198254868529152
+    // https://github.com/facebook/lexical/issues/6863
+    const div = document.createElement('div');
+    div.style.cssText =
+      'position: absolute; opacity: 0; width: 100px; left: -1000px;';
+    document.body.appendChild(div);
+    const noZoom = div.getBoundingClientRect();
+    div.style.zoom = '2';
+    NEEDS_MANUAL_ZOOM = div.getBoundingClientRect().width > noZoom.width;
+    document.body.removeChild(div);
+  }
+  return NEEDS_MANUAL_ZOOM;
+}
+
 /**
  * Calculates the zoom level of an element as a result of using
- * css zoom property.
+ * css zoom property. For browsers that implement standardized CSS
+ * zoom (Firefox, Chrome >= 128), this will always return 1.
  * @param element
  */
 export function calculateZoomLevel(element: Element | null): number {
-  if (IS_FIREFOX) {
-    return 1;
-  }
   let zoom = 1;
-  while (element) {
-    zoom *= Number(window.getComputedStyle(element).getPropertyValue('zoom'));
-    element = element.parentElement;
+  if (needsManualZoom()) {
+    while (element) {
+      zoom *= Number(window.getComputedStyle(element).getPropertyValue('zoom'));
+      element = element.parentElement;
+    }
   }
   return zoom;
 }

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -659,7 +659,7 @@ function needsManualZoom(): boolean {
       'position: absolute; opacity: 0; width: 100px; left: -1000px;';
     document.body.appendChild(div);
     const noZoom = div.getBoundingClientRect();
-    div.style.zoom = '2';
+    div.style.setProperty('zoom', '2');
     NEEDS_MANUAL_ZOOM = div.getBoundingClientRect().width > noZoom.width;
     document.body.removeChild(div);
   }


### PR DESCRIPTION
## Description

Add feature detection to `calculateZoomLevel` in situations when we are not sure if the browser implements standardized CSS zoom. We still assume that Firefox does, but since only Chrome >= 128 implements it and Safari doesn't implement it yet we use feature detection (creating a div in the document but off-screen, measuring it with and without zoom, then removing it). It's measured twice in case there's a zoom on the body which could cancel out a static measurement.

Closes #6863

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*