### PR TITLE
[lexical-utils] Bug Fix: don't include siblings of startNode in $dfs

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -184,27 +184,25 @@ describe('LexicalNodeHelpers tests', () => {
         });
       });
 
-      test('DFS from the middle', async () => {
+      test('DFS from the middle returns descendants but not siblings', async () => {
         const editor: LexicalEditor = testEnv.editor;
         editor.update(
           () => {
             const root = $getRoot();
+            const p1 = $createParagraphNode().append($createTextNode('Text'));
+            const p2 = $createParagraphNode().append(
+              $createTextNode('Hello'),
+              $createTextNode('world').toggleFormat('bold'),
+            );
+            const p3 = $createParagraphNode().append($createTextNode('!!'));
 
-            root
-              .clear()
-              .append(
-                $createParagraphNode().append(
-                  $createTextNode('Hello'),
-                  $createTextNode('world').toggleFormat('bold'),
-                  $createTextNode('!'),
-                ),
-              );
+            root.clear().append(p1, p2, p3);
 
-            const paragraph = root.getFirstChildOrThrow<ElementNode>();
-            const children = paragraph.getChildren();
-            expect($dfs(children[1])).toEqual([
-              {depth: 2, node: children[1]},
-              {depth: 2, node: children[2]},
+            const textNodes = p2.getChildren();
+            expect($dfs(p2)).toEqual([
+              {depth: 1, node: p2},
+              {depth: 2, node: textNodes[0]},
+              {depth: 2, node: textNodes[1]},
             ]);
           },
           {discrete: true},


### PR DESCRIPTION
The introduction of [Carets](https://github.com/facebook/lexical/pull/7046/files#diff-33353db27f56a5d74e7281df0a8a2fc223eef41e9dc2efc723a412560a0148c9R239) changed the semantics of `$dfs` to include siblings of the start node, with https://github.com/facebook/lexical/pull/7174 adding a test case to cover that case specifically.

This isn't how DFS is expected to work, nor is it the function's documented behaviour:

```
 * @param endNode - The node to end the search, if omitted, it will find all descendants of the startingNode.
```

I've fixed the test case and confirmed that the test passes on 0.24.0, i.e. before the caret changes were introduced. I haven't got myself familiarised with the caret API yet though, and couldn't easily see what needed to change to fix this behaviour.

Interestingly, the `DFS of empty ParagraphNode returns only itself` test below _does_ have the expected behaviour, though it's doing the `$dfs` in a separate update block. If I update this test with the below, then it also passes:

```
[...]
            root.clear().append(p1, p2, p3);
          }
        );

        editor.update(() => {
          const paragraph = $getRoot().getChildAtIndex<ParagraphNode>(1)!
          const textNodes = paragraph.getChildren();
          expect($dfs(paragraph)).toEqual([
            {depth: 1, node: paragraph},
            {depth: 2, node: textNodes[0]},
            {depth: 2, node: textNodes[1]},
          ]);
        })
```