### PR TITLE
[ci] Bug Fix: Force tag update so create release branch can be run multiple times

### DIFF
--- a/scripts/npm/postversion.js
+++ b/scripts/npm/postversion.js
@@ -56,6 +56,7 @@ async function main() {
     [
       'git',
       'tag',
+      '-f',
       '-a',
       `v${npm_package_version}`,
       '-m',


### PR DESCRIPTION
## Description

In situations where the release tag needs to be created multiple times, such as when an issue is found before doing the release, or when testing the create release branch workflow, it can be beneficial to overwrite an existing tag.

## Test plan

* Run create release branch workflow multiple times with the same settings
  * This previously failed https://github.com/facebook/lexical/actions/runs/13188051075/job/36814809716 because an v0.24.0 tag was created while testing
* Verify that the subsequent run succeeded and it overwrote the tag and branches
  * Precondition: the https://github.com/facebook/lexical/releases/tag/v0.24.0 tag is currently at https://github.com/facebook/lexical/commit/d6d68edec7da8ecfa5dc4fc32f9c364c6d11f317 from #7143 / #7144 testing and this is also where the https://github.com/facebook/lexical/tree/0.24.0__release branch points

✅ This succeeded https://github.com/facebook/lexical/actions/runs/13189827205/job/36820366940

```
git tag -f -a v0.24.0 -m v0.24.0
Updated tag 'v0.24.0' (was faeebd2e9)
git push origin +refs/tags/v0.24.0 +refs/heads/latest__release +refs/heads/latest__release:refs/heads/0.24.0__release
To https://github.com/facebook/lexical
 + d6d68edec...dad5777a5 latest__release -> 0.24.0__release (forced update)
 + d6d68edec...dad5777a5 latest__release -> latest__release (forced update)
 + faeebd2e9...42ff65776 v0.24.0 -> v0.24.0 (forced update)
```