### PR TITLE
[lexical] Feature: Add mutatedNodes to UpdateListener payload

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -252,7 +252,7 @@ export interface UpdateListenerPayload {
    */
   editorState: EditorState;
   /**
-   * The Map of LexicalNode constructors to a Map<NodeKey, NodeMutation>,
+   * The Map of LexicalNode constructors to a `Map<NodeKey, NodeMutation>`,
    * this is useful when you have a mutation listener type use cases that
    * should apply to all or most nodes. Will be null if no DOM was mutated,
    * such as when only the selection changed.

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -18,10 +18,10 @@ import {
   EditorUpdateOptions,
   LexicalCommand,
   LexicalEditor,
-  Listener,
   MutatedNodes,
   RegisteredNodes,
   resetEditor,
+  SetListeners,
   Transform,
 } from './LexicalEditor';
 import {
@@ -685,6 +685,7 @@ export function $commitPendingUpdates(
     dirtyElements,
     dirtyLeaves,
     editorState: pendingEditorState,
+    mutatedNodes,
     normalizedNodes,
     prevEditorState: recoveryEditorState || currentEditorState,
     tags,
@@ -729,19 +730,20 @@ function triggerMutationListeners(
   }
 }
 
-export function triggerListeners(
-  type: 'update' | 'root' | 'decorator' | 'textcontent' | 'editable',
+export function triggerListeners<T extends keyof SetListeners>(
+  type: T,
   editor: LexicalEditor,
   isCurrentlyEnqueuingUpdates: boolean,
-  ...payload: unknown[]
+  ...payload: SetListeners[T]
 ): void {
   const previouslyUpdating = editor._updating;
   editor._updating = isCurrentlyEnqueuingUpdates;
 
   try {
-    const listeners = Array.from<Listener>(editor._listeners[type]);
+    const listeners = Array.from(
+      editor._listeners[type] as Set<(...args: SetListeners[T]) => void>,
+    );
     for (let i = 0; i < listeners.length; i++) {
-      // @ts-ignore
       listeners[i].apply(null, payload);
     }
   } finally {

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -148,6 +148,7 @@ export type {
   Spread,
   Transform,
   UpdateListener,
+  UpdateListenerPayload,
 } from './LexicalEditor';
 export {
   COMMAND_PRIORITY_CRITICAL,


### PR DESCRIPTION
## Description

In order to better support NodeState and other use cases (e.g. some sort of "createdDOM/updateDOM" middleware) where it's useful to know about *all* nodes that were mutated in the DOM this adds the mutatedNodes property to UpdateListenerPayload and adds some API docs.

With this change it would be possible to implement mutation listeners as an updateListener so we could reduce some surface area in the future with a reduced core.

## Test plan

Includes unit tests for expected behavior of the payload.