### PR TITLE
chore: add no-imports-from-self eslint rule to monorepo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -161,6 +161,7 @@ module.exports = {
     'no-only-tests',
     'lexical',
     '@lexical',
+    'lexical-monorepo',
   ],
 
   // Stop ESLint from looking for a configuration file in parent folders
@@ -169,7 +170,6 @@ module.exports = {
   // and then enable some React specific ones.
   rules: {
     'accessor-pairs': OFF,
-
     'consistent-return': OFF,
     curly: [ERROR, 'all'],
     'dot-location': [ERROR, 'property'],
@@ -199,6 +199,8 @@ module.exports = {
     'jsx-quotes': [ERROR, 'prefer-double'],
 
     'keyword-spacing': [ERROR, {after: true, before: true}],
+
+    'lexical-monorepo/no-imports-from-self': ERROR,
 
     // Enforced by Prettier
     // TODO: Prettier doesn't handle long strings or long comments. Not a big

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "eslint-plugin-jest": "^28.5.0",
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "eslint-plugin-lexical": "file:./eslint-plugin",
+        "eslint-plugin-lexical-monorepo": "file:./scripts/eslint",
         "eslint-plugin-no-function-declare-after-return": "^1.1.0",
         "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-react": "^7.34.1",
@@ -18090,6 +18091,10 @@
     },
     "node_modules/eslint-plugin-lexical": {
       "resolved": "eslint-plugin",
+      "link": true
+    },
+    "node_modules/eslint-plugin-lexical-monorepo": {
+      "resolved": "scripts/eslint",
       "link": true
     },
     "node_modules/eslint-plugin-no-function-declare-after-return": {
@@ -40489,6 +40494,14 @@
       "dependencies": {
         "lexical": "0.26.0"
       }
+    },
+    "scripts/eslint": {
+      "name": "eslint-plugin-lexical-monorepo",
+      "version": "1.0.0",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": "^7.31.0 || ^8.0.0"
+      }
     }
   },
   "dependencies": {
@@ -52694,6 +52707,9 @@
     },
     "eslint-plugin-lexical": {
       "version": "file:eslint-plugin"
+    },
+    "eslint-plugin-lexical-monorepo": {
+      "version": "file:scripts/eslint"
     },
     "eslint-plugin-no-function-declare-after-return": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "eslint-plugin-jest": "^28.5.0",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-lexical": "file:./eslint-plugin",
+    "eslint-plugin-lexical-monorepo": "file:./scripts/eslint",
     "eslint-plugin-no-function-declare-after-return": "^1.1.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-react": "^7.34.1",

--- a/scripts/eslint/no-imports-from-self.js
+++ b/scripts/eslint/no-imports-from-self.js
@@ -1,0 +1,92 @@
+/**
+ * From: https://github.com/payloadcms/payload/blob/main/packages/eslint-plugin/customRules/no-imports-from-self.js
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018-2025 Payload CMS, Inc. <info@payloadcms.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * 'Software'), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('node:path');
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  create(context) {
+    let packageName = null;
+
+    return {
+      ImportDeclaration(node) {
+        const importPath = node.source.value;
+        const pkgName = getPackageName(context, packageName);
+        if (pkgName && importPath.startsWith(pkgName)) {
+          context.report({
+            message: `Package "${pkgName}" should not import from itself. Use relative instead.`,
+            node,
+          });
+        }
+      },
+    };
+  },
+
+  meta: {
+    docs: {
+      category: 'Best Practices',
+      description: 'Disallow a package from importing from itself',
+      recommended: true,
+    },
+    schema: [],
+  },
+};
+
+/**
+ * @param {import('eslint').Rule.RuleContext} context
+ * @param {string|undefined} packageName
+ */
+function getPackageName(context, packageName) {
+  if (packageName) {
+    return packageName;
+  }
+
+  const fileName = context.getFilename();
+  const pkg = findNearestPackageJson(path.dirname(fileName));
+  if (pkg) {
+    return pkg.name;
+  }
+}
+
+/**
+ * @param {string} startDir
+ */
+function findNearestPackageJson(startDir) {
+  let currentDir = startDir;
+  while (currentDir !== path.dirname(currentDir)) {
+    // Root directory check
+    const pkgPath = path.join(currentDir, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      const pkgContent = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      return pkgContent;
+    }
+    currentDir = path.dirname(currentDir);
+  }
+  return null;
+}

--- a/scripts/eslint/package.json
+++ b/scripts/eslint/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "eslint-plugin-lexical-monorepo",
+  "version": "1.0.0",
+  "private": true,
+  "description": "ESLint plugin for lexical monorepo",
+  "main": "plugin.js",
+  "peerDependencies": {
+    "eslint": "^7.31.0 || ^8.0.0"
+  }
+}

--- a/scripts/eslint/plugin.js
+++ b/scripts/eslint/plugin.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'no-imports-from-self': require('./no-imports-from-self'),
+  },
+};


### PR DESCRIPTION
This adds a new `no-imports-from-self` eslint rule to this monorepo, which will prevent regression of https://github.com/facebook/lexical/pull/7271 - cc @etrepum

![CleanShot 2025-03-01 at 23 17 16@2x](https://github.com/user-attachments/assets/41ea2794-64ae-4298-9b94-170aaccdbf76)

The rule is taken from [here](https://github.com/payloadcms/payload/blob/main/packages/eslint-plugin/customRules/no-imports-from-self.js). We cannot install `@payloadcms/eslint-plugin` directly, as that's an esm-only package which would require us to move to the flat eslint config.

I added the rule to scripts/eslint, where we can also add more custom monorepo-only eslint rules in the future. Could move it to the monorepo root, but I didn't want to bloat it with yet another folder.

## Todo

Runnin npm lint shows that there are 110 violations of this rule - mostly in tests:

![CleanShot 2025-03-01 at 23 25 51@2x](https://github.com/user-attachments/assets/a7aec3c8-5441-4229-ae09-1887b56a3018)

I will fix those imports shortly