### PR TITLE
[lexical-mark] Bug Fix: reverse ternary in MarkNode.addID

### DIFF
--- a/packages/lexical-mark/src/MarkNode.ts
+++ b/packages/lexical-mark/src/MarkNode.ts
@@ -117,7 +117,7 @@ export class MarkNode extends ElementNode {
 
   addID(id: string): this {
     const self = this.getWritable();
-    return self.__ids.includes(id) ? self.setIDs([...self.__ids, id]) : self;
+    return self.__ids.includes(id) ? self : self.setIDs([...self.__ids, id]);
   }
 
   deleteID(id: string): this {


### PR DESCRIPTION
## Description

Ternary logic introduced in https://github.com/facebook/lexical/commit/7c21d4ff39a6ede7dcbe061af17ec11b0ed48b2c#diff-b30867251dac89bfc41aba98899f9ca7e6b1045cc8bcfbcc9e9824caaf53d695R112-R122 is the wrong way around. Trying to add a new ID is a no-op, and adding an existing ID duplicates it.

## Test plan

I have the following test code to replace IDs:

```
console.dir(oldIdToNewId);
console.dir(node.getIDs());

const newId = oldIdToNewId[id];
node.addID(newId);
node.deleteID(id);

console.log('replaced %s with %s', id, newId);
console.dir(node.getIDs());
```

Which produces the following on 0.23.0:

```
{
  'e338a2b4-3a70-4a73-9871-6b61f2ed8caa': '57404623-3ae5-5cfa-812f-762e507a69ae'
}
[ 'e338a2b4-3a70-4a73-9871-6b61f2ed8caa' ]
replaced e338a2b4-3a70-4a73-9871-6b61f2ed8caa with 57404623-3ae5-5cfa-812f-762e507a69ae
[]
```

That last line should be `[ '57404623-3ae5-5cfa-812f-762e507a69ae' ]`. To further confirm, I changed the code to just call `node.addID(id)` (i.e. the old ID), which then prints:

```
[
  'e338a2b4-3a70-4a73-9871-6b61f2ed8caa',
  'e338a2b4-3a70-4a73-9871-6b61f2ed8caa'
]
```
