### PR TITLE
Refactor: exportJSON

### DIFF
--- a/examples/vanilla-js-plugin/src/emoji-plugin/EmojiNode.ts
+++ b/examples/vanilla-js-plugin/src/emoji-plugin/EmojiNode.ts
@@ -60,7 +60,6 @@ export class EmojiNode extends TextNode {
   exportJSON(): SerializedEmojiNode {
     return {
       ...super.exportJSON(),
-      type: 'emoji',
       unifiedID: this.__unifiedID,
     };
   }

--- a/packages/lexical-code/src/CodeHighlightNode.ts
+++ b/packages/lexical-code/src/CodeHighlightNode.ts
@@ -175,8 +175,6 @@ export class CodeHighlightNode extends TextNode {
     return {
       ...super.exportJSON(),
       highlightType: this.getHighlightType(),
-      type: 'code-highlight',
-      version: 1,
     };
   }
 

--- a/packages/lexical-code/src/CodeNode.ts
+++ b/packages/lexical-code/src/CodeNode.ts
@@ -223,8 +223,6 @@ export class CodeNode extends ElementNode {
     return {
       ...super.exportJSON(),
       language: this.getLanguage(),
-      type: 'code',
-      version: 1,
     };
   }
 

--- a/packages/lexical-hashtag/src/LexicalHashtagNode.ts
+++ b/packages/lexical-hashtag/src/LexicalHashtagNode.ts
@@ -45,13 +45,6 @@ export class HashtagNode extends TextNode {
     return node;
   }
 
-  exportJSON(): SerializedTextNode {
-    return {
-      ...super.exportJSON(),
-      type: 'hashtag',
-    };
-  }
-
   canInsertTextBefore(): boolean {
     return false;
   }

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -44,7 +44,7 @@ import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
 
 type SerializedCustomTextNode = Spread<
-  {type: ReturnType<typeof CustomTextNode.getType>; classes: string[]},
+  {type: string; classes: string[]},
   SerializedTextNode
 >;
 
@@ -87,7 +87,6 @@ class CustomTextNode extends TextNode {
     return {
       ...super.exportJSON(),
       classes: Array.from(this.getClasses()),
-      type: this.constructor.getType(),
     };
   }
 }

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -195,9 +195,7 @@ export class LinkNode extends ElementNode {
       rel: this.getRel(),
       target: this.getTarget(),
       title: this.getTitle(),
-      type: 'link',
       url: this.getURL(),
-      version: 1,
     };
   }
 
@@ -425,8 +423,6 @@ export class AutoLinkNode extends LinkNode {
     return {
       ...super.exportJSON(),
       isUnlinked: this.__isUnlinked,
-      type: 'autolink',
-      version: 1,
     };
   }
 

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -143,9 +143,7 @@ export class ListItemNode extends ElementNode {
     return {
       ...super.exportJSON(),
       checked: this.getChecked(),
-      type: 'listitem',
       value: this.getValue(),
-      version: 1,
     };
   }
 

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -171,8 +171,6 @@ export class ListNode extends ElementNode {
       listType: this.getListType(),
       start: this.getStart(),
       tag: this.getTag(),
-      type: 'list',
-      version: 1,
     };
   }
 

--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -58,8 +58,6 @@ export class MarkNode extends ElementNode {
     return {
       ...super.exportJSON(),
       ids: Array.from(this.getIDs()),
-      type: 'mark',
-      version: 1,
     };
   }
 

--- a/packages/lexical-overflow/src/index.ts
+++ b/packages/lexical-overflow/src/index.ts
@@ -42,13 +42,6 @@ export class OverflowNode extends ElementNode {
     this.__type = 'overflow';
   }
 
