### PR TITLE
[*] Chore: Refactor shared/invariant for easier dev debugging

### DIFF
--- a/packages/shared/src/formatDevErrorMessage.ts
+++ b/packages/shared/src/formatDevErrorMessage.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// Do not require this module directly! Use normal `invariant` calls.
+
+export default function formatDevErrorMessage(message: string): never {
+  throw new Error(message);
+}

--- a/packages/shared/src/formatProdErrorMessage.ts
+++ b/packages/shared/src/formatProdErrorMessage.ts
@@ -6,18 +6,19 @@
  *
  */
 
-'use strict';
-
 // Do not require this module directly! Use normal `invariant` calls with
 // template literal strings. The messages will be replaced with error codes
 // during build.
 
-function formatProdErrorMessage(code) {
+export default function formatProdErrorMessage(
+  code: string,
+  ...args: string[]
+): never {
   const url = new URL('https://lexical.dev/docs/error');
   const params = new URLSearchParams();
   params.append('code', code);
-  for (let i = 1; i < arguments.length; i++) {
-    params.append('v', arguments[i]);
+  for (const arg of args) {
+    params.append('v', arg);
   }
   url.search = params.toString();
 
@@ -25,5 +26,3 @@ function formatProdErrorMessage(code) {
     `Minified Lexical error #${code}; visit ${url.toString()} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`,
   );
 }
-
-module.exports = formatProdErrorMessage;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -216,15 +216,6 @@ async function build(
           ['@babel/preset-react', {runtime: 'automatic'}],
         ],
       }),
-      {
-        resolveId(importee, importer) {
-          if (importee === 'formatProdErrorMessage') {
-            return path.resolve(
-              './scripts/error-codes/formatProdErrorMessage.js',
-            );
-          }
-        },
-      },
       commonjs(),
       json(),
       replace(

--- a/scripts/error-codes/__tests__/unit/transform-error-messages.test.js
+++ b/scripts/error-codes/__tests__/unit/transform-error-messages.test.js
@@ -53,10 +53,10 @@ function fmt(strings: TemplateStringsArray, ...keys: unknown[]) {
     .replace(/.use strict.;\n/g, '')
     .replace(/var _[^;]+;\n/g, '')
     .replace(/function _interopRequireDefault\([^)]*\) {[^;]+?;[\s\n]*}\n/g, '')
-    .replace(/_formatProdErrorMessage\d+/g, 'formatProdErrorMessage')
+    .replace(/_format(Dev|Prod)ErrorMessage\d+/g, 'format$1ErrorMessage')
     .replace(
-      /\(0,\s*formatProdErrorMessage\.default\)/g,
-      'formatProdErrorMessage',
+      /\(0,\s*format(Dev|Prod)ErrorMessage\.default\)/g,
+      'format$1ErrorMessage',
     )
     .trim();
   return prettier.format(before, {
@@ -108,14 +108,10 @@ describe('transform-error-messages', () => {
         `,
         codeExpect: `
         if (!condition) {
-          {
-            formatProdErrorMessage(1);
-          }
+          formatProdErrorMessage(1);
         }
         if (!condition) {
-          {
-            formatProdErrorMessage(0, adj, noun);
-          }
+          formatProdErrorMessage(0, adj, noun);
         }`,
         messageMapBefore: KNOWN_MSG_MAP,
         messageMapExpect: NEW_MSG_MAP,
@@ -133,10 +129,10 @@ describe('transform-error-messages', () => {
         `,
         codeExpect: `
         if (!condition) {
-          throw Error(\`A new invariant\`);
+          formatDevErrorMessage(\`A new invariant\`);
         }
         if (!condition) {
-          throw Error(\`A \${adj} message that contains \${noun}\`);
+          formatDevErrorMessage(\`A \${adj} message that contains \${noun}\`);
         }`,
         messageMapBefore: KNOWN_MSG_MAP,
         messageMapExpect: NEW_MSG_MAP,
@@ -153,9 +149,7 @@ describe('transform-error-messages', () => {
         )}, adj, noun)`,
         codeExpect: `
           if (!condition) {
-            {
-              formatProdErrorMessage(0, adj, noun);
-            }
+            formatProdErrorMessage(0, adj, noun);
           }
         `,
         messageMapBefore: KNOWN_MSG_MAP,
@@ -169,7 +163,7 @@ describe('transform-error-messages', () => {
         codeExpect: `
           /*FIXME (minify-errors-in-prod): Unminified error message in production build!*/
           if (!condition) {
-            throw Error(\`A new invariant\`);
+            formatDevErrorMessage(\`A new invariant\`);
           }
        `,
         messageMapBefore: KNOWN_MSG_MAP,


### PR DESCRIPTION
## Description

Refactor the invariant and its associated transform-error-messages babel plug-in to use a format function regardless of whether it's in dev or prod mode. This makes it easier to place a breakpoint where an exception will be thrown since now there is a function called unconditionally in error situations.

In this refactor I also moved the format*Error functions to TypeScript modules in the shared package so they could get picked up easily by vite and maintained in the same syntax as the rest of the project without having any additional aliases or resolution functions.

Separately we might consider renaming these functions to `throw*ErrorMessage` instead of `format*ErrorMessage` to be more clear that they don't return, but I didn't know if there was any internal tooling at Meta that would be affected by a rename.

## Test plan

This change should only affect dev stack traces and the dev build output. The tests for the transform-error-messages plug-in have been changed accordingly.
