### PR TITLE
[lexical-list] Bug Fix: Prevent error when calling formatList when selection is at root

### DIFF
--- a/packages/lexical-list/src/__tests__/unit/formatList.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/formatList.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createTableCellNode,
+  $createTableNode,
+  $createTableRowNode,
+  TableCellNode,
+  TableNode,
+} from '@lexical/table';
+import {$getRoot} from 'lexical';
+import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+
+import {TableRowNode} from '../../../../lexical-table/LexicalTable';
+import {insertList} from '../../formatList';
+import {$isListNode} from '../../LexicalListNode';
+
+describe('insertList', () => {
+  initializeUnitTest((testEnv) => {
+    test('inserting with empty root selection', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        $getRoot().select();
+      });
+
+      insertList(editor, 'number');
+
+      editor.read(() => {
+        const root = $getRoot();
+
+        expect(root.getChildrenSize()).toBe(1);
+
+        const firstChild = root.getFirstChildOrThrow();
+
+        expect($isListNode(firstChild)).toBe(true);
+      });
+    });
+
+    test('inserting with empty shadow root selection', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const table = $createTableNode();
+        const row = $createTableRowNode();
+        const cell = $createTableCellNode();
+        $getRoot().append(table.append(row.append(cell)));
+        cell.select();
+      });
+
+      insertList(editor, 'number');
+
+      editor.read(() => {
+        const cell = $getRoot()
+          .getFirstChildOrThrow<TableNode>()
+          .getFirstChildOrThrow<TableRowNode>()
+          .getFirstChildOrThrow<TableCellNode>();
+
+        expect(cell.getChildrenSize()).toBe(1);
+
+        const firstChild = cell.getFirstChildOrThrow();
+
+        expect($isListNode(firstChild)).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/lexical-list/src/__tests__/unit/formatList.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/formatList.test.ts
@@ -17,7 +17,7 @@ import {
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 
-import {insertList} from '../../formatList';
+import {$insertList} from '../../formatList';
 import {$isListNode} from '../../LexicalListNode';
 
 describe('insertList', () => {
@@ -29,7 +29,9 @@ describe('insertList', () => {
         $getRoot().select();
       });
 
-      insertList(editor, 'number');
+      await editor.update(() => {
+        $insertList('number');
+      });
 
       editor.read(() => {
         const root = $getRoot();
@@ -52,7 +54,9 @@ describe('insertList', () => {
         );
       });
 
-      insertList(editor, 'number');
+      await editor.update(() => {
+        $insertList('number');
+      });
 
       editor.read(() => {
         const root = $getRoot();
@@ -76,7 +80,9 @@ describe('insertList', () => {
         cell.select();
       });
 
-      insertList(editor, 'number');
+      await editor.update(() => {
+        $insertList('number');
+      });
 
       editor.read(() => {
         const cell = $getRoot()

--- a/packages/lexical-list/src/__tests__/unit/formatList.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/formatList.test.ts
@@ -14,7 +14,7 @@ import {
   TableNode,
   TableRowNode,
 } from '@lexical/table';
-import {$getRoot} from 'lexical';
+import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 
 import {insertList} from '../../formatList';
@@ -27,6 +27,29 @@ describe('insertList', () => {
 
       await editor.update(() => {
         $getRoot().select();
+      });
+
+      insertList(editor, 'number');
+
+      editor.read(() => {
+        const root = $getRoot();
+
+        expect(root.getChildrenSize()).toBe(1);
+
+        const firstChild = root.getFirstChildOrThrow();
+
+        expect($isListNode(firstChild)).toBe(true);
+      });
+    });
+
+    test('inserting in root selection with existing child', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        $getRoot().select();
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('hello')),
+        );
       });
 
       insertList(editor, 'number');

--- a/packages/lexical-list/src/__tests__/unit/formatList.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/formatList.test.ts
@@ -12,11 +12,11 @@ import {
   $createTableRowNode,
   TableCellNode,
   TableNode,
+  TableRowNode,
 } from '@lexical/table';
 import {$getRoot} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 
-import {TableRowNode} from '../../../../lexical-table/LexicalTable';
 import {insertList} from '../../formatList';
 import {$isListNode} from '../../LexicalListNode';
 

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -83,9 +83,7 @@ export function $insertList(listType: ListType): void {
           anchorNode.append(paragraph);
           nodes = paragraph.select().getNodes();
         }
-      }
-
-      if ($isSelectingEmptyListItem(anchorNode, nodes)) {
+      } else if ($isSelectingEmptyListItem(anchorNode, nodes)) {
         const list = $createListNode(listType);
 
         if ($isRootOrShadowRoot(anchorNodeParent)) {

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -9,11 +9,13 @@
 import {$getNearestNodeOfType} from '@lexical/utils';
 import {
   $createParagraphNode,
+  $getRoot,
   $getSelection,
   $isElementNode,
   $isLeafNode,
   $isRangeSelection,
   $isRootOrShadowRoot,
+  $setSelection,
   ElementNode,
   LexicalNode,
   NodeKey,
@@ -73,6 +75,20 @@ export function $insertList(listType: ListType): void {
       const [anchor] = anchorAndFocus;
       const anchorNode = anchor.getNode();
       const anchorNodeParent = anchorNode.getParent();
+
+      if (anchor.key === 'root') {
+        const root = $getRoot();
+        const firstChild = root.getFirstChild();
+        if (firstChild) {
+          $setSelection(firstChild.selectStart());
+        } else {
+          const paragraph = $createParagraphNode();
+          root.append(paragraph);
+          $setSelection(paragraph.select());
+        }
+        insertList(editor, listType);
+        return;
+      }
 
       if ($isSelectingEmptyListItem(anchorNode, nodes)) {
         const list = $createListNode(listType);

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -9,13 +9,11 @@
 import {$getNearestNodeOfType} from '@lexical/utils';
 import {
   $createParagraphNode,
-  $getRoot,
   $getSelection,
   $isElementNode,
   $isLeafNode,
   $isRangeSelection,
   $isRootOrShadowRoot,
-  $setSelection,
   ElementNode,
   LexicalNode,
   NodeKey,
@@ -65,7 +63,7 @@ export function $insertList(listType: ListType): void {
   const selection = $getSelection();
 
   if (selection !== null) {
-    const nodes = selection.getNodes();
+    let nodes = selection.getNodes();
     if ($isRangeSelection(selection)) {
       const anchorAndFocus = selection.getStartEndPoints();
       invariant(
@@ -76,18 +74,15 @@ export function $insertList(listType: ListType): void {
       const anchorNode = anchor.getNode();
       const anchorNodeParent = anchorNode.getParent();
 
-      if (anchor.key === 'root') {
-        const root = $getRoot();
-        const firstChild = root.getFirstChild();
+      if ($isRootOrShadowRoot(anchorNode)) {
+        const firstChild = anchorNode.getFirstChild();
         if (firstChild) {
-          $setSelection(firstChild.selectStart());
+          nodes = firstChild.selectStart().getNodes();
         } else {
           const paragraph = $createParagraphNode();
-          root.append(paragraph);
-          $setSelection(paragraph.select());
+          anchorNode.append(paragraph);
+          nodes = paragraph.select().getNodes();
         }
-        insertList(editor, listType);
-        return;
       }
 
       if ($isSelectingEmptyListItem(anchorNode, nodes)) {


### PR DESCRIPTION
## Description

Currently, if the selection is at the root and you toggle one of the list options, it throws an error `Error: replace: cannot be called on root nodes`.

This PR fixes this by selecting the first child of the root if available, or creating a new paragraph, appending and selecting it before re-running the `insertList` function.

### Before

https://github.com/user-attachments/assets/af17623e-5240-4552-91f3-cb01222fe703

### After

https://github.com/user-attachments/assets/23e87498-03bd-45bc-a999-a61849854737
