### PR TITLE
[lexical-playground] Bug Fix: Fix equation rendering in Safari

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -1020,7 +1020,11 @@ test.describe.parallel('Markdown', () => {
             class="editor-equation"
             contenteditable="false"
             data-lexical-decorator="true">
-            <img alt="" src="#" />
+            <img
+              alt=""
+              height="0"
+              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+              width="0" />
             <span role="button" tabindex="-1">
               <span class="katex">
                 <span class="katex-html" aria-hidden="true">
@@ -1031,7 +1035,11 @@ test.describe.parallel('Markdown', () => {
                 </span>
               </span>
             </span>
-            <img alt="" src="#" />
+            <img
+              alt=""
+              height="0"
+              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+              width="0" />
           </span>
           <br />
         </p>

--- a/packages/lexical-playground/__tests__/regression/6974-delete-character-backward.spec.mjs
+++ b/packages/lexical-playground/__tests__/regression/6974-delete-character-backward.spec.mjs
@@ -38,7 +38,11 @@ test.describe('Regression tests for #6974', () => {
     const beforeHtml = html`
       <p>
         <span contenteditable="false" data-lexical-decorator="true">
-          <img alt="" src="#" />
+          <img
+            alt=""
+            height="0"
+            src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+            width="0" />
           <span role="button" tabindex="-1">
             <span>
               <span aria-hidden="true">
@@ -49,7 +53,11 @@ test.describe('Regression tests for #6974', () => {
               </span>
             </span>
           </span>
-          <img alt="" src="#" />
+          <img
+            alt=""
+            height="0"
+            src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+            width="0" />
         </span>
         <br />
       </p>
@@ -64,7 +72,11 @@ test.describe('Regression tests for #6974', () => {
     const afterHtml = html`
       <p dir="ltr">
         <span contenteditable="false" data-lexical-decorator="true">
-          <img alt="" src="#" />
+          <img
+            alt=""
+            height="0"
+            src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+            width="0" />
           <span role="button" tabindex="-1">
             <span>
               <span aria-hidden="true">
@@ -75,7 +87,11 @@ test.describe('Regression tests for #6974', () => {
               </span>
             </span>
           </span>
-          <img alt="" src="#" />
+          <img
+            alt=""
+            height="0"
+            src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+            width="0" />
         </span>
         <span data-lexical-text="true">test</span>
       </p>

--- a/packages/lexical-playground/src/ui/KatexRenderer.tsx
+++ b/packages/lexical-playground/src/ui/KatexRenderer.tsx
@@ -43,14 +43,24 @@ export default function KatexRenderer({
     // inner text from Katex. There didn't seem to be any other way of making this work,
     // without having a physical space.
     <>
-      <img src="#" alt="" />
+      <img
+        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+        width="0"
+        height="0"
+        alt=""
+      />
       <span
         role="button"
         tabIndex={-1}
         onDoubleClick={onDoubleClick}
         ref={katexElementRef}
       />
-      <img src="#" alt="" />
+      <img
+        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+        width="0"
+        height="0"
+        alt=""
+      />
     </>
   );
 }


### PR DESCRIPTION
## Description

Current Behavior: 
The KatexRenderer component uses empty image tags with `src="#"` around equations to prevent Android composition issues. However, this causes Safari to display question marks around the equations, creating an undesirable visual artifact.

Changes being added:
This PR replaces the empty image tags' src attribute with a transparent 1x1 pixel GIF data URL and adds width/height=0 attributes. This maintains the Android composition prevention functionality while fixing the Safari display issue. The images will now be completely invisible across all browsers.

Closes #6824

## Test plan

### Before
When adding an equation in Safari:
- Question marks appear on either side of the equation
- The issue is specific to Safari browser
![image](https://github.com/user-attachments/assets/f9aeb021-0b47-4257-bd6e-486c67a0eb44)

### After
- No question marks visible around equations in Safari
- Equations render cleanly without any visual artifacts
- Android composition prevention still works as expected
- No visual changes in other browsers (Chrome, Firefox, etc.)

![image](https://github.com/user-attachments/assets/c9ef40e2-6866-466b-a441-9e4f407754f3)
