### PR TITLE
[Breaking Change][*] Chore: Use terser for optimizing cjs prod build

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -9,7 +9,74 @@ jobs:
     env:
       CI_JOB_NUMBER: 1
     steps:
+      # See also:
+      # https://github.com/facebook/lexical/issues/6852
+      # https://github.com/NixOS/nixpkgs/blob/c8db8bd9656ee3d373ce9445063c25c47f442118/.github/workflows/check-by-name.yml#L31-L92
+      # https://github.com/getsentry/sentry/issues/22432
+      # https://github.com/getsentry/sentry/pull/22344
+      # This step has to be in this file,
+      # because it's needed to determine which revision of the repository to fetch,
+      # and we can only use other files from the repository once it's fetched.
+      - id: merge-commit
+        name: Resolving the merge commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # This checks for mergeability of a pull request as recommended in
+          # https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28#checking-mergeability-of-pull-requests
+
+          # Retry the API query this many times
+          retryCount=3
+          # Start with 5 seconds, but double every retry
+          retryInterval=5
+          while true; do
+            echo "Checking whether the pull request can be merged"
+            prInfo=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/"$GITHUB_REPOSITORY"/pulls/${{ github.event.pull_request.number }})
+            mergeable=$(jq -r .mergeable <<< "$prInfo")
+            mergedSha=$(jq -r .merge_commit_sha <<< "$prInfo")
+
+            if [[ "$mergeable" == "null" ]]; then
+              if (( retryCount == 0 )); then
+                echo "Not retrying anymore, probably GitHub is having internal issues"
+                exit 1
+              else
+                (( retryCount -= 1 )) || true
+
+                # null indicates that GitHub is still computing whether it's mergeable
+                # Wait a couple seconds before trying again
+                echo "GitHub is still computing whether this PR can be merged, waiting $retryInterval seconds before trying again ($retryCount retries left)"
+                sleep "$retryInterval"
+
+                (( retryInterval *= 2 )) || true
+              fi
+            else
+              break
+            fi
+          done
+
+          if [[ "$mergeable" == "true" ]]; then
+            echo "The PR can be merged, checking the merge commit $mergedSha"
+          else
+            echo "The PR cannot be merged, it has a merge conflict, cancelling the workflow.."
+            gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/"$GITHUB_REPOSITORY"/actions/runs/"$GITHUB_RUN_ID"/cancel
+            sleep 60
+            # If it's still not canceled after a minute, something probably went wrong, just exit
+            exit 1
+          fi
+          echo "mergedSha=$mergedSha" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
+        with:
+          # pull_request_target checks out the base branch by default
+          ref: ${{ steps.merge-commit.outputs.mergedSha }}
+          # Fetches the merge commit and its parents
+          fetch-depth: 2
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,6 +1,6 @@
 name: 'Bundles'
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
 jobs:

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -83,3 +83,4 @@ jobs:
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          build_script: build-prod

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,5 +1,8 @@
 name: 'Bundles'
 on:
+  pull_request:
+    branches:
+      - main
   pull_request_target:
     branches:
       - main

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,8 +1,5 @@
 name: 'Bundles'
 on:
-  pull_request:
-    branches:
-      - main
   pull_request_target:
     branches:
       - main

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,6 +1,6 @@
 name: 'Bundles'
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
 jobs:

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -24,12 +24,9 @@ const path = require('node:path');
  * Looks like:
  *
  *   {
- *     lexical: 'packages/lexical/dist/index.js',
- *     '@lexical/rich-text': 'packages/lexical-rich-text/dist/index.js',
+ *     lexical: 'packages/lexical/dist/Lexical.js',
+ *     '@lexical/rich-text': 'packages/lexical-rich-text/dist/LexicalRichText.js',
  *   }
