### PR TITLE
[lexical-playground] Refactor: editor styles should in PlaygroundEditorTheme.css

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1766,22 +1766,6 @@ button.item.dropdown-item-active i {
   z-index: 3;
 }
 
-.PlaygroundEditorTheme__blockCursor {
-  display: block;
-  pointer-events: none;
-  position: absolute;
-}
-
-.PlaygroundEditorTheme__blockCursor:after {
-  content: '';
-  display: block;
-  position: absolute;
-  top: -2px;
-  width: 20px;
-  border-top: 1px solid black;
-  animation: CursorBlink 1.1s steps(2, start) infinite;
-}
-
 @keyframes CursorBlink {
   to {
     visibility: hidden;

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -89,6 +89,20 @@
   text-decoration: underline;
   cursor: pointer;
 }
+.PlaygroundEditorTheme__blockCursor {
+  display: block;
+  pointer-events: none;
+  position: absolute;
+}
+.PlaygroundEditorTheme__blockCursor:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: -2px;
+  width: 20px;
+  border-top: 1px solid black;
+  animation: CursorBlink 1.1s steps(2, start) infinite;
+}
 .PlaygroundEditorTheme__code {
   background-color: rgb(240, 242, 245);
   font-family: Menlo, Consolas, Monaco, monospace;


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

All editor styles are defined are defined in `PlaygroundEditorTheme.css` but two that are in `index.css`. This PR moves the two styles to their right place.
