### PR TITLE
[WIP] Feature: $config protocol + NodeState registration/flattening

### DIFF
--- a/packages/lexical-html/src/index.ts
+++ b/packages/lexical-html/src/index.ts
@@ -29,6 +29,7 @@ import {
   $isTextNode,
   ArtificialNode__DO_NOT_USE,
   ElementNode,
+  getRegisteredNode,
   isDocumentFragment,
   isInlineDomNode,
 } from 'lexical';
@@ -110,7 +111,7 @@ function $appendNodesToHTML(
     target = clone;
   }
   const children = $isElementNode(target) ? target.getChildren() : [];
-  const registeredNode = editor._nodes.get(target.getType());
+  const registeredNode = getRegisteredNode(editor, target.getType());
   let exportOutput;
 
   // Use HTMLConfig overrides, if available.

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -21,6 +21,7 @@ import type {
   RangeSelection,
   SerializedElementNode,
   Spread,
+  StaticNodeConfigRecord,
 } from 'lexical';
 
 import {
@@ -57,6 +58,26 @@ export class ListItemNode extends ElementNode {
   __value: number;
   /** @internal */
   __checked?: boolean;
+
+  /** @internal */
+  $config(): StaticNodeConfigRecord<
+    'listitem',
+    {$transform: (node: ListItemNode) => void}
+  > {
+    return this.config('listitem', {
+      $transform: (node: ListItemNode): void => {
+        if (node.__checked == null) {
+          return;
+        }
+        const parent = node.getParent();
+        if ($isListNode(parent)) {
+          if (parent.getListType() !== 'check' && node.getChecked() != null) {
+            node.setChecked(undefined);
+          }
+        }
+      },
+    });
+  }
 
   static getType(): string {
     return 'listitem';
@@ -108,21 +129,6 @@ export class ListItemNode extends ElementNode {
       }
     }
     return false;
-  }
-
-  static transform(): (node: LexicalNode) => void {
-    return (node: LexicalNode) => {
-      invariant($isListItemNode(node), 'node is not a ListItemNode');
-      if (node.__checked == null) {
-        return;
-      }
-      const parent = node.getParent();
-      if ($isListNode(parent)) {
-        if (parent.getListType() !== 'check' && node.getChecked() != null) {
-          node.setChecked(undefined);
-        }
-      }
-    };
   }
 
   static importDOM(): DOMConversionMap | null {

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -27,8 +27,8 @@ import {
   NodeKey,
   SerializedElementNode,
   Spread,
+  StaticNodeConfigRecord,
 } from 'lexical';
-import invariant from 'shared/invariant';
 import normalizeClassNames from 'shared/normalizeClassNames';
 
 import {$createListItemNode, $isListItemNode, ListItemNode} from '.';
@@ -59,6 +59,19 @@ export class ListNode extends ElementNode {
   __start: number;
   /** @internal */
   __listType: ListType;
+
+  /** @internal */
+  $config(): StaticNodeConfigRecord<
+    'list',
+    {$transform: (node: ListNode) => void}
+  > {
+    return this.config('list', {
+      $transform: (node: ListNode): void => {
+        mergeNextSiblingListIfSameType(node);
+        updateChildrenListItemValue(node);
+      },
+    });
+  }
 
   static getType(): string {
     return 'list';
@@ -127,14 +140,6 @@ export class ListNode extends ElementNode {
     $setListThemeClassNames(dom, config.theme, this);
 
     return false;
-  }
-
-  static transform(): (node: LexicalNode) => void {
-    return (node: LexicalNode) => {
-      invariant($isListNode(node), 'node is not a ListNode');
-      mergeNextSiblingListIfSameType(node);
-      updateChildrenListItemValue(node);
-    };
   }
 
   static importDOM(): DOMConversionMap | null {

--- a/packages/lexical-overflow/src/index.ts
+++ b/packages/lexical-overflow/src/index.ts
@@ -11,29 +11,27 @@ import type {
   LexicalNode,
   RangeSelection,
   SerializedElementNode,
+  StaticNodeConfigRecord,
 } from 'lexical';
 
 import {$applyNodeReplacement, ElementNode} from 'lexical';
-import invariant from 'shared/invariant';
 
 export type SerializedOverflowNode = SerializedElementNode;
 
 /** @noInheritDoc */
 export class OverflowNode extends ElementNode {
-  static getType(): string {
-    return 'overflow';
-  }
-
-  static clone(node: OverflowNode): OverflowNode {
-    return new OverflowNode(node.__key);
-  }
-
-  static importJSON(serializedNode: SerializedOverflowNode): OverflowNode {
-    return $createOverflowNode().updateFromJSON(serializedNode);
-  }
-
-  static importDOM(): null {
-    return null;
+  /** @internal */
+  $config(): StaticNodeConfigRecord<
+    'overflow',
+    {$transform: (node: OverflowNode) => void}
+  > {
+    return this.config('overflow', {
+      $transform(node: OverflowNode) {
+        if (node.isEmpty()) {
+          node.remove();
+        }
+      },
+    });
   }
 
   createDOM(config: EditorConfig): HTMLElement {
@@ -59,15 +57,6 @@ export class OverflowNode extends ElementNode {
 
   excludeFromCopy(): boolean {
     return true;
-  }
-
-  static transform(): (node: LexicalNode) => void {
-    return (node: LexicalNode) => {
-      invariant($isOverflowNode(node), 'node is not a OverflowNode');
-      if (node.isEmpty()) {
-        node.remove();
-      }
-    };
   }
 }
 

--- a/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
+++ b/packages/lexical-playground/src/plugins/CollapsiblePlugin/CollapsibleTitleNode.ts
@@ -16,15 +16,13 @@ import {
   LexicalEditor,
   LexicalNode,
   RangeSelection,
-  SerializedElementNode,
+  StaticNodeConfigRecord,
 } from 'lexical';
 import {IS_CHROME} from 'shared/environment';
 import invariant from 'shared/invariant';
 
 import {$isCollapsibleContainerNode} from './CollapsibleContainerNode';
 import {$isCollapsibleContentNode} from './CollapsibleContentNode';
-
-type SerializedCollapsibleTitleNode = SerializedElementNode;
 
 export function $convertSummaryElement(
   domNode: HTMLElement,
@@ -35,13 +33,20 @@ export function $convertSummaryElement(
   };
 }
 
+/** @noInheritDoc */
 export class CollapsibleTitleNode extends ElementNode {
-  static getType(): string {
-    return 'collapsible-title';
-  }
-
-  static clone(node: CollapsibleTitleNode): CollapsibleTitleNode {
-    return new CollapsibleTitleNode(node.__key);
+  /** @internal */
+  $config(): StaticNodeConfigRecord<
+    'collapsible-title',
+    {$transform: (node: CollapsibleTitleNode) => void}
+  > {
+    return this.config('collapsible-title', {
+      $transform(node: CollapsibleTitleNode) {
+        if (node.isEmpty()) {
+          node.remove();
+        }
+      },
+    });
   }
 
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
@@ -74,24 +79,6 @@ export class CollapsibleTitleNode extends ElementNode {
           priority: 1,
         };
       },
-    };
-  }
-
-  static importJSON(
-    serializedNode: SerializedCollapsibleTitleNode,
-  ): CollapsibleTitleNode {
-    return $createCollapsibleTitleNode().updateFromJSON(serializedNode);
-  }
-
-  static transform(): (node: LexicalNode) => void {
-    return (node: LexicalNode) => {
-      invariant(
-        $isCollapsibleTitleNode(node),
-        'node is not a CollapsibleTitleNode',
-      );
-      if (node.isEmpty()) {
-        node.remove();
-      }
     };
   }
 

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -16,7 +16,9 @@ import {
   LexicalComposerContext,
 } from '@lexical/react/LexicalComposerContext';
 import {
+  createSharedNodeState,
   EditorThemeClasses,
+  getRegisteredNode,
   Klass,
   LexicalEditor,
   LexicalNode,
@@ -83,6 +85,7 @@ export function LexicalNestedComposer({
             klass: entry.klass,
             replace: entry.replace,
             replaceWithKlass: entry.replaceWithKlass,
+            sharedNodeState: createSharedNodeState(entry.klass),
             transforms: getTransformSetFromKlass(entry.klass),
           });
         }
@@ -97,13 +100,17 @@ export function LexicalNestedComposer({
             replace = options.with;
             replaceWithKlass = options.withKlass || null;
           }
-          const registeredKlass = initialEditor._nodes.get(klass.getType());
+          const registeredKlass = getRegisteredNode(
+            initialEditor,
+            klass.getType(),
+          );
 
           initialEditor._nodes.set(klass.getType(), {
             exportDOM: registeredKlass ? registeredKlass.exportDOM : undefined,
             klass,
             replace,
             replaceWithKlass,
+            sharedNodeState: createSharedNodeState(klass),
             transforms: getTransformSetFromKlass(klass),
           });
         }

--- a/packages/lexical/src/LexicalConstants.ts
+++ b/packages/lexical/src/LexicalConstants.ts
@@ -156,3 +156,4 @@ export const TEXT_TYPE_TO_MODE: Record<number, TextModeType> = {
 };
 
 export const NODE_STATE_KEY = '$';
+export const PROTOTYPE_CONFIG_METHOD = '$config';

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -23,8 +23,16 @@ import {
   $isTextNode,
   type DecoratorNode,
   ElementNode,
+  NODE_STATE_KEY,
 } from '.';
-import {$updateStateFromJSON, type NodeState} from './LexicalNodeState';
+import {PROTOTYPE_CONFIG_METHOD} from './LexicalConstants';
+import {
+  $updateStateFromJSON,
+  type NodeState,
+  type NodeStateJSON,
+  type Prettify,
+  type RequiredNodeStateConfig,
+} from './LexicalNodeState';
 import {
   $getSelection,
   $isNodeSelection,
@@ -48,6 +56,7 @@ import {
   $setNodeKey,
   $setSelection,
   errorOnInsertTextNodeOnRoot,
+  getRegisteredNode,
   internalMarkNodeAsDirty,
   removeFromParent,
 } from './LexicalUtils';
@@ -62,8 +71,148 @@ export type SerializedLexicalNode = {
   type: string;
   /** A numeric version for this schema, defaulting to 1, but not generally recommended for use */
   version: number;
+  /**
+   * Any state persisted with the NodeState API that is not
+   * configured for flat storage
+   */
   [NODE_STATE_KEY]?: Record<string, unknown>;
 };
+
+/**
+ * EXPERIMENTAL
+ * The configuration of a node returned by LexicalNode.$config()
+ *
+ * @example
+ * ```ts
+ * class CustomText extends TextNode {
+ *   $config() {
+ *     return this.config('custom-text', {extends: TextNode}};
+ *   }
+ * }
+ * ```
+ */
+export interface StaticNodeConfigValue<
+  T extends LexicalNode,
+  Type extends string,
+> {
+  /**
+   * The exact type of T.getType(), e.g. 'text' - the method itself must
+   * have a more generic 'string' type to be compatible wtih subclassing.
+   */
+  readonly type?: Type;
+  /**
+   * An alternative to the internal static transform() method
+   * that provides better DX
+   */
+  readonly $transform?: (node: T) => void;
+  /**
+   * EXPERIMENTAL
+   *
+   * An array of RequiredNodeStateConfig to initialize your node with
+   * its state requirements. This may be used to configure serialization of
+   * that state.
+   *
+   * This function will be called (at most) once per editor initialization,
+   * directly on your node's prototype. It must not depend on any state
+   * initialized in the constructor.
+   *
+   * @example
+   * ```ts
+   * const flatState = createState("flat", {parse: parseNumber});
+   * const nestedState = createState("nested", {parse: parseNumber});
+   * class MyNode extends TextNode {
+   *   $config() {
+   *     return this.config(
+   *       'my-node',
+   *       {
+   *         extends: TextNode,
+   *         stateConfigs: [
+   *           { stateConfig: flatState, flat: true},
+   *           nestedState,
+   *         ]
+   *       },
+   *     );
+   *   }
+   * }
+   * ```
+   */
+  readonly stateConfigs?: readonly RequiredNodeStateConfig[];
+  /**
+   * If specified, this must be the exact superclass of the node. It is not
+   * checked at compile time and it is provided automatically at runtime.
+   *
+   * You would want to specify this when you are extending a node that
+   * has non-trivial configuration in its $config such
+   * as required state. If you do not specify this, the inferred
+   * types for your node class might be missing some of that.
+   */
+  readonly extends?: Klass<LexicalNode>;
+}
+
+/**
+ * This is the type of LexicalNode.$config() that can be
+ * overridden by subclasses.
+ */
+export type BaseStaticNodeConfig = {
+  readonly [K in string]?: StaticNodeConfigValue<LexicalNode, string>;
+};
+
+/**
+ * Used to extract the node and type from a StaticNodeConfigRecord
+ */
+export type StaticNodeConfig<
+  T extends LexicalNode,
+  Type extends string,
+> = BaseStaticNodeConfig & {
+  readonly [K in Type]?: StaticNodeConfigValue<T, Type>;
+};
+
+/**
+ * Any StaticNodeConfigValue (for generics and collections)
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyStaticNodeConfigValue = StaticNodeConfigValue<any, any>;
+
+/**
+ * @internal
+ *
+ * This is the more specific type than BaseStaticNodeConfig that a subclass
+ * should return from $config()
+ */
+export type StaticNodeConfigRecord<
+  Type extends string,
+  Config extends AnyStaticNodeConfigValue,
+> = BaseStaticNodeConfig & {
+  readonly [K in Type]?: Config;
+};
+
+/**
+ * Extract the type from a node based on its $config
+ *
+ * @example
+ * ```ts
+ * type TextNodeType = GetStaticNodeType<TextNode>;
+ *      // ? 'text'
+ * ```
+ */
+export type GetStaticNodeType<T extends LexicalNode> = ReturnType<
+  T[typeof PROTOTYPE_CONFIG_METHOD]
+> extends StaticNodeConfig<T, infer Type>
+  ? Type
+  : string;
+
+/**
+ * The most precise type we can infer for the JSON that will
+ * be produced by T.exportJSON().
+ *
+ * Do not use this for the return type of T.exportJSON()! It must be
+ * a more generic type to be compatible with subclassing.
+ */
+export type LexicalExportJSON<T extends LexicalNode> = Prettify<
+  Omit<ReturnType<T['exportJSON']>, 'type'> & {
+    type: GetStaticNodeType<T>;
+  } & NodeStateJSON<T>
+>;
 
 /**
  * Omit the children, type, and version properties from the given SerializedLexicalNode definition.
@@ -236,6 +385,40 @@ export class LexicalNode {
       'LexicalNode: Node %s does not implement .clone().',
       this.name,
     );
+  }
+
+  /**
+   * Override this to implement the new static node configuration protocol,
+   * this method is called directly on the prototype and must not depend
+   * on anything initialized in the constructor. Generally it should be
+   * a trivial implementation.
+   *
+   * @example
+   * ```ts
+   * class MyNode extends TextNode {
+   *   $config() {
+   *     return this.config('my-node', {extends: TextNode});
+   *   }
+   * }
+   * ```
+   */
+  $config(): BaseStaticNodeConfig {
+    return {};
+  }
+
+  /**
+   * This is a convenience method for $config that
+   * aids in type inference. See {@link LexicalNode.$config}
+   * for example usage.
+   */
+  config<Type extends string, Config extends StaticNodeConfigValue<this, Type>>(
+    type: Type,
+    config: Config,
+  ): StaticNodeConfigRecord<Type, Config> {
+    const parentKlass =
+      config.extends || Object.getPrototypeOf(this.constructor);
+    Object.assign(config, {extends: parentKlass, type});
+    return {[type]: config} as StaticNodeConfigRecord<Type, Config>;
   }
 
   /**
@@ -1216,7 +1399,7 @@ function errorOnTypeKlassMismatch(
   type: string,
   klass: Klass<LexicalNode>,
 ): void {
-  const registeredNode = getActiveEditor()._nodes.get(type);
+  const registeredNode = getRegisteredNode(getActiveEditor(), type);
   // Common error - split in its own invariant
   if (registeredNode === undefined) {
     invariant(

--- a/packages/lexical/src/LexicalNodeState.ts
+++ b/packages/lexical/src/LexicalNodeState.ts
@@ -6,71 +6,20 @@
  *
  */
 
-import type {LexicalNode} from './LexicalNode';
-
+import {
+  $getEditor,
+  type Klass,
+  type LexicalNode,
+  type LexicalNodeConfig,
+  NODE_STATE_KEY,
+  type Spread,
+  type StaticNodeConfigRecord,
+} from 'lexical';
 import invariant from 'shared/invariant';
 
-import {NODE_STATE_KEY} from './LexicalConstants';
+import {PROTOTYPE_CONFIG_METHOD} from './LexicalConstants';
 import {errorOnReadOnly} from './LexicalUpdates';
-
-function coerceToJSON(v: unknown): unknown {
-  return v;
-}
-
-/**
- * The return value of {@link createState}, for use with
- * {@link $getState} and {@link $setState}.
- */
-export class StateConfig<K extends string, V> {
-  /** The string key used when serializing this state to JSON */
-  readonly key: K;
-  /** The parse function from the StateValueConfig passed to createState */
-  readonly parse: (value?: unknown) => V;
-  /**
-   * The unparse function from the StateValueConfig passed to createState,
-   * with a default that is simply a pass-through that assumes the value is
-   * JSON serializable.
-   */
-  readonly unparse: (value: V) => unknown;
-  /**
-   * An equality function from the StateValueConfig, with a default of
-   * Object.is.
-   */
-  readonly isEqual: (a: V, b: V) => boolean;
-  /**
-   * The result of `stateValueConfig.parse(undefined)`, which is computed only
-   * once and used as the default value. When the current value `isEqual` to
-   * the `defaultValue`, it will not be serialized to JSON.
-   */
-  readonly defaultValue: V;
-  constructor(key: K, stateValueConfig: StateValueConfig<V>) {
-    this.key = key;
-    this.parse = stateValueConfig.parse.bind(stateValueConfig);
-    this.unparse = (stateValueConfig.unparse || coerceToJSON).bind(
-      stateValueConfig,
-    );
-    this.isEqual = (stateValueConfig.isEqual || Object.is).bind(
-      stateValueConfig,
-    );
-    this.defaultValue = this.parse(undefined);
-  }
-}
-
-/**
- * For advanced use cases, using this type is not recommended unless
- * it is required (due to TypeScript's lack of features like
- * higher-kinded types).
- *
- * A {@link StateConfig} type with any key and any value that can be
- * used in situations where the key and value type can not be known,
- * such as in a generic constraint when working with a collection of
- * StateConfig.
- *
- * {@link StateConfigKey} and {@link StateConfigValue} will be
- * useful when this is used as a generic constraint.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyStateConfig = StateConfig<any, any>;
+import {getRegisteredNodeOrThrow, getStaticNodeConfig} from './LexicalUtils';
 
 /**
  * Get the value type (V) from a StateConfig
@@ -90,11 +39,118 @@ export type StateConfigKey<S extends AnyStateConfig> = S extends StateConfig<
 >
   ? K
   : never;
+
 /**
  * A value type, or an updater for that value type. For use with
  * {@link $setState} or any user-defined wrappers around it.
  */
 export type ValueOrUpdater<V> = V | ((prevValue: V) => V);
+
+/**
+ * A type alias to make it easier to define setter methods on your node class
+ *
+ * @example
+ * ```ts
+ * const fooState = createState("foo", { parse: ... });
+ * class MyClass extends TextNode {
+ *   // ...
+ *   setFoo(valueOrUpdater: StateValueOrUpdater<typeof fooState>): this {
+ *     return $setState(this, fooState, valueOrUpdater);
+ *   }
+ * }
+ * ```
+ */
+export type StateValueOrUpdater<Cfg extends AnyStateConfig> = ValueOrUpdater<
+  StateConfigValue<Cfg>
+>;
+
+export interface NodeStateConfig<S extends AnyStateConfig> {
+  stateConfig: S;
+  flat?: boolean;
+}
+
+export type RequiredNodeStateConfig =
+  | NodeStateConfig<AnyStateConfig>
+  | AnyStateConfig;
+
+export type StateConfigJSON<S> = S extends StateConfig<infer K, infer V>
+  ? {[Key in K]?: V}
+  : Record<never, never>;
+
+export type RequiredNodeStateConfigJSON<
+  Config extends RequiredNodeStateConfig,
+  Flat extends boolean,
+> = StateConfigJSON<
+  Config extends NodeStateConfig<infer S>
+    ? Spread<Config, {flat: false}> extends {flat: Flat}
+      ? S
+      : never
+    : false extends Flat
+    ? Config
+    : never
+>;
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type Prettify<T> = {[K in keyof T]: T[K]} & {};
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type UnionToIntersection<T> = (
+  T extends any ? (x: T) => any : never
+) extends (x: infer R) => any
+  ? R
+  : never;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export type CollectStateJSON<
+  Tuple extends readonly RequiredNodeStateConfig[],
+  Flat extends boolean,
+> = UnionToIntersection<
+  {[K in keyof Tuple]: RequiredNodeStateConfigJSON<Tuple[K], Flat>}[number]
+>;
+
+type GetStaticNodeConfig<T extends LexicalNode> = ReturnType<
+  T[typeof PROTOTYPE_CONFIG_METHOD]
+> extends infer Record
+  ? Record extends StaticNodeConfigRecord<infer Type, infer Config>
+    ? Config & {readonly type: Type}
+    : never
+  : never;
+type GetStaticNodeConfigs<T extends LexicalNode> =
+  GetStaticNodeConfig<T> extends infer OwnConfig
+    ? OwnConfig extends never
+      ? []
+      : OwnConfig extends {extends: Klass<infer Parent>}
+      ? GetStaticNodeConfig<Parent> extends infer ParentNodeConfig
+        ? ParentNodeConfig extends never
+          ? [OwnConfig]
+          : [OwnConfig, ...GetStaticNodeConfigs<Parent>]
+        : OwnConfig
+      : [OwnConfig]
+    : [];
+
+type CollectStateConfigs<Configs> = Configs extends [
+  infer OwnConfig,
+  ...infer ParentConfigs,
+]
+  ? OwnConfig extends {stateConfigs: infer StateConfigs}
+    ? StateConfigs extends readonly RequiredNodeStateConfig[]
+      ? [...StateConfigs, ...CollectStateConfigs<ParentConfigs>]
+      : CollectStateConfigs<ParentConfigs>
+    : CollectStateConfigs<ParentConfigs>
+  : [];
+
+export type GetNodeStateConfig<T extends LexicalNode> = CollectStateConfigs<
+  GetStaticNodeConfigs<T>
+>;
+
+/**
+ * The NodeState JSON produced by this LexicalNode
+ */
+export type NodeStateJSON<T extends LexicalNode> = Prettify<
+  {
+    [NODE_STATE_KEY]?: Prettify<CollectStateJSON<GetNodeStateConfig<T>, false>>;
+  } & CollectStateJSON<GetNodeStateConfig<T>, true>
+>;
 
 /**
  * Configure a value to be used with StateConfig.
@@ -177,6 +233,61 @@ export interface StateValueConfig<V> {
 }
 
 /**
+ * The return value of {@link createState}, for use with
+ * {@link $getState} and {@link $setState}.
+ */
+export class StateConfig<K extends string, V> {
+  /** The string key used when serializing this state to JSON */
+  readonly key: K;
+  /** The parse function from the StateValueConfig passed to createState */
+  readonly parse: (value?: unknown) => V;
+  /**
+   * The unparse function from the StateValueConfig passed to createState,
+   * with a default that is simply a pass-through that assumes the value is
+   * JSON serializable.
+   */
+  readonly unparse: (value: V) => unknown;
+  /**
+   * An equality function from the StateValueConfig, with a default of
+   * Object.is.
+   */
+  readonly isEqual: (a: V, b: V) => boolean;
+  /**
+   * The result of `stateValueConfig.parse(undefined)`, which is computed only
+   * once and used as the default value. When the current value `isEqual` to
+   * the `defaultValue`, it will not be serialized to JSON.
+   */
+  readonly defaultValue: V;
+  constructor(key: K, stateValueConfig: StateValueConfig<V>) {
+    this.key = key;
+    this.parse = stateValueConfig.parse.bind(stateValueConfig);
+    this.unparse = (stateValueConfig.unparse || coerceToJSON).bind(
+      stateValueConfig,
+    );
+    this.isEqual = (stateValueConfig.isEqual || Object.is).bind(
+      stateValueConfig,
+    );
+    this.defaultValue = this.parse(undefined);
+  }
+}
+
+/**
+ * For advanced use cases, using this type is not recommended unless
+ * it is required (due to TypeScript's lack of features like
+ * higher-kinded types).
+ *
+ * A {@link StateConfig} type with any key and any value that can be
+ * used in situations where the key and value type can not be known,
+ * such as in a generic constraint when working with a collection of
+ * StateConfig.
+ *
+ * {@link StateConfigKey} and {@link StateConfigValue} will be
+ * useful when this is used as a generic constraint.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyStateConfig = StateConfig<any, any>;
+
+/**
  * Create a StateConfig for the given string key and StateValueConfig.
  *
  * The key must be locally unique. In dev you wil get a key collision error
@@ -194,30 +305,6 @@ export function createState<K extends string, V>(
   valueConfig: StateValueConfig<V>,
 ): StateConfig<K, V> {
   return new StateConfig(key, valueConfig);
-}
-
-/**
- * Given two versions of a node and a stateConfig, compare their state values
- * using `$getState(nodeVersion, stateConfig, 'direct')`.
- * If the values are equal according to `stateConfig.isEqual`, return `null`,
- * otherwise return `[value, prevValue]`.
- *
- * This is useful for implementing updateDOM. Note that the `'direct'`
- * version argument is used for both nodes.
- *
- * @param node Any LexicalNode
- * @param prevNode A previous version of node
- * @param stateConfig The configuration of the state to read
- * @returns `[value, prevValue]` if changed, otherwise `null`
- */
-export function $getStateChange<T extends LexicalNode, K extends string, V>(
-  node: T,
-  prevNode: T,
-  stateConfig: StateConfig<K, V>,
-): null | [value: V, prevValue: V] {
-  const value = $getState(node, stateConfig, 'direct');
-  const prevValue = $getState(prevNode, stateConfig, 'direct');
-  return stateConfig.isEqual(value, prevValue) ? null : [value, prevValue];
 }
 
 /**
@@ -254,29 +341,27 @@ export function $getState<K extends string, V>(
 }
 
 /**
- * @internal
+ * Given two versions of a node and a stateConfig, compare their state values
+ * using `$getState(nodeVersion, stateConfig, 'direct')`.
+ * If the values are equal according to `stateConfig.isEqual`, return `null`,
+ * otherwise return `[value, prevValue]`.
  *
- * Register the config to this node's sharedConfigMap and throw an exception in
- * `__DEV__` when a collision is detected.
+ * This is useful for implementing updateDOM. Note that the `'direct'`
+ * version argument is used for both nodes.
+ *
+ * @param node Any LexicalNode
+ * @param prevNode A previous version of node
+ * @param stateConfig The configuration of the state to read
+ * @returns `[value, prevValue]` if changed, otherwise `null`
  */
-function $checkCollision<Node extends LexicalNode, K extends string, V>(
-  node: Node,
+export function $getStateChange<T extends LexicalNode, K extends string, V>(
+  node: T,
+  prevNode: T,
   stateConfig: StateConfig<K, V>,
-  state: NodeState<Node>,
-): void {
-  if (__DEV__) {
-    const collision = state.sharedConfigMap.get(stateConfig.key);
-    if (collision !== undefined && collision !== stateConfig) {
-      invariant(
-        false,
-        '$setState: State key collision %s detected in %s node with type %s and key %s. Only one StateConfig with a given key should be used on a node.',
-        JSON.stringify(stateConfig.key),
-        node.constructor.name,
-        node.getType(),
-        node.getKey(),
-      );
-    }
-  }
+): null | [value: V, prevValue: V] {
+  const value = $getState(node, stateConfig, 'direct');
+  const prevValue = $getState(prevNode, stateConfig, 'direct');
+  return stateConfig.isEqual(value, prevValue) ? null : [value, prevValue];
 }
 
 /**
@@ -326,8 +411,87 @@ export function $setState<Node extends LexicalNode, K extends string, V>(
   return writable;
 }
 
+/**
+ * @internal
+ *
+ * Register the config to this node's sharedConfigMap and throw an exception in
+ * `__DEV__` when a collision is detected.
+ */
+function $checkCollision<Node extends LexicalNode, K extends string, V>(
+  node: Node,
+  stateConfig: StateConfig<K, V>,
+  state: NodeState<Node>,
+): void {
+  if (__DEV__) {
+    const collision = state.sharedNodeState.sharedConfigMap.get(
+      stateConfig.key,
+    );
+    if (collision !== undefined && collision !== stateConfig) {
+      invariant(
+        false,
+        '$setState: State key collision %s detected in %s node with type %s and key %s. Only one StateConfig with a given key should be used on a node.',
+        JSON.stringify(stateConfig.key),
+        node.constructor.name,
+        node.getType(),
+        node.getKey(),
+      );
+    }
+  }
+}
+
+/**
+ * @internal
+ *
+ * Opaque state to be stored on the editor's RegisterNode for use by NodeState
+ */
+export type SharedNodeState = {
+  sharedConfigMap: SharedConfigMap;
+  flatKeys: Set<string>;
+};
+
+/**
+ * @internal
+ *
+ * Create the state to store on RegisteredNode
+ */
+export function createSharedNodeState(
+  nodeConfig: LexicalNodeConfig,
+): SharedNodeState {
+  const sharedConfigMap = new Map<string, AnyStateConfig>();
+  const flatKeys = new Set<string>();
+  for (
+    let klass =
+      typeof nodeConfig === 'function' ? nodeConfig : nodeConfig.replace;
+    klass.prototype && klass.prototype.getType !== undefined;
+    klass = Object.getPrototypeOf(klass)
+  ) {
+    const {ownNodeConfig} = getStaticNodeConfig(klass);
+    if (ownNodeConfig && ownNodeConfig.stateConfigs) {
+      for (const requiredStateConfig of ownNodeConfig.stateConfigs) {
+        let stateConfig: AnyStateConfig;
+        if ('stateConfig' in requiredStateConfig) {
+          stateConfig = requiredStateConfig.stateConfig;
+          if (requiredStateConfig.flat) {
+            flatKeys.add(stateConfig.key);
+          }
+        } else {
+          stateConfig = requiredStateConfig;
+        }
+        sharedConfigMap.set(stateConfig.key, stateConfig);
+      }
+    }
+  }
+  return {flatKeys, sharedConfigMap};
+}
+
 type KnownStateMap = Map<AnyStateConfig, unknown>;
 type UnknownStateRecord = Record<string, unknown>;
+/**
+ * @internal
+ *
+ * A Map of string keys to state configurations to be shared across nodes
+ * and/or node versions.
+ */
 type SharedConfigMap = Map<string, AnyStateConfig>;
 
 /**
@@ -364,8 +528,7 @@ export class NodeState<T extends LexicalNode> {
    * imported but has not been parsed yet.
    *
    * It stays here until a get state requires us to parse it, and since we
-   * then know the value is safe we move it to knownState and garbage collect
-   * it at the next version.
+   * then know the value is safe we move it to knownState.
    *
    * Note that since only string keys are used here, we can only allow this
    * state to pass-through on export or on the next version since there is
@@ -379,10 +542,11 @@ export class NodeState<T extends LexicalNode> {
   /**
    * @internal
    *
-   * This sharedConfigMap is preserved across all versions of a given node and
-   * remains writable. It is how keys are resolved to configuration.
+   * This sharedNodeState is preserved across all instances of a given
+   * node type in an editor and remains writable. It is how keys are resolved
+   * to configuration.
    */
-  readonly sharedConfigMap: SharedConfigMap;
+  readonly sharedNodeState: SharedNodeState;
   /**
    * @internal
    *
@@ -396,15 +560,16 @@ export class NodeState<T extends LexicalNode> {
    */
   constructor(
     node: T,
-    sharedConfigMap: SharedConfigMap = new Map(),
+    sharedNodeState: SharedNodeState,
     unknownState: undefined | UnknownStateRecord = undefined,
     knownState: KnownStateMap = new Map(),
     size: number | undefined = undefined,
   ) {
     this.node = node;
-    this.sharedConfigMap = sharedConfigMap;
+    this.sharedNodeState = sharedNodeState;
     this.unknownState = unknownState;
     this.knownState = knownState;
+    const {sharedConfigMap} = this.sharedNodeState;
     const computedSize =
       size !== undefined
         ? size
@@ -427,13 +592,21 @@ export class NodeState<T extends LexicalNode> {
     this.size = computedSize;
   }
 
-  /** @internal */
+  /**
+   * @internal
+   *
+   * Get the value from knownState, or parse it from unknownState
+   * if it contains the given key.
+   *
+   * Updates the sharedConfigMap when no known state is found.
+   * Updates unknownState and knownState when an unknownState is parsed.
+   */
   getValue<K extends string, V>(stateConfig: StateConfig<K, V>): V {
     const known = this.knownState.get(stateConfig) as V | undefined;
     if (known !== undefined) {
       return known;
     }
-    this.sharedConfigMap.set(stateConfig.key, stateConfig);
+    this.sharedNodeState.sharedConfigMap.set(stateConfig.key, stateConfig);
     let parsed = stateConfig.defaultValue;
     if (this.unknownState && stateConfig.key in this.unknownState) {
       const jsonValue = this.unknownState[stateConfig.key];
@@ -467,8 +640,9 @@ export class NodeState<T extends LexicalNode> {
    * specific entries in the future when nodes can declare what
    * their required StateConfigs are.
    */
-  toJSON(): {[NODE_STATE_KEY]?: UnknownStateRecord} {
+  toJSON(): NodeStateJSON<T> {
     const state = {...this.unknownState};
+    const flatState: Record<string, unknown> = {};
     for (const [stateConfig, v] of this.knownState) {
       if (stateConfig.isEqual(v, stateConfig.defaultValue)) {
         delete state[stateConfig.key];
@@ -476,7 +650,16 @@ export class NodeState<T extends LexicalNode> {
         state[stateConfig.key] = stateConfig.unparse(v);
       }
     }
-    return undefinedIfEmpty(state) ? {[NODE_STATE_KEY]: state} : {};
+    for (const key of this.sharedNodeState.flatKeys) {
+      if (key in state) {
+        flatState[key] = state[key];
+        delete state[key];
+      }
+    }
+    if (undefinedIfEmpty(state)) {
+      flatState[NODE_STATE_KEY] = state;
+    }
+    return flatState as NodeStateJSON<T>;
   }
 
   /**
@@ -499,18 +682,16 @@ export class NodeState<T extends LexicalNode> {
     if (this.node === node) {
       return this;
     }
+    const {sharedNodeState, unknownState} = this;
     const nextKnownState = new Map(this.knownState);
-    const nextUnknownState = cloneUnknownState(this.unknownState);
-    if (nextUnknownState) {
-      // Garbage collection
-      for (const stateConfig of nextKnownState.keys()) {
-        delete nextUnknownState[stateConfig.key];
-      }
-    }
     return new NodeState(
       node,
-      this.sharedConfigMap,
-      undefinedIfEmpty(nextUnknownState),
+      sharedNodeState,
+      parseAndPruneNextUnknownState(
+        sharedNodeState.sharedConfigMap,
+        nextKnownState,
+        unknownState,
+      ),
       nextKnownState,
       this.size,
     );
@@ -522,11 +703,15 @@ export class NodeState<T extends LexicalNode> {
     value: V,
   ): void {
     const key = stateConfig.key;
-    this.sharedConfigMap.set(key, stateConfig);
+    this.sharedNodeState.sharedConfigMap.set(key, stateConfig);
     const {knownState, unknownState} = this;
     if (
       !(knownState.has(stateConfig) || (unknownState && key in unknownState))
     ) {
+      if (unknownState) {
+        delete unknownState[key];
+        this.unknownState = undefinedIfEmpty(unknownState);
+      }
       this.size++;
     }
     knownState.set(stateConfig, value);
@@ -547,7 +732,7 @@ export class NodeState<T extends LexicalNode> {
    * @param v The unknown value from an UnknownStateRecord
    */
   updateFromUnknown(k: string, v: unknown): void {
-    const stateConfig = this.sharedConfigMap.get(k);
+    const stateConfig = this.sharedNodeState.sharedConfigMap.get(k);
     if (stateConfig) {
       this.updateFromKnown(stateConfig, stateConfig.parse(v));
     } else {
@@ -580,54 +765,13 @@ export class NodeState<T extends LexicalNode> {
     // the size starts at the number of known keys
     // and will be updated as we traverse the new state
     this.size = knownState.size;
-    this.unknownState = {};
+    this.unknownState = undefined;
     if (unknownState) {
       for (const [k, v] of Object.entries(unknownState)) {
         this.updateFromUnknown(k, v);
       }
     }
-    this.unknownState = undefinedIfEmpty(this.unknownState);
   }
-}
-
-function computeSize(
-  sharedConfigMap: SharedConfigMap,
-  unknownState: UnknownStateRecord | undefined,
-  knownState: KnownStateMap,
-): number {
-  let size = knownState.size;
-  if (unknownState) {
-    for (const k in unknownState) {
-      const sharedConfig = sharedConfigMap.get(k);
-      if (!sharedConfig || !knownState.has(sharedConfig)) {
-        size++;
-      }
-    }
-  }
-  return size;
-}
-
-/**
- * Return obj if it is an object with at least one property, otherwise
- * return undefined.
- */
-function undefinedIfEmpty<T extends object>(obj: undefined | T): undefined | T {
-  if (obj) {
-    for (const key in obj) {
-      return obj;
-    }
-  }
-  return undefined;
-}
-
-/**
- * Return undefined if unknownState is undefined or an empty object,
- * otherwise return a shallow clone of it.
- */
-function cloneUnknownState(
-  unknownState: undefined | UnknownStateRecord,
-): undefined | UnknownStateRecord {
-  return undefinedIfEmpty(unknownState) && {...unknownState};
 }
 
 /**
@@ -643,9 +787,20 @@ export function $getWritableNodeState<T extends LexicalNode>(
   const writable = node.getWritable();
   const state = writable.__state
     ? writable.__state.getWritable(writable)
-    : new NodeState(writable);
+    : new NodeState(writable, $getSharedNodeState(writable));
   writable.__state = state;
   return state;
+}
+
+/**
+ * @internal
+ *
+ * Get the SharedNodeState for a node on this editor
+ */
+export function $getSharedNodeState<T extends LexicalNode>(
+  node: T,
+): SharedNodeState {
+  return getRegisteredNodeOrThrow($getEditor(), node.getType()).sharedNodeState;
 }
 
 /**
@@ -676,7 +831,7 @@ export function $updateStateFromJSON<T extends LexicalNode>(
  * to determine when TextNode are being merged, not a lot of use cases
  * otherwise.
  */
-export function $nodeStatesAreEquivalent<T extends LexicalNode>(
+export function nodeStatesAreEquivalent<T extends LexicalNode>(
   a: undefined | NodeState<T>,
   b: undefined | NodeState<T>,
 ): boolean {
@@ -687,50 +842,147 @@ export function $nodeStatesAreEquivalent<T extends LexicalNode>(
     return false;
   }
   const keys = new Set<string>();
-  const hasUnequalMapEntry = (
-    sourceState: NodeState<T>,
-    otherState?: NodeState<T>,
-  ): boolean => {
-    for (const [stateConfig, value] of sourceState.knownState) {
-      if (keys.has(stateConfig.key)) {
+  return !(
+    (a && hasUnequalMapEntry(keys, a, b)) ||
+    (b && hasUnequalMapEntry(keys, b, a)) ||
+    (a && hasUnequalRecordEntry(keys, a, b)) ||
+    (b && hasUnequalRecordEntry(keys, b, a))
+  );
+}
+
+/**
+ * Compute the number of distinct keys that will be in a NodeState
+ */
+function computeSize(
+  sharedConfigMap: SharedConfigMap,
+  unknownState: UnknownStateRecord | undefined,
+  knownState: KnownStateMap,
+): number {
+  let size = knownState.size;
+  if (unknownState) {
+    for (const k in unknownState) {
+      const sharedConfig = sharedConfigMap.get(k);
+      if (!sharedConfig || !knownState.has(sharedConfig)) {
+        size++;
+      }
+    }
+  }
+  return size;
+}
+
+/**
+ * @internal
+ *
+ * Return obj if it is an object with at least one property, otherwise
+ * return undefined.
+ */
+function undefinedIfEmpty<T extends object>(obj: undefined | T): undefined | T {
+  if (obj) {
+    for (const key in obj) {
+      return obj;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * @internal
+ *
+ * Cast the given v to unknown
+ */
+function coerceToJSON(v: unknown): unknown {
+  return v;
+}
+
+/**
+ * @internal
+ *
+ * Parse all knowable values in an UnknownStateRecord into nextKnownState
+ * and return the unparsed values in a new UnknownStateRecord. Returns
+ * undefined if no unknown values remain.
+ */
+function parseAndPruneNextUnknownState(
+  sharedConfigMap: SharedConfigMap,
+  nextKnownState: KnownStateMap,
+  unknownState: undefined | UnknownStateRecord,
+): undefined | UnknownStateRecord {
+  let nextUnknownState: undefined | UnknownStateRecord = undefined;
+  if (unknownState) {
+    for (const [k, v] of Object.entries(unknownState)) {
+      const stateConfig = sharedConfigMap.get(k);
+      if (stateConfig) {
+        if (!nextKnownState.has(stateConfig)) {
+          nextKnownState.set(stateConfig, stateConfig.parse(v));
+        }
+      } else {
+        nextUnknownState = nextUnknownState || {};
+        nextUnknownState[k] = v;
+      }
+    }
+  }
+  return nextUnknownState;
+}
+
+/**
+ * @internal
+ *
+ * Compare each entry of sourceState.knownState that is not in keys to
+ * otherState (or the default value if otherState is undefined.
+ * Note that otherState will return the defaultValue as well if it
+ * has never been set. Any checked entry's key will be added to keys.
+ *
+ * @returns true if any difference is found, false otherwise
+ */
+function hasUnequalMapEntry<T extends LexicalNode>(
+  keys: Set<string>,
+  sourceState: NodeState<T>,
+  otherState?: NodeState<T>,
+): boolean {
+  for (const [stateConfig, value] of sourceState.knownState) {
+    if (keys.has(stateConfig.key)) {
+      continue;
+    }
+    keys.add(stateConfig.key);
+    const otherValue = otherState
+      ? otherState.getValue(stateConfig)
+      : stateConfig.defaultValue;
+    if (otherValue !== value && !stateConfig.isEqual(otherValue, value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @internal
+ *
+ * Compare each entry of sourceState.unknownState that is not in keys to
+ * otherState.unknownState (or undefined if otherState is undefined).
+ * Any checked entry's key will be added to keys.
+ *
+ * Notably since we have already checked hasUnequalMapEntry on both sides,
+ * we do not do any parsing or checking of knownState.
+ *
+ * @returns true if any difference is found, false otherwise
+ */
+function hasUnequalRecordEntry<T extends LexicalNode>(
+  keys: Set<string>,
+  sourceState: NodeState<T>,
+  otherState?: NodeState<T>,
+): boolean {
+  const {unknownState} = sourceState;
+  const otherUnknownState = otherState ? otherState.unknownState : undefined;
+  if (unknownState) {
+    for (const [key, value] of Object.entries(unknownState)) {
+      if (keys.has(key)) {
         continue;
       }
-      keys.add(stateConfig.key);
-      const otherValue = otherState
-        ? otherState.getValue(stateConfig)
-        : stateConfig.defaultValue;
-      if (otherValue !== value && !stateConfig.isEqual(otherValue, value)) {
+      keys.add(key);
+      const otherValue = otherUnknownState ? otherUnknownState[key] : undefined;
+      if (value !== otherValue) {
         return true;
       }
     }
-    return false;
-  };
-  const hasUnequalRecordEntry = (
-    sourceState: NodeState<T>,
-    otherState?: NodeState<T>,
-  ): boolean => {
-    const {unknownState} = sourceState;
-    const otherUnknownState = otherState ? otherState.unknownState : undefined;
-    if (unknownState) {
-      for (const [key, value] of Object.entries(unknownState)) {
-        if (keys.has(key)) {
-          continue;
-        }
-        keys.add(key);
-        const otherValue = otherUnknownState
-          ? otherUnknownState[key]
-          : undefined;
-        if (value !== otherValue) {
-          return true;
-        }
-      }
-    }
-    return false;
-  };
-  return !(
-    (a && hasUnequalMapEntry(a, b)) ||
-    (b && hasUnequalMapEntry(b, a)) ||
-    (a && hasUnequalRecordEntry(a, b)) ||
-    (b && hasUnequalRecordEntry(b, a))
-  );
+  }
+  return false;
 }

--- a/packages/lexical/src/LexicalNormalization.ts
+++ b/packages/lexical/src/LexicalNormalization.ts
@@ -10,7 +10,7 @@ import type {RangeSelection, TextNode} from '.';
 import type {PointType} from './LexicalSelection';
 
 import {$isElementNode, $isTextNode} from '.';
-import {$nodeStatesAreEquivalent} from './LexicalNodeState';
+import {nodeStatesAreEquivalent} from './LexicalNodeState';
 import {getActiveEditor} from './LexicalUpdates';
 
 function $canSimpleTextNodesBeMerged(
@@ -31,7 +31,7 @@ function $canSimpleTextNodesBeMerged(
     (node1Style === null || node1Style === node2Style) &&
     (node1.__state === null ||
       node1State === node2State ||
-      $nodeStatesAreEquivalent(node1State, node2State))
+      nodeStatesAreEquivalent(node1State, node2State))
   );
 }
 

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -55,6 +55,7 @@ import {
   isLexicalEditor,
   removeDOMBlockCursorElement,
   scheduleMicroTask,
+  setPendingNodeToClone,
   updateDOMBlockCursorElement,
 } from './LexicalUtils';
 
@@ -411,6 +412,7 @@ export function parseEditorState(
   activeEditorState = editorState;
   isReadOnlyMode = false;
   activeEditor = editor;
+  setPendingNodeToClone(null);
 
   try {
     const registeredNodes = editor._nodes;
@@ -913,6 +915,7 @@ function $beginUpdate(
   editor._updating = true;
   activeEditor = editor;
   const headless = editor._headless || editor.getRootElement() === null;
+  setPendingNodeToClone(null);
 
   try {
     if (editorStateWasCloned) {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -25,6 +25,7 @@ import type {
   LexicalPrivateDOM,
   NodeKey,
   NodeMap,
+  StaticNodeConfigValue,
 } from './LexicalNode';
 import type {
   BaseSelection,
@@ -61,6 +62,7 @@ import {
   DOM_TEXT_TYPE,
   HAS_DIRTY_NODES,
   LTR_REGEX,
+  PROTOTYPE_CONFIG_METHOD,
   RTL_REGEX,
   TEXT_TYPE_TO_FORMAT,
 } from './LexicalConstants';
@@ -81,6 +83,16 @@ export const emptyFunction = () => {
   return;
 };
 
+let pendingNodeToClone: null | LexicalNode = null;
+export function setPendingNodeToClone(pendingNode: null | LexicalNode): void {
+  pendingNodeToClone = pendingNode;
+}
+export function getPendingNodeToClone(): null | LexicalNode {
+  const node = pendingNodeToClone;
+  pendingNodeToClone = null;
+  return node;
+}
+
 let keyCounter = 1;
 
 export function resetRandomKey(): void {
@@ -91,15 +103,28 @@ export function generateRandomKey(): string {
   return '' + keyCounter++;
 }
 
+/**
+ * @internal
+ */
 export function getRegisteredNodeOrThrow(
   editor: LexicalEditor,
   nodeType: string,
 ): RegisteredNode {
-  const registeredNode = editor._nodes.get(nodeType);
+  const registeredNode = getRegisteredNode(editor, nodeType);
   if (registeredNode === undefined) {
     invariant(false, 'registeredNode: Type %s not found', nodeType);
   }
   return registeredNode;
+}
+
+/**
+ * @internal
+ */
+export function getRegisteredNode(
+  editor: LexicalEditor,
+  nodeType: string,
+): undefined | RegisteredNode {
+  return editor._nodes.get(nodeType);
 }
 
 export const isArray = Array.isArray;
@@ -263,9 +288,11 @@ export function $setNodeKey(
   node: LexicalNode,
   existingKey: NodeKey | null | undefined,
 ): void {
+  const pendingNode = getPendingNodeToClone();
+  existingKey = existingKey || (pendingNode && pendingNode.__key);
   if (existingKey != null) {
     if (__DEV__) {
-      errorOnNodeKeyConstructorMismatch(node, existingKey);
+      errorOnNodeKeyConstructorMismatch(node, existingKey, pendingNode);
     }
     node.__key = existingKey;
     return;
@@ -290,6 +317,7 @@ export function $setNodeKey(
 function errorOnNodeKeyConstructorMismatch(
   node: LexicalNode,
   existingKey: NodeKey,
+  pendingNode: null | LexicalNode,
 ) {
   const editorState = internalGetActiveEditorState();
   if (!editorState) {
@@ -297,6 +325,16 @@ function errorOnNodeKeyConstructorMismatch(
     return;
   }
   const existingNode = editorState._nodeMap.get(existingKey);
+  if (pendingNode) {
+    invariant(
+      existingKey === pendingNode.__key,
+      'Lexical node with constructor %s (type %s) has an incorrect clone implementation, got %s for nodeKey when expecting %s',
+      node.constructor.name,
+      node.getType(),
+      String(existingKey),
+      pendingNode.__key,
+    );
+  }
   if (existingNode && existingNode.constructor !== node.constructor) {
     // Lifted condition to if statement because the inverted logic is a bit confusing
     if (node.constructor.name !== existingNode.constructor.name) {
@@ -1507,8 +1545,8 @@ export function $copyNode<T extends LexicalNode>(node: T): T {
 
 export function $applyNodeReplacement<N extends LexicalNode>(node: N): N {
   const editor = getActiveEditor();
-  const nodeType = node.constructor.getType();
-  const registeredNode = editor._nodes.get(nodeType);
+  const nodeType = node.getType();
+  const registeredNode = getRegisteredNode(editor, nodeType);
   invariant(
     registeredNode !== undefined,
     '$applyNodeReplacement node %s with type %s must be registered to the editor. You can do this by passing the node class via the "nodes" array in the editor config.',
@@ -1940,7 +1978,7 @@ function computeTypeToNodeMap(editorState: EditorState): TypeToNodeMap {
  * do not try and use this function to duplicate or copy an existing node.
  *
  * Does not mutate the EditorState.
- * @param node - The node to be cloned.
+ * @param latestNode - The node to be cloned.
  * @returns The clone of the node.
  */
 export function $cloneWithProperties<T extends LexicalNode>(latestNode: T): T {
@@ -1994,4 +2032,111 @@ export function setDOMUnmanaged(elementDom: HTMLElement): void {
 export function isDOMUnmanaged(elementDom: Node): boolean {
   const el: Node & LexicalPrivateDOM = elementDom;
   return el.__lexicalUnmanaged === true;
+}
+
+/**
+ * @internal
+ *
+ * Object.hasOwn ponyfill
+ */
+export function hasOwn(o: object, k: string): boolean {
+  return Object.prototype.hasOwnProperty.call(o, k);
+}
+
+/** @internal */
+function isAbstractNodeClass(klass: Klass<LexicalNode>): boolean {
+  return (
+    klass === DecoratorNode ||
+    klass === ElementNode ||
+    klass === Object.getPrototypeOf(ElementNode)
+  );
+}
+
+/** @internal */
+export function getStaticNodeConfig(klass: Klass<LexicalNode>): {
+  ownNodeType: undefined | string;
+  ownNodeConfig: undefined | StaticNodeConfigValue<LexicalNode, string>;
+} {
+  const nodeConfigRecord =
+    PROTOTYPE_CONFIG_METHOD in klass.prototype
+      ? klass.prototype[PROTOTYPE_CONFIG_METHOD]()
+      : undefined;
+  const isAbstract = isAbstractNodeClass(klass);
+  const nodeType =
+    !isAbstract && hasOwn(klass, 'getType') ? klass.getType() : undefined;
+  let ownNodeConfig: undefined | StaticNodeConfigValue<LexicalNode, string>;
+  let ownNodeType = nodeType;
+  if (nodeConfigRecord) {
+    if (nodeType) {
+      ownNodeConfig = nodeConfigRecord[nodeType];
+    } else {
+      for (const [k, v] of Object.entries(nodeConfigRecord)) {
+        ownNodeType = k;
+        ownNodeConfig = v;
+      }
+    }
+  }
+  if (!isAbstract && ownNodeType) {
+    if (!hasOwn(klass, 'getType')) {
+      klass.getType = () => ownNodeType;
+    }
+    if (!hasOwn(klass, 'clone')) {
+      if (__DEV__) {
+        invariant(
+          klass.length === 0,
+          '%s (type %s) must implement a static clone method since its constructor has %s required arguments (expecting 0). Use an explicit default in the first argument of your constructor(prop: T=X, nodeKey?: NodeKey).',
+          klass.name,
+          ownNodeType,
+          String(klass.length),
+        );
+      }
+      klass.clone = (prevNode: LexicalNode) => {
+        setPendingNodeToClone(prevNode);
+        return new klass();
+      };
+    }
+    if (!hasOwn(klass, 'importJSON')) {
+      if (__DEV__) {
+        invariant(
+          klass.length === 0,
+          '%s (type %s) must implement a static importJSON method since its constructor has %s required arguments (expecting 0). Use an explicit default in the first argument of your constructor(prop: T=X, nodeKey?: NodeKey).',
+          klass.name,
+          ownNodeType,
+          String(klass.length),
+        );
+      }
+      klass.importJSON = (serializedNode) =>
+        new klass().updateFromJSON(serializedNode);
+    }
+  }
+  return {ownNodeConfig, ownNodeType};
+}
+
+/**
+ * Create an node from its class.
+ *
+ * Note that this will directly construct the final `withKlass` node type,
+ * and will ignore the deprecated `with` functions. This allows $create to skip
+ * any intermediate steps where the replaced node would be created and then
+ * immediately discarded (once per configured replacement of that node).
+ *
+ * This does not support any arguments to the constructor.
+ * Setters which can be used to initialize your node, and they can
+ * be chained. You can of course write your own mutliple-argument functions
+ * to wrap that.
+ *
+ * @example
+ * ```ts
+ * function $createTokenText(text: string): TextNode {
+ *   return $create(TextNode).setTextContent(text).setMode('token');
+ * }
+ * ```
+ */
+export function $create<T extends LexicalNode>(klass: Klass<T>): T {
+  const editor = $getEditor();
+  errorOnReadOnly();
+  const registeredNode = editor.resolveRegisteredNodeAfterReplacements(
+    editor.getRegisteredNode(klass),
+  );
+  return new registeredNode.klass() as T;
 }

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2584,6 +2584,7 @@ describe('LexicalEditor tests', () => {
           {
             replace: TextNode,
             with: (node: TextNode) => new TestTextNode(node.getTextContent()),
+            withKlass: TestTextNode,
           },
         ],
         onError: onError,
@@ -2621,6 +2622,7 @@ describe('LexicalEditor tests', () => {
             replace: TextNode,
             with: (node: TextNode) =>
               new TestTextNode(node.getTextContent(), node.getKey()),
+            withKlass: TestTextNode,
           },
         ],
         onError: onError,
@@ -2650,7 +2652,9 @@ describe('LexicalEditor tests', () => {
 
     it('node transform to the nodes specified by "replace" should not be applied to the nodes specified by "with" when "withKlass" is not specified', async () => {
       const onError = jest.fn();
-
+      const mockWarning = jest
+        .spyOn(console, 'warn')
+        .mockImplementationOnce(() => {});
       const newEditor = createTestEditor({
         nodes: [
           TestTextNode,
@@ -2668,6 +2672,10 @@ describe('LexicalEditor tests', () => {
           },
         },
       });
+      expect(mockWarning).toHaveBeenCalledWith(
+        `Override for TextNode specifies 'replace' without 'withKlass'. 'withKlass' will be required in a future version.`,
+      );
+      mockWarning.mockRestore();
 
       newEditor.setRootElement(container);
 

--- a/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {makeStateWrapper} from '@lexical/utils';
+
 import {
   $createParagraphNode,
   $createTextNode,
@@ -15,13 +15,15 @@ import {
   $isParagraphNode,
   $setState,
   createState,
+  LexicalExportJSON,
   NODE_STATE_KEY,
+  type NodeStateJSON,
   ParagraphNode,
   RootNode,
-  SerializedLexicalNode,
+  StateValueOrUpdater,
 } from 'lexical';
 
-import {$nodeStatesAreEquivalent} from '../../LexicalNodeState';
+import {nodeStatesAreEquivalent} from '../../LexicalNodeState';
 import {initializeUnitTest, invariant} from '../utils';
 import {TestNode} from './LexicalNode.test';
 
@@ -36,20 +38,77 @@ type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y
 const numberState = createState('numberState', {
   parse: (v) => (typeof v === 'number' ? v : 0),
 });
-const numberStateWrapper = makeStateWrapper(numberState);
+const boolState = createState('boolState', {parse: Boolean});
 class StateNode extends TestNode {
-  static getType() {
-    return 'state';
+  $config() {
+    return this.config('state', {
+      extends: TestNode,
+      stateConfigs: [{flat: true, stateConfig: numberState}, boolState],
+    });
   }
-  static clone(node: StateNode) {
-    return new StateNode(node.__key);
+  getNumber() {
+    return $getState(this, numberState);
   }
-  static importJSON(serializedNode: SerializedLexicalNode): TestNode {
-    return new StateNode().updateFromJSON(serializedNode);
+  setNumber(valueOrUpdater: StateValueOrUpdater<typeof numberState>): this {
+    return $setState(this, numberState, valueOrUpdater);
   }
-  getNumber = numberStateWrapper.makeGetterMethod<this>();
-  setNumber = numberStateWrapper.makeSetterMethod<this>();
 }
+
+const extraState = createState('extra', {parse: String});
+class ExtraStateNode extends StateNode {
+  $config() {
+    return this.config('extra-state', {
+      extends: StateNode,
+      stateConfigs: [{flat: true, stateConfig: extraState}],
+    });
+  }
+}
+
+type StateNodeStateJSON = NodeStateJSON<StateNode>;
+type _TestNodeStateJSON = Expect<
+  Equal<
+    StateNodeStateJSON,
+    {
+      [NODE_STATE_KEY]?: {boolState?: boolean | undefined} | undefined;
+      numberState?: number | undefined;
+    }
+  >
+>;
+type StateNodeExportJSON = LexicalExportJSON<StateNode>;
+type _TestStateNodeExportJSON = Expect<
+  Equal<
+    StateNodeExportJSON,
+    {
+      state?:
+        | (Record<string, unknown> & {
+            boolState?: boolean | undefined;
+          })
+        | undefined;
+      version: number;
+      type: 'state';
+      numberState?: number | undefined;
+    }
+  >
+>;
+
+type ExtraStateNodeExportJSON = LexicalExportJSON<ExtraStateNode>;
+type _TestExtraStateNodeExportJSON = Expect<
+  Equal<
+    ExtraStateNodeExportJSON,
+    {
+      state?:
+        | (Record<string, unknown> & {
+            boolState?: boolean | undefined;
+          })
+        | undefined;
+      version: number;
+      type: 'extra-state';
+      numberState?: number | undefined;
+      extra?: string | undefined;
+    }
+  >
+>;
+
 function $createStateNode() {
   return new StateNode();
 }
@@ -168,8 +227,11 @@ describe('LexicalNode state', () => {
           expect(stateNode.getNumber()).toBe(1);
           stateNode.setNumber((n) => n + 1);
           expect(stateNode.getNumber()).toBe(2);
-          expect(stateNode.exportJSON()[NODE_STATE_KEY]).toStrictEqual({
+          $setState(stateNode, boolState, true);
+          expect(stateNode.exportJSON()).toMatchObject({
+            [NODE_STATE_KEY]: {boolState: true},
             numberState: 2,
+            type: 'state',
           });
         });
       });
@@ -291,9 +353,9 @@ describe('LexicalNode state', () => {
         expect(noState.read(() => $getState(v0, vk, 'direct'))).toBe(0);
         expect(noState.read(() => $getState(v1, vk, 'direct'))).toBe(1);
       });
-      describe('$nodeStatesAreEquivalent', () => {
+      describe('nodeStatesAreEquivalent', () => {
         test('undefined states are equivalent', () => {
-          expect($nodeStatesAreEquivalent(undefined, undefined)).toBe(true);
+          expect(nodeStatesAreEquivalent(undefined, undefined)).toBe(true);
         });
         test('TextNode merging only with equivalent state', () => {
           const {editor} = testEnv;
@@ -437,8 +499,8 @@ describe('LexicalNode state', () => {
               const bSet = equivalences[j];
               for (const a of aSet) {
                 for (const b of bSet) {
-                  expect($nodeStatesAreEquivalent(a, b)).toBe(false);
-                  expect($nodeStatesAreEquivalent(b, a)).toBe(false);
+                  expect(nodeStatesAreEquivalent(a, b)).toBe(false);
+                  expect(nodeStatesAreEquivalent(b, a)).toBe(false);
                 }
               }
             }
@@ -446,8 +508,8 @@ describe('LexicalNode state', () => {
               const a0 = aSet[j];
               for (let k = j + 1; k < aSet.length; k++) {
                 const a1 = aSet[k];
-                expect($nodeStatesAreEquivalent(a0, a1)).toBe(true);
-                expect($nodeStatesAreEquivalent(a1, a0)).toBe(true);
+                expect(nodeStatesAreEquivalent(a0, a1)).toBe(true);
+                expect(nodeStatesAreEquivalent(a1, a0)).toBe(true);
               }
             }
           }

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -409,6 +409,7 @@ describe('$applyNodeReplacement', () => {
         {
           replace: TextNode,
           with: (node) => $createExtendedTextNode().initWithTextNode(node),
+          withKlass: ExtendedExtendedTextNode,
         },
       ],
       onError(err) {
@@ -455,6 +456,9 @@ describe('$applyNodeReplacement', () => {
     );
   });
   test('validates replace node type change', () => {
+    const mockWarning = jest
+      .spyOn(console, 'warn')
+      .mockImplementationOnce(() => {});
     const editor = createEditor({
       nodes: [
         {
@@ -466,6 +470,10 @@ describe('$applyNodeReplacement', () => {
         throw err;
       },
     });
+    expect(mockWarning).toHaveBeenCalledWith(
+      `Override for TextNode specifies 'replace' without 'withKlass'. 'withKlass' will be required in a future version.`,
+    );
+    mockWarning.mockRestore();
     expect(() => {
       editor.update(
         () => {
@@ -486,6 +494,7 @@ describe('$applyNodeReplacement', () => {
           replace: TextNode,
           with: (node: TextNode) =>
             new ExtendedTextNode(node.__text, node.getKey()),
+          withKlass: ExtendedTextNode,
         },
       ],
       onError(err) {
@@ -539,6 +548,7 @@ describe('$applyNodeReplacement', () => {
           replace: ExtendedTextNode,
           with: (node) =>
             $createExtendedExtendedTextNode().initWithExtendedTextNode(node),
+          withKlass: ExtendedExtendedTextNode,
         },
       ],
       onError(err) {

--- a/packages/lexical/src/caret/LexicalCaretUtils.ts
+++ b/packages/lexical/src/caret/LexicalCaretUtils.ts
@@ -219,7 +219,7 @@ function $isCaretAttached<Caret extends PointCaret<CaretDirection>>(
  * blocks then the remaining contents of the later block will be merged with
  * the earlier block.
  *
- * @param range The range to remove text and nodes from
+ * @param initialRange The range to remove text and nodes from
  * @param sliceMode If 'preserveEmptyTextPointCaret' it will leave an empty TextPointCaret at the anchor for insert if one exists, otherwise empty slices will be removed
  * @returns The new collapsed range (biased towards the earlier node)
  */
@@ -563,8 +563,9 @@ export function $getChildCaretAtIndex<D extends CaretDirection>(
  * R -> P -> T1, T2
  *   -> P2
  * returns T2 for node T1, P2 for node T2, and null for node P2.
- * @param node LexicalNode.
- * @returns An array (tuple) containing the found Lexical node and the depth difference, or null, if this node doesn't exist.
+ * @param startCaret The initial caret
+ * @param rootMode The root mode, 'root' ('default') or 'shadowRoot'
+ * @returns An array (tuple) containing the found caret and the depth difference, or null, if this node doesn't exist.
  */
 export function $getAdjacentSiblingOrParentSiblingCaret<
   D extends CaretDirection,

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -140,6 +140,7 @@ export type {
   KlassConstructor,
   LexicalCommand,
   LexicalEditor,
+  LexicalNodeConfig,
   LexicalNodeReplacement,
   MutationListener,
   NodeMutation,
@@ -163,6 +164,7 @@ export type {
 } from './LexicalEditorState';
 export type {EventHandler} from './LexicalEvents';
 export type {
+  BaseStaticNodeConfig,
   DOMChildConversion,
   DOMConversion,
   DOMConversionFn,
@@ -170,11 +172,15 @@ export type {
   DOMConversionOutput,
   DOMExportOutput,
   DOMExportOutputMap,
+  LexicalExportJSON,
   LexicalNode,
   LexicalUpdateJSON,
   NodeKey,
   NodeMap,
   SerializedLexicalNode,
+  StaticNodeConfig,
+  StaticNodeConfigRecord,
+  StaticNodeConfigValue,
 } from './LexicalNode';
 export {
   $getState,
@@ -182,11 +188,14 @@ export {
   $getWritableNodeState,
   $setState,
   type AnyStateConfig,
+  createSharedNodeState,
   createState,
+  type NodeStateJSON,
   type StateConfig,
   type StateConfigKey,
   type StateConfigValue,
   type StateValueConfig,
+  type StateValueOrUpdater,
   type ValueOrUpdater,
 } from './LexicalNodeState';
 export {$normalizeSelection as $normalizeSelection__EXPERIMENTAL} from './LexicalNormalization';
@@ -219,6 +228,7 @@ export {
   $applyNodeReplacement,
   $cloneWithProperties,
   $copyNode,
+  $create,
   $getAdjacentNode,
   $getEditor,
   $getNearestNodeFromDOMNode,
@@ -244,6 +254,8 @@ export {
   getDOMTextNode,
   getEditorPropertyFromDOMNode,
   getNearestEditorFromDOMNode,
+  getRegisteredNode,
+  getRegisteredNodeOrThrow,
   INTERNAL_$isBlock,
   isBlockDomNode,
   isDocumentFragment,


### PR DESCRIPTION
## Description

Based on the future needs of NodeState (#7117) - specifically allowing nodes to statically declare their required state - this RFC refactors LexicalNode and the associated internals to remove the need for any static methods, vastly reducing the boilerplate in order to subclass nodes. This is a squashed/rebased version of the original #7189 PR that explored this feature.

The short story is that this sort of thing will let us get better type-level information about nodes. We can't have `node.getType()` ever give a more specific type than `string` but we could write a `$getType(node)` that does infer to the exact type if we want. Same thing for `node.exportJSON()` and similar methods.

It also facilitates scrapping all of the node subclass boilerplate, except for this one method, so long as the class has a compatible signature (trivial constructor)

<details>
<summary>Example of extension and inference capability from the tests</summary>

```ts
const numberState = createState('numberState', {
  parse: (v) => (typeof v === 'number' ? v : 0),
});
const boolState = createState('boolState', {parse: Boolean});
class StateNode extends TestNode {
  $config() {
    return this.config('state', {
      extends: TestNode,
      stateConfigs: [{flat: true, stateConfig: numberState}, boolState],
    });
  }
  getNumber() {
    return $getState(this, numberState);
  }
  setNumber(valueOrUpdater: StateValueOrUpdater<typeof numberState>): this {
    return $setState(this, numberState, valueOrUpdater);
  }
}

const extraState = createState('extra', {parse: String});
class ExtraStateNode extends StateNode {
  $config() {
    return this.config('extra-state', {
      extends: StateNode,
      stateConfigs: [{flat: true, stateConfig: extraState}],
    });
  }
}

type _TestExtraStateNodeExportJSON = Expect<
  Equal<
    ExtraStateNodeExportJSON,
    {
      state?:
        | (Record<string, unknown> & {
            boolState?: boolean | undefined;
          })
        | undefined;
      version: number;
      type: 'extra-state';
      numberState?: number | undefined;
      extra?: string | undefined;
    }
  >
>;
```
</details>

## How it works

The proposed protocol for declaring nodes would scale down to something like this:

```ts
class CustomTextNode extends TextNode {
  $config() {
    return this.config('custom-text', {extends: TextNode});
  }
}
```

The two method interface is useful for TypeScript reasons, basically. The outer `getStaticNodeConfig` (could come up with a shorter and/or more memorable name) is the API and the `this.configureNode(…)` is a helper method that has the right generics to make it easy to return something with the right shape and type. The types are very delicate, if you don't have all of the annotations just right then the type will simplify into something without information that can be extracted. Basically it is just returning an object like this, but in a way where TypeScript doesn't collapse the type into something simpler (kind of like using `as const` or `satisfies` in the right place):

```ts
{'custom-text': {type: 'custom-text', extends: TextNode}}
```

On the LexicalEditor side, during createEditor, `CustomTextNode.prototype.$config()` is called and can grab the type and any other useful metadata (e.g. a defined transform, registered state, anything else we want to put in there). For compatibility reasons it will also monkeypatch `getType`, `importJSON`, and `clone` static methods onto the node class if they are not already there. It adds a module global variable to inject cloned node keys so it doesn't need to break any compatibility with multi-argument constructors, it only requires that they have a 0-argument form.

I've also put a `$create` method in there which reduces the boilerplate and increases the efficiency there, assuming that we'd be willing to deprecate `with` in the node overrides and go directly to `withKlass` so that we don't have to construct any intermediate garbage when that's configured.

I think this covers most of the breaking-ish changes I would want to make to the lowest level stuff, in exchange for better DX and no loss of performance (probably better, even if just code size improves).

## Future direction

I think this is where we fix the rest of the #6998 things here with some combination of middleware-style functions or automatic super calls (like `$afterCloneFrom`) instead of methods so that we can control things better without variance violations.