### PR TITLE
[Breaking Change][lexical][lexical-table] Bug Fix: Scrollable TableNode updateDOM fixes and getDOMSlot type refactoring

### DIFF
--- a/packages/lexical-table/flow/LexicalTable.js.flow
+++ b/packages/lexical-table/flow/LexicalTable.js.flow
@@ -18,6 +18,7 @@ import type {
   LexicalEditor,
   TextFormatType,
   LexicalCommand,
+  ElementDOMSlot,
 } from 'lexical';
 
 import {
@@ -108,6 +109,7 @@ declare export class TableNode extends ElementNode {
   getCellNodeFromCords(x: number, y: number, table: TableDOMTable): ?TableCellNode;
   getCellNodeFromCordsOrThrow(x: number, y: number, table: TableDOMTable): TableCellNode;
   canSelectBefore(): true;
+  getDOMSlot(element: HTMLElement): ElementDOMSlot<HTMLTableElement>;
 }
 declare export function $createTableNode(): TableNode;
 declare export function $isTableNode(

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -72,6 +72,7 @@ import {
   getDOMSelection,
   INSERT_PARAGRAPH_COMMAND,
   isDOMNode,
+  isHTMLElement,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
@@ -110,6 +111,10 @@ const isPointerDownOnEvent = (event: PointerEvent) => {
   return (event.buttons & 1) === 1;
 };
 
+export function isHTMLTableElement(el: unknown): el is HTMLTableElement {
+  return isHTMLElement(el) && el.nodeName === 'TABLE';
+}
+
 export function getTableElement<T extends HTMLElement | null>(
   tableNode: TableNode,
   dom: T,
@@ -118,7 +123,7 @@ export function getTableElement<T extends HTMLElement | null>(
     return dom as T & null;
   }
   const element = (
-    dom.nodeName === 'TABLE' ? dom : tableNode.getDOMSlot(dom).element
+    isHTMLTableElement(dom) ? dom : tableNode.getDOMSlot(dom).element
   ) as HTMLTableElementWithWithTableSelectionState;
   invariant(
     element.nodeName === 'TABLE',

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -818,10 +818,10 @@ declare export function $isElementNode(
 /**
  * ElementDOMSlot
  */
-declare export class ElementDOMSlot<T: HTMLElement> {
-  element: HTMLElement;
-  before: Node | null;
-  after: Node | null;
+declare export class ElementDOMSlot<+T: HTMLElement> {
+  +element: HTMLElement;
+  +before: Node | null;
+  +after: Node | null;
   constructor(element: HTMLElement, before?: Node | null | void, after?: Node | null | void): void;
   withBefore(before: Node | null | void): ElementDOMSlot<T>;
   withAfter(after: Node | null | void): ElementDOMSlot<T>;

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -809,7 +809,7 @@ declare export class ElementNode extends LexicalNode {
     nodesToInsert: Array<LexicalNode>,
   ): this;
   exportJSON(): SerializedElementNode;
-  getDOMSlot(dom: HTMLElement): ElementDOMSlot;
+  getDOMSlot(dom: HTMLElement): ElementDOMSlot<HTMLElement>;
 }
 declare export function $isElementNode(
   node: ?LexicalNode,
@@ -818,14 +818,14 @@ declare export function $isElementNode(
 /**
  * ElementDOMSlot
  */
-declare export class ElementDOMSlot {
+declare export class ElementDOMSlot<T: HTMLElement> {
   element: HTMLElement;
   before: Node | null;
   after: Node | null;
   constructor(element: HTMLElement, before?: Node | null | void, after?: Node | null | void): void;
-  withBefore(before: Node | null | void): ElementDOMSlot;
-  withAfter(after: Node | null | void): ElementDOMSlot;
-  withElement(element: HTMLElement): ElementDOMSlot;
+  withBefore(before: Node | null | void): ElementDOMSlot<T>;
+  withAfter(after: Node | null | void): ElementDOMSlot<T>;
+  withElement<ElementType: HTMLElement>(element: ElementType): ElementDOMSlot<ElementType>;
   insertChild(dom: Node): this;
   removeChild(dom: Node): this;
   replaceChild(dom: Node, prevDom: Node): this;

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -84,9 +84,9 @@ export interface ElementNode {
  * A utility class for managing the DOM children of an ElementNode
  */
 export class ElementDOMSlot<T extends HTMLElement = HTMLElement> {
-  element: T;
-  before: Node | null;
-  after: Node | null;
+  readonly element: T;
+  readonly before: Node | null;
+  readonly after: Node | null;
   constructor(
     /** The element returned by createDOM */
     element: T,

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -83,13 +83,13 @@ export interface ElementNode {
 /**
  * A utility class for managing the DOM children of an ElementNode
  */
-export class ElementDOMSlot {
-  element: HTMLElement;
+export class ElementDOMSlot<T extends HTMLElement = HTMLElement> {
+  element: T;
   before: Node | null;
   after: Node | null;
   constructor(
     /** The element returned by createDOM */
-    element: HTMLElement,
+    element: T,
     /** All managed children will be inserted before this node, if defined */
     before?: Node | undefined | null,
     /** All managed children will be inserted after this node, if defined */
@@ -102,19 +102,24 @@ export class ElementDOMSlot {
   /**
    * Return a new ElementDOMSlot where all managed children will be inserted before this node
    */
-  withBefore(before: Node | undefined | null): ElementDOMSlot {
+  withBefore(before: Node | undefined | null): ElementDOMSlot<T> {
     return new ElementDOMSlot(this.element, before, this.after);
   }
   /**
    * Return a new ElementDOMSlot where all managed children will be inserted after this node
    */
-  withAfter(after: Node | undefined | null): ElementDOMSlot {
+  withAfter(after: Node | undefined | null): ElementDOMSlot<T> {
     return new ElementDOMSlot(this.element, this.before, after);
   }
   /**
    * Return a new ElementDOMSlot with an updated root element
    */
-  withElement(element: HTMLElement): ElementDOMSlot {
+  withElement<ElementType extends HTMLElement>(
+    element: ElementType,
+  ): ElementDOMSlot<ElementType> {
+    if (this.element === (element as HTMLElement)) {
+      return this as unknown as ElementDOMSlot<ElementType>;
+    }
     return new ElementDOMSlot(element, this.before, this.after);
   }
   /**
@@ -815,7 +820,7 @@ export class ElementNode extends LexicalNode {
    * or accessory nodes before or after the children. The root of the node returned
    * by createDOM must still be exactly one HTMLElement.
    */
-  getDOMSlot(element: HTMLElement): ElementDOMSlot {
+  getDOMSlot(element: HTMLElement): ElementDOMSlot<HTMLElement> {
     return new ElementDOMSlot(element);
   }
   exportDOM(editor: LexicalEditor): DOMExportOutput {


### PR DESCRIPTION
## Breaking Changes

If you're using the undocumented internal getDOMSlot API, you may need to change your types. There is now a type parameter for ElementDOMSlot so that the element property can be specialized.

## Description

TableNode.updateDOM didn't work correctly when there was a wrapper node involved in certain situations. This unifies the createDOM and updateDOM code paths and refines the types for ElementDOMSlot and its usage in TableNode so that this mistake can't be made again.

## Test plan

### Before

Try toggling striping off in a node loaded with striping on, it won't do anything

[playground repro](https://playground.lexical.dev/#doc=H4sIAAAAAAAAE-2ZwWvCMBTG_5d3DtJWoTPXwc6DHjyIh5i82bAsKa-vOhH_96FVUGHDedhEHhRCaL7k6-_1fZdsAJ3nRBUbRtAboJR4N9raB0cYQU_PJjMFzhNa9imCjl0ICt4SfRgGDaDAR4eRQWcKeN0gaGgMmQWZpgYFS6R2L8wVMH7yy0GZ9dOK12Enga363sG_e_v9MWzmAS2GcHHM3Nj3BaUuuucUEh03sylUjemX1GgcHsszVEBpdXj3E6OHJ5ELCSEhJK4icaMPSqszG1dn8sPjLeRHO5DIhISQEBJXkZAYlhiWlhMSQkJi-JHwSgxLywkJISExLDF8FySk5YSEkPjbGL5xn4tvsSlMvOO6BT0dF-rkmfWumXzj4wI0U4cXZbzbyu2vVM9obRUE03JlluhA5-UoH5dP49FwmJcK2tSR3eleg1n3lT1VQzYoykEB2y-sk6sMux0AAA)

### After

Try toggling striping off in a node loaded with striping on, it should work (same document as above)

[preview repro](https://lexical-playground-git-fork-etrepum-table-u-fd96d2-fbopensource.vercel.app/#doc=H4sIAAAAAAAAE-2ZwWvCMBTG_5d3DtJWoTPXwc6DHjyIh5i82bAsKa-vOhH_96FVUGHDedhEHhRCaL7k6-_1fZdsAJ3nRBUbRtAboJR4N9raB0cYQU_PJjMFzhNa9imCjl0ICt4SfRgGDaDAR4eRQWcKeN0gaGgMmQWZpgYFS6R2L8wVMH7yy0GZ9dOK12Enga363sG_e_v9MWzmAS2GcHHM3Nj3BaUuuucUEh03sylUjemX1GgcHsszVEBpdXj3E6OHJ5ELCSEhJK4icaMPSqszG1dn8sPjLeRHO5DIhISQEBJXkZAYlhiWlhMSQkJi-JHwSgxLywkJISExLDF8FySk5YSEkPjbGL5xn4tvsSlMvOO6BT0dF-rkmfWumXzj4wI0U4cXZbzbyu2vVM9obRUE03JlluhA5-UoH5dP49FwmJcK2tSR3eleg1n3lT1VQzYoykEB2y-sk6sMux0AAA)