### PR TITLE
[lexical-yjs] Bug Fix: don't sync ElementNode __dir property

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1233,21 +1233,21 @@ test.describe.parallel('Tables', () => {
               <p dir="ltr"><span data-lexical-text="true">aa</span></p>
             </th>
             <th>
-              <p><span data-lexical-text="true">bb</span></p>
+              <p dir="ltr"><span data-lexical-text="true">bb</span></p>
             </th>
             <th>
-              <p><span data-lexical-text="true">cc</span></p>
+              <p dir="ltr"><span data-lexical-text="true">cc</span></p>
             </th>
           </tr>
           <tr>
             <th>
-              <p><span data-lexical-text="true">d</span></p>
+              <p dir="ltr"><span data-lexical-text="true">d</span></p>
             </th>
             <td>
-              <p><span data-lexical-text="true">e</span></p>
+              <p dir="ltr"><span data-lexical-text="true">e</span></p>
             </td>
             <td>
-              <p><span data-lexical-text="true">f</span></p>
+              <p dir="ltr"><span data-lexical-text="true">f</span></p>
             </td>
           </tr>
         </table>

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -51,6 +51,7 @@ const elementExcludedProperties = new Set<string>([
   '__first',
   '__last',
   '__size',
+  '__dir',
 ]);
 const rootExcludedProperties = new Set<string>(['__cachedText']);
 const textExcludedProperties = new Set<string>(['__text']);

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -387,10 +387,12 @@ function reconcileBlockDirection(
         classList.remove(...previousDirectionTheme);
       }
 
-      if (
+      const nodeDirection =
         direction === null ||
         (hasEmptyDirectionedTextContent && direction === 'ltr')
-      ) {
+          ? null
+          : direction;
+      if (nodeDirection === null) {
         // Remove direction
         dom.removeAttribute('dir');
       } else {
@@ -408,12 +410,12 @@ function reconcileBlockDirection(
         }
 
         // Update direction
-        dom.dir = direction;
+        dom.dir = nodeDirection;
       }
 
       if (!activeEditorStateReadOnly) {
         const writableNode = element.getWritable();
-        writableNode.__dir = direction;
+        writableNode.__dir = nodeDirection;
       }
     }
 

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -387,12 +387,10 @@ function reconcileBlockDirection(
         classList.remove(...previousDirectionTheme);
       }
 
-      const nodeDirection =
+      if (
         direction === null ||
         (hasEmptyDirectionedTextContent && direction === 'ltr')
-          ? null
-          : direction;
-      if (nodeDirection === null) {
+      ) {
         // Remove direction
         dom.removeAttribute('dir');
       } else {
@@ -410,12 +408,12 @@ function reconcileBlockDirection(
         }
 
         // Update direction
-        dom.dir = nodeDirection;
+        dom.dir = direction;
       }
 
       if (!activeEditorStateReadOnly) {
         const writableNode = element.getWritable();
-        writableNode.__dir = nodeDirection;
+        writableNode.__dir = direction;
       }
     }
 

--- a/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createLineBreakNode,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  ParagraphNode,
+} from 'lexical';
+
+import {initializeUnitTest} from '../utils';
+
+describe('LexicalNode state', () => {
+  initializeUnitTest((testEnv) => {
+    test('Should set "rtl" direction if node has no directioned text and previous sibling is "rtl"', async () => {
+      const {editor} = testEnv;
+      const rtlText = '\u0591';
+
+      // Add paragraph with RTL text, then another with a non-TextNode child
+      editor.update(() => {
+        const root = $getRoot().clear();
+        root.append(
+          $createParagraphNode().append($createTextNode(rtlText)),
+          $createParagraphNode().append($createLineBreakNode()),
+        );
+      });
+
+      const para2Dir = editor.read(() => {
+        return $getRoot().getChildAtIndex<ParagraphNode>(1)!.getDirection();
+      });
+      expect(para2Dir).toEqual('rtl');
+    });
+
+    test('Should not set "ltr" direction if node has no directioned text and previous sibling is "ltr"', async () => {
+      const {editor} = testEnv;
+      const ltrText = 'Hello';
+
+      editor.update(() => {
+        const root = $getRoot().clear();
+        root.append(
+          $createParagraphNode().append($createTextNode(ltrText)),
+          $createParagraphNode().append($createLineBreakNode()),
+        );
+      });
+
+      const para2Dir = editor.read(() => {
+        return $getRoot().getChildAtIndex<ParagraphNode>(1)!.getDirection();
+      });
+      expect(para2Dir).toBeNull();
+    });
+
+    test('Should use activeEditorDirection as the direction for a node with no directioned text', async () => {
+      const {editor} = testEnv;
+      const ltrText = 'Hello';
+      const rtlText = '\u0591';
+
+      editor.update(() => {
+        const root = $getRoot().clear();
+        root.append(
+          $createParagraphNode().append($createTextNode(rtlText)),
+          $createParagraphNode().append($createTextNode(ltrText)),
+          $createParagraphNode().append($createLineBreakNode()),
+        );
+      });
+
+      let para3Dir = editor.read(() => {
+        return $getRoot().getChildAtIndex<ParagraphNode>(2)!.getDirection();
+      });
+      expect(para3Dir).toBeNull();
+
+      editor.update(() => {
+        $getRoot().getChildAtIndex<ParagraphNode>(0)!.markDirty();
+        $getRoot().getChildAtIndex<ParagraphNode>(2)!.markDirty();
+      });
+
+      para3Dir = editor.read(() => {
+        return $getRoot().getChildAtIndex<ParagraphNode>(2)!.getDirection();
+      });
+      expect(para3Dir).toEqual('rtl');
+    });
+  });
+});


### PR DESCRIPTION
## Description

`LexicalReconciler` tries to determine whether text should be LTR or RTL based on a regex.

- https://github.com/facebook/lexical/blob/7c0ce40/packages/lexical/src/LexicalReconciler.ts#L367-L369
- https://github.com/facebook/lexical/blob/7c0ce40/packages/lexical/src/LexicalUtils.ts#L185-L193
- https://github.com/facebook/lexical/blob/7c0ce40/packages/lexical/src/LexicalConstants.ts#L101-L104

If a given block has no directioned text, then the `activeEditorDirection` is used. This more-or-less-global variable is set to `null` at the start of reconciliation but updated when a node with directioned text is encountered.

That's fine when processing the whole tree: node get updated in reading order. However, if you process only _some_ nodes in the tree, then you can end up changing the direction of a node in an unexpected way. ~~This is shown in the third test case where marking the first and third nodes as dirty changes the direction of the latter to RTL.~~

**Edit 2025-03-27**: updated the PR to use the second approach below, i.e. exclude `__dir` for Yjs syncing.

## Potential fixes

**Don't set node direction to LTR if no directioned text**

This makes it so that the node direction is more in sync with the `dir` property set in the DOM. Currently the reconciler clears the `dir` property if direction is null OR if it's LTR and the node has no directioned text: https://github.com/facebook/lexical/blob/main/packages/lexical/src/LexicalReconciler.ts#L390-L395

~~This approach is the one I've gone with in the current PR. The result is that the two editors have slightly different DOMs ('ltr' is removed in left editor but kept in right editor), however I don't think this is a huge issue. That said, a bunch of unit tests are failing.~~

**Mark `__dir` as an excluded property for Yjs syncing**

Based on what the reconciler is doing, figuring out direction from the text content, arguably `__dir` is a derived node property in the same way that `__cachedText` is on the root node: https://github.com/facebook/lexical/blob/main/packages/lexical-yjs/src/Utils.ts#L50-L54

I tried adding `__dir` to the excluded list for element nodes and it was still only the Table test that needed updating.

This feels like a reasonable approach to me, given `__dir` is derived state, however it would mean you could end up with two editors that display a given node with different directions. ~~Take the example from the third test case - the two nodes were marked dirty but had no changes, so nothing would be synced to Lexical, so other editors would still have `null` as the direction for the third paragraph.~~

**Backtrack through the tree to determine `activeEditorDirection`**

This would be the most complete fix, however could be a significant change. Didn't want to go down this path without first discussing (and ruling out) the two options above.

The idea here would be to not use `activeEditorState` but instead look at the previous block node in the tree (direct sibling, or sibling of a parent) and use its direction, assuming you were processing a node with no directioned text. That should give the same result as processing the whole tree in order.

**Process the whole tree when reconciling direction**

This would give consistent results and would be a small code change, but is a bad idea for obvious performance reasons.