### PR TITLE
[lexical-playground] Refactor: Remove redundant Suspense from node decorators

### DIFF
--- a/packages/lexical-playground/src/nodes/EquationNode.tsx
+++ b/packages/lexical-playground/src/nodes/EquationNode.tsx
@@ -20,7 +20,6 @@ import type {JSX} from 'react';
 import katex from 'katex';
 import {$applyNodeReplacement, DecoratorNode, DOMExportOutput} from 'lexical';
 import * as React from 'react';
-import {Suspense} from 'react';
 
 const EquationComponent = React.lazy(() => import('./EquationComponent'));
 
@@ -147,13 +146,11 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
 
   decorate(): JSX.Element {
     return (
-      <Suspense fallback={null}>
-        <EquationComponent
-          equation={this.__equation}
-          inline={this.__inline}
-          nodeKey={this.__key}
-        />
-      </Suspense>
+      <EquationComponent
+        equation={this.__equation}
+        inline={this.__inline}
+        nodeKey={this.__key}
+      />
     );
   }
 }

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/index.tsx
@@ -21,7 +21,6 @@ import type {JSX} from 'react';
 
 import {DecoratorNode} from 'lexical';
 import * as React from 'react';
-import {Suspense} from 'react';
 
 type Dimension = number | 'inherit';
 
@@ -180,14 +179,12 @@ export class ExcalidrawNode extends DecoratorNode<JSX.Element> {
 
   decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {
     return (
-      <Suspense fallback={null}>
-        <ExcalidrawComponent
-          nodeKey={this.getKey()}
-          data={this.__data}
-          width={this.__width}
-          height={this.__height}
-        />
-      </Suspense>
+      <ExcalidrawComponent
+        nodeKey={this.getKey()}
+        data={this.__data}
+        width={this.__width}
+        height={this.__height}
+      />
     );
   }
 }

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -23,7 +23,6 @@ import type {JSX} from 'react';
 
 import {$applyNodeReplacement, createEditor, DecoratorNode} from 'lexical';
 import * as React from 'react';
-import {Suspense} from 'react';
 
 const ImageComponent = React.lazy(() => import('./ImageComponent'));
 
@@ -221,20 +220,18 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
 
   decorate(): JSX.Element {
     return (
-      <Suspense fallback={null}>
-        <ImageComponent
-          src={this.__src}
-          altText={this.__altText}
-          width={this.__width}
-          height={this.__height}
-          maxWidth={this.__maxWidth}
-          nodeKey={this.getKey()}
-          showCaption={this.__showCaption}
-          caption={this.__caption}
-          captionsEnabled={this.__captionsEnabled}
-          resizable={true}
-        />
-      </Suspense>
+      <ImageComponent
+        src={this.__src}
+        altText={this.__altText}
+        width={this.__width}
+        height={this.__height}
+        maxWidth={this.__maxWidth}
+        nodeKey={this.getKey()}
+        showCaption={this.__showCaption}
+        caption={this.__caption}
+        captionsEnabled={this.__captionsEnabled}
+        resizable={true}
+      />
     );
   }
 }

--- a/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageNode.tsx
@@ -28,7 +28,6 @@ import {
   isHTMLElement,
 } from 'lexical';
 import * as React from 'react';
-import {Suspense} from 'react';
 
 const InlineImageComponent = React.lazy(() => import('./InlineImageComponent'));
 
@@ -255,18 +254,16 @@ export class InlineImageNode extends DecoratorNode<JSX.Element> {
 
   decorate(): JSX.Element {
     return (
-      <Suspense fallback={null}>
-        <InlineImageComponent
-          src={this.__src}
-          altText={this.__altText}
-          width={this.__width}
-          height={this.__height}
-          nodeKey={this.getKey()}
-          showCaption={this.__showCaption}
-          caption={this.__caption}
-          position={this.__position}
-        />
-      </Suspense>
+      <InlineImageComponent
+        src={this.__src}
+        altText={this.__altText}
+        width={this.__width}
+        height={this.__height}
+        nodeKey={this.getKey()}
+        showCaption={this.__showCaption}
+        caption={this.__caption}
+        position={this.__position}
+      />
     );
   }
 }

--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -19,7 +19,6 @@ import {
   Spread,
 } from 'lexical';
 import * as React from 'react';
-import {Suspense} from 'react';
 
 export type Options = ReadonlyArray<Option>;
 
@@ -186,13 +185,11 @@ export class PollNode extends DecoratorNode<JSX.Element> {
 
   decorate(): JSX.Element {
     return (
-      <Suspense fallback={null}>
-        <PollComponent
-          question={this.__question}
-          options={this.__options}
-          nodeKey={this.__key}
-        />
-      </Suspense>
+      <PollComponent
+        question={this.__question}
+        options={this.__options}
+        nodeKey={this.__key}
+      />
     );
   }
 }

--- a/packages/lexical-playground/src/nodes/StickyNode.tsx
+++ b/packages/lexical-playground/src/nodes/StickyNode.tsx
@@ -20,7 +20,6 @@ import type {JSX} from 'react';
 
 import {$setSelection, createEditor, DecoratorNode} from 'lexical';
 import * as React from 'react';
-import {Suspense} from 'react';
 import {createPortal} from 'react-dom';
 
 const StickyComponent = React.lazy(() => import('./StickyComponent'));
@@ -125,15 +124,13 @@ export class StickyNode extends DecoratorNode<JSX.Element> {
 
   decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {
     return createPortal(
-      <Suspense fallback={null}>
-        <StickyComponent
-          color={this.__color}
-          x={this.__x}
-          y={this.__y}
-          nodeKey={this.getKey()}
-          caption={this.__caption}
-        />
-      </Suspense>,
+      <StickyComponent
+        color={this.__color}
+        x={this.__x}
+        y={this.__y}
+        nodeKey={this.getKey()}
+        caption={this.__caption}
+      />,
       document.body,
     );
   }


### PR DESCRIPTION
## Description
Current behavior:
- Playground node decorators (`PollNode`, `ImageNode`, etc.) have redundant Suspense wrappers in their decorate methods
- Each decorator is wrapped twice in Suspense components - once by `useDecorators` hook and again in the node's `decorate` method
- This creates unnecessary component nesting and impacts React's reconciliation efficiency

Changes being added:
- Removes redundant Suspense wrappers from node `decorate` methods since `useDecorators` already provides `Suspense` functionality
- Removes unused `Suspense` imports from affected files
- Simplifies component tree and improves React reconciliation process
- Affects the following nodes:
  - PollNode
  - ImageNode
  - InlineImageNode
  - ExcalidrawNode
  - StickyNode
  - EquationNode

This PR removes redundant Suspense wrappers from playground node decorators, making the code more efficient and maintainable. The `@lexical/react` `useDecorators` hook already wraps each decorator in `<Suspense fallback={null}>`, making additional Suspense wrappers unnecessary.

Closes #7211

## Test plan

### Before
1. Open React DevTools
2. Inspect any decorated node (Poll, Image, Equation etc.)
3. You'll see redundant nesting pattern:
![image](https://github.com/user-attachments/assets/3f24905c-d514-4417-847c-6b8fa6e74346)

### After
1. Open React DevTools
2. Inspect the same decorated nodes
3. Verify single Suspense wrapper from useDecorators:
![image](https://github.com/user-attachments/assets/4b521888-ede7-421a-8937-b4387fc0d101)