### PR TITLE
[lexical-playground] Bug Fix: Allow scrolling if the table cell content overflows

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -15,6 +15,7 @@
 .PlaygroundEditorTheme__paragraph {
   margin: 0;
   position: relative;
+  overflow: inherit;
 }
 .PlaygroundEditorTheme__quote {
   margin: 0;
@@ -213,6 +214,7 @@
   padding: 6px 8px;
   position: relative;
   outline: none;
+  overflow: auto;
 }
 .PlaygroundEditorTheme__tableCellResizer {
   position: absolute;

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -15,12 +15,6 @@
 .PlaygroundEditorTheme__paragraph {
   margin: 0;
   position: relative;
-
-  /*
-    A firefox workaround to allow scrolling of overflowing table cell
-    ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1904159  
-  */
-  overflow: inherit;
 }
 .PlaygroundEditorTheme__quote {
   margin: 0;
@@ -220,6 +214,13 @@
   position: relative;
   outline: none;
   overflow: auto;
+}
+/*
+  A firefox workaround to allow scrolling of overflowing table cell
+  ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1904159
+*/
+.PlaygroundEditorTheme__tableCell > * {
+  overflow: inherit;
 }
 .PlaygroundEditorTheme__tableCellResizer {
   position: absolute;

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -15,6 +15,11 @@
 .PlaygroundEditorTheme__paragraph {
   margin: 0;
   position: relative;
+
+  /*
+    A firefox workaround to allow scrolling of overflowing table cell
+    ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1904159  
+  */
   overflow: inherit;
 }
 .PlaygroundEditorTheme__quote {


### PR DESCRIPTION
fix 6931: CSS changes in the playground to allow scrolling if the cell content overflows, and inheriting the same behavior for the nested `<p>` tag.

<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->
Bug Fix
## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*
Made changes to the playground CSS to allow scroll of table content, since there's a nested p tag, have added scroll:inherit to it

Closes #6931

## Test plan
Try scrolling of various contents inside playground table's cells
### Before

*Insert relevant screenshots/recordings/automated-tests*
![image](https://github.com/user-attachments/assets/5e93d5bc-e18f-45ce-8683-72fe9d656e4c)


### After

https://github.com/user-attachments/assets/8605cc74-b300-4cda-bcc4-e2fa259c1d4f


*Insert relevant screenshots/recordings/automated-tests*