### PR TITLE
[bugfix] Fix flow typedef for links plugin to include attributes

### DIFF
--- a/packages/lexical-react/flow/LexicalLinkPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalLinkPlugin.js.flow
@@ -7,8 +7,15 @@
  * @flow strict
  */
 
+type LinkAttributes = {
+  rel?: null | string;
+  target?: null | string;
+  title?: null | string;
+};
+
 type Props = $ReadOnly<{
   validateUrl?: (url: string) => boolean,
+  attributes?: LinkAttributes,
 }>;
 
 declare export function LinkPlugin(props: Props): null;


### PR DESCRIPTION
Flow type def was not in sync with original source:

https://github.com/facebook/lexical/blob/87eeb95ec756df34ee4972ed86d29cc3ed7d5ec8/packages/lexical-react/src/LexicalLinkPlugin.ts#L26-L30