### PR TITLE
[lexical-react] Refactor: Replace `React$MixedElement` and `React$Node` with `React.MixedElement` and `React.Node`

### DIFF
--- a/packages/lexical-react/flow/LexicalAutoLinkPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalAutoLinkPlugin.js.flow
@@ -29,4 +29,4 @@ declare export function createLinkMatcherWithRegExp(
 declare export function AutoLinkPlugin(props: {
   matchers: Array<LinkMatcher>,
   onChange?: ChangeHandler,
-}): React$Node;
+}): React.Node;

--- a/packages/lexical-react/flow/LexicalBlockWithAlignableContents.js.flow
+++ b/packages/lexical-react/flow/LexicalBlockWithAlignableContents.js.flow
@@ -16,7 +16,7 @@ import type {
 } from 'lexical';
 
 type Props = $ReadOnly<{
-  children: React$Node,
+  children: React.Node,
   format: ?ElementFormatType,
   nodeKey: NodeKey,
   className: $ReadOnly<{
@@ -25,4 +25,4 @@ type Props = $ReadOnly<{
   }>,
 }>;
 
-declare export function BlockWithAlignableContents(Props): React$Node;
+declare export function BlockWithAlignableContents(Props): React.Node;

--- a/packages/lexical-react/flow/LexicalCharacterLimitPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalCharacterLimitPlugin.js.flow
@@ -9,4 +9,4 @@
 
 declare export function CharacterLimitPlugin(props: {
   charset: 'UTF-8' | 'UTF-16',
-}): React$Node;
+}): React.Node;

--- a/packages/lexical-react/flow/LexicalClearEditorPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalClearEditorPlugin.js.flow
@@ -11,4 +11,4 @@ type Props = $ReadOnly<{
   onClear?: () => void,
 }>;
 
-declare export function ClearEditorPlugin(Props): React$Node;
+declare export function ClearEditorPlugin(Props): React.Node;

--- a/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalCollaborationPlugin.js.flow
@@ -47,4 +47,4 @@ declare export function CollaborationPlugin(arg0: {
   cursorsContainerRef?: CursorsContainerRef,
   initialEditorState?: InitialEditorStateType,
   excludedProperties?: ExcludedProperties,
-}): React$Node;
+}): React.Node;

--- a/packages/lexical-react/flow/LexicalComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalComposer.js.flow
@@ -34,7 +34,7 @@ export type InitialConfigType = $ReadOnly<{
 
 type Props = {
   initialConfig: InitialConfigType,
-  children: React$Node,
+  children: React.Node,
 };
 
-declare export function LexicalComposer(Props): React$MixedElement;
+declare export function LexicalComposer(Props): React.MixedElement;

--- a/packages/lexical-react/flow/LexicalContentEditable.js.flow
+++ b/packages/lexical-react/flow/LexicalContentEditable.js.flow
@@ -51,9 +51,9 @@ export type PlaceholderProps =
   | $ReadOnly<{
       'aria-placeholder': string,
       placeholder:
-        | ((isEditable: boolean) => null | React$Node)
+        | ((isEditable: boolean) => null | React.Node)
         | null
-        | React$Node,
+        | React.Node,
     }>;
 
 export type Props = $ReadOnly<{

--- a/packages/lexical-react/flow/LexicalDraggableBlockPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalDraggableBlockPlugin.js.flow
@@ -20,4 +20,4 @@ type Props = $ReadOnly<{
 	
 declare export function DraggableBlockPlugin_EXPERIMENTAL(
   props: Props,
-): React$MixedElement;
+): React.MixedElement;

--- a/packages/lexical-react/flow/LexicalErrorBoundary.js.flow
+++ b/packages/lexical-react/flow/LexicalErrorBoundary.js.flow
@@ -8,13 +8,13 @@
  */
 
 export type LexicalErrorBoundaryProps = $ReadOnly<{
-  children: React$Node,
+  children: React.Node,
   onError: (error: Error) => void,
 }>;
 
 declare export function LexicalErrorBoundary(
   props: LexicalErrorBoundaryProps,
-): React$Node;
+): React.Node;
 
 /** @deprecated use the named export {@link LexicalErrorBoundary} */
 export default typeof LexicalErrorBoundary;

--- a/packages/lexical-react/flow/LexicalHashtagPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalHashtagPlugin.js.flow
@@ -7,4 +7,4 @@
  * @flow strict
  */
 
-declare export function HashtagPlugin(): React$Node;
+declare export function HashtagPlugin(): React.Node;

--- a/packages/lexical-react/flow/LexicalHistoryPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalHistoryPlugin.js.flow
@@ -23,6 +23,6 @@ export type HistoryState = {
 
 declare export function HistoryPlugin({
   externalHistoryState?: HistoryState,
-}): React$Node;
+}): React.Node;
 
 declare export function createEmptyHistoryState(): HistoryState;

