### PR TITLE
[lexical-react][lexical-playground] Feature: Makes the sidebar available inside Column Layout

### DIFF
--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.css
@@ -12,7 +12,7 @@
 }
 
 .draggable-block-highlight {
-  outline: 1px dashed deepskyblue;
+  box-shadow: -3px 0px 0px 0px rgba(0, 191, 255, 0.3);
 }
 
 .draggable-block-depth-0 {

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.css
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.css
@@ -11,10 +11,22 @@
   gap: 2px;
 }
 
+.draggable-block-highlight {
+  outline: 1px dashed deepskyblue;
+}
+
+.draggable-block-depth-0 {
+  left: -40px;
+}
+
+.draggable-block-depth-1 {
+  left: -20px;
+}
+
 .draggable-block-menu .icon {
   width: 16px;
   height: 16px;
-  opacity: 0.3;
+  opacity: 0.6;
   background-image: url(../../images/icons/draggable-block-menu.svg);
 }
 

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -10,10 +10,7 @@ import type {JSX} from 'react';
 import './index.css';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {
-  DraggableBlockPlugin_EXPERIMENTAL,
-  ElementInfosHolder,
-} from '@lexical/react/LexicalDraggableBlockPlugin';
+import {DraggableBlockPlugin_EXPERIMENTAL} from '@lexical/react/LexicalDraggableBlockPlugin';
 import {
   $createParagraphNode,
   $getNearestNodeFromDOMNode,
@@ -40,20 +37,27 @@ export default function DraggableBlockPlugin({
   const [editor] = useLexicalComposerContext();
   const menuRef = useRef<HTMLDivElement>(null);
   const targetLineRef = useRef<HTMLDivElement>(null);
-  const [draggableElement, setDraggableElement] =
-    useState<ElementInfosHolder | null>(null);
+  const [draggableElement, setDraggableElement] = useState<HTMLElement | null>(
+    null,
+  );
+  const [draggableElementDepth, setDraggableElementDepth] = useState<number>(0);
 
-  function handleDraggableElementChanged(eih: ElementInfosHolder | null) {
+  function handleDraggableElementChanged(
+    element: HTMLElement | null,
+    nodeKey: string,
+    depth: number,
+  ) {
+    setDraggableElementDepth(depth);
     setDraggableElement((prev) => {
       if (prev) {
-        prev.element.classList.remove('draggable-block-highlight');
+        prev.classList.remove('draggable-block-highlight');
       }
 
-      if (eih) {
-        eih.element.classList.add('draggable-block-highlight');
+      if (element) {
+        element.classList.add('draggable-block-highlight');
       }
 
-      return eih;
+      return element;
     });
   }
 
@@ -64,7 +68,7 @@ export default function DraggableBlockPlugin({
       }
 
       editor.update(() => {
-        const node = $getNearestNodeFromDOMNode(draggableElement.element);
+        const node = $getNearestNodeFromDOMNode(draggableElement);
         if (!node) {
           return;
         }
@@ -113,7 +117,7 @@ export default function DraggableBlockPlugin({
           ref={menuRef}
           className={`icon draggable-block-menu ${
             draggableElement
-              ? `draggable-block-depth-${draggableElement.depth}`
+              ? `draggable-block-depth-${draggableElementDepth}`
               : ''
           }`}>
           <button
@@ -121,9 +125,7 @@ export default function DraggableBlockPlugin({
             className="icon icon-plus"
             onClick={insertBlock}
           />
-          {draggableElement && draggableElement.depth === 0 && (
-            <div className="icon" />
-          )}
+          {draggableElementDepth === 0 && <div className="icon" />}
         </div>
       }
       targetLineComponent={

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -109,18 +109,22 @@ export default function DraggableBlockPlugin({
       menuRef={menuRef}
       targetLineRef={targetLineRef}
       menuComponent={
-        draggableElement && (
-          <div
-            ref={menuRef}
-            className={`icon draggable-block-menu draggable-block-depth-${draggableElement.depth}`}>
-            <button
-              title="Click to add below"
-              className="icon icon-plus"
-              onClick={insertBlock}
-            />
-            {draggableElement.depth === 0 && <div className="icon" />}
-          </div>
-        )
+        <div
+          ref={menuRef}
+          className={`icon draggable-block-menu ${
+            draggableElement
+              ? `draggable-block-depth-${draggableElement.depth}`
+              : ''
+          }`}>
+          <button
+            title="Click to add below&#10;Cmd/Alt+Click to add above"
+            className="icon icon-plus"
+            onClick={insertBlock}
+          />
+          {draggableElement && draggableElement.depth === 0 && (
+            <div className="icon" />
+          )}
+        </div>
       }
       targetLineComponent={
         <div ref={targetLineRef} className="draggable-block-target-line" />

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -49,7 +49,7 @@ export default function DraggableBlockPlugin({
         prev.element.classList.remove('draggable-block-highlight');
       }
 
-      if (eih && eih.depth > 0) {
+      if (eih) {
         eih.element.classList.add('draggable-block-highlight');
       }
 

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -86,7 +86,7 @@ export default function DraggableBlockPlugin({
   );
 
   const $getInnerNodes = useCallback(
-    (node: LexicalNode, depth: number): string[] => {
+    (node: LexicalNode, depth: number): string[][] => {
       if (depth >= MAX_DRAGGABLEPLUGIN_DEPTH) {
         return [];
       }
@@ -95,7 +95,7 @@ export default function DraggableBlockPlugin({
         return [];
       }
 
-      return node.getChildrenKeys().flatMap((childKey) => {
+      return node.getChildrenKeys().map((childKey) => {
         const childNode = $getNodeByKey(childKey);
         if ($isLayoutItemNode(childNode)) {
           return childNode.getChildrenKeys();

--- a/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/DraggableBlockPlugin/index.tsx
@@ -10,11 +10,23 @@ import type {JSX} from 'react';
 import './index.css';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {DraggableBlockPlugin_EXPERIMENTAL} from '@lexical/react/LexicalDraggableBlockPlugin';
-import {$createParagraphNode, $getNearestNodeFromDOMNode} from 'lexical';
-import {useRef, useState} from 'react';
+import {
+  DraggableBlockPlugin_EXPERIMENTAL,
+  ElementInfosHolder,
+} from '@lexical/react/LexicalDraggableBlockPlugin';
+import {
+  $createParagraphNode,
+  $getNearestNodeFromDOMNode,
+  $getNodeByKey,
+  LexicalNode,
+} from 'lexical';
+import {useCallback, useRef, useState} from 'react';
+
+import {$isLayoutContainerNode} from '../../nodes/LayoutContainerNode';
+import {$isLayoutItemNode} from '../../nodes/LayoutItemNode';
 
 const DRAGGABLE_BLOCK_MENU_CLASSNAME = 'draggable-block-menu';
+const MAX_DRAGGABLEPLUGIN_DEPTH = 1;
 
 function isOnMenu(element: HTMLElement): boolean {
   return !!element.closest(`.${DRAGGABLE_BLOCK_MENU_CLASSNAME}`);
@@ -28,30 +40,68 @@ export default function DraggableBlockPlugin({
   const [editor] = useLexicalComposerContext();
   const menuRef = useRef<HTMLDivElement>(null);
   const targetLineRef = useRef<HTMLDivElement>(null);
-  const [draggableElement, setDraggableElement] = useState<HTMLElement | null>(
-    null,
-  );
+  const [draggableElement, setDraggableElement] =
+    useState<ElementInfosHolder | null>(null);
 
-  function insertBlock(e: React.MouseEvent) {
-    if (!draggableElement || !editor) {
-      return;
-    }
+  function handleDraggableElementChanged(eih: ElementInfosHolder | null) {
+    setDraggableElement((prev) => {
+      if (prev) {
+        prev.element.classList.remove('draggable-block-highlight');
+      }
 
-    editor.update(() => {
-      const node = $getNearestNodeFromDOMNode(draggableElement);
-      if (!node) {
+      if (eih && eih.depth > 0) {
+        eih.element.classList.add('draggable-block-highlight');
+      }
+
+      return eih;
+    });
+  }
+
+  const insertBlock = useCallback(
+    (e: React.MouseEvent) => {
+      if (!draggableElement || !editor) {
         return;
       }
 
-      const pNode = $createParagraphNode();
-      if (e.altKey || e.ctrlKey) {
-        node.insertBefore(pNode);
-      } else {
-        node.insertAfter(pNode);
+      editor.update(() => {
+        const node = $getNearestNodeFromDOMNode(draggableElement.element);
+        if (!node) {
+          return;
+        }
+
+        const pNode = $createParagraphNode();
+        if (e.altKey || e.ctrlKey) {
+          node.insertBefore(pNode);
+        } else {
+          node.insertAfter(pNode);
+        }
+        pNode.select();
+      });
+    },
+    [draggableElement, editor],
+  );
+
+  const $getInnerNodes = useCallback(
+    (node: LexicalNode, depth: number): string[] => {
+      if (depth >= MAX_DRAGGABLEPLUGIN_DEPTH) {
+        return [];
       }
-      pNode.select();
-    });
-  }
+
+      if (!$isLayoutContainerNode(node)) {
+        return [];
+      }
+
+      return node.getChildrenKeys().flatMap((childKey) => {
+        const childNode = $getNodeByKey(childKey);
+        if ($isLayoutItemNode(childNode)) {
+          return childNode.getChildrenKeys();
+        }
+
+        return [];
+      });
+    },
+    [],
+  );
 
   return (
     <DraggableBlockPlugin_EXPERIMENTAL
@@ -59,20 +109,25 @@ export default function DraggableBlockPlugin({
       menuRef={menuRef}
       targetLineRef={targetLineRef}
       menuComponent={
-        <div ref={menuRef} className="icon draggable-block-menu">
-          <button
-            title="Click to add below"
-            className="icon icon-plus"
-            onClick={insertBlock}
-          />
-          <div className="icon" />
-        </div>
+        draggableElement && (
+          <div
+            ref={menuRef}
+            className={`icon draggable-block-menu draggable-block-depth-${draggableElement.depth}`}>
+            <button
+              title="Click to add below"
+              className="icon icon-plus"
+              onClick={insertBlock}
+            />
+            {draggableElement.depth === 0 && <div className="icon" />}
+          </div>
+        )
       }
       targetLineComponent={
         <div ref={targetLineRef} className="draggable-block-target-line" />
       }
       isOnMenu={isOnMenu}
-      onElementChanged={setDraggableElement}
+      onElementChanged={handleDraggableElementChanged}
+      $getInnerNodes={$getInnerNodes}
     />
   );
 }

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -278,17 +278,9 @@ function setMenuPosition(
   }
 
   const targetRect = targetInfos.element.getBoundingClientRect();
-  const targetStyle = window.getComputedStyle(targetInfos.element);
   const anchorElementRect = anchorElem.getBoundingClientRect();
 
-  // top left
-  let targetCalculateHeight: number = parseInt(targetStyle.lineHeight, 10);
-  if (isNaN(targetCalculateHeight)) {
-    // middle
-    targetCalculateHeight = targetRect.bottom - targetRect.top;
-  }
   const top = targetRect.top - anchorElementRect.top;
-
   const left = targetRect.left - anchorElementRect.left;
 
   floatingElem.style.opacity = '1';

--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -43,7 +43,7 @@ const Downward = 1;
 const Upward = -1;
 const Indeterminate = 0;
 
-export interface ElementInfosHolder {
+interface ElementInfosHolder {
   element: HTMLElement;
   nodeKey: string;
   depth: number;
@@ -348,7 +348,11 @@ function useDraggableBlockMenu(
   menuComponent: ReactNode,
   targetLineComponent: ReactNode,
   isOnMenu: (element: HTMLElement) => boolean,
-  onElementChanged: (element: ElementInfosHolder | null) => void,
+  onElementChanged: (
+    element: HTMLElement | null,
+    nodeKey: string,
+    depth: number,
+  ) => void,
   $getInnerNodes?: (node: LexicalNode, depth: number) => string[],
 ): JSX.Element {
   const scrollerElem = anchorElem.parentElement;
@@ -358,7 +362,15 @@ function useDraggableBlockMenu(
     useState<ElementInfosHolder | null>(null);
 
   useEffect(() => {
-    onElementChanged(draggableBlock);
+    if (draggableBlock) {
+      onElementChanged(
+        draggableBlock.element,
+        draggableBlock.nodeKey,
+        draggableBlock.depth,
+      );
+    } else {
+      onElementChanged(null, '', 0);
+    }
   }, [draggableBlock, onElementChanged]);
 
   useEffect(() => {
@@ -555,7 +567,11 @@ export function DraggableBlockPlugin_EXPERIMENTAL({
   menuComponent: ReactNode;
   targetLineComponent: ReactNode;
   isOnMenu: (element: HTMLElement) => boolean;
-  onElementChanged?: (element: ElementInfosHolder | null) => void;
+  onElementChanged?: (
+    element: HTMLElement | null,
+    nodeKey: string,
+    depth: number,
+  ) => void;
   $getInnerNodes?: (node: LexicalNode, depth: number) => string[];
 }): JSX.Element {
   const [editor] = useLexicalComposerContext();


### PR DESCRIPTION
## Description
The DraggablePlugin currently only works on top-level nodes. For instance, when using the Column Layout block, users cannot access the "Add Above" or "Add Below" buttons inside a column. This limitation makes it difficult to work with nested structures.

This PR introduces a new mechanism allowing users to provide a function to control how deeply the plugin navigates and how to retrieve inner nodes within complex structures. This enhancement gives users greater flexibility to customize the plugin's behavior and user interface.

Additionally, this PR introduces the ability to replicate Notion-like behaviors for column layouts. However, it does not address drag-and-drop functionality inside columns, as that is already unsupported. This PR serves as a first step toward enabling drag-and-drop within column layouts, which will be probably tackled in a separate PR.

## Test plan

### Before


https://github.com/user-attachments/assets/c7c84a89-fddf-4df4-b12f-870bed165ad8


### After


https://github.com/user-attachments/assets/38ccaf05-ba25-4b20-8b82-d90fd70288cb

