### PR TITLE
Change fork modules to use production only when NODE_ENV explicitly set to production

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -353,7 +353,7 @@ function forkModuleContent(
   if (target === 'cjs') {
     lines.push(
       `'use strict'`,
-      `const ${outputFileName} = process.env.NODE_ENV === 'development' ? require('${devFileName}') : require('${prodFileName}');`,
+      `const ${outputFileName} = process.env.NODE_ENV !== 'production' ? require('${devFileName}') : require('${prodFileName}');`,
       `module.exports = ${outputFileName};`,
     );
   } else {
@@ -361,11 +361,11 @@ function forkModuleContent(
       lines.push(
         `import * as modDev from '${devFileName}';`,
         `import * as modProd from '${prodFileName}';`,
-        `const mod = process.env.NODE_ENV === 'development' ? modDev : modProd;`,
+        `const mod = process.env.NODE_ENV !== 'production' ? modDev : modProd;`,
       );
     } else if (target === 'node') {
       lines.push(
-        `const mod = await (process.env.NODE_ENV === 'development' ? import('${devFileName}') : import('${prodFileName}'));`,
+        `const mod = await (process.env.NODE_ENV !== 'production' ? import('${devFileName}') : import('${prodFileName}'));`,
       );
     }
     for (const name of exports) {


### PR DESCRIPTION
## Description

The four common values of NODE_ENV are `undefined`, `'production'`, `'development'`, and `'test'`. Previously we were loading the dev modules for `NODE_ENV === 'development'` but based on recent vitest changes it probably makes more sense to load the dev modules for `NODE_ENV !== 'production'` because it generally makes more sense to use development when using `'test'` or when it's `undefined` (e.g. just in the node repl without bundler infrastructure running).

Closes #7064

## Test plan

See #7064 for details
