### PR TITLE
[lexical-playground] Chore: Update Prettier to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30584,6 +30584,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -39153,7 +39154,7 @@
         "katex": "^0.16.10",
         "lexical": "0.21.0",
         "lodash-es": "^4.17.21",
-        "prettier": "^2.3.2",
+        "prettier": "^3.4.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^3.1.4",
@@ -39171,6 +39172,21 @@
         "vite": "^5.2.11",
         "vite-plugin-replace": "^0.1.1",
         "vite-plugin-static-copy": "^2.1.0"
+      }
+    },
+    "packages/lexical-playground/node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/lexical-react": {
@@ -56265,7 +56281,7 @@
         "katex": "^0.16.10",
         "lexical": "0.21.0",
         "lodash-es": "^4.17.21",
-        "prettier": "^2.3.2",
+        "prettier": "^3.4.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^3.1.4",
@@ -56275,6 +56291,13 @@
         "vite-plugin-static-copy": "^2.1.0",
         "y-websocket": "^1.5.4",
         "yjs": ">=13.5.42"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+          "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ=="
+        }
       }
     },
     "lib0": {
@@ -60208,7 +60231,8 @@
     "prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true
     },
     "prettier-plugin-hermes-parser": {
       "version": "0.20.1",

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -225,7 +225,7 @@ async function assertHTMLOnPageOrFrame(
   frameName,
   actualHtmlModificationsCallback = (actualHtml) => actualHtml,
 ) {
-  const expected = prettifyHTML(expectedHtml.replace(/\n/gm, ''), {
+  const expected = await prettifyHTML(expectedHtml.replace(/\n/gm, ''), {
     ignoreClasses,
     ignoreInlineStyles,
   });
@@ -236,7 +236,7 @@ async function assertHTMLOnPageOrFrame(
         .first()
         .innerHTML(),
     );
-    let actual = prettifyHTML(actualHtml.replace(/\n/gm, ''), {
+    let actual = await prettifyHTML(actualHtml.replace(/\n/gm, ''), {
       ignoreClasses,
       ignoreInlineStyles,
     });
@@ -780,7 +780,10 @@ export async function dragImage(
   );
 }
 
-export function prettifyHTML(string, {ignoreClasses, ignoreInlineStyles} = {}) {
+export async function prettifyHTML(
+  string,
+  {ignoreClasses, ignoreInlineStyles} = {},
+) {
   let output = string;
 
   if (ignoreClasses) {
@@ -793,15 +796,14 @@ export function prettifyHTML(string, {ignoreClasses, ignoreInlineStyles} = {}) {
 
   output = output.replace(/\s__playwright_target__="[^"]+"/, '');
 
-  return prettier
-    .format(output, {
-      attributeGroups: ['$DEFAULT', '^data-'],
-      attributeSort: 'ASC',
-      bracketSameLine: true,
-      htmlWhitespaceSensitivity: 'ignore',
-      parser: 'html',
-    })
-    .trim();
+  return await prettier.format(output, {
+    attributeGroups: ['$DEFAULT', '^data-'],
+    attributeSort: 'asc',
+    bracketSameLine: true,
+    htmlWhitespaceSensitivity: 'ignore',
+    parser: 'html',
+    plugins: ['prettier-plugin-organize-attributes'],
+  });
 }
 
 // This function does not suppose to do anything, it's only used as a trigger

--- a/packages/lexical-playground/package.json
+++ b/packages/lexical-playground/package.json
@@ -29,7 +29,7 @@
     "katex": "^0.16.10",
     "lexical": "0.21.0",
     "lodash-es": "^4.17.21",
-    "prettier": "^2.3.2",
+    "prettier": "^3.4.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^3.1.4",

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/PrettierButton/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/components/PrettierButton/index.tsx
@@ -10,7 +10,6 @@ import './index.css';
 import {$isCodeNode} from '@lexical/code';
 import {$getNearestNodeFromDOMNode, LexicalEditor} from 'lexical';
 import {Options} from 'prettier';
-import * as React from 'react';
 import {useState} from 'react';
 
 interface Props {
@@ -20,17 +19,27 @@ interface Props {
 }
 
 const PRETTIER_PARSER_MODULES = {
-  css: () => import('prettier/parser-postcss'),
-  html: () => import('prettier/parser-html'),
-  js: () => import('prettier/parser-babel'),
-  markdown: () => import('prettier/parser-markdown'),
+  css: [() => import('prettier/parser-postcss')],
+  html: [() => import('prettier/parser-html')],
+  js: [
+    () => import('prettier/parser-babel'),
+    () => import('prettier/plugins/estree'),
+  ],
+  markdown: [() => import('prettier/parser-markdown')],
+  typescript: [
+    () => import('prettier/parser-typescript'),
+    () => import('prettier/plugins/estree'),
+  ],
 } as const;
 
 type LanguagesType = keyof typeof PRETTIER_PARSER_MODULES;
 
 async function loadPrettierParserByLang(lang: string) {
-  const dynamicImport = PRETTIER_PARSER_MODULES[lang as LanguagesType];
-  return await dynamicImport();
+  const dynamicImports = PRETTIER_PARSER_MODULES[lang as LanguagesType];
+  const modules = await Promise.all(
+    dynamicImports.map((dynamicImport) => dynamicImport()),
+  );
+  return modules;
 }
 
 async function loadPrettierFormat() {
@@ -39,18 +48,11 @@ async function loadPrettierFormat() {
 }
 
 const PRETTIER_OPTIONS_BY_LANG: Record<string, Options> = {
-  css: {
-    parser: 'css',
-  },
-  html: {
-    parser: 'html',
-  },
-  js: {
-    parser: 'babel',
-  },
-  markdown: {
-    parser: 'markdown',
-  },
+  css: {parser: 'css'},
+  html: {parser: 'html'},
+  js: {parser: 'babel'},
+  markdown: {parser: 'markdown'},
+  typescript: {parser: 'typescript'},
 };
 
 const LANG_CAN_BE_PRETTIER = Object.keys(PRETTIER_OPTIONS_BY_LANG);
@@ -76,36 +78,37 @@ export function PrettierButton({lang, editor, getCodeDOMNode}: Props) {
 
   async function handleClick(): Promise<void> {
     const codeDOMNode = getCodeDOMNode();
+    if (!codeDOMNode) {
+      return;
+    }
+
+    let content = '';
+    editor.update(() => {
+      const codeNode = $getNearestNodeFromDOMNode(codeDOMNode);
+      if ($isCodeNode(codeNode)) {
+        content = codeNode.getTextContent();
+      }
+    });
+    if (content === '') {
+      return;
+    }
 
     try {
       const format = await loadPrettierFormat();
       const options = getPrettierOptions(lang);
-      options.plugins = [await loadPrettierParserByLang(lang)];
-
-      if (!codeDOMNode) {
-        return;
-      }
+      const prettierParsers = await loadPrettierParserByLang(lang);
+      options.plugins = prettierParsers.map(
+        (parser) => parser.default || parser,
+      );
+      const formattedCode = await format(content, options);
 
       editor.update(() => {
         const codeNode = $getNearestNodeFromDOMNode(codeDOMNode);
-
         if ($isCodeNode(codeNode)) {
-          const content = codeNode.getTextContent();
-
-          let parsed = '';
-
-          try {
-            parsed = format(content, options);
-          } catch (error: unknown) {
-            setError(error);
-          }
-
-          if (parsed !== '') {
-            const selection = codeNode.select(0);
-            selection.insertText(parsed);
-            setSyntaxError('');
-            setTipsVisible(false);
-          }
+          const selection = codeNode.select(0);
+          selection.insertText(formattedCode);
+          setSyntaxError('');
+          setTipsVisible(false);
         }
       });
     } catch (error: unknown) {


### PR DESCRIPTION
## Description

- **Current behavior**: The codebase uses synchronous `prettier.format` calls compatible with Prettier v2.
  
- **Changes introduced**:
  - Upgraded Prettier from `^2.3.2` to `^3.4.2`.
  - Updated all usages of `prettier.format` to handle its new asynchronous behavior in Prettier v3.
  - Adjusted the handling of Prettier plugins and parsers in `PrettierButton` to ensure compatibility with Prettier v3, including dynamic imports and necessary adaptations.

These changes update the `lexical-playground` package to be fully compatible with the API changes in Prettier v3.
