### PR TITLE
[lexical] Bug fix: Fixes infinite loop in sibling traversal

### DIFF
--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -289,7 +289,7 @@ function indexPath(root: HTMLElement, child: Node): number[] {
     for (
       let sibling = node.previousSibling;
       sibling !== null;
-      sibling = node.previousSibling
+      sibling = sibling.previousSibling
     ) {
       i++;
     }


### PR DESCRIPTION
## Description

The current implementation of sibling traversal contains a logical error that can cause an infinite loop. In the loop that counts previous siblings, the iteration update statement incorrectly references the original node's previousSibling instead of updating the sibling reference:

Current code (always references the same sibling):

https://github.com/facebook/lexical/blob/fcc374018043620ec025262b352baa91d9536b6e/packages/lexical/src/nodes/LexicalElementNode.ts#L287-L297


This PR fixes the issue by properly updating the sibling reference in each iteration:
```javascript
for (
  let sibling = node.previousSibling;
  sibling !== null;
  sibling = sibling.previousSibling // Correctly traverses the sibling chain
) {
  i++;
}
```

This change ensures proper traversal through the DOM tree and prevents potential infinite loops when working with custom node implementations.

Closes #7156

## Test plan

### Before
- When a node has a previous sibling, the traversal loop can enter an infinite loop
- This issue is particularly noticeable when:
  1. Using custom nodes that wrap their content in container elements
  2. Performing operations that trigger DOM traversal (like deleting content)
- Editor becomes unresponsive in these scenarios

### After
- Sibling traversal properly iterates through previous siblings
- No infinite loops occur during DOM traversal
- Custom nodes with wrapped content structures work as expected
- Editor remains responsive during all operations