### PR TITLE
Update core-tests workflow triggers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,6 @@ on:
       - 'packages/lexical-website/**'
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'examples/**'
-      - 'packages/lexical-website/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Removing core tests workflow exclusion for the following reasons:
1. Cost-wise, most PRs fall outside of this bucket
2. We can enforce that status are passing on GitHub 