### PR TITLE
[lexical-playground][TableActionMenuPlugin] Feature: Add an option to achieve the alignment of the entire table

### DIFF
--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -11,6 +11,7 @@ import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
+import {getCSSFromStyleObject, getStyleObjectFromCSS} from '@lexical/selection';
 import {
   $computeTableMapSkipCellCheck,
   $deleteTableColumn__EXPERIMENTAL,
@@ -574,6 +575,34 @@ function TableActionMenu({
     });
   };
 
+  const formatLayoutAlign = (align: 'left' | 'center' | 'right') => {
+    editor.update(() => {
+      const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCellNode);
+      const styleObj = getStyleObjectFromCSS(tableNode.__style);
+      switch (align) {
+        case 'left':
+          tableNode.setStyle(
+            getCSSFromStyleObject({...styleObj, margin: '0 auto 0 0'}),
+          );
+          break;
+
+        case 'center':
+          tableNode.setStyle(
+            getCSSFromStyleObject({...styleObj, margin: '0 auto'}),
+          );
+          break;
+
+        case 'right':
+          tableNode.setStyle(
+            getCSSFromStyleObject({...styleObj, margin: '0 0 0 auto'}),
+          );
+          break;
+      }
+
+      onClose();
+    });
+  };
+
   let mergeCellButton: null | JSX.Element = null;
   if (cellMerge) {
     if (canMergeCells) {
@@ -664,6 +693,43 @@ function TableActionMenu({
           </div>
         </DropDownItem>
       </DropDown>
+
+      <DropDown
+        buttonLabel="Layout Align"
+        buttonClassName="item"
+        buttonAriaLabel="Formatting options for layout alignment">
+        <DropDownItem
+          onClick={() => {
+            formatLayoutAlign('left');
+          }}
+          className="item wide">
+          <div className="icon-text-container">
+            <i className="icon left-align" />
+            <span className="text">Left Align</span>
+          </div>
+        </DropDownItem>
+        <DropDownItem
+          onClick={() => {
+            formatLayoutAlign('center');
+          }}
+          className="item wide">
+          <div className="icon-text-container">
+            <i className="icon center-align" />
+            <span className="text">Center Align</span>
+          </div>
+        </DropDownItem>
+        <DropDownItem
+          onClick={() => {
+            formatLayoutAlign('right');
+          }}
+          className="item wide">
+          <div className="icon-text-container">
+            <i className="icon right-align" />
+            <span className="text">Right Align</span>
+          </div>
+        </DropDownItem>
+      </DropDown>
+
       <button
         type="button"
         className="item"


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

[lexical-playground][TableActionMenuPlugin] Feature: Add an option  to achieve the alignment of the entire table 

Currently, the table can only set the alignment of the internal content, such as horizontal and vertical centering of text, but cannot set the alignment of the entire table.

Now, add an option to TableActionMenu to achieve the alignment of the entire table through setStyle

Closes #7302

## Test plan

### Before

*Tables can only be displayed on the left*

![image](https://github.com/user-attachments/assets/7ea47a88-2761-4ee7-a59a-b7bdaa2d01ab)


### After

*Tables can be displayed in the center*

![image](https://github.com/user-attachments/assets/aec66b53-f3bd-40ba-8e32-05974250d7ad)
