### PR TITLE
Remove Android Chrome workaround from #7122

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -12,7 +12,6 @@ import type {NodeKey} from './LexicalNode';
 import type {ElementNode} from './nodes/LexicalElementNode';
 import type {TextFormatType} from './nodes/LexicalTextNode';
 
-import {IS_ANDROID_CHROME} from 'shared/environment';
 import invariant from 'shared/invariant';
 
 import {
@@ -3102,24 +3101,6 @@ export function updateDOMSelection(
       nextFocusNode,
       nextFocusOffset,
     );
-    // When deleting text across multiple paragraphs, Chrome on Android shifts selection rightwards
-    // This is a workaround to restore the correct selection
-    if (IS_ANDROID_CHROME) {
-      setTimeout(() => {
-        try {
-          domSelection.setBaseAndExtent(
-            nextAnchorNode,
-            nextAnchorOffset,
-            nextFocusNode,
-            nextFocusOffset,
-          );
-        } catch (error) {
-          if (__DEV__) {
-            console.warn(error);
-          }
-        }
-      });
-    }
   } catch (error) {
     // If we encounter an error, continue. This can sometimes
     // occur with FF and there's no good reason as to why it


### PR DESCRIPTION
## Description

The `setTimeout` workaround from #7122 is causing issues, e.g. #7210. A more correct approach needs to be taken in order to fix these bugs.

## Test plan

### Before

Samsung keyboard is unusable

### After

Samsung keyboard works as it did prior to v0.24.0