### PR TITLE
[lexical] Bug Fix: Normalize selection after applyDOMRange to account for Firefox differences

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -524,6 +524,68 @@ test.describe.parallel('Links', () => {
     },
   );
 
+  test(
+    `Can backspace across a link and it deletes text, not the whole link`,
+    {
+      tag: '@flaky',
+    },
+    async ({page}) => {
+      await focusEditor(page);
+      await page.keyboard.type(' abc def ');
+      await moveLeft(page, 5);
+      await selectCharacters(page, 'left', 3);
+
+      // link
+      await click(page, '.link');
+      await click(page, '.link-confirm');
+
+      await assertHTML(
+        page,
+        html`
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true"></span>
+            <a
+              class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              href="https://"
+              rel="noreferrer">
+              <span data-lexical-text="true">abc</span>
+            </a>
+            <span data-lexical-text="true">def</span>
+          </p>
+        `,
+      );
+
+      await moveRight(page, 4);
+
+      await page.keyboard.press('Backspace');
+      await page.keyboard.press('Backspace');
+      await page.keyboard.press('Backspace');
+      await page.keyboard.press('Backspace');
+
+      await assertHTML(
+        page,
+        html`
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span data-lexical-text="true"></span>
+            <a
+              class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              href="https://"
+              rel="noreferrer">
+              <span data-lexical-text="true">ab</span>
+            </a>
+            <span data-lexical-text="true">f</span>
+          </p>
+        `,
+      );
+    },
+  );
+
   test(`Can create a link then replace it with plain text`, async ({page}) => {
     await focusEditor(page);
     await page.keyboard.type(' abc ');

--- a/packages/lexical-selection/src/__tests__/utils/index.ts
+++ b/packages/lexical-selection/src/__tests__/utils/index.ts
@@ -890,10 +890,7 @@ export function $setAnchorPoint(
     return;
   }
 
-  const anchor = selection.anchor;
-  anchor.type = point.type;
-  anchor.offset = point.offset;
-  anchor.key = point.key;
+  selection.anchor.set(point.key, point.offset, point.type);
 }
 
 export function $setFocusPoint(
@@ -911,8 +908,5 @@ export function $setFocusPoint(
     return;
   }
 
-  const focus = selection.focus;
-  focus.type = point.type;
-  focus.offset = point.offset;
-  focus.key = point.key;
+  selection.focus.set(point.key, point.offset, point.type);
 }

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRoot.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRoot.test.tsx
@@ -163,10 +163,16 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
         // to use whatever was passed (e.g. keep selection on root node)
         const selection = $createRangeSelection();
         const type = $isElementNode(selectionNode) ? 'element' : 'text';
-        selection.anchor.key = selection.focus.key = selectionNode.getKey();
-        selection.anchor.offset = selection.focus.offset =
-          testCase.selectionOffset;
-        selection.anchor.type = selection.focus.type = type;
+        selection.anchor.set(
+          selectionNode.getKey(),
+          testCase.selectionOffset,
+          type,
+        );
+        selection.focus.set(
+          selectionNode.getKey(),
+          testCase.selectionOffset,
+          type,
+        );
         $setSelection(selection);
 
         $insertNodeToNearestRoot($createTestDecoratorNode());

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -574,7 +574,7 @@ declare class _Point {
   is(point: PointType): boolean;
   isBefore(b: PointType): boolean;
   getNode(): LexicalNode;
-  set(key: NodeKey, offset: number, type: 'text' | 'element'): void;
+  set(key: NodeKey, offset: number, type: 'text' | 'element', onlyIfChanged?: boolean): void;
 }
 
 declare export function $createRangeSelection(): RangeSelection;

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -288,7 +288,6 @@ function flushMutations(
 
       if (selection !== null) {
         if (shouldRevertSelection) {
-          selection.dirty = true;
           $setSelection(selection);
         }
 

--- a/packages/lexical/src/LexicalNormalization.ts
+++ b/packages/lexical/src/LexicalNormalization.ts
@@ -110,6 +110,7 @@ function $normalizePoint(point: PointType): void {
         nextNode.__key,
         nextOffsetAtEnd ? nextNode.getTextContentSize() : 0,
         'text',
+        true,
       );
       break;
     } else if (!$isElementNode(nextNode)) {
@@ -119,6 +120,7 @@ function $normalizePoint(point: PointType): void {
       nextNode.__key,
       nextOffsetAtEnd ? nextNode.getChildrenSize() : 0,
       'element',
+      true,
     );
   }
 }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -34,6 +34,7 @@ import {
 } from './LexicalEvents';
 import {getIsProcessingMutations} from './LexicalMutations';
 import {insertRangeAfter, LexicalNode} from './LexicalNode';
+import {$normalizeSelection} from './LexicalNormalization';
 import {
   getActiveEditor,
   getActiveEditorState,
@@ -626,7 +627,7 @@ export class RangeSelection implements BaseSelection {
    *
    * @param range a DOM Selection range conforming to the StaticRange interface.
    */
-  applyDOMRange(range: StaticRange): void {
+  applyDOMRange(range: StaticRange, normalize = true): void {
     const editor = getActiveEditor();
     const currentEditorState = editor.getEditorState();
     const lastSelection = currentEditorState._selection;
@@ -654,6 +655,11 @@ export class RangeSelection implements BaseSelection {
       focusPoint.offset,
       focusPoint.type,
     );
+    if (normalize) {
+      // Firefox will use an element point rather than a text point in some cases,
+      // so we normalize for that
+      $normalizeSelection(this);
+    }
     this._cachedNodes = null;
   }
 

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -308,12 +308,8 @@ describe('LexicalNode tests', () => {
             return;
           }
 
-          selection.anchor.type = 'text';
-          selection.anchor.offset = 1;
-          selection.anchor.key = textNode.getKey();
-          selection.focus.type = 'text';
-          selection.focus.offset = 1;
-          selection.focus.key = newTextNode.getKey();
+          selection.anchor.set(textNode.getKey(), 1, 'text');
+          selection.focus.set(newTextNode.getKey(), 1, 'text');
         });
 
         await Promise.resolve().then();
@@ -353,12 +349,8 @@ describe('LexicalNode tests', () => {
         await editor.update(() => {
           const rangeSelection = $createRangeSelection();
 
-          rangeSelection.anchor.type = 'text';
-          rangeSelection.anchor.offset = 1;
-          rangeSelection.anchor.key = textNode.getKey();
-          rangeSelection.focus.type = 'text';
-          rangeSelection.focus.offset = 1;
-          rangeSelection.focus.key = newTextNode.getKey();
+          rangeSelection.anchor.set(textNode.getKey(), 1, 'text');
+          rangeSelection.focus.set(newTextNode.getKey(), 1, 'text');
 
           expect(paragraphNode.isSelected(rangeSelection)).toBe(true);
           expect(textNode.isSelected(rangeSelection)).toBe(true);

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -1080,7 +1080,6 @@ export class TextNode extends LexicalNode {
           target,
           textLength,
         );
-        selection.dirty = true;
       }
       if (focus !== null && focus.key === targetKey) {
         adjustPointOffsetForMergedSibling(
@@ -1090,7 +1089,6 @@ export class TextNode extends LexicalNode {
           target,
           textLength,
         );
-        selection.dirty = true;
       }
     }
     const targetText = target.__text;


### PR DESCRIPTION
## Description

When we use native selection methods to move the cursor in Firefox it will sometimes resolve to an element point, rather than a text point, which violates some assumptions baked into removeText and other internals.

This adds a normalization step to RangeSelection.applyDOMRange (on all platforms) that can be manually toggled off if necessary. I don't think this is needed but I also haven't seen a full e2e test run yet.

Closes #6991
Closes #7049

## Test plan

### Before

Backspacing across the border of an ElementNode will cause the majority of that ElementNode to be deleted in Firefox

### After

Firefox behaves as other browsers do, and now we have an e2e test (with LinkNode) to demonstrate that the behavior is fixed