### PR TITLE
[lexical-yjs] Bug Fix: Normalize multiple adjacent merge conflicts in one block

### DIFF
--- a/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
@@ -14,6 +14,7 @@ import {
   TextNode,
   UNDO_COMMAND,
 } from 'lexical';
+import * as Y from 'yjs';
 
 import {Client, createTestConnection, waitForReact} from './utils';
 
@@ -403,6 +404,72 @@ describe('Collaboration', () => {
     expect(client1.getHTML()).toEqual(client2.getHTML());
     expect(client1.getDocJSON()).toEqual({
       root: '[object Object]Hello world',
+    });
+    expect(client1.getDocJSON()).toEqual(client2.getDocJSON());
+
+    client1.stop();
+    client2.stop();
+  });
+
+  it('Should handle multiple text nodes being normalized due to merge conflict', async () => {
+    const connector = createTestConnection();
+    const client1 = connector.createClient('1');
+    const client2 = connector.createClient('2');
+    client1.start(container!);
+    client2.start(container!);
+
+    await expectCorrectInitialContent(client1, client2);
+
+    client2.disconnect();
+
+    // Add
+    await waitForReact(() => {
+      client1.getEditor().update(() => {
+        const root = $getRoot();
+
+        const paragraph = root.getFirstChild<ParagraphNode>()!;
+        paragraph.append($createTextNode('1'));
+      });
+    });
+
+    expect(client1.getHTML()).toEqual(
+      '<p><span data-lexical-text="true">1</span></p>',
+    );
+    expect(client1.getDocJSON()).toEqual({
+      root: '[object Object]1',
+    });
+
+    // Simulate normalization merge conflicts by inserting YMap+strings directly into Yjs.
+    const yDoc = client1.getDoc();
+    const rootXmlText = yDoc.get('root') as Y.XmlText;
+    const paragraphXmlText = rootXmlText.toDelta()[0].insert as Y.XmlText;
+    const textYMap = paragraphXmlText.toDelta()[0].insert as Y.Map<unknown>;
+    yDoc.transact(() => {
+      paragraphXmlText.insertEmbed(2, textYMap.clone());
+      paragraphXmlText.insert(3, '2');
+      paragraphXmlText.insertEmbed(4, textYMap.clone());
+      paragraphXmlText.insert(5, '3');
+    });
+
+    // Note: client1 HTML won't have been updated yet here because we edited its Yjs doc directly.
+    expect(client1.getHTML()).toEqual(
+      '<p><span data-lexical-text="true">1</span></p>',
+    );
+    expect(client1.getDocJSON()).toEqual({
+      root: '[object Object]1[object Object]2[object Object]3',
+    });
+
+    // When client2 reconnects, it will normalize the three text nodes, which syncs back to client1.
+    await waitForReact(() => {
+      client2.connect();
+    });
+
+    expect(client1.getHTML()).toEqual(
+      '<p><span data-lexical-text="true">123</span></p>',
+    );
+    expect(client1.getHTML()).toEqual(client2.getHTML());
+    expect(client1.getDocJSON()).toEqual({
+      root: '[object Object]123',
     });
     expect(client1.getDocJSON()).toEqual(client2.getDocJSON());
 

--- a/packages/lexical-react/src/__tests__/unit/utils.tsx
+++ b/packages/lexical-react/src/__tests__/unit/utils.tsx
@@ -236,6 +236,10 @@ export class Client implements Provider {
     return (this.getContainer().firstChild as HTMLElement).innerHTML;
   }
 
+  getDoc() {
+    return this._doc;
+  }
+
   getDocJSON() {
     return this._doc.toJSON();
   }

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -154,7 +154,8 @@ function $handleNormalizationMergeConflicts(
   // We handle the merge operations here
   const normalizedNodesKeys = Array.from(normalizedNodes);
   const collabNodeMap = binding.collabNodeMap;
-  const mergedNodes = [];
+  const mergedNodes: [CollabTextNode, string][] = [];
+  const removedNodes: CollabTextNode[] = [];
 
   for (let i = 0; i < normalizedNodesKeys.length; i++) {
     const nodeKey = normalizedNodesKeys[i];
@@ -175,22 +176,25 @@ function $handleNormalizationMergeConflicts(
 
         const parent = collabNode._parent;
         collabNode._normalized = true;
-
         parent._xmlText.delete(offset, 1);
 
-        collabNodeMap.delete(nodeKey);
-        const parentChildren = parent._children;
-        const index = parentChildren.indexOf(collabNode);
-        parentChildren.splice(index, 1);
+        removedNodes.push(collabNode);
       }
     }
   }
 
+  for (let i = 0; i < removedNodes.length; i++) {
+    const collabNode = removedNodes[i];
+    const nodeKey = collabNode.getKey();
+    collabNodeMap.delete(nodeKey);
+    const parentChildren = collabNode._parent._children;
+    const index = parentChildren.indexOf(collabNode);
+    parentChildren.splice(index, 1);
+  }
+
   for (let i = 0; i < mergedNodes.length; i++) {
     const [collabNode, text] = mergedNodes[i];
-    if (collabNode instanceof CollabTextNode && typeof text === 'string') {
-      collabNode._text = text;
-    }
+    collabNode._text = text;
   }
 }
 


### PR DESCRIPTION
## Description

If you have multiple adjacent text nodes in a single block, and they're all merged (normalised) in a single update, and that update is either tagged `collaboration` or `historic`, then Lexical and Yjs get out of sync. This is caused by collab nodes being removed from their parent too early in `$handleNormalizationMergeConflicts`, which leads to offset calculations being wrong.

## Test plan

I don't know how the editor gets into this state through normal user behaviour, but we've seen it in production multiple times now. Most recently today, where a user had a document with lots of repeated content, similar to https://github.com/facebook/lexical/issues/6614#issuecomment-2424855275 (we're on 0.24.0 though).

I'm still working on a repro which could be added to E2E tests, but for now I've resorted to manually getting the Yjs doc into this weird state in a lower-level test.

### Before

```
  ● Collaboration › Should handle multiple text nodes being normalized due to merge conflict

    expect(received).toEqual(expected) // deep equality

    Expected: "<p><span data-lexical-text=\"true\">123</span></p>"
    Received: "<p><span data-lexical-text=\"true\">13</span></p>"

      465 |     });
      466 |
    > 467 |     expect(client1.getHTML()).toEqual(
          |                               ^
      468 |       '<p><span data-lexical-text="true">123</span></p>',
      469 |     );
      470 |     expect(client1.getHTML()).toEqual(client2.getHTML());

      at Object.<anonymous> (packages/lexical-react/src/__tests__/unit/Collaboration.test.ts:467:31)
```

### After

Tests pass.