### PR TITLE
[lexical-yjs] Feature: Allow passing in custom `syncCursorPositions` function to collab hook

### DIFF
--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import type {Binding, Provider} from '@lexical/yjs';
+import type {Binding, Provider, SyncCursorPositionsFn} from '@lexical/yjs';
 import type {LexicalEditor} from 'lexical';
 
 import {mergeRegister} from '@lexical/utils';
@@ -54,6 +54,7 @@ export function useYjsCollaboration(
   cursorsContainerRef?: CursorsContainerRef,
   initialEditorState?: InitialEditorStateType,
   awarenessData?: object,
+  syncCursorPositionsFn: SyncCursorPositionsFn = syncCursorPositions,
 ): JSX.Element {
   const isReloadingDoc = useRef(false);
 
@@ -90,7 +91,7 @@ export function useYjsCollaboration(
     };
 
     const onAwarenessUpdate = () => {
-      syncCursorPositions(binding, provider);
+      syncCursorPositionsFn(binding, provider);
     };
 
     const onYjsTreeChanges = (
@@ -102,7 +103,13 @@ export function useYjsCollaboration(
       const origin = transaction.origin;
       if (origin !== binding) {
         const isFromUndoManger = origin instanceof UndoManager;
-        syncYjsChangesToLexical(binding, provider, events, isFromUndoManger);
+        syncYjsChangesToLexical(
+          binding,
+          provider,
+          events,
+          isFromUndoManger,
+          syncCursorPositionsFn,
+        );
       }
     };
 
@@ -191,6 +198,7 @@ export function useYjsCollaboration(
     shouldBootstrap,
     awarenessData,
     setDoc,
+    syncCursorPositionsFn,
   ]);
   const cursorsContainer = useMemo(() => {
     const ref = (element: null | HTMLElement) => {

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -410,6 +410,11 @@ function getCollabNodeAndOffset(
   return [null, 0];
 }
 
+export type SyncCursorPositionsFn = (
+  binding: Binding,
+  provider: Provider,
+) => void;
+
 export function syncCursorPositions(
   binding: Binding,
   provider: Provider,

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -78,11 +78,14 @@ function $syncEvent(binding: Binding, event: any): void {
   }
 }
 
+type SyncCursorPositionsFn = (binding: Binding, provider: Provider) => void;
+
 export function syncYjsChangesToLexical(
   binding: Binding,
   provider: Provider,
   events: Array<YEvent<YText>>,
   isFromUndoManger: boolean,
+  syncCursorPositionsFn: SyncCursorPositionsFn = syncCursorPositions,
 ): void {
   const editor = binding.editor;
   const currentEditorState = editor._editorState;
@@ -129,7 +132,7 @@ export function syncYjsChangesToLexical(
     },
     {
       onUpdate: () => {
-        syncCursorPositions(binding, provider);
+        syncCursorPositionsFn(binding, provider);
         // If there was a collision on the top level paragraph
         // we need to re-add a paragraph. To ensure this insertion properly syncs with other clients,
         // it must be placed outside of the update block above that has tags 'collaboration' or 'historic'.

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -26,6 +26,7 @@ import {CollabTextNode} from './CollabTextNode';
 import {
   $syncLocalCursorPosition,
   syncCursorPositions,
+  SyncCursorPositionsFn,
   syncLexicalSelectionToYjs,
 } from './SyncCursors';
 import {
@@ -77,8 +78,6 @@ function $syncEvent(binding: Binding, event: any): void {
     invariant(false, 'Expected text, element, or decorator event');
   }
 }
-
-type SyncCursorPositionsFn = (binding: Binding, provider: Provider) => void;
 
 export function syncYjsChangesToLexical(
   binding: Binding,

--- a/packages/lexical-yjs/src/index.ts
+++ b/packages/lexical-yjs/src/index.ts
@@ -114,7 +114,7 @@ export function setLocalStateFocus(
 export {
   getAnchorAndFocusCollabNodesForUserState,
   syncCursorPositions,
-  SyncCursorPositionsFn,
+  type SyncCursorPositionsFn,
 } from './SyncCursors';
 export {
   syncLexicalUpdateToYjs,

--- a/packages/lexical-yjs/src/index.ts
+++ b/packages/lexical-yjs/src/index.ts
@@ -114,6 +114,7 @@ export function setLocalStateFocus(
 export {
   getAnchorAndFocusCollabNodesForUserState,
   syncCursorPositions,
+  SyncCursorPositionsFn,
 } from './SyncCursors';
 export {
   syncLexicalUpdateToYjs,


### PR DESCRIPTION
## Description

We created a custom `syncCursorPositions` function in our app to allow for more advanced styling and behavior than what the implementation exported by `@lexical/yjs` allows (which requires some CSS trickery even just to customize basic styling)

However we were noticing that sometimes some of the cursors would use the styles from the Lexical impl and not ours, even though those styles didn't exist in our codebase. It turned out that the `syncYjsChangesToLexical` function calls the lexical implementation of `syncCursorPositions`, so depending on which implementation ran first, some cursors would use incorrect styles. Also, the lexical implementation removes cursors for user states which are not focusing, while ours does not. This would cause flickering of the cursors since the Lexical impl would remove them and then ours would add them back.

Currently we have used yarn patch to remove this call, but I think it makes sense to allow a custom function to be passed so that it becomes possible to have a custom implementation of collab cursors without the existing lexical implementation also running.