### PR TITLE
[lexical-playground] Fix Columns Layout Item Overflow

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -516,6 +516,8 @@
 .PlaygroundEditorTheme__layoutItem {
   border: 1px dashed #ddd;
   padding: 8px 16px;
+  min-width: 0;
+  max-width: 100%;
 }
 .PlaygroundEditorTheme__autocomplete {
   color: #ccc;


### PR DESCRIPTION
Fix the overflow of individual items in the columns layout.

Before:
<img width="1496" alt="Screenshot 2025-01-19 at 23 04 33" src="https://github.com/user-attachments/assets/e128c7f0-865f-49b2-92af-5fbb28ac935c" />

After:
<img width="1496" alt="Screenshot 2025-01-19 at 23 04 58" src="https://github.com/user-attachments/assets/955b73d7-8a32-42d2-b60e-321c82677826" />
