### PR TITLE
[lexical-table] Add table cell selection handler for touch devices

### DIFF
--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -223,10 +223,8 @@ export default function Editor(): JSX.Element {
             <CollapsiblePlugin />
             <PageBreakPlugin />
             <LayoutPlugin />
-            {floatingAnchorElem && !isSmallWidthViewport && (
+            {floatingAnchorElem && (
               <>
-                <DraggableBlockPlugin anchorElem={floatingAnchorElem} />
-                <CodeActionMenuPlugin anchorElem={floatingAnchorElem} />
                 <FloatingLinkEditorPlugin
                   anchorElem={floatingAnchorElem}
                   isLinkEditMode={isLinkEditMode}
@@ -236,6 +234,12 @@ export default function Editor(): JSX.Element {
                   anchorElem={floatingAnchorElem}
                   cellMerge={true}
                 />
+              </>
+            )}
+            {floatingAnchorElem && !isSmallWidthViewport && (
+              <>
+                <DraggableBlockPlugin anchorElem={floatingAnchorElem} />
+                <CodeActionMenuPlugin anchorElem={floatingAnchorElem} />
                 <TableHoverActionsPlugin anchorElem={floatingAnchorElem} />
                 <FloatingTextFormatToolbarPlugin
                   anchorElem={floatingAnchorElem}

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -907,7 +907,7 @@ function TableCellActionMenuContainer({
 
   useEffect(() => {
     // We call the $moveMenu callback every time the selection changes,
-    // once up front, and once after each mouseUp
+    // once up front, and once after each pointerUp
     let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
     const callback = () => {
       timeoutId = undefined;
@@ -928,10 +928,10 @@ function TableCellActionMenuContainer({
       ),
       editor.registerRootListener((rootElement, prevRootElement) => {
         if (prevRootElement) {
-          prevRootElement.removeEventListener('mouseup', delayedCallback);
+          prevRootElement.removeEventListener('pointerup', delayedCallback);
         }
         if (rootElement) {
-          rootElement.addEventListener('mouseup', delayedCallback);
+          rootElement.addEventListener('pointerup', delayedCallback);
           delayedCallback();
         }
       }),

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -103,7 +103,6 @@ export class TableObserver {
   tableSelection: TableSelection | null;
   hasHijackedSelectionStyles: boolean;
   isSelecting: boolean;
-  pointerType: string | null;
   shouldCheckSelection: boolean;
   abortController: AbortController;
   listenerOptions: {signal: AbortSignal};
@@ -130,7 +129,6 @@ export class TableObserver {
     this.focusCell = null;
     this.hasHijackedSelectionStyles = false;
     this.isSelecting = false;
-    this.pointerType = null;
     this.shouldCheckSelection = false;
     this.abortController = new AbortController();
     this.listenerOptions = {signal: this.abortController.signal};

--- a/packages/lexical-table/src/LexicalTableObserver.ts
+++ b/packages/lexical-table/src/LexicalTableObserver.ts
@@ -103,6 +103,7 @@ export class TableObserver {
   tableSelection: TableSelection | null;
   hasHijackedSelectionStyles: boolean;
   isSelecting: boolean;
+  pointerType: string | null;
   shouldCheckSelection: boolean;
   abortController: AbortController;
   listenerOptions: {signal: AbortSignal};
@@ -129,6 +130,7 @@ export class TableObserver {
     this.focusCell = null;
     this.hasHijackedSelectionStyles = false;
     this.isSelecting = false;
+    this.pointerType = null;
     this.shouldCheckSelection = false;
     this.abortController = new AbortController();
     this.listenerOptions = {signal: this.abortController.signal};

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -307,7 +307,7 @@ export function applyTableHandlers(
     tableElement.removeEventListener('pointerdown', onPointerDown);
   });
 
-  const onTripleClick = (event: PointerEvent) => {
+  const onTripleClick = (event: MouseEvent) => {
     if (event.detail >= 3 && isDOMNode(event.target)) {
       const targetCell = getDOMCellFromTarget(event.target);
       if (targetCell !== null) {
@@ -316,12 +316,12 @@ export function applyTableHandlers(
     }
   };
   tableElement.addEventListener(
-    'pointerdown',
+    'mousedown',
     onTripleClick,
     tableObserver.listenerOptions,
   );
   tableObserver.listenersToRemove.add(() => {
-    tableElement.removeEventListener('pointerdown', onTripleClick);
+    tableElement.removeEventListener('mousedown', onTripleClick);
   });
 
   // Clear selection when clicking outside of dom.


### PR DESCRIPTION
## Description
[commit #fcb7666](https://github.com/facebook/lexical/commit/fcb7666) introduced a regression for table cell selection on touch devices, previously clicking a cell while cursor is inside another cell would select the cells in between, clicking again collapses the selection.

* [`packages/lexical-table/src/LexicalTableSelectionHelpers.ts`](diffhunk://#diff-4efac82ecef2990d8b44ca49b63c50e2767e9496650884a89ba7111c57152e15R309-R341): Implemented a function to handle click events, specifically for touch input, and update the table selection accordingly.