### PR TITLE
[lexical-react] Bug Fix: Import `JSX` type from React to prevent "Cannot find namespace 'JSX'"-error when type-checking with React 19

### DIFF
--- a/examples/react-plain-text/src/plugins/TreeViewPlugin.tsx
+++ b/examples/react-plain-text/src/plugins/TreeViewPlugin.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {TreeView} from '@lexical/react/LexicalTreeView';
 

--- a/examples/react-rich-collab/src/plugins/TreeViewPlugin.tsx
+++ b/examples/react-rich-collab/src/plugins/TreeViewPlugin.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {TreeView} from '@lexical/react/LexicalTreeView';
 

--- a/examples/react-rich/src/plugins/TreeViewPlugin.tsx
+++ b/examples/react-rich/src/plugins/TreeViewPlugin.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {TreeView} from '@lexical/react/LexicalTreeView';
 

--- a/examples/react-table/src/plugins/TreeViewPlugin.tsx
+++ b/examples/react-table/src/plugins/TreeViewPlugin.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {TreeView} from '@lexical/react/LexicalTreeView';
 

--- a/packages/lexical-devtools-core/src/TreeView.tsx
+++ b/packages/lexical-devtools-core/src/TreeView.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {EditorSetOptions, EditorState} from 'lexical';
+import type {JSX} from 'react';
 
 import * as React from 'react';
 import {forwardRef, useCallback, useEffect, useRef, useState} from 'react';

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {createEmptyHistoryState, registerHistory} from '@lexical/history';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';

--- a/packages/lexical-playground/src/App.tsx
+++ b/packages/lexical-playground/src/App.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {$createLinkNode} from '@lexical/link';
 import {$createListItemNode, $createListNode} from '@lexical/list';
 import {LexicalComposer} from '@lexical/react/LexicalComposer';

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {AutoFocusPlugin} from '@lexical/react/LexicalAutoFocusPlugin';
 import {CharacterLimitPlugin} from '@lexical/react/LexicalCharacterLimitPlugin';
 import {CheckListPlugin} from '@lexical/react/LexicalCheckListPlugin';

--- a/packages/lexical-playground/src/Settings.tsx
+++ b/packages/lexical-playground/src/Settings.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {CAN_USE_BEFORE_INPUT} from '@lexical/utils';
 import {useEffect, useMemo, useState} from 'react';
 

