### PR TITLE
[lexical-table] Bug Fix: TableCellNode vertical align not syncing

### DIFF
--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -131,6 +131,7 @@ export class TableCellNode extends ElementNode {
     this.__headerState = headerState;
     this.__width = width;
     this.__backgroundColor = null;
+    this.__verticalAlign = undefined;
   }
 
   createDOM(config: EditorConfig): HTMLTableCellElement {


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
Missing the default initializer for __verticalAlign of TableCellNode -> @lexical/yjs `syncPropertiesFromLexical()` missing that when extract node properties -> the following updates on __verticalAlign won't be sync


Closes #7276

## Test plan

### Before


https://github.com/user-attachments/assets/0fc7af61-0efc-4ba3-a14d-207c6565faba


### After


https://github.com/user-attachments/assets/93374f0d-1b62-4c7e-b194-91d592d03be4

