### PR TITLE
[lexical-table] Bug Fix: Prevent adjacent cell selection on triple-click

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -867,60 +867,32 @@ test.describe.parallel('Selection', () => {
     const tripleClickDelay = 50;
     await lastCellText.click({clickCount: 3, delay: tripleClickDelay});
 
-    if (browserName === 'firefox') {
-      // Firefox correctly selects the last cell + full text content, unlike Chromium which selects the first cell
-      const expectedSelection = createHumanReadableSelection(
-        'the full text of the last cell in the table',
-        {
-          anchorOffset: {desc: 'beginning of cell', value: 0},
-          anchorPath: [
-            {desc: 'index of table in root', value: 1},
-            {desc: 'first table row', value: 1},
-            {desc: 'second cell', value: 1},
-            {desc: 'first paragraph', value: 0},
-            {desc: 'first span', value: 0},
-            {desc: 'beginning of text', value: 0},
-          ],
-          focusOffset: {desc: 'full text length', value: cellText.length},
-          focusPath: [
-            {desc: 'index of table in root', value: 1},
-            {desc: 'first table row', value: 1},
-            {desc: 'second cell', value: 1},
-            {desc: 'first paragraph', value: 0},
-            {desc: 'first span', value: 0},
-            {desc: 'beginning of text', value: 0},
-          ],
-        },
-      );
-      await assertSelection(page, expectedSelection);
-    } else {
-      // Only the first cell should be selected, and not the entire document
-      // Ideally the last cell should be selected since that was what was triple-clicked,
-      // but due to the complex selection logic involved, this was the best that could be done.
-      // The goal ultimately was to prevent dangerous whole document selection.
-      // Getting the last cell precisely selected can be done at a later point.
-      const expectedSelection = createHumanReadableSelection(
-        'cursor at beginning of the first cell in table',
-        {
-          anchorOffset: {desc: 'beginning of cell', value: 0},
-          anchorPath: [
-            {desc: 'index of table in root', value: 1},
-            {desc: 'first table row', value: 1},
-            {desc: 'first cell', value: 0},
-            {desc: 'beginning of text', value: 0},
-          ],
-          focusOffset: {desc: 'beginning of text', value: 0},
-          focusPath: [
-            {desc: 'index of table in root', value: 1},
-            {desc: 'first table row', value: 1},
-            {desc: 'first cell', value: 0},
-            {desc: 'beginning of text', value: 0},
-          ],
-        },
-      );
+    // Expect consistent behavior - select the clicked cell's content
+    const expectedSelection = createHumanReadableSelection(
+      'the full text of the last cell in the table',
+      {
+        anchorOffset: {desc: 'beginning of cell', value: 0},
+        anchorPath: [
+          {desc: 'index of table in root', value: 1},
+          {desc: 'first table row', value: 1},
+          {desc: 'second cell', value: 1},
+          {desc: 'first paragraph', value: 0},
+          {desc: 'first span', value: 0},
+          {desc: 'beginning of text', value: 0},
+        ],
+        focusOffset: {desc: 'full text length', value: cellText.length},
+        focusPath: [
+          {desc: 'index of table in root', value: 1},
+          {desc: 'first table row', value: 1},
+          {desc: 'second cell', value: 1},
+          {desc: 'first paragraph', value: 0},
+          {desc: 'first span', value: 0},
+          {desc: 'beginning of text', value: 0},
+        ],
+      },
+    );
 
-      await assertSelection(page, expectedSelection);
-    }
+    await assertSelection(page, expectedSelection);
   });
 
   /**

--- a/packages/lexical-table/src/LexicalTablePluginHelpers.ts
+++ b/packages/lexical-table/src/LexicalTablePluginHelpers.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  $findMatchingParent,
   $insertFirst,
   $insertNodeToNearestRoot,
   $unwrapAndFilterDescendants,
@@ -14,10 +15,15 @@ import {
 } from '@lexical/utils';
 import {
   $createParagraphNode,
+  $getNearestNodeFromDOMNode,
   $getSelection,
+  $isElementNode,
   $isRangeSelection,
   $isTextNode,
+  CLICK_COMMAND,
   COMMAND_PRIORITY_EDITOR,
+  ElementNode,
+  isDOMNode,
   LexicalEditor,
   NodeKey,
   SELECTION_INSERT_CLIPBOARD_NODES_COMMAND,
@@ -134,6 +140,29 @@ function $tableTransform(node: TableNode) {
       rowNode.append(newCell);
     }
   }
+}
+
+function $tableClickCommand(event: MouseEvent): boolean {
+  if (event.detail < 3 || !isDOMNode(event.target)) {
+    return false;
+  }
+  const startNode = $getNearestNodeFromDOMNode(event.target);
+  if (startNode === null) {
+    return false;
+  }
+  const blockNode = $findMatchingParent(
+    startNode,
+    (node): node is ElementNode => $isElementNode(node) && !node.isInline(),
+  );
+  if (blockNode === null) {
+    return false;
+  }
+  const rootNode = blockNode.getParent();
+  if (!$isTableCellNode(rootNode)) {
+    return false;
+  }
+  blockNode.selectStart();
+  return true;
 }
 
 /**
@@ -276,7 +305,28 @@ export function registerTablePlugin(editor: LexicalEditor): () => void {
   if (!editor.hasNodes([TableNode])) {
     invariant(false, 'TablePlugin: TableNode is not registered on editor');
   }
+
+  // Add mousedown handler for triple clicks or more
+  const removeTripleClickHandler = editor.registerRootListener(
+    (rootElement: null | HTMLElement) => {
+      if (rootElement !== null) {
+        const onMouseDown = (event: MouseEvent) => {
+          if (event.detail >= 3) {
+            // Prevent default multi-click behavior
+            event.preventDefault();
+          }
+        };
+        rootElement.addEventListener('mousedown', onMouseDown);
+        return () => {
+          rootElement.removeEventListener('mousedown', onMouseDown);
+        };
+      }
+      return () => {};
+    },
+  );
+
   return mergeRegister(
+    removeTripleClickHandler,
     editor.registerCommand(
       INSERT_TABLE_COMMAND,
       $insertTableCommandListener,
@@ -292,6 +342,11 @@ export function registerTablePlugin(editor: LexicalEditor): () => void {
           $findTableNode(selection.anchor.getNode()) !== null;
         return isInsideTableCell && nodes.some($isTableNode);
       },
+      COMMAND_PRIORITY_EDITOR,
+    ),
+    editor.registerCommand(
+      CLICK_COMMAND,
+      $tableClickCommand,
       COMMAND_PRIORITY_EDITOR,
     ),
     editor.registerNodeTransform(TableNode, $tableTransform),

--- a/packages/lexical-table/src/LexicalTablePluginHelpers.ts
+++ b/packages/lexical-table/src/LexicalTablePluginHelpers.ts
@@ -161,7 +161,7 @@ function $tableClickCommand(event: MouseEvent): boolean {
   if (!$isTableCellNode(rootNode)) {
     return false;
   }
-  blockNode.selectStart();
+  blockNode.select(0);
   return true;
 }
 

--- a/packages/lexical-table/src/LexicalTablePluginHelpers.ts
+++ b/packages/lexical-table/src/LexicalTablePluginHelpers.ts
@@ -306,27 +306,7 @@ export function registerTablePlugin(editor: LexicalEditor): () => void {
     invariant(false, 'TablePlugin: TableNode is not registered on editor');
   }
 
-  // Add mousedown handler for triple clicks or more
-  const removeTripleClickHandler = editor.registerRootListener(
-    (rootElement: null | HTMLElement) => {
-      if (rootElement !== null) {
-        const onMouseDown = (event: MouseEvent) => {
-          if (event.detail >= 3) {
-            // Prevent default multi-click behavior
-            event.preventDefault();
-          }
-        };
-        rootElement.addEventListener('mousedown', onMouseDown);
-        return () => {
-          rootElement.removeEventListener('mousedown', onMouseDown);
-        };
-      }
-      return () => {};
-    },
-  );
-
   return mergeRegister(
-    removeTripleClickHandler,
     editor.registerCommand(
       INSERT_TABLE_COMMAND,
       $insertTableCommandListener,

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -287,6 +287,26 @@ export function applyTableHandlers(
     onMouseDown,
     tableObserver.listenerOptions,
   );
+  tableObserver.listenersToRemove.add(() => {
+    tableElement.removeEventListener('mousedown', onMouseDown);
+  });
+
+  const onTripleClick = (event: MouseEvent) => {
+    if (event.detail >= 3 && isDOMNode(event.target)) {
+      const targetCell = getDOMCellFromTarget(event.target);
+      if (targetCell !== null) {
+        event.preventDefault();
+      }
+    }
+  };
+  tableElement.addEventListener(
+    'mousedown',
+    onTripleClick,
+    tableObserver.listenerOptions,
+  );
+  tableObserver.listenersToRemove.add(() => {
+    tableElement.removeEventListener('mousedown', onTripleClick);
+  });
 
   // Clear selection when clicking outside of dom.
   const mouseDownCallback = (event: MouseEvent) => {
@@ -312,6 +332,9 @@ export function applyTableHandlers(
     mouseDownCallback,
     tableObserver.listenerOptions,
   );
+  tableObserver.listenersToRemove.add(() => {
+    editorWindow.removeEventListener('mousedown', mouseDownCallback);
+  });
 
   for (const [command, direction] of ARROW_KEY_COMMANDS_WITH_DIRECTION) {
     tableObserver.listenersToRemove.add(


### PR DESCRIPTION
## Description
Current behavior:
- When triple-clicking a table cell, it incorrectly selects adjacent cells
- For cells in the last column, it selects cells in the next row
- Selection behavior is inconsistent across different cells in the table
- Test has browser-specific checks:
  - For Firefox: expects to select the full text content of the clicked cell
  - For Chromium: expects to select the first cell instead of the clicked cell

Changes added by this PR:
- Adds `$tableClickCommand` to handle triple-click events specifically for table cells: (The implementation is based on @etrepum's approach from PR #7005)
  - Checks if clicked block's parent is a table cell
  - Uses `select(0)` to properly select the entire block content
  - Prevents selection from spreading to adjacent cells
- Adds `removeTripleClickHandler` to:
  - Prevent default browser behavior for triple clicks
  - Handle all clicks >= 3 consistently
- Updates e2e test in `Selection.spec.mjs`:
  - Removes browser-specific conditions (Firefox vs Chromium checks) to enforce consistent behavior
  
Both handlers work together to ensure proper and consistent table cell selection behavior. 

Closes #6973
Closes #7005

## Test plan

### Before


https://github.com/user-attachments/assets/99b4ccb5-e68a-4d24-a53e-09cd7b0678e2


### After


https://github.com/user-attachments/assets/2552b134-6e02-4f4d-89e4-2e79371d807a

