### PR TITLE
install babel plugin-transform-runtime

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,6 +14,9 @@ module.exports = {
       require('./scripts/error-codes/transform-error-messages'),
       {noMinify: true},
     ],
+    // When this plugin is enabled, the useBuiltIns option in @babel/preset-env must not be set. Otherwise, this plugin may not able to completely sandbox the environment.
+    // https://babeljs.io/docs/babel-plugin-transform-runtime
+    ['@babel/plugin-transform-runtime'],
   ],
   presets: [
     [

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@babel/core": "^7.24.5",
         "@babel/eslint-parser": "^7.24.5",
         "@babel/plugin-transform-optional-catch-binding": "^7.24.1",
+        "@babel/plugin-transform-runtime": "^7.25.9",
         "@babel/preset-flow": "^7.24.1",
         "@babel/preset-react": "^7.24.1",
         "@babel/preset-typescript": "^7.24.1",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@babel/core": "^7.24.5",
     "@babel/eslint-parser": "^7.24.5",
     "@babel/plugin-transform-optional-catch-binding": "^7.24.1",
+    "@babel/plugin-transform-runtime": "^7.25.9",
     "@babel/preset-flow": "^7.24.1",
     "@babel/preset-react": "^7.24.1",
     "@babel/preset-typescript": "^7.24.1",


### PR DESCRIPTION
T214354208 Getting regeneratorRuntime is not defined errors in lexical clipboard . These errors dont seem to cause any noticeble crashes or behavior when i tried to repro, tho i can repro the error in the logs.


Research:

About the error and possible fix:
[https://stackoverflow.com/questions/61755999/uncaught-referenceerror-regeneratorruntime-is-not-defined-in-react](https://l.facebook.com/l.php?u=https%3A%2F%2Fstackoverflow.com%2Fquestions%2F61755999%2Funcaught-referenceerror-regeneratorruntime-is-not-defined-in-react&h=AT3IyeCaEj6wIHvuEbY12AXfWvlTIQ5HG-wefFJYd0y3ZOV2mLwdgfGSdqutfdVQQupU2G4NRjlNE8v1h6PCePySDOzDPxeASddFQZPTAAZ8q7R8BDV7gfeHwsYH0f9I4F7fGKOo)

How async functions are related to the error:
[https://stackoverflow.com/questions/65378542/what-is-regenerator-runtime-npm-package-used-for](https://l.facebook.com/l.php?u=https%3A%2F%2Fstackoverflow.com%2Fquestions%2F65378542%2Fwhat-is-regenerator-runtime-npm-package-used-for&h=AT3IyeCaEj6wIHvuEbY12AXfWvlTIQ5HG-wefFJYd0y3ZOV2mLwdgfGSdqutfdVQQupU2G4NRjlNE8v1h6PCePySDOzDPxeASddFQZPTAAZ8q7R8BDV7gfeHwsYH0f9I4F7fGKOo)

fix steps: [https://babeljs.io/docs/babel-plugin-transform-runtime](https://l.facebook.com/l.php?u=https%3A%2F%2Fbabeljs.io%2Fdocs%2Fbabel-plugin-transform-runtime&h=AT3IyeCaEj6wIHvuEbY12AXfWvlTIQ5HG-wefFJYd0y3ZOV2mLwdgfGSdqutfdVQQupU2G4NRjlNE8v1h6PCePySDOzDPxeASddFQZPTAAZ8q7R8BDV7gfeHwsYH0f9I4F7fGKOo)

root cause:

- error coming from here: [https://github.com/facebook/lexical/blob/cleanup-size-limit/packages/lexical-clipboard/src/clipboard.ts#L408](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Ffacebook%2Flexical%2Fblob%2Fcleanup-size-limit%2Fpackages%2Flexical-clipboard%2Fsrc%2Fclipboard.ts%23L408&h=AT3IyeCaEj6wIHvuEbY12AXfWvlTIQ5HG-wefFJYd0y3ZOV2mLwdgfGSdqutfdVQQupU2G4NRjlNE8v1h6PCePySDOzDPxeASddFQZPTAAZ8q7R8BDV7gfeHwsYH0f9I4F7fGKOo)

- thrown because of babel transpiler compatibility issues with export async function
could be introduced in [https://github.com/facebook/lexical/pull/7047/](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Ffacebook%2Flexical%2Fpull%2F7047%2F&h=AT3IyeCaEj6wIHvuEbY12AXfWvlTIQ5HG

- unsure, may or may not be related to the build bundle change introduced in https://github.com/facebook/lexical/pull/7047/ because errors started to appear after syncing the most recent sync diff that contains PR7047 over to www