### PR TITLE
[lexical-table] Bug Fix: Ensure rectangular table cell merge behavior (#7161)

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -2445,6 +2445,343 @@ test.describe.parallel('Tables', () => {
     );
   });
 
+  test('Merge/unmerge with already merged cells', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
+
+    if (isCollab) {
+      // The contextual menu positioning needs fixing (it's hardcoded to show on the right side)
+      page.setViewportSize({height: 1000, width: 3000});
+    }
+
+    await focusEditor(page);
+
+    // 1. Create a 5x5 table
+    await insertTable(page, 5, 5);
+
+    // 2. Type the letters in specific cells
+    await click(page, '.PlaygroundEditorTheme__tableCell');
+
+    // Move to cell for 'a' and type
+    await moveRight(page, 1);
+    await moveDown(page, 2);
+    await page.keyboard.type('a');
+
+    // Move to cell for 'b' and type
+    await moveRight(page, 1);
+    await page.keyboard.type('b');
+
+    // Move to cell for 'c' and type
+    await moveLeft(page, 2);
+    await moveDown(page, 1);
+    await page.keyboard.type('c');
+
+    // Move to cell for 'd' and type
+    await moveRight(page, 1);
+    await page.keyboard.type('d');
+
+    // Move to cell for 'e' and type
+    await moveRight(page, 1);
+    await page.keyboard.type('e');
+
+    // Move to cell for 'f' and type
+    await moveDown(page, 1);
+    await page.keyboard.type('f');
+
+    // 3. First merge: Select and merge cells a,b,c,d
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 2},
+      {x: 2, y: 3},
+      false,
+      false,
+    );
+    await mergeTableCells(page);
+    // 4. Second merge: Select and merge cells e,f
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 3},
+      {x: 3, y: 4},
+      false,
+      false,
+    );
+    await mergeTableCells(page);
+
+    // 5. Final merge: Non-rectangular selection attempt
+    await selectCellsFromTableCords(
+      page,
+      {x: 2, y: 4},
+      {x: 1, y: 3},
+      false,
+      false,
+    );
+    await mergeTableCells(page);
+    // 6. Assert the final state
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+          </colgroup>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              colspan="3"
+              rowspan="3">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">a</span>
+              </p>
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">b</span>
+              </p>
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">c</span>
+              </p>
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">d</span>
+              </p>
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">e</span>
+              </p>
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">f</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    await unmergeTableCell(page);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+            <col style="width: 92px;" />
+          </colgroup>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">a</span>
+              </p>
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">b</span>
+              </p>
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">c</span>
+              </p>
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">d</span>
+              </p>
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">e</span>
+              </p>
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr">
+                <span data-lexical-text="true">f</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+        </table>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
   test('Merged cell tab navigation forward', async ({
     page,
     isPlainText,

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -12,6 +12,7 @@ import type {JSX} from 'react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
 import {
+  $computeTableMapSkipCellCheck,
   $deleteTableColumn__EXPERIMENTAL,
   $deleteTableRow__EXPERIMENTAL,
   $getNodeTriplet,
@@ -267,38 +268,105 @@ function TableActionMenu({
     editor.update(() => {
       const selection = $getSelection();
       if ($isTableSelection(selection)) {
-        const {columns, rows} = computeSelectionCount(selection);
+        // Get all selected cells and compute the total area
         const nodes = selection.getNodes();
-        let firstCell: null | TableCellNode = null;
-        for (let i = 0; i < nodes.length; i++) {
-          const node = nodes[i];
-          if ($isTableCellNode(node)) {
-            if (firstCell === null) {
-              node.setColSpan(columns).setRowSpan(rows);
-              firstCell = node;
-              const isEmpty = $cellContainsEmptyParagraph(node);
-              let firstChild;
-              if (
-                isEmpty &&
-                $isParagraphNode((firstChild = node.getFirstChild()))
-              ) {
-                firstChild.remove();
-              }
-            } else if ($isTableCellNode(firstCell)) {
-              const isEmpty = $cellContainsEmptyParagraph(node);
-              if (!isEmpty) {
-                firstCell.append(...node.getChildren());
-              }
-              node.remove();
+        const tableCells = nodes.filter($isTableCellNode);
+
+        if (tableCells.length === 0) {
+          return;
+        }
+
+        // Find the table node
+        const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCells[0]);
+        const [gridMap] = $computeTableMapSkipCellCheck(tableNode, null, null);
+
+        // Find the boundaries of the selection including merged cells
+        let minRow = Infinity;
+        let maxRow = -Infinity;
+        let minCol = Infinity;
+        let maxCol = -Infinity;
+
+        // First pass: find the actual boundaries considering merged cells
+        const processedCells = new Set();
+        for (const row of gridMap) {
+          for (const mapCell of row) {
+            if (!mapCell || !mapCell.cell) {
+              continue;
+            }
+
+            const cellKey = mapCell.cell.getKey();
+            if (processedCells.has(cellKey)) {
+              continue;
+            }
+
+            if (tableCells.some((cell) => cell.is(mapCell.cell))) {
+              processedCells.add(cellKey);
+              // Get the actual position of this cell in the grid
+              const cellStartRow = mapCell.startRow;
+              const cellStartCol = mapCell.startColumn;
+              const cellRowSpan = mapCell.cell.__rowSpan || 1;
+              const cellColSpan = mapCell.cell.__colSpan || 1;
+
+              // Update boundaries considering the cell's actual position and span
+              minRow = Math.min(minRow, cellStartRow);
+              maxRow = Math.max(maxRow, cellStartRow + cellRowSpan - 1);
+              minCol = Math.min(minCol, cellStartCol);
+              maxCol = Math.max(maxCol, cellStartCol + cellColSpan - 1);
             }
           }
         }
-        if (firstCell !== null) {
-          if (firstCell.getChildrenSize() === 0) {
-            firstCell.append($createParagraphNode());
-          }
-          $selectLastDescendant(firstCell);
+
+        // Validate boundaries
+        if (minRow === Infinity || minCol === Infinity) {
+          return;
         }
+
+        // The total span of the merged cell
+        const totalRowSpan = maxRow - minRow + 1;
+        const totalColSpan = maxCol - minCol + 1;
+
+        // Use the top-left cell as the target cell
+        const targetCellMap = gridMap[minRow][minCol];
+        if (!targetCellMap?.cell) {
+          return;
+        }
+        const targetCell = targetCellMap.cell;
+
+        // Set the spans for the target cell
+        targetCell.setColSpan(totalColSpan);
+        targetCell.setRowSpan(totalRowSpan);
+
+        // Move content from other cells to the target cell
+        const seenCells = new Set([targetCell.getKey()]);
+
+        // Second pass: merge content and remove other cells
+        for (let row = minRow; row <= maxRow; row++) {
+          for (let col = minCol; col <= maxCol; col++) {
+            const mapCell = gridMap[row][col];
+            if (!mapCell?.cell) {
+              continue;
+            }
+
+            const currentCell = mapCell.cell;
+            const key = currentCell.getKey();
+
+            if (!seenCells.has(key)) {
+              seenCells.add(key);
+              const isEmpty = $cellContainsEmptyParagraph(currentCell);
+              if (!isEmpty) {
+                targetCell.append(...currentCell.getChildren());
+              }
+              currentCell.remove();
+            }
+          }
+        }
+
+        // Ensure target cell has content
+        if (targetCell.getChildrenSize() === 0) {
+          targetCell.append($createParagraphNode());
+        }
+
+        $selectLastDescendant(targetCell);
         onClose();
       }
     });

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -978,6 +978,7 @@ export function $computeTableCellRectBoundary(
   cellAMap: TableMapValueType,
   cellBMap: TableMapValueType,
 ): TableCellRectBoundary {
+  // Initial boundaries based on the anchor and focus cells
   let minColumn = Math.min(cellAMap.startColumn, cellBMap.startColumn);
   let minRow = Math.min(cellAMap.startRow, cellBMap.startRow);
   let maxColumn = Math.max(
@@ -988,65 +989,61 @@ export function $computeTableCellRectBoundary(
     cellAMap.startRow + cellAMap.cell.__rowSpan - 1,
     cellBMap.startRow + cellBMap.cell.__rowSpan - 1,
   );
-  let exploredMinColumn = minColumn;
-  let exploredMinRow = minRow;
-  let exploredMaxColumn = minColumn;
-  let exploredMaxRow = minRow;
-  function expandBoundary(mapValue: TableMapValueType): void {
-    const {
-      cell,
-      startColumn: cellStartColumn,
-      startRow: cellStartRow,
-    } = mapValue;
-    minColumn = Math.min(minColumn, cellStartColumn);
-    minRow = Math.min(minRow, cellStartRow);
-    maxColumn = Math.max(maxColumn, cellStartColumn + cell.__colSpan - 1);
-    maxRow = Math.max(maxRow, cellStartRow + cell.__rowSpan - 1);
-  }
-  while (
-    minColumn < exploredMinColumn ||
-    minRow < exploredMinRow ||
-    maxColumn > exploredMaxColumn ||
-    maxRow > exploredMaxRow
-  ) {
-    if (minColumn < exploredMinColumn) {
-      // Expand on the left
-      const rowDiff = exploredMaxRow - exploredMinRow;
-      const previousColumn = exploredMinColumn - 1;
-      for (let i = 0; i <= rowDiff; i++) {
-        expandBoundary(map[exploredMinRow + i][previousColumn]);
+
+  // Keep expanding until we have a complete rectangle
+  let hasChanges;
+  do {
+    hasChanges = false;
+
+    // Check all cells in the table
+    for (let row = 0; row < map.length; row++) {
+      for (let col = 0; col < map[0].length; col++) {
+        const cell = map[row][col];
+        if (!cell) {
+          continue;
+        }
+
+        const cellEndCol = cell.startColumn + cell.cell.__colSpan - 1;
+        const cellEndRow = cell.startRow + cell.cell.__rowSpan - 1;
+
+        // Check if this cell intersects with our current selection rectangle
+        const intersectsHorizontally =
+          cell.startColumn <= maxColumn && cellEndCol >= minColumn;
+        const intersectsVertically =
+          cell.startRow <= maxRow && cellEndRow >= minRow;
+
+        // If the cell intersects either horizontally or vertically
+        if (intersectsHorizontally && intersectsVertically) {
+          // Expand boundaries to include this cell completely
+          const newMinColumn = Math.min(minColumn, cell.startColumn);
+          const newMaxColumn = Math.max(maxColumn, cellEndCol);
+          const newMinRow = Math.min(minRow, cell.startRow);
+          const newMaxRow = Math.max(maxRow, cellEndRow);
+
+          // Check if boundaries changed
+          if (
+            newMinColumn !== minColumn ||
+            newMaxColumn !== maxColumn ||
+            newMinRow !== minRow ||
+            newMaxRow !== maxRow
+          ) {
+            minColumn = newMinColumn;
+            maxColumn = newMaxColumn;
+            minRow = newMinRow;
+            maxRow = newMaxRow;
+            hasChanges = true;
+          }
+        }
       }
-      exploredMinColumn = previousColumn;
     }
-    if (minRow < exploredMinRow) {
-      // Expand on top
-      const columnDiff = exploredMaxColumn - exploredMinColumn;
-      const previousRow = exploredMinRow - 1;
-      for (let i = 0; i <= columnDiff; i++) {
-        expandBoundary(map[previousRow][exploredMinColumn + i]);
-      }
-      exploredMinRow = previousRow;
-    }
-    if (maxColumn > exploredMaxColumn) {
-      // Expand on the right
-      const rowDiff = exploredMaxRow - exploredMinRow;
-      const nextColumn = exploredMaxColumn + 1;
-      for (let i = 0; i <= rowDiff; i++) {
-        expandBoundary(map[exploredMinRow + i][nextColumn]);
-      }
-      exploredMaxColumn = nextColumn;
-    }
-    if (maxRow > exploredMaxRow) {
-      // Expand on the bottom
-      const columnDiff = exploredMaxColumn - exploredMinColumn;
-      const nextRow = exploredMaxRow + 1;
-      for (let i = 0; i <= columnDiff; i++) {
-        expandBoundary(map[nextRow][exploredMinColumn + i]);
-      }
-      exploredMaxRow = nextRow;
-    }
-  }
-  return {maxColumn, maxRow, minColumn, minRow};
+  } while (hasChanges);
+
+  return {
+    maxColumn,
+    maxRow,
+    minColumn,
+    minRow,
+  };
 }
 
 export function $getTableCellNodeRect(tableCellNode: TableCellNode): {


### PR DESCRIPTION
## Description

### Current Behavior
Currently, when merging table cells that include already merged cells, the selection and merge behavior can result in:
1. Non-rectangular selections being allowed
2. Table distortion after merging
3. Missing cells in some cases
4. Inconsistent behavior compared to other table editors like Excel

### Changes
This PR fixes the table cell merging functionality to ensure selections are always rectangular and merges are performed correctly:

1. Improved Selection Boundary Calculation
   - Implemented a two-pass algorithm for accurate boundary detection:
     * First pass: Scans the grid to find all cells in selection, including merged cells
     * Second pass: Expands boundaries to ensure a complete rectangle
   - Added proper handling of cell spans:
     * Consider both `startRow + rowSpan - 1` and `startColumn + colSpan - 1` for boundary calculation
     * Track actual cell positions using `startRow` and `startColumn` from grid map
     * Ensure selection includes complete merged cells, not partial ones
   - Enhanced boundary validation:
     * Check for `Infinity` in min/max calculations
     * Validate grid map indices before access
     * Ensure rectangular selection by expanding to cover all intersecting cells

2. Enhanced Merged Cell Handling
   - Added robust cell tracking mechanism:
     * Use `Set` to track processed cells by their keys
     * Prevent duplicate processing of cells in overlapping merged areas
     * Handle cases where merged cells span multiple rows/columns
   - Improved merged cell content management:
     * Properly merge content from all source cells into target cell
     * Preserve content when merging cells with existing merged cells
     * Handle empty cells with proper paragraph node creation
   - Enhanced span calculations:
     * Calculate total spans based on actual grid positions
     * Set correct `rowSpan` and `colSpan` on target cell
     * Handle cases where merged cells intersect selection boundaries

3. Core Implementation Changes
   - Replaced simple iteration with grid-map based approach:
     * Use `$computeTableMapSkipCellCheck` for accurate cell mapping
     * Track cell positions and spans in grid coordinate system
     * Handle cell relationships through grid map references
   - Added boundary computation logic:
     * Track minimum and maximum row/column indices
     * Update boundaries based on cell spans and positions
     * Ensure complete coverage of merged cells
   - Enhanced merge operation:
     * Select top-left cell as merge target
     * Properly remove merged cells after content transfer
     * Maintain table structure during merge operation


Closes #7161

## Test plan

### Before


https://github.com/user-attachments/assets/720b0bd6-4cf1-432e-b325-d8ab55791bac


https://github.com/user-attachments/assets/82bcbed1-efda-44fd-9158-8d0e482500ce




### After


https://github.com/user-attachments/assets/f9bdcf6b-a8fa-4af3-ae1a-f9de9afd42c4

