### PR TITLE
[lexical-list] Feature: Continuous list numbering

### DIFF
--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -151,6 +151,10 @@ export class ListNode extends ElementNode {
       return true;
     }
 
+    if (prevNode.__start !== this.__start) {
+      return true;
+    }
+
     $setListThemeClassNames(dom, config.theme, this);
 
     return false;

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -259,22 +259,21 @@ export class ListNode extends ElementNode {
 
   updateStartFromPreviousList(previousList: ListNode | null) {
     if (
-      !previousList &&
-      this.__continuePreviousNumbering &&
-      this.__listType === 'number' &&
-      this.__start !== 1
+      this.__listType !== 'number' ||
+      !this.__continuePreviousNumbering ||
+      this.getParentOrThrow().getType() === 'listitem'
     ) {
+      // Numbering update not applicable
+      return;
+    }
+
+    if (!previousList && this.__start !== 1) {
       // Previous list was deleted, reset numbering
       this.setStart(1);
       return;
     }
 
-    if (
-      this.__continuePreviousNumbering &&
-      previousList &&
-      previousList.getListType() === 'number' &&
-      this.__listType === 'number'
-    ) {
+    if (previousList && previousList.getListType() === 'number') {
       // Continue previous numbering
       const listItemCount = previousList.getChildrenSize();
       const lastNumber = previousList.getStart() + listItemCount - 1;

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -257,12 +257,25 @@ export class ListNode extends ElementNode {
     return $isListItemNode(child);
   }
 
-  updateStartFromPreviousList(previousList: ListNode) {
+  updateStartFromPreviousList(previousList: ListNode | null) {
     if (
+      !previousList &&
       this.__continuePreviousNumbering &&
       this.__listType === 'number' &&
-      previousList.getListType() === 'number'
+      this.__start !== 1
     ) {
+      // Previous list was deleted, reset numbering
+      this.setStart(1);
+      return;
+    }
+
+    if (
+      this.__continuePreviousNumbering &&
+      previousList &&
+      previousList.getListType() === 'number' &&
+      this.__listType === 'number'
+    ) {
+      // Continue previous numbering
       const listItemCount = previousList.getChildrenSize();
       const lastNumber = previousList.getStart() + listItemCount - 1;
       const nextNumber = lastNumber + 1;

--- a/packages/lexical-list/src/index.ts
+++ b/packages/lexical-list/src/index.ts
@@ -10,8 +10,9 @@ import type {SerializedListItemNode} from './LexicalListItemNode';
 import type {ListType, SerializedListNode} from './LexicalListNode';
 import type {LexicalCommand, LexicalEditor} from 'lexical';
 
-import {mergeRegister} from '@lexical/utils';
+import {$dfs, mergeRegister} from '@lexical/utils';
 import {
+  $getRoot,
   COMMAND_PRIORITY_LOW,
   createCommand,
   INSERT_PARAGRAPH_COMMAND,
@@ -97,6 +98,18 @@ export function registerList(editor: LexicalEditor): () => void {
       },
       COMMAND_PRIORITY_LOW,
     ),
+    editor.registerNodeTransform(ListNode, () => {
+      let previousList: ListNode | null = null;
+      $dfs($getRoot()).forEach(({node}) => {
+        if (!$isListNode(node) || node.getListType() !== 'number') {
+          return;
+        }
+        if (previousList) {
+          node.updateStartFromPreviousList(previousList);
+        }
+        previousList = node;
+      });
+    }),
   );
   return removeListener;
 }

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -1947,3 +1947,119 @@ test.describe.parallel('Nested List', () => {
     );
   });
 });
+
+test.describe('List Continue Previous Numbering', () => {
+  test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+
+  test('continues numbering from previous list when continuePreviousNumbering is true', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    // Create first numbered list
+    await toggleNumberedList(page);
+    await page.keyboard.type('First');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Second');
+
+    // Exit list and add paragraph
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Separating paragraph');
+    await page.keyboard.press('Enter');
+
+    // Create second numbered list
+    await toggleNumberedList(page);
+    await page.keyboard.type('Fourth');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Fifth');
+
+    await assertHTML(
+      page,
+      html`
+        <ol class="PlaygroundEditorTheme__ol1">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="1">
+            <span data-lexical-text="true">First</span>
+          </li>
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="2">
+            <span data-lexical-text="true">Second</span>
+          </li>
+        </ol>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Separating paragraph</span>
+        </p>
+        <ol class="PlaygroundEditorTheme__ol1">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="1">
+            <span data-lexical-text="true">Fourth</span>
+          </li>
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="2">
+            <span data-lexical-text="true">Fifth</span>
+          </li>
+        </ol>
+      `,
+    );
+
+    // Partially select text in second list to trigger floating menu
+    await page.keyboard.press('Shift+ArrowLeft');
+
+    // Click continue numbering button in floating menu
+    await click(
+      page,
+      'button[aria-label="Continue numbering from previous list"]',
+    );
+
+    // Verify the second list now continues numbering
+    await assertHTML(
+      page,
+      html`
+        <ol class="PlaygroundEditorTheme__ol1">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="1">
+            <span data-lexical-text="true">First</span>
+          </li>
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="2">
+            <span data-lexical-text="true">Second</span>
+          </li>
+        </ol>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Separating paragraph</span>
+        </p>
+        <ol class="PlaygroundEditorTheme__ol1" start="3">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="3">
+            <span data-lexical-text="true">Fourth</span>
+          </li>
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="4">
+            <span data-lexical-text="true">Fifth</span>
+          </li>
+        </ol>
+      `,
+    );
+  });
+});

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -884,7 +884,8 @@ i.page-break,
 }
 
 .icon.numbered-list,
