### PR TITLE
[lexical] Bug Fix: add missing flow type for getNearestEditorFromDOMNode

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -887,6 +887,9 @@ export type EventHandler = (event: Event, editor: LexicalEditor) => void;
 declare export function $hasUpdateTag(tag: string): boolean;
 declare export function $addUpdateTag(tag: string): void;
 declare export function $onUpdate(updateFn: () => void): void;
+declare export function getNearestEditorFromDOMNode(
+  node: Node | null,
+): LexicalEditor | null;
 declare export function $getNearestNodeFromDOMNode(
   startingDOM: Node,
 ): LexicalNode | null;


### PR DESCRIPTION
## Description
Current behavior:
- The `getNearestEditorFromDOMNode` function is missing Flow type definition in `Lexical.js.flow`
- This causes Flow errors when importing and using the function, requiring `$FlowFixMe` to suppress

Changes being added:
- Add proper Flow type definition for `getNearestEditorFromDOMNode` in `Lexical.js.flow`
- This allows proper type checking when importing the function
- Removes the need for `$FlowFixMe` suppression

Closes #7148

## Test plan

### Before

```typescript
// packages/lexical-playground/src/test-flow-issue.js.flow
// @flow strict

import {getNearestEditorFromDOMNode} from 'lexical';
// Flow error: Cannot import getNearestEditorFromDOMNode because there is no getNearestEditorFromDOMNode export in lexical. [missing-export]

function test(node: Node) {
  getNearestEditorFromDOMNode(node);
} 
```

![image](https://github.com/user-attachments/assets/f528cf01-bb67-4f29-8335-f7bbd06f7ebe)


### After

```typescript
// packages/lexical-playground/src/test-flow-issue.js.flow
// @flow strict
import {getNearestEditorFromDOMNode} from 'lexical';
// No Flow errors, proper type checking works

function test(node: Node) {
  getNearestEditorFromDOMNode(node);
} 
```

![image](https://github.com/user-attachments/assets/59592c0c-7bae-4490-9296-3f8d77308300)
