### PR TITLE
[lexical-playground] Refactor: switch headings test file names

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Headings/HeadingsEnterAtEnd.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Headings/HeadingsEnterAtEnd.spec.mjs
@@ -7,11 +7,6 @@
  */
 
 import {
-  moveRight,
-  moveToEditorBeginning,
-  STANDARD_KEYPRESS_DELAY_MS,
-} from '../../keyboardShortcuts/index.mjs';
-import {
   assertHTML,
   click,
   focusEditor,
@@ -20,10 +15,10 @@ import {
   test,
 } from '../../utils/index.mjs';
 
-test(`Headings - stays as a heading when you press enter in the middle of a heading`, async ({
+test('Headings - changes to a paragraph when you press enter at the end of a heading', async ({
   page,
-  isCollab,
   isPlainText,
+  isCollab,
 }) => {
   test.skip(isPlainText);
   await initialize({isCollab, page});
@@ -45,10 +40,6 @@ test(`Headings - stays as a heading when you press enter in the middle of a head
     `,
   );
 
-  await moveToEditorBeginning(page);
-
-  await moveRight(page, 5, STANDARD_KEYPRESS_DELAY_MS);
-
   await page.keyboard.press('Enter');
 
   await assertHTML(
@@ -57,13 +48,9 @@ test(`Headings - stays as a heading when you press enter in the middle of a head
       <h1
         class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
         dir="ltr">
-        <span data-lexical-text="true">Welco</span>
+        <span data-lexical-text="true">Welcome to the playground</span>
       </h1>
-      <h1
-        class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
-        dir="ltr">
-        <span data-lexical-text="true">me to the playground</span>
-      </h1>
+      <p class="PlaygroundEditorTheme__paragraph"><br /></p>
     `,
   );
 });

--- a/packages/lexical-playground/__tests__/e2e/Headings/HeadingsEnterInMiddle.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Headings/HeadingsEnterInMiddle.spec.mjs
@@ -7,6 +7,11 @@
  */
 
 import {
+  moveRight,
+  moveToEditorBeginning,
+  STANDARD_KEYPRESS_DELAY_MS,
+} from '../../keyboardShortcuts/index.mjs';
+import {
   assertHTML,
   click,
   focusEditor,
@@ -15,10 +20,10 @@ import {
   test,
 } from '../../utils/index.mjs';
 
-test('Headings - changes to a paragraph when you press enter at the end of a heading', async ({
+test(`Headings - stays as a heading when you press enter in the middle of a heading`, async ({
   page,
-  isPlainText,
   isCollab,
+  isPlainText,
 }) => {
   test.skip(isPlainText);
   await initialize({isCollab, page});
@@ -40,6 +45,10 @@ test('Headings - changes to a paragraph when you press enter at the end of a hea
     `,
   );
 
+  await moveToEditorBeginning(page);
+
+  await moveRight(page, 5, STANDARD_KEYPRESS_DELAY_MS);
+
   await page.keyboard.press('Enter');
 
   await assertHTML(
@@ -48,9 +57,13 @@ test('Headings - changes to a paragraph when you press enter at the end of a hea
       <h1
         class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
         dir="ltr">
-        <span data-lexical-text="true">Welcome to the playground</span>
+        <span data-lexical-text="true">Welco</span>
       </h1>
-      <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      <h1
+        class="PlaygroundEditorTheme__h1 PlaygroundEditorTheme__ltr"
+        dir="ltr">
+        <span data-lexical-text="true">me to the playground</span>
+      </h1>
     `,
   );
 });


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

`HeadingsEnterAtEnd.spec.mjs` was called `HeadingsEnterInMiddle.spec.mjs` and `HeadingsEnterInMiddle.spec.mjs` was called `HeadingsEnterAtEnd.spec.mjs`. Now the file names have been switched.

The file contents have not been touched, their names have just been switched. I did consider if I should pick a new name for one of the files since this would have produced a cleaner diff. Let me know if you would prefer this instead.



<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
