### PR TITLE
[lexical-link] Bug Fix: Remove anchors with empty href during DOM import

### DIFF
--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -304,7 +304,7 @@ export class LinkNode extends ElementNode {
 
 function $convertAnchorElement(domNode: Node): DOMConversionOutput {
   let node = null;
-  if (isHTMLAnchorElement(domNode)) {
+  if (isHTMLAnchorElement(domNode) && domNode.href) {
     const content = domNode.textContent;
     if ((content !== null && content !== '') || domNode.children.length > 0) {
       node = $createLinkNode(domNode.getAttribute('href') || '', {


### PR DESCRIPTION
## Description
Currently, `LinkNode` allows importing DOM with an empty `href`. However, IMO, it doesn't make sense during HTML paste. 

## Test plan

### Before

https://github.com/user-attachments/assets/a2ce4f75-0a7d-451a-8f7e-2ad6791cfcb1

### After

https://github.com/user-attachments/assets/b5adb8bc-6931-4df1-9c4e-b63ae31af911

