### PR TITLE
[lexical-link][lexical-playground] Feature: Add support for image links via NodeSelection

### DIFF
--- a/packages/lexical-link/src/index.ts
+++ b/packages/lexical-link/src/index.ts
@@ -576,47 +576,43 @@ export function $toggleLink(
       return;
     }
 
-    const node = nodes[0];
-    if (url === null) {
-      // If we're removing the link and the node is inside a link, move it out
-      const linkParent = $findMatchingParent(
-        node,
-        (parent): parent is LinkNode =>
-          !$isAutoLinkNode(parent) && $isLinkNode(parent),
-      );
-      if (linkParent) {
-        linkParent.insertBefore(node);
-        if (linkParent.getChildren().length === 0) {
-          linkParent.remove();
+    // Handle all selected nodes
+    nodes.forEach((node) => {
+      if (url === null) {
+        // Remove link
+        const linkParent = $findMatchingParent(
+          node,
+          (parent): parent is LinkNode =>
+            !$isAutoLinkNode(parent) && $isLinkNode(parent),
+        );
+        if (linkParent) {
+          linkParent.insertBefore(node);
+          if (linkParent.getChildren().length === 0) {
+            linkParent.remove();
+          }
+        }
+      } else {
+        // Add/Update link
+        const existingLink = $findMatchingParent(
+          node,
+          (parent): parent is LinkNode =>
+            !$isAutoLinkNode(parent) && $isLinkNode(parent),
+        );
+        if (existingLink) {
+          existingLink.setURL(url);
+          if (target !== undefined) {
+            existingLink.setTarget(target);
+          }
+          if (rel !== undefined) {
+            existingLink.setRel(rel);
+          }
+        } else {
+          const linkNode = $createLinkNode(url, {rel, target});
+          node.insertBefore(linkNode);
+          linkNode.append(node);
         }
       }
-      return;
-    }
-
-    // If the node is already inside a link, update that link
-    const existingLink = $findMatchingParent(
-      node,
-      (parent): parent is LinkNode =>
-        !$isAutoLinkNode(parent) && $isLinkNode(parent),
-    );
-    if (existingLink) {
-      existingLink.setURL(url);
-      if (target !== undefined) {
-        existingLink.setTarget(target);
-      }
-      if (rel !== undefined) {
-        existingLink.setRel(rel);
-      }
-      if (title !== undefined) {
-        existingLink.setTitle(title);
-      }
-      return;
-    }
-
-    // Otherwise, wrap the node in a new link
-    const linkNode = $createLinkNode(url, {rel, target, title});
-    node.insertAfter(linkNode);
-    linkNode.append(node);
+    });
     return;
   }
 

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -26,6 +26,7 @@ import {
   focusEditor,
   html,
   initialize,
+  insertSampleImage,
   keyDownCtrlOrMeta,
   keyUpCtrlOrMeta,
   pasteFromClipboard,
@@ -2122,6 +2123,149 @@ test.describe.parallel('Links', () => {
       `,
       undefined,
       {ignoreClasses: true},
+    );
+  });
+
+  test('Can add, edit and remove links on images', async ({page, isCollab}) => {
+    await focusEditor(page);
+
+    // Insert image
+    await insertSampleImage(page);
+
+    // Add link to image
+    await click(page, '.editor-image img');
+    await click(page, '.link');
+    await focus(page, '.link-input');
+    await page.keyboard.type('lexical.dev');
+    await click(page, '.link-confirm');
+
+    // Verify link was added
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://lexical.dev"
+            rel="noreferrer">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="true">
+                <img
+                  class="focused draggable"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="/src/images/yellow-flower.jpg"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+              <div>
+                <button class="image-caption-button">Add Caption</button>
+                <div class="image-resizer image-resizer-n"></div>
+                <div class="image-resizer image-resizer-ne"></div>
+                <div class="image-resizer image-resizer-e"></div>
+                <div class="image-resizer image-resizer-se"></div>
+                <div class="image-resizer image-resizer-s"></div>
+                <div class="image-resizer image-resizer-sw"></div>
+                <div class="image-resizer image-resizer-w"></div>
+                <div class="image-resizer image-resizer-nw"></div>
+              </div>
+            </span>
+          </a>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: false},
+    );
+
+    // Edit link
+    await click(page, '.editor-image img');
+    await click(page, '.link-edit');
+    await focus(page, '.link-input');
+    await selectAll(page);
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type('https://github.com/facebook/lexical');
+    await click(page, '.link-confirm');
+
+    // Verify link was updated
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://github.com/facebook/lexical"
+            rel="noreferrer">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="true">
+                <img
+                  class="focused draggable"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="/src/images/yellow-flower.jpg"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+              <div>
+                <button class="image-caption-button">Add Caption</button>
+                <div class="image-resizer image-resizer-n"></div>
+                <div class="image-resizer image-resizer-ne"></div>
+                <div class="image-resizer image-resizer-e"></div>
+                <div class="image-resizer image-resizer-se"></div>
+                <div class="image-resizer image-resizer-s"></div>
+                <div class="image-resizer image-resizer-sw"></div>
+                <div class="image-resizer image-resizer-w"></div>
+                <div class="image-resizer image-resizer-nw"></div>
+              </div>
+            </span>
+          </a>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: false},
+    );
+
+    // Remove link
+    await click(page, '.editor-image img');
+    await click(page, '.link-trash');
+
+    // Verify link was removed but image remains
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="true">
+              <img
+                class="focused draggable"
+                alt="Yellow flower in tilt shift lens"
+                draggable="false"
+                src="/src/images/yellow-flower.jpg"
+                style="height: inherit; max-width: 500px; width: inherit" />
+            </div>
+            <div>
+              <button class="image-caption-button">Add Caption</button>
+              <div class="image-resizer image-resizer-n"></div>
+              <div class="image-resizer image-resizer-ne"></div>
+              <div class="image-resizer image-resizer-e"></div>
+              <div class="image-resizer image-resizer-se"></div>
+              <div class="image-resizer image-resizer-s"></div>
+              <div class="image-resizer image-resizer-sw"></div>
+              <div class="image-resizer image-resizer-w"></div>
+              <div class="image-resizer image-resizer-nw"></div>
+            </div>
+          </span>
+          <br />
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: false},
     );
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -2128,6 +2128,8 @@ test.describe.parallel('Links', () => {
   });
 
   test('Can add, edit and remove links on images', async ({page, isCollab}) => {
+    // Skip for collaborative mode
+    test.skip(isCollab);
     await focusEditor(page);
 
     // Insert image
@@ -2272,7 +2274,11 @@ test.describe.parallel('Links', () => {
 
   test('Can add, edit and remove links on multiple selected images', async ({
     page,
+    isCollab,
   }) => {
+    // Skip for collaborative mode
+    test.skip(isCollab);
+
     await focusEditor(page);
 
     // Insert first image

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -2269,6 +2269,255 @@ test.describe.parallel('Links', () => {
       {ignoreClasses: false},
     );
   });
+
+  test('Can add, edit and remove links on multiple selected images', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    // Insert first image
+    await insertSampleImage(page);
+    await page.keyboard.press('Enter');
+
+    // Insert second image
+    await insertSampleImage(page);
+
+    // Select both images
+    await click(page, 'p:nth-child(1) .editor-image img');
+    await page.keyboard.down('Shift');
+    await click(page, 'p:nth-child(2) .editor-image img');
+    await page.keyboard.up('Shift');
+
+    // Add link to both images
+    await click(page, '.link');
+    await focus(page, '.link-input');
+    await page.keyboard.type('lexical.dev');
+    await click(page, '.link-confirm');
+
+    // Verify both images are linked
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://lexical.dev"
+            rel="noreferrer">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="true">
+                <img
+                  class="focused draggable"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="${SAMPLE_IMAGE_URL}"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+              <div>
+                <button class="image-caption-button">Add Caption</button>
+                <div class="image-resizer image-resizer-n"></div>
+                <div class="image-resizer image-resizer-ne"></div>
+                <div class="image-resizer image-resizer-e"></div>
+                <div class="image-resizer image-resizer-se"></div>
+                <div class="image-resizer image-resizer-s"></div>
+                <div class="image-resizer image-resizer-sw"></div>
+                <div class="image-resizer image-resizer-w"></div>
+                <div class="image-resizer image-resizer-nw"></div>
+              </div>
+            </span>
+          </a>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://lexical.dev"
+            rel="noreferrer">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="true">
+                <img
+                  class="focused draggable"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="${SAMPLE_IMAGE_URL}"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+              <div>
+                <button class="image-caption-button">Add Caption</button>
+                <div class="image-resizer image-resizer-n"></div>
+                <div class="image-resizer image-resizer-ne"></div>
+                <div class="image-resizer image-resizer-e"></div>
+                <div class="image-resizer image-resizer-se"></div>
+                <div class="image-resizer image-resizer-s"></div>
+                <div class="image-resizer image-resizer-sw"></div>
+                <div class="image-resizer image-resizer-w"></div>
+                <div class="image-resizer image-resizer-nw"></div>
+              </div>
+            </span>
+          </a>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: false},
+    );
+
+    // Edit link for both images
+    await click(page, 'p:nth-child(1) .editor-image img');
+    await page.keyboard.down('Shift');
+    await click(page, 'p:nth-child(2) .editor-image img');
+    await page.keyboard.up('Shift');
+    await click(page, '.link-edit');
+    await focus(page, '.link-input');
+    await selectAll(page);
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type('https://github.com/facebook/lexical');
+    await click(page, '.link-confirm');
+
+    // Verify both links were updated
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://github.com/facebook/lexical"
+            rel="noreferrer">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="true">
+                <img
+                  class="focused draggable"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="${SAMPLE_IMAGE_URL}"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+              <div>
+                <button class="image-caption-button">Add Caption</button>
+                <div class="image-resizer image-resizer-n"></div>
+                <div class="image-resizer image-resizer-ne"></div>
+                <div class="image-resizer image-resizer-e"></div>
+                <div class="image-resizer image-resizer-se"></div>
+                <div class="image-resizer image-resizer-s"></div>
+                <div class="image-resizer image-resizer-sw"></div>
+                <div class="image-resizer image-resizer-w"></div>
+                <div class="image-resizer image-resizer-nw"></div>
+              </div>
+            </span>
+          </a>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://github.com/facebook/lexical"
+            rel="noreferrer">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="true">
+                <img
+                  class="focused draggable"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="${SAMPLE_IMAGE_URL}"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+              <div>
+                <button class="image-caption-button">Add Caption</button>
+                <div class="image-resizer image-resizer-n"></div>
+                <div class="image-resizer image-resizer-ne"></div>
+                <div class="image-resizer image-resizer-e"></div>
+                <div class="image-resizer image-resizer-se"></div>
+                <div class="image-resizer image-resizer-s"></div>
+                <div class="image-resizer image-resizer-sw"></div>
+                <div class="image-resizer image-resizer-w"></div>
+                <div class="image-resizer image-resizer-nw"></div>
+              </div>
+            </span>
+          </a>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: false},
+    );
+
+    // Remove links from both images
+    await click(page, 'p:nth-child(1) .editor-image img');
+    await page.keyboard.down('Shift');
+    await click(page, 'p:nth-child(2) .editor-image img');
+    await page.keyboard.up('Shift');
+    await click(page, '.link-trash');
+
+    // Verify links were removed but images remain
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="true">
+              <img
+                class="focused draggable"
+                alt="Yellow flower in tilt shift lens"
+                draggable="false"
+                src="${SAMPLE_IMAGE_URL}"
+                style="height: inherit; max-width: 500px; width: inherit" />
+            </div>
+            <div>
+              <button class="image-caption-button">Add Caption</button>
+              <div class="image-resizer image-resizer-n"></div>
+              <div class="image-resizer image-resizer-ne"></div>
+              <div class="image-resizer image-resizer-e"></div>
+              <div class="image-resizer image-resizer-se"></div>
+              <div class="image-resizer image-resizer-s"></div>
+              <div class="image-resizer image-resizer-sw"></div>
+              <div class="image-resizer image-resizer-w"></div>
+              <div class="image-resizer image-resizer-nw"></div>
+            </div>
+          </span>
+          <br />
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="true">
+              <img
+                class="focused draggable"
+                alt="Yellow flower in tilt shift lens"
+                draggable="false"
+                src="${SAMPLE_IMAGE_URL}"
+                style="height: inherit; max-width: 500px; width: inherit" />
+            </div>
+            <div>
+              <button class="image-caption-button">Add Caption</button>
+              <div class="image-resizer image-resizer-n"></div>
+              <div class="image-resizer image-resizer-ne"></div>
+              <div class="image-resizer image-resizer-e"></div>
+              <div class="image-resizer image-resizer-se"></div>
+              <div class="image-resizer image-resizer-s"></div>
+              <div class="image-resizer image-resizer-sw"></div>
+              <div class="image-resizer image-resizer-w"></div>
+              <div class="image-resizer image-resizer-nw"></div>
+            </div>
+          </span>
+          <br />
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: false},
+    );
+  });
 });
 
 test.describe('Link attributes', () => {

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -2127,9 +2127,15 @@ test.describe.parallel('Links', () => {
     );
   });
 
-  test('Can add, edit and remove links on images', async ({page, isCollab}) => {
-    // Skip for collaborative mode
-    test.skip(isCollab);
+  test('Can add, edit and remove links on images', async ({
+    page,
+    isCollab,
+    browserName,
+  }) => {
+    // Skip for collaborative mode and Firefox on Linux
+    test.skip(
+      isCollab || (browserName === 'firefox' && process.platform === 'linux'),
+    );
     await focusEditor(page);
 
     // Insert image
@@ -2275,10 +2281,12 @@ test.describe.parallel('Links', () => {
   test('Can add, edit and remove links on multiple selected images', async ({
     page,
     isCollab,
+    browserName,
   }) => {
-    // Skip for collaborative mode
-    test.skip(isCollab);
-
+    // Skip for collaborative mode and Firefox on Linux
+    test.skip(
+      isCollab || (browserName === 'firefox' && process.platform === 'linux'),
+    );
     await focusEditor(page);
 
     // Insert first image

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -30,6 +30,7 @@ import {
   keyDownCtrlOrMeta,
   keyUpCtrlOrMeta,
   pasteFromClipboard,
+  SAMPLE_IMAGE_URL,
   test,
   withExclusiveClipboardAccess,
 } from '../utils/index.mjs';
@@ -2157,7 +2158,7 @@ test.describe.parallel('Links', () => {
                   class="focused draggable"
                   alt="Yellow flower in tilt shift lens"
                   draggable="false"
-                  src="/src/images/yellow-flower.jpg"
+                  src="${SAMPLE_IMAGE_URL}"
                   style="height: inherit; max-width: 500px; width: inherit" />
               </div>
               <div>
@@ -2206,7 +2207,7 @@ test.describe.parallel('Links', () => {
                   class="focused draggable"
                   alt="Yellow flower in tilt shift lens"
                   draggable="false"
-                  src="/src/images/yellow-flower.jpg"
+                  src="${SAMPLE_IMAGE_URL}"
                   style="height: inherit; max-width: 500px; width: inherit" />
               </div>
               <div>
@@ -2246,7 +2247,7 @@ test.describe.parallel('Links', () => {
                 class="focused draggable"
                 alt="Yellow flower in tilt shift lens"
                 draggable="false"
-                src="/src/images/yellow-flower.jpg"
+                src="${SAMPLE_IMAGE_URL}"
                 style="height: inherit; max-width: 500px; width: inherit" />
             </div>
             <div>


### PR DESCRIPTION
## Description
### Current Behavior
Currently, the `$toggleLink` function in `@lexical/link` package only supports `RangeSelection`, making it impossible to add links to images or other nodes that use `NodeSelection`. The `FloatingLinkEditorPlugin` also doesn't show up when clicking on images, preventing users from adding or editing links on images.

### Changes in this PR
This PR adds support for linking images in Lexical by:
1. Extending `$toggleLink` to handle both `RangeSelection` and `NodeSelection`
2. Updating FloatingLinkEditorPlugin to:
   - Show link toolbar when clicking images
   - Handle link editing for image nodes
   - Position toolbar correctly for image selections
3. Adding comprehensive test coverage for:
   - Adding/editing/removing links on single images

Closes #4645

## Test plan

### Before

https://github.com/user-attachments/assets/3ff74605-82ca-4573-8d83-9c5d25e814bd

### After


https://github.com/user-attachments/assets/53a768fe-48fe-4d2f-bf6a-61e98ac69732



