### PR TITLE
[lexical-table] Bug Fix: Prevent error if pasted table has empty row

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
@@ -818,4 +818,58 @@ test.describe('HTML Tables CopyAndPaste', () => {
       `,
     );
   });
+
+  test('Copy + paste table with empty row', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+
+    await focusEditor(page);
+
+    const clipboard = {
+      'text/html': html`
+        <table>
+          <tr><td>1</td></tr>
+          <tr></tr>
+          <tr><td>2</td></tr>
+        </table>
+      `,
+    };
+
+    await pasteFromClipboard(page, clipboard);
+
+    await assertHTML(
+      page,
+      html`
+        <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+          </colgroup>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph">
+                <span data-lexical-text="true">1</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph">
+                <br />
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph">
+                <span data-lexical-text="true">2</span>
+              </p>
+            </td>
+          </tr>
+        </table>
+      `,
+    );
+  });
 });

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -856,9 +856,7 @@ export function $computeTableMapSkipCellCheck(
       $isTableRowNode(row),
       'Expected TableNode children to be TableRowNode',
     );
-    if (row.getChildrenSize() === 0) {
-      tableMap[rowIdx] = [];
-    }
+    const startMapRow = getMapRow(rowIdx);
     for (
       let cell = row.getFirstChild(), colIdx = 0;
       cell != null;
@@ -869,7 +867,6 @@ export function $computeTableMapSkipCellCheck(
         'Expected TableRowNode children to be TableCellNode',
       );
       // Skip past any columns that were merged from a higher row
-      const startMapRow = getMapRow(rowIdx);
       while (startMapRow[colIdx] !== undefined) {
         colIdx++;
       }

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -856,6 +856,9 @@ export function $computeTableMapSkipCellCheck(
       $isTableRowNode(row),
       'Expected TableNode children to be TableRowNode',
     );
+    if (row.getChildrenSize() === 0) {
+      tableMap[rowIdx] = [];
+    }
     for (
       let cell = row.getFirstChild(), colIdx = 0;
       cell != null;


### PR DESCRIPTION
## Description

Currently, if a table was pasted that has an empty row, the `$tableTransform` would throw an error. This is because in `$computeTableMapSkipCellCheck`, an array for a row is only initialized inside the loop that goes through its children. This causes there to be a gap in the gridMap since an array for the empty row never gets initialized, which then causes `gridMap[i]` to be undefined and throw an error.

This PR fixes this by making sure an empty array is initialized at the index of the empty row, which in turn will be filled with the necessary amount of cells by `$tableTransform`

## Test plan

Added e2e test to cover this scenario

### Before

<img width="1234" alt="image" src="https://github.com/user-attachments/assets/7e13a628-532a-45d6-a648-2b57cb44a7fb" />

### After

<img width="1160" alt="image" src="https://github.com/user-attachments/assets/71fa3a41-fccd-409d-a61c-f40fb12f12a9" />
