### PR TITLE
[Breaking Change][lexical-table][lexical-playground] Bug Fix: Set tableFrozenColumn and tableFrozenRow classes only on the scrollable table wrapper

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -221,7 +221,7 @@
   margin-top: 25px;
   margin-bottom: 30px;
 }
-.PlaygroundEditorTheme__tableFrozenRow {
+.PlaygroundEditorTheme__tableScrollableWrapper.PlaygroundEditorTheme__tableFrozenRow {
   /* position:sticky needs overflow:clip or visible
      https://github.com/w3c/csswg-drafts/issues/865#issuecomment-350585274 */
   overflow-x: clip;

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -1158,47 +1158,52 @@ describe('LexicalTableNode tests', () => {
             });
           });
 
-          test('Toggle frozen first column ON/OFF', async () => {
-            const {editor} = testEnv;
+          if (hasHorizontalScroll) {
+            test('Toggle frozen first column ON/OFF', async () => {
+              const {editor} = testEnv;
 
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = $createTableNodeWithDimensions(4, 4, true);
-              root.append(table);
-            });
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              if (table) {
-                table.setFrozenColumns(1);
-              }
-            });
+              await editor.update(() => {
+                const root = $getRoot();
+                const table = $createTableNodeWithDimensions(4, 4, true);
+                root.append(table);
+              });
+              await editor.update(() => {
+                const root = $getRoot();
+                const table = root.getLastChild<TableNode>();
+                if (table) {
+                  table.setFrozenColumns(1);
+                }
+              });
 
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              expectTableHtmlToBeEqual(
-                table!.createDOM(editorConfig).outerHTML,
-                html`
-                  <table
-                    class="${editorConfig.theme.table} ${editorConfig.theme
-                      .tableFrozenColumn}"
-                    data-lexical-frozen-column="true">
-                    <colgroup>
-                      <col />
-                      <col />
-                      <col />
-                      <col />
-                    </colgroup>
-                  </table>
-                `,
+              await editor.update(() => {
+                const root = $getRoot();
+                const table = root.getLastChild<TableNode>();
+                expectHtmlToBeEqual(
+                  table!.createDOM(editorConfig).outerHTML,
+                  html`
+                    <div
+                      class="${editorConfig.theme
+                        .tableScrollableWrapper} ${editorConfig.theme
+                        .tableFrozenColumn}">
+                      <table
+                        class="${editorConfig.theme.table}"
+                        data-lexical-frozen-column="true">
+                        <colgroup>
+                          <col />
+                          <col />
+                          <col />
+                          <col />
+                        </colgroup>
+                      </table>
+                    </div>
+                  `,
+                );
+              });
+
+              const stringifiedEditorState = JSON.stringify(
+                editor.getEditorState(),
               );
-            });
-
-            const stringifiedEditorState = JSON.stringify(
-              editor.getEditorState(),
-            );
-            const expectedStringifiedEditorState = `{
+              const expectedStringifiedEditorState = `{
               "root": {
                 "children": [
                   {
@@ -1634,36 +1639,39 @@ describe('LexicalTableNode tests', () => {
               }
             }`;
 
-            expect(JSON.parse(stringifiedEditorState)).toEqual(
-              JSON.parse(expectedStringifiedEditorState),
-            );
-
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              if (table) {
-                table.setFrozenColumns(0);
-              }
-            });
-
-            await editor.update(() => {
-              const root = $getRoot();
-              const table = root.getLastChild<TableNode>();
-              expectTableHtmlToBeEqual(
-                table!.createDOM(editorConfig).outerHTML,
-                html`
-                  <table class="${editorConfig.theme.table}">
-                    <colgroup>
-                      <col />
-                      <col />
-                      <col />
-                      <col />
-                    </colgroup>
-                  </table>
-                `,
+              expect(JSON.parse(stringifiedEditorState)).toEqual(
+                JSON.parse(expectedStringifiedEditorState),
               );
+
+              await editor.update(() => {
+                const root = $getRoot();
+                const table = root.getLastChild<TableNode>();
+                if (table) {
+                  table.setFrozenColumns(0);
+                }
+              });
+
+              await editor.update(() => {
+                const root = $getRoot();
+                const table = root.getLastChild<TableNode>();
+                expectHtmlToBeEqual(
+                  table!.createDOM(editorConfig).outerHTML,
+                  html`
+                    <div class="${editorConfig.theme.tableScrollableWrapper}">
+                      <table class="${editorConfig.theme.table}">
+                        <colgroup>
+                          <col />
+                          <col />
+                          <col />
+                          <col />
+                        </colgroup>
+                      </table>
+                    </div>
+                  `,
+                );
+              });
             });
-          });
+          }
 
           test('Change Table-level alignment', async () => {
             const {editor} = testEnv;


### PR DESCRIPTION
## Breaking Change

If you're using the new tableFrozenColumn or tableFrozenRow features you may need to change your CSS or test expectations since the tableFrozenRow and tableFrozenColumn classes are set on the scrollable table wrapper and not the table element. Generally this wouldn't break code unless you are using selectors such as `.tableFrozenColumn > tr` or `table.tableFrozenColumn` that wouldn't work correctly when the class is on the wrapper.

## Description

The tableFrozenRow class needs to affect the table wrapper's overflow-x, so it needs to be set on that element. An alternative solution would be to use the newer `:has` pseudo-selector, but that is only recently available in modern browsers.

Closes #7370

## Test plan

Unit test modified for new behavior