### PR TITLE
[lexical-list][lexical] Bug Fix: Add RTL direction support for list items in output HTML

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -150,6 +150,10 @@ export class ListItemNode extends ElementNode {
   exportDOM(editor: LexicalEditor): DOMExportOutput {
     const element = this.createDOM(editor._config);
     element.style.textAlign = this.getFormatType();
+    const direction = this.getDirection();
+    if (direction) {
+      element.dir = direction;
+    }
     return {
       element,
     };

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -832,6 +832,10 @@ export class ElementNode extends LexicalNode {
         // (see https://github.com/facebook/lexical/pull/4025)
         element.style.paddingInlineStart = `${indent * 40}px`;
       }
+      const direction = this.getDirection();
+      if (direction) {
+        element.dir = direction;
+      }
     }
 
     return {element};

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -91,11 +91,6 @@ export class ParagraphNode extends ElementNode {
 
       const formatType = this.getFormatType();
       element.style.textAlign = formatType;
-
-      const direction = this.getDirection();
-      if (direction) {
-        element.dir = direction;
-      }
     }
 
     return {


### PR DESCRIPTION
## Description
- What is the current behavior that you are modifying?
1. List items (`<li>`) in the output HTML are missing the `dir="rtl"` attribute even when RTL content is entered. While the direction is correctly displayed in the editor, it's not preserved in the exported HTML output.
2. Direction handling was implemented in `ParagraphNode` but wasn't available to other container elements.

- What are the behavior or changes that are being added by this PR?
1. Added explicit direction handling in `ListItemNode.exportDOM()` to ensure RTL direction is properly preserved in the output HTML. We implemented this directly in `ListItemNode` rather than inheriting from `ElementNode` to maintain existing indentation behavior and test compatibility.
2. Architectural improvement:
   - Moved direction handling from `ParagraphNode` to `ElementNode` to make it available for inheritance by other container elements
   - Removed direction code from `ParagraphNode` since it now inherits from `ElementNode`

Closes #7240

## Test plan

### Before

![image](https://github.com/user-attachments/assets/b52f2ac4-b257-460c-97eb-32e859dd0cde)

### After

![image](https://github.com/user-attachments/assets/717f65b3-2eed-4282-81ab-b81aa1d0f522)