### PR TITLE
[Breaking Change][lexical][lexical-playground] Feature: Add a default delete handler for NodeSelection

### DIFF
--- a/packages/lexical-playground/__tests__/regression/7319-delete-character-backward-nodeselection.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/7319-delete-character-backward-nodeselection.spec.mjs
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {deleteBackward, moveLeft} from '../keyboardShortcuts/index.mjs';
+import {
+  assertHTML,
+  focusEditor,
+  html,
+  initialize,
+  pasteFromClipboard,
+  test,
+} from '../utils/index.mjs';
+
+test.describe('Regression tests for #7319', () => {
+  test.beforeEach(({isPlainText, isCollab, page}) =>
+    initialize({isCollab, isPlainText, page}),
+  );
+
+  test(`deleteCharacter after hr with RangeSelection`, async ({
+    page,
+    isCollab,
+    isPlainText,
+  }) => {
+    test.skip(isCollab || isPlainText);
+    await focusEditor(page);
+    await page.keyboard.press('Enter');
+    const hrCount = 3;
+    for (let i = 0; i < hrCount; i++) {
+      await pasteFromClipboard(page, {
+        'text/html': html`
+          <hr />
+        `,
+      });
+    }
+    async function assertHR(count) {
+      const expectedHtml = html`
+        <p><br /></p>
+        ${Array.from(
+          {length: count},
+          () => '<hr contenteditable="false" data-lexical-decorator="true" />',
+        ).join('')}
+        ${count > 0
+          ? '<div contenteditable="false" data-lexical-cursor="true"></div>'
+          : ''}
+      `;
+      await assertHTML(page, expectedHtml, expectedHtml, {
+        ignoreClasses: true,
+        ignoreInlineStyles: true,
+      });
+    }
+    for (let i = hrCount; i > 0; i--) {
+      await assertHR(i);
+      await deleteBackward(page);
+    }
+    await assertHR(0);
+  });
+  test(`deleteCharacter after hr with NodeSelection`, async ({
+    page,
+    isCollab,
+    isPlainText,
+  }) => {
+    test.skip(isCollab || isPlainText);
+    await focusEditor(page);
+    await page.keyboard.press('Enter');
+    const hrCount = 3;
+    for (let i = 0; i < hrCount; i++) {
+      await pasteFromClipboard(page, {
+        'text/html': html`
+          <hr />
+        `,
+      });
+    }
+    async function assertHR(count) {
+      const expectedHtml = html`
+        <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+        ${Array.from(
+          {length: count},
+          (_, i) =>
+            `<hr class="PlaygroundEditorTheme__hr ${
+              i === hrCount - 1 ? 'PlaygroundEditorTheme__hrSelected' : ''
+            }" contenteditable="false" data-lexical-decorator="true" />`,
+        ).join('')}
+        ${count > 0 && count < hrCount
+          ? '<div class="PlaygroundEditorTheme__blockCursor" contenteditable="false" data-lexical-cursor="true"></div>'
+          : ''}
+      `;
+      await assertHTML(page, expectedHtml);
+    }
+    await moveLeft(page, 1);
+    for (let i = hrCount; i > 0; i--) {
+      await assertHR(i);
+      await deleteBackward(page);
+    }
+    await assertHR(0);
+  });
+});

--- a/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ExcalidrawNode/ExcalidrawComponent.tsx
@@ -20,8 +20,6 @@ import {
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   isDOMNode,
-  KEY_BACKSPACE_COMMAND,
-  KEY_DELETE_COMMAND,
 } from 'lexical';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import * as React from 'react';
@@ -53,20 +51,6 @@ export default function ExcalidrawComponent({
   const [isSelected, setSelected, clearSelection] =
     useLexicalNodeSelection(nodeKey);
   const [isResizing, setIsResizing] = useState<boolean>(false);
-
-  const $onDelete = useCallback(
-    (event: KeyboardEvent) => {
-      if (isSelected) {
-        event.preventDefault();
-        const node = $getNodeByKey(nodeKey);
-        if (node) {
-          node.remove();
-        }
-      }
-      return false;
-    },
-    [isSelected, nodeKey],
-  );
 
   useEffect(() => {
     if (!isEditable) {
@@ -105,26 +89,8 @@ export default function ExcalidrawComponent({
         },
         COMMAND_PRIORITY_LOW,
       ),
-      editor.registerCommand(
-        KEY_DELETE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand(
-        KEY_BACKSPACE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
     );
-  }, [
-    clearSelection,
-    editor,
-    isSelected,
-    isResizing,
-    $onDelete,
-    setSelected,
-    isEditable,
-  ]);
+  }, [clearSelection, editor, isSelected, isResizing, setSelected, isEditable]);
 
   const deleteNode = useCallback(() => {
     setModalOpen(false);

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -40,8 +40,6 @@ import {
   COMMAND_PRIORITY_LOW,
   createCommand,
   DRAGSTART_COMMAND,
-  KEY_BACKSPACE_COMMAND,
-  KEY_DELETE_COMMAND,
   KEY_ENTER_COMMAND,
   KEY_ESCAPE_COMMAND,
   LineBreakNode,
@@ -174,23 +172,6 @@ export default function ImageComponent({
   const activeEditorRef = useRef<LexicalEditor | null>(null);
   const [isLoadError, setIsLoadError] = useState<boolean>(false);
   const isEditable = useLexicalEditable();
-
-  const $onDelete = useCallback(
-    (payload: KeyboardEvent) => {
-      const deleteSelection = $getSelection();
-      if (isSelected && $isNodeSelection(deleteSelection)) {
-        const event: KeyboardEvent = payload;
-        event.preventDefault();
-        deleteSelection.getNodes().forEach((node) => {
-          if ($isImageNode(node)) {
-            node.remove();
-          }
-        });
-      }
-      return false;
-    },
-    [isSelected],
-  );
 
   const $onEnter = useCallback(
     (event: KeyboardEvent) => {
@@ -326,16 +307,6 @@ export default function ImageComponent({
         },
         COMMAND_PRIORITY_LOW,
       ),
-      editor.registerCommand(
-        KEY_DELETE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand(
-        KEY_BACKSPACE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
       editor.registerCommand(KEY_ENTER_COMMAND, $onEnter, COMMAND_PRIORITY_LOW),
       editor.registerCommand(
         KEY_ESCAPE_COMMAND,
@@ -356,7 +327,6 @@ export default function ImageComponent({
     isResizing,
     isSelected,
     nodeKey,
-    $onDelete,
     $onEnter,
     $onEscape,
     onClick,

--- a/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/InlineImageNode/InlineImageComponent.tsx
@@ -27,8 +27,6 @@ import {
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   DRAGSTART_COMMAND,
-  KEY_BACKSPACE_COMMAND,
-  KEY_DELETE_COMMAND,
   KEY_ENTER_COMMAND,
   KEY_ESCAPE_COMMAND,
   SELECTION_CHANGE_COMMAND,
@@ -43,7 +41,7 @@ import ContentEditable from '../../ui/ContentEditable';
 import {DialogActions} from '../../ui/Dialog';
 import Select from '../../ui/Select';
 import TextInput from '../../ui/TextInput';
-import {$isInlineImageNode, InlineImageNode} from './InlineImageNode';
+import {InlineImageNode} from './InlineImageNode';
 
 const imageCache = new Set();
 
@@ -204,25 +202,6 @@ export default function InlineImageComponent({
   const activeEditorRef = useRef<LexicalEditor | null>(null);
   const isEditable = useLexicalEditable();
 
-  const $onDelete = useCallback(
-    (payload: KeyboardEvent) => {
-      const deleteSelection = $getSelection();
-      if (isSelected && $isNodeSelection(deleteSelection)) {
-        const event: KeyboardEvent = payload;
-        event.preventDefault();
-        if (isSelected && $isNodeSelection(deleteSelection)) {
-          deleteSelection.getNodes().forEach((node) => {
-            if ($isInlineImageNode(node)) {
-              node.remove();
-            }
-          });
-        }
-      }
-      return false;
-    },
-    [isSelected],
-  );
-
   const $onEnter = useCallback(
     (event: KeyboardEvent) => {
       const latestSelection = $getSelection();
@@ -320,16 +299,6 @@ export default function InlineImageComponent({
         },
         COMMAND_PRIORITY_LOW,
       ),
-      editor.registerCommand(
-        KEY_DELETE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand(
-        KEY_BACKSPACE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
       editor.registerCommand(KEY_ENTER_COMMAND, $onEnter, COMMAND_PRIORITY_LOW),
       editor.registerCommand(
         KEY_ESCAPE_COMMAND,
@@ -346,7 +315,6 @@ export default function InlineImageComponent({
     editor,
     isSelected,
     nodeKey,
-    $onDelete,
     $onEnter,
     $onEscape,
     setSelected,

--- a/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
+++ b/packages/lexical-playground/src/nodes/PageBreakNode/index.tsx
@@ -14,22 +14,18 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {mergeRegister} from '@lexical/utils';
 import {
-  $getSelection,
-  $isNodeSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_HIGH,
   COMMAND_PRIORITY_LOW,
   DecoratorNode,
   DOMConversionMap,
   DOMConversionOutput,
-  KEY_BACKSPACE_COMMAND,
-  KEY_DELETE_COMMAND,
   LexicalNode,
   NodeKey,
   SerializedLexicalNode,
 } from 'lexical';
 import * as React from 'react';
-import {useCallback, useEffect} from 'react';
+import {useEffect} from 'react';
 
 export type SerializedPageBreakNode = SerializedLexicalNode;
 
@@ -37,22 +33,6 @@ function PageBreakComponent({nodeKey}: {nodeKey: NodeKey}) {
   const [editor] = useLexicalComposerContext();
   const [isSelected, setSelected, clearSelection] =
     useLexicalNodeSelection(nodeKey);
-
-  const $onDelete = useCallback(
-    (event: KeyboardEvent) => {
-      event.preventDefault();
-      const deleteSelection = $getSelection();
-      if (isSelected && $isNodeSelection(deleteSelection)) {
-        deleteSelection.getNodes().forEach((node) => {
-          if ($isPageBreakNode(node)) {
-            node.remove();
-          }
-        });
-      }
-      return false;
-    },
-    [isSelected],
-  );
 
   useEffect(() => {
     return mergeRegister(
@@ -73,18 +53,8 @@ function PageBreakComponent({nodeKey}: {nodeKey: NodeKey}) {
         },
         COMMAND_PRIORITY_LOW,
       ),
-      editor.registerCommand(
-        KEY_DELETE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand(
-        KEY_BACKSPACE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
     );
-  }, [clearSelection, editor, isSelected, nodeKey, $onDelete, setSelected]);
+  }, [clearSelection, editor, isSelected, nodeKey, setSelected]);
 
   useEffect(() => {
     const pbElem = editor.getElementByKey(nodeKey);

--- a/packages/lexical-playground/src/nodes/PollComponent.tsx
+++ b/packages/lexical-playground/src/nodes/PollComponent.tsx
@@ -22,12 +22,10 @@ import {
   BaseSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
-  KEY_BACKSPACE_COMMAND,
-  KEY_DELETE_COMMAND,
   NodeKey,
 } from 'lexical';
 import * as React from 'react';
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 
 import Button from '../ui/Button';
 import joinClasses from '../utils/joinClasses';
@@ -145,23 +143,6 @@ export default function PollComponent({
   const [selection, setSelection] = useState<BaseSelection | null>(null);
   const ref = useRef(null);
 
-  const $onDelete = useCallback(
-    (payload: KeyboardEvent) => {
-      const deleteSelection = $getSelection();
-      if (isSelected && $isNodeSelection(deleteSelection)) {
-        const event: KeyboardEvent = payload;
-        event.preventDefault();
-        deleteSelection.getNodes().forEach((node) => {
-          if ($isPollNode(node)) {
-            node.remove();
-          }
-        });
-      }
-      return false;
-    },
-    [isSelected],
-  );
-
   useEffect(() => {
     return mergeRegister(
       editor.registerUpdateListener(({editorState}) => {
@@ -184,18 +165,8 @@ export default function PollComponent({
         },
         COMMAND_PRIORITY_LOW,
       ),
-      editor.registerCommand(
-        KEY_DELETE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand(
-        KEY_BACKSPACE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
     );
-  }, [clearSelection, editor, isSelected, nodeKey, $onDelete, setSelected]);
+  }, [clearSelection, editor, isSelected, nodeKey, setSelected]);
 
   const withPollNode = (
     cb: (node: PollNode) => void,

--- a/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
+++ b/packages/lexical-react/src/LexicalBlockWithAlignableContents.tsx
@@ -19,17 +19,14 @@ import {
 import {
   $getNodeByKey,
   $getSelection,
-  $isDecoratorNode,
   $isNodeSelection,
   $isRangeSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   FORMAT_ELEMENT_COMMAND,
-  KEY_BACKSPACE_COMMAND,
-  KEY_DELETE_COMMAND,
 } from 'lexical';
 import * as React from 'react';
-import {ReactNode, useCallback, useEffect, useRef} from 'react';
+import {ReactNode, useEffect, useRef} from 'react';
 
 type Props = Readonly<{
   children: ReactNode;
@@ -52,22 +49,6 @@ export function BlockWithAlignableContents({
   const [isSelected, setSelected, clearSelection] =
     useLexicalNodeSelection(nodeKey);
   const ref = useRef(null);
-
-  const $onDelete = useCallback(
-    (event: KeyboardEvent) => {
-      const deleteSelection = $getSelection();
-      if (isSelected && $isNodeSelection(deleteSelection)) {
-        event.preventDefault();
-        deleteSelection.getNodes().forEach((node) => {
-          if ($isDecoratorNode(node)) {
-            node.remove();
-          }
-        });
-      }
-      return false;
-    },
-    [isSelected],
-  );
 
   useEffect(() => {
     return mergeRegister(
@@ -120,18 +101,8 @@ export function BlockWithAlignableContents({
         },
         COMMAND_PRIORITY_LOW,
       ),
-      editor.registerCommand(
-        KEY_DELETE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand(
-        KEY_BACKSPACE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
     );
-  }, [clearSelection, editor, isSelected, nodeKey, $onDelete, setSelected]);
+  }, [clearSelection, editor, isSelected, nodeKey, setSelected]);
 
   return (
     <div

--- a/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
+++ b/packages/lexical-react/src/LexicalHorizontalRuleNode.tsx
@@ -27,17 +27,13 @@ import {
 } from '@lexical/utils';
 import {
   $applyNodeReplacement,
-  $getSelection,
-  $isNodeSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   createCommand,
   DecoratorNode,
-  KEY_BACKSPACE_COMMAND,
-  KEY_DELETE_COMMAND,
 } from 'lexical';
 import * as React from 'react';
-import {useCallback, useEffect} from 'react';
+import {useEffect} from 'react';
 
 export type SerializedHorizontalRuleNode = SerializedLexicalNode;
 
@@ -48,22 +44,6 @@ function HorizontalRuleComponent({nodeKey}: {nodeKey: NodeKey}) {
   const [editor] = useLexicalComposerContext();
   const [isSelected, setSelected, clearSelection] =
     useLexicalNodeSelection(nodeKey);
-
-  const $onDelete = useCallback(
-    (event: KeyboardEvent) => {
-      const deleteSelection = $getSelection();
-      if (isSelected && $isNodeSelection(deleteSelection)) {
-        event.preventDefault();
-        deleteSelection.getNodes().forEach((node) => {
-          if ($isHorizontalRuleNode(node)) {
-            node.remove();
-          }
-        });
-      }
-      return false;
-    },
-    [isSelected],
-  );
 
   useEffect(() => {
     return mergeRegister(
@@ -84,18 +64,8 @@ function HorizontalRuleComponent({nodeKey}: {nodeKey: NodeKey}) {
         },
         COMMAND_PRIORITY_LOW,
       ),
-      editor.registerCommand(
-        KEY_DELETE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand(
-        KEY_BACKSPACE_COMMAND,
-        $onDelete,
-        COMMAND_PRIORITY_LOW,
-      ),
     );
-  }, [clearSelection, editor, isSelected, nodeKey, $onDelete, setSelected]);
+  }, [clearSelection, editor, isSelected, nodeKey, setSelected]);
 
   useEffect(() => {
     const hrElem = editor.getElementByKey(nodeKey);

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -41,6 +41,7 @@ import {
   $rewindSiblingCaret,
   $setPointFromCaret,
   $setSelection,
+  $setSelectionFromCaretRange,
   $updateRangeSelectionFromCaretRange,
   CaretRange,
   ChildCaret,
@@ -430,6 +431,22 @@ export class NodeSelection implements BaseSelection {
       textContent += nodes[i].getTextContent();
     }
     return textContent;
+  }
+
+  /**
+   * Remove all nodes in the NodeSelection. If there were any nodes,
+   * replace the selection with a new RangeSelection at the previous
+   * location of the first node.
+   */
+  deleteNodes(): void {
+    const nodes = this.getNodes();
+    if (($getSelection() || $getPreviousSelection()) === this && nodes[0]) {
+      const firstCaret = $getSiblingCaret(nodes[0], 'next');
+      $setSelectionFromCaretRange($getCaretRange(firstCaret, firstCaret));
+    }
+    for (const node of nodes) {
+      node.remove();
+    }
   }
 }
 


### PR DESCRIPTION
## Breaking Change

If you have any `$onDelete` handlers copied from the playground for `KEY_DELETE_COMMAND` and `KEY_BACKSPACE_COMMAND`, you can delete them all now. If you leave them in, it will have similar bugs as prior to this PR.

The default `KEY_DELETE_COMMAND` and `KEY_BACKSPACE_COMMAND` handlers now preventDefault and call `DELETE_CHARACTER_COMMAND` for NodeSelection (in addition to the existing RangeSelection behavior).

The `DELETE_CHARACTER_COMMAND` handler now handles NodeSelection by calling the new `NodeSelection.deleteNodes()` method which places a new RangeSelection where the first selected node was (if any, and if it was the current selection) and then removes all of the selected nodes.

## Description

NodeSelection has no default handler for when the delete or backspace keys are pressed. This results in having every individual decorator node plugin register the same handler to incorrectly deal with this situation.

By centralizing the handler to a default location we can fix up the selection after a delete and remove a bunch of boilerplate code (while still having the option to override this behavior in the same way).

Closes #7319

## Test plan

New e2e regression tests added to catch this specific behavior