### PR TITLE
[lexical] Bug Fix: Ignore input event from inside decorators

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -895,6 +895,13 @@ function onInput(event: InputEvent, editor: LexicalEditor): void {
   updateEditorSync(
     editor,
     () => {
+      if (
+        isHTMLElement(event.target) &&
+        $isSelectionCapturedInDecorator(event.target)
+      ) {
+        return;
+      }
+
       const selection = $getSelection();
       const data = event.data;
       const targetRange = getTargetRange(event);


### PR DESCRIPTION
## Description

The input event can be fired from inside decorators in Firefox and this results in mutating the decorator *and* the editor when there is a lexical selection

Closes #7296
Closes #7071

## Test plan

TODO

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*