### PR TITLE
[lexical-table] Support table alignment

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -196,6 +196,13 @@
   /* Remove the table's margin and put it on the wrapper */
   margin: 0;
 }
+.PlaygroundEditorTheme__tableAlignmentCenter {
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+.PlaygroundEditorTheme__tableAlignmentRight {
+  margin-left: auto !important;
+}
 .PlaygroundEditorTheme__table {
   border-collapse: collapse;
   border-spacing: 0;

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -193,8 +193,9 @@
   margin: 0px 25px 30px 0px;
 }
 .PlaygroundEditorTheme__tableScrollableWrapper > .PlaygroundEditorTheme__table {
-  /* Remove the table's margin and put it on the wrapper */
-  margin: 0;
+  /* Remove the table's vertical margin and put it on the wrapper */
+  margin-top: 0;
+  margin-bottom: 0;
 }
 .PlaygroundEditorTheme__tableAlignmentCenter {
   margin-left: auto !important;

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -198,11 +198,11 @@
   margin-bottom: 0;
 }
 .PlaygroundEditorTheme__tableAlignmentCenter {
-  margin-left: auto !important;
-  margin-right: auto !important;
+  margin-left: auto;
+  margin-right: auto;
 }
 .PlaygroundEditorTheme__tableAlignmentRight {
-  margin-left: auto !important;
+  margin-left: auto;
 }
 .PlaygroundEditorTheme__table {
   border-collapse: collapse;
@@ -211,7 +211,8 @@
   overflow-x: scroll;
   table-layout: fixed;
   width: fit-content;
-  margin: 0px 25px 30px 0px;
+  margin-top: 25px;
+  margin-bottom: 30px;
 }
 .PlaygroundEditorTheme__tableRowStriping tr:nth-child(even) {
   background-color: #f2f5fb;

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.ts
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.ts
@@ -93,6 +93,10 @@ const theme: EditorThemeClasses = {
   specialText: 'PlaygroundEditorTheme__specialText',
   tab: 'PlaygroundEditorTheme__tabNode',
   table: 'PlaygroundEditorTheme__table',
+  tableAlignment: {
+    center: 'PlaygroundEditorTheme__tableAlignmentCenter',
+    right: 'PlaygroundEditorTheme__tableAlignmentRight',
+  },
   tableCell: 'PlaygroundEditorTheme__tableCell',
   tableCellActionButton: 'PlaygroundEditorTheme__tableCellActionButton',
   tableCellActionButtonContainer:

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -93,22 +93,17 @@ function alignTableElement(
   config: EditorConfig,
   formatType: ElementFormatType,
 ): void {
-  if (!dom) {
-    return;
+  const removeClasses: string[] = [];
+  const addClasses: string[] = [];
+  for (const format of ['center', 'right'] as const) {
+    const classes = config.theme.tableAlignment[format];
+    if (!classes) {
+      continue;
+    }
+    (format === formatType ? addClasses : removeClasses).push(classes);
   }
-  if (formatType === 'center') {
-    addClassNamesToElement(dom, config.theme.tableAlignment.center);
-  } else if (formatType === 'right') {
-    addClassNamesToElement(dom, config.theme.tableAlignment.right);
-  } else {
-    removeClassNamesFromElement(
-      dom,
-      ...[
-        config.theme.tableAlignment.center,
-        config.theme.tableAlignment.right,
-      ],
-    );
-  }
+  removeClassNamesFromElement(dom, ...removeClasses);
+  addClassNamesToElement(dom, ...addClasses);
 }
 
 const scrollableEditors = new WeakSet<LexicalEditor>();
@@ -235,9 +230,7 @@ export class TableNode extends ElementNode {
     setDOMUnmanaged(colGroup);
 
     addClassNamesToElement(tableElement, config.theme.table);
-    if (this.__format) {
-      alignTableElement(tableElement, config, this.getFormatType());
-    }
+    alignTableElement(tableElement, config, this.getFormatType());
     if (this.__rowStriping) {
       setRowStriping(tableElement, config, true);
     }
@@ -261,7 +254,12 @@ export class TableNode extends ElementNode {
       setRowStriping(dom, config, this.__rowStriping);
     }
     updateColgroup(dom, config, this.getColumnCount(), this.getColWidths());
-    return prevNode.__format !== this.__format;
+    alignTableElement(
+      this.getDOMSlot(dom).element,
+      config,
+      this.getFormatType(),
+    );
+    return false;
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -22,6 +22,7 @@ import {
   DOMExportOutput,
   EditorConfig,
   ElementDOMSlot,
+  type ElementFormatType,
   ElementNode,
   LexicalEditor,
   LexicalNode,
@@ -77,13 +78,27 @@ function setRowStriping(
   dom: HTMLElement,
   config: EditorConfig,
   rowStriping: boolean,
-) {
+): void {
   if (rowStriping) {
     addClassNamesToElement(dom, config.theme.tableRowStriping);
     dom.setAttribute('data-lexical-row-striping', 'true');
   } else {
     removeClassNamesFromElement(dom, config.theme.tableRowStriping);
     dom.removeAttribute('data-lexical-row-striping');
+  }
+}
+
+function alignTableElement(
+  dom: HTMLElement,
+  formatType: ElementFormatType,
+): void {
+  if (formatType === 'center') {
+    dom.style.marginLeft = 'auto';
+    dom.style.marginRight = 'auto';
+  } else if (formatType === 'right') {
+    dom.style.marginLeft = 'auto';
+  } else {
+    dom.style.marginLeft = '';
   }
 }
 
@@ -211,6 +226,9 @@ export class TableNode extends ElementNode {
     setDOMUnmanaged(colGroup);
 
     addClassNamesToElement(tableElement, config.theme.table);
+    if (this.__format) {
+      alignTableElement(tableElement, this.getFormatType());
+    }
     if (this.__rowStriping) {
       setRowStriping(tableElement, config, true);
     }
@@ -234,7 +252,7 @@ export class TableNode extends ElementNode {
       setRowStriping(dom, config, this.__rowStriping);
     }
     updateColgroup(dom, config, this.getColumnCount(), this.getColWidths());
-    return false;
+    return prevNode.__format !== this.__format;
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -93,6 +93,9 @@ function alignTableElement(
   config: EditorConfig,
   formatType: ElementFormatType,
 ): void {
+  if (!config.theme.tableAlignment) {
+    return;
+  }
   const removeClasses: string[] = [];
   const addClasses: string[] = [];
   for (const format of ['center', 'right'] as const) {

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -90,18 +90,24 @@ function setRowStriping(
 
 function alignTableElement(
   dom: HTMLElement,
+  config: EditorConfig,
   formatType: ElementFormatType,
 ): void {
   if (!dom) {
     return;
   }
   if (formatType === 'center') {
-    dom.style.marginLeft = 'auto';
-    dom.style.marginRight = 'auto';
+    addClassNamesToElement(dom, config.theme.tableAlignment.center);
   } else if (formatType === 'right') {
-    dom.style.marginLeft = 'auto';
+    addClassNamesToElement(dom, config.theme.tableAlignment.right);
   } else {
-    dom.style.marginLeft = '';
+    removeClassNamesFromElement(
+      dom,
+      ...[
+        config.theme.tableAlignment.center,
+        config.theme.tableAlignment.right,
+      ],
+    );
   }
 }
 
@@ -230,7 +236,7 @@ export class TableNode extends ElementNode {
 
     addClassNamesToElement(tableElement, config.theme.table);
     if (this.__format) {
-      alignTableElement(tableElement, this.getFormatType());
+      alignTableElement(tableElement, config, this.getFormatType());
     }
     if (this.__rowStriping) {
       setRowStriping(tableElement, config, true);
@@ -268,6 +274,7 @@ export class TableNode extends ElementNode {
           if (this.__format) {
             alignTableElement(
               tableElement as HTMLElement,
+              editor._config,
               this.getFormatType(),
             );
           }

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -89,7 +89,7 @@ function setRowStriping(
 }
 
 function alignTableElement(
-  dom: HTMLElement | Text | null | undefined,
+  dom: HTMLElement,
   formatType: ElementFormatType,
 ): void {
   if (!dom) {
@@ -266,7 +266,10 @@ export class TableNode extends ElementNode {
         if (superExport.after) {
           tableElement = superExport.after(tableElement);
           if (this.__format) {
-            alignTableElement(tableElement, this.getFormatType());
+            alignTableElement(
+              tableElement as HTMLElement,
+              this.getFormatType(),
+            );
           }
         }
         if (isHTMLElement(tableElement) && tableElement.nodeName !== 'TABLE') {

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -89,9 +89,12 @@ function setRowStriping(
 }
 
 function alignTableElement(
-  dom: HTMLElement,
+  dom: HTMLElement | Text | null | undefined,
   formatType: ElementFormatType,
 ): void {
+  if (!dom) {
+    return;
+  }
   if (formatType === 'center') {
     dom.style.marginLeft = 'auto';
     dom.style.marginRight = 'auto';
@@ -262,6 +265,9 @@ export class TableNode extends ElementNode {
       after: (tableElement) => {
         if (superExport.after) {
           tableElement = superExport.after(tableElement);
+          if (this.__format) {
+            alignTableElement(tableElement, this.getFormatType());
+          }
         }
         if (isHTMLElement(tableElement) && tableElement.nodeName !== 'TABLE') {
           tableElement = tableElement.querySelector('table');

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -82,7 +82,7 @@ import {
   TableNode,
 } from './LexicalTableNode';
 import {TableDOMTable, TableObserver} from './LexicalTableObserver';
-import {$isTableRowNode} from './LexicalTableRowNode';
+import {$isTableRowNode, type TableRowNode} from './LexicalTableRowNode';
 import {$isTableSelection} from './LexicalTableSelection';
 import {
   $computeTableCellRectBoundary,
@@ -561,6 +561,12 @@ export function applyTableHandlers(
         const focusNode = selection.focus.getNode();
         if (!$isTableCellNode(anchorNode) || !$isTableCellNode(focusNode)) {
           return false;
+        }
+
+        // Align table if exact full table selection
+        if ($isFullTableSelection(selection, tableNode)) {
+          tableNode.setFormat(formatType);
+          return true;
         }
 
         const [tableMap, anchorCell, focusCell] = $computeTableMap(
@@ -1577,6 +1583,31 @@ function $isSelectionInTable(
     return isAnchorInside && isFocusInside;
   }
 
+  return false;
+}
+
+function $isFullTableSelection(
+  selection: null | BaseSelection,
+  tableNode: TableNode,
+): boolean {
+  if ($isTableSelection(selection)) {
+    const anchorNode = selection.anchor.getNode();
+    const focusNode = selection.focus.getNode();
+    if (tableNode && anchorNode && focusNode) {
+      const firstRow = tableNode.getFirstChild<TableRowNode>();
+      const lastRow = tableNode.getLastChild<TableRowNode>();
+      if (firstRow && lastRow) {
+        const firstCell = firstRow.getFirstChild<TableCellNode>();
+        const lastCell = lastRow.getLastChild<TableCellNode>();
+        if (firstCell && lastCell) {
+          return (
+            anchorNode.getKey() === firstCell.getKey() &&
+            focusNode.getKey() === lastCell.getKey()
+          );
+        }
+      }
+    }
+  }
   return false;
 }
 

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -563,7 +563,7 @@ export function applyTableHandlers(
           return false;
         }
 
-        // Align table if exact full table selection
+        // Align the table if the entire table is selected
         if ($isFullTableSelection(selection, tableNode)) {
           tableNode.setFormat(formatType);
           return true;

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -82,7 +82,7 @@ import {
   TableNode,
 } from './LexicalTableNode';
 import {TableDOMTable, TableObserver} from './LexicalTableObserver';
-import {$isTableRowNode, type TableRowNode} from './LexicalTableRowNode';
+import {$isTableRowNode} from './LexicalTableRowNode';
 import {$isTableSelection} from './LexicalTableSelection';
 import {
   $computeTableCellRectBoundary,
@@ -1591,21 +1591,14 @@ function $isFullTableSelection(
   tableNode: TableNode,
 ): boolean {
   if ($isTableSelection(selection)) {
-    const anchorNode = selection.anchor.getNode();
-    const focusNode = selection.focus.getNode();
+    const anchorNode = selection.anchor.getNode() as TableCellNode;
+    const focusNode = selection.focus.getNode() as TableCellNode;
     if (tableNode && anchorNode && focusNode) {
-      const firstRow = tableNode.getFirstChild<TableRowNode>();
-      const lastRow = tableNode.getLastChild<TableRowNode>();
-      if (firstRow && lastRow) {
-        const firstCell = firstRow.getFirstChild<TableCellNode>();
-        const lastCell = lastRow.getLastChild<TableCellNode>();
-        if (firstCell && lastCell) {
-          return (
-            anchorNode.getKey() === firstCell.getKey() &&
-            focusNode.getKey() === lastCell.getKey()
-          );
-        }
-      }
+      const [map] = $computeTableMap(tableNode, anchorNode, focusNode);
+      return (
+        anchorNode.getKey() === map[0][0].cell.getKey() &&
+        focusNode.getKey() === map[map.length - 1].at(-1)!.cell.getKey()
+      );
     }
   }
   return false;

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -1064,8 +1064,7 @@ describe('LexicalTableNode tests', () => {
                 html`
                   <table
                     class="${editorConfig.theme.table}"
-                    style="margin-left: auto; margin-right: auto;"
-                    data-lexical-row-striping="true">
+                    style="margin-left: auto; margin-right: auto">
                     <colgroup>
                       <col />
                       <col />

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -73,6 +73,10 @@ const editorConfig = Object.freeze({
   namespace: '',
   theme: {
     table: 'test-table-class',
+    tableAlignment: {
+      center: 'test-table-alignment-center',
+      right: 'test-table-alignment-right',
+    },
     tableRowStriping: 'test-table-row-striping-class',
     tableScrollableWrapper: 'table-scrollable-wrapper',
   },
@@ -1063,8 +1067,8 @@ describe('LexicalTableNode tests', () => {
                 table!.createDOM(editorConfig).outerHTML,
                 html`
                   <table
-                    class="${editorConfig.theme.table}"
-                    style="margin-left: auto; margin-right: auto">
+                    class="${editorConfig.theme.table} ${editorConfig.theme
+                      .tableAlignment.center}">
                     <colgroup>
                       <col />
                       <col />

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -1040,6 +1040,70 @@ describe('LexicalTableNode tests', () => {
             });
           });
 
+          test('Change Table-level alignment', async () => {
+            const {editor} = testEnv;
+
+            await editor.update(() => {
+              const root = $getRoot();
+              const table = $createTableNodeWithDimensions(4, 4, true);
+              root.append(table);
+            });
+            await editor.update(() => {
+              const root = $getRoot();
+              const table = root.getLastChild<TableNode>();
+              if (table) {
+                table.setFormat('center');
+              }
+            });
+
+            await editor.update(() => {
+              const root = $getRoot();
+              const table = root.getLastChild<TableNode>();
+              expectTableHtmlToBeEqual(
+                table!.createDOM(editorConfig).outerHTML,
+                html`
+                  <table
+                    class="${editorConfig.theme.table}"
+                    style="margin-left: auto; margin-right: auto;"
+                    data-lexical-row-striping="true">
+                    <colgroup>
+                      <col />
+                      <col />
+                      <col />
+                      <col />
+                    </colgroup>
+                  </table>
+                `,
+              );
+            });
+
+            await editor.update(() => {
+              const root = $getRoot();
+              const table = root.getLastChild<TableNode>();
+              if (table) {
+                table.setFormat('left');
+              }
+            });
+
+            await editor.update(() => {
+              const root = $getRoot();
+              const table = root.getLastChild<TableNode>();
+              expectTableHtmlToBeEqual(
+                table!.createDOM(editorConfig).outerHTML,
+                html`
+                  <table class="${editorConfig.theme.table}">
+                    <colgroup>
+                      <col />
+                      <col />
+                      <col />
+                      <col />
+                    </colgroup>
+                  </table>
+                `,
+              );
+            });
+          });
+
           test('Update column widths', async () => {
             const {editor} = testEnv;
 

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -103,6 +103,10 @@ describe('LexicalEditor tests', () => {
           nodes: nodes ?? [],
           onError: onError || jest.fn(),
           theme: {
+            tableAlignment: {
+              center: 'editor-table-alignment-center',
+              right: 'editor-table-alignment-right',
+            },
             text: {
               bold: 'editor-text-bold',
               italic: 'editor-text-italic',


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/6909

To differentiate between table alignment and cell text alignment, the table-level alignment logic only kicks in when the selection is the whole exact table. This does introduce the extra step if one wants to align all cell texts to do it in 2 steps, all columns except one and then the last column.

Before:

https://github.com/user-attachments/assets/d1851ec3-6844-4bb7-89f9-02bdf1000abf

After:

https://github.com/user-attachments/assets/30265b64-66c0-4b70-85d2-988f8eb7cb83
