### PR TITLE
[Breaking Change][lexical-table] Bug Fix: Table cell line breaks behave differently from the intended HTML behavior.

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
@@ -212,11 +212,7 @@ test.describe('HTML Tables CopyAndPaste', () => {
                 dir="ltr"
                 style="text-align: left;">
                 <span data-lexical-text="true">b</span>
-              </p>
-              <p
-                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                dir="ltr"
-                style="text-align: left;">
+                <br />
                 <span data-lexical-text="true">b</span>
               </p>
             </td>
@@ -297,10 +293,7 @@ test.describe('HTML Tables CopyAndPaste', () => {
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
                 <span data-lexical-text="true">b</span>
-              </p>
-              <p
-                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
-                dir="ltr">
+                <br />
                 <span data-lexical-text="true">b</span>
               </p>
             </td>

--- a/packages/lexical-table/src/LexicalTableCellNode.ts
+++ b/packages/lexical-table/src/LexicalTableCellNode.ts
@@ -24,8 +24,7 @@ import {addClassNamesToElement} from '@lexical/utils';
 import {
   $applyNodeReplacement,
   $createParagraphNode,
-  $isInlineElementOrDecoratorNode,
-  $isLineBreakNode,
+  $isElementNode,
   $isTextNode,
   ElementNode,
   isHTMLElement,
@@ -368,19 +367,8 @@ export function $convertTableCellNodeElement(
       const result: LexicalNode[] = [];
       let paragraphNode: ParagraphNode | null = null;
 
-      for (let i = 0; i < childLexicalNodes.length; i++) {
-        const prevChild = childLexicalNodes[i - 1];
-        const child = childLexicalNodes[i];
-
-        if ($isLineBreakNode(child)) {
-          if ($isLineBreakNode(prevChild)) {
-            result.push($createParagraphNode());
-          }
-          paragraphNode = null;
-        } else if (
-          $isInlineElementOrDecoratorNode(child) ||
-          $isTextNode(child)
-        ) {
+      for (const child of childLexicalNodes) {
+        if (!$isElementNode(child)) {
           if ($isTextNode(child)) {
             if (hasBoldFontWeight) {
               child.toggleFormat('bold');

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
@@ -113,12 +113,7 @@ describe('LexicalTableCellNode tests', () => {
               <tbody>
                 <tr>
                   <td
-                    style="
-                      border: 1px solid black;
-                      width: 75px;
-                      vertical-align:
-                      top; text-align: start;
-                    ">
+                    style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start;">
                     <p>
                       <test-decorator></test-decorator>
                       <span style="white-space: pre-wrap;">1</span>
@@ -150,18 +145,47 @@ describe('LexicalTableCellNode tests', () => {
               <tbody>
                 <tr>
                   <td
-                    style="
-                      border: 1px solid black;
-                      width: 75px;
-                      vertical-align:
-                      top; text-align: start;
-                    ">
+                    style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start;">
                     <p>
                       <span style="white-space: pre-wrap;">1</span>
                       <br />
                       <br />
                       <br />
                       <br />
+                      <span style="white-space: pre-wrap;">2</span>
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          `,
+        ],
+        [
+          html`
+            <table>
+              <tr>
+                <td>
+                  <p>1</p>
+                  <br />
+                  <p>2</p>
+                </td>
+              </tr>
+            </table>
+          `,
+          html`
+            <table>
+              <colgroup><col /></colgroup>
+              <tbody>
+                <tr>
+                  <td
+                    style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start;">
+                    <p>
+                      <span style="white-space: pre-wrap;">1</span>
+                    </p>
+                    <p>
+                      <br />
+                    </p>
+                    <p>
                       <span style="white-space: pre-wrap;">2</span>
                     </p>
                   </td>

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
@@ -6,8 +6,14 @@
  *
  */
 
+import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
 import {$createTableCellNode, TableCellHeaderStates} from '@lexical/table';
-import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {$getRoot} from 'lexical';
+import {
+  expectHtmlToBeEqual,
+  html,
+  initializeUnitTest,
+} from 'lexical/src/__tests__/utils';
 
 const editorConfig = Object.freeze({
   namespace: '',
@@ -82,6 +88,109 @@ describe('LexicalTableCellNode tests', () => {
         ).toBe(
           `<td style="vertical-align: ${validVerticalAlign};" class="${editorConfig.theme.tableCell}"></td>`,
         );
+      });
+    });
+
+    test('TableCellNode.importDOM', async () => {
+      const {editor} = testEnv;
+      const parser = new DOMParser();
+
+      const cases: Array<[string, string]> = [
+        [
+          html`
+            <table>
+              <tr>
+                <td>
+                  <test-decorator></test-decorator>
+                  1
+                </td>
+              </tr>
+            </table>
+          `,
+          html`
+            <table>
+              <colgroup><col /></colgroup>
+              <tbody>
+                <tr>
+                  <td
+                    style="
+                      border: 1px solid black;
+                      width: 75px;
+                      vertical-align:
+                      top; text-align: start;
+                    ">
+                    <p>
+                      <test-decorator></test-decorator>
+                      <span style="white-space: pre-wrap;">1</span>
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          `,
+        ],
+        [
+          html`
+            <table>
+              <tr>
+                <td>
+                  1
+                  <br />
+                  <br />
+                  <br />
+                  <br />
+                  2
+                </td>
+              </tr>
+            </table>
+          `,
+          html`
+            <table>
+              <colgroup><col /></colgroup>
+              <tbody>
+                <tr>
+                  <td
+                    style="
+                      border: 1px solid black;
+                      width: 75px;
+                      vertical-align:
+                      top; text-align: start;
+                    ">
+                    <p>
+                      <span style="white-space: pre-wrap;">1</span>
+                    </p>
+                    <p>
+                      <br />
+                    </p>
+                    <p>
+                      <br />
+                    </p>
+                    <p>
+                      <br />
+                    </p>
+                    <p>
+                      <span style="white-space: pre-wrap;">2</span>
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          `,
+        ],
+      ];
+
+      await editor.update(() => {
+        const root = $getRoot();
+
+        for (const [input, output] of cases) {
+          root.clear();
+
+          const dom = parser.parseFromString(input, 'text/html');
+          const nodes = $generateNodesFromDOM(editor, dom);
+          root.append(...nodes);
+
+          expectHtmlToBeEqual($generateHtmlFromNodes(editor), output);
+        }
       });
     });
   });

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
@@ -158,17 +158,10 @@ describe('LexicalTableCellNode tests', () => {
                     ">
                     <p>
                       <span style="white-space: pre-wrap;">1</span>
-                    </p>
-                    <p>
                       <br />
-                    </p>
-                    <p>
                       <br />
-                    </p>
-                    <p>
                       <br />
-                    </p>
-                    <p>
+                      <br />
                       <span style="white-space: pre-wrap;">2</span>
                     </p>
                   </td>


### PR DESCRIPTION
## Breaking Change

The importDOM implementation for TableCellNode has been corrected to behave as other Lexical roots do with regard to converting `<br>` tags to `LineBreakNode` and wrapping runs of top-level inline nodes (including inline decorators) with `ParagraphNode`. If you have any specific workarounds accounting for the previous behavior, you can remove them. The one difference from other import paths is that a solitary `<br>` (e.g. `<td><br></td>`) is converted to an empty `ParagraphNode` rather than a `ParagraphNode` containing a `LineBreakNode`.

## Description
Table cell line breaks behave differently from the intended HTML behavior.

Modify the logic to align with the intended HTML line breaks.

Closes #7261

## Test plan

Add TC to `TableCellNode.importDOM`

### Before

| case | html | editor |
| ---- | ---- | ------ |
| inline decorator | \<td><br> \<test-decorator>\</test-decorator><br> 1<br>\</td> | \<td><br> \<p><br> \<test-decorator>\</test-decorator><br> \<br /><br> \</p><br> \<p><br> \<span>1\</span><br> \</p><br>\</td> |
| br | \<td><br> 1<br> \<br /><br> \<br /><br> \<br /><br> \<br /><br> 2<br>\</td> | \<td><br> \<p><br> \<span>1\</span><br> \</p><br> \<p><br> \<span>2\</span><br> \</p><br>\</td> |

### After

| case | html | editor |
| ---- | ---- | ------ |
| inline decorator | \<td><br> \<test-decorator>\</test-decorator><br> 1<br>\</td> | \<td><br> \<p><br> \<test-decorator>\</test-decorator><br> \<span>1\</span><br> \</p><br>\</td> |
| br | \<td><br> 1<br> \<br /><br> \<br /><br> \<br /><br> \<br /><br> 2<br>\</td> | \<td><br> \<p><br> \<span>1\</span><br> \<br /><br> \<br /><br> \<br /><br> \<br /><br> \<span>2\</span><br> \</p><br>\</td> |
