### PR TITLE
[*] Bug Fix: Use GITHUB_OUTPUT instead of GITHUB_ENV for size-limit action

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -70,7 +70,7 @@ jobs:
             # If it's still not canceled after a minute, something probably went wrong, just exit
             exit 1
           fi
-          echo "mergedSha=$mergedSha" >> "$GITHUB_ENV"
+          echo "mergedSha=$mergedSha" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
         with:
           # pull_request_target checks out the base branch by default


### PR DESCRIPTION
## Description

Follow up to #7047 - since we can't properly test pull_request_target triggers until after they are in main this mistake went unnoticed. 

Closes #6852

## Test plan

### Before

size-limit always says 0% difference because it's measuring main and main

### After

size-limit should do something useful