### PR TITLE
[lexical-list] Bug Fix: Correct adjacent list merge algorithm

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -41,8 +41,8 @@ import invariant from 'shared/invariant';
 import normalizeClassNames from 'shared/normalizeClassNames';
 
 import {$createListNode, $isListNode} from './';
-import {$handleIndent, $handleOutdent, mergeLists} from './formatList';
-import {isNestedListNode} from './utils';
+import {$handleIndent, $handleOutdent, $mergeLists} from './formatList';
+import {$isNestedListNode} from './utils';
 
 export type SerializedListItemNode = Spread<
   {
@@ -289,10 +289,10 @@ export class ListItemNode extends ElementNode {
     if (
       prevSibling &&
       nextSibling &&
-      isNestedListNode(prevSibling) &&
-      isNestedListNode(nextSibling)
+      $isNestedListNode(prevSibling) &&
+      $isNestedListNode(nextSibling)
     ) {
-      mergeLists(prevSibling.getFirstChild(), nextSibling.getFirstChild());
+      $mergeLists(prevSibling.getFirstChild(), nextSibling.getFirstChild());
       nextSibling.remove();
     }
   }

--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -33,8 +33,8 @@ import normalizeClassNames from 'shared/normalizeClassNames';
 
 import {$createListItemNode, $isListItemNode, ListItemNode} from '.';
 import {
-  mergeNextSiblingListIfSameType,
-  updateChildrenListItemValue,
+  $mergeNextSiblingListIfSameType,
+  $updateChildrenListItemValue,
 } from './formatList';
 import {$getListDepth, $wrapInListItem} from './utils';
 
@@ -132,8 +132,8 @@ export class ListNode extends ElementNode {
   static transform(): (node: LexicalNode) => void {
     return (node: LexicalNode) => {
       invariant($isListNode(node), 'node is not a ListNode');
-      mergeNextSiblingListIfSameType(node);
-      updateChildrenListItemValue(node);
+      $mergeNextSiblingListIfSameType(node);
+      $updateChildrenListItemValue(node);
     };
   }
 

--- a/packages/lexical-list/src/utils.ts
+++ b/packages/lexical-list/src/utils.ts
@@ -134,7 +134,7 @@ const NestedListNodeBrand: unique symbol = Symbol.for(
  * @param node - The node to be checked.
  * @returns true if the node is a ListItemNode and has a ListNode child, false otherwise.
  */
-export function isNestedListNode(
+export function $isNestedListNode(
   node: LexicalNode | null | undefined,
 ): node is Spread<
   {getFirstChild(): ListNode; [NestedListNodeBrand]: never},


### PR DESCRIPTION
## Description

The order of operations in the adjacent list merge algorithm could end up removing content from nested lists that it wasn't supposed to. I didn't end up tracing exactly why (maybe a bug in the reconciler??) but moving the content and then doing recursive merge was the fix. It also now guards against merging recursive lists of different types.

Closes #7333

## Test plan

TODO

### Before

[Repro link](https://playground.lexical.dev/#doc=H4sIAAAAAAAAE-1UTUsDMRD9K-WdQ9nth9X8AM9CvYmH2IzbwGxSkklxKf3vkvWjbj2oRaEHT5l5YV7eYx7ZgayTEJdihKB3iCFIOVdrxzaSh747rbEkxjF0pfAYYmukL9tgCRq-IAyFJB0XAApCTwKNupTdpoA9orClmFzw0PX-XsG6SCvpe5-ZD-yFw3lLXqDrdw52SZxQO-BR2BrO9BPGasB4xFag25fbh8xM0jsz8VWJaaCRGSc-djby1S-t2BKT0EjWLo3Yefr-xsES8ZXDjYmmiWazPrJZyK8POku7fNP2ydsfp3zyn_JzTfkJies_zcEK9wpskizNlix0vZjVV9P5vJpeXswUUshxVeZu2HRNDNnbj9OoxpPFeIL9M7mE7j6dBQAA)

### After

[Preview Link](https://lexical-playground-git-fork-etrepum-list-merge-fix-fbopensource.vercel.app/#doc=H4sIAAAAAAAAE-1UTUsDMRD9K-WdQ9nth9X8AM9CvYmH2IzbwGxSkklxKf3vkvWjbj2oRaEHT5l5YV7eYx7ZgayTEJdihKB3iCFIOVdrxzaSh747rbEkxjF0pfAYYmukL9tgCRq-IAyFJB0XAApCTwKNupTdpoA9orClmFzw0PX-XsG6SCvpe5-ZD-yFw3lLXqDrdw52SZxQO-BR2BrO9BPGasB4xFag25fbh8xM0jsz8VWJaaCRGSc-djby1S-t2BKT0EjWLo3Yefr-xsES8ZXDjYmmiWazPrJZyK8POku7fNP2ydsfp3zyn_JzTfkJies_zcEK9wpskizNlix0vZjVV9P5vJpeXswUUshxVeZu2HRNDNnbj9OoxpPFeIL9M7mE7j6dBQAA)