### PR TITLE
[Breaking Changes][lexical][lexical-list][lexical-playground] Bug Fix: deleteCharacter through ListNode->ListItemNode

### DIFF
--- a/packages/lexical-playground/__tests__/regression/7246-delete-character-backward-list.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/7246-delete-character-backward-list.spec.mjs
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  deleteBackward,
+  moveToLineBeginning,
+} from '../keyboardShortcuts/index.mjs';
+import {
+  assertHTML,
+  focusEditor,
+  html,
+  initialize,
+  test,
+} from '../utils/index.mjs';
+
+test.describe('Regression tests for #7246', () => {
+  test.beforeEach(({isPlainText, isCollab, page}) =>
+    initialize({isCollab, isPlainText, page}),
+  );
+
+  test(`deleteCharacter merges children from block adjacent to ListNode`, async ({
+    page,
+    isCollab,
+    isPlainText,
+  }) => {
+    test.skip(isCollab || isPlainText);
+    await focusEditor(page);
+    await page.keyboard.type('* list');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('paragraph');
+    const beforeHtml = html`
+      <ul>
+        <li dir="ltr" value="1"><span data-lexical-text="true">list</span></li>
+      </ul>
+      <p dir="ltr"><span data-lexical-text="true">paragraph</span></p>
+    `;
+    await assertHTML(page, beforeHtml, beforeHtml, {
+      ignoreClasses: true,
+      ignoreInlineStyles: true,
+    });
+    await moveToLineBeginning(page);
+    await deleteBackward(page);
+    const afterHtml = html`
+      <ul>
+        <li dir="ltr" value="1">
+          <span data-lexical-text="true">listparagraph</span>
+        </li>
+      </ul>
+    `;
+    await assertHTML(page, afterHtml, afterHtml, {
+      ignoreClasses: true,
+      ignoreInlineStyles: true,
+    });
+  });
+});

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleContainerNode.ts
@@ -57,6 +57,10 @@ export class CollapsibleContainerNode extends ElementNode {
     return new CollapsibleContainerNode(node.__open, node.__key);
   }
 
+  isShadowRoot(): boolean {
+    return true;
+  }
+
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     // details is not well supported in Chrome #5582
     let dom: HTMLElement;

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
@@ -83,11 +83,6 @@ export class CollapsibleTitleNode extends ElementNode {
     return $createCollapsibleTitleNode().updateFromJSON(serializedNode);
   }
 
-  collapseAtStart(_selection: RangeSelection): boolean {
-    this.getParentOrThrow().insertBefore(this);
-    return true;
-  }
-
   static transform(): (node: LexicalNode) => void {
     return (node: LexicalNode) => {
       invariant(

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1894,17 +1894,19 @@ export class RangeSelection implements BaseSelection {
 
       this.modify('extend', isBackward, 'lineboundary');
 
-      // If the selection starts at the beginning of a text node (offset 0),
-      // use the deleteCharacter operation to handle all of the logic associated
-      // with navigating through the parent element
-      if (this.isCollapsed() && this.anchor.offset === 0) {
-        return this.deleteCharacter(isBackward);
-      }
-
+      const useDeleteCharacter = this.isCollapsed() && this.anchor.offset === 0;
       // Adjusts selection to include an extra character added for element anchors to remove it
       if (anchorIsElement) {
         const startPoint = isBackward ? this.anchor : this.focus;
         startPoint.set(startPoint.key, startPoint.offset + 1, startPoint.type);
+      }
+      // If the selection starts at the beginning of a text node (offset 0),
+      // use the deleteCharacter operation to handle all of the logic associated
+      // with navigating through the parent element
+      if (useDeleteCharacter) {
+        // Remove the inserted space, if added above
+        this.removeText();
+        return this.deleteCharacter(isBackward);
       }
     }
     this.removeText();

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -68,6 +68,7 @@ import {
   $getNodeFromDOM,
   $getRoot,
   $hasAncestor,
+  $isRootOrShadowRoot,
   $isTokenOrSegmented,
   $setCompositionKey,
   doesContainSurrogatePair,
@@ -1894,11 +1895,10 @@ export class RangeSelection implements BaseSelection {
       this.modify('extend', isBackward, 'lineboundary');
 
       // If the selection starts at the beginning of a text node (offset 0),
-      // extend the selection by one character in the specified direction.
-      // This ensures that the parent element is deleted along with its content.
-      // Otherwise, only the text content will be deleted, leaving an empty parent node.
+      // use the deleteCharacter operation to handle all of the logic associated
+      // with navigating through the parent element
       if (this.isCollapsed() && this.anchor.offset === 0) {
-        this.modify('extend', isBackward, 'character');
+        return this.deleteCharacter(isBackward);
       }
 
       // Adjusts selection to include an extra character added for element anchors to remove it
@@ -1990,7 +1990,7 @@ function $collapseAtStart(
       if (node.collapseAtStart(selection)) {
         return true;
       }
-      if (!node.isInline()) {
+      if ($isRootOrShadowRoot(node)) {
         break;
       }
     }


### PR DESCRIPTION
## Breaking Changes

As a follow-up to #7180 the collapseAtStart logic now continues through both inline and non-inline nodes so long as there are no previous siblings, roots, or shadow roots encountered. This is because nodes such as CollapsibleTitleNode had a collapseAtStart that returns true but contain nodes that are not inline and have a collapseAtStart that returns false (e.g. ParagraphNode). 

In order to fix an inconsistency for how nested !isInline elements behave, CollapsibleContainerNode is now a shadowRoot. The CollapsibleContentNode was already a shadowRoot. This is now similar to the situation for tables where both TableNode and TableCellNode are both shadowRoot. The fix here also moved collapseAtStart from CollapsibleTitleNode to CollapsibleContainerNode which makes a bit more sense since the whole container gets collapsed, not just the title. The title is still the only location that you can initiate this collapse from, since it is always the first child.

## Description

Fix deleteCharacter regression introduced in #7155 (v0.25.0). This new deleteCharacter implementation did not handle the scenario when a block element contained !isInline elements and no shadow roots were involved. The fix here changes the state machine to keep descending until a stop condition (shadowRoot or sibling caret) is met

Closes #7246

## Test plan

### Before

See #7246 for demo of regression

### After

e2e test to reproduce regression and confirm fix