--- a/packages/lexical-react/flow/LexicalHorizontalRuleNode.js.flow
+++ b/packages/lexical-react/flow/LexicalHorizontalRuleNode.js.flow
@@ -11,13 +11,13 @@ import type {LexicalNode, LexicalCommand} from 'lexical';
 
 import {DecoratorNode} from 'lexical';
 
-declare export class HorizontalRuleNode extends DecoratorNode<React$Node> {
+declare export class HorizontalRuleNode extends DecoratorNode<React.Node> {
   static getType(): string;
   static clone(node: HorizontalRuleNode): HorizontalRuleNode;
   createDOM(): HTMLElement;
   getTextContent(): '\n';
   updateDOM(): false;
-  decorate(): React$Node;
+  decorate(): React.Node;
 }
 
 declare export function $createHorizontalRuleNode(): HorizontalRuleNode;

--- a/packages/lexical-react/flow/LexicalMarkdownShortcutPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalMarkdownShortcutPlugin.js.flow
@@ -13,4 +13,4 @@ declare export var DEFAULT_TRANSFORMERS: Array<Transformer>;
 
 declare export function MarkdownShortcutPlugin({
   transformers?: Array<Transformer>,
-}): React$Node;
+}): React.Node;

--- a/packages/lexical-react/flow/LexicalNestedComposer.js.flow
+++ b/packages/lexical-react/flow/LexicalNestedComposer.js.flow
@@ -15,8 +15,8 @@ import type {
 } from 'lexical';
 
 declare export function LexicalNestedComposer({
-  children: React$Node,
+  children: React.Node,
   initialEditor: LexicalEditor,
   initialTheme?: EditorThemeClasses,
   initialNodes?: $ReadOnlyArray<Class<LexicalNode> | LexicalNodeReplacement>,
-}): React$Node;
+}): React.Node;

--- a/packages/lexical-react/flow/LexicalPlainTextPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalPlainTextPlugin.js.flow
@@ -20,10 +20,10 @@ type InitialEditorStateType =
   | ((editor: LexicalEditor) => void);
 
 declare export function PlainTextPlugin({
-  contentEditable: React$Node,
+  contentEditable: React.Node,
   placeholder?:
-  | ((isEditable: boolean) => null | React$Node)
+  | ((isEditable: boolean) => null | React.Node)
   | null
-  | React$Node;
+  | React.Node;
   ErrorBoundary: LexicalErrorBoundary,
-}): React$Node;
+}): React.Node;

--- a/packages/lexical-react/flow/LexicalRichTextPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalRichTextPlugin.js.flow
@@ -20,10 +20,10 @@ type InitialEditorStateType =
   | ((editor: LexicalEditor) => void);
 
 declare export function RichTextPlugin({
-  contentEditable: React$Node,
+  contentEditable: React.Node,
   placeholder?:
-  | ((isEditable: boolean) => null | React$Node)
+  | ((isEditable: boolean) => null | React.Node)
   | null
-  | React$Node;
+  | React.Node;
   ErrorBoundary: LexicalErrorBoundary,
-}): React$Node;
+}): React.Node;

--- a/packages/lexical-react/flow/LexicalTableOfContentsPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalTableOfContentsPlugin.js.flow
@@ -14,5 +14,5 @@ declare export function TableOfContentsPlugin({
   children: (
     tableOfContents: Array<[NodeKey, string, HeadingTagType]>,
     editor: LexicalEditor,
-  ) => React$Node,
-}): React$Node;
+  ) => React.Node,
+}): React.Node;

--- a/packages/lexical-react/flow/LexicalTreeView.js.flow
+++ b/packages/lexical-react/flow/LexicalTreeView.js.flow
@@ -18,4 +18,4 @@ declare export function TreeView(props: {
   viewClassName: string,
   editor: LexicalEditor,
   customPrintNode?: CustomPrintNodeFn,
-}): React$Node;
+}): React.Node;


### PR DESCRIPTION
## Description

These types can be used without importing React since Flow v0.231.0. This PR replaces them with the non-dollar version, so that Flow can eventually remove these types.

## Test plan

flow