-  exportJSON(): SerializedElementNode {
-    return {
-      ...super.exportJSON(),
-      type: 'overflow',
-    };
-  }
-
   createDOM(config: EditorConfig): HTMLElement {
     const div = document.createElement('span');
     const className = config.theme.characterLimit;

--- a/packages/lexical-playground/src/nodes/AutocompleteNode.tsx
+++ b/packages/lexical-playground/src/nodes/AutocompleteNode.tsx
@@ -62,9 +62,7 @@ export class AutocompleteNode extends TextNode {
   exportJSON(): SerializedAutocompleteNode {
     return {
       ...super.exportJSON(),
-      type: 'autocomplete',
       uuid: this.__uuid,
-      version: 1,
     };
   }
 

--- a/packages/lexical-playground/src/nodes/EmojiNode.tsx
+++ b/packages/lexical-playground/src/nodes/EmojiNode.tsx
@@ -73,7 +73,6 @@ export class EmojiNode extends TextNode {
     return {
       ...super.exportJSON(),
       className: this.getClassName(),
-      type: 'emoji',
     };
   }
 

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -74,10 +74,9 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
 
   exportJSON(): SerializedEquationNode {
     return {
+      ...super.exportJSON(),
       equation: this.getEquation(),
       inline: this.__inline,
-      type: 'equation',
-      version: 1,
     };
   }
 

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -84,10 +84,9 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
 
   exportJSON(): SerializedExcalidrawNode {
     return {
+      ...super.exportJSON(),
       data: this.__data,
       height: this.__height === 'inherit' ? undefined : this.__height,
-      type: 'excalidraw',
-      version: 1,
       width: this.__width === 'inherit' ? undefined : this.__width,
     };
   }

--- a/packages/lexical-playground/src/nodes/FigmaNode.tsx
+++ b/packages/lexical-playground/src/nodes/FigmaNode.tsx
@@ -82,8 +82,6 @@ export class FigmaNode extends DecoratorBlockNode {
     return {
       ...super.exportJSON(),
       documentID: this.__id,
-      type: 'figma',
-      version: 1,
     };
   }
 

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -163,14 +163,13 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
 
   exportJSON(): SerializedImageNode {
     return {
+      ...super.exportJSON(),
       altText: this.getAltText(),
       caption: this.__caption.toJSON(),
       height: this.__height === 'inherit' ? 0 : this.__height,
       maxWidth: this.__maxWidth,
       showCaption: this.__showCaption,
       src: this.getSrc(),
-      type: 'image',
-      version: 1,
       width: this.__width === 'inherit' ? 0 : this.__width,
     };
   }

--- a/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageNode.tsx
@@ -158,14 +158,13 @@ export class InlineImageNode extends DecoratorNode<JSX.Element> {
 
   exportJSON(): SerializedInlineImageNode {
     return {
+      ...super.exportJSON(),
       altText: this.getAltText(),
       caption: this.__caption.toJSON(),
       height: this.__height === 'inherit' ? 0 : this.__height,
       position: this.__position,
       showCaption: this.__showCaption,
       src: this.getSrc(),
-      type: 'inline-image',
-      version: 1,
       width: this.__width === 'inherit' ? 0 : this.__width,
     };
   }

--- a/packages/lexical-playground/src/nodes/KeywordNode.ts
+++ b/packages/lexical-playground/src/nodes/KeywordNode.ts
@@ -30,14 +30,6 @@ export class KeywordNode extends TextNode {
     return node;
   }
 
-  exportJSON(): SerializedKeywordNode {
-    return {
-      ...super.exportJSON(),
-      type: 'keyword',
-      version: 1,
-    };
-  }
-
   createDOM(config: EditorConfig): HTMLElement {
     const dom = super.createDOM(config);
     dom.style.cursor = 'default';

--- a/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
+++ b/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
@@ -110,8 +110,6 @@ export class LayoutContainerNode extends ElementNode {
     return {
       ...super.exportJSON(),
       templateColumns: this.__templateColumns,
-      type: 'layout-container',
-      version: 1,
     };
   }
 

--- a/packages/lexical-playground/src/nodes/LayoutItemNode.ts
+++ b/packages/lexical-playground/src/nodes/LayoutItemNode.ts
@@ -66,14 +66,6 @@ export class LayoutItemNode extends ElementNode {
   isShadowRoot(): boolean {
     return true;
   }
-
-  exportJSON(): SerializedLayoutItemNode {
-    return {
-      ...super.exportJSON(),
-      type: 'layout-item',
-      version: 1,
-    };
-  }
 }
 
 export function $createLayoutItemNode(): LayoutItemNode {

--- a/packages/lexical-playground/src/nodes/MentionNode.ts
+++ b/packages/lexical-playground/src/nodes/MentionNode.ts
@@ -71,8 +71,6 @@ export class MentionNode extends TextNode {
     return {
       ...super.exportJSON(),
       mentionName: this.__mention,
-      type: 'mention',
-      version: 1,
     };
   }
 

--- a/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
@@ -124,13 +124,6 @@ export class PageBreakNode extends DecoratorNode<JSX.Element> {
     };
   }
 
-  exportJSON(): SerializedLexicalNode {
-    return {
-      type: this.getType(),
-      version: 1,
-    };
-  }
-
   createDOM(): HTMLElement {
     const el = document.createElement('figure');
     el.style.pageBreakAfter = 'always';

--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -103,10 +103,9 @@ export class PollNode extends DecoratorNode<JSX.Element> {
 
   exportJSON(): SerializedPollNode {
     return {
+      ...super.exportJSON(),
       options: this.__options,
       question: this.__question,
-      type: 'poll',
-      version: 1,
     };
   }
 

--- a/packages/lexical-playground/src/nodes/SpecialTextNode.tsx
+++ b/packages/lexical-playground/src/nodes/SpecialTextNode.tsx
@@ -57,13 +57,6 @@ export class SpecialTextNode extends TextNode {
     return node;
   }
 
-  exportJSON(): SerializedTextNode {
-    return {
-      ...super.exportJSON(),
-      type: 'specialText',
-    };
-  }
-
   isTextEntity(): true {
     return true;
   }

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -85,10 +85,9 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
 
   exportJSON(): SerializedStickyNode {
     return {
+      ...super.exportJSON(),
       caption: this.__caption.toJSON(),
       color: this.__color,
-      type: 'sticky',
-      version: 1,
       xOffset: this.__x,
       yOffset: this.__y,
     };

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -151,8 +151,6 @@ export class TweetNode extends DecoratorBlockNode {
     return {
       ...super.exportJSON(),
       id: this.getId(),
-      type: 'tweet',
-      version: 1,
     };
   }
 

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -97,8 +97,6 @@ export class YouTubeNode extends DecoratorBlockNode {
   exportJSON(): SerializedYouTubeNode {
     return {
       ...super.exportJSON(),
-      type: 'youtube',
-      version: 1,
       videoID: this.__id,
     };
   }

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -133,8 +133,6 @@ export class CollapsibleContainerNode extends ElementNode {
     return {
       ...super.exportJSON(),
       open: this.__open,
-      type: 'collapsible-container',
-      version: 1,
     };
   }
 

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContentNode.ts
@@ -106,14 +106,6 @@ export class CollapsibleContentNode extends ElementNode {
   isShadowRoot(): boolean {
     return true;
   }
-
-  exportJSON(): SerializedCollapsibleContentNode {
-    return {
-      ...super.exportJSON(),
-      type: 'collapsible-content',
-      version: 1,
-    };
-  }
 }
 
 export function $createCollapsibleContentNode(): CollapsibleContentNode {

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
@@ -83,14 +83,6 @@ export class CollapsibleTitleNode extends ElementNode {
     return $createCollapsibleTitleNode();
   }
 
-  exportJSON(): SerializedCollapsibleTitleNode {
-    return {
-      ...super.exportJSON(),
-      type: 'collapsible-title',
-      version: 1,
-    };
-  }
-
   collapseAtStart(_selection: RangeSelection): boolean {
     this.getParentOrThrow().insertBefore(this);
     return true;

--- a/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
+++ b/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
@@ -33,9 +33,8 @@ export class DecoratorBlockNode extends DecoratorNode<JSX.Element> {
 
   exportJSON(): SerializedDecoratorBlockNode {
     return {
+      ...super.exportJSON(),
       format: this.__format || '',
-      type: 'decorator-block',
-      version: 1,
     };
   }
 

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -138,13 +138,6 @@ export class HorizontalRuleNode extends DecoratorNode<JSX.Element> {
     };
   }
 
-  exportJSON(): SerializedLexicalNode {
-    return {
-      type: 'horizontalrule',
-      version: 1,
-    };
-  }
-
   exportDOM(): DOMExportOutput {
     return {element: document.createElement('hr')};
   }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -182,13 +182,6 @@ export class QuoteNode extends ElementNode {
     return node;
   }
 
-  exportJSON(): SerializedElementNode {
-    return {
-      ...super.exportJSON(),
-      type: 'quote',
-    };
-  }
-
   // Mutation
 
   insertNewAfter(_: RangeSelection, restoreSelection?: boolean): ParagraphNode {
@@ -352,8 +345,6 @@ export class HeadingNode extends ElementNode {
     return {
       ...super.exportJSON(),
       tag: this.getTag(),
-      type: 'heading',
-      version: 1,
     };
   }
 

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -183,7 +183,6 @@ export class TableCellNode extends ElementNode {
       colSpan: this.__colSpan,
       headerState: this.__headerState,
       rowSpan: this.__rowSpan,
-      type: 'tablecell',
       width: this.getWidth(),
     };
   }

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -168,8 +168,6 @@ export class TableNode extends ElementNode {
       ...super.exportJSON(),
       colWidths: this.getColWidths(),
       rowStriping: this.__rowStriping ? this.__rowStriping : undefined,
-      type: 'table',
-      version: 1,
     };
   }
 

--- a/packages/lexical-table/src/LexicalTableRowNode.ts
+++ b/packages/lexical-table/src/LexicalTableRowNode.ts
@@ -65,8 +65,6 @@ export class TableRowNode extends ElementNode {
     return {
       ...super.exportJSON(),
       ...(this.getHeight() && {height: this.getHeight()}),
-      type: 'tablerow',
-      version: 1,
     };
   }
 

--- a/packages/lexical-website/docs/concepts/serialization.md
+++ b/packages/lexical-website/docs/concepts/serialization.md
@@ -170,7 +170,7 @@ const jsonString = JSON.stringify(editorState);
 
 #### `LexicalNode.exportJSON()`
 
-You can control how a `LexicalNode` is represented as JSON by adding an `exportJSON()` method. It's important to ensure your serialized JSON node has a `type` field and a `children` field if it's an `ElementNode`.
+You can control how a `LexicalNode` is represented as JSON by adding an `exportJSON()` method. It's important that you extend the serialization of the superclass by invoking `super`: e.g. `{ ...super.exportJSON(), /* your other properties */ }`.
 
 ```js
 export type SerializedLexicalNode = {
@@ -197,8 +197,6 @@ exportJSON(): SerializedHeadingNode {
   return {
     ...super.exportJSON(),
     tag: this.getTag(),
-    type: 'heading',
-    version: 1,
   };
 }
 ```
@@ -373,13 +371,7 @@ export class ExtendedTextNode extends TextNode {
     return this.__type === 'extended-text' && this.__mode === 0;
   }
 
-  exportJSON(): SerializedTextNode {
-    return {
-      ...super.exportJSON(),
-      type: 'extended-text',
-      version: 1,
-    }
-  }
+  // no need to add exportJSON here, since we are not adding any new properties
 }
 
 export function $createExtendedTextNode(text: string): ExtendedTextNode {

--- a/packages/lexical-website/docs/getting-started/creating-plugin.md
+++ b/packages/lexical-website/docs/getting-started/creating-plugin.md
@@ -75,7 +75,6 @@ export class EmojiNode extends TextNode {
   exportJSON(): SerializedEmojiNode {
     return {
       ...super.exportJSON(),
-      type: 'emoji',
       unifiedID: this.__unifiedID,
     };
   }

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -514,14 +514,6 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
               `${name} should implement "importJSON" method to ensure JSON and default HTML serialization works as expected`,
             );
           }
-          if (
-            // eslint-disable-next-line no-prototype-builtins
-            !proto.hasOwnProperty('exportJSON')
-          ) {
-            console.warn(
-              `${name} should implement "exportJSON" method to ensure JSON and default HTML serialization works as expected`,
-            );
-          }
         }
       }
       const type = klass.getType();

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -869,7 +869,10 @@ export class LexicalNode {
    *
    * */
   exportJSON(): SerializedLexicalNode {
-    invariant(false, 'exportJSON: base method not extended');
+    return {
+      type: this.__type,
+      version: 1,
+    };
   }
 
   /**

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2778,10 +2778,6 @@ describe('LexicalEditor tests', () => {
       static importJSON() {
         return new CustomParagraphNode();
       }
-
-      exportJSON() {
-        return {...super.exportJSON(), type: 'custom-paragraph'};
-      }
     }
 
     createTestEditor({nodes: [CustomParagraphNode]});

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -51,10 +51,6 @@ class TestNode extends LexicalNode {
   static importJSON() {
     return new TestNode();
   }
-
-  exportJSON() {
-    return {type: 'test', version: 1};
-  }
 }
 
 class InlineDecoratorNode extends DecoratorNode<string> {
@@ -68,10 +64,6 @@ class InlineDecoratorNode extends DecoratorNode<string> {
 
   static importJSON() {
     return new InlineDecoratorNode();
-  }
-
-  exportJSON() {
-    return {type: 'inline-decorator', version: 1};
   }
 
   createDOM(): HTMLElement {
@@ -164,9 +156,6 @@ describe('LexicalNode tests', () => {
             return new VersionedTextNode(node.__text, node.__key);
           }
           static importJSON(node: SerializedTextNode): VersionedTextNode {
-            throw new Error('Not implemented');
-          }
-          exportJSON(): SerializedTextNode {
             throw new Error('Not implemented');
           }
           afterCloneFrom(node: this): void {

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -807,9 +807,6 @@ describe('Regression tests for #6701', () => {
       isInline() {
         return true;
       }
-      exportJSON() {
-        return {...super.exportJSON(), type: this.getType()};
-      }
       createDOM() {
         return document.createElement('span');
       }

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -372,9 +372,6 @@ describe('$applyNodeReplacement', () => {
     static clone(node: ExtendedTextNode): ExtendedTextNode {
       return new ExtendedTextNode(node.__text, node.getKey());
     }
-    exportJSON(): SerializedTextNode {
-      return {...super.exportJSON(), type: this.getType()};
-    }
     initWithTextNode(node: TextNode): this {
       this.__text = node.__text;
       TextNode.prototype.afterCloneFrom.call(this, node);
@@ -406,9 +403,6 @@ describe('$applyNodeReplacement', () => {
       serializedNode: SerializedTextNode,
     ): ExtendedExtendedTextNode {
       return $createExtendedExtendedTextNode().initWithJSON(serializedNode);
-    }
-    exportJSON(): SerializedTextNode {
-      return {...super.exportJSON(), type: this.getType()};
     }
   }
   function $createExtendedTextNode(text: string = '') {

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -182,13 +182,6 @@ export class TestElementNode extends ElementNode {
     return node;
   }
 
-  // exportJSON(): SerializedTestElementNode {
-  //   return {
-  //     ...super.exportJSON(),
-  //     type: 'test_block',
-  //   };
-  // }
-
   createDOM() {
     return document.createElement('div');
   }
@@ -216,13 +209,6 @@ export class TestTextNode extends TextNode {
   static importJSON(serializedNode: SerializedTestTextNode): TestTextNode {
     return new TestTextNode(serializedNode.text);
   }
-
-  exportJSON(): SerializedTestTextNode {
-    return {
-      ...super.exportJSON(),
-      type: 'test_text',
-    };
-  }
 }
 
 export type SerializedTestInlineElementNode = SerializedElementNode;
@@ -244,13 +230,6 @@ export class TestInlineElementNode extends ElementNode {
     node.setIndent(serializedNode.indent);
     node.setDirection(serializedNode.direction);
     return node;
-  }
-
-  exportJSON(): SerializedTestInlineElementNode {
-    return {
-      ...super.exportJSON(),
-      type: 'test_inline_block',
-    };
   }
 
   createDOM() {
@@ -291,13 +270,6 @@ export class TestShadowRootNode extends ElementNode {
     return node;
   }
 
-  exportJSON(): SerializedTestShadowRootNode {
-    return {
-      ...super.exportJSON(),
-      type: 'test_block',
-    };
-  }
-
   createDOM() {
     return document.createElement('div');
   }
@@ -336,13 +308,6 @@ export class TestSegmentedNode extends TextNode {
     node.setStyle(serializedNode.style);
     return node;
   }
-
-  exportJSON(): SerializedTestSegmentedNode {
-    return {
-      ...super.exportJSON(),
-      type: 'test_segmented',
-    };
-  }
 }
 
 export function $createTestSegmentedNode(text: string): TestSegmentedNode {
@@ -368,13 +333,6 @@ export class TestExcludeFromCopyElementNode extends ElementNode {
     node.setIndent(serializedNode.indent);
     node.setDirection(serializedNode.direction);
     return node;
-  }
-
-  exportJSON(): SerializedTestExcludeFromCopyElementNode {
-    return {
-      ...super.exportJSON(),
-      type: 'test_exclude_from_copy_block',
-    };
   }
 
   createDOM() {
@@ -409,13 +367,6 @@ export class TestDecoratorNode extends DecoratorNode<JSX.Element> {
     serializedNode: SerializedTestDecoratorNode,
   ): TestDecoratorNode {
     return $createTestDecoratorNode();
-  }
-
-  exportJSON(): SerializedTestDecoratorNode {
-    return {
-      ...super.exportJSON(),
-      type: 'test_decorator',
-    };
   }
 
   static importDOM() {

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -182,13 +182,12 @@ export class TestElementNode extends ElementNode {
     return node;
   }
 
-  exportJSON(): SerializedTestElementNode {
-    return {
-      ...super.exportJSON(),
-      type: 'test_block',
-      version: 1,
-    };
-  }
+  // exportJSON(): SerializedTestElementNode {
+  //   return {
+  //     ...super.exportJSON(),
+  //     type: 'test_block',
+  //   };
+  // }
 
   createDOM() {
     return document.createElement('div');
@@ -222,7 +221,6 @@ export class TestTextNode extends TextNode {
     return {
       ...super.exportJSON(),
       type: 'test_text',
-      version: 1,
     };
   }
 }
@@ -252,7 +250,6 @@ export class TestInlineElementNode extends ElementNode {
     return {
       ...super.exportJSON(),
       type: 'test_inline_block',
-      version: 1,
     };
   }
 
@@ -298,7 +295,6 @@ export class TestShadowRootNode extends ElementNode {
     return {
       ...super.exportJSON(),
       type: 'test_block',
-      version: 1,
     };
   }
 
@@ -345,7 +341,6 @@ export class TestSegmentedNode extends TextNode {
     return {
       ...super.exportJSON(),
       type: 'test_segmented',
-      version: 1,
     };
   }
 }
@@ -379,7 +374,6 @@ export class TestExcludeFromCopyElementNode extends ElementNode {
     return {
       ...super.exportJSON(),
       type: 'test_exclude_from_copy_block',
-      version: 1,
     };
   }
 
@@ -421,7 +415,6 @@ export class TestDecoratorNode extends DecoratorNode<JSX.Element> {
     return {
       ...super.exportJSON(),
       type: 'test_decorator',
-      version: 1,
     };
   }
 

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -792,6 +792,9 @@ export class ElementNode extends LexicalNode {
       direction: this.getDirection(),
       format: this.getFormatType(),
       indent: this.getIndent(),
+      // As an exception here we invoke super at the end for historical reasons.
+      // Namely, to preserve the order of the properties and not to break the tests
+      // that use the serialized string representation.
       ...super.exportJSON(),
     };
   }

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -792,8 +792,7 @@ export class ElementNode extends LexicalNode {
       direction: this.getDirection(),
       format: this.getFormatType(),
       indent: this.getIndent(),
-      type: 'element',
-      version: 1,
+      ...super.exportJSON(),
     };
   }
   // These are intended to be extends for specific element heuristics.

--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -66,13 +66,6 @@ export class LineBreakNode extends LexicalNode {
   ): LineBreakNode {
     return $createLineBreakNode();
   }
-
-  exportJSON(): SerializedLexicalNode {
-    return {
-      type: 'linebreak',
-      version: 1,
-    };
-  }
 }
 
 function $convertLineBreakElement(node: Node): DOMConversionOutput {

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -173,8 +173,6 @@ export class ParagraphNode extends ElementNode {
       ...super.exportJSON(),
       textFormat: this.getTextFormat(),
       textStyle: this.getTextStyle(),
-      type: 'paragraph',
-      version: 1,
     };
   }
 

--- a/packages/lexical/src/nodes/LexicalRootNode.ts
+++ b/packages/lexical/src/nodes/LexicalRootNode.ts
@@ -107,12 +107,11 @@ export class RootNode extends ElementNode {
 
   exportJSON(): SerializedRootNode {
     return {
+      ...super.exportJSON(),
       children: [],
       direction: this.getDirection(),
       format: this.getFormatType(),
       indent: this.getIndent(),
-      type: 'root',
-      version: 1,
     };
   }
 

--- a/packages/lexical/src/nodes/LexicalRootNode.ts
+++ b/packages/lexical/src/nodes/LexicalRootNode.ts
@@ -105,16 +105,6 @@ export class RootNode extends ElementNode {
     return node;
   }
 
-  exportJSON(): SerializedRootNode {
-    return {
-      ...super.exportJSON(),
-      children: [],
-      direction: this.getDirection(),
-      format: this.getFormatType(),
-      indent: this.getIndent(),
-    };
-  }
-
   collapseAtStart(): true {
     return true;
   }

--- a/packages/lexical/src/nodes/LexicalTabNode.ts
+++ b/packages/lexical/src/nodes/LexicalTabNode.ts
@@ -66,14 +66,6 @@ export class TabNode extends TextNode {
     return node;
   }
 
-  exportJSON(): SerializedTabNode {
-    return {
-      ...super.exportJSON(),
-      type: 'tab',
-      version: 1,
-    };
-  }
-
   setTextContent(_text: string): this {
     invariant(false, 'TabNode does not support setTextContent');
   }

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -652,8 +652,7 @@ export class TextNode extends LexicalNode {
       mode: this.getMode(),
       style: this.getStyle(),
       text: this.getTextContent(),
-      type: 'text',
-      version: 1,
+      ...super.exportJSON(),
     };
   }
 

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -652,6 +652,9 @@ export class TextNode extends LexicalNode {
       mode: this.getMode(),
       style: this.getStyle(),
       text: this.getTextContent(),
+      // As an exception here we invoke super at the end for historical reasons.
+      // Namely, to preserve the order of the properties and not to break the tests
+      // that use the serialized string representation.
       ...super.exportJSON(),
     };
   }


### PR DESCRIPTION
exportJSON refactoring. Advantages:

- Less boilerplate on nodes. With this change many nodes no longer require `exportJSON`, and those that do no longer need to repeat "type" and "version".
- DRY. Any changes we make in the future can be done in a single node and propagated to subclasses. This will make reviewing PRs that modify JSON serialization easier, as far fewer files are modified.

Discussed internally with @etrepum
