### PR TITLE
[workflow] disable size-limit job

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -5,6 +5,8 @@ on:
       - main
 jobs:
   size-limit:
+    # remove below line to enable this job
+    if: false
     runs-on: ubuntu-latest
     env:
       CI_JOB_NUMBER: 1


### PR DESCRIPTION
mitigate S487385

risk of merging this: might not be able to catch size regressions on github. However on www, we can still catch size regressions on the sync diff triggered daily with unigraph signals