### PR TITLE
[lexical][lexical-mark] Bug Fix: Identify <mark> as inline element

### DIFF
--- a/packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts
+++ b/packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import {$generateNodesFromDOM} from '@lexical/html';
 import {$wrapSelectionInMarkNode, MarkNode} from '@lexical/mark';
 import {
   $createParagraphNode,
@@ -12,6 +13,7 @@ import {
   $createTextNode,
   $getRoot,
   ParagraphNode,
+  TextNode,
 } from 'lexical';
 import {
   $createTestDecoratorNode,
@@ -178,6 +180,39 @@ describe('LexicalMarkNode tests', () => {
           expect(markNode.getType()).toEqual('mark');
           expect(markNode.getChildren()).toHaveLength(1);
           expect(markNode.getTextContent()).toEqual('more text');
+        });
+      });
+    });
+    describe('$generateNodesFromDOM', () => {
+      beforeEach(() => {
+        testEnv.editor.update(
+          () => {
+            $getRoot().clear();
+          },
+          {discrete: true},
+        );
+      });
+
+      test('retains spaces around mark elements', () => {
+        const {editor} = testEnv;
+
+        editor.update(() => {
+          const dom = new DOMParser().parseFromString(
+            `<html><body><p><span>Foo </span><mark>Bar</mark><span> !</span></p></body></html>`,
+            'text/html',
+          );
+          const nodes = $generateNodesFromDOM(editor, dom);
+
+          expect(nodes).toHaveLength(1);
+          const paragraphNode = nodes[0] as ParagraphNode;
+          expect(paragraphNode.getChildren()).toHaveLength(3);
+          const textNode1 = paragraphNode.getChildAtIndex(0) as TextNode;
+          const markNode = paragraphNode.getChildAtIndex(1) as MarkNode;
+          const textNode2 = paragraphNode.getChildAtIndex(2) as TextNode;
+
+          expect(textNode1.getTextContent()).toEqual('Foo ');
+          expect(markNode.getTextContent()).toEqual('Bar');
+          expect(textNode2.getTextContent()).toEqual(' !');
         });
       });
     });

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1813,7 +1813,7 @@ export function isDocumentFragment(x: unknown): x is DocumentFragment {
  */
 export function isInlineDomNode(node: Node) {
   const inlineNodes = new RegExp(
-    /^(a|abbr|acronym|b|cite|code|del|em|i|ins|kbd|label|output|q|ruby|s|samp|span|strong|sub|sup|time|u|tt|var|#text)$/,
+    /^(a|abbr|acronym|b|cite|code|del|em|i|ins|kbd|label|mark|output|q|ruby|s|samp|span|strong|sub|sup|time|u|tt|var|#text)$/,
     'i',
   );
   return node.nodeName.match(inlineNodes) !== null;


### PR DESCRIPTION
## Description
The [&lt;mark&gt;](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element) element was not correctly identified as an inline element.

Closes #4641

## Test plan

All pre-existing unit tests pass. A simple `<mark>`-specific test was added to the `lexical-mark` unit tests.

### Before

```typescript
const dom = new DOMParser().parseFromString(
    `<html><body>Foo <mark>Bar</mark> !</body></html>`,
    'text/html',
);
const nodes = $generateNodesFromDOM(editor, dom);
```
Output:
```html
<span data-lexical-text="true">Foo</span><mark data-lexical-text="true"><span>Bar</span></mark><span data-lexical-text="true">!</span>
```

### After

```typescript
const dom = new DOMParser().parseFromString(
    `<html><body>Foo <mark>Bar</mark> !</body></html>`,
    'text/html',
);
const nodes = $generateNodesFromDOM(editor, dom);
```
Output:
```html
<span data-lexical-text="true">Foo </span><mark data-lexical-text="true"><span>Bar</span></mark><span data-lexical-text="true"> !</span>
```