### PR TITLE
[lexical-website] Add Discord to the community section of the footer

### DIFF
--- a/packages/lexical-website/docusaurus.config.js
+++ b/packages/lexical-website/docusaurus.config.js
@@ -336,6 +336,10 @@ const config = {
           {
             items: [
               {
+                href: 'https://discord.gg/KmG4wQnnD9',
+                label: 'Discord',
+              },
+              {
                 href: 'https://stackoverflow.com/questions/tagged/lexicaljs',
                 label: 'Stack Overflow',
               },


### PR DESCRIPTION
## Description

The community section of the website features Discord prominently but it's not in the footer. This adds it to the footer for quick reference.
