### PR TITLE
[lexical] Bug Fix: Point.isBefore could return incorrect result due to normalization

### DIFF
--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -98,10 +98,18 @@ export function $setBlocksType<T extends ElementNode>(
     prevNode.replace(element, true);
     if (newSelection) {
       if (key === newSelection.anchor.key) {
-        newSelection.anchor.key = element.getKey();
+        newSelection.anchor.set(
+          element.getKey(),
+          newSelection.anchor.offset,
+          newSelection.anchor.type,
+        );
       }
       if (key === newSelection.focus.key) {
-        newSelection.focus.key = element.getKey();
+        newSelection.focus.set(
+          element.getKey(),
+          newSelection.focus.offset,
+          newSelection.focus.type,
+        );
       }
     }
   }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -17,6 +17,7 @@ import invariant from 'shared/invariant';
 import {
   $caretFromPoint,
   $caretRangeFromSelection,
+  $comparePointCaretNext,
   $createLineBreakNode,
   $createParagraphNode,
   $createTextNode,
@@ -151,23 +152,12 @@ export class Point {
   }
 
   isBefore(b: PointType): boolean {
-    let aNode = this.getNode();
-    let bNode = b.getNode();
-    const aOffset = this.offset;
-    const bOffset = b.offset;
-
-    if ($isElementNode(aNode)) {
-      const aNodeDescendant = aNode.getDescendantByIndex<ElementNode>(aOffset);
-      aNode = aNodeDescendant != null ? aNodeDescendant : aNode;
+    if (this.key === b.key) {
+      return this.offset < b.offset;
     }
-    if ($isElementNode(bNode)) {
-      const bNodeDescendant = bNode.getDescendantByIndex<ElementNode>(bOffset);
-      bNode = bNodeDescendant != null ? bNodeDescendant : bNode;
-    }
-    if (aNode === bNode) {
-      return aOffset < bOffset;
-    }
-    return aNode.isBefore(bNode);
+    const aCaret = $normalizeCaret($caretFromPoint(this, 'next'));
+    const bCaret = $normalizeCaret($caretFromPoint(b, 'next'));
+    return $comparePointCaretNext(aCaret, bCaret) < 0;
   }
 
   getNode(): LexicalNode {

--- a/packages/lexical/src/caret/LexicalCaretUtils.ts
+++ b/packages/lexical/src/caret/LexicalCaretUtils.ts
@@ -39,6 +39,7 @@ import {
   type TextNode,
 } from '../nodes/LexicalTextNode';
 import {
+  $comparePointCaretNext,
   $getAdjacentChildCaret,
   $getCaretRange,
   $getChildCaret,
@@ -56,7 +57,7 @@ import {
  * @returns a PointCaret for the point
  */
 export function $caretFromPoint<D extends CaretDirection>(
-  point: PointType,
+  point: Pick<PointType, 'type' | 'key' | 'offset'>,
   direction: D,
 ): PointCaret<D> {
   const {type, key, offset} = point;
@@ -154,10 +155,13 @@ export function $caretRangeFromSelection(
   selection: RangeSelection,
 ): CaretRange {
   const {anchor, focus} = selection;
-  const direction = focus.isBefore(anchor) ? 'previous' : 'next';
+  const anchorCaret = $caretFromPoint(anchor, 'next');
+  const focusCaret = $caretFromPoint(focus, 'next');
+  const direction =
+    $comparePointCaretNext(anchorCaret, focusCaret) <= 0 ? 'next' : 'previous';
   return $getCaretRange(
-    $caretFromPoint(anchor, direction),
-    $caretFromPoint(focus, direction),
+    $getCaretInDirection(anchorCaret, direction),
+    $getCaretInDirection(focusCaret, direction),
   );
 }
 


### PR DESCRIPTION
## Description

Fixes a long-standing bug in Point.isBefore by using the NodeCaret implementation of `$comparePointCaretNext`

Closes #3181

## Test plan

### Before

If two points that are not normalized are compared, and isBefore's incorrect normalization causes the compared nodes to match (without fixing up the offsets) then the result can be wrong because the offsets refer to a different node entirely.

### After

The normalization is now correctly performed with carets, and there's a unit test to confirm that the known broken situation is now fixed.