### PR TITLE
[lexical-playground] Table actions should clear selection instead of moving it to the beginning

### DIFF
--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -35,12 +35,12 @@ import {
 import {mergeRegister} from '@lexical/utils';
 import {
   $createParagraphNode,
-  $getRoot,
   $getSelection,
   $isElementNode,
   $isParagraphNode,
   $isRangeSelection,
   $isTextNode,
+  $setSelection,
   COMMAND_PRIORITY_CRITICAL,
   getDOMSelection,
   isDOMNode,
@@ -256,9 +256,7 @@ function TableActionMenu({
         tableNode.markDirty();
         updateTableCellNode(tableCellNode.getLatest());
       }
-
-      const rootNode = $getRoot();
-      rootNode.selectStart();
+      $setSelection(null);
     });
   }, [editor, tableCellNode]);
 


### PR DESCRIPTION
## Description

The playground table actions `clearSelection()` sets the selection to the beginning of the document for no good reason, which causes the page to scroll.

Closes #7335

## Test plan

### Before

See #7335

### After

The selection is actually cleared