### PR TITLE
[lexical-playground] fix: hard coded theme classes for table hover actions

### DIFF
--- a/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
@@ -24,7 +24,12 @@ import {
   TableRowNode,
 } from '@lexical/table';
 import {$findMatchingParent, mergeRegister} from '@lexical/utils';
-import {$getNearestNodeFromDOMNode, isHTMLElement, NodeKey} from 'lexical';
+import {
+  $getNearestNodeFromDOMNode,
+  EditorThemeClasses,
+  isHTMLElement,
+  NodeKey,
+} from 'lexical';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import * as React from 'react';
 import {createPortal} from 'react-dom';
@@ -38,7 +43,7 @@ function TableHoverActionsContainer({
 }: {
   anchorElem: HTMLElement;
 }): JSX.Element | null {
-  const [editor] = useLexicalComposerContext();
+  const [editor, {getTheme}] = useLexicalComposerContext();
   const isEditable = useLexicalEditable();
   const [isShownRow, setShownRow] = useState<boolean>(false);
   const [isShownColumn, setShownColumn] = useState<boolean>(false);
@@ -50,7 +55,7 @@ function TableHoverActionsContainer({
 
   const debouncedOnMouseMove = useDebounce(
     (event: MouseEvent) => {
-      const {isOutside, tableDOMNode} = getMouseInfo(event);
+      const {isOutside, tableDOMNode} = getMouseInfo(event, getTheme);
 
       if (isOutside) {
         setShownRow(false);
@@ -256,14 +261,14 @@ function TableHoverActionsContainer({
     <>
       {isShownRow && (
         <button
-          className={'PlaygroundEditorTheme__tableAddRows'}
+          className={`${getTheme()?.tableAddRows}`}
           style={{...position}}
           onClick={() => insertAction(true)}
         />
       )}
       {isShownColumn && (
         <button
-          className={'PlaygroundEditorTheme__tableAddColumns'}
+          className={`${getTheme()?.tableAddColumns}`}
           style={{...position}}
           onClick={() => insertAction(false)}
         />
@@ -272,7 +277,10 @@ function TableHoverActionsContainer({
   );
 }
 
-function getMouseInfo(event: MouseEvent): {
+function getMouseInfo(
+  event: MouseEvent,
+  getTheme: () => EditorThemeClasses | null | undefined,
+): {
   tableDOMNode: HTMLElement | null;
   isOutside: boolean;
 } {
@@ -280,17 +288,13 @@ function getMouseInfo(event: MouseEvent): {
 
   if (isHTMLElement(target)) {
     const tableDOMNode = target.closest<HTMLElement>(
-      'td.PlaygroundEditorTheme__tableCell, th.PlaygroundEditorTheme__tableCell',
+      `td.${getTheme()?.tableCell}, th.${getTheme()?.tableCell}`,
     );
 
     const isOutside = !(
       tableDOMNode ||
-      target.closest<HTMLElement>(
-        'button.PlaygroundEditorTheme__tableAddRows',
-      ) ||
-      target.closest<HTMLElement>(
-        'button.PlaygroundEditorTheme__tableAddColumns',
-      ) ||
+      target.closest<HTMLElement>(`button.${getTheme()?.tableAddRows}`) ||
+      target.closest<HTMLElement>(`button.${getTheme()?.tableAddColumns}`) ||
       target.closest<HTMLElement>('div.TableCellResizer__resizer')
     );
 

--- a/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx
@@ -34,6 +34,7 @@ import {useEffect, useMemo, useRef, useState} from 'react';
 import * as React from 'react';
 import {createPortal} from 'react-dom';
 
+import {getThemeSelector} from '../../utils/getThemeSelector';
 import {useDebounce} from '../CodeActionMenuPlugin/utils';
 
 const BUTTON_WIDTH_PX = 20;
@@ -285,16 +286,21 @@ function getMouseInfo(
   isOutside: boolean;
 } {
   const target = event.target;
+  const tableCellClass = getThemeSelector(getTheme, 'tableCell');
 
   if (isHTMLElement(target)) {
     const tableDOMNode = target.closest<HTMLElement>(
-      `td.${getTheme()?.tableCell}, th.${getTheme()?.tableCell}`,
+      `td${tableCellClass}, th${tableCellClass}`,
     );
 
     const isOutside = !(
       tableDOMNode ||
-      target.closest<HTMLElement>(`button.${getTheme()?.tableAddRows}`) ||
-      target.closest<HTMLElement>(`button.${getTheme()?.tableAddColumns}`) ||
+      target.closest<HTMLElement>(
+        `button${getThemeSelector(getTheme, 'tableAddRows')}`,
+      ) ||
+      target.closest<HTMLElement>(
+        `button${getThemeSelector(getTheme, 'tableAddColumns')}`,
+      ) ||
       target.closest<HTMLElement>('div.TableCellResizer__resizer')
     );
 

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.ts
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.ts
@@ -93,6 +93,8 @@ const theme: EditorThemeClasses = {
   specialText: 'PlaygroundEditorTheme__specialText',
   tab: 'PlaygroundEditorTheme__tabNode',
   table: 'PlaygroundEditorTheme__table',
+  tableAddColumns: 'PlaygroundEditorTheme__tableAddColumns',
+  tableAddRows: 'PlaygroundEditorTheme__tableAddRows',
   tableAlignment: {
     center: 'PlaygroundEditorTheme__tableAlignmentCenter',
     right: 'PlaygroundEditorTheme__tableAlignmentRight',

--- a/packages/lexical-playground/src/utils/getThemeSelector.ts
+++ b/packages/lexical-playground/src/utils/getThemeSelector.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {EditorThemeClasses} from 'lexical';
+import invariant from 'shared/invariant';
+
+export function getThemeSelector(
+  getTheme: () => EditorThemeClasses | null | undefined,
+  name: keyof EditorThemeClasses,
+): string {
+  const className = getTheme()?.[name];
+  invariant(
+    typeof className === 'string',
+    'getThemeClass: required theme property %s not defined',
+    String(name),
+  );
+  return className
+    .split(/\s+/g)
+    .map((cls) => `.${cls}`)
+    .join();
+}


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

The [TableHoverActionsPlugin](packages/lexical-playground/src/plugins/TableHoverActionsPlugin/index.tsx) has following class names hard coded instead of being referenced from theme.

- PlaygroundEditorTheme__tableAddRows
- PlaygroundEditorTheme__tableAddColumns
- PlaygroundEditorTheme__tableCell

This PR fixes the hard coded names.

## Test plan

There is no change in behaviour due to the fix. It only enables the Table Hover Action Plugin to keep working if the Playground theme is modified.