### PR TITLE
[lexical] Bug Fix: catch setTimeout wrapped setBaseAndExtent call

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2932,12 +2932,18 @@ export function updateDOMSelection(
     // This is a workaround to restore the correct selection
     if (IS_ANDROID_CHROME) {
       setTimeout(() => {
-        domSelection.setBaseAndExtent(
-          nextAnchorNode,
-          nextAnchorOffset,
-          nextFocusNode,
-          nextFocusOffset,
-        );
+        try {
+          domSelection.setBaseAndExtent(
+            nextAnchorNode,
+            nextAnchorOffset,
+            nextFocusNode,
+            nextFocusOffset,
+          );
+        } catch (error) {
+          if (__DEV__) {
+            console.warn(error);
+          }
+        }
       });
     }
   } catch (error) {


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
https://github.com/facebook/lexical/pull/7122 added a `setBaseAndExtent` call on `LexicalSelection.ts` line `2935` that as far as I understand is intended to be caught and ignored if an error is thrown, but since it's wrapped inside of a `setTimeout` callback it's still uncaught. 

Would be nice if it was handled the same way as the `setBaseAndExtent` call which isn't in the `setTimeout` callback (line `2925`). if that's the intention at least. 

lmk if it makes sense, thx.

## Test plan

### Before
potential Uncaught `Failed to execute 'setBaseAndExtent'` may happen

### After
potential Uncaught `Failed to execute 'setBaseAndExtent'` don't happen, as I assume was the intention