### PR TITLE
[lexical-rich-text][lexical-playground][lexical-react]: Update selection when something is selected inside a DecoratorNode

### DIFF
--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -16,9 +16,7 @@ import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {mergeRegister} from '@lexical/utils';
 import {
   $getNodeByKey,
-  CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
-  isDOMNode,
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
 } from 'lexical';
@@ -75,35 +73,6 @@ export default function ExcalidrawComponent({
       return;
     }
     return mergeRegister(
-      editor.registerCommand(
-        CLICK_COMMAND,
-        (event: MouseEvent) => {
-          const buttonElem = buttonRef.current;
-          const eventTarget = event.target;
-
-          if (isResizing) {
-            return true;
-          }
-
-          if (
-            buttonElem !== null &&
-            isDOMNode(eventTarget) &&
-            buttonElem.contains(eventTarget)
-          ) {
-            if (!event.shiftKey) {
-              clearSelection();
-            }
-            setSelected(!isSelected);
-            if (event.detail > 1) {
-              setModalOpen(true);
-            }
-            return true;
-          }
-
-          return false;
-        },
-        COMMAND_PRIORITY_LOW,
-      ),
       editor.registerCommand(
         KEY_DELETE_COMMAND,
         $onDelete,

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -45,7 +45,6 @@ export default function ExcalidrawComponent({
     data === '[]' && editor.isEditable(),
   );
   const imageContainerRef = useRef<HTMLDivElement | null>(null);
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
   const captionButtonRef = useRef<HTMLButtonElement | null>(null);
   const [isSelected, setSelected, clearSelection] =
     useLexicalNodeSelection(nodeKey);
@@ -190,9 +189,7 @@ export default function ExcalidrawComponent({
         />
       )}
       {elements.length > 0 && (
-        <button
-          ref={buttonRef}
-          className={`excalidraw-button ${isSelected ? 'selected' : ''}`}>
+        <div className={`excalidraw-button ${isSelected ? 'selected' : ''}`}>
           <ExcalidrawImage
             imageContainerRef={imageContainerRef}
             className="image"
@@ -203,9 +200,8 @@ export default function ExcalidrawComponent({
             height={height}
           />
           {isSelected && isEditable && (
-            <div
+            <button
               className="image-edit-button"
-              role="button"
               tabIndex={0}
               onMouseDown={(event) => event.preventDefault()}
               onClick={openModal}
@@ -223,7 +219,7 @@ export default function ExcalidrawComponent({
               captionsEnabled={true}
             />
           )}
-        </button>
+        </div>
       )}
     </>
   );

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -35,7 +35,6 @@ import {
   $isNodeSelection,
   $isRangeSelection,
   $setSelection,
-  CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   createCommand,
   DRAGSTART_COMMAND,
@@ -298,11 +297,6 @@ export default function ImageComponent({
           activeEditorRef.current = activeEditor;
           return false;
         },
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand<MouseEvent>(
-        CLICK_COMMAND,
-        onClick,
         COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand<MouseEvent>(

--- a/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageComponent.tsx
@@ -23,7 +23,6 @@ import {
   $getSelection,
   $isNodeSelection,
   $setSelection,
-  CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   DRAGSTART_COMMAND,
   KEY_BACKSPACE_COMMAND,
@@ -284,24 +283,6 @@ export default function InlineImageComponent({
         SELECTION_CHANGE_COMMAND,
         (_, activeEditor) => {
           activeEditorRef.current = activeEditor;
-          return false;
-        },
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand<MouseEvent>(
-        CLICK_COMMAND,
-        (payload) => {
-          const event = payload;
-          if (event.target === imageRef.current) {
-            if (event.shiftKey) {
-              setSelected(!isSelected);
-            } else {
-              clearSelection();
-              setSelected(true);
-            }
-            return true;
-          }
-
           return false;
         },
         COMMAND_PRIORITY_LOW,

--- a/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
@@ -13,7 +13,6 @@ import {mergeRegister} from '@lexical/utils';
 import {
   $getSelection,
   $isNodeSelection,
-  CLICK_COMMAND,
   COMMAND_PRIORITY_HIGH,
   COMMAND_PRIORITY_LOW,
   DecoratorNode,
@@ -53,23 +52,6 @@ function PageBreakComponent({nodeKey}: {nodeKey: NodeKey}) {
 
   useEffect(() => {
     return mergeRegister(
-      editor.registerCommand(
-        CLICK_COMMAND,
-        (event: MouseEvent) => {
-          const pbElem = editor.getElementByKey(nodeKey);
-
-          if (event.target === pbElem) {
-            if (!event.shiftKey) {
-              clearSelection();
-            }
-            setSelected(!isSelected);
-            return true;
-          }
-
-          return false;
-        },
-        COMMAND_PRIORITY_LOW,
-      ),
       editor.registerCommand(
         KEY_DELETE_COMMAND,
         $onDelete,

--- a/packages/lexical-playground/src/nodes/PollComponent.tsx
+++ b/packages/lexical-playground/src/nodes/PollComponent.tsx
@@ -19,7 +19,6 @@ import {
   $getSelection,
   $isNodeSelection,
   BaseSelection,
-  CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
@@ -166,23 +165,6 @@ export default function PollComponent({
       editor.registerUpdateListener(({editorState}) => {
         setSelection(editorState.read(() => $getSelection()));
       }),
-      editor.registerCommand<MouseEvent>(
-        CLICK_COMMAND,
-        (payload) => {
-          const event = payload;
-
-          if (event.target === ref.current) {
-            if (!event.shiftKey) {
-              clearSelection();
-            }
-            setSelected(!isSelected);
-            return true;
-          }
-
-          return false;
-        },
-        COMMAND_PRIORITY_LOW,
-      ),
       editor.registerCommand(
         KEY_DELETE_COMMAND,
         $onDelete,

--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -21,7 +21,6 @@ import {
   $isDecoratorNode,
   $isNodeSelection,
   $isRangeSelection,
-  CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   FORMAT_ELEMENT_COMMAND,
   KEY_BACKSPACE_COMMAND,
@@ -95,23 +94,6 @@ export function BlockWithAlignableContents({
               }
             }
 
-            return true;
-          }
-
-          return false;
-        },
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand<MouseEvent>(
-        CLICK_COMMAND,
-        (event) => {
-          if (event.target === ref.current) {
-            event.preventDefault();
-            if (!event.shiftKey) {
-              clearSelection();
-            }
-
-            setSelected(!isSelected);
             return true;
           }
 

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -28,7 +28,6 @@ import {
   $applyNodeReplacement,
   $getSelection,
   $isNodeSelection,
-  CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   createCommand,
   DecoratorNode,
@@ -66,23 +65,6 @@ function HorizontalRuleComponent({nodeKey}: {nodeKey: NodeKey}) {
 
   useEffect(() => {
     return mergeRegister(
-      editor.registerCommand(
-        CLICK_COMMAND,
-        (event: MouseEvent) => {
-          const hrElem = editor.getElementByKey(nodeKey);
-
-          if (event.target === hrElem) {
-            if (!event.shiftKey) {
-              clearSelection();
-            }
-            setSelected(!isSelected);
-            return true;
-          }
-
-          return false;
-        },
-        COMMAND_PRIORITY_LOW,
-      ),
       editor.registerCommand(
         KEY_DELETE_COMMAND,
         $onDelete,

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -44,6 +44,7 @@ import {
 } from '@lexical/utils';
 import {
   $applyNodeReplacement,
+  $createNodeSelection,
   $createParagraphNode,
   $createRangeSelection,
   $createTabNode,
@@ -565,13 +566,25 @@ export function registerRichText(editor: LexicalEditor): () => void {
   const removeListener = mergeRegister(
     editor.registerCommand(
       CLICK_COMMAND,
-      (payload) => {
-        const selection = $getSelection();
-        if ($isNodeSelection(selection)) {
-          selection.clear();
-          return true;
+      (event) => {
+        if (!(event.target instanceof Element)) {
+          return false;
         }
-        return false;
+        const decorator = event.target.closest(
+          '[data-lexical-decorator="true"]',
+        );
+        if (!decorator) {
+          return false;
+        }
+        editor.update(() => {
+          const node = $getNearestNodeFromDOMNode(decorator);
+          if ($isDecoratorNode(node)) {
+            const selection = $createNodeSelection();
+            selection.add(node.getKey());
+            $setSelection(selection);
+          }
+        });
+        return true;
       },
       0,
     ),

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -786,7 +786,7 @@ export class LexicalEditor {
    * deterministically in the order of registration.
    *
    * @param command - the command that will trigger the callback.
-   * @param listener - the function that will execute when the command is dispatched.
+   * @param listener - the function that will execute when the command is dispatched. Returns true to stop propagation, false to continue.
    * @param priority - the relative priority of the listener. 0 | 1 | 2 | 3 | 4
    *   (or {@link COMMAND_PRIORITY_EDITOR} |
    *     {@link COMMAND_PRIORITY_LOW} |


### PR DESCRIPTION
Closes:
- https://github.com/facebook/lexical/issues/7071
- https://github.com/facebook/lexical/issues/6632

This PR:
- Update selection when something is selected inside a DecoratorNode.
- The logic is centralized in RichTextPlugin so that it does not have to be repeated in all nodes. This had caused some nodes to forget to implement this logic, or to be inconsistent:
  - Sometimes it seems that the intention was to deselect a decorator node if it was already selected with a second click.
  - Other times it was intended to deselect if shift + click was pressed.
  - Other times clicking on a selected decorator node leaves the selection unchanged. This is the default behavior chosen in this PR, but if anyone prefers either of the above two options please say so.
- I took the opportunity to improve a couple of details in Excalidraw. The option to open with double click was removed for reasons of simplicity and consistency, considering that the component already has a button at the top right to open the editor.

By having the behavior of the click command centralized, fixing other bugs later should be easier, such as:
- https://github.com/facebook/lexical/issues/7070
- https://github.com/facebook/lexical/issues/3748