- *
- * Currently this alias map points at the cjs version of the build product,
- * as that is what was measured previously in #3600.
  */
 const {packagesManager} = require('./scripts/shared/packagesManager');
 const getAliasType = (type) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "yjs": "^13.5.42"
       },
       "devDependencies": {
-        "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
         "@babel/core": "^7.24.5",
         "@babel/eslint-parser": "^7.24.5",
         "@babel/plugin-transform-optional-catch-binding": "^7.24.1",
@@ -655,121 +654,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-0.2.0.tgz",
-      "integrity": "sha512-a4EztS9/GOVQjX5Ol+Iz33TFhaXvYBF7aB6D8+Qz0/SCIxOm3UNRhGZiwcCuJ8/Ifc6NCogp3S48kc5hFxRpUw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "1.0.0",
-        "sourcemap-codec": "1.4.8"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@ampproject/rollup-plugin-closure-compiler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/rollup-plugin-closure-compiler/-/rollup-plugin-closure-compiler-0.27.0.tgz",
-      "integrity": "sha512-stpAOn2ZZEJuAV39HFw9cnKJYNhEeHtcsoa83orpLDhSxsxSbVEKwHaWlFBaQYpQRSOdapC4eJhJnCzocZxnqg==",
-      "dev": true,
-      "dependencies": {
-        "@ampproject/remapping": "0.2.0",
-        "acorn": "7.3.1",
-        "acorn-walk": "7.1.1",
-        "estree-walker": "2.0.1",
-        "google-closure-compiler": "20210808.0.0",
-        "magic-string": "0.25.7",
-        "uuid": "8.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "rollup": ">=1.27"
-      }
-    },
-    "node_modules/@ampproject/rollup-plugin-closure-compiler/node_modules/google-closure-compiler": {
-      "version": "20210808.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20210808.0.0.tgz",
-      "integrity": "sha512-+R2+P1tT1lEnDDGk8b+WXfyVZgWjcCK9n1mmZe8pMEzPaPWxqK7GMetLVWnqfTDJ5Q+LRspOiFBv3Is+0yuhCA==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "2.x",
-        "google-closure-compiler-java": "^20210808.0.0",
-        "minimist": "1.x",
-        "vinyl": "2.x",
-        "vinyl-sourcemaps-apply": "^0.2.0"
-      },
-      "bin": {
-        "google-closure-compiler": "cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "optionalDependencies": {
-        "google-closure-compiler-linux": "^20210808.0.0",
-        "google-closure-compiler-osx": "^20210808.0.0",
-        "google-closure-compiler-windows": "^20210808.0.0"
-      }
-    },
-    "node_modules/@ampproject/rollup-plugin-closure-compiler/node_modules/google-closure-compiler-java": {
-      "version": "20210808.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20210808.0.0.tgz",
-      "integrity": "sha512-7dEQfBzOdwdjwa/Pq8VAypNBKyWRrOcKjnNYOO9gEg2hjh8XVMeQzTqw4uANfVvvANGdE/JjD+HF6zHVgLRwjg==",
-      "dev": true
-    },
-    "node_modules/@ampproject/rollup-plugin-closure-compiler/node_modules/google-closure-compiler-linux": {
-      "version": "20210808.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20210808.0.0.tgz",
-      "integrity": "sha512-byKi5ITUiWRvEIcQo76i1siVnOwrTmG+GNcBG4cJ7x8IE6+4ki9rG5pUe4+DOYHkfk52XU6XHt9aAAgCcFDKpg==",
-      "cpu": [
-        "x64",
-        "x86"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@ampproject/rollup-plugin-closure-compiler/node_modules/google-closure-compiler-osx": {
-      "version": "20210808.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20210808.0.0.tgz",
-      "integrity": "sha512-iwyAY6dGj1FrrBdmfwKXkjtTGJnqe8F+9WZbfXxiBjkWLtIsJt2dD1+q7g/sw3w8mdHrGQAdxtDZP/usMwj/Rg==",
-      "cpu": [
-        "x64",
-        "x86",
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@ampproject/rollup-plugin-closure-compiler/node_modules/google-closure-compiler-windows": {
-      "version": "20210808.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20210808.0.0.tgz",
-      "integrity": "sha512-VI+UUYwtGWDYwpiixrWRD8EklHgl6PMbiEaHxQSrQbH8PDXytwaOKqmsaH2lWYd5Y/BOZie2MzjY7F5JI69q1w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@ampproject/rollup-plugin-closure-compiler/node_modules/uuid": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
-      "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6754,15 +6638,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz",
-      "integrity": "sha512-9oLAnygRMi8Q5QkYEU4XWK04B+nuoXoxjRvRxgjuChkLZFBja0YPSgdZ7dZtwhncLBcQe/I/E+fLuk5qxcYVJA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/set-array": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
@@ -10308,15 +10183,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
-      "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/address": {
@@ -18078,12 +17944,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
-    },
-    "node_modules/estree-walker": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
-      "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
-      "dev": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -39758,82 +39618,6 @@
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "dev": true
     },
-    "@ampproject/remapping": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-0.2.0.tgz",
-      "integrity": "sha512-a4EztS9/GOVQjX5Ol+Iz33TFhaXvYBF7aB6D8+Qz0/SCIxOm3UNRhGZiwcCuJ8/Ifc6NCogp3S48kc5hFxRpUw==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/resolve-uri": "1.0.0",
-        "sourcemap-codec": "1.4.8"
-      }
-    },
-    "@ampproject/rollup-plugin-closure-compiler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/rollup-plugin-closure-compiler/-/rollup-plugin-closure-compiler-0.27.0.tgz",
-      "integrity": "sha512-stpAOn2ZZEJuAV39HFw9cnKJYNhEeHtcsoa83orpLDhSxsxSbVEKwHaWlFBaQYpQRSOdapC4eJhJnCzocZxnqg==",
-      "dev": true,
-      "requires": {
-        "@ampproject/remapping": "0.2.0",
-        "acorn": "7.3.1",
-        "acorn-walk": "7.1.1",
-        "estree-walker": "2.0.1",
-        "google-closure-compiler": "20210808.0.0",
-        "magic-string": "0.25.7",
-        "uuid": "8.1.0"
-      },
-      "dependencies": {
-        "google-closure-compiler": {
-          "version": "20210808.0.0",
-          "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20210808.0.0.tgz",
-          "integrity": "sha512-+R2+P1tT1lEnDDGk8b+WXfyVZgWjcCK9n1mmZe8pMEzPaPWxqK7GMetLVWnqfTDJ5Q+LRspOiFBv3Is+0yuhCA==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.x",
-            "google-closure-compiler-java": "^20210808.0.0",
-            "google-closure-compiler-linux": "^20210808.0.0",
-            "google-closure-compiler-osx": "^20210808.0.0",
-            "google-closure-compiler-windows": "^20210808.0.0",
-            "minimist": "1.x",
-            "vinyl": "2.x",
-            "vinyl-sourcemaps-apply": "^0.2.0"
-          }
-        },
-        "google-closure-compiler-java": {
-          "version": "20210808.0.0",
-          "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20210808.0.0.tgz",
-          "integrity": "sha512-7dEQfBzOdwdjwa/Pq8VAypNBKyWRrOcKjnNYOO9gEg2hjh8XVMeQzTqw4uANfVvvANGdE/JjD+HF6zHVgLRwjg==",
-          "dev": true
-        },
-        "google-closure-compiler-linux": {
-          "version": "20210808.0.0",
-          "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20210808.0.0.tgz",
-          "integrity": "sha512-byKi5ITUiWRvEIcQo76i1siVnOwrTmG+GNcBG4cJ7x8IE6+4ki9rG5pUe4+DOYHkfk52XU6XHt9aAAgCcFDKpg==",
-          "dev": true,
-          "optional": true
-        },
-        "google-closure-compiler-osx": {
-          "version": "20210808.0.0",
-          "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20210808.0.0.tgz",
-          "integrity": "sha512-iwyAY6dGj1FrrBdmfwKXkjtTGJnqe8F+9WZbfXxiBjkWLtIsJt2dD1+q7g/sw3w8mdHrGQAdxtDZP/usMwj/Rg==",
-          "dev": true,
-          "optional": true
-        },
-        "google-closure-compiler-windows": {
-          "version": "20210808.0.0",
-          "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20210808.0.0.tgz",
-          "integrity": "sha512-VI+UUYwtGWDYwpiixrWRD8EklHgl6PMbiEaHxQSrQbH8PDXytwaOKqmsaH2lWYd5Y/BOZie2MzjY7F5JI69q1w==",
-          "dev": true,
-          "optional": true
-        },
-        "uuid": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
-          "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==",
-          "dev": true
-        }
-      }
-    },
     "@babel/code-frame": {
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
@@ -43922,12 +43706,6 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
-    "@jridgewell/resolve-uri": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz",
-      "integrity": "sha512-9oLAnygRMi8Q5QkYEU4XWK04B+nuoXoxjRvRxgjuChkLZFBja0YPSgdZ7dZtwhncLBcQe/I/E+fLuk5qxcYVJA==",
-      "dev": true
-    },
     "@jridgewell/set-array": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
