### PR TITLE
[lexical-yjs] Bug Fix: prevent collab element nodes from removing other nodes from node map

### DIFF
--- a/packages/lexical-yjs/src/CollabDecoratorNode.ts
+++ b/packages/lexical-yjs/src/CollabDecoratorNode.ts
@@ -95,7 +95,9 @@ export class CollabDecoratorNode {
 
   destroy(binding: Binding): void {
     const collabNodeMap = binding.collabNodeMap;
-    collabNodeMap.delete(this._key);
+    if (collabNodeMap.get(this._key) === this) {
+      collabNodeMap.delete(this._key);
+    }
   }
 }
 

--- a/packages/lexical-yjs/src/CollabElementNode.ts
+++ b/packages/lexical-yjs/src/CollabElementNode.ts
@@ -679,7 +679,9 @@ export class CollabElementNode {
       children[i].destroy(binding);
     }
 
-    collabNodeMap.delete(this._key);
+    if (collabNodeMap.get(this._key) === this) {
+      collabNodeMap.delete(this._key);
+    }
   }
 }
 

--- a/packages/lexical-yjs/src/CollabLineBreakNode.ts
+++ b/packages/lexical-yjs/src/CollabLineBreakNode.ts
@@ -54,7 +54,9 @@ export class CollabLineBreakNode {
 
   destroy(binding: Binding): void {
     const collabNodeMap = binding.collabNodeMap;
-    collabNodeMap.delete(this._key);
+    if (collabNodeMap.get(this._key) === this) {
+      collabNodeMap.delete(this._key);
+    }
   }
 }
 

--- a/packages/lexical-yjs/src/CollabTextNode.ts
+++ b/packages/lexical-yjs/src/CollabTextNode.ts
@@ -162,7 +162,9 @@ export class CollabTextNode {
 
   destroy(binding: Binding): void {
     const collabNodeMap = binding.collabNodeMap;
-    collabNodeMap.delete(this._key);
+    if (collabNodeMap.get(this._key) === this) {
+      collabNodeMap.delete(this._key);
+    }
   }
 }
 


### PR DESCRIPTION
## Description

When element nodes are syncing from Lexical to YJS, if there are any child nodes that weren't previously children, then a [new collab node is created](https://github.com/facebook/lexical/blob/6416a254871c9d695bcf7d33b2c9e6b8a3be2bf3/packages/lexical-yjs/src/CollabElementNode.ts#L512-L519):

```
          // Create or replace
          const nextChildNode = $getNodeByKeyOrThrow(nextKey);
          const collabNode = $createCollabNodeFromLexicalNode(
            binding,
            nextChildNode,
            this,
          );
          collabNodeMap.set(nextKey, collabNode);
```

A new collab node is needed because the child will use a new data structure in Yjs (i.e. there's no reparenting of YXmlText or YMap in the sync code). However, because it's the same Lexical node, the same key is used for the map, meaning that the existing collab node is replaced.

The issue then comes when processing the parent element from which the children were removed. `syncChildrenFromLexical` calls `splice` to remove the child, which in turn calls `destroy` on the collab node. However, this collab node has already been replaced in the node map, and so it ends up [removing](https://github.com/facebook/lexical/blob/6416a254871c9d695bcf7d33b2c9e6b8a3be2bf3/packages/lexical-yjs/src/CollabElementNode.ts#L636-L642) the newly created collab node.

```
    if (delCount !== 0) {
      const childrenToDelete = children.slice(index, index + delCount);

      for (let i = 0; i < childrenToDelete.length; i++) {
        childrenToDelete[i].destroy(binding);
      }
    }
```

The collab node map is called in two places where this matters. First is `createRelativePosition` which fails to find the node, which causes the cursor not to show on other clients (no big deal). The second is normalisation code, and things break here if the collab node can't be found.

Note this is only an issue when nodes are reparented to somewhere earlier in the tree. If they're moved later in the tree, then `collabNodeMap.set` is called after `destroy` and everything is fine.

The fix is to have each of the collab nodes' `destroy` functions check that the node in the map is the collab node itself, i.e. that the node hasn't been replaced.

## Test plan

Prior to this change, the new test case fails with:

```
    Error: innerHTML of contenteditable in right frame did not match

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

      <p
        class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
        dir="ltr">
    -   <span data-lexical-text="true">AC</span>
    +   <span data-lexical-text="true">A</span>
      </p>
```