### PR TITLE
[lexical] Fix TabNode deserialization regression 

### DIFF
--- a/packages/lexical/src/nodes/LexicalTabNode.ts
+++ b/packages/lexical/src/nodes/LexicalTabNode.ts
@@ -71,7 +71,7 @@ export class TabNode extends TextNode {
   }
 
   setMode(type: TextModeType): this {
-    invariant(type !== 'normal', 'TabNode does not support setMode');
+    invariant(type === 'normal', 'TabNode does not support setMode');
     return this;
   }
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
@@ -23,6 +23,7 @@ import {
   $insertNodes,
   $isElementNode,
   $isRangeSelection,
+  $isTabNode,
   $isTextNode,
   $setSelection,
   KEY_TAB_COMMAND,
@@ -252,6 +253,31 @@ describe('LexicalTabNode tests', () => {
       expect(testEnv.innerHTML).toBe(
         '<p dir="ltr"><span data-lexical-text="true">\t</span><span data-lexical-text="true">f</span><span data-lexical-text="true">\t</span></p>',
       );
+    });
+
+    test('can be serialized and deserialized', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        $getRoot()
+          .clear()
+          .append($createParagraphNode().append($createTabNode()));
+        const textNodes = $getRoot().getAllTextNodes();
+        expect(textNodes).toHaveLength(1);
+        expect($isTabNode(textNodes[0])).toBe(true);
+      });
+      const json = editor.getEditorState().toJSON();
+      await editor.update(() => {
+        $getRoot().clear().append($createParagraphNode());
+      });
+      editor.read(() => {
+        expect($getRoot().getAllTextNodes()).toHaveLength(0);
+      });
+      await editor.setEditorState(editor.parseEditorState(json));
+      editor.read(() => {
+        const textNodes = $getRoot().getAllTextNodes();
+        expect(textNodes).toHaveLength(1);
+        expect($isTabNode(textNodes[0])).toBe(true);
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes TabNode serialization regression in the https://github.com/facebook/lexical/pull/6970 refactor. The invariant condition was inverted.

Closes #7030

## Test plan

### Before

No test coverage of TabNode serialization, so this failure went undetected.

### After

Fixed invariant and added test coverage