@@ -46493,12 +46271,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
-    },
-    "acorn-walk": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
-      "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
-      "dev": true
     },
     "address": {
       "version": "1.2.0",
@@ -51894,12 +51666,6 @@
           "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
         }
       }
-    },
-    "estree-walker": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
-      "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
-      "dev": true
     },
     "esutils": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "size": "npm run build-prod && size-limit"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@babel/core": "^7.24.5",
     "@babel/eslint-parser": "^7.24.5",
     "@babel/plugin-transform-optional-catch-binding": "^7.24.1",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -18,7 +18,6 @@ const commonjs = require('@rollup/plugin-commonjs');
 const replace = require('@rollup/plugin-replace');
 const json = require('@rollup/plugin-json');
 const alias = require('@rollup/plugin-alias');
-const compiler = require('@ampproject/rollup-plugin-closure-compiler');
 const terser = require('@rollup/plugin-terser');
 const {exec} = require('child-process-promise');
 const {packagesManager} = require('./shared/packagesManager');
@@ -33,19 +32,6 @@ const isProduction = argv.prod;
 const isRelease = argv.release;
 const isWWW = argv.www;
 const extractCodes = argv.codes;
-
-const closureOptions = {
-  apply_input_source_maps: false,
-  assume_function_wrapper: true,
-  compilation_level: 'SIMPLE',
-  inject_libraries: false,
-  language_in: 'ECMASCRIPT_2019',
-  language_out: 'ECMASCRIPT_2019',
-  process_common_js_modules: false,
-  rewrite_polyfills: false,
-  use_types_for_optimization: false,
-  warning_level: 'QUIET',
-};
 
 const modulePackageMappings = Object.fromEntries(
   packagesManager.getPublicPackages().flatMap((pkg) => {
@@ -254,13 +240,10 @@ async function build(
           isWWW && strictWWWMappings,
         ),
       ),
-      // terser is used for esm builds because
-      // @ampproject/rollup-plugin-closure-compiler doesn't compile
-      // `export default function X()` correctly
-      isProd &&
-        (format === 'esm'
-          ? terser({ecma: 2019, module: true})
-          : compiler(closureOptions)),
+      // terser is used because @ampproject/rollup-plugin-closure-compiler
+      // doesn't compile `export default function X()` correctly and hasn't
+      // been updated since Aug 2021
+      isProd && terser({ecma: 2019, module: format === 'esm'}),
       {
         renderChunk(source) {
           // Assets pipeline might use "export" word in the beginning of the line


### PR DESCRIPTION
## Breaking Change

This may cause some regression in the cjs build size or cause some other configuration related issue, particularly for www\. I suspect that most people in OSS are using esm builds at this point, but some extra scrutiny should be used at Meta when evaluating this PR.

## Description

The cjs prod build has used @ampproject/rollup-plugin-closure-compiler for some time, but that project is abandoned (last release Aug 2021) and causes hard to debug issues whenever you end up using syntax that is valid JS according to the rest of the toolchain but not supported by that abandoned project (e.g. property initializers in classes).

terser is already used for the lexical esm build which has been in production for some time now, it is currently the most popular tool for this purpose, and it is maintained on top of a current toolchain.

To investigate the difference between the two I audited our size-limit action since I knew there was an outstanding issue related to it (#6852). Turns out that issue is correct and the size-limit action hasn't done anything useful since we moved it to a pull_request_target trigger. Our size-limit action also only measured dev builds which is fast but not useful, so I changed it to prod. Unfortunately for (good) security reasons you can't really test these in a PR since the workflow code is guaranteed to come from main, so I had a few commits here testing the action with the pull_request trigger. We might still want to consider having a more abstract method for measuring size, e.g. publishing an artifact that a safer workflow trigger can measure.

Closes #6852

## Test plan

### Before

Get an acorn stack trace in prod builds that only includes the line number in some build artifact and not any real indication of where the error is (fortunately you can attach a debugger locally, but it's a pain) whenever modern JS syntax is used. Most recently I ran into this working on #7046 but this isn't the first time.

### After

Syntax support is consistent across all builds, dev and prod.
