### PR TITLE
Fix selection shifting when deleting paragraphs on android

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -292,7 +292,8 @@ function onSelectionChange(
     // sibling instead.
     if (
       shouldSkipSelectionChange(anchorDOM, anchorOffset) &&
-      shouldSkipSelectionChange(focusDOM, focusOffset)
+      shouldSkipSelectionChange(focusDOM, focusOffset) &&
+      !postDeleteSelectionToRestore
     ) {
       return;
     }


### PR DESCRIPTION
## Description
Fixes #4340 

This is a second attempt to fix the abovementioned bug, following the unsuccessful attempt in #7122 (apologies for the issues introduced then)

In this PR, selection is only restored during deletion and when several other criteria have been met, this should minimise the chances of any unintended side effects.

## Test plan

### Before
https://github.com/user-attachments/assets/6f555449-8112-400b-8d21-ed35b249f428

### After
https://github.com/user-attachments/assets/7617e10e-faf6-4d25-b1ab-e73c5f8a0dad


