### PR TITLE
[fix] DFS depths when starting from inline node

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -202,9 +202,9 @@ describe('LexicalNodeHelpers tests', () => {
 
             const paragraph = root.getFirstChildOrThrow<ElementNode>();
             const children = paragraph.getChildren();
-            expect($dfs(children[1]).map((step) => step.node)).toEqual([
-              children[1],
-              children[2],
+            expect($dfs(children[1])).toEqual([
+              {depth: 2, node: children[1]},
+              {depth: 2, node: children[2]},
             ]);
           },
           {discrete: true},

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -247,7 +247,7 @@ function $dfsCaretIterator<D extends CaretDirection>(
   const startCaret = $isElementNode(start)
     ? $getChildCaret(start, direction)
     : $getSiblingCaret(start, direction);
-  const startDepth = $getDepth(startCaret.getParentAtCaret());
+  const startDepth = $getDepth(start);
   const endCaret = $getAdjacentChildCaret(
     endNode
       ? $getChildCaretOrSelf($getSiblingCaret(endNode, direction))


### PR DESCRIPTION
Missed in #7174 that depth was not calculated properly if we're starting iterator from inline node. In that case depth of its parent was used:


```
    P
T1 T2 T3
```

```js
$dfs(T2) -> [[depth: 1, node: T2], [depth: 1, node: T3]]
```

while expected

```js
$dfs(T2) -> [[depth: 2, node: T2], [depth: 2, node: T3]]
```