### PR TITLE
Warn about "display: flex" container for the editor

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1070,6 +1070,19 @@ export class LexicalEditor {
         if (classNames != null) {
           nextRootElement.classList.add(...classNames);
         }
+        if (__DEV__) {
+          const nextRootElementParent = nextRootElement.parentElement;
+          if (
+            nextRootElementParent != null &&
+            ['flex', 'inline-flex'].includes(
+              getComputedStyle(nextRootElementParent).display,
+            )
+          ) {
+            console.warn(
+              `When using "display: flex" or "display: inline-flex" on an element containing content editable, Chrome may have unwanted focusing behavior when clicking outside of it. Consider wrapping the content editable within a non-flex element.`,
+            );
+          }
+        }
       } else {
         // If content editable is unmounted we'll reset editor state back to original
         // (or pending) editor state since there will be no reconciliation


### PR DESCRIPTION
Chrome has issues with focusing into content editable when it's within a flex element. We don't want to manually introduce wrapper is it will break styling in apps, but can at least warn in dev mode:

https://github.com/user-attachments/assets/1c1b4a88-25f5-46e2-9a85-7de024430267

