### PR TITLE
[Breaking Change][lexical] Bug Fix: Commit updates on editor.setRootElement(null)

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1096,11 +1096,15 @@ export class LexicalEditor {
           }
         }
       } else {
-        // If content editable is unmounted we'll reset editor state back to original
-        // (or pending) editor state since there will be no reconciliation
-        this._editorState = pendingEditorState;
-        this._pendingEditorState = null;
+        // When the content editable is unmounted we will still trigger a
+        // reconciliation so that any pending updates are flushed,
+        // to match the previous state change when
+        // `_editorState = pendingEditorState` was used, but by
+        // using a commit we preserve the readOnly invariant
+        // for editor.getEditorState().
         this._window = null;
+        this._updateTags.add('history-merge');
+        $commitPendingUpdates(this);
       }
 
       triggerListeners('root', this, false, nextRootElement, prevRootElement);

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1017,7 +1017,7 @@ describe('LexicalEditor tests', () => {
     });
 
     expect(rootListener).toHaveBeenCalledTimes(3);
-    expect(updateListener).toHaveBeenCalledTimes(3);
+    expect(updateListener).toHaveBeenCalledTimes(4);
     expect(container.innerHTML).toBe(
       '<span contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="ltr"><span data-lexical-text="true">Change successful</span></p></span>',
     );
@@ -1032,7 +1032,13 @@ describe('LexicalEditor tests', () => {
       init();
       const contentEditable = editor.getRootElement();
       editor.setEditable(editable);
+      editor.update(() => {
+        // Cause the editor to become dirty, so we can ensure
+        // that the getEditorState()._readOnly invariant holds
+        $getRoot().markDirty();
+      });
       editor.setRootElement(null);
+      expect(editor.getEditorState()._readOnly).toBe(true);
       const editorState = editor.parseEditorState(JSON_EDITOR_STATE);
       editor.setEditorState(editorState);
       editor.update(() => {


### PR DESCRIPTION
## Description

`setRootElement(null)` now triggers the same sort of reconciliation with a `history-merge` tag that `setRootElement(element)` triggered.

Previously, when `setRootElement(null)` was called with any pending updates, it would put the editor in a situation where `editor.getEditorState()` would return a writable EditorState. Now the invariant is preserved such that `editor.getEditorState()` always returns a fully reconciled and read-only EditorState, but to match previous semantics such that the current editorState would synchronously get set from the pendingEditorState, `setRootElement` now always causes a commit when the root element changes instead of just when it changes to a non-null element.

I think there were likely other subtle bugs due to the previous behavior, since setting _editorState directly from _pendingEditorState also won't run transforms, but it would only be possible to notice if you were inspecting this state while still "headless" since a full reconcile would be performed once a new root element is attached.

Closes #7022

## Upgrade Information

This change means that a reconciliation will happen on `setRootElement(null)`. Previously, this call would set the pending editor state to the current editor state which means that update listeners, transforms, etc. would not run in this particular scenario. Now they do.

This should not have any effect on normal code, but it is a breaking change because it can trigger test failures if you are counting the number of times that an update listener is called, or doing something similar to that.

## Test plan

### Before

If `setRootElement(null)` was called with any pending updates, it would put the editor in a situation where `editor.getEditorState()` would return a writable EditorState. Now the invariant is preserved such that `editor.getEditorState()` always returns a fully reconciled and read-only EditorState, but to match previous semantics setRootElement now always causes a commit when the root element changes.

The problems due to this invariant being violated surfaced after #6894 was released

### After

Unit test coverage for this readOnly scenario.