### PR TITLE
[lexical-playground][lexical-react] Feature: Push Draggable Element to Parent

### DIFF
--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.css
@@ -7,6 +7,8 @@
   left: 0;
   top: 0;
   will-change: transform;
+  display: flex;
+  gap: 2px;
 }
 
 .draggable-block-menu .icon {
@@ -16,11 +18,16 @@
   background-image: url(../../images/icons/draggable-block-menu.svg);
 }
 
+.draggable-block-menu .icon-plus {
+  cursor: pointer;
+  background-image: url(../../images/icons/plus.svg);
+}
+
 .draggable-block-menu:active {
   cursor: grabbing;
 }
 
-.draggable-block-menu:hover {
+.draggable-block-menu .icon:hover {
   background-color: #efefef;
 }
 

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -64,7 +64,7 @@ export default function DraggableBlockPlugin({
         <div ref={targetLineRef} className="draggable-block-target-line" />
       }
       isOnMenu={isOnMenu}
-      onTargetElementChanged={setDraggableElement}
+      onElementChanged={setDraggableElement}
     />
   );
 }

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -44,7 +44,7 @@ export default function DraggableBlockPlugin({
       }
 
       const pNode = $createParagraphNode();
-      if (e.metaKey || e.ctrlKey) {
+      if (e.altKey || e.ctrlKey) {
         node.insertBefore(pNode);
       } else {
         node.insertAfter(pNode);

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -9,8 +9,10 @@ import type {JSX} from 'react';
 
 import './index.css';
 
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {DraggableBlockPlugin_EXPERIMENTAL} from '@lexical/react/LexicalDraggableBlockPlugin';
-import {useRef} from 'react';
+import {$createParagraphNode, $getNearestNodeFromDOMNode} from 'lexical';
+import {useRef, useState} from 'react';
 
 const DRAGGABLE_BLOCK_MENU_CLASSNAME = 'draggable-block-menu';
 
@@ -23,8 +25,29 @@ export default function DraggableBlockPlugin({
 }: {
   anchorElem?: HTMLElement;
 }): JSX.Element {
+  const [editor] = useLexicalComposerContext();
   const menuRef = useRef<HTMLDivElement>(null);
   const targetLineRef = useRef<HTMLDivElement>(null);
+  const [draggableElement, setDraggableElement] = useState<HTMLElement | null>(
+    null,
+  );
+
+  function insertBlockBefore() {
+    if (!draggableElement || !editor) {
+      return;
+    }
+
+    editor.update(() => {
+      const node = $getNearestNodeFromDOMNode(draggableElement);
+      if (!node) {
+        return;
+      }
+
+      const pNode = $createParagraphNode();
+      node.insertBefore(pNode);
+      pNode.select();
+    });
+  }
 
   return (
     <DraggableBlockPlugin_EXPERIMENTAL
@@ -33,6 +56,7 @@ export default function DraggableBlockPlugin({
       targetLineRef={targetLineRef}
       menuComponent={
         <div ref={menuRef} className="icon draggable-block-menu">
+          <div className="icon icon-plus" onClick={insertBlockBefore} />
           <div className="icon" />
         </div>
       }
@@ -40,6 +64,7 @@ export default function DraggableBlockPlugin({
         <div ref={targetLineRef} className="draggable-block-target-line" />
       }
       isOnMenu={isOnMenu}
+      onTargetElementChanged={setDraggableElement}
     />
   );
 }

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -32,7 +32,7 @@ export default function DraggableBlockPlugin({
     null,
   );
 
-  function insertBlockBefore() {
+  function insertBlock(e: React.MouseEvent) {
     if (!draggableElement || !editor) {
       return;
     }
@@ -44,7 +44,11 @@ export default function DraggableBlockPlugin({
       }
 
       const pNode = $createParagraphNode();
-      node.insertBefore(pNode);
+      if (e.metaKey || e.ctrlKey) {
+        node.insertBefore(pNode);
+      } else {
+        node.insertAfter(pNode);
+      }
       pNode.select();
     });
   }
@@ -56,7 +60,7 @@ export default function DraggableBlockPlugin({
       targetLineRef={targetLineRef}
       menuComponent={
         <div ref={menuRef} className="icon draggable-block-menu">
-          <div className="icon icon-plus" onClick={insertBlockBefore} />
+          <div className="icon icon-plus" onClick={insertBlock} />
           <div className="icon" />
         </div>
       }

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -366,7 +366,7 @@ function useFloatingLinkEditorToolbar(
           if ($isRangeSelection(selection)) {
             const node = getSelectedNode(selection);
             const linkNode = $findMatchingParent(node, $isLinkNode);
-            if ($isLinkNode(linkNode) && (payload.metaKey || payload.ctrlKey)) {
+            if ($isLinkNode(linkNode) && (payload.altKey || payload.ctrlKey)) {
               window.open(linkNode.getURL(), '_blank');
               return true;
             }

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -366,7 +366,7 @@ function useFloatingLinkEditorToolbar(
           if ($isRangeSelection(selection)) {
             const node = getSelectedNode(selection);
             const linkNode = $findMatchingParent(node, $isLinkNode);
-            if ($isLinkNode(linkNode) && (payload.altKey || payload.ctrlKey)) {
+            if ($isLinkNode(linkNode) && (payload.metaKey || payload.ctrlKey)) {
               window.open(linkNode.getURL(), '_blank');
               return true;
             }

--- a/packages/lexical-playground/src/ui/ContentEditable.css
+++ b/packages/lexical-playground/src/ui/ContentEditable.css
@@ -12,7 +12,7 @@
   display: block;
   position: relative;
   outline: 0;
-  padding: 8px 28px 40px;
+  padding: 8px 46px 40px;
   min-height: 150px;
 }
 @media (max-width: 1025px) {
@@ -29,7 +29,7 @@
   position: absolute;
   text-overflow: ellipsis;
   top: 8px;
-  left: 28px;
+  left: 46px;
   right: 28px;
   user-select: none;
   white-space: nowrap;

--- a/packages/lexical-react/flow/LexicalDraggableBlockPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalDraggableBlockPlugin.js.flow
@@ -16,6 +16,7 @@ type Props = $ReadOnly<{
   menuComponent: React.Node,
   targetLineComponent: React.Node,
   isOnMenu: (element: HTMLElement) => boolean,
+  onTargetElementChanged?: (targetElement: HTMLElement | null) => void
 }>;
 	
 declare export function DraggableBlockPlugin_EXPERIMENTAL(

--- a/packages/lexical-react/flow/LexicalDraggableBlockPlugin.js.flow
+++ b/packages/lexical-react/flow/LexicalDraggableBlockPlugin.js.flow
@@ -16,7 +16,7 @@ type Props = $ReadOnly<{
   menuComponent: React.Node,
   targetLineComponent: React.Node,
   isOnMenu: (element: HTMLElement) => boolean,
-  onTargetElementChanged?: (targetElement: HTMLElement | null) => void
+  onElementChanged?: (element: HTMLElement | null) => void
 }>;
 	
 declare export function DraggableBlockPlugin_EXPERIMENTAL(

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -24,6 +24,7 @@ import {
 import {
   DragEvent as ReactDragEvent,
   ReactNode,
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -269,12 +270,23 @@ function useDraggableBlockMenu(
   menuComponent: ReactNode,
   targetLineComponent: ReactNode,
   isOnMenu: (element: HTMLElement) => boolean,
+  onElementChanged?: (element: HTMLElement | null) => void,
 ): JSX.Element {
   const scrollerElem = anchorElem.parentElement;
 
   const isDraggingBlockRef = useRef<boolean>(false);
-  const [draggableBlockElem, setDraggableBlockElem] =
+  const [draggableBlockElem, setDraggableBlockElemState] =
     useState<HTMLElement | null>(null);
+
+  const setDraggableBlockElem = useCallback(
+    (elem: HTMLElement | null) => {
+      setDraggableBlockElemState(elem);
+      if (onElementChanged) {
+        onElementChanged(elem);
+      }
+    },
+    [onElementChanged],
+  );
 
   useEffect(() => {
     function onMouseMove(event: MouseEvent) {
@@ -308,7 +320,7 @@ function useDraggableBlockMenu(
         scrollerElem.removeEventListener('mouseleave', onMouseLeave);
       }
     };
-  }, [scrollerElem, anchorElem, editor, isOnMenu]);
+  }, [scrollerElem, anchorElem, editor, isOnMenu, setDraggableBlockElem]);
 
   useEffect(() => {
     if (menuRef.current) {
@@ -401,7 +413,7 @@ function useDraggableBlockMenu(
         COMMAND_PRIORITY_HIGH,
       ),
     );
-  }, [anchorElem, editor, targetLineRef]);
+  }, [anchorElem, editor, targetLineRef, setDraggableBlockElem]);
 
   function onDragStart(event: ReactDragEvent<HTMLDivElement>): void {
     const dataTransfer = event.dataTransfer;
@@ -442,6 +454,7 @@ export function DraggableBlockPlugin_EXPERIMENTAL({
   menuComponent,
   targetLineComponent,
   isOnMenu,
+  onElementChanged,
 }: {
   anchorElem?: HTMLElement;
   menuRef: React.RefObject<HTMLElement>;
@@ -449,6 +462,7 @@ export function DraggableBlockPlugin_EXPERIMENTAL({
   menuComponent: ReactNode;
   targetLineComponent: ReactNode;
   isOnMenu: (element: HTMLElement) => boolean;
+  onElementChanged?: (element: HTMLElement | null) => void;
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();
   return useDraggableBlockMenu(
@@ -460,5 +474,6 @@ export function DraggableBlockPlugin_EXPERIMENTAL({
     menuComponent,
     targetLineComponent,
     isOnMenu,
+    onElementChanged,
   );
 }


### PR DESCRIPTION
## Description
Allows passing a function to receive the DOM element identified by the DraggableBlockPlugin. 

An example application of this is the addition of a "+" button that allows the creation of a block above the identified one. This feature is particularly useful in the playground, as it allows adding a new block at the top of the page without having to drag and drop, for example.

## Test plan

### Before

![image](https://github.com/user-attachments/assets/045ac851-99bf-4ffc-8153-a14c84d7037e)


### After

![image](https://github.com/user-attachments/assets/42fe6f6f-a231-4101-b3d0-b46e3d6a9289)
