### PR TITLE
[lexical-playground] Feature: Add touch support for TableCellResizer

### DIFF
--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.css
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.css
@@ -9,6 +9,7 @@
 
 .TableCellResizer__resizer {
   position: absolute;
+  touch-action: none;
 }
 
 @media (pointer: coarse) {

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.css
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.css
@@ -10,3 +10,10 @@
 .TableCellResizer__resizer {
   position: absolute;
 }
+
+@media (pointer: coarse) {
+  .TableCellResizer__resizer {
+    background-color: #adf;
+    mix-blend-mode: color;
+  }
+}

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -173,24 +173,25 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
 
     const onClick = (event: MouseEvent) => {
       const pointerEvent = event as PointerEvent;
-      if (pointerEvent.pointerType !== 'touch') {
-        return;
+      if (pointerEvent.pointerType === 'touch') {
+        updateIsMouseDown(false);
+        onPointerMove(pointerEvent);
       }
-      updateIsMouseDown(false);
-      onPointerMove(pointerEvent);
     };
 
     const onTouchMove = (event: TouchEvent) => {
-      event.preventDefault();
-      event.stopPropagation();
-      if (!event.touches || event.touches.length === 0) {
-        return;
+      if (draggingDirection) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!event.touches || event.touches.length === 0) {
+          return;
+        }
+        const touch = event.touches[0];
+        updateMouseCurrentPos({
+          x: touch.clientX,
+          y: touch.clientY,
+        });
       }
-      const touch = event.touches[0];
-      updateMouseCurrentPos({
-        x: touch.clientX,
-        y: touch.clientY,
-      });
     };
 
     const resizerContainer = resizerRef.current;
@@ -407,16 +408,16 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
           backgroundColor: 'none',
           cursor: 'row-resize',
           height: `${zoneWidth}px`,
-          left: `${window.scrollX + tableRect.left}px`,
+          left: `${window.scrollX + left}px`,
           top: `${window.scrollY + top + height - zoneWidth / 2}px`,
-          width: `${tableRect.width}px`,
+          width: `${width}px`,
         },
         right: {
           backgroundColor: 'none',
           cursor: 'col-resize',
-          height: `${tableRect.height}px`,
+          height: `${height}px`,
           left: `${window.scrollX + left + width - zoneWidth / 2}px`,
-          top: `${window.scrollY + tableRect.top}px`,
+          top: `${window.scrollY + top}px`,
           width: `${zoneWidth}px`,
         },
       };


### PR DESCRIPTION
This pull request includes several changes to improve touch support for the `TableCellResizer` plugin.

Enhancements to touch support and event handling:

* [`packages/lexical-playground/src/plugins/TableCellResizer/index.css`](diffhunk://#diff-dd8f4a9b1046befb4eff4fc8d818e1c75740c8edc8d1680403ca778229e8356dR13-R19): Added styles for coarse pointer devices to improve touch interaction.
* [`packages/lexical-playground/src/plugins/TableCellResizer/index.tsx`](diffhunk://#diff-21abbbd7f4404e12ac6e30e272b3ceaed16a4a7a184c2814a88e478090ca40a0L109-R113): Replaced `MouseEvent` with `PointerEvent` to handle both mouse and touch events, and added specific handling for touch events such as `onTouchMove` and `onClick`. [[1]](diffhunk://#diff-21abbbd7f4404e12ac6e30e272b3ceaed16a4a7a184c2814a88e478090ca40a0L109-R113) [[2]](diffhunk://#diff-21abbbd7f4404e12ac6e30e272b3ceaed16a4a7a184c2814a88e478090ca40a0R174-R216) [[3]](diffhunk://#diff-21abbbd7f4404e12ac6e30e272b3ceaed16a4a7a184c2814a88e478090ca40a0L307-R343) [[4]](diffhunk://#diff-21abbbd7f4404e12ac6e30e272b3ceaed16a4a7a184c2814a88e478090ca40a0L334-R368) [[5]](diffhunk://#diff-21abbbd7f4404e12ac6e30e272b3ceaed16a4a7a184c2814a88e478090ca40a0L343-R377) [[6]](diffhunk://#diff-21abbbd7f4404e12ac6e30e272b3ceaed16a4a7a184c2814a88e478090ca40a0L359-R438) [[7]](diffhunk://#diff-21abbbd7f4404e12ac6e30e272b3ceaed16a4a7a184c2814a88e478090ca40a0L435-R466)

General improvements:

* [`packages/lexical-playground/src/plugins/TableCellResizer/index.tsx`](diffhunk://#diff-21abbbd7f4404e12ac6e30e272b3ceaed16a4a7a184c2814a88e478090ca40a0L359-R438): Updated the `zoneWidth` and adjusted the calculation of resizer styles for better accuracy and usability.