### PR TITLE
[lexical-table] Bug Fix: TableNode exportDOM fixes for partial table selection

### DIFF
--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -26,6 +26,7 @@ import {
   $isLineBreakNode,
   $isTextNode,
   ElementNode,
+  isHTMLElement,
 } from 'lexical';
 
 import {COLUMN_WIDTH, PIXEL_VALUE_REG_EXP} from './constants';
@@ -150,8 +151,12 @@ export class TableCellNode extends ElementNode {
   exportDOM(editor: LexicalEditor): DOMExportOutput {
     const output = super.exportDOM(editor);
 
-    if (output.element) {
+    if (output.element && isHTMLElement(output.element)) {
       const element = output.element as HTMLTableCellElement;
+      element.setAttribute(
+        'data-temporary-table-cell-lexical-key',
+        this.getKey(),
+      );
       element.style.border = '1px solid black';
       if (this.__colSpan > 1) {
         element.colSpan = this.__colSpan;

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import type {Spread} from 'lexical';
+import type {BaseSelection, Spread} from 'lexical';
 
 import {addClassNamesToElement} from '@lexical/utils';
 import {
@@ -79,6 +79,14 @@ export class TableRowNode extends ElementNode {
     addClassNamesToElement(element, config.theme.tableRow);
 
     return element;
+  }
+
+  extractWithChild(
+    child: LexicalNode,
+    selection: BaseSelection | null,
+    destination: 'clone' | 'html',
+  ): boolean {
+    return destination === 'html';
   }
 
   isShadowRoot(): boolean {


### PR DESCRIPTION
## Description

The exportDOM for TableNode didn't consider partial table selections, and didn't have any tests.

Follow-up to #6884

## Test plan

### Before

No tests. Would export the full table colgroup and/or not have all of the wrapping elements.

### After

TableNode exportDOM behaves as expected with tests.