### PR TITLE
[lexical] temporarily set editor to not writable when calling getCachedTypeToNodeMap

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -909,9 +909,15 @@ export class LexicalEditor {
     klass: Klass<LexicalNode>,
   ): void {
     const prevEditorState = this._editorState;
+    const originalIsEditable = this.isEditable();
+    // Temporarily freeze the editor before calling getCachedTypeToNodeMap
+    if (originalIsEditable) {
+      this.setEditable(false);
+    }
     const nodeMap = getCachedTypeToNodeMap(prevEditorState).get(
       klass.getType(),
     );
+    this.setEditable(originalIsEditable);
     if (!nodeMap) {
       return;
     }

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -534,6 +534,7 @@ export function markNodesWithTypesAsDirty(
   // We only need to mark nodes dirty if they were in the previous state.
   // If they aren't, then they are by definition dirty already.
   const cachedMap = getCachedTypeToNodeMap(editor.getEditorState());
+  editor.setEditable(originalIsEditable);
   const dirtyNodeMaps: NodeMap[] = [];
   for (const type of types) {
     const nodeMap = cachedMap.get(type);
@@ -565,7 +566,6 @@ export function markNodesWithTypesAsDirty(
         }
       : undefined,
   );
-  editor.setEditable(originalIsEditable);
 }
 
 export function $getRoot(): RootNode {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1892,6 +1892,10 @@ export function getCachedTypeToNodeMap(
   if (!editorState._readOnly && editorState.isEmpty()) {
     return EMPTY_TYPE_TO_NODE_MAP;
   }
+  invariant(
+    editorState._readOnly,
+    'getCachedTypeToNodeMap called with a writable EditorState',
+  );
   let typeToNodeMap = cachedNodeMaps.get(editorState);
   if (!typeToNodeMap) {
     typeToNodeMap = computeTypeToNodeMap(editorState);


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

Closes #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*