### PR TITLE
[lexical-playground] Bug Fix Table Action Menu dropdown positioning

### DIFF
--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -212,9 +212,9 @@ function TableActionMenu({
       let topPosition = menuButtonRect.top;
       if (topPosition + dropDownElementRect.height > window.innerHeight) {
         const position = menuButtonRect.bottom - dropDownElementRect.height;
-        topPosition = (position < 0 ? margin : position) + window.pageYOffset;
+        topPosition = position < 0 ? margin : position;
       }
-      dropDownElement.style.top = `${topPosition + +window.pageYOffset}px`;
+      dropDownElement.style.top = `${topPosition}px`;
     }
   }, [contextRef, dropDownRef, editor]);
 


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

Table Action Menu is not positioned properly when the window is vertically scrolled.

## Test plan

### Before

https://github.com/user-attachments/assets/be36b015-03b1-47f3-b6ab-db2c8bc382b6

### After

https://github.com/user-attachments/assets/b816f51e-c2e1-4b2f-941e-1e017379639f

I have tested the following scenarios and they work fine after the fix:
- when there is enough space below the Menu Button to display the Menu
- when there is not enough space below the Menu Button but enough space above
- when there is not enough space below and above the Menu Button
- tested the above three scenarios when page is scrolled and not scrolled
