### PR TITLE
[Breaking Changes][lexical] Bug Fix: Address deleteLine regression in #7248

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -9,12 +9,15 @@
 import {
   deleteBackward,
   deleteForward,
+  deleteLineBackward,
+  deleteLineForward,
   moveDown,
   moveLeft,
   moveRight,
   moveToEditorBeginning,
   moveToEditorEnd,
   moveToLineBeginning,
+  moveToLineEnd,
   moveToPrevWord,
   moveUp,
   pressShiftEnter,
@@ -41,11 +44,11 @@ import {
   IS_LINUX,
   IS_MAC,
   IS_WINDOWS,
-  keyDownCtrlOrMeta,
-  keyUpCtrlOrMeta,
   pasteFromClipboard,
   pressToggleBold,
   pressToggleItalic,
+  prettifyHTML,
+  SAMPLE_IMAGE_URL,
   selectFromFormatDropdown,
   sleep,
   test,
@@ -165,7 +168,7 @@ test.describe.parallel('Selection', () => {
     );
   });
 
-  test('can delete text by line with CMD+delete', async ({
+  test('can delete text by line backwards with CMD+delete', async ({
     page,
     isPlainText,
   }) => {
@@ -178,55 +181,85 @@ test.describe.parallel('Selection', () => {
     await page.keyboard.press('Enter');
     await page.keyboard.type('Three');
 
-    const deleteLine = async () => {
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('Backspace');
-      await keyUpCtrlOrMeta(page);
-    };
-
-    const lines = [
-      html`
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">One</span>
-        </p>
-      `,
-      html`
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">Two</span>
-        </p>
-      `,
-      html`
-        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
-      `,
-      html`
-        <p
-          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-          dir="ltr">
-          <span data-lexical-text="true">Three</span>
-        </p>
-      `,
-    ];
-    const empty = html`
-      <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+    const p = (text) =>
+      text
+        ? html`
+            <p
+              class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+              dir="ltr">
+              <span data-lexical-text="true">${text}</span>
+            </p>
+          `
+        : html`
+            <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+          `;
+    const lines = (...args) => html`
+      ${args.map(p).join('')}
     `;
 
-    await deleteLine();
-    await assertHTML(page, [lines[0], lines[1], lines[2], empty].join(''));
+    await deleteLineBackward(page);
+    await assertHTML(page, lines('One', 'Two', '', ''));
     await page.keyboard.press('Backspace');
-    await deleteLine();
-    await assertHTML(page, [lines[0], lines[1]].join(''));
-    await deleteLine();
-    await assertHTML(page, [lines[0], empty].join(''));
+    await deleteLineBackward(page);
+    await assertHTML(page, lines('One', 'Two'));
+    await deleteLineBackward(page);
+    await assertHTML(page, lines('One', ''));
     await page.keyboard.press('Backspace');
-    await deleteLine();
-    await assertHTML(page, empty);
+    await deleteLineBackward(page);
+    await assertHTML(page, lines(''));
   });
 
-  test('can delete line which ends with element with CMD+delete', async ({
+  test('can delete text by line forwards with opt+CMD+delete', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText || !IS_MAC);
+    await focusEditor(page);
+    await page.keyboard.type('One');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Two');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Three');
+
+    const p = (text) =>
+      text
+        ? html`
+            <p
+              class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+              dir="ltr">
+              <span data-lexical-text="true">${text}</span>
+            </p>
+          `
+        : html`
+            <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+          `;
+    const lines = (...args) => html`
+      ${args.map(p).join('')}
+    `;
+    await assertHTML(page, lines('One', 'Two', '', 'Three'));
+    // Move to the end of the line of 'Two'
+    await moveUp(page, 2);
+    await deleteLineForward(page);
+    await assertHTML(page, lines('One', 'Two', 'Three'));
+    await deleteLineForward(page);
+    await assertHTML(page, lines('One', 'TwoThree'));
+    await deleteLineForward(page);
+    await assertHTML(page, lines('One', 'Two'));
+    await deleteLineForward(page);
+    await assertHTML(page, lines('One', 'Two'));
+    await moveToEditorBeginning(page);
+    await deleteLineForward(page);
+    await assertHTML(page, lines('', 'Two'));
+    await deleteLineForward(page);
+    await assertHTML(page, lines('Two'));
+    await deleteLineForward(page);
+    await assertHTML(page, lines(''));
+    await deleteLineForward(page);
+    await assertHTML(page, lines(''));
+  });
+
+  test('can delete line which ends with element backwards with CMD+delete', async ({
     page,
     isPlainText,
   }) => {
@@ -240,19 +273,12 @@ test.describe.parallel('Selection', () => {
       'text/html': `
           <span class="editor-image" data-lexical-decorator="true" contenteditable="false">
             <div draggable="false">
-              <img src="/assets/yellow-flower-vav9Hsve.jpg" alt="Yellow flower in tilt shift lens" draggable="false" style="height: inherit; max-width: 500px; width: inherit;">
+              <img src="${SAMPLE_IMAGE_URL}" alt="Yellow flower in tilt shift lens" draggable="false" style="height: inherit; max-width: 500px; width: inherit;">
             </div>
           </span>
         `,
     });
-
-    const deleteLine = async () => {
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('Backspace');
-      await keyUpCtrlOrMeta(page);
-    };
-
-    await deleteLine();
+    await deleteLineBackward(page);
     await page.keyboard.press('Backspace');
     await assertHTML(
       page,
@@ -265,8 +291,182 @@ test.describe.parallel('Selection', () => {
       `,
     );
     await page.keyboard.press('Backspace');
-    await deleteLine();
+    await deleteLineBackward(page);
     await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+  });
+
+  test('can delete line which starts with element forwards with opt+CMD+delete', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText || !IS_MAC);
+    const modifyImageHTML = async (originalHtml) =>
+      await prettifyHTML(
+        originalHtml
+          .replace(
+            /<button\s+class="image-edit-button">\s*Edit\s*<\/button>/gi,
+            '',
+          )
+          .replace(/(src=")https?:\/\/[^/]+/gi, '$1'),
+      );
+    const assertImageHTML = async (page_, expectedHtml) => {
+      await assertHTML(
+        page_,
+        expectedHtml,
+        expectedHtml,
+        {ignoreInlineStyles: true},
+        modifyImageHTML,
+      );
+    };
+    const pasteImageHtml = html`
+      <img
+        alt="Yellow flower in tilt shift lens"
+        draggable="false"
+        src="${SAMPLE_IMAGE_URL}"
+        style="height: inherit; max-width: 500px; width: inherit;" />
+    `;
+    const imageHtml = html`
+      <span
+        class="inline-editor-image"
+        contenteditable="false"
+        data-lexical-decorator="true">
+        <span draggable="false">${pasteImageHtml}</span>
+      </span>
+    `;
+
+    await focusEditor(page);
+    await page.keyboard.type('One');
+    await page.keyboard.press('Enter');
+    await assertImageHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">One</span>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    await pasteFromClipboard(page, {
+      'text/html': pasteImageHtml,
+    });
+    await assertImageHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">One</span>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph">
+          ${imageHtml}
+          <br />
+        </p>
+      `,
+    );
+
+    await page.keyboard.type('Two');
+    await page.keyboard.press('Enter');
+    await assertImageHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">One</span>
+        </p>
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          ${imageHtml}
+          <span data-lexical-text="true">Two</span>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    // This puts the caret before the decorator in an awkward way, see comments below
+    await moveToEditorBeginning(page);
+    await moveToLineEnd(page);
+    await moveRight(page, 1);
+    // TODO: move arrow down doesn't work for this because it skips over the inline decorator
+    // if (arrow_down_works_with_decorators) {
+    //   await moveToEditorBeginning(page);
+    //   await moveDown(page, 1);
+    // }
+    // TODO: move to line beginning stops after the inline decorator
+    // if (line_beginning_works_with_decorators) {
+    //   await moveUp(page, 1);
+    //   await moveToLineBeginning(page);
+    // }
+    await deleteLineForward(page);
+    await assertImageHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">One</span>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    await deleteLineForward(page);
+    await assertImageHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">One</span>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    // We're now at the end of the document so delete forward is a no-op
+    await deleteLineForward(page);
+    await assertImageHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">One</span>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    await moveToEditorBeginning(page);
+    await deleteLineForward(page);
+    await assertImageHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    await deleteLineForward(page);
+    await assertImageHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+      `,
+    );
+
+    await deleteLineForward(page);
+    await assertImageHTML(
       page,
       html`
         <p class="PlaygroundEditorTheme__paragraph"><br /></p>
@@ -282,12 +482,7 @@ test.describe.parallel('Selection', () => {
     await page.keyboard.press('Enter');
     await page.keyboard.press('ArrowUp');
 
-    const deleteLine = async () => {
-      await keyDownCtrlOrMeta(page);
-      await page.keyboard.press('Backspace');
-      await keyUpCtrlOrMeta(page);
-    };
-    await deleteLine();
+    await deleteLineBackward(page);
     await assertHTML(
       page,
       html`

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -299,8 +299,6 @@ test.describe.parallel('Tables', () => {
     test.skip(isPlainText);
     await initialize({isCollab, page});
 
-    // Table edge cursor doesn't show up in Firefox.
-    test.fixme(browserName === 'firefox');
     test.fixme(
       legacyEvents && browserName === 'chromium' && IS_WINDOWS,
       'Flaky on Windows + Chromium + legacy events',
@@ -356,24 +354,12 @@ test.describe.parallel('Tables', () => {
     );
 
     await moveRight(page, 1);
-    if (WRAPPER.length === 0) {
-      // The native window selection should be on the root, whereas
-      // the editor selection should be on the last cell of the table.
-      await assertSelection(page, {
-        anchorOffset: 2,
-        anchorPath: [],
-        focusOffset: 2,
-        focusPath: [],
-      });
-    } else {
-      // The native window selection is in the wrapper after the table
-      await assertSelection(page, {
-        anchorOffset: WRAPPER[0] + 1,
-        anchorPath: [1],
-        focusOffset: WRAPPER[0] + 1,
-        focusPath: [1],
-      });
-    }
+    await assertSelection(page, {
+      anchorOffset: 2,
+      anchorPath: [],
+      focusOffset: 2,
+      focusPath: [],
+    });
 
     await page.keyboard.press('Enter');
     await assertSelection(page, {
@@ -423,8 +409,6 @@ test.describe.parallel('Tables', () => {
     browserName,
   }) => {
     test.skip(isPlainText);
-    // Table edge cursor doesn't show up in Firefox.
-    test.fixme(browserName === 'firefox');
     // After typing, the dom selection gets set back to the internal previous selection during the update.
     test.fixme(LEGACY_EVENTS);
 
@@ -898,10 +882,6 @@ test.describe.parallel('Tables', () => {
 
     await page.keyboard.down('Shift');
     await page.keyboard.press('ArrowRight');
-    // Firefox range selection spans across cells after two arrow key press
-    if (browserName === 'firefox') {
-      await page.keyboard.press('ArrowRight');
-    }
     await page.keyboard.press('ArrowDown');
     await page.keyboard.up('Shift');
 
@@ -1721,10 +1701,6 @@ test.describe.parallel('Tables', () => {
 
       await page.keyboard.down('Shift');
       await page.keyboard.press('ArrowRight');
-      // Firefox range selection spans across cells after two arrow key press
-      if (browserName === 'firefox') {
-        await page.keyboard.press('ArrowRight');
-      }
       await page.keyboard.press('ArrowDown');
       await page.keyboard.up('Shift');
 

--- a/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
+++ b/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
@@ -103,6 +103,24 @@ export async function deleteNextWord(page) {
   await keyUpCtrlOrAlt(page);
 }
 
+export async function deleteLineBackward(page) {
+  if (!IS_MAC) {
+    throw new Error('deleteLineBackward is only supported on Mac');
+  }
+  await page.keyboard.down('Meta');
+  await page.keyboard.press('Backspace');
+  await page.keyboard.up('Meta');
+}
+
+export async function deleteLineForward(page) {
+  if (!IS_MAC) {
+    throw new Error('deleteLineForward is only supported on Mac');
+  }
+  await page.keyboard.down('Meta');
+  await page.keyboard.press('Delete');
+  await page.keyboard.up('Meta');
+}
+
 export async function deleteBackward(page) {
   if (IS_MAC) {
     await page.keyboard.down('Control');

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -241,7 +241,7 @@ async function assertHTMLOnPageOrFrame(
       ignoreInlineStyles,
     });
 
-    actual = actualHtmlModificationsCallback(actual);
+    actual = await actualHtmlModificationsCallback(actual);
 
     expect(
       actual,

--- a/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageNode.tsx
@@ -22,6 +22,10 @@ import type {
 import type {JSX} from 'react';
 
 import {
+  addClassNamesToElement,
+  removeClassNamesFromElement,
+} from '@lexical/utils';
+import {
   $applyNodeReplacement,
   createEditor,
   DecoratorNode,
@@ -71,6 +75,10 @@ export type SerializedInlineImageNode = Spread<
   },
   SerializedLexicalNode
 >;
+
+function getPositionClass(position: Position | undefined): string | undefined {
+  return typeof position === 'string' ? `position-${position}` : undefined;
+}
 
 export class InlineImageNode extends DecoratorNode<JSX.Element> {
   __src: string;
@@ -234,9 +242,13 @@ export class InlineImageNode extends DecoratorNode<JSX.Element> {
 
   createDOM(config: EditorConfig): HTMLElement {
     const span = document.createElement('span');
-    const className = `${config.theme.inlineImage} position-${this.__position}`;
-    if (className !== undefined) {
-      span.className = className;
+    for (const cls of [
+      config.theme.inlineImage,
+      getPositionClass(this.__position),
+    ]) {
+      if (cls) {
+        addClassNamesToElement(span, cls);
+      }
     }
     return span;
   }
@@ -244,10 +256,8 @@ export class InlineImageNode extends DecoratorNode<JSX.Element> {
   updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): false {
     const position = this.__position;
     if (position !== prevNode.__position) {
-      const className = `${config.theme.inlineImage} position-${position}`;
-      if (className !== undefined) {
-        dom.className = className;
-      }
+      removeClassNamesFromElement(dom, getPositionClass(prevNode.__position));
+      addClassNamesToElement(dom, getPositionClass(position));
     }
     return false;
   }

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -1598,6 +1598,9 @@ function $isSelectionInTable(
   tableNode: TableNode,
 ): boolean {
   if ($isRangeSelection(selection) || $isTableSelection(selection)) {
+    // TODO this should probably return false if there's an unrelated
+    //      shadow root between the node and the table (e.g. another table,
+    //      collapsible, etc.)
     const isAnchorInside = tableNode.isParentOf(selection.anchor.getNode());
     const isFocusInside = tableNode.isParentOf(selection.focus.getNode());
 

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -1226,3 +1226,7 @@ declare export function $getCommonAncestor<
 declare export function $extendCaretToRange<D: CaretDirection>(
   anchor: PointCaret<D>,
 ): CaretRange<D>;
+
+declare export function $isExtendableTextPointCaret<D: CaretDirection>(
+  caret: PointCaret<D>
+): implies caret is TextPointCaret<TextNode, D>;

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -3345,6 +3345,11 @@ function $modifySelectionAroundDecoratorsAndBlocks(
           }
         } else if ($isElementNode(nextCaret.origin)) {
           continue;
+        } else if (
+          $isDecoratorNode(nextCaret.origin) &&
+          !nextCaret.origin.isInline()
+        ) {
+          focus = nextCaret;
         }
         break;
       }
@@ -3357,7 +3362,6 @@ function $modifySelectionAroundDecoratorsAndBlocks(
   // different block, so we should stop regardless of the granularity
   if (
     collapse &&
-    !checkForBlock &&
     !isLineBoundary &&
     $isDecoratorNode(focus.origin) &&
     focus.origin.isKeyboardSelectable()

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -27,6 +27,7 @@ import {
   $getCaretRangeInDirection,
   $getChildCaret,
   $getSiblingCaret,
+  $getTextNodeOffset,
   $isChildCaret,
   $isDecoratorNode,
   $isElementNode,
@@ -61,7 +62,6 @@ import {
   isCurrentlyReadOnlyMode,
 } from './LexicalUpdates';
 import {
-  $getAdjacentNode,
   $getAncestor,
   $getCompositionKey,
   $getNearestRootOrShadowRoot,
@@ -1521,55 +1521,13 @@ export class RangeSelection implements BaseSelection {
     isBackward: boolean,
     granularity: 'character' | 'word' | 'lineboundary',
   ): void {
-    const focus = this.focus;
-    const anchor = this.anchor;
+    if (
+      $modifySelectionAroundDecorators(this, alter, isBackward, granularity)
+    ) {
+      return;
+    }
     const collapse = alter === 'move';
 
-    // Handle the selection movement around decorators.
-    const possibleNode = $getAdjacentNode(focus, isBackward);
-    if ($isDecoratorNode(possibleNode) && !possibleNode.isIsolated()) {
-      // Make it possible to move selection from range selection to
-      // node selection on the node.
-      if (collapse && possibleNode.isKeyboardSelectable()) {
-        const nodeSelection = $createNodeSelection();
-        nodeSelection.add(possibleNode.__key);
-        $setSelection(nodeSelection);
-        return;
-      }
-      const sibling = isBackward
-        ? possibleNode.getPreviousSibling()
-        : possibleNode.getNextSibling();
-
-      if (!$isTextNode(sibling)) {
-        const parent = possibleNode.getParentOrThrow();
-        let offset;
-        let elementKey;
-
-        if ($isElementNode(sibling)) {
-          elementKey = sibling.__key;
-          offset = isBackward ? sibling.getChildrenSize() : 0;
-        } else {
-          offset = possibleNode.getIndexWithinParent();
-          elementKey = parent.__key;
-          if (!isBackward) {
-            offset++;
-          }
-        }
-        focus.set(elementKey, offset, 'element');
-        if (collapse) {
-          anchor.set(elementKey, offset, 'element');
-        }
-        return;
-      } else {
-        const siblingKey = sibling.__key;
-        const offset = isBackward ? sibling.getTextContent().length : 0;
-        focus.set(siblingKey, offset, 'text');
-        if (collapse) {
-          anchor.set(siblingKey, offset, 'text');
-        }
-        return;
-      }
-    }
     const editor = getActiveEditor();
     const domSelection = getDOMSelection(getWindow(editor));
 
@@ -1578,17 +1536,43 @@ export class RangeSelection implements BaseSelection {
     }
     const blockCursorElement = editor._blockCursorElement;
     const rootElement = editor._rootElement;
+    const focusNode = this.focus.getNode();
     // Remove the block cursor element if it exists. This will ensure selection
     // works as intended. If we leave it in the DOM all sorts of strange bugs
     // occur. :/
     if (
       rootElement !== null &&
       blockCursorElement !== null &&
-      $isElementNode(possibleNode) &&
-      !possibleNode.isInline() &&
-      !possibleNode.canBeEmpty()
+      $isElementNode(focusNode) &&
+      !focusNode.isInline() &&
+      !focusNode.canBeEmpty()
     ) {
       removeDOMBlockCursorElement(blockCursorElement, editor, rootElement);
+    }
+    if (this.dirty) {
+      let nextAnchorDOM: HTMLElement | Text | null = getElementByKeyOrThrow(
+        editor,
+        this.anchor.key,
+      );
+      let nextFocusDOM: HTMLElement | Text | null = getElementByKeyOrThrow(
+        editor,
+        this.focus.key,
+      );
+      if (this.anchor.type === 'text') {
+        nextAnchorDOM = getDOMTextNode(nextAnchorDOM);
+      }
+      if (this.focus.type === 'text') {
+        nextFocusDOM = getDOMTextNode(nextFocusDOM);
+      }
+      if (nextAnchorDOM && nextFocusDOM) {
+        setDOMSelectionBaseAndExtent(
+          domSelection,
+          nextAnchorDOM,
+          this.anchor.offset,
+          nextFocusDOM,
+          this.focus.offset,
+        );
+      }
     }
     // We use the DOM selection.modify API here to "tell" us what the selection
     // will be. We then use it to update the Lexical selection accordingly. This
@@ -1656,6 +1640,9 @@ export class RangeSelection implements BaseSelection {
         }
       }
     }
+    if (granularity === 'lineboundary') {
+      $modifySelectionAroundDecorators(this, alter, isBackward, granularity);
+    }
   }
   /**
    * Helper for handling forward character and word deletion that prevents element nodes
@@ -1713,7 +1700,6 @@ export class RangeSelection implements BaseSelection {
           .getTextSlices()
           .every((slice) => slice === null || slice.distance === 0)
       ) {
-        // debugger;
         // There's no text in the direction of the deletion so we can explore our options
         let state:
           | {type: 'initial'}
@@ -1874,32 +1860,16 @@ export class RangeSelection implements BaseSelection {
    */
   deleteLine(isBackward: boolean): void {
     if (this.isCollapsed()) {
-      // Since `domSelection.modify('extend', ..., 'lineboundary')` works well for text selections
-      // but doesn't properly handle selections which end on elements, a space character is added
-      // for such selections transforming their anchor's type to 'text'
-      const anchorIsElement = this.anchor.type === 'element';
-      if (anchorIsElement) {
-        this.insertText(' ');
-      }
-
       this.modify('extend', isBackward, 'lineboundary');
-
-      const useDeleteCharacter = this.isCollapsed() && this.anchor.offset === 0;
-      // Adjusts selection to include an extra character added for element anchors to remove it
-      if (anchorIsElement) {
-        const startPoint = isBackward ? this.anchor : this.focus;
-        startPoint.set(startPoint.key, startPoint.offset + 1, startPoint.type);
-      }
-      // If the selection starts at the beginning of a text node (offset 0),
+    }
+    if (this.isCollapsed()) {
+      // If the selection was already collapsed at the lineboundary,
       // use the deleteCharacter operation to handle all of the logic associated
       // with navigating through the parent element
-      if (useDeleteCharacter) {
-        // Remove the inserted space, if added above
-        this.removeText();
-        return this.deleteCharacter(isBackward);
-      }
+      this.deleteCharacter(isBackward);
+    } else {
+      this.removeText();
     }
-    this.removeText();
   }
 
   /**
@@ -2913,6 +2883,32 @@ export function adjustPointOffsetForMergedSibling(
   }
 }
 
+function setDOMSelectionBaseAndExtent(
+  domSelection: Selection,
+  nextAnchorDOM: HTMLElement | Text,
+  nextAnchorOffset: number,
+  nextFocusDOM: HTMLElement | Text,
+  nextFocusOffset: number,
+): void {
+  // Apply the updated selection to the DOM. Note: this will trigger
+  // a "selectionchange" event, although it will be asynchronous.
+  try {
+    domSelection.setBaseAndExtent(
+      nextAnchorDOM,
+      nextAnchorOffset,
+      nextFocusDOM,
+      nextFocusOffset,
+    );
+  } catch (error) {
+    // If we encounter an error, continue. This can sometimes
+    // occur with FF and there's no good reason as to why it
+    // should happen.
+    if (__DEV__) {
+      console.warn(error);
+    }
+  }
+}
+
 export function updateDOMSelection(
   prevSelection: BaseSelection | null,
   nextSelection: BaseSelection | null,
@@ -3032,21 +3028,13 @@ export function updateDOMSelection(
 
   // Apply the updated selection to the DOM. Note: this will trigger
   // a "selectionchange" event, although it will be asynchronous.
-  try {
-    domSelection.setBaseAndExtent(
-      nextAnchorNode,
-      nextAnchorOffset,
-      nextFocusNode,
-      nextFocusOffset,
-    );
-  } catch (error) {
-    // If we encounter an error, continue. This can sometimes
-    // occur with FF and there's no good reason as to why it
-    // should happen.
-    if (__DEV__) {
-      console.warn(error);
-    }
-  }
+  setDOMSelectionBaseAndExtent(
+    domSelection,
+    nextAnchorNode,
+    nextAnchorOffset,
+    nextFocusNode,
+    nextFocusOffset,
+  );
   if (
     !tags.has('skip-scroll-into-view') &&
     nextSelection.isCollapsed() &&
@@ -3301,4 +3289,64 @@ function $getNodesFromCaretRangeCompat(
     nodes.push(node);
   }
   return nodes;
+}
+
+/**
+ * @internal
+ *
+ * Modify the focus of the focus around possible decorators and return true
+ * if the movement is done.
+ */
+function $modifySelectionAroundDecorators(
+  selection: RangeSelection,
+  alter: 'move' | 'extend',
+  isBackward: boolean,
+  granularity: 'character' | 'word' | 'lineboundary',
+): boolean {
+  const initialFocus = $caretFromPoint(
+    selection.focus,
+    isBackward ? 'previous' : 'next',
+  );
+  const isLineBoundary = granularity === 'lineboundary';
+  const collapse = alter === 'move';
+  let focus = initialFocus;
+  if (
+    !(
+      $isTextPointCaret(focus) &&
+      focus.offset !== $getTextNodeOffset(focus.origin, focus.direction)
+    )
+  ) {
+    for (const siblingCaret of focus) {
+      const {origin} = siblingCaret;
+      if ($isDecoratorNode(origin) && !origin.isIsolated()) {
+        focus = siblingCaret;
+        if (isLineBoundary && origin.isInline()) {
+          continue;
+        }
+      }
+      break;
+    }
+  }
+  if (focus === initialFocus) {
+    return false;
+  }
+  if (
+    collapse &&
+    !isLineBoundary &&
+    $isDecoratorNode(focus.origin) &&
+    focus.origin.isKeyboardSelectable()
+  ) {
+    // Make it possible to move selection from range selection to
+    // node selection on the node.
+    const nodeSelection = $createNodeSelection();
+    nodeSelection.add(focus.origin.getKey());
+    $setSelection(nodeSelection);
+    return true;
+  }
+  focus = $normalizeCaret(focus);
+  if (collapse) {
+    $setPointFromCaret(selection.anchor, focus);
+  }
+  $setPointFromCaret(selection.focus, focus);
+  return !isLineBoundary;
 }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -3315,6 +3315,21 @@ function $modifySelectionAroundDecoratorsAndBlocks(
   granularity: 'character' | 'word' | 'lineboundary',
   mode: 'decorators-and-blocks' | 'decorators' = 'decorators-and-blocks',
 ): boolean {
+  if (
+    alter === 'move' &&
+    granularity === 'character' &&
+    !selection.isCollapsed()
+  ) {
+    // moving left or right when the selection isn't collapsed will
+    // just set the anchor to the focus or vice versa depending on
+    // direction
+    const [src, dst] =
+      isBackward === selection.isBackward()
+        ? [selection.focus, selection.anchor]
+        : [selection.anchor, selection.focus];
+    dst.set(src.key, src.offset, src.type);
+    return true;
+  }
   const initialFocus = $caretFromPoint(
     selection.focus,
     isBackward ? 'previous' : 'next',

--- a/packages/lexical/src/caret/LexicalCaretUtils.ts
+++ b/packages/lexical/src/caret/LexicalCaretUtils.ts
@@ -486,6 +486,26 @@ export function $normalizeCaret<D extends CaretDirection>(
     : caret;
 }
 
+declare const PointCaretIsExtendableBrand: unique symbol;
+/**
+ * Determine whether the TextPointCaret's offset can be extended further without leaving the TextNode.
+ * Returns false if the given caret is not a TextPointCaret or the offset can not be moved further in
+ * direction.
+ *
+ * @param caret A PointCaret
+ * @returns true if caret is a TextPointCaret with an offset that is not at the end of the text given the direction.
+ */
+export function $isExtendableTextPointCaret<D extends CaretDirection>(
+  caret: PointCaret<D>,
+): caret is TextPointCaret<TextNode, D> & {
+  [PointCaretIsExtendableBrand]: never;
+} {
+  return (
+    $isTextPointCaret(caret) &&
+    caret.offset !== $getTextNodeOffset(caret.origin, caret.direction)
+  );
+}
+
 /**
  * Return the caret if it's in the given direction, otherwise return
  * caret.getFlipped().

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -55,6 +55,7 @@ export {
   $getCaretInDirection,
   $getCaretRangeInDirection,
   $getChildCaretAtIndex,
+  $isExtendableTextPointCaret,
   $normalizeCaret,
   $removeTextFromCaretRange,
   $rewindSiblingCaret,


### PR DESCRIPTION
## Breaking Changes

To handle platform differences and avoid piercing shadow roots, arrow key navigation for RangeSelection is now handled by lexical in more scenarios when crossing the boundaries of elements. This should only affect "exotic" custom element nodes such as TableNode. All code in @lexical/table has been updated accordingly, but if you have something like a custom table implementation then it may require additional updates (probably in the direction of removing workarounds rather than adding them).

## Description

Address deleteLine regression in #7248. The selection movement code had some logic errors and adding carets to the mix (which validate text offsets) messed it up. This fixes the problem mostly by improving RangeSelection.modify.

It now:
* Checks for decorators around the focus and manually implements the appropriate movement (a decorator counts as a character or word, and any span of inline decorators will be skipped over for a lineboundary)
* If no adjacent sibling is found (decorator or otherwise) then it will check to see if we are at the boundary between blocks and if so navigate that manually
* Modifies the DOM selection to match the RangeSelection (since we may have already extended or moved around decorators) *before* asking the native platform to modify the selection
* For lineboundary it will continue to skip through inline decorators afterwards if present

After fixing these issues, some of the TableNode selection code had to change as well, since it was dependent on the browsers doing weird things across shadow roots and fixing things up afterwards. Once that was cleaned up it also fixed some Firefox and table wrapper discrepancies (resulting in fewer test workarounds and skips). Note that I focused the scope of this specifically on left/right arrow keys for tables, up/down navigation should work as it did before.

Closes #7267

## Test plan

All existing e2e tests pass, plus additional test coverage for forward deletion which had no coverage previously.
