### PR TITLE
[lexical-list] Bug Fix: empty list item type change

### DIFF
--- a/packages/lexical-list/src/__tests__/unit/formatList.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/formatList.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import {
   $createTableCellNode,
   $createTableNode,
@@ -14,11 +13,18 @@ import {
   TableNode,
   TableRowNode,
 } from '@lexical/table';
-import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $nodesOfType,
+  $selectAll,
+} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
 
 import {$insertList} from '../../formatList';
-import {$isListNode} from '../../LexicalListNode';
+import {$createListItemNode} from '../../LexicalListItemNode';
+import {$createListNode, $isListNode, ListNode} from '../../LexicalListNode';
 
 describe('insertList', () => {
   initializeUnitTest((testEnv) => {
@@ -95,6 +101,33 @@ describe('insertList', () => {
         const firstChild = cell.getFirstChildOrThrow();
 
         expect($isListNode(firstChild)).toBe(true);
+      });
+    });
+
+    test('formatting empty list items', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        $getRoot().append(
+          $createListNode('bullet').append(
+            $createListItemNode().append($createTextNode('Level 1')),
+            $createListItemNode().append(
+              $createListNode('bullet').append($createListItemNode()),
+            ),
+          ),
+        );
+      });
+
+      await editor.update(() => {
+        $selectAll();
+        $insertList('number');
+      });
+
+      editor.read(() => {
+        const lists = $nodesOfType(ListNode).filter(
+          (node) => node.getListType() === 'number',
+        );
+        expect(lists.length).toBe(2);
       });
     });
   });

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -121,31 +121,34 @@ export function $insertList(listType: ListType): void {
         continue;
       }
 
-      if ($isLeafNode(node)) {
-        let parent = node.getParent();
-        while (parent != null) {
-          const parentKey = parent.getKey();
+      let parent = $isLeafNode(node)
+        ? node.getParent()
+        : $isListItemNode(node) && node.isEmpty()
+        ? node
+        : null;
 
-          if ($isListNode(parent)) {
-            if (!handled.has(parentKey)) {
-              const newListNode = $createListNode(listType);
-              append(newListNode, parent.getChildren());
-              parent.replace(newListNode);
-              handled.add(parentKey);
-            }
+      while (parent != null) {
+        const parentKey = parent.getKey();
 
-            break;
-          } else {
-            const nextParent = parent.getParent();
-
-            if ($isRootOrShadowRoot(nextParent) && !handled.has(parentKey)) {
-              handled.add(parentKey);
-              $createListOrMerge(parent, listType);
-              break;
-            }
-
-            parent = nextParent;
+        if ($isListNode(parent)) {
+          if (!handled.has(parentKey)) {
+            const newListNode = $createListNode(listType);
+            append(newListNode, parent.getChildren());
+            parent.replace(newListNode);
+            handled.add(parentKey);
           }
+
+          break;
+        } else {
+          const nextParent = parent.getParent();
+
+          if ($isRootOrShadowRoot(nextParent) && !handled.has(parentKey)) {
+            handled.add(parentKey);
+            $createListOrMerge(parent, listType);
+            break;
+          }
+
+          parent = nextParent;
         }
       }
     }


### PR DESCRIPTION
When we select empty nested list (meaning there's no content in it), and try to format to a different type it won't work and only change list type for those having at least some text in it. 

Updated code assumed that there will be some content within list items to traverse up to list item itself, while it's not the case for empty ones.

Before

https://github.com/user-attachments/assets/39430f32-65c6-40b0-b79f-abea3f34bc95

After

https://github.com/user-attachments/assets/f8bb1666-ddbf-436a-84f1-172d48ad9ab9



