### PR TITLE
[lexical-selection] Bug Fix: Wrong selection type in $setBlocksType

### DIFF
--- a/packages/lexical-selection/flow/LexicalSelection.js.flow
+++ b/packages/lexical-selection/flow/LexicalSelection.js.flow
@@ -51,7 +51,7 @@ declare export function $wrapNodes(
   wrappingElement?: ElementNode,
 ): void;
 declare export function $setBlocksType(
-  selection: RangeSelection,
+  selection: BaseSelection | null,
   createElement: () => ElementNode,
 ): void;
 declare export function $isAtNodeEnd(point: Point): boolean;


### PR DESCRIPTION
## Description
selection parameter in $setBlocksType is set to _RangeSelection_ however, the function defines selection as a _BaseSelection | null_ type.