### PR TITLE
[Breaking Change][lexical] Bug Fix: Fix bug in transformer loop that would cause nodes not to get reconciled

### DIFF
--- a/packages/lexical-list/src/LexicalListNode.ts
+++ b/packages/lexical-list/src/LexicalListNode.ts
@@ -193,31 +193,26 @@ export class ListNode extends ElementNode {
     return false;
   }
 
-  append(...nodesToAppend: LexicalNode[]): this {
-    for (let i = 0; i < nodesToAppend.length; i++) {
-      const currentNode = nodesToAppend[i];
-
-      if ($isListItemNode(currentNode)) {
-        super.append(currentNode);
-      } else {
-        const listItemNode = $createListItemNode();
-
-        if ($isListNode(currentNode)) {
-          listItemNode.append(currentNode);
-        } else if ($isElementNode(currentNode)) {
-          if (currentNode.isInline()) {
-            listItemNode.append(currentNode);
-          } else {
-            const textNode = $createTextNode(currentNode.getTextContent());
-            listItemNode.append(textNode);
-          }
-        } else {
-          listItemNode.append(currentNode);
+  splice(
+    start: number,
+    deleteCount: number,
+    nodesToInsert: LexicalNode[],
+  ): this {
+    let listItemNodesToInsert = nodesToInsert;
+    for (let i = 0; i < nodesToInsert.length; i++) {
+      const node = nodesToInsert[i];
+      if (!$isListItemNode(node)) {
+        if (listItemNodesToInsert === nodesToInsert) {
+          listItemNodesToInsert = [...nodesToInsert];
         }
-        super.append(listItemNode);
+        listItemNodesToInsert[i] = $createListItemNode().append(
+          $isElementNode(node) && !($isListNode(node) || node.isInline())
+            ? $createTextNode(node.getTextContent())
+            : node,
+        );
       }
     }
-    return this;
+    return super.splice(start, deleteCount, listItemNodesToInsert);
   }
 
   extractWithChild(child: LexicalNode): boolean {

--- a/packages/lexical-website/docs/concepts/transforms.md
+++ b/packages/lexical-website/docs/concepts/transforms.md
@@ -44,6 +44,37 @@ editor.registerUpdateListener(() => {
 
 :::
 
+### Dirty Nodes
+
+*Dirty Leaves* (any LexicalNode that is not an ElementNode) and *Dirty Elements*
+are tracked separately to support the transform heuristic.
+
+Internally, there are two states for dirty nodes:
+* Intentionally Dirty nodes (leaves or elements) had `node.getWritable()` or
+  `node.markDirty()` (an alias) called on them. Maintaining the
+  tree-of-doubly-linked-lists structure of a lexical document requires that
+  this Intentionally Dirty state will propagate to immediate siblings and in
+  some cases the parent node.
+* Unintentionally Dirty Element nodes are an ancestor of a
+  dirty node that were not explicitly marked as Intentionally Dirty
+  Only elements can be Unintentionally Dirty, because
+  leaves by definition can not have children.
+
+The reconciler works by starting at the RootNode (which is the ancestor
+of any attached node, and thus always dirty whenever any attached node
+is dirty). Intentionally Dirty nodes have their createDOM and/or updateDOM
+called. Dirty Elements reconcile all of their children. Thus, reconciliation
+stops at the highest node in a subtree that has no dirty nodes (unless it
+is running with a flag to do a full reconciliation which considers all
+nodes as Intentionally Dirty).
+
+:::info
+
+The transform heuristic depends on these internal implementation details to
+find a fixed point where no more transforms are required.
+
+:::
+
 ### Transform heuristic
 
 1. We transform leaves first. If transforms generate additional dirty nodes we repeat `step 1`. The reasoning behind this is that marking a leaf as dirty marks all its parent elements as dirty too.
@@ -57,7 +88,7 @@ Node will be marked as dirty on any (or most) modifications done to it, it's chi
 
 Preconditions are fundamental for transforms to prevent them from running multiple times and ultimately causing an infinite loop.
 
-Transforms are designed to run when nodes have been modified (aka marking nodes dirty). For the most part, transforms only need to run once after the update but the sequential nature of transforms makes it possible to have order bias. Hence, transforms are run over and over until this particular type of Node is no longer marked as dirty by any of the transforms.
+Transforms are designed to run when nodes have been modified (aka Interntionally Dirty). For the most part, transforms only need to run once after the update but the sequential nature of transforms makes it possible to have order bias. Hence, transforms are run over and over until this particular type of Node is no longer marked as intentionally dirty by any of the transforms.
 
 Hence, we have to make sure that the transforms do not mark the node dirty unnecessarily.
 

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -617,7 +617,7 @@ function $reconcileNode(
     return dom;
   }
   // If the node key doesn't point to the same instance in both maps,
-  // it means it were cloned. If they're also dirty, we mark them as mutated.
+  // it was cloned. If it's also dirty, we mark it as mutated.
   if (prevNode !== nextNode && isDirty) {
     setMutatedNode(
       mutatedNodes,

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -308,6 +308,7 @@ function $applyAllTransforms(
     for (const currentUntransformedDirtyElement of untransformedDirtyElements) {
       const nodeKey = currentUntransformedDirtyElement[0];
       const intentionallyMarkedAsDirty = currentUntransformedDirtyElement[1];
+      dirtyElements.set(nodeKey, intentionallyMarkedAsDirty);
       if (nodeKey !== 'root' && !intentionallyMarkedAsDirty) {
         continue;
       }
@@ -320,8 +321,6 @@ function $applyAllTransforms(
       ) {
         $applyTransforms(editor, node, transformsCache);
       }
-
-      dirtyElements.set(nodeKey, intentionallyMarkedAsDirty);
     }
 
     untransformedDirtyLeaves = editor._dirtyLeaves;

--- a/packages/lexical/src/nodes/LexicalRootNode.ts
+++ b/packages/lexical/src/nodes/LexicalRootNode.ts
@@ -82,18 +82,18 @@ export class RootNode extends ElementNode {
   }
 
   // Mutate
-
-  append(...nodesToAppend: LexicalNode[]): this {
-    for (let i = 0; i < nodesToAppend.length; i++) {
-      const node = nodesToAppend[i];
-      if (!$isElementNode(node) && !$isDecoratorNode(node)) {
-        invariant(
-          false,
-          'rootNode.append: Only element or decorator nodes can be appended to the root node',
-        );
-      }
+  splice(
+    start: number,
+    deleteCount: number,
+    nodesToInsert: LexicalNode[],
+  ): this {
+    for (const node of nodesToInsert) {
+      invariant(
+        $isElementNode(node) || $isDecoratorNode(node),
+        'rootNode.splice: Only element or decorator nodes can be inserted to the root node',
+      );
     }
-    return super.append(...nodesToAppend);
+    return super.splice(start, deleteCount, nodesToInsert);
   }
 
   static importJSON(serializedNode: SerializedRootNode): RootNode {


### PR DESCRIPTION
## Breaking Change

This PR moves the incorrectly overridden `append` methods for RootNode and ListNode and moves it to the ElementNode's primitive `splice` method. For RootNode this means that the exception you'd get for appending a leaf node to the root will be thrown in all situations when that node is inserted, rather than just append. For ListNode this means that the automatic ListItemNode wrapping applies in all situations when children are inserted into the node, not just append.

## Description

The `$applyAllTransforms` loop has a fast path to ignore ElementNode that were not intentionally marked as dirty (ancestors of parents).

```ts
      if (nodeKey !== 'root' && !intentionallyMarkedAsDirty) {
        continue;
      }
```

This is a sensible thing to do, but the way it was implemented *discarded* the fact that this node was not intentionally marked as dirty, which is information that the reconciler needs. The reconciler starts a traversal from the root and only reconciles dirty leaves and elements (regardless of whether intentional or not). If this information goes missing, that subtree does not get reconciled, and you can end up with situations where nodes exist in the NodeMap but were not rendered to the DOM if they were moved in a particular way (such as in #7333) *and* a transform exists.

While I was researching this issue I cleaned up the append overrides for RootNode and ListItemNode and added some documentation about how reconciliation and transforms interact.

Closes #7333

## Test plan

See #7333 and added unit test