### PR TITLE
[lexical-playground] Bug Fix: Ensure Delete Node handles all node types

### DIFF
--- a/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
@@ -17,6 +17,7 @@ import {
 import {
   $getNearestNodeFromDOMNode,
   $getSelection,
+  $isDecoratorNode,
   $isNodeSelection,
   $isRangeSelection,
   COPY_COMMAND,
@@ -186,16 +187,8 @@ export default function ContextMenuPlugin(): JSX.Element {
             ancestorNodeWithRootAsParent?.remove();
           } else if ($isNodeSelection(selection)) {
             const selectedNodes = selection.getNodes();
-            const deletableNodeTypes = new Set([
-              'image',
-              'inline-image',
-              'page-break',
-              'excalidraw',
-              'horizontalrule',
-            ]);
-
             selectedNodes.forEach((node) => {
-              if (deletableNodeTypes.has(node.getType())) {
+              if ($isDecoratorNode(node)) {
                 node.remove();
               }
             });

--- a/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
@@ -15,6 +15,7 @@ import {
 import {
   $getNearestNodeFromDOMNode,
   $getSelection,
+  $isNodeSelection,
   $isRangeSelection,
   COPY_COMMAND,
   CUT_COMMAND,
@@ -181,6 +182,21 @@ export default function ContextMenuPlugin(): JSX.Element {
               .at(-2);
 
             ancestorNodeWithRootAsParent?.remove();
+          } else if ($isNodeSelection(selection)) {
+            const selectedNodes = selection.getNodes();
+            const deletableNodeTypes = new Set([
+              'image',
+              'inline-image',
+              'page-break',
+              'excalidraw',
+              'horizontal-rule',
+            ]);
+
+            selectedNodes.forEach((node) => {
+              if (deletableNodeTypes.has(node.getType())) {
+                node.remove();
+              }
+            });
           }
         },
       }),

--- a/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
@@ -189,7 +189,7 @@ export default function ContextMenuPlugin(): JSX.Element {
               'inline-image',
               'page-break',
               'excalidraw',
-              'horizontal-rule',
+              'horizontalrule',
             ]);
 
             selectedNodes.forEach((node) => {


### PR DESCRIPTION
##  [lexical-playground] Bug Fix: Ensure Delete Node handles all node types

- Fixed an issue where Delete Node did not handle specific node types ( `image`, `inline-image`, `page-break`, `excalidraw`, `horizontalrule`).
- Added support for these node types to ensure consistent deletion behavior.

## Description
### Current Behavior:
Previously, the "Delete Node" option in the context menu did not handle specific node types (`image`, `inline-image`, `page-break`, `excalidraw`, `horizontalrule`). Attempting to delete these nodes would fail, causing inconsistent behavior.

**Changes in this PR:**
This PR fixes the issue by adding support for these node types. The following updates were made:

Added handling for `isNodeSelection` to delete selected nodes of specific types.
Extended the list of deletable node types.
Imported `$isNodeSelection` from Lexical to support these changes.
This PR ensures that users can delete nodes of all supported types consistently.

## Code Changes
### File Modified

> packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx

### Code Added/Modified
Here’s the updated snippet for the ContextMenuOption:
```
new ContextMenuOption(`Delete Node`, {
  onSelect: (_node) => {
    const selection = $getSelection();
    if ($isRangeSelection(selection)) {
      const currentNode = selection.anchor.getNode();
      const ancestorNodeWithRootAsParent = currentNode
        .getParents()
        .at(-2);

      ancestorNodeWithRootAsParent?.remove();
    } else if ($isNodeSelection(selection)) {
      const selectedNodes = selection.getNodes();
      const deletableNodeTypes = new Set([
        'image',
        'inline-image',
        'page-break',
        'excalidraw',
        'horizontalrule',
      ]);

      selectedNodes.forEach((node) => {
        if (deletableNodeTypes.has(node.getType())) {
          node.remove();
        }
      });
    }
  },
}),
```


### Imports Added
In the same file, ensure the following import line includes _isNodeSelection:_
```
import {
  $getNearestNodeFromDOMNode,
  $getSelection,
  $isNodeSelection, // Added import
  $isRangeSelection,
  COPY_COMMAND,
  CUT_COMMAND,
  type LexicalNode,
  PASTE_COMMAND,
} from 'lexical';

```
## Test Plan
### Before

1. Attempted to delete nodes of types like `image`, `inline-image`, `page-break`, etc., using the "Delete Node" option.
2. Observed that the nodes were not deleted and remained in the editor.

### After

1. Selected nodes of types like `image`, `inline-image`, `page-break`, etc.
2. Used the "Delete Node" option, and the nodes were successfully deleted.

## Screenshots/Recordings
### Before: 

https://github.com/user-attachments/assets/c4b4fd8c-ab86-45d4-b3b8-dcfc9f76b087


### After:

https://github.com/user-attachments/assets/5a8b43fa-8979-43a1-b9e4-4592973fbce9




