### PR TITLE
[lexical-react] Refactor: Replace `React$Context` with `React.Context`

### DIFF
--- a/packages/lexical-react/flow/LexicalCollaborationContext.js.flow
+++ b/packages/lexical-react/flow/LexicalCollaborationContext.js.flow
@@ -17,5 +17,5 @@ type CollaborationContextType = {
   yjsDocMap: Map<string, Doc>,
 };
 
-declare export var CollaborationContext: React$Context<CollaborationContextType>;
+declare export var CollaborationContext: React.Context<CollaborationContextType>;
 declare export function useCollaborationContext(): CollaborationContextType;

--- a/packages/lexical-react/flow/LexicalComposerContext.js.flow
+++ b/packages/lexical-react/flow/LexicalComposerContext.js.flow
@@ -18,7 +18,7 @@ export type LexicalComposerContextWithEditor = [
   LexicalComposerContextType,
 ];
 
-declare export var LexicalComposerContext: React$Context<?LexicalComposerContextWithEditor>;
+declare export var LexicalComposerContext: React.Context<?LexicalComposerContextWithEditor>;
 
 declare export function createLexicalComposerContext(
   parent: ?LexicalComposerContextWithEditor,


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

Similar to https://github.com/facebook/lexical/pull/6984.

These types can be used without importing React since Flow v0.231.0. This PR replaces them with the non-dollar version, so that Flow can eventually remove these types.

## Test plan

flow