### PR TITLE
[lexical] Bug Fix: Fix non-ElementNode regression in getCommonAncestor

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -599,7 +599,9 @@ export class LexicalNode {
   getCommonAncestor<T extends ElementNode = ElementNode>(
     node: LexicalNode,
   ): T | null {
-    const result = $getCommonAncestor(this, node);
+    const a = $isElementNode(this) ? this : this.getParent();
+    const b = $isElementNode(node) ? node : node.getParent();
+    const result = a && b ? $getCommonAncestor(a, b) : null;
     return result
       ? (result.commonAncestor as T) /* TODO this type cast is a lie, but fixing it would break backwards compatibility */
       : null;

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -766,6 +766,7 @@ describe('LexicalNode tests', () => {
           bazParagraphNode = new ParagraphNode();
           bazTextNode = new TextNode('baz');
           bazTextNode.toggleUnmergeable();
+          expect(bazTextNode.getCommonAncestor(bazTextNode)).toBe(null);
           quxTextNode = new TextNode('qux');
           quxTextNode.toggleUnmergeable();
           paragraphNode.append(quxTextNode);
@@ -773,6 +774,9 @@ describe('LexicalNode tests', () => {
           barParagraphNode.append(barTextNode);
           bazParagraphNode.append(bazTextNode);
           expect(barTextNode.getCommonAncestor(bazTextNode)).toBe(null);
+          expect(bazTextNode.getCommonAncestor(bazTextNode)).toBe(
+            bazParagraphNode,
+          );
           rootNode.append(barParagraphNode, bazParagraphNode);
         });
 


### PR DESCRIPTION
## Description

There was a regression v0.26.0 (#7135) in `node.getCommonAncestor(node)` when `!$isElementNode(node)`

Closes #7286

## Test plan

### Before

node.getCommonAncestor(node) would always return node without checking for ElementNode first, which didn't get caught because the function itself has a bad type signature that requires a cast to implement it in a backwards compatible way.

### After

The type is checked appropriately and the parent is used when either node is not an ElementNode.
