### PR TITLE
[lexical-list] Fix appending an empty list for block nodes

### DIFF
--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -323,6 +323,9 @@ export function mergeNextSiblingListIfSameType(list: ListNode): void {
   ) {
     mergeLists(list, nextSibling);
   }
+  if (list && nextSibling && !$isListNode(nextSibling)) {
+    list.insertBefore(nextSibling);
+  }
 }
 
 /**


### PR DESCRIPTION
Fix https://github.com/facebook/lexical/issues/6849

After:

https://github.com/user-attachments/assets/d354d605-8e59-4040-9b65-366e9525ec45

