### PR TITLE
[lexical-utils] Feature: Add type predicate to objectKlassEquals

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -449,9 +449,7 @@ export async function copyToClipboard(
             window.clearTimeout(clipboardEventTimeout);
             clipboardEventTimeout = null;
           }
-          resolve(
-            $copyToClipboardEvent(editor, secondEvent as ClipboardEvent, data),
-          );
+          resolve($copyToClipboardEvent(editor, secondEvent, data));
         }
         // Block the entire copy flow while we wait for the next ClipboardEvent
         return true;

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -56,7 +56,7 @@ function onCopyForPlainText(
     if (event !== null) {
       const clipboardData = objectKlassEquals(event, KeyboardEvent)
         ? null
-        : (event as ClipboardEvent).clipboardData;
+        : event.clipboardData;
       const selection = $getSelection();
 
       if (selection !== null && clipboardData != null) {

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -81,7 +81,9 @@ function onPasteForPlainText(
   editor.update(
     () => {
       const selection = $getSelection();
-      const {clipboardData} = event as ClipboardEvent;
+      const clipboardData = objectKlassEquals(event, ClipboardEvent)
+        ? event.clipboardData
+        : null;
       if (clipboardData != null && $isRangeSelection(selection)) {
         $insertDataTransferForPlainText(clipboardData, selection);
       }

--- a/packages/lexical-react/src/LexicalLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalLinkPlugin.ts
@@ -73,12 +73,10 @@ export function LinkPlugin({validateUrl, attributes}: Props): null {
               ) {
                 return false;
               }
-              const clipboardEvent = event as ClipboardEvent;
-              if (clipboardEvent.clipboardData === null) {
+              if (event.clipboardData === null) {
                 return false;
               }
-              const clipboardText =
-                clipboardEvent.clipboardData.getData('text');
+              const clipboardText = event.clipboardData.getData('text');
               if (!validateUrl(clipboardText)) {
                 return false;
               }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -453,7 +453,7 @@ function onPasteForRichText(
         objectKlassEquals(event, InputEvent) ||
         objectKlassEquals(event, KeyboardEvent)
           ? null
-          : (event as ClipboardEvent).clipboardData;
+          : event.clipboardData;
       if (clipboardData != null && selection !== null) {
         $insertDataTransferForRichText(clipboardData, selection, editor);
       }
@@ -470,7 +470,7 @@ async function onCutForRichText(
 ): Promise<void> {
   await copyToClipboard(
     editor,
-    objectKlassEquals(event, ClipboardEvent) ? (event as ClipboardEvent) : null,
+    objectKlassEquals(event, ClipboardEvent) ? event : null,
   );
   editor.update(() => {
     const selection = $getSelection();
@@ -490,9 +490,9 @@ export function eventFiles(
 ): [boolean, Array<File>, boolean] {
   let dataTransfer: null | DataTransfer = null;
   if (objectKlassEquals(event, DragEvent)) {
-    dataTransfer = (event as DragEvent).dataTransfer;
+    dataTransfer = event.dataTransfer;
   } else if (objectKlassEquals(event, ClipboardEvent)) {
-    dataTransfer = (event as ClipboardEvent).clipboardData;
+    dataTransfer = event.clipboardData;
   }
 
   if (dataTransfer === null) {
@@ -1052,9 +1052,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
       (event) => {
         copyToClipboard(
           editor,
-          objectKlassEquals(event, ClipboardEvent)
-            ? (event as ClipboardEvent)
-            : null,
+          objectKlassEquals(event, ClipboardEvent) ? event : null,
         );
         return true;
       },

--- a/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
+++ b/packages/lexical-table/src/LexicalTableSelectionHelpers.ts
@@ -537,9 +537,7 @@ export function applyTableHandlers(
           // before we delete it
           void copyToClipboard(
             editor,
-            objectKlassEquals(event, ClipboardEvent)
-              ? (event as ClipboardEvent)
-              : null,
+            objectKlassEquals(event, ClipboardEvent) ? event : null,
             $getClipboardDataFromSelection(selection),
           );
           const intercepted = $deleteCellHandler(event);

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -624,7 +624,7 @@ export type ObjectKlass<T> = new (...args: any[]) => T;
 export function objectKlassEquals<T>(
   object: unknown,
   objectClass: ObjectKlass<T>,
-): boolean {
+): object is T {
   return object !== null
     ? Object.getPrototypeOf(object).constructor.name === objectClass.name
     : false;


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

- adds type predicate to `objectKlassEquals`
- removes unnecessary type assertions following `objectKlassEquals` calls

it is backward compatible since the return type is still boolean but just with type predicate.