### PR TITLE
[Breaking Change][lexical-playground]: Refactor: Remove special case for collapsible forward deletion

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -380,7 +380,7 @@ test.describe.parallel('Selection', () => {
     );
   });
 
-  test('Can delete forward a Collapsible', async ({page, isPlainText}) => {
+  test(`Can't delete forward a Collapsible`, async ({page, isPlainText}) => {
     test.skip(isPlainText);
     if (!IS_MAC) {
       // Do Windows/Linux have equivalent shortcuts?
@@ -389,6 +389,7 @@ test.describe.parallel('Selection', () => {
     await focusEditor(page);
     await page.keyboard.type('abc');
     await insertCollapsible(page);
+    await page.keyboard.type('title');
     await moveToEditorBeginning(page);
     await moveRight(page, 3);
     await deleteForward(page);
@@ -401,15 +402,68 @@ test.describe.parallel('Selection', () => {
           dir="ltr">
           <span data-lexical-text="true">abc</span>
         </p>
-        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <div class="Collapsible__container" open="">
+          <summary class="Collapsible__title">
+            <p
+              class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+              dir="ltr">
+              <span data-lexical-text="true">title</span>
+            </p>
+          </summary>
+          <div class="Collapsible__content">
+            <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+          </div>
+        </div>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
       `,
     );
   });
 
-  // TODO I don't think this test is correct but at least this test will prevent it from regressing
-  // even further
-  test('Can delete forward a Table', async ({page, isPlainText}) => {
+  test(`Can't delete backward a Collapsible`, async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+    if (!IS_MAC) {
+      // Do Windows/Linux have equivalent shortcuts?
+      return;
+    }
+    await focusEditor(page);
+    await page.keyboard.type('abc');
+    await insertCollapsible(page);
+    await page.keyboard.type('title');
+    await moveRight(page, 2);
+    await page.keyboard.type('after');
+    await moveLeft(page, 'after'.length);
+    await deleteBackward(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">abc</span>
+        </p>
+        <div class="Collapsible__container" open="">
+          <summary class="Collapsible__title">
+            <p
+              class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+              dir="ltr">
+              <span data-lexical-text="true">title</span>
+            </p>
+          </summary>
+          <div class="Collapsible__content">
+            <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+          </div>
+        </div>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">after</span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Can't delete forward a Table`, async ({page, isPlainText}) => {
     test.skip(isPlainText);
     if (!IS_MAC) {
       // Do Windows/Linux have equivalent shortcuts?
@@ -447,6 +501,53 @@ test.describe.parallel('Selection', () => {
           </tr>
         </table>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test(`Can't delete backward a Table`, async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+    if (!IS_MAC) {
+      // Do Windows/Linux have equivalent shortcuts?
+      return;
+    }
+    await focusEditor(page);
+    await page.keyboard.type('abc');
+    await insertTable(page, 1, 2);
+    await moveToEditorEnd(page);
+    await page.keyboard.type('after');
+    await moveLeft(page, 'after'.length);
+    await deleteBackward(page);
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">abc</span>
+        </p>
+        <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+            <th
+              class="PlaygroundEditorTheme__tableCell PlaygroundEditorTheme__tableCellHeader">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </th>
+          </tr>
+        </table>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">after</span>
+        </p>
       `,
     );
   });

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -380,7 +380,11 @@ test.describe.parallel('Selection', () => {
     );
   });
 
-  test(`Can't delete forward a Collapsible`, async ({page, isPlainText}) => {
+  test(`Can't delete forward a Collapsible`, async ({
+    page,
+    browserName,
+    isPlainText,
+  }) => {
     test.skip(isPlainText);
     if (!IS_MAC) {
       // Do Windows/Linux have equivalent shortcuts?
@@ -394,6 +398,7 @@ test.describe.parallel('Selection', () => {
     await moveRight(page, 3);
     await deleteForward(page);
 
+    const collapsibleTag = browserName === 'chromium' ? 'div' : 'details';
     await assertHTML(
       page,
       html`
@@ -402,7 +407,7 @@ test.describe.parallel('Selection', () => {
           dir="ltr">
           <span data-lexical-text="true">abc</span>
         </p>
-        <div class="Collapsible__container" open="">
+        <${collapsibleTag} class="Collapsible__container" open="">
           <summary class="Collapsible__title">
             <p
               class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
@@ -413,13 +418,17 @@ test.describe.parallel('Selection', () => {
           <div class="Collapsible__content">
             <p class="PlaygroundEditorTheme__paragraph"><br /></p>
           </div>
-        </div>
+        </${collapsibleTag}>
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
       `,
     );
   });
 
-  test(`Can't delete backward a Collapsible`, async ({page, isPlainText}) => {
+  test(`Can't delete backward a Collapsible`, async ({
+    page,
+    browserName,
+    isPlainText,
+  }) => {
     test.skip(isPlainText);
     if (!IS_MAC) {
       // Do Windows/Linux have equivalent shortcuts?
@@ -434,6 +443,7 @@ test.describe.parallel('Selection', () => {
     await moveLeft(page, 'after'.length);
     await deleteBackward(page);
 
+    const collapsibleTag = browserName === 'chromium' ? 'div' : 'details';
     await assertHTML(
       page,
       html`
@@ -442,7 +452,7 @@ test.describe.parallel('Selection', () => {
           dir="ltr">
           <span data-lexical-text="true">abc</span>
         </p>
-        <div class="Collapsible__container" open="">
+        <${collapsibleTag} class="Collapsible__container" open="">
           <summary class="Collapsible__title">
             <p
               class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
@@ -453,7 +463,7 @@ test.describe.parallel('Selection', () => {
           <div class="Collapsible__content">
             <p class="PlaygroundEditorTheme__paragraph"><br /></p>
           </div>
-        </div>
+        </${collapsibleTag}>
         <p
           class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
           dir="ltr">


### PR DESCRIPTION
## Description

Now that we have more robust handling of deleteCharacter around decorators and shadow roots, we can get rid of the expectation that CollapsibleContainerNode does something weird. AFAICT this behavior was a result of the implementation and not something that was specifically intended?

Follow-up to #7155 
Related #3082 #4257 https://github.com/facebook/lexical/blame/f5e6329c3773a3e968eeb06a50ae002ce8b1318f/packages/lexical-playground/src/plugins/CollapsiblePlugin/index.ts#L169

Closes #7203

## Test plan

### Before

Delete forward before a CollapsibleNode would pierce the shadow root and unroll its content at the caret

### After

Delete forward before a CollapsibleNode will do nothing, like other shadow roots (e.g. table)