### PR TITLE
[scripts] add @noEnforceES3 to build script

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -301,6 +301,7 @@ function getComment() {
     ' * @preserve-invariant-messages',
     ' * @preserve-whitespace',
     ' * @preventMunge',
+    ' * @noEnforceES3',
   );
   return lines.join('\n');
 }


### PR DESCRIPTION
## Description
T214354208 Getting regeneratorRuntime is not defined errors in lexical clipboard . These errors dont seem to cause any noticeble crashes or behavior 



root cause:

- error coming from here: [https://github.com/facebook/lexical/blob/cleanup-size-limit/packages/lexical-clipboard/src/clipboard.ts#L408](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Ffacebook%2Flexical%2Fblob%2Fcleanup-size-limit%2Fpackages%2Flexical-clipboard%2Fsrc%2Fclipboard.ts%23L408&h=AT3IyeCaEj6wIHvuEbY12AXfWvlTIQ5HG-wefFJYd0y3ZOV2mLwdgfGSdqutfdVQQupU2G4NRjlNE8v1h6PCePySDOzDPxeASddFQZPTAAZ8q7R8BDV7gfeHwsYH0f9I4F7fGKOo)

- [tbc, but likely] thrown because haste in www does a validation for non es3 features. async function is not supported in es3, hence the  regeneratorRuntime is not defined error without any noticable crashes or bugs because the browser supports async functions.

- where i found the fix: https://fb.workplace.com/groups/staticresources/permalink/27378543488434240/

old pr: https://github.com/facebook/lexical/pull/7130

## Test plan

[D69444058](https://www.internalfb.com/diff/D69444058) - simulate @noEnforceES3 annotation