### PR TITLE
[lexical-website] Feature: Document the withKlass option for node replacement

### DIFF
--- a/packages/lexical-website/docs/concepts/node-replacement.md
+++ b/packages/lexical-website/docs/concepts/node-replacement.md
@@ -1,6 +1,6 @@
 
 
-# Node Overrides
+# Node Overrides / Node Replacements
 
 Some of the most commonly used Lexical Nodes are owned and maintained by the core library. For example, ParagraphNode, HeadingNode, QuoteNode, List(Item)Node etc - these are all provided by Lexical packages, which provides an easier out-of-the-box experience for some editor features, but makes it difficult to override their behavior. For instance, if you wanted to change the behavior of ListNode, you would typically extend the class and override the methods. However, how would you tell Lexical to use *your* ListNode subclass in the ListPlugin instead of using the core ListNode? That's where Node Overrides can help.
 
@@ -22,6 +22,10 @@ const editorConfig = {
     ]
 }
 ```
+In the snippet above,
+- `replace`: Specifies the core node type to be replaced. 
+- `with`: Defines a transformation function to replace instances of the original node to the custom node.  
+- `withKlass`: This option ensures that behaviors associated with the original node type work seamlessly with the replacement. For instance, node transforms or listeners targeting ParagraphNode will also apply to CustomParagraphNode when withKlass is specified. Without this option, the custom node might not fully integrate with the editor's built-in features, leading to unexpected behavior.
 
 Once this is done, Lexical will replace all ParagraphNode instances with CustomParagraphNode instances. One important use case for this feature is overriding the serialization behavior of core nodes. Check out the full example below.
 


### PR DESCRIPTION
## Description
Currently, the withKlass option for node replacement is not documented, making it challenging for developers to use this functionality effectively.

This PR:
- Changes the concerned doc section header from **Node overrides** to **Node overrides / Node Replacements** as _node replacements_ is more in line with the terminology used in the code base.
- Includes an explanation of the arguments used for a node replacement type including the withKlass option.

Closes #6398 


## Test Plan
### Before
No documentation available for withKlass.
### After
Updated documentation includes details for using withKlass in node replacement.
Verified documentation rendering.