### PR TITLE
[lexical-playground] Refactor: Image component rerenders on every editor update

### DIFF
--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -285,12 +285,14 @@ export default function ImageComponent({
   );
 
   useEffect(() => {
-    let isMounted = true;
     const rootElement = editor.getRootElement();
     const unregister = mergeRegister(
       editor.registerUpdateListener(({editorState}) => {
-        if (isMounted) {
-          setSelection(editorState.read(() => $getSelection()));
+        const updatedSelection = editorState.read(() => $getSelection());
+        if ($isNodeSelection(updatedSelection)) {
+          setSelection(updatedSelection);
+        } else {
+          setSelection(null);
         }
       }),
       editor.registerCommand(
@@ -345,7 +347,6 @@ export default function ImageComponent({
     rootElement?.addEventListener('contextmenu', onRightClick);
 
     return () => {
-      isMounted = false;
       unregister();
       rootElement?.removeEventListener('contextmenu', onRightClick);
     };


### PR DESCRIPTION

## Description

Currently the image element in editor sheet rerenders on every character modified in the editor, which leads to typing speed latency when more number of images are present in the editor. Updated the code to ensure its only rerendered when needed


### Before

https://github.com/user-attachments/assets/5475d683-0f95-4971-8442-76fde72bfc35


### After


https://github.com/user-attachments/assets/178ede8b-3f0b-4e68-9e8e-1095249755c3



*Insert relevant screenshots/recordings/automated-tests*