### PR TITLE
[lexical-utils] Feature: add reverse dfs iterator

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -21,132 +21,161 @@ import {
   invariant,
 } from 'lexical/src/__tests__/utils';
 
-import {$dfs, $getNextSiblingOrParentSibling} from '../..';
+import {$dfs, $getNextSiblingOrParentSibling, $reverseDfs} from '../..';
 
 describe('LexicalNodeHelpers tests', () => {
   initializeUnitTest((testEnv) => {
-    /**
-     *               R
-     *        P1            P2
-     *     B1     B2     T4 T5 B3
-     *     T1   T2 T3          T6
-     *
-     *  DFS: R, P1, B1, T1, B2, T2, T3, P2, T4, T5, B3, T6
-     */
-    test('DFS node order', async () => {
-      const editor: LexicalEditor = testEnv.editor;
-
+    describe('dfs order', () => {
       let expectedKeys: Array<{
         depth: number;
         node: NodeKey;
       }> = [];
 
-      await editor.update(() => {
-        const root = $getRoot();
+      /**
+       *               R
+       *        P1            P2
+       *     B1     B2     T4 T5 B3
+       *     T1   T2 T3          T6
+       *
+       *  DFS: R, P1, B1, T1, B2, T2, T3, P2, T4, T5, B3, T6
+       */
+      beforeEach(async () => {
+        const editor: LexicalEditor = testEnv.editor;
+        await editor.update(() => {
+          const root = $getRoot();
 
-        const paragraph1 = $createParagraphNode();
-        const paragraph2 = $createParagraphNode();
+          const paragraph1 = $createParagraphNode();
+          const paragraph2 = $createParagraphNode();
 
-        const block1 = $createTestElementNode();
-        const block2 = $createTestElementNode();
-        const block3 = $createTestElementNode();
+          const block1 = $createTestElementNode();
+          const block2 = $createTestElementNode();
+          const block3 = $createTestElementNode();
 
-        const text1 = $createTextNode('text1');
-        const text2 = $createTextNode('text2');
-        const text3 = $createTextNode('text3');
-        const text4 = $createTextNode('text4');
-        const text5 = $createTextNode('text5');
-        const text6 = $createTextNode('text6');
+          const text1 = $createTextNode('text1');
+          const text2 = $createTextNode('text2');
+          const text3 = $createTextNode('text3');
+          const text4 = $createTextNode('text4');
+          const text5 = $createTextNode('text5');
+          const text6 = $createTextNode('text6');
 
-        root.append(paragraph1, paragraph2);
-        paragraph1.append(block1, block2);
-        paragraph2.append(text4, text5);
+          root.append(paragraph1, paragraph2);
+          paragraph1.append(block1, block2);
+          paragraph2.append(text4, text5);
 
-        text5.toggleFormat('bold'); // Prevent from merging with text 4
+          text5.toggleFormat('bold'); // Prevent from merging with text 4
 
-        paragraph2.append(block3);
-        block1.append(text1);
-        block2.append(text2, text3);
+          paragraph2.append(block3);
+          block1.append(text1);
+          block2.append(text2, text3);
 
-        text3.toggleFormat('bold'); // Prevent from merging with text2
+          text3.toggleFormat('bold'); // Prevent from merging with text2
 
-        block3.append(text6);
+          block3.append(text6);
 
-        expectedKeys = [
-          {
-            depth: 0,
-            node: root.getKey(),
-          },
-          {
-            depth: 1,
-            node: paragraph1.getKey(),
-          },
-          {
-            depth: 2,
-            node: block1.getKey(),
-          },
-          {
-            depth: 3,
-            node: text1.getKey(),
-          },
-          {
-            depth: 2,
-            node: block2.getKey(),
-          },
-          {
-            depth: 3,
-            node: text2.getKey(),
-          },
-          {
-            depth: 3,
-            node: text3.getKey(),
-          },
-          {
-            depth: 1,
-            node: paragraph2.getKey(),
-          },
-          {
-            depth: 2,
-            node: text4.getKey(),
-          },
-          {
-            depth: 2,
-            node: text5.getKey(),
-          },
-          {
-            depth: 2,
-            node: block3.getKey(),
-          },
-          {
-            depth: 3,
-            node: text6.getKey(),
-          },
-        ];
+          expectedKeys = [
+            {
+              depth: 0,
+              node: root.getKey(),
+            },
+            {
+              depth: 1,
+              node: paragraph1.getKey(),
+            },
+            {
+              depth: 2,
+              node: block1.getKey(),
+            },
+            {
+              depth: 3,
+              node: text1.getKey(),
+            },
+            {
+              depth: 2,
+              node: block2.getKey(),
+            },
+            {
+              depth: 3,
+              node: text2.getKey(),
+            },
+            {
+              depth: 3,
+              node: text3.getKey(),
+            },
+            {
+              depth: 1,
+              node: paragraph2.getKey(),
+            },
+            {
+              depth: 2,
+              node: text4.getKey(),
+            },
+            {
+              depth: 2,
+              node: text5.getKey(),
+            },
+            {
+              depth: 2,
+              node: block3.getKey(),
+            },
+            {
+              depth: 3,
+              node: text6.getKey(),
+            },
+          ];
+        });
       });
 
-      editor.getEditorState().read(() => {
-        const expectedNodes = expectedKeys.map(({depth, node: nodeKey}) => ({
-          depth,
-          node: $getNodeByKey(nodeKey)!.getLatest(),
-        }));
+      test('DFS node order', async () => {
+        const editor: LexicalEditor = testEnv.editor;
+        editor.getEditorState().read(() => {
+          const expectedNodes = expectedKeys.map(({depth, node: nodeKey}) => ({
+            depth,
+            node: $getNodeByKey(nodeKey)!.getLatest(),
+          }));
 
-        const first = expectedNodes[0];
-        const second = expectedNodes[1];
-        const last = expectedNodes[expectedNodes.length - 1];
-        const secondToLast = expectedNodes[expectedNodes.length - 2];
+          const first = expectedNodes[0];
+          const second = expectedNodes[1];
+          const last = expectedNodes[expectedNodes.length - 1];
+          const secondToLast = expectedNodes[expectedNodes.length - 2];
 
-        expect($dfs(first.node, last.node)).toEqual(expectedNodes);
-        expect($dfs(second.node, secondToLast.node)).toEqual(
-          expectedNodes.slice(1, expectedNodes.length - 1),
-        );
-        expect($dfs()).toEqual(expectedNodes);
-        expect($dfs($getRoot())).toEqual(expectedNodes);
+          expect($dfs(first.node, last.node)).toEqual(expectedNodes);
+          expect($dfs(second.node, secondToLast.node)).toEqual(
+            expectedNodes.slice(1, expectedNodes.length - 1),
+          );
+          expect($dfs()).toEqual(expectedNodes);
+          expect($dfs($getRoot())).toEqual(expectedNodes);
+        });
+      });
+
+      test('Reverse DFS node order', async () => {
+        const editor: LexicalEditor = testEnv.editor;
+        editor.getEditorState().read(() => {
+          const expectedNodes = expectedKeys
+            .map(({depth, node: nodeKey}) => ({
+              depth,
+              node: $getNodeByKey(nodeKey)!.getLatest(),
+            }))
+            .reverse();
+
+          const first = expectedNodes[0];
+          const second = expectedNodes[1];
+          const last = expectedNodes[expectedNodes.length - 1];
+          const secondToLast = expectedNodes[expectedNodes.length - 2];
+
+          expect($reverseDfs(first.node, last.node)).toEqual(expectedNodes);
+          expect($reverseDfs(second.node, secondToLast.node)).toEqual(
+            expectedNodes.slice(1, expectedNodes.length - 1),
+          );
+          expect($reverseDfs()).toEqual(expectedNodes);
+          expect($reverseDfs($getRoot().getLastDescendant()!)).toEqual(
+            expectedNodes,
+          );
+        });
       });
     });
 
     test('DFS triggers getLatest()', async () => {
       const editor: LexicalEditor = testEnv.editor;
-
       let rootKey: string;
       let paragraphKey: string;
       let block1Key: string;
@@ -204,9 +233,67 @@ describe('LexicalNodeHelpers tests', () => {
       });
     });
 
+    test('reverse DFS triggers getLatest()', async () => {
+      const editor: LexicalEditor = testEnv.editor;
+      let rootKey: string;
+      let paragraphKey: string;
+      let block1Key: string;
+      let block2Key: string;
+
+      await editor.update(() => {
+        const root = $getRoot();
+
+        const paragraph = $createParagraphNode();
+        const block1 = $createTestElementNode();
+        const block2 = $createTestElementNode();
+
+        rootKey = root.getKey();
+        paragraphKey = paragraph.getKey();
+        block1Key = block1.getKey();
+        block2Key = block2.getKey();
+
+        root.append(paragraph);
+        paragraph.append(block1, block2);
+      });
+
+      await editor.update(() => {
+        const root = $getNodeByKey(rootKey);
+        const paragraph = $getNodeByKey(paragraphKey);
+        const block1 = $getNodeByKey(block1Key);
+        const block2 = $getNodeByKey(block2Key);
+
+        const block3 = $createTestElementNode();
+        invariant($isElementNode(block1));
+
+        block1.append(block3);
+
+        expect($reverseDfs()).toEqual([
+          {
+            depth: 2,
+            node: block2!.getLatest(),
+          },
+          {
+            depth: 3,
+            node: block3.getLatest(),
+          },
+          {
+            depth: 2,
+            node: block1.getLatest(),
+          },
+          {
+            depth: 1,
+            node: paragraph!.getLatest(),
+          },
+          {
+            depth: 0,
+            node: root!.getLatest(),
+          },
+        ]);
+      });
+    });
+
     test('DFS of empty ParagraphNode returns only itself', async () => {
       const editor: LexicalEditor = testEnv.editor;
-
       let paragraphKey: string;
 
       await editor.update(() => {
@@ -233,9 +320,49 @@ describe('LexicalNodeHelpers tests', () => {
       });
     });
 
-    test('$getNextSiblingOrParentSibling', async () => {
+    test('reverse DFS of empty ParagraphNode returns only itself', async () => {
+      const editor: LexicalEditor = testEnv.editor;
+      let paragraphKey: string;
+
+      await editor.update(() => {
+        const root = $getRoot();
+
+        const paragraph = $createParagraphNode();
+        const paragraph2 = $createParagraphNode();
+        const text = $createTextNode('test');
+
+        paragraphKey = paragraph.getKey();
+
+        paragraph2.append(text);
+        root.append(paragraph, paragraph2);
+      });
+      await editor.update(() => {
+        const paragraph = $getNodeByKey(paragraphKey)!;
+
+        expect($reverseDfs(paragraph, paragraph)).toEqual([
+          {
+            depth: 1,
+            node: paragraph?.getLatest(),
+          },
+        ]);
+      });
+    });
+
+    test('reverse DFS of empty RootNode returns only itself', async () => {
       const editor: LexicalEditor = testEnv.editor;
 
+      await editor.update(() => {
+        expect($reverseDfs()).toEqual([
+          {
+            depth: 0,
+            node: $getRoot().getLatest(),
+          },
+        ]);
+      });
+    });
+
+    test('$getNextSiblingOrParentSibling', async () => {
+      const editor: LexicalEditor = testEnv.editor;
       await editor.update(() => {
         const root = $getRoot();
         const paragraph = $createParagraphNode();

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -187,7 +187,7 @@ export function $dfs(
 
 /**
  * A function which will return exactly the reversed order of $dfs. That means that the tree is traversed
- * from left to right, starting at the leaf and working towards the root.
+ * from right to left, starting at the leaf and working towards the root.
  * @param startNode - The node to start the search. If omitted, it will start at the last leaf node in the tree.
  * @param endNode - The node to end the search. If omitted, it will work backwards all the way to the root node
  * @returns An array of objects of all the nodes found by the search, including their depth into the tree.
@@ -840,8 +840,7 @@ function $unwrapAndFilterDescendantsImpl(
  *
  * This function is read-only and performs no mutation operations, which makes
  * it suitable for import and export purposes but likely not for any in-place
- * mutation. You shimport { $getRoot } from 'lexical';
-ould use {@link $unwrapAndFilterDescendants} for in-place
+ * mutation. You should use {@link $unwrapAndFilterDescendants} for in-place
  * mutations such as node transforms.
  *
  * @param children The children to traverse


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
I previously submitted https://github.com/facebook/lexical/pull/7094, which changed the behaviour of `$dfsIterator` to allow it to sometimes traverse the tree backwards. The feedback there was that changing the behaviour would not be the safest choice, and instead this should be implemented as a new function that developers can choose to use in their application code.

The use-case for this is to traverse backwards from a starting point, towards the beginning of the editor, until you meet some condition. For example:

```
let previousTextNode = null;
for (const node of $dfsIterator(startNode, $getRootNode())) {
    if ($isTextNode(node)) {
        previousTextNode = node;
        break
    }
}
```
The alternative is to call $dfs().reverse(), but that is slow for editors with many nodes (lots of overhead).

It is really useful that the traversal algorithm is exactly the same forwards and backwards, so that an application can have consistency. 

<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*
- added `$reverseDfsIterator` to mirror `dfsIterator`
- added `$reverseDfs` to mirror `$dfs`
Closes #<!-- issue number -->

## Test plan
Unit tests are added
