### PR TITLE
[lexical][lexical-table] Bug fix: TablePlugin:  - check is current selection in target table node

### DIFF
--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -18,7 +18,6 @@ import {
   $createTextNode,
   $getEditor,
   $getNodeByKey,
-  $getRoot,
   $getSelection,
   $isElementNode,
   $isParagraphNode,
@@ -470,8 +469,6 @@ export class TableObserver {
       tableNode.selectPrevious();
       // Delete entire table
       tableNode.remove();
-      const rootNode = $getRoot();
-      rootNode.selectStart();
       return;
     }
 

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -456,6 +456,10 @@ export function applyTableHandlers(
       return false;
     }
 
+    if (!$isSelectionInTable(selection, tableNode)) {
+      return false;
+    }
+
     if ($isTableSelection(selection)) {
       if (event) {
         event.preventDefault();


### PR DESCRIPTION
## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
For `$deleteCellHandler` method, like for `deleteTextHandler` and etc., a check has been added to ensure the current selection belongs in the target table node (`tableNode` param passed to `applyTableHandlers`)

Closes #6972

## Test plan
1. Open playground
2. Remove all content
3. Append first table
4. Append some text
5. Append second table
6. Select all cell's of second table
7. Press `Del`

### Before
First table deleted

https://github.com/user-attachments/assets/63e8f39a-fdbd-4bd9-8621-f139cd4ed90c


### After
Second(selected table) deleted

https://github.com/user-attachments/assets/625bc97c-29c0-4c8d-acf2-f8a9bd440790

