### PR TITLE
[Breaking Change][lexical][lexical-utils]: Bug Fix: Handle canBeEmpty in $splitNodes

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/HorizontalRule.spec.mjs
@@ -15,6 +15,7 @@ import {
 import {
   assertHTML,
   assertSelection,
+  click,
   copyToClipboard,
   focusEditor,
   html,
@@ -25,6 +26,11 @@ import {
   waitForSelector,
   withExclusiveClipboardAccess,
 } from '../utils/index.mjs';
+
+async function toggleBulletList(page) {
+  await click(page, '.block-controls');
+  await click(page, '.dropdown .icon.bullet-list');
+}
 
 test.describe('HorizontalRule', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
@@ -209,7 +215,7 @@ test.describe('HorizontalRule', () => {
     });
   });
 
-  test('Will add a horizontal rule and split a TextNode across 2 paragraphs if the carat is in the middle of the TextNode, moving selection to the start of the new ParagraphNode.', async ({
+  test('Will add a horizontal rule and split a TextNode across 2 paragraphs if the caret is in the middle of the TextNode, moving selection to the start of the new ParagraphNode.', async ({
     page,
     isPlainText,
   }) => {
@@ -274,6 +280,142 @@ test.describe('HorizontalRule', () => {
       anchorPath: [2, 0, 0],
       focusOffset: 0,
       focusPath: [2, 0, 0],
+    });
+  });
+
+  test('Will add a horizontal rule and split a TextNode across 2 ListItemNode if the caret is in the middle of the TextNode, moving selection to the start of the new ParagraphNode', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    await toggleBulletList(page);
+
+    await page.keyboard.type('Test');
+
+    await assertSelection(page, {
+      anchorOffset: 4,
+      anchorPath: [0, 0, 0, 0],
+      focusOffset: 4,
+      focusPath: [0, 0, 0, 0],
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="1">
+            <span data-lexical-text="true">Test</span>
+          </li>
+        </ul>
+      `,
+    );
+
+    await moveLeft(page, 2);
+
+    await assertSelection(page, {
+      anchorOffset: 2,
+      anchorPath: [0, 0, 0, 0],
+      focusOffset: 2,
+      focusPath: [0, 0, 0, 0],
+    });
+
+    await selectFromInsertDropdown(page, '.horizontal-rule');
+
+    await waitForSelector(page, 'hr');
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="1">
+            <span data-lexical-text="true">Te</span>
+          </li>
+        </ul>
+        <hr
+          class="PlaygroundEditorTheme__hr"
+          contenteditable="false"
+          data-lexical-decorator="true" />
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="1">
+            <span data-lexical-text="true">st</span>
+          </li>
+        </ul>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [2, 0, 0, 0],
+      focusOffset: 0,
+      focusPath: [2, 0, 0, 0],
+    });
+  });
+
+  test('Will add a horizontal rule and split a TextNode across 2 ListItemNode if the caret is in an empty ListItemNode, moving selection to the start of the new ListItemNode (#6849)', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+    await toggleBulletList(page);
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [0, 0],
+      focusOffset: 0,
+      focusPath: [0, 0],
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <br />
+          </li>
+        </ul>
+      `,
+    );
+
+    await selectFromInsertDropdown(page, '.horizontal-rule');
+
+    await waitForSelector(page, 'hr');
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <br />
+          </li>
+        </ul>
+        <hr
+          class="PlaygroundEditorTheme__hr"
+          contenteditable="false"
+          data-lexical-decorator="true" />
+        <ul class="PlaygroundEditorTheme__ul">
+          <li class="PlaygroundEditorTheme__listItem" value="1">
+            <br />
+          </li>
+        </ul>
+      `,
+    );
+
+    await assertSelection(page, {
+      anchorOffset: 0,
+      anchorPath: [2, 0],
+      focusOffset: 0,
+      focusPath: [2, 0],
     });
   });
 

--- a/packages/lexical-utils/flow/LexicalUtils.js.flow
+++ b/packages/lexical-utils/flow/LexicalUtils.js.flow
@@ -15,6 +15,8 @@ import type {
   CaretDirection,
   SiblingCaret,
   RootMode,
+  SplitAtPointCaretNextOptions,
+  PointCaret,
 } from 'lexical';
 declare export function addClassNamesToElement(
   element: HTMLElement,
@@ -102,7 +104,9 @@ declare export function $restoreEditorState(
   editorState: EditorState,
 ): void;
 
+
 declare export function $insertNodeToNearestRoot<T: LexicalNode>(node: T): T;
+declare export function $insertNodeToNearestRootAtCaret<T: LexicalNode>(node: T, caret: PointCaret<CaretDirection>, options?: SplitAtPointCaretNextOptions): T;
 
 declare export function $wrapNodeInElement(
   node: LexicalNode,

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRoot.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRoot.test.tsx
@@ -86,7 +86,7 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
         '<test-decorator></test-decorator>' +
         '<p><br></p>',
       initialHtml: '<p>Hello world</p>',
-      selectionOffset: 12, // Selection on text node after "Hello" world
+      selectionOffset: 'Hello world'.length, // Selection on text node after "Hello" world
       selectionPath: [0, 0],
     },
     {
@@ -96,7 +96,7 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
         '<test-decorator></test-decorator>' +
         '<p><span style="white-space: pre-wrap;">Hello world</span></p>',
       initialHtml: '<p>Hello world</p>',
-      selectionOffset: 0, // Selection on text node after "Hello" world
+      selectionOffset: 0, // Selection on text node before "Hello" world
       selectionPath: [0, 0],
     },
     {
@@ -175,7 +175,7 @@ describe('LexicalUtils#insertNodeToNearestRoot', () => {
         );
         $setSelection(selection);
 
-        $insertNodeToNearestRoot($createTestDecoratorNode());
+        $insertNodeToNearestRoot($createTestDecoratorNode().setIsInline(false));
 
         // Cleaning up list value attributes as it's not really needed in this test
         // and it clutters expected output

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -1227,7 +1227,22 @@ declare export function $getCommonAncestor<
 declare export function $extendCaretToRange<D: CaretDirection>(
   anchor: PointCaret<D>,
 ): CaretRange<D>;
-
+declare export function $getCollapsedCaretRange<D: CaretDirection>(
+  anchor: PointCaret<D>,
+): CaretRange<D>;
 declare export function $isExtendableTextPointCaret<D: CaretDirection>(
   caret: PointCaret<D>
 ): implies caret is TextPointCaret<TextNode, D>;
+
+export interface SplitAtPointCaretNextOptions {
+  $copyElementNode?: (node: ElementNode) => ElementNode;
+  $splitTextPointCaretNext?: (
+    caret: TextPointCaret<TextNode, 'next'>,
+  ) => NodeCaret<'next'>;
+  rootMode?: RootMode;
+  $shouldSplit?: (node: ElementNode, edge: 'first' | 'last') => boolean;
+}
+declare export function $splitAtPointCaretNext(
+  pointCaret: PointCaret<'next'>,
+  options?: SplitAtPointCaretNextOptions,
+): null | NodeCaret<'next'>;

--- a/packages/lexical/src/caret/LexicalCaret.ts
+++ b/packages/lexical/src/caret/LexicalCaret.ts
@@ -1122,6 +1122,15 @@ export function $extendCaretToRange<D extends CaretDirection>(
 }
 
 /**
+ * Construct a collapsed CaretRange that starts and ends at anchor.
+ */
+export function $getCollapsedCaretRange<D extends CaretDirection>(
+  anchor: PointCaret<D>,
+): CaretRange<D> {
+  return $getCaretRange(anchor, anchor);
+}
+
+/**
  * Construct a CaretRange from anchor and focus carets pointing in the
  * same direction. In order to get the expected behavior,
  * the anchor must point towards the focus or be the same point.

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -34,6 +34,7 @@ export {
   $getCaretRange,
   $getChildCaret,
   $getChildCaretOrSelf,
+  $getCollapsedCaretRange,
   $getCommonAncestor,
   $getCommonAncestorResultBranchOrder,
   $getSiblingCaret,
@@ -61,7 +62,9 @@ export {
   $rewindSiblingCaret,
   $setPointFromCaret,
   $setSelectionFromCaretRange,
+  $splitAtPointCaretNext,
   $updateRangeSelectionFromCaretRange,
+  type SplitAtPointCaretNextOptions,
 } from './caret/LexicalCaretUtils';
 export type {PasteCommandType} from './LexicalCommands';
 export {


### PR DESCRIPTION
This is a rebased #7342 to see if Vercel's failure is cache related

## Breaking Change

Previously `$insertNodeToNearestRoot` could create empty ElementNode when splitting the current node, now it respects `canBeEmpty()` and will not split in those cases.

## Description

This change makes `$insertNodeToNearestRoot` to respect the `canBeEmpty()` method of the nodes it is splitting and provides infrastructure to better control splitting (`SplitAtPointCaretNextOptions`, `$insertNodeToNearestRootAtCaret`, `$splitAtPointCaretNext`).

New lexical APIs:
  * `$splitAtPointCaretNext` - a lower-level API to split at the given caret exactly once (not recursive) with full control over how that happens
  * `$getCollapsedCaretRange(pointCaret)` - convenience for `$getCaretRange(pointCaret, pointCaret)` to reduce redundant code

New @lexical/utils API:
  * `$insertNodeToNearestRootAtCaret` - lower-level API that does `$insertNodeToNearestRoot` recursive split and then insert without the quirks and selection changes (those happen in the `$insertNodeToNearestRoot` function).

I'm not very fond of the manner in which nodes are split (the empty splits are a bit awkward especially when not a ParagraphNode), but this doesn't break backwards compatibility in any case that we test and this function is only used in the playground and the implementation of commands that can be easily overridden (e.g. `INSERT_HORIZONTAL_RULE_COMMAND`). Now that the lower-level functions are exposed, people can control how this works for better UX.

Closes #6849

## Test plan

All existing e2e tests pass, new ListNode split test

### Before

Splitting an empty ListItemNode creates a broken list:

```html
<ul class="PlaygroundEditorTheme__ul"></ul>
<hr>
<ul class="PlaygroundEditorTheme__ul">
  <li value="1" class="PlaygroundEditorTheme__listItem"></li>
</ul>
```

### After

Splitting an empty ListItemNode creates a complete second list:

```html
<ul class="PlaygroundEditorTheme__ul">
  <li value="1" class="PlaygroundEditorTheme__listItem"></li>
</ul>
<hr>
<ul class="PlaygroundEditorTheme__ul">
  <li value="1" class="PlaygroundEditorTheme__listItem"></li>
</ul>
```