### PR TITLE
[lexical-yjs] Bug Fix: handle text node being split by Yjs redo

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Collaboration.spec.mjs
@@ -413,4 +413,256 @@ test.describe('Collaboration', () => {
       `,
     );
   });
+
+  test('Undo/redo where text node is split by formatting change', async ({
+    isRichText,
+    page,
+    isCollab,
+    browserName,
+  }) => {
+    test.skip(!isCollab);
+
+    // Left collaborator types two words, sets the second one to bold.
+    await focusEditor(page);
+    await page.keyboard.type('normal bold');
+
+    await sleep(1050);
+    await selectCharacters(page, 'left', 'bold'.length);
+    await toggleBold(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">normal</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            bold
+          </strong>
+        </p>
+      `,
+    );
+
+    // Right collaborator types in the middle of the bold word.
+    await page
+      .frameLocator('iframe[name="right"]')
+      .locator('[data-lexical-editor="true"]')
+      .focus();
+    await page.keyboard.press('ArrowDown', {delay: 50});
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.type('BOLD');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">normal</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            boBOLDld
+          </strong>
+        </p>
+      `,
+    );
+
+    // Left collaborator undoes their bold text.
+    await page.frameLocator('iframe[name="left"]').getByLabel('Undo').click();
+
+    // The undo causes the text to be appended to the original string, like in the above test.
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">normal boldBOLD</span>
+        </p>
+      `,
+    );
+
+    // Left collaborator redoes the bold text.
+    await page.frameLocator('iframe[name="left"]').getByLabel('Redo').click();
+
+    // The text should be back as it was prior to the undo.
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">normal</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            boBOLDld
+          </strong>
+        </p>
+      `,
+    );
+
+    // Collaboration should still work.
+    await page
+      .frameLocator('iframe[name="right"]')
+      .locator('[data-lexical-editor="true"]')
+      .focus();
+    await page.keyboard.press('ArrowDown', {delay: 50});
+    await page.keyboard.type(' text');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">normal</span>
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            data-lexical-text="true">
+            boBOLDld text
+          </strong>
+        </p>
+      `,
+    );
+  });
+
+  test('Undo/redo where text node is split by inline element node', async ({
+    isRichText,
+    page,
+    isCollab,
+    browserName,
+  }) => {
+    test.skip(!isCollab);
+
+    // Left collaborator types some text, then splits the text nodes with an element node.
+    await focusEditor(page);
+    await page.keyboard.type('Check out the website!');
+
+    await sleep(1050);
+    await page.keyboard.press('ArrowLeft');
+    await selectCharacters(page, 'left', 'website'.length);
+    await page
+      .frameLocator('iframe[name="left"]')
+      .getByLabel('Insert link')
+      .first()
+      .click();
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Check out the</span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">website</span>
+          </a>
+          <span data-lexical-text="true">!</span>
+        </p>
+      `,
+    );
+
+    // Right collaborator adds some text.
+    await page
+      .frameLocator('iframe[name="right"]')
+      .locator('[data-lexical-editor="true"]')
+      .focus();
+    await page.keyboard.press('ArrowDown', {delay: 50});
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.type(' now');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Check out the</span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">website</span>
+          </a>
+          <span data-lexical-text="true">now!</span>
+        </p>
+      `,
+    );
+
+    // Left collaborator undoes the link.
+    await page.frameLocator('iframe[name="left"]').getByLabel('Undo').click();
+
+    // The undo causes the text to be appended to the original string, like in the above test.
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Check out the website! now</span>
+        </p>
+      `,
+    );
+
+    // Left collaborator redoes the link.
+    await page.frameLocator('iframe[name="left"]').getByLabel('Redo').click();
+
+    // The text should be back as it was prior to the undo.
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Check out the</span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">website</span>
+          </a>
+          <span data-lexical-text="true">now!</span>
+        </p>
+      `,
+    );
+
+    // Collaboration should still work.
+    await page
+      .frameLocator('iframe[name="right"]')
+      .locator('[data-lexical-editor="true"]')
+      .focus();
+    await page.keyboard.press('ArrowDown', {delay: 50});
+    await page.keyboard.type(' Check it out.');
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Check out the</span>
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://"
+            rel="noreferrer">
+            <span data-lexical-text="true">website</span>
+          </a>
+          <span data-lexical-text="true">now! Check it out.</span>
+        </p>
+      `,
+    );
+  });
 });


### PR DESCRIPTION
## Description

Fixes a bug in `applyChildrenYjsDelta` which caused Lexical and Yjs to get out of sync. Once in this state, some changes would not sync to other clients; the changes would be lost on refresh.

This can be reproduced in the Playground with the following steps:

1. In the left editor, type "Hello World"
2. Select "World" and change the formatting to bold
3. In the right editor, type a character in the middle of "World", eg "Wor_ld"
4. In the left editor, click undo then redo
5. Any text added at the end in the left editor won't be synced to the right editor

When applying change deltas from Yjs, an `insertDelta` can be a string or a `sharedType`. If `currIndex` is pointing to some position within a text node and `insertDelta` is a string, then the new text is spliced in correctly. If `insertDelta` represents a shared type, then the newly created `collabNode` is inserted in the wrong position (_before_ said text node).

This PR updates the logic in `applyChildrenYjsDelta` to handle inserting a `sharedType` node in the middle of a text node.

## Test plan

The repro steps above are covered in an end-to-end test. I added a second E2E test to cover the case where the first `insertDelta` corresponds to an `ElementNode`, then the second delta is the `TextNode`.

### Before

https://github.com/user-attachments/assets/5e5d9186-3db2-4251-b118-35f57496b2e8

### After

https://github.com/user-attachments/assets/d9569c31-d1b2-4b2c-a766-f43debf48521
