### PR TITLE
[Breaking Change][lexical] Bug Fix: Only select RootNode on removal of last child if there was an existing selection

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1280,7 +1280,11 @@ export class LexicalEditor {
   }
 
   /**
-   * Focuses the editor
+   * Focuses the editor by marking the existing selection as dirty, or by
+   * creating a new selection at `defaultSelection` if one does not already
+   * exist. If you want to force a specific selection, you should call
+   * `root.selectStart()` or `root.selectEnd()` in an update.
+   *
    * @param callbackFn - A function to run after the editor is focused.
    * @param options - A bag of options
    * @param options.defaultSelection - Where to move selection when the editor is

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -148,7 +148,12 @@ export function $removeNode(
   ) {
     $removeNode(parent, restoreSelection);
   }
-  if (restoreSelection && $isRootNode(parent) && parent.isEmpty()) {
+  if (
+    restoreSelection &&
+    selection &&
+    $isRootNode(parent) &&
+    parent.isEmpty()
+  ) {
     parent.selectEnd();
   }
 }

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
@@ -157,7 +157,7 @@ describe('LexicalRootNode tests', () => {
       });
     });
 
-    test('RootNode is selected when its only child removed', async () => {
+    test('RootNode is selected when its selected child is removed', async () => {
       const {editor} = testEnv;
 
       await editor.update(() => {
@@ -184,6 +184,28 @@ describe('LexicalRootNode tests', () => {
 
         expect(selection.anchor.getNode()).toBe(root);
         expect(selection.focus.getNode()).toBe(root);
+      });
+    });
+
+    test('RootNode is not selected when all children are removed with no selection', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        expect($getSelection()).toBe(null);
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
+        expect($getSelection()).toBe(null);
+      });
+
+      await editor.update(() => {
+        expect($getSelection()).toBe(null);
+        $getRoot().clear();
+        expect($getSelection()).toBe(null);
+      });
+
+      await editor.update(() => {
+        expect($getSelection()).toBe(null);
       });
     });
 


### PR DESCRIPTION
## Breaking Change

If you are somehow relying on an editor always creating a `RangeSelection` in an update when the `RootNode's` last child was removed, then you will have to change your code to explicitly set a selection before or after the editor is made empty. The intent of this code was to *move* a selection to the root if all of its children were removed, but a bug in `LexicalNode.remove()` would *always* create that selection when the root became empty during an update. A more likely scenario is that you might be able to remove `setSelection(null)` and/or `$addUpdateTag('skip-dom-selection')` workarounds for this specific issue (leaving them in should not cause any issue).

## Description

Removing the last child of RootNode would always create a RangeSelection, when the intent should be to do so only in cases when there was an existing selection to preserve.

Also updates LexicalEditor.focus documentation for clarity.

Closes #7350

## Test plan

Added a unit test to verify new expectation

### Before

`$getRoot().clear()` would unconditionally create a selection

### After

`$getRoot().clear()` should only create a selection when one previously existed