### PR TITLE
[lexical-table][lexical-utils][lexical-react]: Bug Fix: Enforce table integrity with transforms and move non-React plugin code to @lexical/table

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -3737,7 +3737,9 @@ test.describe.parallel('Tables', () => {
                 <span data-lexical-text="true">Hello world</span>
               </p>
             </td>
-            <td class="PlaygroundEditorTheme__tableCell"><br /></td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
@@ -3747,8 +3749,12 @@ test.describe.parallel('Tables', () => {
             </td>
           </tr>
           <tr>
-            <td class="PlaygroundEditorTheme__tableCell"><br /></td>
-            <td class="PlaygroundEditorTheme__tableCell"><br /></td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"

--- a/packages/lexical-playground/src/plugins/TablePlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TablePlugin.tsx
@@ -8,22 +8,13 @@
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
-  $createTableNodeWithDimensions,
   INSERT_TABLE_COMMAND,
+  TableCellNode,
   TableNode,
+  TableRowNode,
 } from '@lexical/table';
-import {
-  $insertNodes,
-  COMMAND_PRIORITY_EDITOR,
-  createCommand,
-  EditorThemeClasses,
-  Klass,
-  LexicalCommand,
-  LexicalEditor,
-  LexicalNode,
-} from 'lexical';
+import {EditorThemeClasses, Klass, LexicalEditor, LexicalNode} from 'lexical';
 import {createContext, useContext, useEffect, useMemo, useState} from 'react';
-import * as React from 'react';
 import invariant from 'shared/invariant';
 
 import Button from '../ui/Button';
@@ -52,9 +43,6 @@ export type CellEditorConfig = Readonly<{
   readOnly?: boolean;
   theme?: EditorThemeClasses;
 }>;
-
-export const INSERT_NEW_TABLE_COMMAND: LexicalCommand<InsertTableCommandPayload> =
-  createCommand('INSERT_NEW_TABLE_COMMAND');
 
 export const CellContext = createContext<CellContextShape>({
   cellEditorConfig: null,
@@ -155,28 +143,16 @@ export function TablePlugin({
 }): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const cellContext = useContext(CellContext);
-
   useEffect(() => {
-    if (!editor.hasNodes([TableNode])) {
-      invariant(false, 'TablePlugin: TableNode is not registered on editor');
+    if (!editor.hasNodes([TableNode, TableRowNode, TableCellNode])) {
+      invariant(
+        false,
+        'TablePlugin: TableNode, TableRowNode, or TableCellNode is not registered on editor',
+      );
     }
-
+  }, [editor]);
+  useEffect(() => {
     cellContext.set(cellEditorConfig, children);
-
-    return editor.registerCommand<InsertTableCommandPayload>(
-      INSERT_NEW_TABLE_COMMAND,
-      ({columns, rows, includeHeaders}) => {
-        const tableNode = $createTableNodeWithDimensions(
-          Number(rows),
-          Number(columns),
-          includeHeaders,
-        );
-        $insertNodes([tableNode]);
-        return true;
-      },
-      COMMAND_PRIORITY_EDITOR,
-    );
-  }, [cellContext, cellEditorConfig, children, editor]);
-
+  }, [cellContext, cellEditorConfig, children]);
   return null;
 }

--- a/packages/lexical-react/src/LexicalTablePlugin.ts
+++ b/packages/lexical-react/src/LexicalTablePlugin.ts
@@ -6,43 +6,15 @@
  *
  */
 
-import type {
-  HTMLTableElementWithWithTableSelectionState,
-  InsertTableCommandPayload,
-  TableObserver,
-} from '@lexical/table';
-import type {NodeKey} from 'lexical';
-
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
-  $computeTableMap,
-  $computeTableMapSkipCellCheck,
-  $createTableCellNode,
-  $createTableNodeWithDimensions,
-  $getNodeTriplet,
-  $getTableAndElementByKey,
-  $isTableCellNode,
-  $isTableRowNode,
-  applyTableHandlers,
-  getTableElement,
-  INSERT_TABLE_COMMAND,
+  registerTableCellUnmergeTransform,
+  registerTablePlugin,
+  registerTableSelectionObserver,
   setScrollableTablesActive,
   TableCellNode,
-  TableNode,
-  TableRowNode,
 } from '@lexical/table';
-import {
-  $insertFirst,
-  $insertNodeToNearestRoot,
-  mergeRegister,
-} from '@lexical/utils';
-import {
-  $createParagraphNode,
-  $isTextNode,
-  COMMAND_PRIORITY_EDITOR,
-} from 'lexical';
 import {useEffect} from 'react';
-import invariant from 'shared/invariant';
 
 export interface TablePluginProps {
   /**
@@ -82,181 +54,18 @@ export function TablePlugin({
     setScrollableTablesActive(editor, hasHorizontalScroll);
   }, [editor, hasHorizontalScroll]);
 
-  useEffect(() => {
-    if (!editor.hasNodes([TableNode, TableCellNode, TableRowNode])) {
-      invariant(
-        false,
-        'TablePlugin: TableNode, TableCellNode or TableRowNode not registered on editor',
-      );
-    }
+  useEffect(() => registerTablePlugin(editor), [editor]);
 
-    return mergeRegister(
-      editor.registerCommand<InsertTableCommandPayload>(
-        INSERT_TABLE_COMMAND,
-        ({columns, rows, includeHeaders}) => {
-          const tableNode = $createTableNodeWithDimensions(
-            Number(rows),
-            Number(columns),
-            includeHeaders,
-          );
-          $insertNodeToNearestRoot(tableNode);
-
-          const firstDescendant = tableNode.getFirstDescendant();
-          if ($isTextNode(firstDescendant)) {
-            firstDescendant.select();
-          }
-
-          return true;
-        },
-        COMMAND_PRIORITY_EDITOR,
-      ),
-      editor.registerNodeTransform(TableNode, (node) => {
-        const [gridMap] = $computeTableMapSkipCellCheck(node, null, null);
-        const maxRowLength = gridMap.reduce((curLength, row) => {
-          return Math.max(curLength, row.length);
-        }, 0);
-        const rowNodes = node.getChildren();
-        for (let i = 0; i < gridMap.length; ++i) {
-          const rowNode = rowNodes[i];
-          if (!rowNode) {
-            continue;
-          }
-          const rowLength = gridMap[i].reduce(
-            (acc, cell) => (cell ? 1 + acc : acc),
-            0,
-          );
-          if (rowLength === maxRowLength) {
-            continue;
-          }
-          for (let j = rowLength; j < maxRowLength; ++j) {
-            // TODO: inherit header state from another header or body
-            const newCell = $createTableCellNode(0);
-            newCell.append($createParagraphNode());
-            (rowNode as TableRowNode).append(newCell);
-          }
-        }
-      }),
-    );
-  }, [editor]);
-
-  useEffect(() => {
-    const tableSelections = new Map<
-      NodeKey,
-      [TableObserver, HTMLTableElementWithWithTableSelectionState]
-    >();
-
-    const initializeTableNode = (
-      tableNode: TableNode,
-      nodeKey: NodeKey,
-      dom: HTMLElement,
-    ) => {
-      const tableElement = getTableElement(tableNode, dom);
-      const tableSelection = applyTableHandlers(
-        tableNode,
-        tableElement,
-        editor,
-        hasTabHandler,
-      );
-      tableSelections.set(nodeKey, [tableSelection, tableElement]);
-    };
-
-    const unregisterMutationListener = editor.registerMutationListener(
-      TableNode,
-      (nodeMutations) => {
-        editor.getEditorState().read(
-          () => {
-            for (const [nodeKey, mutation] of nodeMutations) {
-              const tableSelection = tableSelections.get(nodeKey);
-              if (mutation === 'created' || mutation === 'updated') {
-                const {tableNode, tableElement} =
-                  $getTableAndElementByKey(nodeKey);
-                if (tableSelection === undefined) {
-                  initializeTableNode(tableNode, nodeKey, tableElement);
-                } else if (tableElement !== tableSelection[1]) {
-                  // The update created a new DOM node, destroy the existing TableObserver
-                  tableSelection[0].removeListeners();
-                  tableSelections.delete(nodeKey);
-                  initializeTableNode(tableNode, nodeKey, tableElement);
-                }
-              } else if (mutation === 'destroyed') {
-                if (tableSelection !== undefined) {
-                  tableSelection[0].removeListeners();
-                  tableSelections.delete(nodeKey);
-                }
-              }
-            }
-          },
-          {editor},
-        );
-      },
-      {skipInitialization: false},
-    );
-
-    return () => {
-      unregisterMutationListener();
-      // Hook might be called multiple times so cleaning up tables listeners as well,
-      // as it'll be reinitialized during recurring call
-      for (const [, [tableSelection]] of tableSelections) {
-        tableSelection.removeListeners();
-      }
-    };
-  }, [editor, hasTabHandler]);
+  useEffect(
+    () => registerTableSelectionObserver(editor, hasTabHandler),
+    [editor, hasTabHandler],
+  );
 
   // Unmerge cells when the feature isn't enabled
   useEffect(() => {
-    if (hasCellMerge) {
-      return;
+    if (!hasCellMerge) {
+      return registerTableCellUnmergeTransform(editor);
     }
-    return editor.registerNodeTransform(TableCellNode, (node) => {
-      if (node.getColSpan() > 1 || node.getRowSpan() > 1) {
-        // When we have rowSpan we have to map the entire Table to understand where the new Cells
-        // fit best; let's analyze all Cells at once to save us from further transform iterations
-        const [, , gridNode] = $getNodeTriplet(node);
-        const [gridMap] = $computeTableMap(gridNode, node, node);
-        // TODO this function expects Tables to be normalized. Look into this once it exists
-        const rowsCount = gridMap.length;
-        const columnsCount = gridMap[0].length;
-        let row = gridNode.getFirstChild();
-        invariant(
-          $isTableRowNode(row),
-          'Expected TableNode first child to be a RowNode',
-        );
-        const unmerged = [];
-        for (let i = 0; i < rowsCount; i++) {
-          if (i !== 0) {
-            row = row.getNextSibling();
-            invariant(
-              $isTableRowNode(row),
-              'Expected TableNode first child to be a RowNode',
-            );
-          }
-          let lastRowCell: null | TableCellNode = null;
-          for (let j = 0; j < columnsCount; j++) {
-            const cellMap = gridMap[i][j];
-            const cell = cellMap.cell;
-            if (cellMap.startRow === i && cellMap.startColumn === j) {
-              lastRowCell = cell;
-              unmerged.push(cell);
-            } else if (cell.getColSpan() > 1 || cell.getRowSpan() > 1) {
-              invariant(
-                $isTableCellNode(cell),
-                'Expected TableNode cell to be a TableCellNode',
-              );
-              const newCell = $createTableCellNode(cell.__headerState);
-              if (lastRowCell !== null) {
-                lastRowCell.insertAfter(newCell);
-              } else {
-                $insertFirst(row, newCell);
-              }
-            }
-          }
-        }
-        for (const cell of unmerged) {
-          cell.setColSpan(1);
-          cell.setRowSpan(1);
-        }
-      }
-    });
   }, [editor, hasCellMerge]);
 
   // Remove cell background color when feature is disabled

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -14,7 +14,7 @@ import {
   OverflowNode,
 } from '@lexical/overflow';
 import {$rootTextContent} from '@lexical/text';
-import {$dfs, mergeRegister} from '@lexical/utils';
+import {$dfs, $unwrapNode, mergeRegister} from '@lexical/utils';
 import {
   $getSelection,
   $isElementNode,
@@ -252,18 +252,6 @@ function $wrapNode(node: LexicalNode): OverflowNode {
   node.replace(overflowNode);
   overflowNode.append(node);
   return overflowNode;
-}
-
-function $unwrapNode(node: OverflowNode): LexicalNode | null {
-  const children = node.getChildren();
-  const childrenLength = children.length;
-
-  for (let i = 0; i < childrenLength; i++) {
-    node.insertBefore(children[i]);
-  }
-
-  node.remove();
-  return childrenLength > 0 ? children[childrenLength - 1] : null;
 }
 
 export function $mergePrevious(overflowNode: OverflowNode): void {

--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -75,7 +75,7 @@ declare export class TableCellNode extends ElementNode {
   canBeEmpty(): false;
 }
 declare export function $createTableCellNode(
-  headerState: TableCellHeaderState,
+  headerState?: TableCellHeaderState,
   colSpan?: number,
   width?: ?number,
 ): TableCellNode;
@@ -351,3 +351,13 @@ export type InsertTableCommandPayload = $ReadOnly<{
 }>;
 
 declare export var INSERT_TABLE_COMMAND: LexicalCommand<InsertTableCommandPayload>;
+
+/**
+ * LexicalTablePluginHelpers
+ */
+
+declare export function registerTableCellUnmergeTransform(editor: LexicalEditor): () => void;
+
+declare export function registerTablePlugin(editor: LexicalEditor): () => void;
+
+declare export function registerTableSelectionObserver(editor: LexicalEditor, hasTabHandler?: boolean): () => void;

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -366,7 +366,7 @@ export function $convertTableCellNodeElement(
 }
 
 export function $createTableCellNode(
-  headerState: TableCellHeaderState,
+  headerState: TableCellHeaderState = TableCellHeaderStates.NO_STATUS,
   colSpan = 1,
   width?: number,
 ): TableCellNode {

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -6,9 +6,8 @@
  *
  */
 
-import type {TableRowNode} from './LexicalTableRowNode';
-
 import {
+  $descendantsMatching,
   addClassNamesToElement,
   isHTMLElement,
   removeClassNamesFromElement,
@@ -36,6 +35,7 @@ import invariant from 'shared/invariant';
 import {PIXEL_VALUE_REG_EXP} from './constants';
 import {$isTableCellNode, type TableCellNode} from './LexicalTableCellNode';
 import {TableDOMCell, TableDOMTable} from './LexicalTableObserver';
+import {$isTableRowNode, type TableRowNode} from './LexicalTableRowNode';
 import {
   $getNearestTableCellInTableFromDOMNode,
   getTable,
@@ -498,7 +498,10 @@ export function $convertTableElement(
       tableNode.setColWidths(columns);
     }
   }
-  return {node: tableNode};
+  return {
+    after: (children) => $descendantsMatching(children, $isTableRowNode),
+    node: tableNode,
+  };
 }
 
 export function $createTableNode(): TableNode {

--- a/packages/lexical-table/src/LexicalTablePluginHelpers.ts
+++ b/packages/lexical-table/src/LexicalTablePluginHelpers.ts
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $insertFirst,
+  $insertNodeToNearestRoot,
+  $unwrapAndFilterDescendants,
+  mergeRegister,
+} from '@lexical/utils';
+import {
+  $createParagraphNode,
+  $isTextNode,
+  COMMAND_PRIORITY_EDITOR,
+  LexicalEditor,
+  NodeKey,
+} from 'lexical';
+import invariant from 'shared/invariant';
+
+import {
+  $createTableCellNode,
+  $isTableCellNode,
+  TableCellNode,
+} from './LexicalTableCellNode';
+import {
+  INSERT_TABLE_COMMAND,
+  InsertTableCommandPayload,
+} from './LexicalTableCommands';
+import {$isTableNode, TableNode} from './LexicalTableNode';
+import {$getTableAndElementByKey, TableObserver} from './LexicalTableObserver';
+import {$isTableRowNode, TableRowNode} from './LexicalTableRowNode';
+import {
+  applyTableHandlers,
+  getTableElement,
+  HTMLTableElementWithWithTableSelectionState,
+} from './LexicalTableSelectionHelpers';
+import {
+  $computeTableMap,
+  $computeTableMapSkipCellCheck,
+  $createTableNodeWithDimensions,
+  $getNodeTriplet,
+} from './LexicalTableUtils';
+
+function $insertTableCommandListener({
+  rows,
+  columns,
+  includeHeaders,
+}: InsertTableCommandPayload): boolean {
+  const tableNode = $createTableNodeWithDimensions(
+    Number(rows),
+    Number(columns),
+    includeHeaders,
+  );
+  $insertNodeToNearestRoot(tableNode);
+
+  const firstDescendant = tableNode.getFirstDescendant();
+  if ($isTextNode(firstDescendant)) {
+    firstDescendant.select();
+  }
+
+  return true;
+}
+
+function $tableCellTransform(node: TableCellNode) {
+  if (!$isTableRowNode(node.getParent())) {
+    // TableCellNode must be a child of TableRowNode.
+    node.remove();
+  } else if (node.isEmpty()) {
+    // TableCellNode should never be empty
+    node.append($createParagraphNode());
+  }
+}
+
+function $tableRowTransform(node: TableRowNode) {
+  if (!$isTableNode(node.getParent())) {
+    // TableRowNode must be a child of TableNode.
+    // TODO: Future support of tbody/thead/tfoot may change this
+    node.remove();
+  } else {
+    $unwrapAndFilterDescendants(node, $isTableCellNode);
+  }
+}
+
+function $tableTransform(node: TableNode) {
+  // TableRowNode is the only valid child for TableNode
+  // TODO: Future support of tbody/thead/tfoot/caption may change this
+  $unwrapAndFilterDescendants(node, $isTableRowNode);
+
+  const [gridMap] = $computeTableMapSkipCellCheck(node, null, null);
+  const maxRowLength = gridMap.reduce((curLength, row) => {
+    return Math.max(curLength, row.length);
+  }, 0);
+  const rowNodes = node.getChildren();
+  for (let i = 0; i < gridMap.length; ++i) {
+    const rowNode = rowNodes[i];
+    if (!rowNode) {
+      continue;
+    }
+    invariant(
+      $isTableRowNode(rowNode),
+      'TablePlugin: Expecting all children of TableNode to be TableRowNode, found %s (type %s)',
+      rowNode.constructor.name,
+      rowNode.getType(),
+    );
+    const rowLength = gridMap[i].reduce(
+      (acc, cell) => (cell ? 1 + acc : acc),
+      0,
+    );
+    if (rowLength === maxRowLength) {
+      continue;
+    }
+    for (let j = rowLength; j < maxRowLength; ++j) {
+      // TODO: inherit header state from another header or body
+      const newCell = $createTableCellNode();
+      newCell.append($createParagraphNode());
+      rowNode.append(newCell);
+    }
+  }
+}
+
+/**
+ * Register a transform to ensure that all TableCellNode have a colSpan and rowSpan of 1.
+ * This should only be registered when you do not want to support merged cells.
+ *
+ * @param editor The editor
+ * @returns An unregister callback
+ */
+export function registerTableCellUnmergeTransform(
+  editor: LexicalEditor,
+): () => void {
+  return editor.registerNodeTransform(TableCellNode, (node) => {
+    if (node.getColSpan() > 1 || node.getRowSpan() > 1) {
+      // When we have rowSpan we have to map the entire Table to understand where the new Cells
+      // fit best; let's analyze all Cells at once to save us from further transform iterations
+      const [, , gridNode] = $getNodeTriplet(node);
+      const [gridMap] = $computeTableMap(gridNode, node, node);
+      // TODO this function expects Tables to be normalized. Look into this once it exists
+      const rowsCount = gridMap.length;
+      const columnsCount = gridMap[0].length;
+      let row = gridNode.getFirstChild();
+      invariant(
+        $isTableRowNode(row),
+        'Expected TableNode first child to be a RowNode',
+      );
+      const unmerged = [];
+      for (let i = 0; i < rowsCount; i++) {
+        if (i !== 0) {
+          row = row.getNextSibling();
+          invariant(
+            $isTableRowNode(row),
+            'Expected TableNode first child to be a RowNode',
+          );
+        }
+        let lastRowCell: null | TableCellNode = null;
+        for (let j = 0; j < columnsCount; j++) {
+          const cellMap = gridMap[i][j];
+          const cell = cellMap.cell;
+          if (cellMap.startRow === i && cellMap.startColumn === j) {
+            lastRowCell = cell;
+            unmerged.push(cell);
+          } else if (cell.getColSpan() > 1 || cell.getRowSpan() > 1) {
+            invariant(
+              $isTableCellNode(cell),
+              'Expected TableNode cell to be a TableCellNode',
+            );
+            const newCell = $createTableCellNode(cell.__headerState);
+            if (lastRowCell !== null) {
+              lastRowCell.insertAfter(newCell);
+            } else {
+              $insertFirst(row, newCell);
+            }
+          }
+        }
+      }
+      for (const cell of unmerged) {
+        cell.setColSpan(1);
+        cell.setRowSpan(1);
+      }
+    }
+  });
+}
+
+export function registerTableSelectionObserver(
+  editor: LexicalEditor,
+  hasTabHandler: boolean = true,
+): () => void {
+  const tableSelections = new Map<
+    NodeKey,
+    [TableObserver, HTMLTableElementWithWithTableSelectionState]
+  >();
+
+  const initializeTableNode = (
+    tableNode: TableNode,
+    nodeKey: NodeKey,
+    dom: HTMLElement,
+  ) => {
+    const tableElement = getTableElement(tableNode, dom);
+    const tableSelection = applyTableHandlers(
+      tableNode,
+      tableElement,
+      editor,
+      hasTabHandler,
+    );
+    tableSelections.set(nodeKey, [tableSelection, tableElement]);
+  };
+
+  const unregisterMutationListener = editor.registerMutationListener(
+    TableNode,
+    (nodeMutations) => {
+      editor.getEditorState().read(
+        () => {
+          for (const [nodeKey, mutation] of nodeMutations) {
+            const tableSelection = tableSelections.get(nodeKey);
+            if (mutation === 'created' || mutation === 'updated') {
+              const {tableNode, tableElement} =
+                $getTableAndElementByKey(nodeKey);
+              if (tableSelection === undefined) {
+                initializeTableNode(tableNode, nodeKey, tableElement);
+              } else if (tableElement !== tableSelection[1]) {
+                // The update created a new DOM node, destroy the existing TableObserver
+                tableSelection[0].removeListeners();
+                tableSelections.delete(nodeKey);
+                initializeTableNode(tableNode, nodeKey, tableElement);
+              }
+            } else if (mutation === 'destroyed') {
+              if (tableSelection !== undefined) {
+                tableSelection[0].removeListeners();
+                tableSelections.delete(nodeKey);
+              }
+            }
+          }
+        },
+        {editor},
+      );
+    },
+    {skipInitialization: false},
+  );
+
+  return () => {
+    unregisterMutationListener();
+    // Hook might be called multiple times so cleaning up tables listeners as well,
+    // as it'll be reinitialized during recurring call
+    for (const [, [tableSelection]] of tableSelections) {
+      tableSelection.removeListeners();
+    }
+  };
+}
+
+/**
+ * Register the INSERT_TABLE_COMMAND listener and the table integrity transforms. The
+ * table selection observer should be registered separately after this with
+ * {@link registerTableSelectionObserver}.
+ *
+ * @param editor The editor
+ * @returns An unregister callback
+ */
+export function registerTablePlugin(editor: LexicalEditor): () => void {
+  if (!editor.hasNodes([TableNode])) {
+    invariant(false, 'TablePlugin: TableNode is not registered on editor');
+  }
+  return mergeRegister(
+    editor.registerCommand(
+      INSERT_TABLE_COMMAND,
+      $insertTableCommandListener,
+      COMMAND_PRIORITY_EDITOR,
+    ),
+    editor.registerNodeTransform(TableNode, $tableTransform),
+    editor.registerNodeTransform(TableRowNode, $tableRowTransform),
+    editor.registerNodeTransform(TableCellNode, $tableCellTransform),
+  );
+}

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -8,7 +8,7 @@
 
 import type {BaseSelection, Spread} from 'lexical';
 
-import {addClassNamesToElement} from '@lexical/utils';
+import {$descendantsMatching, addClassNamesToElement} from '@lexical/utils';
 import {
   $applyNodeReplacement,
   DOMConversionMap,
@@ -21,6 +21,7 @@ import {
 } from 'lexical';
 
 import {PIXEL_VALUE_REG_EXP} from './constants';
+import {$isTableCellNode} from './LexicalTableCellNode';
 
 export type SerializedTableRowNode = Spread<
   {
@@ -124,7 +125,10 @@ export function $convertTableRowElement(domNode: Node): DOMConversionOutput {
     height = parseFloat(domNode_.style.height);
   }
 
-  return {node: $createTableRowNode(height)};
+  return {
+    after: (children) => $descendantsMatching(children, $isTableCellNode),
+    node: $createTableRowNode(height),
+  };
 }
 
 export function $createTableRowNode(height?: number): TableRowNode {

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -317,6 +317,318 @@ describe('LexicalTableNode tests', () => {
             );
           });
 
+          test('Copy table with caption/tbody/thead/tfoot from an external source', async () => {
+            const {editor} = testEnv;
+
+            const dataTransfer = new DataTransferMock();
+            dataTransfer.setData(
+              'text/html',
+              // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead
+              html`
+                <meta charset="utf-8" />
+                <table
+                  style="box-sizing: border-box; border-collapse: collapse; border: 2px solid rgb(140, 140, 140); font-family: sans-serif; font-size: 0.8rem; letter-spacing: 1px; color: rgb(21, 20, 26); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; orphans: 2; text-align: start; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
+                  <caption
+                    style="box-sizing: border-box; caption-side: bottom; padding: 10px;">
+                    Council budget (in £) 2018
+                  </caption>
+                  <thead
+                    style="box-sizing: border-box; background-color: rgb(44, 94, 119); color: rgb(255, 255, 255);">
+                    <tr style="box-sizing: border-box;">
+                      <th
+                        scope="col"
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px;">
+                        Items
+                      </th>
+                      <th
+                        scope="col"
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px;">
+                        Expenditure
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    style="box-sizing: border-box; background-color: rgb(228, 240, 245);">
+                    <tr style="box-sizing: border-box;">
+                      <th
+                        scope="row"
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px;">
+                        Donuts
+                      </th>
+                      <td
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; text-align: center;">
+                        3,000
+                      </td>
+                    </tr>
+                    <tr style="box-sizing: border-box;">
+                      <th
+                        scope="row"
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px;">
+                        Stationery
+                      </th>
+                      <td
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; text-align: center;">
+                        18,000
+                      </td>
+                    </tr>
+                  </tbody>
+                  <tfoot
+                    style="box-sizing: border-box; background-color: rgb(44, 94, 119); color: rgb(255, 255, 255);">
+                    <tr style="box-sizing: border-box;">
+                      <th
+                        scope="row"
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px;">
+                        Totals
+                      </th>
+                      <td
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; text-align: center;">
+                        21,000
+                      </td>
+                    </tr>
+                  </tfoot>
+                </table>
+              `,
+            );
+            await editor.update(() => {
+              const selection = $getSelection();
+              invariant(
+                $isRangeSelection(selection),
+                'isRangeSelection(selection)',
+              );
+              $insertDataTransferForRichText(dataTransfer, selection, editor);
+            });
+            // Here we are testing the createDOM, not the exportDOM, so the tbody is not there
+            expectTableHtmlToBeEqual(
+              testEnv.innerHTML,
+              html`
+                <table class="test-table-class">
+                  <colgroup>
+                    <col />
+                    <col />
+                  </colgroup>
+                  <tr style="text-align: start">
+                    <th>
+                      <p dir="ltr">
+                        <span data-lexical-text="true">Items</span>
+                      </p>
+                    </th>
+                    <th>
+                      <p dir="ltr">
+                        <span data-lexical-text="true">Expenditure</span>
+                      </p>
+                    </th>
+                  </tr>
+                  <tr style="text-align: start">
+                    <th>
+                      <p dir="ltr">
+                        <span data-lexical-text="true">Donuts</span>
+                      </p>
+                    </th>
+                    <td>
+                      <p style="text-align: center;">
+                        <span data-lexical-text="true">3,000</span>
+                      </p>
+                    </td>
+                  </tr>
+                  <tr style="text-align: start">
+                    <th>
+                      <p dir="ltr">
+                        <span data-lexical-text="true">Stationery</span>
+                      </p>
+                    </th>
+                    <td>
+                      <p style="text-align: center;">
+                        <span data-lexical-text="true">18,000</span>
+                      </p>
+                    </td>
+                  </tr>
+                  <tr style="text-align: start">
+                    <th>
+                      <p dir="ltr">
+                        <span data-lexical-text="true">Totals</span>
+                      </p>
+                    </th>
+                    <td>
+                      <p style="text-align: center;">
+                        <span data-lexical-text="true">21,000</span>
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              `,
+            );
+          });
+
+          test('Copy table with caption from an external source', async () => {
+            const {editor} = testEnv;
+
+            const dataTransfer = new DataTransferMock();
+            dataTransfer.setData(
+              'text/html',
+              // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption
+              html`
+                <meta charset="utf-8" />
+                <table
+                  style="box-sizing: border-box; border-collapse: collapse; border: 2px solid rgb(140, 140, 140); font-family: sans-serif; font-size: 0.8rem; letter-spacing: 1px; color: rgb(21, 20, 26); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; orphans: 2; text-align: start; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
+                  <caption
+                    style="box-sizing: border-box; caption-side: bottom; padding: 10px; font-weight: bold;">
+                    He-Man and Skeletor facts
+                  </caption>
+                  <tbody style="box-sizing: border-box;">
+                    <tr style="box-sizing: border-box;">
+                      <td
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; text-align: center; background-color: rgb(240, 240, 240);"></td>
+                      <th
+                        class="heman"
+                        scope="col"
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; background-color: rgb(230, 230, 230); font: 1.4rem molot; text-shadow: rgb(255, 255, 255) 1px 1px 1px, rgb(0, 0, 0) 2px 2px 1px;">
+                        He-Man
+                      </th>
+                      <th
+                        class="skeletor"
+                        scope="col"
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; background-color: rgb(230, 230, 230); font: 1.7rem rapscallion; letter-spacing: 3px; text-shadow: rgb(255, 255, 255) 1px 1px 0px, rgb(0, 0, 0) 0px 0px 9px;">
+                        Skeletor
+                      </th>
+                    </tr>
+                    <tr style="box-sizing: border-box;">
+                      <th
+                        scope="row"
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; background-color: rgb(230, 230, 230);">
+                        Role
+                      </th>
+                      <td
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; text-align: center; background-color: rgb(250, 250, 250);">
+                        Hero
+                      </td>
+                      <td
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; text-align: center; background-color: rgb(250, 250, 250);">
+                        Villain
+                      </td>
+                    </tr>
+                    <tr style="box-sizing: border-box;">
+                      <th
+                        scope="row"
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; background-color: rgb(230, 230, 230);">
+                        Weapon
+                      </th>
+                      <td
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; text-align: center; background-color: rgb(240, 240, 240);">
+                        Power Sword
+                      </td>
+                      <td
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; text-align: center; background-color: rgb(240, 240, 240);">
+                        Havoc Staff
+                      </td>
+                    </tr>
+                    <tr style="box-sizing: border-box;">
+                      <th
+                        scope="row"
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; background-color: rgb(230, 230, 230);">
+                        Dark secret
+                      </th>
+                      <td
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; text-align: center; background-color: rgb(250, 250, 250);">
+                        Expert florist
+                      </td>
+                      <td
+                        style="box-sizing: border-box; border: 1px solid rgb(160, 160, 160); padding: 8px 10px; text-align: center; background-color: rgb(250, 250, 250);">
+                        Cries at romcoms
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              `,
+            );
+            await editor.update(() => {
+              const selection = $getSelection();
+              invariant(
+                $isRangeSelection(selection),
+                'isRangeSelection(selection)',
+              );
+              $insertDataTransferForRichText(dataTransfer, selection, editor);
+            });
+            // Here we are testing the createDOM, not the exportDOM, so the tbody is not there
+            expectTableHtmlToBeEqual(
+              testEnv.innerHTML,
+              html`
+                <table class="test-table-class">
+                  <colgroup>
+                    <col />
+                    <col />
+                    <col />
+                  </colgroup>
+                  <tr style="text-align: start">
+                    <td style="background-color: rgb(240, 240, 240)">
+                      <p style="text-align: center"><br /></p>
+                    </td>
+                    <th style="background-color: rgb(230, 230, 230)">
+                      <p dir="ltr">
+                        <span data-lexical-text="true">He-Man</span>
+                      </p>
+                    </th>
+                    <th style="background-color: rgb(230, 230, 230)">
+                      <p dir="ltr">
+                        <span data-lexical-text="true">Skeletor</span>
+                      </p>
+                    </th>
+                  </tr>
+                  <tr style="text-align: start">
+                    <th style="background-color: rgb(230, 230, 230)">
+                      <p dir="ltr">
+                        <span data-lexical-text="true">Role</span>
+                      </p>
+                    </th>
+                    <td style="background-color: rgb(250, 250, 250)">
+                      <p dir="ltr" style="text-align: center">
+                        <span data-lexical-text="true">Hero</span>
+                      </p>
+                    </td>
+                    <td style="background-color: rgb(250, 250, 250)">
+                      <p dir="ltr" style="text-align: center">
+                        <span data-lexical-text="true">Villain</span>
+                      </p>
+                    </td>
+                  </tr>
+                  <tr style="text-align: start">
+                    <th style="background-color: rgb(230, 230, 230)">
+                      <p dir="ltr">
+                        <span data-lexical-text="true">Weapon</span>
+                      </p>
+                    </th>
+                    <td style="background-color: rgb(240, 240, 240)">
+                      <p dir="ltr" style="text-align: center">
+                        <span data-lexical-text="true">Power Sword</span>
+                      </p>
+                    </td>
+                    <td style="background-color: rgb(240, 240, 240)">
+                      <p dir="ltr" style="text-align: center">
+                        <span data-lexical-text="true">Havoc Staff</span>
+                      </p>
+                    </td>
+                  </tr>
+                  <tr style="text-align: start">
+                    <th style="background-color: rgb(230, 230, 230)">
+                      <p dir="ltr">
+                        <span data-lexical-text="true">Dark secret</span>
+                      </p>
+                    </th>
+                    <td style="background-color: rgb(250, 250, 250)">
+                      <p dir="ltr" style="text-align: center">
+                        <span data-lexical-text="true">Expert florist</span>
+                      </p>
+                    </td>
+                    <td style="background-color: rgb(250, 250, 250)">
+                      <p dir="ltr" style="text-align: center">
+                        <span data-lexical-text="true">Cries at romcoms</span>
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              `,
+            );
+          });
+
           test('Copy table from an external source like gdoc with formatting', async () => {
             const {editor} = testEnv;
 

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -29,6 +29,11 @@ export {
 } from './LexicalTableNode';
 export type {TableDOMCell} from './LexicalTableObserver';
 export {$getTableAndElementByKey, TableObserver} from './LexicalTableObserver';
+export {
+  registerTableCellUnmergeTransform,
+  registerTablePlugin,
+  registerTableSelectionObserver,
+} from './LexicalTablePluginHelpers';
 export type {SerializedTableRowNode} from './LexicalTableRowNode';
 export {
   $createTableRowNode,

--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -130,3 +130,9 @@ declare export function $unwrapAndFilterDescendants(
   root: ElementNode,
   $predicate: (node: LexicalNode) => boolean,
 ): boolean;
+
+declare export function $firstToLastIterator(node: ElementNode): Iterable<LexicalNode>;
+
+declare export function $lastToFirstIterator(node: ElementNode): Iterable<LexicalNode>;
+
+declare export function $unwrapNode(node: ElementNode): void;

--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -125,3 +125,8 @@ declare export function $splitNode(
 declare export function calculateZoomLevel(element: Element | null): number;
 
 declare export function $isEditorIsNestedEditor(editor: LexicalEditor): boolean;
+
+declare export function $unwrapAndFilterDescendants(
+  root: ElementNode,
+  $predicate: (node: LexicalNode) => boolean,
+): boolean;

--- a/packages/lexical-utils/src/__tests__/unit/descendantsMatching.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/descendantsMatching.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import type {Klass, LexicalEditor, LexicalNode} from 'lexical';
+
+import {$descendantsMatching} from '@lexical/utils';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isTextNode,
+  ParagraphNode,
+} from 'lexical';
+import {createTestEditor} from 'lexical/src/__tests__/utils';
+
+function assertClass<T extends LexicalNode>(v: unknown, klass: Klass<T>): T {
+  if (v instanceof klass) {
+    return v as T;
+  }
+  throw new Error(`Value does not extend ${klass.name}`);
+}
+
+function $createTextAndParagraphWithDepth(depth: number): LexicalNode[] {
+  if (depth <= 0) {
+    return [$createTextNode(`<${depth} />`)];
+  }
+  return [
+    $createTextNode(`<${depth}>`),
+    $createParagraphNode().append(
+      ...$createTextAndParagraphWithDepth(depth - 1),
+    ),
+    $createTextNode(`</${depth}>`),
+  ];
+}
+
+function textContentForDepth(i: number): string {
+  return i > 0 ? `<${i}>${textContentForDepth(i - 1)}</${i}>` : `<${i} />`;
+}
+
+describe('$descendantsMatching', () => {
+  let editor: LexicalEditor;
+
+  beforeEach(async () => {
+    editor = createTestEditor();
+    editor._headless = true;
+  });
+
+  [0, 1, 2].forEach((depth) =>
+    it(`Can un-nest children at depth ${depth}`, () => {
+      editor.update(
+        () => {
+          const firstNode = $createParagraphNode();
+          $getRoot()
+            .clear()
+            .append(
+              firstNode.append(...$createTextAndParagraphWithDepth(depth)),
+            );
+        },
+        {discrete: true},
+      );
+      editor.update(
+        () => {
+          const firstNode = assertClass(
+            $getRoot().getFirstChildOrThrow(),
+            ParagraphNode,
+          );
+          expect(firstNode.getChildren().every($isTextNode)).toBe(depth === 0);
+          firstNode.splice(
+            0,
+            firstNode.getChildrenSize(),
+            $descendantsMatching(firstNode.getChildren(), $isTextNode),
+          );
+          expect(firstNode.getChildren().every($isTextNode)).toBe(true);
+          expect(firstNode.getTextContent()).toBe(textContentForDepth(depth));
+        },
+        {discrete: true},
+      );
+    }),
+  );
+});

--- a/packages/lexical-utils/src/__tests__/unit/iterators.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/iterators.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import type {Klass, LexicalEditor, LexicalNode} from 'lexical';
+
+import {$firstToLastIterator, $lastToFirstIterator} from '@lexical/utils';
+import {$createParagraphNode, $createTextNode, TextNode} from 'lexical';
+import {createTestEditor} from 'lexical/src/__tests__/utils';
+
+function assertClass<T extends LexicalNode>(v: unknown, klass: Klass<T>): T {
+  if (v instanceof klass) {
+    return v as T;
+  }
+  throw new Error(`Value does not extend ${klass.name}`);
+}
+
+describe('$firstToLastIterator', () => {
+  let editor: LexicalEditor;
+
+  beforeEach(async () => {
+    editor = createTestEditor();
+    editor._headless = true;
+  });
+
+  it(`Iterates from first to last`, () => {
+    editor.update(
+      () => {
+        const parent = $createParagraphNode().splice(
+          0,
+          0,
+          Array.from({length: 5}, (_v, i) => $createTextNode(`${i}`)),
+        );
+        // Check initial state
+        expect(
+          parent.getAllTextNodes().map((node) => node.getTextContent()),
+        ).toEqual(['0', '1', '2', '3', '4']);
+        expect(
+          Array.from($firstToLastIterator(parent), (node) => {
+            return assertClass(node, TextNode).getTextContent();
+          }),
+        ).toEqual(['0', '1', '2', '3', '4']);
+        // Parent was not affected
+        expect(
+          parent.getAllTextNodes().map((node) => node.getTextContent()),
+        ).toEqual(['0', '1', '2', '3', '4']);
+      },
+      {discrete: true},
+    );
+  });
+  it(`Can handle node removal`, () => {
+    editor.update(
+      () => {
+        const parent = $createParagraphNode().splice(
+          0,
+          0,
+          Array.from({length: 5}, (_v, i) => $createTextNode(`${i}`)),
+        );
+        // Check initial state
+        expect(
+          parent.getAllTextNodes().map((node) => node.getTextContent()),
+        ).toEqual(['0', '1', '2', '3', '4']);
+        expect(
+          Array.from($firstToLastIterator(parent), (node) => {
+            const rval = assertClass(node, TextNode).getTextContent();
+            node.remove();
+            return rval;
+          }),
+        ).toEqual(['0', '1', '2', '3', '4']);
+        expect(parent.getChildren()).toEqual([]);
+      },
+      {discrete: true},
+    );
+  });
+  it(`Detects cycles when nodes move incorrectly`, () => {
+    editor.update(
+      () => {
+        const parent = $createParagraphNode().splice(
+          0,
+          0,
+          Array.from({length: 5}, (_v, i) => $createTextNode(`${i}`)),
+        );
+        // Check initial state
+        expect(
+          parent.getAllTextNodes().map((node) => node.getTextContent()),
+        ).toEqual(['0', '1', '2', '3', '4']);
+        expect(() =>
+          Array.from($firstToLastIterator(parent), (node) => {
+            const rval = assertClass(node, TextNode).getTextContent();
+            parent.append(node);
+            return rval;
+          }),
+        ).toThrow(/\$childIterator: Cycle detected/);
+      },
+      {discrete: true},
+    );
+  });
+  it(`Can handle nodes moving in the other direction`, () => {
+    editor.update(
+      () => {
+        const parent = $createParagraphNode().splice(
+          0,
+          0,
+          Array.from({length: 5}, (_v, i) => $createTextNode(`${i}`)),
+        );
+        // Check initial state
+        expect(
+          parent.getAllTextNodes().map((node) => node.getTextContent()),
+        ).toEqual(['0', '1', '2', '3', '4']);
+        expect(
+          Array.from($firstToLastIterator(parent), (node) => {
+            const rval = assertClass(node, TextNode).getTextContent();
+            if (node.getPreviousSibling() !== null) {
+              parent.splice(0, 0, [node]);
+            }
+            return rval;
+          }),
+        ).toEqual(['0', '1', '2', '3', '4']);
+        // This mutation reversed the nodes while traversing
+        expect(
+          parent.getAllTextNodes().map((node) => node.getTextContent()),
+        ).toEqual(['4', '3', '2', '1', '0']);
+      },
+      {discrete: true},
+    );
+  });
+});
+
+describe('$lastToFirstIterator', () => {
+  let editor: LexicalEditor;
+
+  beforeEach(async () => {
+    editor = createTestEditor();
+    editor._headless = true;
+  });
+
+  it(`Iterates from last to first`, () => {
+    editor.update(
+      () => {
+        const parent = $createParagraphNode().splice(
+          0,
+          0,
+          Array.from({length: 5}, (_v, i) => $createTextNode(`${i}`)),
+        );
+        // Check initial state
+        expect(
+          parent.getAllTextNodes().map((node) => node.getTextContent()),
+        ).toEqual(['0', '1', '2', '3', '4']);
+        expect(
+          Array.from($lastToFirstIterator(parent), (node) => {
+            return assertClass(node, TextNode).getTextContent();
+          }),
+        ).toEqual(['4', '3', '2', '1', '0']);
+        // Parent was not affected
+        expect(
+          parent.getAllTextNodes().map((node) => node.getTextContent()),
+        ).toEqual(['0', '1', '2', '3', '4']);
+      },
+      {discrete: true},
+    );
+  });
+  it(`Can handle node removal`, () => {
+    editor.update(
+      () => {
+        const parent = $createParagraphNode().splice(
+          0,
+          0,
+          Array.from({length: 5}, (_v, i) => $createTextNode(`${i}`)),
+        );
+        // Check initial state
+        expect(
+          parent.getAllTextNodes().map((node) => node.getTextContent()),
+        ).toEqual(['0', '1', '2', '3', '4']);
+        expect(
+          Array.from($lastToFirstIterator(parent), (node) => {
+            const rval = assertClass(node, TextNode).getTextContent();
+            node.remove();
+            return rval;
+          }),
+        ).toEqual(['4', '3', '2', '1', '0']);
+        expect(parent.getChildren()).toEqual([]);
+      },
+      {discrete: true},
+    );
+  });
+  it(`Can handle nodes moving in the other direction`, () => {
+    editor.update(
+      () => {
+        const parent = $createParagraphNode().splice(
+          0,
+          0,
+          Array.from({length: 5}, (_v, i) => $createTextNode(`${i}`)),
+        );
+        // Check initial state
+        expect(
+          parent.getAllTextNodes().map((node) => node.getTextContent()),
+        ).toEqual(['0', '1', '2', '3', '4']);
+        expect(
+          Array.from($lastToFirstIterator(parent), (node) => {
+            const rval = assertClass(node, TextNode).getTextContent();
+            parent.append(node);
+            return rval;
+          }),
+        ).toEqual(['4', '3', '2', '1', '0']);
+        // This mutation reversed the nodes while traversing
+        expect(
+          parent.getAllTextNodes().map((node) => node.getTextContent()),
+        ).toEqual(['4', '3', '2', '1', '0']);
+      },
+      {discrete: true},
+    );
+  });
+});

--- a/packages/lexical-utils/src/__tests__/unit/unwrapAndFilterDescendants.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/unwrapAndFilterDescendants.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import type {Klass, LexicalEditor, LexicalNode} from 'lexical';
+
+import {$unwrapAndFilterDescendants} from '@lexical/utils';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isParagraphNode,
+  $isTextNode,
+  ParagraphNode,
+} from 'lexical';
+import {createTestEditor} from 'lexical/src/__tests__/utils';
+
+function assertClass<T extends LexicalNode>(v: unknown, klass: Klass<T>): T {
+  if (v instanceof klass) {
+    return v as T;
+  }
+  throw new Error(`Value does not extend ${klass.name}`);
+}
+
+function $createTextAndParagraphWithDepth(depth: number): LexicalNode[] {
+  if (depth <= 0) {
+    return [$createTextNode(`<${depth} />`)];
+  }
+  return [
+    $createTextNode(`<${depth}>`),
+    $createParagraphNode().append(
+      ...$createTextAndParagraphWithDepth(depth - 1),
+    ),
+    $createTextNode(`</${depth}>`),
+  ];
+}
+
+function textContentForDepth(i: number): string {
+  return i > 0 ? `<${i}>${textContentForDepth(i - 1)}</${i}>` : `<${i} />`;
+}
+
+describe('$unwrapAndFilterDescendants', () => {
+  let editor: LexicalEditor;
+
+  beforeEach(async () => {
+    editor = createTestEditor();
+    editor._headless = true;
+  });
+
+  it('Is a no-op with valid children', () => {
+    editor.update(
+      () => {
+        $getRoot().clear().append($createParagraphNode());
+      },
+      {discrete: true},
+    );
+    editor.update(
+      () => {
+        expect($unwrapAndFilterDescendants($getRoot(), $isParagraphNode)).toBe(
+          false,
+        );
+        expect($getRoot().getChildrenSize()).toBe(1);
+        expect($isParagraphNode($getRoot().getFirstChild())).toBe(true);
+      },
+      {discrete: true},
+    );
+  });
+  [0, 1, 2].forEach((depth) =>
+    it(`Can un-nest children at depth ${depth}`, () => {
+      editor.update(
+        () => {
+          const firstNode = $createParagraphNode();
+          $getRoot()
+            .clear()
+            .append(
+              firstNode.append(...$createTextAndParagraphWithDepth(depth)),
+            );
+        },
+        {discrete: true},
+      );
+      editor.update(
+        () => {
+          const firstNode = assertClass(
+            $getRoot().getFirstChildOrThrow(),
+            ParagraphNode,
+          );
+          expect(firstNode.getChildren().every($isTextNode)).toBe(depth === 0);
+          expect($unwrapAndFilterDescendants(firstNode, $isTextNode)).toBe(
+            depth > 0,
+          );
+          expect(firstNode.getChildren().every($isTextNode)).toBe(true);
+          expect(firstNode.getTextContent()).toBe(textContentForDepth(depth));
+        },
+        {discrete: true},
+      );
+    }),
+  );
+});

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -833,3 +833,15 @@ function $childIterator(
     },
   };
 }
+
+/**
+ * Insert all children before this node, and then remove it.
+ *
+ * @param node The ElementNode to unwrap and remove
+ */
+export function $unwrapNode(node: ElementNode): void {
+  for (const child of $firstToLastIterator(node)) {
+    node.insertBefore(child);
+  }
+  node.remove();
+}

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2210,7 +2210,7 @@ describe('LexicalEditor tests', () => {
 
     await editor.update(() => {
       const root = $getRoot();
-      const tableCell = $createTableCellNode(0);
+      const tableCell = $createTableCellNode();
       const tableRow = $createTableRowNode();
       const table = $createTableNode();
 
@@ -2225,7 +2225,7 @@ describe('LexicalEditor tests', () => {
 
     await editor.update(() => {
       const tableRow = $getNodeByKey(tableRowKey) as TableRowNode;
-      const tableCell = $createTableCellNode(0);
+      const tableCell = $createTableCellNode();
       tableRow.append(tableCell);
     });
 


### PR DESCRIPTION
## Description

* Enforce Table invariants with node transforms that are registered by the table plugin
* Move the majority of the Table plugin's code to `@lexical/table` so that it can be more easily used in non-React applications
* Add a new `$unwrapAndFilterDescendants` to `@lexical/utils` for use in these transforms (it's possibly useful elsewhere that we have a fixed schema, like ListNode/ListItemNode)

### New Import & Transform Invariants:

TableNode
- may only have TableRowNode children

TableRowNode
- must have a TableNode parent
- may only have TableCellNode children

TableCellNode
- must have a TableRowNode parent,
- must be non-empty (an empty ParagraphNode will be added)

Closes #6910

## Test plan

### Before

Playground crash when pasting a table that has tbody, thead, tfoot, or and/or caption

### After

No crash, new unit tests for new functionality, specifically testing that the import behaves as expected