### PR TITLE
Documentation Update: `ContentEditable` placeholder` in React Getting Started 

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,12 @@ function Editor() {
   return (
     <LexicalComposer initialConfig={initialConfig}>
       <PlainTextPlugin
-        contentEditable={<ContentEditable />}
-        placeholder={<div>Enter some text...</div>}
+        contentEditable={
+          <ContentEditable
+            placeholder={<div>Enter some text...</div>}
+            aria-placeholder={'Enter some text...'}
+          />
+        }
         ErrorBoundary={LexicalErrorBoundary}
       />
       <OnChangePlugin onChange={onChange} />

--- a/packages/lexical-website/docs/getting-started/react.md
+++ b/packages/lexical-website/docs/getting-started/react.md
@@ -61,8 +61,12 @@ function Editor() {
   return (
     <LexicalComposer initialConfig={initialConfig}>
       <RichTextPlugin
-        contentEditable={<ContentEditable />}
-        placeholder={<div>Enter some text...</div>}
+        contentEditable={
+          <ContentEditable
+            placeholder={<div>Enter some text...</div>}
+            aria-placeholder={'Enter some text...'}
+          />
+        }
         ErrorBoundary={LexicalErrorBoundary}
       />
       <HistoryPlugin />
@@ -135,8 +139,12 @@ function Editor() {
   return (
     <LexicalComposer initialConfig={initialConfig}>
       <RichTextPlugin
-        contentEditable={<ContentEditable />}
-        placeholder={<div>Enter some text...</div>}
+        contentEditable={
+          <ContentEditable
+            aria-placeholder={'Enter some text...'}
+            placeholder={<div>Enter some text...</div>}
+          />
+        }
         ErrorBoundary={LexicalErrorBoundary}
       />
       <HistoryPlugin />


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

When adding placeholders, I stumbled upon the `placeholder` prop within `ContentEditable`, the TODO, and subsequently #6171.

I had blindly copied the example from the docs, but that is out-of-date given this is the preferred prop now for a11y.

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*

N/A

### After

*Insert relevant screenshots/recordings/automated-tests*