-.icon.number {
+.icon.number,
+i.numbered-list {
   background-image: url(images/icons/list-ol.svg);
 }
 

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -10,7 +10,7 @@ import './index.css';
 
 import {$isCodeHighlightNode} from '@lexical/code';
 import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
-import {ListNode} from '@lexical/list';
+import {$isListItemNode, ListNode} from '@lexical/list';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$getNearestNodeOfType, mergeRegister} from '@lexical/utils';
 import {
@@ -49,7 +49,7 @@ function TextFormatFloatingToolbar({
   isSuperscript,
   setIsLinkEditMode,
   isContinuousNumbering,
-  isNumberedList,
+  canUpdateListNumbering,
 }: {
   editor: LexicalEditor;
   anchorElem: HTMLElement;
@@ -66,7 +66,7 @@ function TextFormatFloatingToolbar({
   isUnderline: boolean;
   setIsLinkEditMode: Dispatch<boolean>;
   isContinuousNumbering: boolean;
-  isNumberedList: boolean;
+  canUpdateListNumbering: boolean;
 }): JSX.Element {
   const popupCharStylesEditorRef = useRef<HTMLDivElement | null>(null);
 
@@ -323,7 +323,7 @@ function TextFormatFloatingToolbar({
             aria-label="Insert link">
             <i className="format link" />
           </button>
-          {isNumberedList && (
+          {canUpdateListNumbering && (
             <button
               type="button"
               onClick={toggleContinuousNumbering}
@@ -366,8 +366,8 @@ function useFloatingTextFormatToolbar(
   const [isSubscript, setIsSubscript] = useState(false);
   const [isSuperscript, setIsSuperscript] = useState(false);
   const [isCode, setIsCode] = useState(false);
-  const [isNumberedList, setIsNumberedList] = useState(false);
   const [isContinuousNumbering, setIsContinuousNumbering] = useState(false);
+  const [canUpdateListNumbering, setCanUpdateListNumbering] = useState(false);
 
   const updatePopup = useCallback(() => {
     editor.getEditorState().read(() => {
@@ -397,7 +397,11 @@ function useFloatingTextFormatToolbar(
 
       // Update list numbering strategy
       const listNode = $getNearestNodeOfType(node, ListNode);
-      setIsNumberedList(!!listNode && listNode.getListType() === 'number');
+      setCanUpdateListNumbering(
+        !!listNode &&
+          listNode.getListType() === 'number' &&
+          !$isListItemNode(listNode.getParentOrThrow()),
+      );
       if (listNode) {
         setIsContinuousNumbering(listNode.getContinuePreviousNumbering());
       }
@@ -480,7 +484,7 @@ function useFloatingTextFormatToolbar(
       isCode={isCode}
       setIsLinkEditMode={setIsLinkEditMode}
       isContinuousNumbering={isContinuousNumbering}
-      isNumberedList={isNumberedList}
+      canUpdateListNumbering={canUpdateListNumbering}
     />,
     anchorElem,
   );


### PR DESCRIPTION
## Description

Currently, each new numbered ListNode starts it's numbering at "1". The user can create a new list with a custom start value by typing the number, followed by a period, followed by space (eg. "12. "). If the user tries to create continuous lists this way, they will not stay in sync when new items are added/deleted from previous lists.

Continuous lists are a feature of word/google docs accessed via the context menu and are important in certain types of documents:
<img width="626" alt="Screenshot 2025-01-14 at 3 22 13 PM" src="https://github.com/user-attachments/assets/2e332300-fe88-443e-862d-613ae17e3ab4" />

This PR adds this feature via the following changes:

- A new property `__continuePreviousNumbering` to ListNode
- ListNode method to update the numbering
- Listeners in ListPlugin to trigger updates

## Test plan

Included basic unit and playground tests, can add more if this PR is promising.

Demo:

https://github.com/user-attachments/assets/09eac18b-59e2-47e9-9d9e-3da2a77dd351
