### PR TITLE
[lexical] Fix flow error: change this to any

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -421,7 +421,8 @@ declare export class LexicalNode {
   getTextContentSize(includeDirectionless?: boolean): number;
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement;
   updateDOM(
-    prevNode: this,
+    // $FlowFixMe[unclear-type]
+    prevNode: any,
     dom: HTMLElement,
     config: EditorConfig,
   ): boolean;


### PR DESCRIPTION
Seems that flow isnt able to compile `this` type as an input param type: see sample 
[error](https://flow.org/try/#1N4Igxg9gdgZglgcxALlAIwIZoKYBsD6uEEAztvhgE6UYCe+JADpdhgCYowa5kA0I2KAFcAtiRQAXSkOz9sADwxgJ+NPTbYuQ3BMnTZA+Y2yU4IwRO4A6SFBIrGVDGM7c+h46fNRLuKxJIGWh8MeT0ZfhYlCStpHzNsFBAMIQkIEQwJODAQfiEyfBE4eWw2fDgofDBMsAALfAA3KjgsXGxxZC4eAw0G-GhcWn9aY3wWZldu-g1mbGqJUoBaCRHEzrcDEgBrbAk62kXhXFxJ923d-cPRHEpTgyEoMDaqZdW7vKgoOfaSKgOKpqmDA+d4gB5fMA-P6LCCMLLQbiLOoYCqgh6-GDYRYIXYLSgkRZkCR4jpddwPfJLZjpOBkO4AX34kA0SQAOlB2U8MCQSAACAAyCmy3AAchANLzgOzebyhIw2JlsAARADyAFkABTSmW82YNMUaZC8iS1Wm8bUASkl2plLAkQkoUAA3Nr6ey3VBciAGiYSHBoEkGgAGKwAJgArAB2KwARhA9KAA)

This results in downstream errors such as this scenerio:
```
export class QuoteLineNode extends TextNode {

  updateDOM(
    prevNode: TextNode,
    dom: HTMLElement,
    config: EditorConfig,
  ): boolean {
    // errors here
    const shouldUpdate = super.updateDOM(prevNode, dom, config);
    return shouldUpdate;
  }
}
```

In this example, super is a TextNode, and prevNode, being this typed, should be a TextNode, but flow isnt able to determine that. The error:
```
Cannot call super.updateDOM with prevNode bound to prevNode because TextNode [1]
is incompatible with this [2]. [incompatible-call]
```

In this PR, changing this to any as a quick fix for the flow apis. Will look into adding stricter typing for each node's updateDom in future PRs, refer to https://github.com/facebook/lexical/pull/6894/files for possible places

I also tried changing the flow api to `updateDOM(prevNode: LexicalNode, ...` but that resulted in errors everywhere as flow isnt able to eg. tell that a ParagraphNode is a LexicalNode, strangely.