### PR TITLE
[lexical-react] Bug Fix: Make typeahead menu respect read-only mode

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -242,6 +242,12 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
   useEffect(() => {
     const updateListener = () => {
       editor.getEditorState().read(() => {
+        // Check if editor is in read-only mode
+        if (!editor.isEditable()) {
+          closeTypeahead();
+          return;
+        }
+
         const editorWindow = editor._window || window;
         const range = editorWindow.document.createRange();
         const selection = $getSelection();
@@ -296,6 +302,22 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
     closeTypeahead,
     openTypeahead,
   ]);
+
+  // Add effect to listen for editable state changes
+  useEffect(() => {
+    const editableListener = (isEditable: boolean) => {
+      if (!isEditable) {
+        closeTypeahead();
+      }
+    };
+
+    const removeEditableListener =
+      editor.registerEditableListener(editableListener);
+
+    return () => {
+      removeEditableListener();
+    };
+  }, [editor, closeTypeahead]);
 
   return resolution === null ||
     editor === null ||

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -303,21 +303,15 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
     openTypeahead,
   ]);
 
-  // Add effect to listen for editable state changes
-  useEffect(() => {
-    const editableListener = (isEditable: boolean) => {
-      if (!isEditable) {
-        closeTypeahead();
-      }
-    };
-
-    const removeEditableListener =
-      editor.registerEditableListener(editableListener);
-
-    return () => {
-      removeEditableListener();
-    };
-  }, [editor, closeTypeahead]);
+  useEffect(
+    () =>
+      editor.registerEditableListener((isEditable) => {
+        if (!isEditable) {
+          closeTypeahead();
+        }
+      }),
+    [editor, closeTypeahead],
+  );
 
   return resolution === null ||
     editor === null ||


### PR DESCRIPTION
## Description
Currently, the typeahead menu (emoji/mentions picker) does not respect the editor's read-only mode. When the editor is in read-only mode:
1. The typeahead menu still opens when typing triggers (: or @)
2. Users can still select and insert emojis/mentions
3. The menu stays open even if editor switches to read-only mode while menu is open

This PR fixes the issue by:
1. Adding a read-only mode check before showing the typeahead menu
2. Adding an editable state listener to close the menu when editor becomes read-only
3. Ensuring complete compliance with read-only mode behavior

Closes #7160

## Test plan

### Before

https://github.com/user-attachments/assets/61473734-e4db-486c-985e-f9480d9aa4c7

### After

https://github.com/user-attachments/assets/2eb0e34f-66b9-44c3-87b2-8e129e89defa
