### PR TITLE
[lexical-playground] Bug Fix: Preserve the selection using the link editor from a table

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -19,6 +19,7 @@ import {
   $getSelection,
   $isLineBreakNode,
   $isRangeSelection,
+  $setSelection,
   BaseSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_CRITICAL,
@@ -205,6 +206,7 @@ function FloatingLinkEditor({
     if (lastSelection !== null) {
       if (linkUrl !== '') {
         editor.update(() => {
+          $setSelection(lastSelection.clone());
           editor.dispatchCommand(
             TOGGLE_LINK_COMMAND,
             sanitizeUrl(editedLinkUrl),

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -19,7 +19,6 @@ import {
   $getSelection,
   $isLineBreakNode,
   $isRangeSelection,
-  $setSelection,
   BaseSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_CRITICAL,
@@ -37,6 +36,12 @@ import {createPortal} from 'react-dom';
 import {getSelectedNode} from '../../utils/getSelectedNode';
 import {setFloatingElemPositionForLinkEditor} from '../../utils/setFloatingElemPositionForLinkEditor';
 import {sanitizeUrl} from '../../utils/url';
+
+function preventDefault(
+  event: React.KeyboardEvent<HTMLInputElement> | React.MouseEvent<HTMLElement>,
+): void {
+  event.preventDefault();
+}
 
 function FloatingLinkEditor({
   editor,
@@ -184,19 +189,22 @@ function FloatingLinkEditor({
     event: React.KeyboardEvent<HTMLInputElement>,
   ) => {
     if (event.key === 'Enter') {
-      event.preventDefault();
-      handleLinkSubmission();
+      handleLinkSubmission(event);
     } else if (event.key === 'Escape') {
       event.preventDefault();
       setIsLinkEditMode(false);
     }
   };
 
-  const handleLinkSubmission = () => {
+  const handleLinkSubmission = (
+    event:
+      | React.KeyboardEvent<HTMLInputElement>
+      | React.MouseEvent<HTMLElement>,
+  ) => {
+    event.preventDefault();
     if (lastSelection !== null) {
       if (linkUrl !== '') {
         editor.update(() => {
-          $setSelection(lastSelection.clone());
           editor.dispatchCommand(
             TOGGLE_LINK_COMMAND,
             sanitizeUrl(editedLinkUrl),
@@ -240,7 +248,7 @@ function FloatingLinkEditor({
               className="link-cancel"
               role="button"
               tabIndex={0}
-              onMouseDown={(event) => event.preventDefault()}
+              onMouseDown={preventDefault}
               onClick={() => {
                 setIsLinkEditMode(false);
               }}
@@ -250,7 +258,7 @@ function FloatingLinkEditor({
               className="link-confirm"
               role="button"
               tabIndex={0}
-              onMouseDown={(event) => event.preventDefault()}
+              onMouseDown={preventDefault}
               onClick={handleLinkSubmission}
             />
           </div>
@@ -267,8 +275,9 @@ function FloatingLinkEditor({
             className="link-edit"
             role="button"
             tabIndex={0}
-            onMouseDown={(event) => event.preventDefault()}
-            onClick={() => {
+            onMouseDown={preventDefault}
+            onClick={(event) => {
+              event.preventDefault();
               setEditedLinkUrl(linkUrl);
               setIsLinkEditMode(true);
             }}
@@ -277,7 +286,7 @@ function FloatingLinkEditor({
             className="link-trash"
             role="button"
             tabIndex={0}
-            onMouseDown={(event) => event.preventDefault()}
+            onMouseDown={preventDefault}
             onClick={() => {
               editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
             }}

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -19,7 +19,6 @@ import {
   $getSelection,
   $isLineBreakNode,
   $isRangeSelection,
-  $setSelection,
   BaseSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_CRITICAL,
@@ -206,7 +205,6 @@ function FloatingLinkEditor({
     if (lastSelection !== null) {
       if (linkUrl !== '') {
         editor.update(() => {
-          $setSelection(lastSelection.clone());
           editor.dispatchCommand(
             TOGGLE_LINK_COMMAND,
             sanitizeUrl(editedLinkUrl),

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -19,6 +19,7 @@ import {
   $getSelection,
   $isLineBreakNode,
   $isRangeSelection,
+  $setSelection,
   BaseSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_CRITICAL,
@@ -194,8 +195,12 @@ function FloatingLinkEditor({
   const handleLinkSubmission = () => {
     if (lastSelection !== null) {
       if (linkUrl !== '') {
-        editor.dispatchCommand(TOGGLE_LINK_COMMAND, sanitizeUrl(editedLinkUrl));
         editor.update(() => {
+          $setSelection(lastSelection.clone());
+          editor.dispatchCommand(
+            TOGGLE_LINK_COMMAND,
+            sanitizeUrl(editedLinkUrl),
+          );
           const selection = $getSelection();
           if ($isRangeSelection(selection)) {
             const parent = getSelectedNode(selection).getParent();

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -88,27 +88,27 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
 
   useEffect(() => {
     const onMouseMove = (event: MouseEvent) => {
-      setTimeout(() => {
-        const target = event.target;
+      const target = event.target;
 
-        if (draggingDirection) {
-          updateMouseCurrentPos({
-            x: event.clientX,
-            y: event.clientY,
-          });
-          return;
-        }
-        updateIsMouseDown(isMouseDownOnEvent(event));
-        if (resizerRef.current && resizerRef.current.contains(target as Node)) {
-          return;
-        }
+      if (draggingDirection) {
+        updateMouseCurrentPos({
+          x: event.clientX,
+          y: event.clientY,
+        });
+        return;
+      }
+      updateIsMouseDown(isMouseDownOnEvent(event));
+      if (resizerRef.current && resizerRef.current.contains(target as Node)) {
+        return;
+      }
 
-        if (targetRef.current !== target) {
-          targetRef.current = target as HTMLElement;
-          const cell = getDOMCellFromTarget(target as HTMLElement);
+      if (targetRef.current !== target) {
+        targetRef.current = target as HTMLElement;
+        const cell = getDOMCellFromTarget(target as HTMLElement);
 
-          if (cell && activeCell !== cell) {
-            editor.update(() => {
+        if (cell && activeCell !== cell) {
+          editor.getEditorState().read(
+            () => {
               const tableCellNode = $getNearestNodeFromDOMNode(cell.elem);
               if (!tableCellNode) {
                 throw new Error('TableCellResizer: Table cell node not found.');
@@ -128,24 +128,21 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
               targetRef.current = target as HTMLElement;
               tableRectRef.current = tableElement.getBoundingClientRect();
               updateActiveCell(cell);
-            });
-          } else if (cell == null) {
-            resetState();
-          }
+            },
+            {editor},
+          );
+        } else if (cell == null) {
+          resetState();
         }
-      }, 0);
+      }
     };
 
     const onMouseDown = (event: MouseEvent) => {
-      setTimeout(() => {
-        updateIsMouseDown(true);
-      }, 0);
+      updateIsMouseDown(true);
     };
 
     const onMouseUp = (event: MouseEvent) => {
-      setTimeout(() => {
-        updateIsMouseDown(false);
-      }, 0);
+      updateIsMouseDown(false);
     };
 
     const removeRootListener = editor.registerRootListener(

--- a/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
@@ -66,40 +66,44 @@ function TableHoverActionsContainer({
       let hoveredColumnNode: TableCellNode | null = null;
       let tableDOMElement: HTMLElement | null = null;
 
-      editor.update(() => {
-        const maybeTableCell = $getNearestNodeFromDOMNode(tableDOMNode);
+      editor.getEditorState().read(
+        () => {
+          const maybeTableCell = $getNearestNodeFromDOMNode(tableDOMNode);
 
-        if ($isTableCellNode(maybeTableCell)) {
-          const table = $findMatchingParent(maybeTableCell, (node) =>
-            $isTableNode(node),
-          );
-          if (!$isTableNode(table)) {
-            return;
-          }
+          if ($isTableCellNode(maybeTableCell)) {
+            const table = $findMatchingParent(maybeTableCell, (node) =>
+              $isTableNode(node),
+            );
+            if (!$isTableNode(table)) {
+              return;
+            }
 
-          tableDOMElement = getTableElement(
-            table,
-            editor.getElementByKey(table.getKey()),
-          );
+            tableDOMElement = getTableElement(
+              table,
+              editor.getElementByKey(table.getKey()),
+            );
 
-          if (tableDOMElement) {
-            const rowCount = table.getChildrenSize();
-            const colCount = (
-              (table as TableNode).getChildAtIndex(0) as TableRowNode
-            )?.getChildrenSize();
+            if (tableDOMElement) {
+              const rowCount = table.getChildrenSize();
+              const colCount = (
+                (table as TableNode).getChildAtIndex(0) as TableRowNode
+              )?.getChildrenSize();
 
-            const rowIndex = $getTableRowIndexFromTableCellNode(maybeTableCell);
-            const colIndex =
-              $getTableColumnIndexFromTableCellNode(maybeTableCell);
+              const rowIndex =
+                $getTableRowIndexFromTableCellNode(maybeTableCell);
+              const colIndex =
+                $getTableColumnIndexFromTableCellNode(maybeTableCell);
 
-            if (rowIndex === rowCount - 1) {
-              hoveredRowNode = maybeTableCell;
-            } else if (colIndex === colCount - 1) {
-              hoveredColumnNode = maybeTableCell;
+              if (rowIndex === rowCount - 1) {
+                hoveredRowNode = maybeTableCell;
+              } else if (colIndex === colCount - 1) {
+                hoveredColumnNode = maybeTableCell;
+              }
             }
           }
-        }
-      });
+        },
+        {editor},
+      );
 
       if (tableDOMElement) {
         const {


### PR DESCRIPTION
## Description

When used in a table cell, the link editor loses focus and the link is not applied. Finding the root cause of this one was tricky, but the gist of it was that we were calling editor.update on mousemove for TableHoverActions and TableCellResizer and because of how reconciliation currently works the DOM selection is always resolved during an editor.update cycle so it would get reset under these circumstances since the DOM selection was in a portal for the link editing modal.

### Failed debugging strategies:

* Trying to narrow it down by disabling one mousemove plugin at a time didn't work because two plugins had the same bug
* Replacing EditorState._selection with a getter/setter that had debugging logs and a breakpoint didn't work because this was happening during reconciliation when this change goes through module global variables and not a `$setSelection`

### What worked:

* Setting a breakpoint in updateDOMSelection when the selection changed in this specific way (prevSelection from a RangeSelection, nextSelection to null, domSelection anchor on `.link-input`)
* Adding a local variable that stored `updateFn` to the `scheduleMicroTask(() => { … })` closure so that I could track down which update function was responsible for this happening in the debugger scope (normally this information is lost since that function only closes over editor)

### Future considerations:

I've never loved how editor reconciliation always tries to eagerly do things with the selection based on the DOM, because of situations like this. Maybe we should at least add an update tag similar to `skip-scroll-into-view` which avoids the forced selection reconciliation without having to temporarily set the editor to readonly or do other weird things.

Closes #6821

## Test plan

### Before

https://github.com/user-attachments/assets/fc445e9b-084a-409a-8a63-98744d0d68aa

### After

https://github.com/user-attachments/assets/4e89f688-4657-4dbb-a447-641cf247f89b