### PR TITLE
[lexical-list] Bug Fix: retain selection styling when exiting nested list

### DIFF
--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -499,8 +499,6 @@ export function $handleListInsertParagraph(): boolean {
 
   if ($isRootOrShadowRoot(grandparent)) {
     replacementNode = $createParagraphNode();
-    replacementNode.setTextStyle(selection.style);
-    replacementNode.setTextFormat(selection.format);
     topListNode.insertAfter(replacementNode);
   } else if ($isListItemNode(grandparent)) {
     replacementNode = $createListItemNode();
@@ -508,6 +506,8 @@ export function $handleListInsertParagraph(): boolean {
   } else {
     return false;
   }
+  replacementNode.setTextStyle(selection.style);
+  replacementNode.setTextFormat(selection.format);
   replacementNode.select();
 
   const nextSiblings = anchor.getNextSiblings();

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -170,15 +170,76 @@ test.describe.parallel('Nested List', () => {
 
     await selectFromColorPicker(page);
     await toggleBold(page);
-    await page.keyboard.type('Hello');
-    //Double-enter to exit list
+    await page.keyboard.type('Item one');
+    await page.keyboard.press('Enter');
+    await clickIndentButton(page);
+    await page.keyboard.type('Nested item two');
+    // Double-enter to exit nested list
     await page.keyboard.press('Enter');
     await page.keyboard.press('Enter');
-    await page.keyboard.type('World');
+    await page.keyboard.type('Item three');
+    // Double-enter to exit list
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Normal text');
+
+    const expectedColor = 'rgb(208, 2, 27)';
 
     await assertHTML(
       page,
-      '<ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><strong class="PlaygroundEditorTheme__textBold" style="color: rgb(208, 2, 27)" data-lexical-text="true">Hello</strong></li></ul><p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><strong class="PlaygroundEditorTheme__textBold" style="color: rgb(208, 2, 27)" data-lexical-text="true">World</strong></p>',
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="1">
+            <strong
+              class="PlaygroundEditorTheme__textBold"
+              style="color: ${expectedColor};"
+              data-lexical-text="true">
+              Item one
+            </strong>
+          </li>
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"
+            value="2">
+            <ul class="PlaygroundEditorTheme__ul">
+              <li
+                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                value="1">
+                <strong
+                  class="PlaygroundEditorTheme__textBold"
+                  style="color: ${expectedColor};"
+                  data-lexical-text="true">
+                  Nested item two
+                </strong>
+              </li>
+            </ul>
+          </li>
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="2">
+            <strong
+              class="PlaygroundEditorTheme__textBold"
+              style="color: ${expectedColor};"
+              data-lexical-text="true">
+              Item three
+            </strong>
+          </li>
+        </ul>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <strong
+            class="PlaygroundEditorTheme__textBold"
+            style="color: ${expectedColor};"
+            data-lexical-text="true">
+            Normal text
+          </strong>
+        </p>
+      `,
     );
   });
 


### PR DESCRIPTION
## Description

List item node loses selection style and format when exit nested list.

## Test plan

### Before

- Go to Playground
- Insert a new list
- Change text style, i.e. font, color or formatting
- Write a bullet point
- Press `Enter` and `Tab` to start nested list
- Write a text
- Press enter twice to exit nested list
- Write a text
- [Bug] Expect the text losing styles and format

https://github.com/user-attachments/assets/f02edaa0-d1cf-40a2-8909-2480e2f93bf8

### After

https://github.com/user-attachments/assets/155248d2-f5eb-482f-8656-574b308508fd
