### PR TITLE
[lexical] Bug Fix: invalid import from self

### DIFF
--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -6,13 +6,11 @@
  *
  */
 
-import type {
-  BaseSelection,
-  ElementFormatType,
-  LexicalCommand,
-  LexicalNode,
-  TextFormatType,
-} from 'lexical';
+import type {LexicalCommand} from './LexicalEditor';
+import type {LexicalNode} from './LexicalNode';
+import type {BaseSelection} from './LexicalSelection';
+import type {ElementFormatType} from './nodes/LexicalElementNode';
+import type {TextFormatType} from './nodes/LexicalTextNode';
 
 export type PasteCommandType = ClipboardEvent | InputEvent | KeyboardEvent;
 

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -7,10 +7,14 @@
  */
 
 /* eslint-disable no-constant-condition */
-import type {EditorConfig, LexicalEditor} from './LexicalEditor';
+import type {
+  EditorConfig,
+  Klass,
+  KlassConstructor,
+  LexicalEditor,
+} from './LexicalEditor';
 import type {BaseSelection, RangeSelection} from './LexicalSelection';
 
-import {Klass, KlassConstructor, NODE_STATE_KEY} from 'lexical';
 import invariant from 'shared/invariant';
 
 import {
@@ -23,6 +27,7 @@ import {
   $isTextNode,
   type DecoratorNode,
   ElementNode,
+  NODE_STATE_KEY,
 } from '.';
 import {$updateStateFromJSON, type NodeState} from './LexicalNodeState';
 import {


### PR DESCRIPTION
Updating to 0.26.0 causes our project to crash executing a standalone node script that imports from `lexical` (this cannot be reproduced when importing lexical from a bundler).

The reason for that is this import that made it into the lexical build:

![CleanShot 2025-03-01 at 21 30 26@2x](https://github.com/user-attachments/assets/cfc0acec-e8c1-45dc-bc09-a0c0455e92fe)

This is caused by the following newly introduced import statement in `packages/lexical/src/LexicalNode.ts`:

`import {Klass, KlassConstructor, NODE_STATE_KEY} from 'lexical';`

Imports from self like that are not valid and cause issues. I have verified that removing it fixes our issue.

Notably, such self-import statements can easily slip in (especially with VS Code’s auto-import suggestions). To help guard against this, we’ve created a custom ESLint rule ([no-imports-from-self](https://github.com/payloadcms/payload/blob/main/packages/eslint-plugin/customRules/no-imports-from-self.js)) that warns developers if they accidentally import from the same package. I think it would be a good idea to introduce something like that in this monorepo - feel free to copy this rule or use our `@payloadcms/eslint-plugin` package if interested.

## To Reproduce

1. Create a script.js:

```ts
import { TabNode } from 'lexical'
console.log(TabNode)
```

2. Run it using `node src/script.js`
3. The following error will be thrown:

```
Warning: Detected unsettled top-level await at
file:///Users/alessio/Documents/GitHub/payload20/node_modules/.pnpm/lexical@0.26.0/node_modules/lexical/Lexical.node.mjs:9
const mod = await (process.env.NODE_ENV !== 'production' ? import('./Lexical.dev.mjs') : import('./Lexical.prod.mjs'));
```