### PR TITLE
Fix: Use already defined RegisteredNodes type

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -447,7 +447,7 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
   ];
   const {onError, html} = config;
   const isEditable = config.editable !== undefined ? config.editable : true;
-  let registeredNodes: Map<string, RegisteredNode>;
+  let registeredNodes: RegisteredNodes;
 
   if (editorConfig === undefined && activeEditor !== null) {
     registeredNodes = activeEditor._nodes;


### PR DESCRIPTION

[lexical] Refactor: Use RegisteredNodes type

## Description
Currently, the Map<string, RegisteredNode> type is directly used for the registeredNodes variable instead of utilizing the predefined RegisteredNodes type.This PR updates the type definition for the registeredNodes variable to use the RegisteredNodes type instead of Map<string, RegisteredNode>. This improves code consistency and adheres to the existing type alias for better readability and maintainability.