### PR TITLE
Fix ListItemNode serialization throws

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -349,11 +349,11 @@ export class ListItemNode extends ElementNode {
   getIndent(): number {
     // If we don't have a parent, we are likely serializing
     const parent = this.getParent();
-    if (parent === null) {
+    if (parent === null || !this.isAttached()) {
       return this.getLatest().__indent;
     }
     // ListItemNode should always have a ListNode for a parent.
-    let listNodeParent = parent.getParent();
+    let listNodeParent = parent.getParentOrThrow();
     let indentLevel = 0;
     while ($isListItemNode(listNodeParent)) {
       listNodeParent = listNodeParent.getParentOrThrow().getParentOrThrow();

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -353,7 +353,7 @@ export class ListItemNode extends ElementNode {
       return this.getLatest().__indent;
     }
     // ListItemNode should always have a ListNode for a parent.
-    let listNodeParent = parent.getParentOrThrow();
+    let listNodeParent = parent.getParent();
     let indentLevel = 0;
     while ($isListItemNode(listNodeParent)) {
       listNodeParent = listNodeParent.getParentOrThrow().getParentOrThrow();

--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
@@ -20,6 +20,7 @@ import {
 
 import {
   $createListItemNode,
+  $createListNode,
   $isListItemNode,
   ListItemNode,
   ListNode,
@@ -1358,6 +1359,25 @@ describe('LexicalListItemNode tests', () => {
 
         await editor.update(() => {
           expect(listItemNode1.getIndent()).toBe(0);
+        });
+      });
+    });
+
+    test('Can serialize a node that is not attached', async () => {
+      const {editor} = testEnv;
+      await editor.update(() => {
+        const listItemNode = $createListItemNode();
+        const listNode = $createListNode();
+        listNode.append(listItemNode);
+        expect(listItemNode.exportJSON()).toEqual({
+          checked: undefined,
+          children: [],
+          direction: null,
+          format: '',
+          indent: 0,
+          type: 'listitem',
+          value: 1,
+          version: 1,
         });
       });
     });


### PR DESCRIPTION
`getIndent` and `toJSON` serialization should account for Nodes that are not attached. Currently, we have a very simple parent check.

Otherwise, I think that the strict parent relationship expressed in the `getIndent` function is correct.

Closes https://github.com/facebook/lexical/issues/7115