### PR TITLE
[lexical] Bug Fix: Fix Chrome on android deletion bugs

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -606,7 +606,7 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
           const hasSelectedAllTextInNode =
             selection.anchor.offset === 0 &&
             selection.focus.offset === selectedNodeText.length;
-          const shouldLetBrowserHandleDelete =
+          let shouldLetBrowserHandleDelete =
             IS_ANDROID_CHROME &&
             isSelectionAnchorSameAsFocus &&
             !hasSelectedAllTextInNode &&
@@ -614,7 +614,9 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
           // Check if selection is collapsed and if the previous node is a decorator node
           // If so, the browser will not be able to handle the deletion
           if (shouldLetBrowserHandleDelete && selection.isCollapsed()) {
-            shouldLetBrowserHandleDelete = !$isDecoratorNode($getAdjacentNode(selection.anchor, true));
+            shouldLetBrowserHandleDelete = !$isDecoratorNode(
+              $getAdjacentNode(selection.anchor, true),
+            );
           }
           if (!shouldLetBrowserHandleDelete) {
             dispatchCommand(editor, DELETE_CHARACTER_COMMAND, true);

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -613,14 +613,10 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
             selectedNodeCanInsertTextAfter;
           // Check if selection is collapsed and if the previous node is a decorator node
           // If so, the browser will not be able to handle the deletion
-          let browserAbleToDelete = true;
-          if (selection.isCollapsed()) {
-            const prevNode = $getAdjacentNode(selection.anchor, true);
-            if ($isDecoratorNode(prevNode)) {
-              browserAbleToDelete = false;
-            }
+          if (shouldLetBrowserHandleDelete && selection.isCollapsed()) {
+            shouldLetBrowserHandleDelete = !$isDecoratorNode($getAdjacentNode(selection.anchor, true));
           }
-          if (!(shouldLetBrowserHandleDelete && browserAbleToDelete)) {
+          if (!shouldLetBrowserHandleDelete) {
             dispatchCommand(editor, DELETE_CHARACTER_COMMAND, true);
           }
         }

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -25,6 +25,7 @@ import {
   $getPreviousSelection,
   $getRoot,
   $getSelection,
+  $isDecoratorNode,
   $isElementNode,
   $isRangeSelection,
   $isRootNode,
@@ -79,6 +80,7 @@ import {getActiveEditor, updateEditorSync} from './LexicalUpdates';
 import {
   $findMatchingParent,
   $flushMutations,
+  $getAdjacentNode,
   $getNodeByKey,
   $isSelectionCapturedInDecorator,
   $isTokenOrSegmented,
@@ -609,7 +611,16 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
             isSelectionAnchorSameAsFocus &&
             !hasSelectedAllTextInNode &&
             selectedNodeCanInsertTextAfter;
-          if (!shouldLetBrowserHandleDelete) {
+          // Check if selection is collapsed and if the previous node is a decorator node
+          // If so, the browser will not be able to handle the deletion
+          let browserAbleToDelete = true;
+          if (selection.isCollapsed()) {
+            const prevNode = $getAdjacentNode(selection.anchor, true);
+            if ($isDecoratorNode(prevNode)) {
+              browserAbleToDelete = false;
+            }
+          }
+          if (!(shouldLetBrowserHandleDelete && browserAbleToDelete)) {
             dispatchCommand(editor, DELETE_CHARACTER_COMMAND, true);
           }
         }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -12,6 +12,7 @@ import type {NodeKey} from './LexicalNode';
 import type {ElementNode} from './nodes/LexicalElementNode';
 import type {TextFormatType} from './nodes/LexicalTextNode';
 
+import {IS_ANDROID_CHROME} from 'shared/environment';
 import invariant from 'shared/invariant';
 
 import {
@@ -2905,6 +2906,18 @@ export function updateDOMSelection(
       nextFocusNode,
       nextFocusOffset,
     );
+    // When deleting text across multiple paragraphs, Chrome on Android shifts selection rightwards
+    // This is a workaround to restore the correct selection
+    if (IS_ANDROID_CHROME) {
+      setTimeout(() => {
+        domSelection.setBaseAndExtent(
+          nextAnchorNode,
+          nextAnchorOffset,
+          nextFocusNode,
+          nextFocusOffset,
+        );
+      });
+    }
   } catch (error) {
     // If we encounter an error, continue. This can sometimes
     // occur with FF and there's no good reason as to why it


### PR DESCRIPTION

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
Fixes #4340, #5042 and #1965 

1. On Chrome on Android, deletions are usually handled by the browser instead of the `DELETE_CHARACTER_COMMAND`, however the browser is unable to deleted decorator nodes, this PR detects this scenario and dispatches `DELETE_CHARACTER_COMMAND` accordingly
2. When deleting text across paragraphs, Chrome on Android shifts the selection rightwards, this PR restores the correct selection

## Test plan

### Before
https://github.com/user-attachments/assets/b5842cfe-9fba-47a4-a063-6f13766b25f6


### After
https://github.com/user-attachments/assets/87ffbb2b-1dce-4b6a-ad72-a321b2ec41c7

