### PR TITLE
[lexical-website] Bug Fix: Fix vite.config.ts for gallery examples

### DIFF
--- a/examples/react-plain-text/package.json
+++ b/examples/react-plain-text/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "monorepo:dev": "cross-env LEXICAL_MONOREPO=1 npm run dev --",
+    "monorepo:dev": "vite -c vite.config.monorepo.ts",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },

--- a/examples/react-plain-text/vite.config.monorepo.ts
+++ b/examples/react-plain-text/vite.config.monorepo.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {mergeConfig} from 'vite';
+
+import lexicalMonorepoPlugin from '../../packages/shared/lexicalMonorepoPlugin';
+import config from './vite.config';
+
+export default mergeConfig(config, {
+  plugins: [lexicalMonorepoPlugin()],
+});

--- a/examples/react-plain-text/vite.config.ts
+++ b/examples/react-plain-text/vite.config.ts
@@ -9,18 +9,6 @@ import react from '@vitejs/plugin-react';
 import {defineConfig} from 'vite';
 
 // https://vitejs.dev/config/
-export default defineConfig(async () => ({
-  plugins: [
-    react(),
-    // This is only used for development in the lexical repository
-    ...(process.env.LEXICAL_MONOREPO === '1'
-      ? [
-          (
-            await import(
-              '../../packages/shared/lexicalMonorepoPlugin' as string
-            )
-          ).default(),
-        ]
-      : []),
-  ],
-}));
+export default defineConfig({
+  plugins: [react()],
+});

--- a/examples/react-rich-collab/package.json
+++ b/examples/react-rich-collab/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "vite",
     "dev:local": "cross-env NODE_ENV=development concurrently \"npm:server:ws\" \"npm:server:webrtc\" \"vite\"",
-    "monorepo:dev": "cross-env LEXICAL_MONOREPO=1  run dev --",
-    "monorepo:dev:local": "cross-env LEXICAL_MONOREPO=1 npm run dev:local --",
+    "monorepo:dev": "vite -c vite.config.monorepo.ts",
+    "monorepo:dev:local": "cross-env NODE_ENV=development concurrently \"npm:server:ws\" \"npm:server:webrtc\" \"vite -c vite.config.monorepo.ts\"",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "server:ws": "cross-env HOST=localhost PORT=1234 YPERSISTENCE=./yjs-wss-db npx y-websocket",

--- a/examples/react-rich-collab/vite.config.monorepo.ts
+++ b/examples/react-rich-collab/vite.config.monorepo.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {mergeConfig} from 'vite';
+
+import lexicalMonorepoPlugin from '../../packages/shared/lexicalMonorepoPlugin';
+import config from './vite.config';
+
+export default mergeConfig(config, {
+  plugins: [lexicalMonorepoPlugin()],
+});

--- a/examples/react-rich-collab/vite.config.ts
+++ b/examples/react-rich-collab/vite.config.ts
@@ -10,7 +10,7 @@ import {resolve} from 'path';
 import {defineConfig} from 'vite';
 
 // https://vitejs.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig({
   build: {
     rollupOptions: {
       input: {
@@ -19,17 +19,5 @@ export default defineConfig(async () => ({
       },
     },
   },
-  plugins: [
-    react(),
-    // This is only used for development in the lexical repository
-    ...(process.env.LEXICAL_MONOREPO === '1'
-      ? [
-          (
-            await import(
-              '../../packages/shared/lexicalMonorepoPlugin' as string
-            )
-          ).default(),
-        ]
-      : []),
-  ],
-}));
+  plugins: [react()],
+});

--- a/examples/react-rich/package.json
+++ b/examples/react-rich/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "monorepo:dev": "cross-env LEXICAL_MONOREPO=1 npm run dev --",
+    "monorepo:dev": "vite -c vite.config.monorepo.ts",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },

--- a/examples/react-rich/vite.config.monorepo.ts
+++ b/examples/react-rich/vite.config.monorepo.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {mergeConfig} from 'vite';
+
+import lexicalMonorepoPlugin from '../../packages/shared/lexicalMonorepoPlugin';
+import config from './vite.config';
+
+export default mergeConfig(config, {
+  plugins: [lexicalMonorepoPlugin()],
+});

--- a/examples/react-rich/vite.config.ts
+++ b/examples/react-rich/vite.config.ts
@@ -9,18 +9,6 @@ import react from '@vitejs/plugin-react';
 import {defineConfig} from 'vite';
 
 // https://vitejs.dev/config/
-export default defineConfig(async () => ({
-  plugins: [
-    react(),
-    // This is only used for development in the lexical repository
-    ...(process.env.LEXICAL_MONOREPO === '1'
-      ? [
-          (
-            await import(
-              '../../packages/shared/lexicalMonorepoPlugin' as string
-            )
-          ).default(),
-        ]
-      : []),
-  ],
-}));
+export default defineConfig({
+  plugins: [react()],
+});

--- a/examples/react-table/package.json
+++ b/examples/react-table/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "monorepo:dev": "cross-env LEXICAL_MONOREPO=1 npm run dev --",
+    "monorepo:dev": "vite -c vite.config.monorepo.ts",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },

--- a/examples/react-table/vite.config.monorepo.ts
+++ b/examples/react-table/vite.config.monorepo.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {mergeConfig} from 'vite';
+
+import lexicalMonorepoPlugin from '../../packages/shared/lexicalMonorepoPlugin';
+import config from './vite.config';
+
+export default mergeConfig(config, {
+  plugins: [lexicalMonorepoPlugin()],
+});

