### PR TITLE
[RFC] setEditorState precedence over update

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -27,6 +27,7 @@ import {
   $commitPendingUpdates,
   internalGetActiveEditor,
   parseEditorState,
+  setActiveEditorState,
   triggerListeners,
   updateEditor,
   updateEditorSync,
@@ -1168,6 +1169,7 @@ export class LexicalEditor {
       $commitPendingUpdates(this);
     }
 
+    setActiveEditorState(writableEditorState);
     this._pendingEditorState = writableEditorState;
     this._dirtyType = FULL_RECONCILE;
     this._dirtyElements.set('root', false);

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -107,6 +107,10 @@ export function getActiveEditorState(): EditorState {
   return activeEditorState;
 }
 
+export function setActiveEditorState(editorState: EditorState) {
+  activeEditorState = editorState;
+}
+
 export function getActiveEditor(): LexicalEditor {
   if (activeEditor === null) {
     invariant(

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2589,6 +2589,20 @@ describe('LexicalEditor tests', () => {
     expect(editor.getEditorState().read($rootTextContent)).toBe('currentnext');
   });
 
+  it('throws when referring to Nodes prior to setEditorState', async () => {
+    editor = createTestEditor({});
+    await editor.update(() => {
+      const text = $createTextNode('next');
+      const state = editor.parseEditorState(
+        `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"current","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+      );
+      editor.setEditorState(state);
+      expect(() => $insertNodes([text])).toThrow();
+    });
+    // A writable version of the EditorState may have been created, we settle for equal serializations
+    expect(editor.getEditorState().read($rootTextContent)).toBe('current');
+  });
+
   describe('node replacement', () => {
     it('should work correctly', async () => {
       const onError = jest.fn();

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -20,6 +20,7 @@ import {
   TableCellNode,
   TableRowNode,
 } from '@lexical/table';
+import {$rootTextContent} from '@lexical/text';
 import {
   $createLineBreakNode,
   $createNodeSelection,
@@ -30,6 +31,7 @@ import {
   $getNearestNodeFromDOMNode,
   $getNodeByKey,
   $getRoot,
+  $insertNodes,
   $isParagraphNode,
   $isTextNode,
   $parseSerializedNode,
@@ -2572,6 +2574,19 @@ describe('LexicalEditor tests', () => {
     // A writable version of the EditorState may have been created, we settle for equal serializations
     expect(editor._editorState.toJSON()).toEqual(state.toJSON());
     expect(editor._pendingEditorState).toBe(null);
+  });
+
+  it('updates the relevant pendingEditorState after setEditorState', async () => {
+    editor = createTestEditor({});
+    await editor.update(() => {
+      const state = editor.parseEditorState(
+        `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"current","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+      );
+      editor.setEditorState(state);
+      $insertNodes([$createTextNode('next')]);
+    });
+    // A writable version of the EditorState may have been created, we settle for equal serializations
+    expect(editor.getEditorState().read($rootTextContent)).toBe('currentnext');
   });
 
   describe('node replacement', () => {


### PR DESCRIPTION
_This PR is in response to patterns that we've seen internally. Irrespective of this PR, the use of `setEditorState` inside an update has pitfalls and is a clear antipattern._

Currently, `setEditorState` will replace the current `pendingEditorState` but not the `activeEditorState`. This has implications:
1. The current solution is safer because it assures that the referenced nodes in the update will always be present/attached. This will avoid crashes but can lead to correctness errors because the EditorState will be dismissed.
2. Replacing `activeEditorState` allows `setEditorState` to be used within the same update but it can mistakenly lead to crashes.

