### PR TITLE
[lexical-react]: Chore: remove unused dependencies from @lexical/react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40357,9 +40357,6 @@
         "lexical": "0.27.2",
         "react-error-boundary": "^3.1.4"
       },
-      "devDependencies": {
-        "@lexical/code": "0.27.2"
-      },
       "peerDependencies": {
         "react": ">=17.x",
         "react-dom": ">=17.x"
@@ -45324,7 +45321,6 @@
     "@lexical/react": {
       "version": "file:packages/lexical-react",
       "requires": {
-        "@lexical/code": "0.27.2",
         "@lexical/devtools-core": "0.27.2",
         "@lexical/dragon": "0.27.2",
         "@lexical/hashtag": "0.27.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40339,8 +40339,6 @@
       "version": "0.27.2",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.27.2",
-        "@lexical/code": "0.27.2",
         "@lexical/devtools-core": "0.27.2",
         "@lexical/dragon": "0.27.2",
         "@lexical/hashtag": "0.27.2",
@@ -40352,13 +40350,15 @@
         "@lexical/overflow": "0.27.2",
         "@lexical/plain-text": "0.27.2",
         "@lexical/rich-text": "0.27.2",
-        "@lexical/selection": "0.27.2",
         "@lexical/table": "0.27.2",
         "@lexical/text": "0.27.2",
         "@lexical/utils": "0.27.2",
         "@lexical/yjs": "0.27.2",
         "lexical": "0.27.2",
         "react-error-boundary": "^3.1.4"
+      },
+      "devDependencies": {
+        "@lexical/code": "0.27.2"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -45324,7 +45324,6 @@
     "@lexical/react": {
       "version": "file:packages/lexical-react",
       "requires": {
-        "@lexical/clipboard": "0.27.2",
         "@lexical/code": "0.27.2",
         "@lexical/devtools-core": "0.27.2",
         "@lexical/dragon": "0.27.2",
@@ -45337,7 +45336,6 @@
         "@lexical/overflow": "0.27.2",
         "@lexical/plain-text": "0.27.2",
         "@lexical/rich-text": "0.27.2",
-        "@lexical/selection": "0.27.2",
         "@lexical/table": "0.27.2",
         "@lexical/text": "0.27.2",
         "@lexical/utils": "0.27.2",

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -10,8 +10,6 @@
   "license": "MIT",
   "version": "0.27.2",
   "dependencies": {
-    "@lexical/clipboard": "0.27.2",
-    "@lexical/code": "0.27.2",
     "@lexical/devtools-core": "0.27.2",
     "@lexical/dragon": "0.27.2",
     "@lexical/hashtag": "0.27.2",
@@ -23,13 +21,15 @@
     "@lexical/overflow": "0.27.2",
     "@lexical/plain-text": "0.27.2",
     "@lexical/rich-text": "0.27.2",
-    "@lexical/selection": "0.27.2",
     "@lexical/table": "0.27.2",
     "@lexical/text": "0.27.2",
     "@lexical/utils": "0.27.2",
     "@lexical/yjs": "0.27.2",
     "lexical": "0.27.2",
     "react-error-boundary": "^3.1.4"
+  },
+  "devDependencies": {
+    "@lexical/code": "0.27.2"
   },
   "peerDependencies": {
     "react": ">=17.x",

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -28,9 +28,6 @@
     "lexical": "0.27.2",
     "react-error-boundary": "^3.1.4"
   },
-  "devDependencies": {
-    "@lexical/code": "0.27.2"
-  },
   "peerDependencies": {
     "react": ">=17.x",
     "react-dom": ">=17.x"

--- a/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import {CodeHighlightNode, CodeNode} from '@lexical/code';
 import {HashtagNode} from '@lexical/hashtag';
 import {AutoLinkNode, LinkNode} from '@lexical/link';
 import {ListItemNode, ListNode} from '@lexical/list';
@@ -38,12 +37,10 @@ const RICH_TEXT_NODES = [
   ListNode,
   ListItemNode,
   QuoteNode,
-  CodeNode,
   TableNode,
   TableCellNode,
   TableRowNode,
   HashtagNode,
-  CodeHighlightNode,
   AutoLinkNode,
   LinkNode,
   OverflowNode,


### PR DESCRIPTION
This reduces the amount of dependencies installed by `@lexical/react`.

- `@lexical/clipboard`: This is not _directly_ used in @lexical/react
- `@lexical/selection`: This is not _directly_ used in @lexical/react
- `@lexical/code`: This is only used in a test file and does not have to be installed by the end-user. => I moved it to `devDependencies`.

This is the first step to ensuring that `@lexical/code` is not installed in projects that don't use it. The next step would be to remove it from `@lexical/markdown`.

![CleanShot 2025-03-11 at 17 51 23@2x](https://github.com/user-attachments/assets/0ac0c346-9e37-4c74-8816-a013afdb6e5b)
