### PR TITLE
[lexical-utils] Bug Fix: Validate decorator node is not isolated in needsBlockCursor

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1598,7 +1598,8 @@ function createBlockCursorElement(editorConfig: EditorConfig): HTMLDivElement {
 
 function needsBlockCursor(node: null | LexicalNode): boolean {
   return (
-    ($isDecoratorNode(node) || ($isElementNode(node) && !node.canBeEmpty())) &&
+    (($isDecoratorNode(node) && !node.isIsolated()) ||
+      ($isElementNode(node) && !node.canBeEmpty())) &&
     !node.isInline()
   );
 }


### PR DESCRIPTION
## Description
Currently, when a decorator block node is isolated and at the beginning of the document, you can still place the block cursor next to it. This leads to behavior where the cursor can appear to be "stuck" next to the node even if you are trying to select text elsewhere (since the real cursor is transparent). This is especially evident when testing on iOS/Android.

This PR fixes this issue by preventing the fake block cursor from appearing next to an isolated node.

## Test plan

1. Add the following code to [YouTubeNode.tsx](https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/nodes/YouTubeNode.tsx#L81) to make it an isolated node (there isn't a good one to test with by default):
```
isIsolated(): boolean {
  return true;
}
```
2. Open Lexical playground
3. Add a YouTube video and move it up to the beginning of the document
4. Select the video
5. Press Up arrow key

### Before

The block cursor is getting placed above the YouTube video:

https://github.com/user-attachments/assets/37169bc6-0fd3-4e54-8531-babe888277a5

### After

The block cursor is no longer being placed. Instead, the cursor moves back down

https://github.com/user-attachments/assets/43bd620a-3784-4712-95aa-05f8efbf9977

