### PR TITLE
[lexical-react] positionMenu on rendering typeahead mentions menu

### DIFF
--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -561,6 +561,7 @@ export function useMenuAnchorRef(
     parent,
   ]);
 
+  positionMenu();
   useEffect(() => {
     const rootElement = editor.getRootElement();
     if (resolution !== null) {

--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -491,6 +491,7 @@ export function useMenuAnchorRef(
   const anchorElementRef = useRef<HTMLElement | null>(
     CAN_USE_DOM ? document.createElement('div') : null,
   );
+  const hasPositioned = useRef(false);
   const positionMenu = useCallback(() => {
     if (anchorElementRef.current === null || parent === undefined) {
       return;
@@ -561,7 +562,12 @@ export function useMenuAnchorRef(
     parent,
   ]);
 
-  positionMenu();
+  // position menu on first render
+  if (!hasPositioned.current) {
+    positionMenu();
+    hasPositioned.current = true;
+  }
+
   useEffect(() => {
     const rootElement = editor.getRootElement();
     if (resolution !== null) {


### PR DESCRIPTION
## Description
kudos to Cindy for this potential fix! im only helping to bring the changes to oss from D69406624

S488810 - the mentions menu autoflips wrongly causing janky behavior on diffs/tasks comments

issue reported by users:

https://github.com/user-attachments/assets/0f9c1610-c17d-45e9-8b6c-32df3bd58b22

so far im unable to repro the comments box flicker, this is what i get, an overflowing typeahead menu

https://github.com/user-attachments/assets/e4a004a0-31bc-4091-bf46-41064de1ac8b



## Test plan


https://github.com/user-attachments/assets/48b18905-9a34-4b70-abd1-3e11cf718aa8 

- looks ok on playground, also tried repositioning the @ to change menu pos, etc

