### PR TITLE
[lexical-table] Feature: Support TableNode.__style in createDOM and updateDOM

### DIFF
--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -264,6 +264,9 @@ export class TableNode extends ElementNode {
 
   createDOM(config: EditorConfig, editor?: LexicalEditor): HTMLElement {
     const tableElement = document.createElement('table');
+    if (this.__style) {
+      tableElement.style.cssText = this.__style;
+    }
     const colGroup = document.createElement('colgroup');
     tableElement.appendChild(colGroup);
     updateColgroup(
@@ -311,11 +314,11 @@ export class TableNode extends ElementNode {
       setFrozenRows(dom, config, this.__frozenRowCount);
     }
     updateColgroup(dom, config, this.getColumnCount(), this.getColWidths());
-    alignTableElement(
-      this.getDOMSlot(dom).element,
-      config,
-      this.getFormatType(),
-    );
+    const tableElement = this.getDOMSlot(dom).element;
+    if (prevNode.__style !== this.__style) {
+      tableElement.style.cssText = this.__style;
+    }
+    alignTableElement(tableElement, config, this.getFormatType());
     return false;
   }
 


### PR DESCRIPTION
## Description

TableNode ignored its __style attribute, this PR adds support for it

Closes #7201

## Test plan

### Before

`tableNode.setStyle(…)` has no effect on the DOM

### After

`tableNode.setStyle(…)` is reconciled to the DOM, and this is unit tested.