--- a/packages/lexical-playground/src/context/FlashMessageContext.tsx
+++ b/packages/lexical-playground/src/context/FlashMessageContext.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {
   createContext,
   ReactNode,

--- a/packages/lexical-playground/src/context/SettingsContext.tsx
+++ b/packages/lexical-playground/src/context/SettingsContext.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {SettingName} from '../appSettings';
+import type {JSX} from 'react';
 
 import * as React from 'react';
 import {

--- a/packages/lexical-playground/src/context/SharedHistoryContext.tsx
+++ b/packages/lexical-playground/src/context/SharedHistoryContext.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {HistoryState} from '@lexical/react/LexicalHistoryPlugin';
+import type {JSX} from 'react';
 
 import {createEmptyHistoryState} from '@lexical/react/LexicalHistoryPlugin';
 import * as React from 'react';

--- a/packages/lexical-playground/src/context/ToolbarContext.tsx
+++ b/packages/lexical-playground/src/context/ToolbarContext.tsx
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
+import type {JSX} from 'react';
+
 import {ElementFormatType} from 'lexical';
 import React, {
   createContext,

--- a/packages/lexical-playground/src/hooks/useModal.tsx
+++ b/packages/lexical-playground/src/hooks/useModal.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useCallback, useMemo, useState} from 'react';
 import * as React from 'react';
 

--- a/packages/lexical-playground/src/nodes/EquationComponent.tsx
+++ b/packages/lexical-playground/src/nodes/EquationComponent.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {mergeRegister} from '@lexical/utils';

--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -15,6 +15,7 @@ import type {
   SerializedLexicalNode,
   Spread,
 } from 'lexical';
+import type {JSX} from 'react';
 
 import katex from 'katex';
 import {$applyNodeReplacement, DecoratorNode, DOMExportOutput} from 'lexical';

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -8,6 +8,7 @@
 
 import type {ExcalidrawInitialElements} from '../../ui/ExcalidrawModal';
 import type {NodeKey} from 'lexical';
+import type {JSX} from 'react';
 
 import {AppState, BinaryFiles} from '@excalidraw/excalidraw/types/types';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawImage.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {exportToSvg} from '@excalidraw/excalidraw';
 import {
   ExcalidrawElement,

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -17,6 +17,7 @@ import type {
   SerializedLexicalNode,
   Spread,
 } from 'lexical';
+import type {JSX} from 'react';
 
 import {DecoratorNode} from 'lexical';
 import * as React from 'react';

--- a/packages/lexical-playground/src/nodes/FigmaNode.tsx
+++ b/packages/lexical-playground/src/nodes/FigmaNode.tsx
@@ -14,6 +14,7 @@ import type {
   NodeKey,
   Spread,
 } from 'lexical';
+import type {JSX} from 'react';
 
 import {BlockWithAlignableContents} from '@lexical/react/LexicalBlockWithAlignableContents';
 import {

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -12,6 +12,7 @@ import type {
   LexicalEditor,
   NodeKey,
 } from 'lexical';
+import type {JSX} from 'react';
 
 import './ImageNode.css';
 

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -19,6 +19,7 @@ import type {
   SerializedLexicalNode,
   Spread,
 } from 'lexical';
+import type {JSX} from 'react';
 
 import {$applyNodeReplacement, createEditor, DecoratorNode} from 'lexical';
 import * as React from 'react';

--- a/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageComponent.tsx
@@ -7,6 +7,7 @@
  */
 import type {Position} from './InlineImageNode';
 import type {BaseSelection, LexicalEditor, NodeKey} from 'lexical';
+import type {JSX} from 'react';
 
 import './InlineImageNode.css';
 

--- a/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageNode.tsx
@@ -19,6 +19,7 @@ import type {
   SerializedLexicalNode,
   Spread,
 } from 'lexical';
+import type {JSX} from 'react';
 
 import {
   $applyNodeReplacement,

--- a/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
+import type {JSX} from 'react';
+
 import './index.css';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';

--- a/packages/lexical-playground/src/nodes/PollComponent.tsx
+++ b/packages/lexical-playground/src/nodes/PollComponent.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {Option, Options, PollNode} from './PollNode';
+import type {JSX} from 'react';
 
 import './PollNode.css';
 

--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {
   DecoratorNode,
   DOMConversionMap,

--- a/packages/lexical-playground/src/nodes/StickyComponent.tsx
+++ b/packages/lexical-playground/src/nodes/StickyComponent.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {LexicalEditor, NodeKey} from 'lexical';
+import type {JSX} from 'react';
 
 import './StickyNode.css';
 

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -16,6 +16,7 @@ import type {
   SerializedLexicalNode,
   Spread,
 } from 'lexical';
+import type {JSX} from 'react';
 
 import {$setSelection, createEditor, DecoratorNode} from 'lexical';
 import * as React from 'react';

--- a/packages/lexical-playground/src/nodes/TweetNode.tsx
+++ b/packages/lexical-playground/src/nodes/TweetNode.tsx
@@ -17,6 +17,7 @@ import type {
   NodeKey,
   Spread,
 } from 'lexical';
+import type {JSX} from 'react';
 
 import {BlockWithAlignableContents} from '@lexical/react/LexicalBlockWithAlignableContents';
 import {

--- a/packages/lexical-playground/src/nodes/YouTubeNode.tsx
+++ b/packages/lexical-playground/src/nodes/YouTubeNode.tsx
@@ -17,6 +17,7 @@ import type {
   NodeKey,
   Spread,
 } from 'lexical';
+import type {JSX} from 'react';
 
 import {BlockWithAlignableContents} from '@lexical/react/LexicalBlockWithAlignableContents';
 import {

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {LexicalEditor} from 'lexical';
+import type {JSX} from 'react';
 
 import {$createCodeNode, $isCodeNode} from '@lexical/code';
 import {

--- a/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {LexicalEditor} from 'lexical';
+import type {JSX} from 'react';
 
 import {
   AutoEmbedOption,

--- a/packages/lexical-playground/src/plugins/AutoLinkPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoLinkPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {
   AutoLinkPlugin,
   createLinkMatcherWithRegExp,

--- a/packages/lexical-playground/src/plugins/AutocompletePlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutocompletePlugin/index.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {BaseSelection, NodeKey, TextNode} from 'lexical';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$isAtNodeEnd} from '@lexical/selection';

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
@@ -8,6 +8,8 @@
 
 import './index.css';
 
+import type {JSX} from 'react';
+
 import {
   $isCodeNode,
   CodeNode,

--- a/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CodeActionMenuPlugin/index.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './index.css';
-
 import type {JSX} from 'react';
+
+import './index.css';
 
 import {
   $isCodeNode,

--- a/packages/lexical-playground/src/plugins/CodeHighlightPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/CodeHighlightPlugin/index.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {registerCodeHighlighting} from '@lexical/code';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -14,8 +14,8 @@ import type {
   NodeKey,
   RangeSelection,
 } from 'lexical';
-import type {Doc} from 'yjs';
 import type {JSX} from 'react';
+import type {Doc} from 'yjs';
 
 import './index.css';
 

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -15,6 +15,7 @@ import type {
   RangeSelection,
 } from 'lexical';
 import type {Doc} from 'yjs';
+import type {JSX} from 'react';
 
 import './index.css';
 

--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {$createCodeNode} from '@lexical/code';
 import {
   INSERT_CHECK_LIST_COMMAND,

--- a/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {

--- a/packages/lexical-playground/src/plugins/DocsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DocsPlugin/index.tsx
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
+import type {JSX} from 'react';
+
 import * as React from 'react';
 
 export default function DocsPlugin(): JSX.Element {

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -7,6 +7,8 @@
  */
 import './index.css';
 
+import type {JSX} from 'react';
+
 import {DraggableBlockPlugin_EXPERIMENTAL} from '@lexical/react/LexicalDraggableBlockPlugin';
 import {useRef} from 'react';
 

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import './index.css';
-
 import type {JSX} from 'react';
+
+import './index.css';
 
 import {DraggableBlockPlugin_EXPERIMENTAL} from '@lexical/react/LexicalDraggableBlockPlugin';
 import {useRef} from 'react';

--- a/packages/lexical-playground/src/plugins/EmojisPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/EmojisPlugin/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type {LexicalEditor} from 'lexical';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {TextNode} from 'lexical';

--- a/packages/lexical-playground/src/plugins/EquationsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/EquationsPlugin/index.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import 'katex/dist/katex.css';
-
 import type {JSX} from 'react';
+
+import 'katex/dist/katex.css';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$wrapNodeInElement} from '@lexical/utils';

--- a/packages/lexical-playground/src/plugins/EquationsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/EquationsPlugin/index.tsx
@@ -8,6 +8,8 @@
 
 import 'katex/dist/katex.css';
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$wrapNodeInElement} from '@lexical/utils';
 import {

--- a/packages/lexical-playground/src/plugins/ExcalidrawPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ExcalidrawPlugin/index.tsx
@@ -7,6 +7,7 @@
  */
 import type {ExcalidrawInitialElements} from '../../ui/ExcalidrawModal';
 import type {AppState, BinaryFiles} from '@excalidraw/excalidraw/types/types';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$wrapNodeInElement} from '@lexical/utils';

--- a/packages/lexical-playground/src/plugins/FigmaPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FigmaPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$insertNodeToNearestRoot} from '@lexical/utils';
 import {COMMAND_PRIORITY_EDITOR, createCommand, LexicalCommand} from 'lexical';

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import './index.css';
-
 import type {JSX} from 'react';
+
+import './index.css';
 
 import {
   $createLinkNode,

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -7,6 +7,8 @@
  */
 import './index.css';
 
+import type {JSX} from 'react';
+
 import {
   $createLinkNode,
   $isAutoLinkNode,

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -8,6 +8,8 @@
 
 import './index.css';
 
+import type {JSX} from 'react';
+
 import {$isCodeHighlightNode} from '@lexical/code';
 import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './index.css';
-
 import type {JSX} from 'react';
+
+import './index.css';
 
 import {$isCodeHighlightNode} from '@lexical/code';
 import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';

--- a/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$wrapNodeInElement, mergeRegister} from '@lexical/utils';
 import {

--- a/packages/lexical-playground/src/plugins/InlineImagePlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/InlineImagePlugin/index.tsx
@@ -6,6 +6,7 @@
  *
  */
 import type {Position} from '../../nodes/InlineImageNode/InlineImageNode';
+import type {JSX} from 'react';
 
 import '../../nodes/InlineImageNode/InlineImageNode.css';
 

--- a/packages/lexical-playground/src/plugins/KeywordsPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/KeywordsPlugin/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type {TextNode} from 'lexical';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalTextEntity} from '@lexical/react/useLexicalTextEntity';

--- a/packages/lexical-playground/src/plugins/LayoutPlugin/InsertLayoutDialog.tsx
+++ b/packages/lexical-playground/src/plugins/LayoutPlugin/InsertLayoutDialog.tsx
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
+import type {JSX} from 'react';
+
 import {LexicalEditor} from 'lexical';
 import * as React from 'react';
 import {useState} from 'react';

--- a/packages/lexical-playground/src/plugins/LinkPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/LinkPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {LinkPlugin as LexicalLinkPlugin} from '@lexical/react/LexicalLinkPlugin';
 import * as React from 'react';
 

--- a/packages/lexical-playground/src/plugins/MarkdownShortcutPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/MarkdownShortcutPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {MarkdownShortcutPlugin} from '@lexical/react/LexicalMarkdownShortcutPlugin';
 import * as React from 'react';
 

--- a/packages/lexical-playground/src/plugins/MentionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/MentionsPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   LexicalTypeaheadMenuPlugin,

--- a/packages/lexical-playground/src/plugins/PageBreakPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/PageBreakPlugin/index.tsx
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$insertNodeToNearestRoot, mergeRegister} from '@lexical/utils';
 import {

--- a/packages/lexical-playground/src/plugins/PasteLogPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/PasteLogPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {COMMAND_PRIORITY_NORMAL, PASTE_COMMAND} from 'lexical';
 import * as React from 'react';

--- a/packages/lexical-playground/src/plugins/PollPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/PollPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$wrapNodeInElement} from '@lexical/utils';
 import {

--- a/packages/lexical-playground/src/plugins/SpecialTextPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/SpecialTextPlugin/index.ts
@@ -6,6 +6,7 @@
  *
  */
 import type {LexicalEditor} from 'lexical';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {TextNode} from 'lexical';

--- a/packages/lexical-playground/src/plugins/StickyPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/StickyPlugin/index.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
 

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {ElementNode, LexicalEditor} from 'lexical';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -7,6 +7,7 @@
  */
 import type {TableCellNode, TableDOMCell, TableMapType} from '@lexical/table';
 import type {LexicalEditor} from 'lexical';
+import type {JSX} from 'react';
 
 import './index.css';
 

--- a/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {

--- a/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableOfContentsPlugin/index.tsx
@@ -8,6 +8,7 @@
 import type {TableOfContentsEntry} from '@lexical/react/LexicalTableOfContentsPlugin';
 import type {HeadingTagType} from '@lexical/rich-text';
 import type {NodeKey} from 'lexical';
+import type {JSX} from 'react';
 
 import './index.css';
 

--- a/packages/lexical-playground/src/plugins/TablePlugin.tsx
+++ b/packages/lexical-playground/src/plugins/TablePlugin.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   INSERT_TABLE_COMMAND,

--- a/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TestRecorderPlugin/index.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {BaseSelection, LexicalEditor} from 'lexical';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {
   $isCodeNode,
   CODE_LANGUAGE_FRIENDLY_NAME_MAP,

--- a/packages/lexical-playground/src/plugins/TreeViewPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TreeViewPlugin/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {TreeView} from '@lexical/react/LexicalTreeView';
 import * as React from 'react';

--- a/packages/lexical-playground/src/plugins/TwitterPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/TwitterPlugin/index.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$insertNodeToNearestRoot} from '@lexical/utils';
 import {COMMAND_PRIORITY_EDITOR, createCommand, LexicalCommand} from 'lexical';

--- a/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/TypingPerfPlugin/index.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useEffect} from 'react';
 
 import useReport from '../../hooks/useReport';

--- a/packages/lexical-playground/src/plugins/YouTubePlugin/index.ts
+++ b/packages/lexical-playground/src/plugins/YouTubePlugin/index.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$insertNodeToNearestRoot} from '@lexical/utils';
 import {COMMAND_PRIORITY_EDITOR, createCommand, LexicalCommand} from 'lexical';

--- a/packages/lexical-playground/src/ui/Button.tsx
+++ b/packages/lexical-playground/src/ui/Button.tsx
@@ -8,6 +8,8 @@
 
 import './Button.css';
 
+import type {JSX} from 'react';
+
 import * as React from 'react';
 import {ReactNode} from 'react';
 

--- a/packages/lexical-playground/src/ui/Button.tsx
+++ b/packages/lexical-playground/src/ui/Button.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './Button.css';
-
 import type {JSX} from 'react';
+
+import './Button.css';
 
 import * as React from 'react';
 import {ReactNode} from 'react';

--- a/packages/lexical-playground/src/ui/ColorPicker.tsx
+++ b/packages/lexical-playground/src/ui/ColorPicker.tsx
@@ -8,6 +8,8 @@
 
 import './ColorPicker.css';
 
+import type {JSX} from 'react';
+
 import {calculateZoomLevel} from '@lexical/utils';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import * as React from 'react';

--- a/packages/lexical-playground/src/ui/ColorPicker.tsx
+++ b/packages/lexical-playground/src/ui/ColorPicker.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './ColorPicker.css';
-
 import type {JSX} from 'react';
+
+import './ColorPicker.css';
 
 import {calculateZoomLevel} from '@lexical/utils';
 import {useEffect, useMemo, useRef, useState} from 'react';

--- a/packages/lexical-playground/src/ui/ContentEditable.tsx
+++ b/packages/lexical-playground/src/ui/ContentEditable.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './ContentEditable.css';
-
 import type {JSX} from 'react';
+
+import './ContentEditable.css';
 
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import * as React from 'react';

--- a/packages/lexical-playground/src/ui/ContentEditable.tsx
+++ b/packages/lexical-playground/src/ui/ContentEditable.tsx
@@ -8,6 +8,8 @@
 
 import './ContentEditable.css';
 
+import type {JSX} from 'react';
+
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import * as React from 'react';
 

--- a/packages/lexical-playground/src/ui/Dialog.tsx
+++ b/packages/lexical-playground/src/ui/Dialog.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './Dialog.css';
-
 import type {JSX} from 'react';
+
+import './Dialog.css';
 
 import * as React from 'react';
 import {ReactNode} from 'react';

--- a/packages/lexical-playground/src/ui/Dialog.tsx
+++ b/packages/lexical-playground/src/ui/Dialog.tsx
@@ -8,6 +8,8 @@
 
 import './Dialog.css';
 
+import type {JSX} from 'react';
+
 import * as React from 'react';
 import {ReactNode} from 'react';
 

--- a/packages/lexical-playground/src/ui/DropDown.tsx
+++ b/packages/lexical-playground/src/ui/DropDown.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {isDOMNode} from 'lexical';
 import * as React from 'react';
 import {

--- a/packages/lexical-playground/src/ui/EquationEditor.tsx
+++ b/packages/lexical-playground/src/ui/EquationEditor.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {Ref, RefObject} from 'react';
+import type {JSX} from 'react';
 
 import './EquationEditor.css';
 

--- a/packages/lexical-playground/src/ui/EquationEditor.tsx
+++ b/packages/lexical-playground/src/ui/EquationEditor.tsx
@@ -6,8 +6,7 @@
  *
  */
 
-import type {Ref, RefObject} from 'react';
-import type {JSX} from 'react';
+import type {JSX, Ref, RefObject} from 'react';
 
 import './EquationEditor.css';
 

--- a/packages/lexical-playground/src/ui/ExcalidrawModal.tsx
+++ b/packages/lexical-playground/src/ui/ExcalidrawModal.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './ExcalidrawModal.css';
-
 import type {JSX} from 'react';
+
+import './ExcalidrawModal.css';
 
 import {Excalidraw} from '@excalidraw/excalidraw';
 import {

--- a/packages/lexical-playground/src/ui/ExcalidrawModal.tsx
+++ b/packages/lexical-playground/src/ui/ExcalidrawModal.tsx
@@ -8,6 +8,8 @@
 
 import './ExcalidrawModal.css';
 
+import type {JSX} from 'react';
+
 import {Excalidraw} from '@excalidraw/excalidraw';
 import {
   AppState,

--- a/packages/lexical-playground/src/ui/FileInput.tsx
+++ b/packages/lexical-playground/src/ui/FileInput.tsx
@@ -8,6 +8,8 @@
 
 import './Input.css';
 
+import type {JSX} from 'react';
+
 import * as React from 'react';
 
 type Props = Readonly<{

--- a/packages/lexical-playground/src/ui/FileInput.tsx
+++ b/packages/lexical-playground/src/ui/FileInput.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './Input.css';
-
 import type {JSX} from 'react';
+
+import './Input.css';
 
 import * as React from 'react';
 

--- a/packages/lexical-playground/src/ui/FlashMessage.tsx
+++ b/packages/lexical-playground/src/ui/FlashMessage.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './FlashMessage.css';
-
 import type {JSX} from 'react';
+
+import './FlashMessage.css';
 
 import {ReactNode} from 'react';
 import {createPortal} from 'react-dom';

--- a/packages/lexical-playground/src/ui/FlashMessage.tsx
+++ b/packages/lexical-playground/src/ui/FlashMessage.tsx
@@ -8,6 +8,8 @@
 
 import './FlashMessage.css';
 
+import type {JSX} from 'react';
+
 import {ReactNode} from 'react';
 import {createPortal} from 'react-dom';
 

--- a/packages/lexical-playground/src/ui/ImageResizer.tsx
+++ b/packages/lexical-playground/src/ui/ImageResizer.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {LexicalEditor} from 'lexical';
+import type {JSX} from 'react';
 
 import {calculateZoomLevel} from '@lexical/utils';
 import * as React from 'react';

--- a/packages/lexical-playground/src/ui/KatexEquationAlterer.tsx
+++ b/packages/lexical-playground/src/ui/KatexEquationAlterer.tsx
@@ -8,6 +8,8 @@
 
 import './KatexEquationAlterer.css';
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
 import {useCallback, useState} from 'react';

--- a/packages/lexical-playground/src/ui/KatexEquationAlterer.tsx
+++ b/packages/lexical-playground/src/ui/KatexEquationAlterer.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './KatexEquationAlterer.css';
-
 import type {JSX} from 'react';
+
+import './KatexEquationAlterer.css';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';

--- a/packages/lexical-playground/src/ui/KatexRenderer.tsx
+++ b/packages/lexical-playground/src/ui/KatexRenderer.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import katex from 'katex';
 import * as React from 'react';
 import {useEffect, useRef} from 'react';

--- a/packages/lexical-playground/src/ui/Modal.tsx
+++ b/packages/lexical-playground/src/ui/Modal.tsx
@@ -8,6 +8,8 @@
 
 import './Modal.css';
 
+import type {JSX} from 'react';
+
 import {isDOMNode} from 'lexical';
 import * as React from 'react';
 import {ReactNode, useEffect, useRef} from 'react';

--- a/packages/lexical-playground/src/ui/Modal.tsx
+++ b/packages/lexical-playground/src/ui/Modal.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './Modal.css';
-
 import type {JSX} from 'react';
+
+import './Modal.css';
 
 import {isDOMNode} from 'lexical';
 import * as React from 'react';

--- a/packages/lexical-playground/src/ui/Select.tsx
+++ b/packages/lexical-playground/src/ui/Select.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './Select.css';
-
 import type {JSX} from 'react';
+
+import './Select.css';
 
 import * as React from 'react';
 

--- a/packages/lexical-playground/src/ui/Select.tsx
+++ b/packages/lexical-playground/src/ui/Select.tsx
@@ -8,6 +8,8 @@
 
 import './Select.css';
 
+import type {JSX} from 'react';
+
 import * as React from 'react';
 
 type SelectIntrinsicProps = JSX.IntrinsicElements['select'];

--- a/packages/lexical-playground/src/ui/Switch.tsx
+++ b/packages/lexical-playground/src/ui/Switch.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import * as React from 'react';
 import {useMemo} from 'react';
 

--- a/packages/lexical-playground/src/ui/TextInput.tsx
+++ b/packages/lexical-playground/src/ui/TextInput.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import './Input.css';
-
 import type {JSX} from 'react';
+
+import './Input.css';
 
 import * as React from 'react';
 import {HTMLInputTypeAttribute} from 'react';

--- a/packages/lexical-playground/src/ui/TextInput.tsx
+++ b/packages/lexical-playground/src/ui/TextInput.tsx
@@ -8,6 +8,8 @@
 
 import './Input.css';
 
+import type {JSX} from 'react';
+
 import * as React from 'react';
 import {HTMLInputTypeAttribute} from 'react';
 

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -10,6 +10,7 @@ import type {
   LexicalNode,
   MutationListener,
 } from 'lexical';
+import type {JSX} from 'react';
 
 import {$isLinkNode, AutoLinkNode, LinkNode} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -8,6 +8,7 @@
 
 import type {AutoLinkAttributes} from '@lexical/link';
 import type {ElementNode, LexicalEditor, LexicalNode} from 'lexical';
+import type {JSX} from 'react';
 
 import {
   $createAutoLinkNode,

--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {ElementFormatType, NodeKey} from 'lexical';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$isDecoratorBlockNode} from '@lexical/react/LexicalDecoratorBlockNode';

--- a/packages/lexical-react/src/LexicalCharacterLimitPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCharacterLimitPlugin.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import * as React from 'react';
 import {useMemo, useState} from 'react';

--- a/packages/lexical-react/src/LexicalClearEditorPlugin.ts
+++ b/packages/lexical-react/src/LexicalClearEditorPlugin.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $createParagraphNode,

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
@@ -6,8 +6,8 @@
  *
  */
 
-import type {Doc} from 'yjs';
 import type {JSX} from 'react';
+import type {Doc} from 'yjs';
 
 import {
   type CollaborationContextType,

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {Doc} from 'yjs';
+import type {JSX} from 'react';
 
 import {
   type CollaborationContextType,

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {LexicalComposerContextType} from '@lexical/react/LexicalComposerContext';
+import type {JSX} from 'react';
 
 import {
   createLexicalComposerContext,

--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -8,6 +8,7 @@
 
 import type {Props as ElementProps} from './shared/LexicalContentEditableElement';
 import type {LexicalEditor} from 'lexical';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {forwardRef, Ref, useLayoutEffect, useState} from 'react';

--- a/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalContextMenuPlugin.tsx
@@ -6,6 +6,7 @@
  *
  */
 import type {MenuRenderFn, MenuResolution} from './shared/LexicalMenu';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {calculateZoomLevel} from '@lexical/utils';

--- a/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
+++ b/packages/lexical-react/src/LexicalDecoratorBlockNode.ts
@@ -14,6 +14,7 @@ import type {
   SerializedLexicalNode,
   Spread,
 } from 'lexical';
+import type {JSX} from 'react';
 
 import {DecoratorNode} from 'lexical';
 

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {eventFiles} from '@lexical/rich-text';
 import {calculateZoomLevel, isHTMLElement, mergeRegister} from '@lexical/utils';

--- a/packages/lexical-react/src/LexicalErrorBoundary.tsx
+++ b/packages/lexical-react/src/LexicalErrorBoundary.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import * as React from 'react';
 import {ErrorBoundary as ReactErrorBoundary} from 'react-error-boundary';
 

--- a/packages/lexical-react/src/LexicalHashtagPlugin.ts
+++ b/packages/lexical-react/src/LexicalHashtagPlugin.ts
@@ -7,6 +7,7 @@
  */
 
 import type {TextNode} from 'lexical';
+import type {JSX} from 'react';
 
 import {$createHashtagNode, HashtagNode} from '@lexical/hashtag';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -16,6 +16,7 @@ import type {
   NodeKey,
   SerializedLexicalNode,
 } from 'lexical';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -8,6 +8,7 @@
 
 import type {LexicalComposerContextType} from '@lexical/react/LexicalComposerContext';
 import type {KlassConstructor, Transform} from 'lexical';
+import type {JSX} from 'react';
 
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {

--- a/packages/lexical-react/src/LexicalNodeMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeMenuPlugin.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {MenuRenderFn, MenuResolution} from './shared/LexicalMenu';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {

--- a/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalPlainTextPlugin.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import * as React from 'react';

--- a/packages/lexical-react/src/LexicalRichTextPlugin.tsx
+++ b/packages/lexical-react/src/LexicalRichTextPlugin.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import * as React from 'react';

--- a/packages/lexical-react/src/LexicalTableOfContentsPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTableOfContentsPlugin.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$isHeadingNode, HeadingNode, HeadingTagType} from '@lexical/rich-text';
 import {$getNextRightPreorderNode} from '@lexical/utils';

--- a/packages/lexical-react/src/LexicalTablePlugin.ts
+++ b/packages/lexical-react/src/LexicalTablePlugin.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   registerTableCellUnmergeTransform,

--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {EditorState, LexicalEditor} from 'lexical';
+import type {JSX} from 'react';
 
 import {
   CustomPrintNodeFn,

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -12,6 +12,7 @@ import type {
   MenuTextMatch,
   TriggerFn,
 } from './shared/LexicalMenu';
+import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {

--- a/packages/lexical-react/src/shared/LexicalContentEditableElement.tsx
+++ b/packages/lexical-react/src/shared/LexicalContentEditableElement.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {LexicalEditor} from 'lexical';
+import type {JSX} from 'react';
 
 import * as React from 'react';
 import {forwardRef, Ref, useCallback, useMemo, useState} from 'react';

--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
 import {

--- a/packages/lexical-react/src/shared/useDecorators.tsx
+++ b/packages/lexical-react/src/shared/useDecorators.tsx
@@ -7,6 +7,7 @@
  */
 
 import type {LexicalEditor, NodeKey} from 'lexical';
+import type {JSX} from 'react';
 
 import {Suspense, useEffect, useMemo, useState} from 'react';
 import * as React from 'react';

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -8,6 +8,7 @@
 
 import type {Binding, Provider, SyncCursorPositionsFn} from '@lexical/yjs';
 import type {LexicalEditor} from 'lexical';
+import type {JSX} from 'react';
 
 import {mergeRegister} from '@lexical/utils';
 import {

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';

--- a/packages/lexical/src/__tests__/unit/LexicalListPlugin.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalListPlugin.test.tsx
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
+import type {JSX} from 'react';
+
 import {ListItemNode, ListNode} from '@lexical/list';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {CodeHighlightNode, CodeNode} from '@lexical/code';
 import {HashtagNode} from '@lexical/hashtag';
 import {createHeadlessEditor} from '@lexical/headless';

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/src/components/plugins/TreeViewPlugin.tsx
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/src/components/plugins/TreeViewPlugin.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {TreeView} from '@lexical/react/LexicalTreeView';
 // import * as React from 'react';

--- a/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/app/plugins/TreeViewPlugin.tsx
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/app/plugins/TreeViewPlugin.tsx
@@ -6,6 +6,8 @@
  *
  */
 
+import type {JSX} from 'react';
+
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {TreeView} from '@lexical/react/LexicalTreeView';
 // import * as React from 'react';


### PR DESCRIPTION
## Description

When using `@lexical/react` with Typescript and React 19, we get several "Cannot find namespace 'JSX'" errors. As described in the [React 19 Upgrade Guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript) the global `JSX` namespace has been removed in favor of `React.JSX`.

Here's some of the errors I get when running type-check on our project after adding `@lexical/react`:
```
node_modules/@lexical/react/LexicalComposer.d.ts(23,78): error TS2503: Cannot find namespace 'JSX'.
node_modules/@lexical/react/LexicalContentEditable.d.ts(15,51): error TS2503: Cannot find namespace 'JSX'.
node_modules/@lexical/react/LexicalContentEditable.d.ts(15,66): error TS2503: Cannot find namespace 'JSX'.
node_modules/@lexical/react/LexicalErrorBoundary.d.ts(10,15): error TS2503: Cannot find namespace 'JSX'.
node_modules/@lexical/react/LexicalErrorBoundary.d.ts(13,98): error TS2503: Cannot find namespace 'JSX'.
node_modules/@lexical/react/LexicalRichTextPlugin.d.ts(11,22): error TS2503: Cannot find namespace 'JSX'.
node_modules/@lexical/react/LexicalRichTextPlugin.d.ts(12,52): error TS2503: Cannot find namespace 'JSX'.
node_modules/@lexical/react/LexicalRichTextPlugin.d.ts(12,74): error TS2503: Cannot find namespace 'JSX'.
node_modules/@lexical/react/LexicalRichTextPlugin.d.ts(14,5): error TS2503: Cannot find namespace 'JSX'.
node_modules/@lexical/react/shared/useDecorators.d.ts(11,15): error TS2503: Cannot find namespace 'JSX'.
node_modules/@lexical/react/shared/useDecorators.d.ts(15,103): error TS2503: Cannot find namespace 'JSX'.
```

In this PR I've attempted to replace all cases of `JSX.Element` with `React.JSX.Element` under `packages/lexical-react`.

I have also added ~~`import type {React} from 'react';`~~`import * as React from 'react';` to the files which didn't already have `import * as React from 'react';` in the file. (using `import type {React} from 'react';` seems to have triggered "error TS2596: 'React' can only be imported by turning on the 'esModuleInterop' flag and using a default import.", so I just did `import * as React from 'react';` instead, which I see have been used other places in the codebase as well)