### PR TITLE
[lexical-utils] Bug Fix: don't include parent's siblings when starting $dfs at last child

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {$createMarkNode, MarkNode} from '@lexical/mark';
+import {$createMarkNode, $isMarkNode} from '@lexical/mark';
 import {
   $createParagraphNode,
   $createTextNode,
@@ -223,7 +223,8 @@ describe('LexicalNodeHelpers tests', () => {
 
           root.clear().append(p1, p2);
 
-          const markNode = p1.getChildAtIndex<MarkNode>(1)!;
+          const markNode = p1.getChildAtIndex(1);
+          invariant($isMarkNode(markNode), 'first child must be MarkNode');
           const textNodes = markNode.getChildren();
           expect($dfs(markNode)).toEqual([
             {depth: 2, node: markNode},

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -240,23 +240,32 @@ export function $dfsIterator(
   return $dfsCaretIterator('next', startNode, endNode);
 }
 
+function $getEndCaret<D extends CaretDirection>(
+  startNode: LexicalNode,
+  direction: D,
+): null | NodeCaret<D> {
+  const rval = $getAdjacentSiblingOrParentSiblingCaret(
+    $getSiblingCaret(startNode, direction),
+  );
+  return rval && rval[0];
+}
+
 function $dfsCaretIterator<D extends CaretDirection>(
   direction: D,
   startNode?: LexicalNode,
   endNode?: LexicalNode,
 ): IterableIterator<DFSNode> {
-  const rootMode = 'root';
   const root = $getRoot();
   const start = startNode || root;
   const startCaret = $isElementNode(start)
     ? $getChildCaret(start, direction)
     : $getSiblingCaret(start, direction);
   const startDepth = $getDepth(start);
-  const endCaret = $getAdjacentChildCaret(
-    endNode
-      ? $getChildCaretOrSelf($getSiblingCaret(endNode, direction))
-      : startCaret.getParentCaret(rootMode),
-  );
+  const endCaret = endNode
+    ? $getAdjacentChildCaret(
+        $getChildCaretOrSelf($getSiblingCaret(endNode, direction)),
+      )
+    : $getEndCaret(start, direction);
   let depth = startDepth;
   return makeStepwiseIterator({
     hasNext: (state): state is NodeCaret<'next'> => state !== null,


### PR DESCRIPTION
Take #2 of https://github.com/facebook/lexical/pull/7274

The introduction of [Carets](https://github.com/facebook/lexical/pull/7046/files#diff-33353db27f56a5d74e7281df0a8a2fc223eef41e9dc2efc723a412560a0148c9R239) changed `$dfs` to include siblings of the start node's parent, if the start node is the last child of its parent.

I've added a test case and confirmed that the test passes on 0.24.0, i.e. before the caret changes were introduced. I haven't got myself familiarised with the caret API yet though, and couldn't easily see what needed to change to fix this behaviour. On main, test fails with:

```
  ● LexicalNodeHelpers tests › dfs order › DFS starting at last child of element node should not include parent's siblings

    expect(received).toEqual(expected) // deep equality

    - Expected  -  0
    + Received  + 34

    @@ -32,6 +32,40 @@
            "__style": "",
            "__text": "world",
            "__type": "text",
          },
        },
    +   Object {
    +     "depth": 1,
    +     "node": ParagraphNode {
    +       "__dir": null,
    +       "__first": "17",
    +       "__format": 0,
    +       "__indent": 0,
    +       "__key": "16",
    +       "__last": "17",
    +       "__next": null,
    +       "__parent": "root",
    +       "__prev": "12",
    +       "__size": 1,
    +       "__style": "",
    +       "__textFormat": 0,
    +       "__textStyle": "",
    +       "__type": "paragraph",
    +     },
    +   },
    +   Object {
    +     "depth": 2,
    +     "node": TextNode {
    +       "__detail": 0,
    +       "__format": 0,
    +       "__key": "17",
    +       "__mode": 0,
    +       "__next": null,
    +       "__parent": "16",
    +       "__prev": null,
    +       "__style": "",
    +       "__text": "!!",
    +       "__type": "text",
    +     },
    +   },
      ]
```

I also came across https://github.com/facebook/lexical/pull/7174 which adds a test case for `$dfs` including the siblings of the startNode itself, if the start node is not an element node. It's not obvious why you'd want to DFS a leaf node, but in any case this was also a change from 0.24.0, so I've updated that test as well. Fails on main with:

```
  ● LexicalNodeHelpers tests › dfs order › DFS from middle leaf node should only include that node

    expect(received).toEqual(expected) // deep equality

    - Expected  -  0
    + Received  + 15

    @@ -12,6 +12,21 @@
            "__style": "",
            "__text": "world",
            "__type": "text",
          },
        },
    +   Object {
    +     "depth": 2,
    +     "node": TextNode {
    +       "__detail": 0,
    +       "__format": 0,
    +       "__key": "15",
    +       "__mode": 0,
    +       "__next": null,
    +       "__parent": "12",
    +       "__prev": "14",
    +       "__style": "",
    +       "__text": "!",
    +       "__type": "text",
    +     },
    +   },
      ]
```