### PR TITLE
[Breaking Change][lexical-list] Bug Fix: Move ListItemNode text style inheritance to custom properties and CSS

### DIFF
--- a/packages/lexical-list/package.json
+++ b/packages/lexical-list/package.json
@@ -12,6 +12,7 @@
   "main": "LexicalList.js",
   "types": "index.d.ts",
   "dependencies": {
+    "@lexical/selection": "0.27.2",
     "@lexical/utils": "0.27.2",
     "lexical": "0.27.2"
   },

--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -23,6 +23,7 @@ import type {
   Spread,
 } from 'lexical';
 
+import {getStyleObjectFromCSS} from '@lexical/selection';
 import {
   addClassNamesToElement,
   removeClassNamesFromElement,
@@ -50,6 +51,26 @@ export type SerializedListItemNode = Spread<
   },
   SerializedElementNode
 >;
+
+function applyMarkerStyles(
+  dom: HTMLElement,
+  node: ListItemNode,
+  prevNode: ListItemNode | null,
+): void {
+  const styles: Record<string, string> = getStyleObjectFromCSS(
+    node.__textStyle,
+  );
+  for (const k in styles) {
+    dom.style.setProperty(`--listitem-marker-${k}`, styles[k]);
+  }
+  if (prevNode) {
+    for (const k in getStyleObjectFromCSS(prevNode.__textStyle)) {
+      if (!(k in styles)) {
+        dom.style.removeProperty(`--listitem-marker-${k}`);
+      }
+    }
+  }
+}
 
 /** @noInheritDoc */
 export class ListItemNode extends ElementNode {
@@ -80,10 +101,11 @@ export class ListItemNode extends ElementNode {
     }
     element.value = this.__value;
     $setListItemThemeClassNames(element, config.theme, this);
-    const nextStyle = this.__style || this.__textStyle;
+    const nextStyle = this.__style;
     if (nextStyle) {
       element.style.cssText = nextStyle;
     }
+    applyMarkerStyles(element, this, null);
     return element;
   }
 
@@ -99,14 +121,16 @@ export class ListItemNode extends ElementNode {
     // @ts-expect-error - this is always HTMLListItemElement
     dom.value = this.__value;
     $setListItemThemeClassNames(dom, config.theme, this);
-    const prevStyle = prevNode.__style || prevNode.__textStyle;
-    const nextStyle = this.__style || this.__textStyle;
+    const prevStyle = prevNode.__style;
+    const nextStyle = this.__style;
     if (prevStyle !== nextStyle) {
-      dom.style.cssText = nextStyle;
       if (nextStyle === '') {
         dom.removeAttribute('style');
+      } else {
+        dom.style.cssText = nextStyle;
       }
     }
+    applyMarkerStyles(dom, this, prevNode);
     return false;
   }
 

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -183,8 +183,10 @@ test.describe.parallel('Nested List', () => {
     await page.keyboard.press('Enter');
     await page.keyboard.type('Normal text');
 
-    const expectedColor = 'rgb(208, 2, 27)';
-
+    // This color is normalized by the browser
+    const expectedTextStyle = 'color: rgb(208, 2, 27);';
+    // This isn't (yet) parsed as a color, so it isn't normalized
+    const expectedMarkerStyle = '--listitem-marker-color: #d0021b;';
     await assertHTML(
       page,
       html`
@@ -192,28 +194,28 @@ test.describe.parallel('Nested List', () => {
           <li
             class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
             dir="ltr"
-            style="color: ${expectedColor};"
+            style="${expectedMarkerStyle}"
             value="1">
             <strong
               class="PlaygroundEditorTheme__textBold"
-              style="color: ${expectedColor};"
+              style="${expectedTextStyle}"
               data-lexical-text="true">
               Item one
             </strong>
           </li>
           <li
             class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"
-            style="color: ${expectedColor};"
+            style="${expectedMarkerStyle}"
             value="2">
             <ul class="PlaygroundEditorTheme__ul">
               <li
                 class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
                 dir="ltr"
-                style="color: ${expectedColor};"
+                style="${expectedMarkerStyle}"
                 value="1">
                 <strong
                   class="PlaygroundEditorTheme__textBold"
-                  style="color: ${expectedColor};"
+                  style="${expectedTextStyle}"
                   data-lexical-text="true">
                   Nested item two
                 </strong>
@@ -223,11 +225,11 @@ test.describe.parallel('Nested List', () => {
           <li
             class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
             dir="ltr"
-            style="color: ${expectedColor};"
+            style="${expectedMarkerStyle}"
             value="2">
             <strong
               class="PlaygroundEditorTheme__textBold"
-              style="color: ${expectedColor};"
+              style="${expectedTextStyle}"
               data-lexical-text="true">
               Item three
             </strong>
@@ -238,7 +240,7 @@ test.describe.parallel('Nested List', () => {
           dir="ltr">
           <strong
             class="PlaygroundEditorTheme__textBold"
-            style="color: ${expectedColor};"
+            style="${expectedTextStyle}"
             data-lexical-text="true">
             Normal text
           </strong>

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -450,6 +450,12 @@
 .PlaygroundEditorTheme__listItem {
   margin: 0 32px;
 }
+.PlaygroundEditorTheme__listItem::marker {
+  color: var(--listitem-marker-color);
+  background-color: var(--listitem-marker-background-color);
+  font-family: var(--listitem-marker-font-family);
+  font-size: var(--listitem-marker-font-size);
+}
 .PlaygroundEditorTheme__listItemChecked,
 .PlaygroundEditorTheme__listItemUnchecked {
   position: relative;


### PR DESCRIPTION
## Breaking Change

The approach used in #7024 (since v0.26.0) to have a ListItemNode bullet inherit the style of the first text node was too broad, the inline style on the ListItemNode cascades to *all* of its children. The only way around this is to change the approach.

To retain this feature, you need to add CSS to your theme to specifically style the marker pseudo-element based on these new custom properties. Here's an example from the playground css:

```css
.PlaygroundEditorTheme__listItem::marker {
  color: var(--listitem-marker-color);
  background-color: var(--listitem-marker-background-color);
  font-family: var(--listitem-marker-font-family);
  font-size: var(--listitem-marker-font-size);
}
```

## Description

The first approach to applying text styles to ListItemNode simply set the style attribute, which has the unfortunate effect of cascading to children. The only solution to prevent the cascade is to have this feature be supported by CSS custom properties and some custom CSS.

This parses the text style and creates custom properties for each property of the style, these may be handled from CSS in whatever way makes sense for the project.

Closes #7322

## Test plan

Relevant e2e test has been updated

### Before

```html
<!-- irrelevant attrs elided -->
<li style="color: rgb(208, 2, 27);">
  <span style="color: rgb(208, 2, 27);">text</span>
</li>
```

### After

```html
<!-- irrelevant attrs elided -->
<li style="--listitem-marker-color: #d0021b;">
  <span style="color: rgb(208, 2, 27);">text</span>
</li>
```