### PR TITLE
[lexical-react][lexical-playground] Feature: Makes an inline node more easily linkable

### DIFF
--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -29,6 +29,7 @@ import {
   $applyNodeReplacement,
   $getSelection,
   $isElementNode,
+  $isNodeSelection,
   $isRangeSelection,
   $normalizeSelection__EXPERIMENTAL,
   $setSelection,
@@ -562,9 +563,13 @@ export function $toggleLink(
   const rel = attributes.rel === undefined ? 'noreferrer' : attributes.rel;
   const selection = $getSelection();
 
-  if (!$isRangeSelection(selection)) {
+  if (
+    !$isRangeSelection(selection) &&
+    (!$isNodeSelection(selection) || !selection.getNodes()[0].isInline())
+  ) {
     return;
   }
+
   const nodes = selection.extract();
 
   if (url === null) {

--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -648,11 +648,6 @@ export function $toggleLink(
         continue;
       }
 
-      // Pas sûr....
-      if ($isDecoratorNode(node) && !node.isInline()) {
-        continue;
-      }
-
       if ($isElementNode(node)) {
         if (!node.isInline()) {
           // Ignore block nodes, if there are any children we will see them
@@ -678,6 +673,12 @@ export function $toggleLink(
           continue;
         }
       }
+
+      if ($isDecoratorNode(node) && !node.isInline()) {
+        // Like for ElementNode: ignore Block nodes
+        continue;
+      }
+
       const prevLinkNode = node.getPreviousSibling();
       if ($isLinkNode(prevLinkNode) && prevLinkNode.is(linkNode)) {
         prevLinkNode.append(node);

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -21,7 +21,6 @@ import {
   $getSelection,
   $isLineBreakNode,
   $isNodeSelection,
-  $isRangeSelection,
   BaseSelection,
   CLICK_COMMAND,
   COMMAND_PRIORITY_CRITICAL,
@@ -71,11 +70,7 @@ function FloatingLinkEditor({
 
   const $updateLinkEditor = useCallback(() => {
     const selection = $getSelection();
-    const node = $isRangeSelection(selection)
-      ? getSelectedNode(selection)
-      : $isNodeSelection(selection) && selection.getNodes()[0]?.isInline()
-      ? selection.getNodes()[0]
-      : null;
+    const node = getSelectedNode(selection);
 
     if (node) {
       const linkParent = $findMatchingParent(node, $isLinkNode);
@@ -91,6 +86,7 @@ function FloatingLinkEditor({
         setEditedLinkUrl(linkUrl);
       }
     }
+
     const editorElem = editorRef.current;
     const nativeSelection = getDOMSelection(editor._window);
     const activeElement = document.activeElement;
@@ -225,8 +221,9 @@ function FloatingLinkEditor({
             sanitizeUrl(editedLinkUrl),
           );
           const selection = $getSelection();
-          if ($isRangeSelection(selection)) {
-            const parent = getSelectedNode(selection).getParent();
+          const node = getSelectedNode(selection);
+          if (node) {
+            const parent = node.getParent();
             if ($isAutoLinkNode(parent)) {
               const linkNode = $createLinkNode(parent.getURL(), {
                 rel: parent.__rel,
@@ -326,15 +323,11 @@ function useFloatingLinkEditorToolbar(
       const selection = $getSelection();
       if (!selection) {
         setIsLink(false);
+
         return;
       }
 
-      const focusNode = $isRangeSelection(selection)
-        ? getSelectedNode(selection)
-        : $isNodeSelection(selection) && selection.getNodes()[0]?.isInline()
-        ? selection.getNodes()[0]
-        : null;
-
+      const focusNode = getSelectedNode(selection);
       if (!focusNode) {
         setIsLink(false);
         return;
@@ -389,8 +382,8 @@ function useFloatingLinkEditorToolbar(
         CLICK_COMMAND,
         (payload) => {
           const selection = $getSelection();
-          if ($isRangeSelection(selection)) {
-            const node = getSelectedNode(selection);
+          const node = getSelectedNode(selection);
+          if (node) {
             const linkNode = $findMatchingParent(node, $isLinkNode);
             if ($isLinkNode(linkNode) && (payload.metaKey || payload.ctrlKey)) {
               window.open(linkNode.getURL(), '_blank');

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -110,7 +110,11 @@ function FloatingLinkEditor({
         setFloatingElemPositionForLinkEditor(domRect, editorElem, anchorElem);
       }
       setLastSelection(selection);
-    } else if ($isNodeSelection(selection)) {
+    } else if (
+      $isNodeSelection(selection) &&
+      selection.getNodes().length > 0 &&
+      editor.isEditable()
+    ) {
       const domRect = editor
         .getElementByKey(selection.getNodes()[0].getKey())
         ?.getBoundingClientRect();

--- a/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingTextFormatToolbarPlugin/index.tsx
@@ -355,13 +355,20 @@ function useFloatingTextFormatToolbar(
         return;
       }
 
+      const node = getSelectedNode(selection);
+      // Update links
+      const parent = node?.getParent();
+      if ($isLinkNode(parent) || $isLinkNode(node)) {
+        setIsLink(true);
+      } else {
+        setIsLink(false);
+      }
+
+      // Update text format
       if (!$isRangeSelection(selection)) {
         return;
       }
 
-      const node = getSelectedNode(selection);
-
-      // Update text format
       setIsBold(selection.hasFormat('bold'));
       setIsItalic(selection.hasFormat('italic'));
       setIsUnderline(selection.hasFormat('underline'));
@@ -372,14 +379,6 @@ function useFloatingTextFormatToolbar(
       setIsSubscript(selection.hasFormat('subscript'));
       setIsSuperscript(selection.hasFormat('superscript'));
       setIsCode(selection.hasFormat('code'));
-
-      // Update links
-      const parent = node.getParent();
-      if ($isLinkNode(parent) || $isLinkNode(node)) {
-        setIsLink(true);
-      } else {
-        setIsLink(false);
-      }
 
       if (
         !$isCodeHighlightNode(selection.anchor.getNode()) &&

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -532,13 +532,11 @@ export default function ToolbarPlugin({
 
       updateToolbarState('isRTL', $isParentElementRTL(selection));
 
-      if (node) {
-        const tableNode = $findMatchingParent(node, $isTableNode);
-        if ($isTableNode(tableNode)) {
-          updateToolbarState('rootType', 'table');
-        } else {
-          updateToolbarState('rootType', 'root');
-        }
+      const tableNode = $findMatchingParent(node, $isTableNode);
+      if ($isTableNode(tableNode)) {
+        updateToolbarState('rootType', 'table');
+      } else {
+        updateToolbarState('rootType', 'root');
       }
 
       if (elementDOM !== null) {
@@ -595,7 +593,7 @@ export default function ToolbarPlugin({
       if ($isLinkNode(parent)) {
         // If node is a link, we need to fetch the parent paragraph node to set format
         matchingParent = $findMatchingParent(
-          node!, // if we have a parent, node is not null
+          node,
           (parentNode) => $isElementNode(parentNode) && !parentNode.isInline(),
         );
       }

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -521,15 +521,17 @@ export default function ToolbarPlugin({
 
       // Update links
       const node = getSelectedNode(selection);
-      const parent = node.getParent();
+      const parent = node?.getParent();
       const isLink = $isLinkNode(parent) || $isLinkNode(node);
       updateToolbarState('isLink', isLink);
 
-      const tableNode = $findMatchingParent(node, $isTableNode);
-      if ($isTableNode(tableNode)) {
-        updateToolbarState('rootType', 'table');
-      } else {
-        updateToolbarState('rootType', 'root');
+      if (node) {
+        const tableNode = $findMatchingParent(node, $isTableNode);
+        if ($isTableNode(tableNode)) {
+          updateToolbarState('rootType', 'table');
+        } else {
+          updateToolbarState('rootType', 'root');
+        }
       }
 
       if (elementDOM !== null) {
@@ -586,7 +588,7 @@ export default function ToolbarPlugin({
       if ($isLinkNode(parent)) {
         // If node is a link, we need to fetch the parent paragraph node to set format
         matchingParent = $findMatchingParent(
-          node,
+          node!, // if we have a parent, node is not null
           (parentNode) => $isElementNode(parentNode) && !parentNode.isInline(),
         );
       }
@@ -601,6 +603,7 @@ export default function ToolbarPlugin({
           : parent?.getFormatType() || 'left',
       );
     }
+
     if ($isRangeSelection(selection) || $isTableSelection(selection)) {
       // Update text format
       updateToolbarState('isBold', selection.hasFormat('bold'));

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -488,6 +488,19 @@ export default function ToolbarPlugin({
 
   const $updateToolbar = useCallback(() => {
     const selection = $getSelection();
+    const node = getSelectedNode(selection);
+    const parent = node?.getParent();
+
+    if (!node) {
+      updateToolbarState('isLink', false);
+
+      return;
+    }
+
+    // Update links
+    const isLink = $isLinkNode(parent) || $isLinkNode(node);
+    updateToolbarState('isLink', isLink);
+
     if ($isRangeSelection(selection)) {
       if (activeEditor !== editor && $isEditorIsNestedEditor(activeEditor)) {
         const rootElement = activeEditor.getRootElement();
@@ -506,8 +519,8 @@ export default function ToolbarPlugin({
         anchorNode.getKey() === 'root'
           ? anchorNode
           : $findMatchingParent(anchorNode, (e) => {
-              const parent = e.getParent();
-              return parent !== null && $isRootOrShadowRoot(parent);
+              const p = e.getParent();
+              return p !== null && $isRootOrShadowRoot(p);
             });
 
       if (element === null) {
@@ -518,12 +531,6 @@ export default function ToolbarPlugin({
       const elementDOM = activeEditor.getElementByKey(elementKey);
 
       updateToolbarState('isRTL', $isParentElementRTL(selection));
-
-      // Update links
-      const node = getSelectedNode(selection);
-      const parent = node?.getParent();
-      const isLink = $isLinkNode(parent) || $isLinkNode(node);
-      updateToolbarState('isLink', isLink);
 
       if (node) {
         const tableNode = $findMatchingParent(node, $isTableNode);

--- a/packages/lexical-playground/src/utils/getSelectedNode.ts
+++ b/packages/lexical-playground/src/utils/getSelectedNode.ts
@@ -7,20 +7,15 @@
  */
 import {$isAtNodeEnd} from '@lexical/selection';
 import {
-  $isDecoratorNode,
-  $isElementNode,
   $isNodeSelection,
   $isRangeSelection,
-  $isTextNode,
   BaseSelection,
-  DecoratorNode,
-  ElementNode,
-  TextNode,
+  LexicalNode,
 } from 'lexical';
 
-export function getSelectedNode<T>(
+export function getSelectedNode(
   selection: BaseSelection | null,
-): TextNode | ElementNode | DecoratorNode<T> | null {
+): LexicalNode | null {
   if (!selection) {
     return null;
   }
@@ -42,24 +37,9 @@ export function getSelectedNode<T>(
   }
 
   if ($isNodeSelection(selection)) {
-    const nodes = selection
-      .getNodes()
-      .filter(
-        (n) => $isTextNode(n) || $isElementNode(n) || $isDecoratorNode<T>(n),
-      );
+    const nodes = selection.getNodes();
 
-    if (nodes.length === 0) {
-      return null;
-    }
-
-    if (nodes.length === 1) {
-      return nodes[0];
-    }
-
-    const isBackward = selection.isBackward();
-    const n = isBackward ? nodes[nodes.length - 1] : nodes[0];
-
-    return n;
+    return nodes.length > 0 ? nodes[0] : null;
   }
 
   return null;

--- a/packages/lexical-playground/src/utils/setFloatingElemPositionForLinkEditor.ts
+++ b/packages/lexical-playground/src/utils/setFloatingElemPositionForLinkEditor.ts
@@ -5,14 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-const VERTICAL_GAP = 10;
+const VERTICAL_OFFSET = 5;
 const HORIZONTAL_OFFSET = 5;
 
 export function setFloatingElemPositionForLinkEditor(
   targetRect: DOMRect | null,
   floatingElem: HTMLElement,
   anchorElem: HTMLElement,
-  verticalGap: number = VERTICAL_GAP,
   horizontalOffset: number = HORIZONTAL_OFFSET,
 ): void {
   const scrollerElem = anchorElem.parentElement;
@@ -27,11 +26,11 @@ export function setFloatingElemPositionForLinkEditor(
   const anchorElementRect = anchorElem.getBoundingClientRect();
   const editorScrollerRect = scrollerElem.getBoundingClientRect();
 
-  let top = targetRect.top - verticalGap;
+  let top = targetRect.bottom + VERTICAL_OFFSET;
   let left = targetRect.left - horizontalOffset;
 
   if (top < editorScrollerRect.top) {
-    top += floatingElemRect.height + targetRect.height + verticalGap * 2;
+    top += floatingElemRect.height + targetRect.height;
   }
 
   if (left + floatingElemRect.width > editorScrollerRect.right) {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1460,10 +1460,13 @@ export function getWindow(editor: LexicalEditor): Window {
   return windowObj;
 }
 
+export function $isInlineElementNode(node: LexicalNode): node is ElementNode {
+  return $isElementNode(node) && node.isInline();
+}
+
 export function $isInlineElementOrDecoratorNode(node: LexicalNode): boolean {
   return (
-    ($isElementNode(node) && node.isInline()) ||
-    ($isDecoratorNode(node) && node.isInline())
+    $isInlineElementNode(node) || ($isDecoratorNode(node) && node.isInline())
   );
 }
 

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -233,6 +233,7 @@ export {
   $getRoot,
   $hasAncestor,
   $hasUpdateTag,
+  $isInlineElementNode,
   $isInlineElementOrDecoratorNode,
   $isLeafNode,
   $isRootOrShadowRoot,


### PR DESCRIPTION
## Description

Currently if you want to put a link around an image, you need to be clever and "select" around the image. It works in a way, but is not easy to use neither well presented.
Thanks to these changes, we globally allow to put a link on an inline node such as the ImageNode from the playground
### Before
_Nothing to show_

### After

![image](https://github.com/user-attachments/assets/317e300c-62ef-4e4a-92f5-e49bb981be6d)
