### PR TITLE
[workflow] disable build_script: build-prod in .github/workflows/size-limit.yml

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -80,4 +80,4 @@ jobs:
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          build_script: build-prod
+          # build_script: build-prod


### PR DESCRIPTION
attempt to mitigate S487385

disabling build_script: build-prod will use the default build as per https://github.com/andresz1/size-limit-action/tree/v1/

incase this is insufficient, disabling the whole job https://github.com/facebook/lexical/pull/7125 would work to mitigate the sev


