### PR TITLE
[@lexical/react]  Bug Fix: anchor element not cleanup when component unmount

### DIFF
--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -577,7 +577,7 @@ export function useMenuAnchorRef(
       if (rootElement !== null) {
         rootElement.removeAttribute('aria-controls');
       }
-  
+
       const containerDiv = anchorElementRef.current;
       if (containerDiv !== null && containerDiv.isConnected) {
         containerDiv.remove();

--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -572,18 +572,18 @@ export function useMenuAnchorRef(
     const rootElement = editor.getRootElement();
     if (resolution !== null) {
       positionMenu();
-      return () => {
-        if (rootElement !== null) {
-          rootElement.removeAttribute('aria-controls');
-        }
-
-        const containerDiv = anchorElementRef.current;
-        if (containerDiv !== null && containerDiv.isConnected) {
-          containerDiv.remove();
-          containerDiv.removeAttribute('id');
-        }
-      };
     }
+    return () => {
+      if (rootElement !== null) {
+        rootElement.removeAttribute('aria-controls');
+      }
+  
+      const containerDiv = anchorElementRef.current;
+      if (containerDiv !== null && containerDiv.isConnected) {
+        containerDiv.remove();
+        containerDiv.removeAttribute('id');
+      }
+    };
   }, [editor, positionMenu, resolution]);
 
   const onVisibilityChange = useCallback(


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
anchor element not cleanup when component unmount

![image](https://github.com/user-attachments/assets/80048f6b-3541-4513-a2e7-61a5cb059e16)

