### PR TITLE
[Breaking Change][lexical][lexical-link] Bug Fix: Collapse through inline elements in deleteCharacter

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -14,7 +14,9 @@ import {
   moveRight,
   moveToEditorBeginning,
   moveToEditorEnd,
+  moveToLineBeginning,
   moveToParagraphEnd,
+  pressBackspace,
   redo,
   selectAll,
   selectCharacters,
@@ -1943,6 +1945,97 @@ test.describe.parallel('Nested List', () => {
             </ul>
           </li>
         </ul>
+      `,
+    );
+  });
+  test('collapseAtStart for trivial bullet list', async ({page}) => {
+    await focusEditor(page);
+    await toggleBulletList(page);
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <br />
+          </li>
+        </ul>
+      `,
+    );
+    await pressBackspace(page);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+  test('collapseAtStart for bullet list with text', async ({page}) => {
+    await focusEditor(page);
+    await toggleBulletList(page);
+    await page.keyboard.type('Hello World');
+    await moveToLineBeginning(page);
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="1">
+            <span data-lexical-text="true">Hello World</span>
+          </li>
+        </ul>
+      `,
+    );
+    await pressBackspace(page);
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello World</span>
+        </p>
+      `,
+    );
+  });
+  test('collapseAtStart for bullet list with text inside autolink', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await toggleBulletList(page);
+    await page.keyboard.type('www.example.com');
+    await moveToLineBeginning(page);
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="1">
+            <a
+              class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              href="https://www.example.com">
+              <span data-lexical-text="true">www.example.com</span>
+            </a>
+          </li>
+        </ul>
+      `,
+    );
+    await pressBackspace(page);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            href="https://www.example.com">
+            <span data-lexical-text="true">www.example.com</span>
+          </a>
+        </p>
       `,
     );
   });

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1842,11 +1842,7 @@ export class RangeSelection implements BaseSelection {
         $updateCaretSelectionForUnicodeCharacter(this, isBackward);
       } else if (isBackward && anchor.offset === 0) {
         // Special handling around rich text nodes
-        const element =
-          anchor.type === 'element'
-            ? anchor.getNode()
-            : anchor.getNode().getParentOrThrow();
-        if (element.collapseAtStart(this)) {
+        if ($collapseAtStart(this, anchor.getNode())) {
           return;
         }
       }
@@ -1863,9 +1859,9 @@ export class RangeSelection implements BaseSelection {
       if (
         anchorNode.isEmpty() &&
         $isRootNode(anchorNode.getParent()) &&
-        anchorNode.getIndexWithinParent() === 0
+        anchorNode.getPreviousSibling() === null
       ) {
-        anchorNode.collapseAtStart(this);
+        $collapseAtStart(this, anchorNode);
       }
     }
   }
@@ -1970,6 +1966,30 @@ export function $getCharacterOffsets(
     return [0, 0];
   }
   return [getCharacterOffset(anchor), getCharacterOffset(focus)];
+}
+
+function $collapseAtStart(
+  selection: RangeSelection,
+  startNode: LexicalNode,
+): boolean {
+  for (
+    let node: null | LexicalNode = startNode;
+    node;
+    node = node.getParent()
+  ) {
+    if ($isElementNode(node)) {
+      if (node.collapseAtStart(selection)) {
+        return true;
+      }
+      if (!node.isInline()) {
+        break;
+      }
+    }
+    if (node.getPreviousSibling()) {
+      break;
+    }
+  }
+  return false;
 }
 
 function $swapPoints(selection: RangeSelection): void {

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -880,9 +880,15 @@ export class ElementNode extends LexicalNode {
     return true;
   }
   /*
-   * This method controls the behavior of a the node during backwards
+   * This method controls the behavior of the node during backwards
    * deletion (i.e., backspace) when selection is at the beginning of
-   * the node (offset 0)
+   * the node (offset 0). You may use this to have the node replace
+   * itself, change its state, or do nothing. When you do make such
+   * a change, you should return true.
+   *
+   * When true is returned, the collapse phase will stop.
+   * When false is returned, and isInline() is true, and getPreviousSibling() is null,
+   * then this function will be called on its parent.
    */
   collapseAtStart(selection: RangeSelection): boolean {
     return false;


### PR DESCRIPTION
# Breaking Change

`ElementNode.collapseAtStart(range)` would previously only be called on the direct parent of the anchor's node, so the presence of anything like a LinkNode would prevent a ListItemNode from collapsing. Now it will also be called on parents under certain conditions.

## Description

Previously the collapse algorithm looked only at the direct parent of the anchor. If the anchor is inside an inline node (e.g. a TextNode in a LinkNode) then the expected behavior will not happen (such as a LinkItemNode being replaced with a ParagraphNode).

Now the algorithm works like this:

- Start with the anchor node (if its offset is 0) and then all of its parents:
  - If the current node is an ElementNode
    - If node.collapseAtStart(range) returns true, stop
    - If node.isInline() returns false, stop
  - If the node is not the first child of its parent, stop
 
Closes #7150

## Test plan

e2e tests for new behavior

### Before

Pressing delete at the beginning of a ListItemNode would not collapse the node if the anchor was inside of an inline element (such as a LinkNode)


### After

Pressing delete at the beginning of a ListItemNode collapses through inline element node(s) as expected