### PR TITLE
[lexical-markdown] Refactor: Update regExpEnd optional type in MultilineElementTransformer

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -113,7 +113,7 @@ export type MultilineElementTransformer = {
          * Whether the end match is optional. If true, the end match is not required to match for the transformer to be triggered.
          * The entire text from regexpStart to the end of the document will then be matched.
          */
-        optional?: true;
+        optional?: boolean;
         regExp: RegExp;
       };
   /**


### PR DESCRIPTION
[lexical-markdown] Refactor: Broaden regExpEnd optional type to boolean

## Description

**Current Behavior:**
In the [MultilineElementTransformer](cci:2://file:///Users/untilhamza/Developer/jenga-codelabs/lexical/packages/lexical-markdown/src/MarkdownTransformers.ts:76:0-206:48) interface, the `regExpEnd` property's `optional` field was unnecessarily restricted to only accept `true` as a value. This strict typing didn't provide any practical benefit and limited potential use cases where `false` might be a valid state.

**Changes:**
- Modified the type definition of `optional` in `regExpEnd` from `true` to `boolean`
- This change allows for more flexible usage of the optional flag
- Makes the type definition more intuitive and consistent with typical boolean flag patterns

Closes #[issue number]

## Test plan

### Before
The `regExpEnd` type was overly restrictive:
```typescript
regExpEnd?: RegExp | {
  optional?: true;  // Could only be true
  regExp: RegExp;
};
```

### After
The `regExpEnd` type now allows both true and false values:

```typescript
CopyInsert
regExpEnd?: RegExp | {
  optional?: boolean;  // Can be either true or false
  regExp: RegExp;
};
```

This change maintains backward compatibility while providing more flexibility in how the optional flag can be used.

