### PR TITLE
[lexical][lexical-playground] Bug Fix: Allow setEditorState to work correctly inside of an update

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Autocomplete.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Autocomplete.spec.mjs
@@ -156,8 +156,14 @@ test.describe('Autocomplete', () => {
       `,
     );
   });
-  test('Undo does not cause an exception', async ({page, isPlainText}) => {
+  test('Undo does not cause an exception', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
     test.skip(isPlainText);
+    // Autocomplete has known issues in collab https://github.com/facebook/lexical/issues/6844
+    test.skip(isCollab);
     await focusEditor(page);
     await toggleBold(page);
     await toggleItalic(page);

--- a/packages/lexical-playground/__tests__/e2e/Autocomplete.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Autocomplete.spec.mjs
@@ -13,6 +13,7 @@ import {
   toggleItalic,
   toggleStrikethrough,
   toggleUnderline,
+  undo,
 } from '../keyboardShortcuts/index.mjs';
 import {
   assertHTML,
@@ -151,6 +152,127 @@ test.describe('Autocomplete', () => {
             imonials
           </strong>
           <span style="font-size: 15px;" data-lexical-text="true">2024</span>
+        </p>
+      `,
+    );
+  });
+  test('Undo does not cause an exception', async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    await toggleBold(page);
+    await toggleItalic(page);
+    await toggleUnderline(page);
+    await toggleStrikethrough(page);
+    await increaseFontSize(page);
+
+    await page.keyboard.type('Test');
+    await sleep(500);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <strong
+            class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+            style="font-size: 17px;"
+            data-lexical-text="true">
+            Test
+          </strong>
+          <strong
+            class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__autocomplete"
+            style="font-size: 17px;"
+            data-lexical-text="true">
+            imonials (TAB)
+          </strong>
+        </p>
+      `,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <strong
+            class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+            style="font-size: 17px;"
+            data-lexical-text="true">
+            Test
+          </strong>
+          <span data-lexical-text="true"></span>
+        </p>
+      `,
+    );
+
+    await page.keyboard.press('Tab');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <strong
+            class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+            style="font-size: 17px;"
+            data-lexical-text="true">
+            Test
+          </strong>
+          <strong
+            class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+            style="font-size: 17px;"
+            data-lexical-text="true">
+            imonials
+          </strong>
+        </p>
+      `,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <strong
+            class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+            style="font-size: 17px;"
+            data-lexical-text="true">
+            Test
+          </strong>
+          <span data-lexical-text="true"></span>
+        </p>
+      `,
+    );
+
+    await undo(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <strong
+            class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+            style="font-size: 17px;"
+            data-lexical-text="true">
+            Test
+          </strong>
+          <strong
+            class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic PlaygroundEditorTheme__autocomplete"
+            style="font-size: 17px;"
+            data-lexical-text="true">
+            imonials (TAB)
+          </strong>
+        </p>
+      `,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <strong
+            class="PlaygroundEditorTheme__textUnderlineStrikethrough PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic"
+            style="font-size: 17px;"
+            data-lexical-text="true">
+            Test
+          </strong>
+          <span data-lexical-text="true"></span>
         </p>
       `,
     );

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -19,7 +19,7 @@ import invariant from 'shared/invariant';
 
 import {$getRoot, $getSelection, TextNode} from '.';
 import {FULL_RECONCILE, NO_DIRTY_NODES} from './LexicalConstants';
-import {createEmptyEditorState} from './LexicalEditorState';
+import {cloneEditorState, createEmptyEditorState} from './LexicalEditorState';
 import {addRootElementEvents, removeRootElementEvents} from './LexicalEvents';
 import {$flushRootMutations, initMutationObserver} from './LexicalMutations';
 import {LexicalNode} from './LexicalNode';
@@ -1111,6 +1111,16 @@ export class LexicalEditor {
       );
     }
 
+    // Ensure that we have a writable EditorState so that transforms can run
+    // during a historic operation
+    let writableEditorState = editorState;
+    if (writableEditorState._readOnly) {
+      writableEditorState = cloneEditorState(editorState);
+      writableEditorState._selection = editorState._selection
+        ? editorState._selection.clone()
+        : null;
+    }
+
     $flushRootMutations(this);
     const pendingEditorState = this._pendingEditorState;
     const tags = this._updateTags;
@@ -1120,11 +1130,10 @@ export class LexicalEditor {
       if (tag != null) {
         tags.add(tag);
       }
-
       $commitPendingUpdates(this);
     }
 
-    this._pendingEditorState = editorState;
+    this._pendingEditorState = writableEditorState;
     this._dirtyType = FULL_RECONCILE;
     this._dirtyElements.set('root', false);
     this._compositionKey = null;
@@ -1133,7 +1142,12 @@ export class LexicalEditor {
       tags.add(tag);
     }
 
-    $commitPendingUpdates(this);
+    // Only commit pending updates if not already in an editor.update
+    // (e.g. dispatchCommand) otherwise this will cause a second commit
+    // with an already read-only state and selection
+    if (!this._updating) {
+      $commitPendingUpdates(this);
+    }
   }
 
   /**

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2549,7 +2549,8 @@ describe('LexicalEditor tests', () => {
       `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Hello world","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
     );
     editor.setEditorState(state);
-    expect(editor._editorState).toBe(state);
+    // A writable version of the EditorState may have been created, we settle for equal serializations
+    expect(editor._editorState.toJSON()).toEqual(state.toJSON());
     expect(editor._pendingEditorState).toBe(null);
   });
 


### PR DESCRIPTION
## Description

LexicalEditor.setEditorState has a bunch of shared code with LexicalEditor.update such that it doesn't need to be issued from inside of an update. However, if it is issued inside of an update then it will cause an extra `$commitPendingUpdates` call after the state and selection are already read-only which will throw in some situations when node transforms are in use.

This fix ensures that setEditorState is working with a writable state and selection so that transforms can run, and skips the redundant `$commitPendingUpdates` call for the scenarios when it is being called from inside an existing update context (e.g. a dispatchCommand from the history plugin)

Closes #6843

## Test plan

### Before

https://github.com/user-attachments/assets/c36ca953-d9cd-4b23-9d96-b9ba1b7b0a98

### After


https://github.com/user-attachments/assets/29e7af39-f620-4e48-afe7-f5a48f1e4eeb

