### PR TITLE
[fix] $dfs traversal from the middle of the tree leaves

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -183,6 +183,33 @@ describe('LexicalNodeHelpers tests', () => {
           expect($reverseDfs($getRoot())).toEqual(expectedNodes);
         });
       });
+
+      test('DFS from the middle', async () => {
+        const editor: LexicalEditor = testEnv.editor;
+        editor.update(
+          () => {
+            const root = $getRoot();
+
+            root
+              .clear()
+              .append(
+                $createParagraphNode().append(
+                  $createTextNode('Hello'),
+                  $createTextNode('world').toggleFormat('bold'),
+                  $createTextNode('!'),
+                ),
+              );
+
+            const paragraph = root.getFirstChildOrThrow<ElementNode>();
+            const children = paragraph.getChildren();
+            expect($dfs(children[1]).map((step) => step.node)).toEqual([
+              children[1],
+              children[2],
+            ]);
+          },
+          {discrete: true},
+        );
+      });
     });
 
     test('DFS triggers getLatest()', async () => {

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -246,7 +246,7 @@ function $dfsCaretIterator<D extends CaretDirection>(
   const start = startNode || root;
   const startCaret = $isElementNode(start)
     ? $getChildCaret(start, direction)
-    : $rewindSiblingCaret($getSiblingCaret(start, direction));
+    : $getSiblingCaret(start, direction);
   const startDepth = $getDepth(startCaret.getParentAtCaret());
   const endCaret = $getAdjacentChildCaret(
     endNode


### PR DESCRIPTION
Running $dfs from non-first child node would reset caret and traverse from the first child:

```
    P1
T1  T2 T3

$dfs(T2) -> [T1, T2, T3]

while expected

[T2, T3]
```

@etrepum wondering if you recall why that $rewind() was added