### PR TITLE
[lexical-playground] plugins TableOfContent Scroll smooth behaviour A…

### DIFF
--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -56,7 +56,7 @@ function TableOfContentsList({
     editor.getEditorState().read(() => {
       const domElement = editor.getElementByKey(key);
       if (domElement !== null) {
-        domElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        domElement.scrollIntoView({behavior: 'smooth', block: 'center'});
         setSelectedKey(key);
         selectedIndex.current = currIndex;
       }

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -56,7 +56,7 @@ function TableOfContentsList({
     editor.getEditorState().read(() => {
       const domElement = editor.getElementByKey(key);
       if (domElement !== null) {
-        domElement.scrollIntoView();
+        domElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
         setSelectedKey(key);
         selectedIndex.current = currIndex;
       }


### PR DESCRIPTION
## [lexical-playground] Feature: Add smooth scroll behavior for Table of Contents

## Description

### Current Behavior

    Clicking a heading in the Table of Contents scrolls to the heading in the editor instantly without any smooth transition.
    This abrupt behavior can be jarring for users and detracts from the overall user experience.

### New Behavior

    Smooth scrolling has been implemented when clicking on a heading in the Table of Contents.
    The user will experience a seamless transition to the relevant section of the editor.

This change improves usability and aligns with modern UI/UX standards.

## Changes Made

> file path: lexical-plaground/src/plugins/TableOfContentsPlugin/index.tsx

1. Modified the scrollToNode function in the TableOfContentsList component to include smooth scrolling:
`domElement.scrollIntoView({ behavior: "smooth", block: "center" });`
2.Tested the implementation across multiple headings and ensured compatibility with varying editor states.


## Test plan

### Before

*Clicking on a heading resulted in an instant, abrupt jump to the section without a smooth transition.*


### After

*Clicking on a heading in the Table of Contents now triggers a smooth scrolling animation to the corresponding section in the Editor.*

## Steps to Test:

    Open the lexical-playground with the Table of Contents plugin enabled.
    Add headings (H1, H2, H3) to the document in the editor.
    Click on any heading in the Table of Contents.
    Verify the editor smoothly scrolls to the selected heading.

## Screenshots/Recordings:

### Before

https://github.com/user-attachments/assets/0b289fb0-4f2a-42f2-b5be-4a29eb5b86fb

### After

https://github.com/user-attachments/assets/c179480e-4e7a-438a-919a-1ff11e9f6687


