### PR TITLE
[ci] Chore: Remove unused GITHUB_TOKEN secrets from workflows

### DIFF
--- a/.github/workflows/call-core-tests.yml
+++ b/.github/workflows/call-core-tests.yml
@@ -11,7 +11,6 @@ jobs:
         node-version: [20.11.0]
     env:
       CI: true
-      GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/close-stale-pr.yml
+++ b/.github/workflows/close-stale-pr.yml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - run: gh pr close "$NUMBER" --comment "$COMMENT"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.number }}
           COMMENT: >


### PR DESCRIPTION
## Description

The GITHUB_TOKEN secrets present in these workflows shouldn't be necessary, since the workflow generates tokens with the requested permissions
