### PR TITLE
[ci] Chore: Remove SSH_KEY secret

### DIFF
--- a/.github/workflows/call-increment-version.yml
+++ b/.github/workflows/call-increment-version.yml
@@ -11,12 +11,6 @@ on:
       channel:
         required: true
         type: string
-      git-repo:
-        required: true
-        type: string
-    secrets:
-      SSH_KEY:
-        required: true
     outputs:
       version:
         description: 'The new package.json version, e.g. "0.16.0"'
@@ -35,10 +29,11 @@ jobs:
       version: ${{ steps.increment-version.outputs.version }}
       tag-ref: ${{ steps.increment-version.outputs.tag-ref }}
       latest-release: ${{ steps.latest.outputs.release }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
-          ssh-key: ${{ secrets.SSH_KEY }}
           fetch-depth: 0
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
@@ -64,4 +59,3 @@ jobs:
           CHANNEL: ${{ inputs.channel }}
           LATEST_RELEASE: ${{ steps.latest.outputs.release }}
           DRY_RUN: ${{ inputs.dry-run && '1' || '' }}
-          GIT_REPO: ${{ inputs.git-repo }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -12,9 +12,6 @@ jobs:
       channel: nightly
       increment: prerelease
       dry-run: false
-      git-repo: 'git@github.com:facebook/lexical.git'
-    secrets:
-      SSH_KEY: ${{ secrets.SSH_KEY }}
   npm-release:
     uses: ./.github/workflows/call-npm-publish.yml
     needs: [increment-version]

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -18,6 +18,3 @@ jobs:
       increment: ${{ inputs.increment }}
       dry-run: false
       channel: ${{ inputs.increment == 'prerelease' && 'next' || 'latest' }}
-      git-repo: 'git@github.com:facebook/lexical.git'
-    secrets:
-      SSH_KEY: ${{ secrets.SSH_KEY }}

--- a/scripts/npm/postversion.js
+++ b/scripts/npm/postversion.js
@@ -12,7 +12,7 @@
 
 const {spawn} = require('child-process-promise');
 
-const {npm_package_version, CHANNEL, GIT_REPO, GITHUB_OUTPUT} = process.env;
+const {npm_package_version, CHANNEL, GITHUB_OUTPUT} = process.env;
 
 // Previously this script was defined directly in package.json as the
 // following (in one line):
@@ -31,7 +31,6 @@ async function main() {
   // CHANNEL should already be validated by increment-version which calls this (indirectly)
   for (const [k, v] of Object.entries({
     CHANNEL,
-    GIT_REPO,
     npm_package_version,
   })) {
     if (!v) {
@@ -77,7 +76,7 @@ async function main() {
     'git',
     'push',
     ...(process.env.DRY_RUN === '1' ? ['--dry-run'] : []),
-    GIT_REPO,
+    'origin',
     ...refs.map((ref) => `+${ref}`),
   ]);
   if (GITHUB_OUTPUT) {


### PR DESCRIPTION
## Description

Committing to the repo doesn't need an SSH_KEY secret because the GITHUB_TOKEN can do it all in safer manner.

## Test plan

* Use the updated workflow to create a release branch
  * ✅ https://github.com/facebook/lexical/actions/runs/13185564867/job/36806710812
* The workflow should create the release branch correctly
  * ✅ https://github.com/facebook/lexical/tree/latest__release
  * ✅ https://github.com/facebook/lexical/tree/0.24.0__release
* The tests should run after creating a PR with the branch
  * IIRC there are some limitations in the GitHub APIs to prevent workflows from infinitely triggering other workflows, but I think since a human manually creates the release PR this might not be an issue for us. Be careful to verify this.
  * ✅ https://github.com/facebook/lexical/pull/7144