### PR TITLE
No forward slash in template

### DIFF
--- a/scripts/error-codes/formatProdErrorMessage.js
+++ b/scripts/error-codes/formatProdErrorMessage.js
@@ -13,15 +13,16 @@
 // during build.
 
 function formatProdErrorMessage(code) {
+  const url = new URL('https://lexical.dev/docs/error');
   const params = new URLSearchParams();
   params.append('code', code);
   for (let i = 1; i < arguments.length; i++) {
     params.append('v', arguments[i]);
   }
+  url.search = params.toString();
+
   throw Error(
-    `Minified Lexical error #${code}; visit https://lexical.dev/docs/error?${params} for the full message or ` +
-      'use the non-minified dev environment for full errors and additional ' +
-      'helpful warnings.',
+    `Minified Lexical error #${code}; visit ${url.toString()} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`,
   );
 }
 


### PR DESCRIPTION
Internal requirement, no template strings with 2 forward slahes, otherwise our parser gets angry.

Tested manually it still works
![Screenshot 2025-02-14 at 10 37 03 AM](https://github.com/user-attachments/assets/43724906-662f-48d1-a133-9b0979415ea2)


