### PR TITLE
[lexical] Chore: Rename variable and add comments for Safari compositing workaround

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1009,6 +1009,11 @@ function onCompositionEnd(
   if (IS_FIREFOX) {
     isFirefoxEndingComposition = true;
   } else if (!IS_IOS && (IS_SAFARI || IS_APPLE_WEBKIT)) {
+    // Fix：https://github.com/facebook/lexical/pull/7061
+    // In safari, onCompositionEnd triggers before keydown
+    // This will cause an extra character to be deleted when exiting the IME
+    // Therefore, a flag is used to mark that the keydown event is triggered after onCompositionEnd
+    // Ensure that an extra character is not deleted due to the backspace event being triggered in the keydown event.
     isSafariEndingComposition = true;
     safariEndCompositionEventData = event.data;
   } else {

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -176,7 +176,7 @@ let isSelectionChangeFromDOMUpdate = false;
 let isSelectionChangeFromMouseDown = false;
 let isInsertLineBreak = false;
 let isFirefoxEndingComposition = false;
-let isSafariEndComposition = false;
+let isSafariEndingComposition = false;
 let safariEndCompositionEventData = '';
 let collapsedSelectionFormat: [number, string, number, NodeKey, number] = [
   0,
@@ -1009,7 +1009,7 @@ function onCompositionEnd(
   if (IS_FIREFOX) {
     isFirefoxEndingComposition = true;
   } else if (!IS_IOS && (IS_SAFARI || IS_APPLE_WEBKIT)) {
-    isSafariEndComposition = true;
+    isSafariEndingComposition = true;
     safariEndCompositionEventData = event.data;
   } else {
     updateEditorSync(editor, () => {
@@ -1034,11 +1034,11 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
   if (key == null) {
     return;
   }
-  if (isSafariEndComposition && isBackspace(lastKeyCode)) {
+  if (isSafariEndingComposition && isBackspace(lastKeyCode)) {
     updateEditorSync(editor, () => {
       $onCompositionEndImpl(editor, safariEndCompositionEventData);
     });
-    isSafariEndComposition = false;
+    isSafariEndingComposition = false;
     safariEndCompositionEventData = '';
     return;
   }


### PR DESCRIPTION
## Description

Add comments and rename the internal `isSafariEndComposition` variable to `isSafariEndingComposition` introduced in the Safari compositing workaround https://github.com/facebook/lexical/pull/7061

## Test plan

No need, this is a variable rename and the addition of some comments