--- a/examples/react-table/vite.config.ts
+++ b/examples/react-table/vite.config.ts
@@ -9,18 +9,6 @@ import react from '@vitejs/plugin-react';
 import {defineConfig} from 'vite';
 
 // https://vitejs.dev/config/
-export default defineConfig(async () => ({
-  plugins: [
-    react(),
-    // This is only used for development in the lexical repository
-    ...(process.env.LEXICAL_MONOREPO === '1'
-      ? [
-          (
-            await import(
-              '../../packages/shared/lexicalMonorepoPlugin' as string
-            )
-          ).default(),
-        ]
-      : []),
-  ],
-}));
+export default defineConfig({
+  plugins: [react()],
+});

--- a/examples/vanilla-js-iframe/package.json
+++ b/examples/vanilla-js-iframe/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "monorepo:dev": "cross-env LEXICAL_MONOREPO=1 npm run dev --",
+    "monorepo:dev": "vite -c vite.config.monorepo.ts",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },

--- a/examples/vanilla-js-iframe/vite.config.monorepo.ts
+++ b/examples/vanilla-js-iframe/vite.config.monorepo.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {mergeConfig} from 'vite';
+
+import lexicalMonorepoPlugin from '../../packages/shared/lexicalMonorepoPlugin';
+import config from './vite.config';
+
+export default mergeConfig(config, {
+  plugins: [lexicalMonorepoPlugin()],
+});

--- a/examples/vanilla-js-iframe/vite.config.ts
+++ b/examples/vanilla-js-iframe/vite.config.ts
@@ -8,17 +8,4 @@
 import {defineConfig} from 'vite';
 
 // https://vitejs.dev/config/
-export default defineConfig(async () => ({
-  plugins: [
-    // This is only used for development in the lexical repository
-    ...(process.env.LEXICAL_MONOREPO === '1'
-      ? [
-          (
-            await import(
-              '../../packages/shared/lexicalMonorepoPlugin' as string
-            )
-          ).default(),
-        ]
-      : []),
-  ],
-}));
+export default defineConfig({});

--- a/examples/vanilla-js-plugin/package.json
+++ b/examples/vanilla-js-plugin/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "monorepo:dev": "cross-env LEXICAL_MONOREPO=1 npm run dev --",
+    "monorepo:dev": "vite -c vite.config.monorepo.ts",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },

--- a/examples/vanilla-js-plugin/vite.config.monorepo.ts
+++ b/examples/vanilla-js-plugin/vite.config.monorepo.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {mergeConfig} from 'vite';
+
+import lexicalMonorepoPlugin from '../../packages/shared/lexicalMonorepoPlugin';
+import config from './vite.config';
+
+export default mergeConfig(config, {
+  plugins: [lexicalMonorepoPlugin()],
+});

--- a/examples/vanilla-js-plugin/vite.config.ts
+++ b/examples/vanilla-js-plugin/vite.config.ts
@@ -9,19 +9,7 @@ import path from 'path';
 import {defineConfig} from 'vite';
 
 // https://vitejs.dev/config/
-export default defineConfig(async () => ({
-  plugins: [
-    // This is only used for development in the lexical repository
-    ...(process.env.LEXICAL_MONOREPO === '1'
-      ? [
-          (
-            await import(
-              '../../packages/shared/lexicalMonorepoPlugin' as string
-            )
-          ).default(),
-        ]
-      : []),
-  ],
+export default defineConfig({
   resolve: {
     alias: {
       '@emoji-datasource-facebook': path.resolve(
@@ -30,4 +18,4 @@ export default defineConfig(async () => ({
       ),
     },
   },
-}));
+});

--- a/examples/vanilla-js/package.json
+++ b/examples/vanilla-js/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "monorepo:dev": "cross-env LEXICAL_MONOREPO=1 npm run dev --",
+    "monorepo:dev": "vite -c vite.config.monorepo.ts",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },

--- a/examples/vanilla-js/vite.config.monorepo.ts
+++ b/examples/vanilla-js/vite.config.monorepo.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {mergeConfig} from 'vite';
+
+import lexicalMonorepoPlugin from '../../packages/shared/lexicalMonorepoPlugin';
+import config from './vite.config';
+
+export default mergeConfig(config, {
+  plugins: [lexicalMonorepoPlugin()],
+});

--- a/examples/vanilla-js/vite.config.ts
+++ b/examples/vanilla-js/vite.config.ts
@@ -8,17 +8,4 @@
 import {defineConfig} from 'vite';
 
 // https://vitejs.dev/config/
-export default defineConfig(async () => ({
-  plugins: [
-    // This is only used for development in the lexical repository
-    ...(process.env.LEXICAL_MONOREPO === '1'
-      ? [
-          (
-            await import(
-              '../../packages/shared/lexicalMonorepoPlugin' as string
-            )
-          ).default(),
-        ]
-      : []),
-  ],
-}));
+export default defineConfig({});


### PR DESCRIPTION
## Description

Since typescript configs are used the conditional import approach (#7208) didn't work for conditional vite plugins, since they still had to exist on disk for rollup to process it. This splits the configuration for all example projects into two files, vite.config.ts and vite.config.monorepo.ts which works around the problem.

## Test plan

### Before

Gallery examples didn't work on stackblitz, because only the example was checked out and not the whole repo

https://lexical.dev/gallery

### After

Gallery examples work: https://lexical-git-fork-etrepum-fix-gallery-vite-config-fbopensource.vercel.app/gallery