### PR TITLE
[lexical] Fix whitespace stripping issue in textDOMNode conversion

### DIFF
--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -1197,7 +1197,10 @@ function $convertTextDOMNode(domNode: Node): DOMConversionOutput {
     }
     return {node: nodes};
   }
-  textContent = textContent.replace(/\r/g, '').replace(/[ \t\n]+/g, ' ');
+  textContent = textContent
+    .replace(/\r/g, '')
+    .replace(/[\t\n]+/g, ' ')
+    .replace(/[ ]/g, ' ');
   if (textContent === '') {
     return {node: null};
   }


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
The existing logic:
```textContent = textContent.replace(/\r/g, '').replace(/[ \t\n]+/g, ' ');```
will replace multiple whitespaces with a single whitespace, which will mess up the format of texts.

We have seen issues when people convert html to text node using lexical-html, especially for codes.

## Test plan

### Before

https://github.com/user-attachments/assets/88d71b94-9ca9-46c1-8340-0180c6948db7

### After

https://github.com/user-attachments/assets/defdd0c4-9912-4aeb-b323-2d32cccc1958
