### PR TITLE
[lexical-website] Docs: Fix broken links to React Rich Collab Example

### DIFF
--- a/examples/react-rich-collab/README.md
+++ b/examples/react-rich-collab/README.md
@@ -4,4 +4,4 @@ Here we have simplest Lexical collaboration mode setup. Use it as a starting poi
 
 **Run it locally:** `npm i && npm run dev:local`
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/facebook/lexical/tree/fix/collab_example/examples/react-rich-collab?file=src/main.ts)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-rich-collab?file=src/main.ts)

--- a/packages/lexical-website/src/components/Gallery/pluginList.tsx
+++ b/packages/lexical-website/src/components/Gallery/pluginList.tsx
@@ -30,7 +30,7 @@ export const plugins = (customFields: {
     description: 'Learn how to create an editor with Real Time Collaboration',
     tags: ['opensource', 'favorite'],
     title: 'Collab RichText',
-    uri: 'https://stackblitz.com/github/facebook/lexical/tree/fix/collab_example/examples/react-rich-collab?ctl=0&file=src%2Fmain.tsx&terminalHeight=0&embed=1',
+    uri: `${customFields.STACKBLITZ_PREFIX}examples/react-rich-collab?ctl=0&file=src%2Fmain.tsx&terminalHeight=0&embed=1`,
   },
   {
     description: 'Learn how to create an editor with Tables',


### PR DESCRIPTION
## Description

Docs had broken links to this example

I had already fixed this in #7294 but that's not ready for merge yet

Closes #7345
