### PR TITLE
[Breaking Change][lexical-markdown] Feature: Support escaping markdown characters

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -207,6 +207,12 @@ function exportTextFormat(
   // bring the whitespace back. So our returned string looks like this: "   **foo**   "
   const frozenString = textContent.trim();
   let output = frozenString;
+
+  if (!node.hasFormat('code')) {
+    // Escape any markdown characters in the text content
+    output = output.replace(/([*_`~\\])/g, '\\$1');
+  }
+
   // the opening tags to be added to the result
   let openingTags = '';
   // the closing tags to be added to the result

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -297,10 +297,6 @@ function createTextFormatTransformersIndex(
   const openTagsRegExp: string[] = [];
   const escapeRegExp = `(?<![\\\\])`;
 
-  // Sort `textTransformers` so that longer tags come before shorter ones
-  // (prevents `*` from "stealing" text that should match `**`).
-  textTransformers.sort((a, b) => b.tag.length - a.tag.length);
-
   for (const transformer of textTransformers) {
     const {tag} = transformer;
     transformersByTag[tag] = transformer;

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -300,7 +300,6 @@ function createTextFormatTransformersIndex(
   for (const transformer of textTransformers) {
     const {tag} = transformer;
     transformersByTag[tag] = transformer;
-
     const tagRegExp = tag.replace(/(\*|\^|\+)/g, '\\$1');
     openTagsRegExp.push(tagRegExp);
 

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -24,7 +24,6 @@ import {
   $getRoot,
   $getSelection,
   $isParagraphNode,
-  $isTextNode,
   ElementNode,
 } from 'lexical';
 
@@ -247,15 +246,6 @@ function $importBlocks(
     textFormatTransformersIndex,
     textMatchTransformers,
   );
-
-  // Go through every text node in the element node and handle escape characters
-  for (const child of elementNode.getChildren()) {
-    if ($isTextNode(child)) {
-      const textContent = child.getTextContent();
-      const escapedText = textContent.replace(/\\([*_`~])/g, '$1');
-      child.setTextContent(escapedText);
-    }
-  }
 
   // If no transformer found and we left with original paragraph node
   // can check if its content can be appended to the previous node

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -583,6 +583,10 @@ describe('Markdown', () => {
       html: '<p><b><strong style="white-space: pre-wrap;">Backtick and asteriks: `**`.</strong></b></p>',
       md: '**Backtick and asteriks: \\`\\*\\*\\`.**',
     },
+    {
+      html: '<p><b><strong style="white-space: pre-wrap;">*test*</strong></b></p>',
+      md: '**\\*test\\***',
+    },
   ];
 
   const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -605,6 +605,10 @@ describe('Markdown', () => {
       html: '<p><a href="https://lexical.dev"><span style="white-space: pre-wrap;">text </span><b><strong style="white-space: pre-wrap;">bold</strong></b><span style="white-space: pre-wrap;"> *normal*</span></a></p>',
       md: '[text **bold** \\*normal\\*](https://lexical.dev)',
     },
+    {
+      html: '<p><span style="white-space: pre-wrap;">*Hello* world</span></p>',
+      md: '\\*Hello\\* world',
+    },
   ];
 
   const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -492,7 +492,7 @@ describe('Markdown', () => {
     {
       // Export only: import will use $...$ to transform <span /> to <mark /> due to HIGHLIGHT_TEXT_MATCH_IMPORT
       html: "<p><span style='white-space: pre-wrap;'>$$H$&e$`l$'l$o$</span></p>",
-      md: "$$H$&e$`l$'l$o$",
+      md: "$$H$&e$\\`l$'l$o$",
       skipImport: true,
     },
     {
@@ -570,6 +570,18 @@ describe('Markdown', () => {
     {
       html: '<p><b><code spellcheck="false" style="white-space: pre-wrap;"><strong>Bold Code</strong></code></b></p>',
       md: '**`Bold Code`**',
+    },
+    {
+      html: '<p><span style="white-space: pre-wrap;">This is an asterisk: *</span></p>',
+      md: 'This is an asterisk: \\*',
+    },
+    {
+      html: '<p><span style="white-space: pre-wrap;">Backtick and asteriks: `**`.</span></p>',
+      md: 'Backtick and asteriks: \\`\\*\\*\\`.',
+    },
+    {
+      html: '<p><b><strong style="white-space: pre-wrap;">Backtick and asteriks: `**`.</strong></b></p>',
+      md: '**Backtick and asteriks: \\`\\*\\*\\`.**',
     },
   ];
 

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -576,12 +576,12 @@ describe('Markdown', () => {
       md: 'This is an asterisk: \\*',
     },
     {
-      html: '<p><span style="white-space: pre-wrap;">Backtick and asteriks: `**`.</span></p>',
-      md: 'Backtick and asteriks: \\`\\*\\*\\`.',
+      html: '<p><span style="white-space: pre-wrap;">Backtick and asteriks: `**`</span></p>',
+      md: 'Backtick and asteriks: \\`\\*\\*\\`',
     },
     {
-      html: '<p><b><strong style="white-space: pre-wrap;">Backtick and asteriks: `**`.</strong></b></p>',
-      md: '**Backtick and asteriks: \\`\\*\\*\\`.**',
+      html: '<p><b><strong style="white-space: pre-wrap;">Backtick and asteriks: `**`</strong></b></p>',
+      md: '**Backtick and asteriks: \\`\\*\\*\\`**',
     },
     {
       html: '<p><b><strong style="white-space: pre-wrap;">*test*</strong></b></p>',

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -587,6 +587,20 @@ describe('Markdown', () => {
       html: '<p><b><strong style="white-space: pre-wrap;">*test*</strong></b></p>',
       md: '**\\*test\\***',
     },
+    {
+      html: '<p><b><strong style="white-space: pre-wrap;">some bold text with an escaped star: *</strong></b><span style="white-space: pre-wrap;"> normal text</span></p>',
+      md: '**some bold text with an escaped star: \\*** normal text',
+    },
+    {
+      html: '<p><span style="white-space: pre-wrap;">*This text should </span><b><strong style="white-space: pre-wrap;">not</strong></b><span style="white-space: pre-wrap;"> be italic*</span></p>',
+      md: '\\*This text should **not** be italic*',
+      mdAfterExport: '\\*This text should **not** be italic\\*',
+    },
+    {
+      html: '<p><span style="white-space: pre-wrap;">*some text*</span></p>',
+      md: '\\*some text*',
+      mdAfterExport: '\\*some text\\*',
+    },
   ];
 
   const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -601,6 +601,10 @@ describe('Markdown', () => {
       md: '\\*some text*',
       mdAfterExport: '\\*some text\\*',
     },
+    {
+      html: '<p><a href="https://lexical.dev"><span style="white-space: pre-wrap;">text </span><b><strong style="white-space: pre-wrap;">bold</strong></b><span style="white-space: pre-wrap;"> *normal*</span></a></p>',
+      md: '[text **bold** \\*normal\\*](https://lexical.dev)',
+    },
   ];
 
   const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {

--- a/packages/lexical-markdown/src/importTextTransformers.ts
+++ b/packages/lexical-markdown/src/importTextTransformers.ts
@@ -96,7 +96,6 @@ export function importTextTransformers(
         textMatchTransformers,
       );
     }
-    return;
   } else if (foundTextMatch) {
     const result = importFoundTextMatchTransformer(
       textNode,
@@ -130,9 +129,10 @@ export function importTextTransformers(
         textMatchTransformers,
       );
     }
-    return;
-  } else {
-    // Done!
-    return;
   }
+
+  // Handle escape characters
+  const textContent = textNode.getTextContent();
+  const escapedText = textContent.replace(/\\([*_`~])/g, '$1');
+  textNode.setTextContent(escapedText);
 }

--- a/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Hashtags.spec.mjs
@@ -471,7 +471,10 @@ test.describe('Hashtags', () => {
 
   test('Should not break while importing and exporting multiple matches', async ({
     page,
+    isPlainText,
   }) => {
+    test.skip(isPlainText);
+
     await focusEditor(page);
     await page.keyboard.type('```markdown #hello#invalid #a #b');
 


### PR DESCRIPTION
Fixes https://github.com/facebook/lexical/issues/2715

This PR adds full support for escaping markdown characters during import and export. For example, `\*` now correctly becomes a literal `*` in the editor, and when exporting back to markdown, those special characters are automatically escaped (e.g. `*` becomes `\*`), preventing accidental formatting on re-import.

Safari [now has much better support for negative lookbehind regex](https://caniuse.com/?search=Negative%20Lookbehind), which is why I removed the conditions specific to it.

## Breaking Changes

### Markdown Imports

Previously, any escaped characters (e.g. `\*`) were imported as literal `\*`. Now the backslash is stripped, and the escaped character (`*`) is imported instead.

### Markdown Exports

Previously, all markdown characters that were part of a text node (e.g. `**`) were exported unescaped. Now they are exported escaped (e.g. `\*\*`), preventing unwanted formatting if the text is re-imported.

### Example:

- **Old Behavior**
	- Text node: `Some **text**`
	- Exported to Markdown as: `Some **text**` (bold if re-imported)
	- Text node If re-imported: Some **text**
- **New Behavior**
	- Text node: `Some **text**`
	- Exported to Markdown as: `Some \*\*text\*\*` (literal asterisks if re-imported)
	- Text node If re-imported: `Some **text**`