### PR TITLE
[Breaking Change][lexical-react] Refactor: LexicalNestedComposer add skipEditableListener prop and deprecate initialNodes prop and implicit namespace setting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,6 +25,8 @@ const moduleNameMapper = {
     ),
   ),
   '^shared/invariant$': '<rootDir>/packages/shared/src/__mocks__/invariant.ts',
+  '^shared/warnOnlyOnce$':
+    '<rootDir>/packages/shared/src/__mocks__/warnOnlyOnce.ts',
 };
 
 module.exports = {

--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -16,8 +16,6 @@ import type {JSX} from 'react';
 
 import './ImageNode.css';
 
-import {HashtagNode} from '@lexical/hashtag';
-import {LinkNode} from '@lexical/link';
 import {AutoFocusPlugin} from '@lexical/react/LexicalAutoFocusPlugin';
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 import {CollaborationPlugin} from '@lexical/react/LexicalCollaborationPlugin';
@@ -42,11 +40,7 @@ import {
   DRAGSTART_COMMAND,
   KEY_ENTER_COMMAND,
   KEY_ESCAPE_COMMAND,
-  LineBreakNode,
-  ParagraphNode,
-  RootNode,
   SELECTION_CHANGE_COMMAND,
-  TextNode,
 } from 'lexical';
 import * as React from 'react';
 import {Suspense, useCallback, useEffect, useRef, useState} from 'react';
@@ -62,9 +56,7 @@ import MentionsPlugin from '../plugins/MentionsPlugin';
 import TreeViewPlugin from '../plugins/TreeViewPlugin';
 import ContentEditable from '../ui/ContentEditable';
 import ImageResizer from '../ui/ImageResizer';
-import {EmojiNode} from './EmojiNode';
 import {$isImageNode} from './ImageNode';
-import {KeywordNode} from './KeywordNode';
 
 const imageCache = new Set();
 
@@ -397,18 +389,7 @@ export default function ImageComponent({
 
         {showCaption && (
           <div className="image-caption-container">
-            <LexicalNestedComposer
-              initialEditor={caption}
-              initialNodes={[
-                RootNode,
-                TextNode,
-                LineBreakNode,
-                ParagraphNode,
-                LinkNode,
-                EmojiNode,
-                HashtagNode,
-                KeywordNode,
-              ]}>
+            <LexicalNestedComposer initialEditor={caption}>
               <AutoFocusPlugin />
               <MentionsPlugin />
               <LinkPlugin />

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -21,8 +21,21 @@ import type {
 } from 'lexical';
 import type {JSX} from 'react';
 
-import {$applyNodeReplacement, createEditor, DecoratorNode} from 'lexical';
+import {HashtagNode} from '@lexical/hashtag';
+import {LinkNode} from '@lexical/link';
+import {
+  $applyNodeReplacement,
+  createEditor,
+  DecoratorNode,
+  LineBreakNode,
+  ParagraphNode,
+  RootNode,
+  TextNode,
+} from 'lexical';
 import * as React from 'react';
+
+import {EmojiNode} from './EmojiNode';
+import {KeywordNode} from './KeywordNode';
 
 const ImageComponent = React.lazy(() => import('./ImageComponent'));
 
@@ -162,7 +175,16 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     this.__caption =
       caption ||
       createEditor({
-        nodes: [],
+        nodes: [
+          RootNode,
+          TextNode,
+          LineBreakNode,
+          ParagraphNode,
+          LinkNode,
+          EmojiNode,
+          HashtagNode,
+          KeywordNode,
+        ],
       });
     this.__captionsEnabled = captionsEnabled || captionsEnabled === undefined;
   }

--- a/packages/lexical-playground/src/nodes/ImageNode.tsx
+++ b/packages/lexical-playground/src/nodes/ImageNode.tsx
@@ -175,6 +175,7 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     this.__caption =
       caption ||
       createEditor({
+        namespace: 'Playground/ImageNodeCaption',
         nodes: [
           RootNode,
           TextNode,

--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -6,17 +6,21 @@
  *
  */
 
-import type {Props as ElementProps} from './shared/LexicalContentEditableElement';
 import type {LexicalEditor} from 'lexical';
 import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {forwardRef, Ref, useLayoutEffect, useState} from 'react';
 
-import {ContentEditableElement} from './shared/LexicalContentEditableElement';
+import {
+  ContentEditableElement,
+  type ContentEditableElementProps,
+} from './shared/LexicalContentEditableElement';
 import {useCanShowPlaceholder} from './shared/useCanShowPlaceholder';
 
-export type ContentEditableProps = Omit<ElementProps, 'editor'> &
+export {ContentEditableElement, type ContentEditableElementProps};
+
+export type ContentEditableProps = Omit<ContentEditableElementProps, 'editor'> &
   (
     | {
         'aria-placeholder'?: void;

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -51,6 +51,12 @@ export interface LexicalNestedComposerProps {
   initialTheme?: EditorThemeClasses;
   /**
    * @deprecated This feature is not safe or correctly implemented and will be removed in v0.30.0. The only correct time to configure the nodes is when creating the initialEditor.
+   *
+   * @example
+   * ```ts
+   * // This is normally in the implementation of a LexicalNode that owns the nested editor
+   * editor = createEditor({nodes: [], parentEditor: $getEditor()});
+   * ```
    */
   initialNodes?: ReadonlyArray<Klass<LexicalNode> | LexicalNodeReplacement>;
   /**
@@ -60,7 +66,7 @@ export interface LexicalNestedComposerProps {
 }
 
 const initialNodesWarning = warnOnlyOnce(
-  `LexicalNestedComposer initialNodes is deprecated and will be removed in v0.30.0. It does not work correctly. You should configure your editor's nodes with createEditor({nodes})`,
+  `LexicalNestedComposer initialNodes is deprecated and will be removed in v0.30.0. It does not work correctly. You should configure your editor's nodes with createEditor({nodes, parentEditor: $getEditor()})`,
 );
 
 export function LexicalNestedComposer({

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -129,6 +129,7 @@ export function LexicalNestedComposer({
             parentEditor._nodes,
           ));
           if (!explicitNamespace) {
+            // This is the only safe situation to inherit the parent's namespace
             initialEditor._config.namespace = parentEditor._config.namespace;
           }
           for (const [type, entry] of parentNodes) {
@@ -142,6 +143,7 @@ export function LexicalNestedComposer({
           }
         } else if (!explicitNamespace) {
           explicitNamespaceWarning();
+          initialEditor._config.namespace = parentEditor._config.namespace;
         }
       } else {
         initialNodesWarning();

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -42,7 +42,7 @@ export interface LexicalNestedComposerProps {
    * operation of those nodes) from the parent editor. If you are using nodes
    * that require plug-ins they must also be instantiated here.
    */
-  children: ReactNode;
+  children?: ReactNode;
   /**
    * The nested editor, created outside of this component (typically in the
    * implementation of a LexicalNode) with {@link createEditor}

--- a/packages/lexical-react/src/LexicalNestedComposer.tsx
+++ b/packages/lexical-react/src/LexicalNestedComposer.tsx
@@ -7,7 +7,7 @@
  */
 
 import type {LexicalComposerContextType} from '@lexical/react/LexicalComposerContext';
-import type {KlassConstructor, Transform} from 'lexical';
+import type {EditableListener, KlassConstructor, Transform} from 'lexical';
 import type {JSX} from 'react';
 
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
@@ -31,18 +31,21 @@ function getTransformSetFromKlass(
   klass: KlassConstructor<typeof LexicalNode>,
 ): Set<Transform<LexicalNode>> {
   const transform = klass.transform();
-  return transform !== null
-    ? new Set<Transform<LexicalNode>>([transform])
-    : new Set<Transform<LexicalNode>>();
+  return new Set(transform ? [transform] : []);
 }
 
 export interface LexicalNestedComposerProps {
   /**
-   * Any children (e.g. plug-ins) for this editor
+   * Any children (e.g. plug-ins) for this editor. Note that the nested editor
+   * does not inherit any plug-ins or registrations from those plug-ins (such
+   * as transforms and command listeners that may be necessary for correct
+   * operation of those nodes) from the parent editor. If you are using nodes
+   * that require plug-ins they must also be instantiated here.
    */
   children: ReactNode;
   /**
-   * The nested editor, created outside of this component with {@link createEditor}
+   * The nested editor, created outside of this component (typically in the
+   * implementation of a LexicalNode) with {@link createEditor}
    */
   initialEditor: LexicalEditor;
   /**
@@ -50,23 +53,39 @@ export interface LexicalNestedComposerProps {
    */
   initialTheme?: EditorThemeClasses;
   /**
-   * @deprecated This feature is not safe or correctly implemented and will be removed in v0.30.0. The only correct time to configure the nodes is when creating the initialEditor.
+   * @deprecated This feature is not safe or correctly implemented and will be
+   * removed in v0.32.0. The only correct time to configure the nodes is when
+   * creating the initialEditor.
    *
    * @example
    * ```ts
-   * // This is normally in the implementation of a LexicalNode that owns the nested editor
+   * // This is normally in the implementation of a LexicalNode that
+   * // owns the nested editor
    * editor = createEditor({nodes: [], parentEditor: $getEditor()});
    * ```
    */
   initialNodes?: ReadonlyArray<Klass<LexicalNode> | LexicalNodeReplacement>;
   /**
-   * If this is not explicitly set to true, and the collab plugin is active, rendering the children of this component will not happen until collab is ready.
+   * If this is not explicitly set to true, and the collab plugin is active,
+   * rendering the children of this component will not happen until collab is ready.
    */
-  skipCollabChecks?: true;
+  skipCollabChecks?: undefined | true;
+  /**
+   * If this is not explicitly set to true, the editable state of the nested
+   * editor will automatically follow the parent editor's editable state.
+   * When set to true, the nested editor is responsible for managing its own
+   * editable state.
+   *
+   * Available since v0.29.0
+   */
+  skipEditableListener?: undefined | true;
 }
 
 const initialNodesWarning = warnOnlyOnce(
-  `LexicalNestedComposer initialNodes is deprecated and will be removed in v0.30.0. It does not work correctly. You should configure your editor's nodes with createEditor({nodes, parentEditor: $getEditor()})`,
+  `LexicalNestedComposer initialNodes is deprecated and will be removed in v0.32.0, it has never worked correctly.\nYou can configure your editor's nodes with createEditor({nodes: [], parentEditor: $getEditor()})`,
+);
+const explicitNamespaceWarning = warnOnlyOnce(
+  `LexicalNestedComposer initialEditor should explicitly initialize its namespace when the node configuration differs from the parentEditor. For backwards compatibility, the namespace will be initialized from parentEditor until v0.32.0, but this has always had incorrect copy/paste behavior when the configuration differed.\nYou can configure your editor's namespace with createEditor({namespace: 'nested-editor-namespace', nodes: [], parentEditor: $getEditor()}).`,
 );
 
 export function LexicalNestedComposer({
@@ -75,6 +94,7 @@ export function LexicalNestedComposer({
   initialNodes,
   initialTheme,
   skipCollabChecks,
+  skipEditableListener,
 }: LexicalNestedComposerProps): JSX.Element {
   const wasCollabPreviouslyReadyRef = useRef(false);
   const parentContext = useContext(LexicalComposerContext);
@@ -99,23 +119,36 @@ export function LexicalNestedComposer({
         initialEditor._config.theme = composerTheme;
       }
 
-      initialEditor._parentEditor = parentEditor;
+      initialEditor._parentEditor = initialEditor._parentEditor || parentEditor;
+      const createEditorArgs = initialEditor._createEditorArgs;
+      const explicitNamespace = createEditorArgs && createEditorArgs.namespace;
 
       if (!initialNodes) {
-        const parentNodes = (initialEditor._nodes = new Map(
-          parentEditor._nodes,
-        ));
-        for (const [type, entry] of parentNodes) {
-          initialEditor._nodes.set(type, {
-            exportDOM: entry.exportDOM,
-            klass: entry.klass,
-            replace: entry.replace,
-            replaceWithKlass: entry.replaceWithKlass,
-            transforms: getTransformSetFromKlass(entry.klass),
-          });
+        if (!(createEditorArgs && createEditorArgs.nodes)) {
+          const parentNodes = (initialEditor._nodes = new Map(
+            parentEditor._nodes,
+          ));
+          if (!explicitNamespace) {
+            initialEditor._config.namespace = parentEditor._config.namespace;
+          }
+          for (const [type, entry] of parentNodes) {
+            initialEditor._nodes.set(type, {
+              exportDOM: entry.exportDOM,
+              klass: entry.klass,
+              replace: entry.replace,
+              replaceWithKlass: entry.replaceWithKlass,
+              transforms: getTransformSetFromKlass(entry.klass),
+            });
+          }
+        } else if (!explicitNamespace) {
+          explicitNamespaceWarning();
         }
       } else {
         initialNodesWarning();
+        if (!explicitNamespace) {
+          explicitNamespaceWarning();
+          initialEditor._config.namespace = parentEditor._config.namespace;
+        }
         for (let klass of initialNodes) {
           let replace = null;
           let replaceWithKlass = null;
@@ -137,10 +170,6 @@ export function LexicalNestedComposer({
           });
         }
       }
-
-      initialEditor._config.namespace = parentEditor._config.namespace;
-
-      initialEditor._editable = parentEditor._editable;
 
       return [initialEditor, context];
     },
@@ -166,10 +195,13 @@ export function LexicalNestedComposer({
 
   // Update `isEditable` state of nested editor in response to the same change on parent editor.
   useEffect(() => {
-    return parentEditor.registerEditableListener((editable) => {
-      initialEditor.setEditable(editable);
-    });
-  }, [initialEditor, parentEditor]);
+    if (!skipEditableListener) {
+      const editableListener: EditableListener = (editable) =>
+        initialEditor.setEditable(editable);
+      editableListener(parentEditor.isEditable());
+      return parentEditor.registerEditableListener(editableListener);
+    }
+  }, [initialEditor, parentEditor, skipEditableListener]);
 
   return (
     <LexicalComposerContext.Provider value={composerContext}>

--- a/packages/lexical-react/src/__tests__/unit/LexicalCollaborationPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalCollaborationPlugin.test.tsx
@@ -6,16 +6,15 @@
  *
  */
 
+import {CollaborationPlugin} from '@lexical/react/LexicalCollaborationPlugin';
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
+import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
 import * as React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
 import * as Y from 'yjs';
-
-import {CollaborationPlugin} from '../../LexicalCollaborationPlugin';
-import {LexicalComposer} from '../../LexicalComposer';
-import {ContentEditable} from '../../LexicalContentEditable';
-import {LexicalErrorBoundary} from '../../LexicalErrorBoundary';
-import {RichTextPlugin} from '../../LexicalRichTextPlugin';
 
 describe(`LexicalCollaborationPlugin`, () => {
   let container: HTMLDivElement;

--- a/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   $createParagraphNode,
@@ -16,8 +17,6 @@ import {
 import * as React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
-
-import {LexicalComposer} from '../../LexicalComposer';
 
 describe('LexicalComposer tests', () => {
   let container: HTMLDivElement | null = null;

--- a/packages/lexical-react/src/__tests__/unit/LexicalContentEditableElement.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalContentEditableElement.test.tsx
@@ -6,11 +6,10 @@
  *
  */
 
+import {ContentEditableElement} from '@lexical/react/LexicalContentEditable';
 import {createEditor, LexicalEditor} from 'lexical';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
-
-import {ContentEditableElement} from '../../shared/LexicalContentEditableElement';
 
 describe('ContentEditableElement tests', () => {
   let container: HTMLDivElement | null = null;

--- a/packages/lexical-react/src/__tests__/unit/LexicalNestedComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalNestedComposer.test.tsx
@@ -1,0 +1,767 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
+import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
+import {LexicalNestedComposer} from '@lexical/react/LexicalNestedComposer';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {
+  $applyNodeReplacement,
+  $createParagraphNode,
+  $createTextNode,
+  $getEditor,
+  $getRoot,
+  createEditor,
+  DecoratorNode,
+  EditorConfig,
+  LexicalEditor,
+  SerializedLexicalNode,
+} from 'lexical';
+import {
+  expectHtmlToBeEqual,
+  html,
+  invariant,
+} from 'lexical/src/__tests__/utils';
+import * as React from 'react';
+import {createRoot, Root} from 'react-dom/client';
+import * as ReactTestUtils from 'shared/react-test-utils';
+
+class ReactDecoratorNode extends DecoratorNode<React.ReactNode> {
+  __decorate?: (node: this) => React.ReactNode;
+  __inline?: boolean;
+  static getType() {
+    return 'react-decorator';
+  }
+  static clone(node: ReactDecoratorNode): ReactDecoratorNode {
+    return new ReactDecoratorNode(node.__key);
+  }
+  static importJSON(json: SerializedLexicalNode): ReactDecoratorNode {
+    throw new Error('not implemented');
+  }
+  createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
+    return (editor._window || window).document.createElement(
+      this.__inline ? 'span' : 'div',
+    );
+  }
+  updateDOM(prevNode: this, _dom: HTMLElement, _config: EditorConfig): boolean {
+    return !!prevNode.__inline !== this.__inline;
+  }
+  afterCloneFrom(prevNode: this): void {
+    super.afterCloneFrom(prevNode);
+    this.__decorate = prevNode.__decorate;
+  }
+  setDecorate(decorate: (typeof this)['__decorate']): this {
+    const self = this.getWritable();
+    self.__decorate = decorate;
+    return self;
+  }
+  setInline(inline: boolean): this {
+    const self = this.getWritable();
+    self.__inline = inline;
+    return self;
+  }
+  isInline(): boolean {
+    return !!this.__inline;
+  }
+  decorate() {
+    return this.__decorate ? this.__decorate(this) : null;
+  }
+}
+function $createReactDecoratorNode() {
+  return $applyNodeReplacement(new ReactDecoratorNode());
+}
+
+describe('LexicalNestedComposer', () => {
+  let container: HTMLDivElement | null = null;
+  let reactRoot: Root;
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    container = document.createElement('div');
+    reactRoot = createRoot(container);
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container!);
+    container = null;
+    warn.mockReset();
+
+    jest.restoreAllMocks();
+  });
+
+  test('with inherited configuration and namespace', async () => {
+    let editor: undefined | LexicalEditor;
+    let nestedEditor: undefined | LexicalEditor;
+    function App() {
+      return (
+        <LexicalComposer
+          initialConfig={{
+            editorState: () => {
+              editor = $getEditor();
+              nestedEditor = createEditor();
+              nestedEditor.update(() =>
+                $getRoot()
+                  .clear()
+                  .append(
+                    $createParagraphNode().append($createTextNode('nested')),
+                  ),
+              );
+              $getRoot()
+                .clear()
+                .append(
+                  $createParagraphNode().append($createTextNode('parent')),
+                  $createReactDecoratorNode()
+                    .setInline(false)
+                    .setDecorate(() => {
+                      return nestedEditor ? (
+                        <LexicalNestedComposer initialEditor={nestedEditor}>
+                          <RichTextPlugin
+                            contentEditable={<ContentEditable />}
+                            placeholder={<></>}
+                            ErrorBoundary={LexicalErrorBoundary}
+                          />
+                        </LexicalNestedComposer>
+                      ) : null;
+                    }),
+                );
+            },
+            namespace: 'parent',
+            nodes: [ReactDecoratorNode],
+            onError: () => {
+              throw Error();
+            },
+          }}>
+          <RichTextPlugin
+            contentEditable={<ContentEditable />}
+            placeholder={<></>}
+            ErrorBoundary={LexicalErrorBoundary}
+          />
+        </LexicalComposer>
+      );
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(<App />);
+    });
+    invariant(editor !== undefined, 'editor defined');
+    invariant(nestedEditor !== undefined, 'nestedEditor defined');
+    // namespace inherited
+    expect(editor._config.namespace).toBe('parent');
+    expect(nestedEditor._config.namespace).toBe('parent');
+    // nodes inherited
+    expect([...nestedEditor._nodes.keys()]).toEqual([...editor._nodes.keys()]);
+    expect(warn.mock.calls).toEqual([]);
+    expectHtmlToBeEqual(
+      container?.innerHTML || '',
+      html`
+        <div
+          contenteditable="true"
+          role="textbox"
+          spellcheck="true"
+          style="user-select: text; white-space: pre-wrap; word-break: break-word"
+          data-lexical-editor="true">
+          <p dir="ltr"><span data-lexical-text="true">parent</span></p>
+          <div data-lexical-decorator="true">
+            <div
+              contenteditable="true"
+              role="textbox"
+              spellcheck="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word"
+              data-lexical-editor="true">
+              <p dir="ltr"><span data-lexical-text="true">nested</span></p>
+            </div>
+          </div>
+        </div>
+      `,
+    );
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(null);
+    });
+  });
+
+  test('with deprecated initialNodes configuration and inherited namespace', async () => {
+    let editor: undefined | LexicalEditor;
+    let nestedEditor: undefined | LexicalEditor;
+    function App() {
+      return (
+        <LexicalComposer
+          initialConfig={{
+            editorState: () => {
+              editor = $getEditor();
+              nestedEditor = createEditor();
+              nestedEditor.update(() =>
+                $getRoot()
+                  .clear()
+                  .append(
+                    $createParagraphNode().append($createTextNode('nested')),
+                  ),
+              );
+              $getRoot()
+                .clear()
+                .append(
+                  $createParagraphNode().append($createTextNode('parent')),
+                  $createReactDecoratorNode()
+                    .setInline(false)
+                    .setDecorate(() => {
+                      return nestedEditor ? (
+                        <LexicalNestedComposer
+                          initialEditor={nestedEditor}
+                          initialNodes={[]}>
+                          <RichTextPlugin
+                            contentEditable={<ContentEditable />}
+                            placeholder={<></>}
+                            ErrorBoundary={LexicalErrorBoundary}
+                          />
+                        </LexicalNestedComposer>
+                      ) : null;
+                    }),
+                );
+            },
+            namespace: 'parent',
+            nodes: [ReactDecoratorNode],
+            onError: () => {
+              throw Error();
+            },
+          }}>
+          <RichTextPlugin
+            contentEditable={<ContentEditable />}
+            placeholder={<></>}
+            ErrorBoundary={LexicalErrorBoundary}
+          />
+        </LexicalComposer>
+      );
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(<App />);
+    });
+    invariant(editor !== undefined, 'editor defined');
+    invariant(nestedEditor !== undefined, 'nestedEditor defined');
+    // namespace inherited
+    expect(editor._config.namespace).toBe('parent');
+    expect(nestedEditor._config.namespace).toBe('parent');
+    // nodes inherited
+    expect([...nestedEditor._nodes.keys()]).toEqual([...editor._nodes.keys()]);
+    expect(warn.mock.calls).toEqual([
+      [
+        `LexicalNestedComposer initialNodes is deprecated and will be removed in v0.32.0, it has never worked correctly.\nYou can configure your editor's nodes with createEditor({nodes: [], parentEditor: $getEditor()})`,
+      ],
+      [
+        `LexicalNestedComposer initialEditor should explicitly initialize its namespace when the node configuration differs from the parentEditor. For backwards compatibility, the namespace will be initialized from parentEditor until v0.32.0, but this has always had incorrect copy/paste behavior when the configuration differed.\nYou can configure your editor's namespace with createEditor({namespace: 'nested-editor-namespace', nodes: [], parentEditor: $getEditor()}).`,
+      ],
+    ]);
+    expectHtmlToBeEqual(
+      container?.innerHTML || '',
+      html`
+        <div
+          contenteditable="true"
+          role="textbox"
+          spellcheck="true"
+          style="user-select: text; white-space: pre-wrap; word-break: break-word"
+          data-lexical-editor="true">
+          <p dir="ltr"><span data-lexical-text="true">parent</span></p>
+          <div data-lexical-decorator="true">
+            <div
+              contenteditable="true"
+              role="textbox"
+              spellcheck="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word"
+              data-lexical-editor="true">
+              <p dir="ltr"><span data-lexical-text="true">nested</span></p>
+            </div>
+          </div>
+        </div>
+      `,
+    );
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(null);
+    });
+  });
+
+  test('with deprecated initialNodes configuration and explicit namespace', async () => {
+    let editor: undefined | LexicalEditor;
+    let nestedEditor: undefined | LexicalEditor;
+    function App() {
+      return (
+        <LexicalComposer
+          initialConfig={{
+            editorState: () => {
+              editor = $getEditor();
+              nestedEditor = createEditor({
+                namespace: 'nested',
+                nodes: [],
+                parentEditor: editor,
+              });
+              nestedEditor.update(() =>
+                $getRoot()
+                  .clear()
+                  .append(
+                    $createParagraphNode().append($createTextNode('nested')),
+                  ),
+              );
+              $getRoot()
+                .clear()
+                .append(
+                  $createParagraphNode().append($createTextNode('parent')),
+                  $createReactDecoratorNode()
+                    .setInline(false)
+                    .setDecorate(() => {
+                      return nestedEditor ? (
+                        <LexicalNestedComposer
+                          initialEditor={nestedEditor}
+                          initialNodes={[ReactDecoratorNode]}>
+                          <RichTextPlugin
+                            contentEditable={<ContentEditable />}
+                            placeholder={<></>}
+                            ErrorBoundary={LexicalErrorBoundary}
+                          />
+                        </LexicalNestedComposer>
+                      ) : null;
+                    }),
+                );
+            },
+            namespace: 'parent',
+            nodes: [ReactDecoratorNode],
+            onError: () => {
+              throw Error();
+            },
+          }}>
+          <RichTextPlugin
+            contentEditable={<ContentEditable />}
+            placeholder={<></>}
+            ErrorBoundary={LexicalErrorBoundary}
+          />
+        </LexicalComposer>
+      );
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(<App />);
+    });
+    invariant(editor !== undefined, 'editor defined');
+    invariant(nestedEditor !== undefined, 'nestedEditor defined');
+    // namespace inherited
+    expect(editor._config.namespace).toBe('parent');
+    expect(nestedEditor._config.namespace).toBe('nested');
+    // nodes inherited
+    expect([...nestedEditor._nodes.keys()].sort()).toEqual(
+      [...editor._nodes.keys()].sort(),
+    );
+    expectHtmlToBeEqual(
+      container?.innerHTML || '',
+      html`
+        <div
+          contenteditable="true"
+          role="textbox"
+          spellcheck="true"
+          style="user-select: text; white-space: pre-wrap; word-break: break-word"
+          data-lexical-editor="true">
+          <p dir="ltr"><span data-lexical-text="true">parent</span></p>
+          <div data-lexical-decorator="true">
+            <div
+              contenteditable="true"
+              role="textbox"
+              spellcheck="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word"
+              data-lexical-editor="true">
+              <p dir="ltr"><span data-lexical-text="true">nested</span></p>
+            </div>
+          </div>
+        </div>
+      `,
+    );
+    expect(warn.mock.calls).toEqual([
+      [
+        `LexicalNestedComposer initialNodes is deprecated and will be removed in v0.32.0, it has never worked correctly.\nYou can configure your editor's nodes with createEditor({nodes: [], parentEditor: $getEditor()})`,
+      ],
+    ]);
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(null);
+    });
+  });
+
+  test('with explicit nodes configuration and explicit namespace', async () => {
+    let editor: undefined | LexicalEditor;
+    let nestedEditor: undefined | LexicalEditor;
+    function App() {
+      return (
+        <LexicalComposer
+          initialConfig={{
+            editorState: () => {
+              editor = $getEditor();
+              nestedEditor = createEditor({
+                namespace: 'nested',
+                nodes: [],
+                parentEditor: editor,
+              });
+              nestedEditor.update(() =>
+                $getRoot()
+                  .clear()
+                  .append(
+                    $createParagraphNode().append($createTextNode('nested')),
+                  ),
+              );
+              $getRoot()
+                .clear()
+                .append(
+                  $createParagraphNode().append($createTextNode('parent')),
+                  $createReactDecoratorNode()
+                    .setInline(false)
+                    .setDecorate(() => {
+                      return nestedEditor ? (
+                        <LexicalNestedComposer initialEditor={nestedEditor}>
+                          <RichTextPlugin
+                            contentEditable={<ContentEditable />}
+                            placeholder={<></>}
+                            ErrorBoundary={LexicalErrorBoundary}
+                          />
+                        </LexicalNestedComposer>
+                      ) : null;
+                    }),
+                );
+            },
+            namespace: 'parent',
+            nodes: [ReactDecoratorNode],
+            onError: () => {
+              throw Error();
+            },
+          }}>
+          <RichTextPlugin
+            contentEditable={<ContentEditable />}
+            placeholder={<></>}
+            ErrorBoundary={LexicalErrorBoundary}
+          />
+        </LexicalComposer>
+      );
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(<App />);
+    });
+    invariant(editor !== undefined, 'editor defined');
+    invariant(nestedEditor !== undefined, 'nestedEditor defined');
+    // namespace inherited
+    expect(editor._config.namespace).toBe('parent');
+    expect(nestedEditor._config.namespace).toBe('nested');
+    // nodes inherited
+    expect([...nestedEditor._nodes.keys()].sort()).toEqual(
+      [...editor._nodes.keys()]
+        .filter((k) => k !== ReactDecoratorNode.getType())
+        .sort(),
+    );
+    expectHtmlToBeEqual(
+      container?.innerHTML || '',
+      html`
+        <div
+          contenteditable="true"
+          role="textbox"
+          spellcheck="true"
+          style="user-select: text; white-space: pre-wrap; word-break: break-word"
+          data-lexical-editor="true">
+          <p dir="ltr"><span data-lexical-text="true">parent</span></p>
+          <div data-lexical-decorator="true">
+            <div
+              contenteditable="true"
+              role="textbox"
+              spellcheck="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word"
+              data-lexical-editor="true">
+              <p dir="ltr"><span data-lexical-text="true">nested</span></p>
+            </div>
+          </div>
+        </div>
+      `,
+    );
+    expect(warn.mock.calls).toEqual([]);
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(null);
+    });
+  });
+
+  test('default editable inheritance', async () => {
+    let editor: undefined | LexicalEditor;
+    let nestedEditor: undefined | LexicalEditor;
+    function App() {
+      return (
+        <LexicalComposer
+          initialConfig={{
+            editorState: () => {
+              editor = $getEditor();
+              nestedEditor = createEditor({
+                // this gets overwritten immediately
+                editable: false,
+                namespace: 'nested',
+                nodes: [],
+                parentEditor: editor,
+              });
+              nestedEditor.update(() =>
+                $getRoot()
+                  .clear()
+                  .append(
+                    $createParagraphNode().append($createTextNode('nested')),
+                  ),
+              );
+              $getRoot()
+                .clear()
+                .append(
+                  $createParagraphNode().append($createTextNode('parent')),
+                  $createReactDecoratorNode()
+                    .setInline(false)
+                    .setDecorate(() => {
+                      return nestedEditor ? (
+                        <LexicalNestedComposer initialEditor={nestedEditor}>
+                          <RichTextPlugin
+                            contentEditable={<ContentEditable />}
+                            placeholder={<></>}
+                            ErrorBoundary={LexicalErrorBoundary}
+                          />
+                        </LexicalNestedComposer>
+                      ) : null;
+                    }),
+                );
+            },
+            namespace: 'parent',
+            nodes: [ReactDecoratorNode],
+            onError: () => {
+              throw Error();
+            },
+          }}>
+          <RichTextPlugin
+            contentEditable={<ContentEditable />}
+            placeholder={<></>}
+            ErrorBoundary={LexicalErrorBoundary}
+          />
+        </LexicalComposer>
+      );
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(<App />);
+    });
+    invariant(editor !== undefined, 'editor defined');
+    invariant(nestedEditor !== undefined, 'nestedEditor defined');
+    // namespace inherited
+    expect(editor._config.namespace).toBe('parent');
+    expect(nestedEditor._config.namespace).toBe('nested');
+    // nodes inherited
+    expect([...nestedEditor._nodes.keys()].sort()).toEqual(
+      [...editor._nodes.keys()]
+        .filter((k) => k !== ReactDecoratorNode.getType())
+        .sort(),
+    );
+    expect(editor.isEditable()).toBe(true);
+    expect(nestedEditor.isEditable()).toBe(true);
+    expectHtmlToBeEqual(
+      container?.innerHTML || '',
+      html`
+        <div
+          contenteditable="true"
+          role="textbox"
+          spellcheck="true"
+          style="user-select: text; white-space: pre-wrap; word-break: break-word"
+          data-lexical-editor="true">
+          <p dir="ltr"><span data-lexical-text="true">parent</span></p>
+          <div data-lexical-decorator="true">
+            <div
+              contenteditable="true"
+              role="textbox"
+              spellcheck="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word"
+              data-lexical-editor="true">
+              <p dir="ltr"><span data-lexical-text="true">nested</span></p>
+            </div>
+          </div>
+        </div>
+      `,
+    );
+    expect(warn.mock.calls).toEqual([]);
+    await ReactTestUtils.act(async () => {
+      editor!.setEditable(false);
+    });
+    expect(editor.isEditable()).toBe(false);
+    expect(nestedEditor.isEditable()).toBe(false);
+    expectHtmlToBeEqual(
+      container?.innerHTML || '',
+      html`
+        <div
+          contenteditable="false"
+          spellcheck="true"
+          style="user-select: text; white-space: pre-wrap; word-break: break-word"
+          aria-autocomplete="none"
+          aria-readonly="true"
+          data-lexical-editor="true">
+          <p dir="ltr"><span data-lexical-text="true">parent</span></p>
+          <div data-lexical-decorator="true">
+            <div
+              contenteditable="false"
+              spellcheck="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word"
+              aria-autocomplete="none"
+              aria-readonly="true"
+              data-lexical-editor="true">
+              <p dir="ltr"><span data-lexical-text="true">nested</span></p>
+            </div>
+          </div>
+        </div>
+      `,
+    );
+    await ReactTestUtils.act(async () => {
+      editor!.setEditable(true);
+    });
+    expect(editor.isEditable()).toBe(true);
+    expect(nestedEditor.isEditable()).toBe(true);
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(null);
+    });
+  });
+
+  test('skipEditableListener', async () => {
+    let editor: undefined | LexicalEditor;
+    let nestedEditor: undefined | LexicalEditor;
+    function App() {
+      return (
+        <LexicalComposer
+          initialConfig={{
+            editorState: () => {
+              editor = $getEditor();
+              nestedEditor = createEditor({
+                // this gets overwritten immediately
+                editable: false,
+                namespace: 'nested',
+                nodes: [],
+                parentEditor: editor,
+              });
+              nestedEditor.update(() =>
+                $getRoot()
+                  .clear()
+                  .append(
+                    $createParagraphNode().append($createTextNode('nested')),
+                  ),
+              );
+              $getRoot()
+                .clear()
+                .append(
+                  $createParagraphNode().append($createTextNode('parent')),
+                  $createReactDecoratorNode()
+                    .setInline(false)
+                    .setDecorate(() => {
+                      return nestedEditor ? (
+                        <LexicalNestedComposer
+                          initialEditor={nestedEditor}
+                          skipEditableListener={true}>
+                          <RichTextPlugin
+                            contentEditable={<ContentEditable />}
+                            placeholder={<></>}
+                            ErrorBoundary={LexicalErrorBoundary}
+                          />
+                        </LexicalNestedComposer>
+                      ) : null;
+                    }),
+                );
+            },
+            namespace: 'parent',
+            nodes: [ReactDecoratorNode],
+            onError: () => {
+              throw Error();
+            },
+          }}>
+          <RichTextPlugin
+            contentEditable={<ContentEditable />}
+            placeholder={<></>}
+            ErrorBoundary={LexicalErrorBoundary}
+          />
+        </LexicalComposer>
+      );
+    }
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(<App />);
+    });
+    invariant(editor !== undefined, 'editor defined');
+    invariant(nestedEditor !== undefined, 'nestedEditor defined');
+    // namespace inherited
+    expect(editor._config.namespace).toBe('parent');
+    expect(nestedEditor._config.namespace).toBe('nested');
+    // nodes inherited
+    expect([...nestedEditor._nodes.keys()].sort()).toEqual(
+      [...editor._nodes.keys()]
+        .filter((k) => k !== ReactDecoratorNode.getType())
+        .sort(),
+    );
+    expect(editor.isEditable()).toBe(true);
+    expect(nestedEditor.isEditable()).toBe(false);
+    expectHtmlToBeEqual(
+      container?.innerHTML || '',
+      html`
+        <div
+          contenteditable="true"
+          role="textbox"
+          spellcheck="true"
+          style="user-select: text; white-space: pre-wrap; word-break: break-word"
+          data-lexical-editor="true">
+          <p dir="ltr"><span data-lexical-text="true">parent</span></p>
+          <div data-lexical-decorator="true">
+            <div
+              contenteditable="false"
+              spellcheck="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word"
+              aria-autocomplete="none"
+              aria-readonly="true"
+              data-lexical-editor="true">
+              <p dir="ltr"><span data-lexical-text="true">nested</span></p>
+            </div>
+          </div>
+        </div>
+      `,
+    );
+    expect(warn.mock.calls).toEqual([]);
+    await ReactTestUtils.act(async () => {
+      editor!.setEditable(false);
+    });
+    expect(editor.isEditable()).toBe(false);
+    expect(nestedEditor.isEditable()).toBe(false);
+    expectHtmlToBeEqual(
+      container?.innerHTML || '',
+      html`
+        <div
+          contenteditable="false"
+          spellcheck="true"
+          style="user-select: text; white-space: pre-wrap; word-break: break-word"
+          aria-autocomplete="none"
+          aria-readonly="true"
+          data-lexical-editor="true">
+          <p dir="ltr"><span data-lexical-text="true">parent</span></p>
+          <div data-lexical-decorator="true">
+            <div
+              contenteditable="false"
+              spellcheck="true"
+              style="user-select: text; white-space: pre-wrap; word-break: break-word"
+              aria-autocomplete="none"
+              aria-readonly="true"
+              data-lexical-editor="true">
+              <p dir="ltr"><span data-lexical-text="true">nested</span></p>
+            </div>
+          </div>
+        </div>
+      `,
+    );
+    await ReactTestUtils.act(async () => {
+      editor!.setEditable(true);
+    });
+    expect(editor.isEditable()).toBe(true);
+    expect(nestedEditor.isEditable()).toBe(false);
+
+    await ReactTestUtils.act(async () => {
+      reactRoot.render(null);
+    });
+  });
+});

--- a/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
@@ -10,8 +10,12 @@ import {HashtagNode} from '@lexical/hashtag';
 import {AutoLinkNode, LinkNode} from '@lexical/link';
 import {ListItemNode, ListNode} from '@lexical/list';
 import {OverflowNode} from '@lexical/overflow';
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
+import {PlainTextPlugin} from '@lexical/react/LexicalPlainTextPlugin';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
 import {$rootTextContent} from '@lexical/text';
@@ -26,11 +30,6 @@ import {
 import * as React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
-
-import {LexicalComposer} from '../../LexicalComposer';
-import {ContentEditable} from '../../LexicalContentEditable';
-import {PlainTextPlugin} from '../../LexicalPlainTextPlugin';
-import {RichTextPlugin} from '../../LexicalRichTextPlugin';
 
 const RICH_TEXT_NODES = [
   HeadingNode,

--- a/packages/lexical-react/src/__tests__/unit/useLexicalIsTextContentEmpty.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalIsTextContentEmpty.test.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import {useLexicalIsTextContentEmpty} from '@lexical/react/useLexicalIsTextContentEmpty';
 import {
   $createParagraphNode,
   $createTextNode,
@@ -18,8 +19,6 @@ import * as React from 'react';
 import {createRef} from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
-
-import {useLexicalIsTextContentEmpty} from '../../useLexicalIsTextContentEmpty';
 
 describe('useLexicalIsTextContentEmpty', () => {
   let container: HTMLDivElement | null = null;

--- a/packages/lexical-react/src/__tests__/unit/utils.tsx
+++ b/packages/lexical-react/src/__tests__/unit/utils.tsx
@@ -6,6 +6,13 @@
  *
  */
 
+import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
+import {CollaborationPlugin} from '@lexical/react/LexicalCollaborationPlugin';
+import {LexicalComposer} from '@lexical/react/LexicalComposer';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
+import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
 import {Provider, UserState} from '@lexical/yjs';
 import {LexicalEditor} from 'lexical';
 import * as React from 'react';
@@ -13,14 +20,6 @@ import {Container} from 'react-dom';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
 import * as Y from 'yjs';
-
-import {useCollaborationContext} from '../../LexicalCollaborationContext';
-import {CollaborationPlugin} from '../../LexicalCollaborationPlugin';
-import {LexicalComposer} from '../../LexicalComposer';
-import {useLexicalComposerContext} from '../../LexicalComposerContext';
-import {ContentEditable} from '../../LexicalContentEditable';
-import {LexicalErrorBoundary} from '../../LexicalErrorBoundary';
-import {RichTextPlugin} from '../../LexicalRichTextPlugin';
 
 function Editor({
   doc,

--- a/packages/lexical-react/src/shared/LexicalContentEditableElement.tsx
+++ b/packages/lexical-react/src/shared/LexicalContentEditableElement.tsx
@@ -15,7 +15,7 @@ import useLayoutEffect from 'shared/useLayoutEffect';
 
 import {mergeRefs} from './mergeRefs';
 
-export type Props = {
+export type ContentEditableElementProps = {
   editor: LexicalEditor;
   ariaActiveDescendant?: React.AriaAttributes['aria-activedescendant'];
   ariaAutoComplete?: React.AriaAttributes['aria-autocomplete'];
@@ -57,7 +57,7 @@ function ContentEditableElementImpl(
     tabIndex,
     'data-testid': testid,
     ...rest
-  }: Props,
+  }: ContentEditableElementProps,
   ref: Ref<HTMLDivElement>,
 ): JSX.Element {
   const [isEditable, setEditable] = useState(editor.isEditable());

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -145,6 +145,18 @@ type DOMConversionCache = Map<
   Array<(node: Node) => DOMConversion | null>,
 >;
 
+export type CreateEditorArgs = {
+  disableEvents?: boolean;
+  editorState?: EditorState;
+  namespace?: string;
+  nodes?: $ReadOnlyArray<Class<LexicalNode> | LexicalNodeReplacement>;
+  onError?: ErrorHandler;
+  parentEditor?: LexicalEditor;
+  editable?: boolean;
+  theme?: EditorThemeClasses;
+  html?: HTMLConfig;
+};
+
 declare export class LexicalEditor {
   _parentEditor: null | LexicalEditor;
   _rootElement: null | HTMLElement;
@@ -166,6 +178,7 @@ declare export class LexicalEditor {
   _pendingDecorators: null | {
     [NodeKey]: mixed,
   };
+  _createEditorArgs?: CreateEditorArgs;
   _config: EditorConfig;
   _dirtyType: 0 | 1 | 2;
   _cloneNotNeeded: Set<NodeKey>;

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -592,6 +592,7 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
     onError ? onError : console.error,
     initializeConversionCache(registeredNodes, html ? html.import : undefined),
     isEditable,
+    editorConfig,
   );
 
   if (initialEditorState !== undefined) {
@@ -665,6 +666,8 @@ export class LexicalEditor {
   _editable: boolean;
   /** @internal */
   _blockCursorElement: null | HTMLDivElement;
+  /** @internal */
+  _createEditorArgs?: undefined | CreateEditorArgs;
 
   /** @internal */
   constructor(
@@ -675,7 +678,9 @@ export class LexicalEditor {
     onError: ErrorHandler,
     htmlConversions: DOMConversionCache,
     editable: boolean,
+    createEditorArgs?: CreateEditorArgs,
   ) {
+    this._createEditorArgs = createEditorArgs;
     this._parentEditor = parentEditor;
     // The root element associated with this editor
     this._rootElement = null;

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -20,6 +20,7 @@ import {
   IS_SAFARI,
 } from 'shared/environment';
 import invariant from 'shared/invariant';
+import warnOnlyOnce from 'shared/warnOnlyOnce';
 
 import {
   $getPreviousSelection,
@@ -1412,13 +1413,18 @@ export function addRootElementEvents(
   }
 }
 
+const rootElementNotRegisteredWarning = warnOnlyOnce(
+  'Root element not registered',
+);
+
 export function removeRootElementEvents(rootElement: HTMLElement): void {
   const doc = rootElement.ownerDocument;
   const documentRootElementsCount = rootElementsRegistered.get(doc);
-  invariant(
-    documentRootElementsCount !== undefined,
-    'Root element not registered',
-  );
+  if (documentRootElementsCount === undefined) {
+    // This can happen if setRootElement() failed
+    rootElementNotRegisteredWarning();
+    return;
+  }
 
   // We only want to have a single global selectionchange event handler, shared
   // between all editor instances.

--- a/packages/shared/src/__mocks__/warnOnlyOnce.ts
+++ b/packages/shared/src/__mocks__/warnOnlyOnce.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export default function warnOnlyOnce(message: string): () => void {
+  // The mock for this warns every time
+  return () => console.warn(message);
+}

--- a/packages/shared/src/warnOnlyOnce.ts
+++ b/packages/shared/src/warnOnlyOnce.ts
@@ -6,15 +6,17 @@
  *
  */
 
-export default function warnOnlyOnce(message: string) {
-  if (!__DEV__) {
-    return;
+/*@__INLINE__*/
+export default function warnOnlyOnce(message: string): () => void {
+  if (__DEV__) {
+    let run = false;
+    return () => {
+      if (!run) {
+        console.warn(message);
+      }
+      run = true;
+    };
+  } else {
+    return () => {};
   }
-  let run = false;
-  return () => {
-    if (!run) {
-      console.warn(message);
-    }
-    run = true;
-  };
 }


### PR DESCRIPTION
## Breaking Changes

LexicalNestedComposer manipulates internal data structures of the LexicalEditor in ways that are unsafe and lead to incorrect behavior.

The `initialNodes` prop is deprecated and will be removed in v0.32.0. The functionality it had can be achieved by configuring the nodes array of the editor correctly when it is created.

Similarly, the forced inheritance of `namespace` is incorrect whenever the nodes configuration differs at all from the parent. It is always safer and more correct to explicitly specify a namespace.


Before
```tsx
<LexicalNestedComposer initialEditor={caption} initialNodes={[/* … */]}>
  {/* … */}
</LexicalNestedComposer>
```
```ts
class ImageNode extends DecoratorNode<JSX.Element> {
  constructor(/* … */) {
      // …
      this.__caption = caption || createEditor();
  }
}
```

After
```tsx
<LexicalNestedComposer initialEditor={caption}>
  {/* … */}
</LexicalNestedComposer>
```
```ts
class ImageNode extends DecoratorNode<JSX.Element> {
  constructor(/* … */) {
      // …
      this.__caption = caption || createEditor({
        namespace: 'Playground/ImageNodeCaption',
        nodes: [/* … */],
      });
  }
}
```

## New APIs

There's a new `skipEditableListener` property of `LexicalNestedComposerProps` that allows you to manually control the editable state of the nested editor. Previously the editable state of the nested editors was always forced to follow the parent editor's editable state.

## Description

initialNodes doesn't work correctly, never really has, and should be deprecated. This deprecates that feature, provides a warning in `__DEV__` with planned removal for v0.32.0.

Additionally other misfeatures of LexicalNestedComposer have been cleaned up allowing for more explicit control over the nested editor's configuration (namespace, editable state).

Internally this was implemented by storing the arguments used to create the editor so that it can be determined whether a value was set explicitly or implicitly (e.g. the automatically created namespace). This will also be useful as an internal implementation detail for other features.

## Test plan

Unit tests for skipEditableListener and the warnings (with a warnOnlyOnce mock that always warns)