### PR TITLE
Fix selected table colors

### DIFF
--- a/examples/react-table/src/styles.css
+++ b/examples/react-table/src/styles.css
@@ -496,8 +496,8 @@ i.justify-align {
   right: 0;
   bottom: 0;
   top: 0;
-  background-color: rgb(172, 206, 247);
-  opacity: 0.6;
+  background-color: highlight;
+  mix-blend-mode: multiply;
   content: '';
   pointer-events: none;
 }

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -173,8 +173,8 @@
   right: 0;
   bottom: 0;
   top: 0;
-  background-color: rgb(172, 206, 247);
-  opacity: 0.6;
+  background-color: highlight;
+  mix-blend-mode: multiply;
   content: '';
   pointer-events: none;
 }


### PR DESCRIPTION
Make it more like the actual browser colors

| Before | After |
| --- | --- |
| <img width="1023" alt="Screenshot 2024-11-30 at 1 55 54 PM" src="https://github.com/user-attachments/assets/4d048dea-5f28-4468-b47a-14adb0fa7763">  | <img width="898" alt="Screenshot 2024-11-30 at 1 55 31 PM" src="https://github.com/user-attachments/assets/0cad01d9-d434-4a92-b0c9-31ae48eb9c0b">  | 

We might also want to be backward compatible with the default selected theming previously built-in, I don't think we want to customize this often so it provides value even beyond backward compatibility (ref https://github.com/facebook/lexical/pull/6658) might follow up on this
 

