### PR TITLE
Revert [Breaking Change][lexical] Bug Fix: Commit updates on editorSetRootElement(null) (#7023)

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1101,15 +1101,11 @@ export class LexicalEditor {
           }
         }
       } else {
-        // When the content editable is unmounted we will still trigger a
-        // reconciliation so that any pending updates are flushed,
-        // to match the previous state change when
-        // `_editorState = pendingEditorState` was used, but by
-        // using a commit we preserve the readOnly invariant
-        // for editor.getEditorState().
+        // If content editable is unmounted we'll reset editor state back to original
+        // (or pending) editor state since there will be no reconciliation
+        this._editorState = pendingEditorState;
+        this._pendingEditorState = null;
         this._window = null;
-        this._updateTags.add('history-merge');
-        $commitPendingUpdates(this);
       }
 
       triggerListeners('root', this, false, nextRootElement, prevRootElement);

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -1017,7 +1017,7 @@ describe('LexicalEditor tests', () => {
     });
 
     expect(rootListener).toHaveBeenCalledTimes(3);
-    expect(updateListener).toHaveBeenCalledTimes(4);
+    expect(updateListener).toHaveBeenCalledTimes(3);
     expect(container.innerHTML).toBe(
       '<span contenteditable="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-lexical-editor="true"><p dir="ltr"><span data-lexical-text="true">Change successful</span></p></span>',
     );
@@ -1032,13 +1032,7 @@ describe('LexicalEditor tests', () => {
       init();
       const contentEditable = editor.getRootElement();
       editor.setEditable(editable);
-      editor.update(() => {
-        // Cause the editor to become dirty, so we can ensure
-        // that the getEditorState()._readOnly invariant holds
-        $getRoot().markDirty();
-      });
       editor.setRootElement(null);
-      expect(editor.getEditorState()._readOnly).toBe(true);
       const editorState = editor.parseEditorState(JSON_EDITOR_STATE);
       editor.setEditorState(editorState);
       editor.update(() => {


### PR DESCRIPTION
S482409: Editors on Meta's www were crashing with error: `Got unexpected null or undefined` on reloading the editor.

the root cause is a nullthrows at 

```
  const parentElementDOM = nullthrows(
    editor.getElementByKey(parentElementNode.getKey()),
  );
```
[MLCFloatingParagraphStylesPlugin.react.js](https://www.internalfb.com/code/www/[32c8b8ca986ab3fd52f78aabcc131eb033653175][blame]/html/js/shared/lexical_composer/plugins/MLCFloatingParagraphStylesPlugin.react.js?lines=61-63) in the www integration layer. More investigation needed to determine whats the best approach to handle null being returned to parentElementDOM.

PR7023 is suspected to cause the change, and carries more risk then expected. Reverting the sync diff with PR7023 mitigates the issue. sorry @etrepum to unblock the syncs, may we revert this PR first?