### PR TITLE
Update dependencies: vite,@babel/runtime,prismjs,@babel/helpers

### DIFF
--- a/examples/react-plain-text/package-lock.json
+++ b/examples/react-plain-text/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@lexical/react-plain-text-example",
-  "version": "0.24.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-plain-text-example",
-      "version": "0.24.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@lexical/react": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/react": "0.29.0",
+        "lexical": "0.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -790,38 +790,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -829,133 +832,143 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -964,61 +977,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1590,6 +1609,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -1626,14 +1646,16 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
+      "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -1745,9 +1767,10 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2027,9 +2050,10 @@
       "dev": true
     },
     "node_modules/yjs": {
-      "version": "13.6.23",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
-      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "version": "13.6.24",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
+      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"

--- a/examples/react-rich-collab/package-lock.json
+++ b/examples/react-rich-collab/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@lexical/react-rich-collab-example",
-  "version": "0.24.0",
+  "version": "0.29.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-rich-collab-example",
-      "version": "0.24.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@lexical/react": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/react": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "y-webrtc": "^10.3.0",
@@ -795,38 +795,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -834,133 +837,143 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -969,61 +982,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -2050,9 +2069,10 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
+      "license": "MIT"
     },
     "node_modules/lib0": {
       "version": "0.2.93",
@@ -2201,9 +2221,10 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3374,227 +3395,225 @@
       }
     },
     "@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
       "requires": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
       "requires": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
       "requires": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
       "requires": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       }
     },
     "@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
       "requires": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
       "requires": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@rollup/rollup-android-arm-eabi": {
@@ -4291,9 +4310,9 @@
       }
     },
     "lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w=="
     },
     "lib0": {
       "version": "0.2.93",
@@ -4390,9 +4409,9 @@
       }
     },
     "prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
     },
     "prr": {
       "version": "1.0.1",

--- a/examples/react-rich/package-lock.json
+++ b/examples/react-rich/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@lexical/react-rich-example",
-  "version": "0.24.0",
+  "version": "0.29.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-rich-example",
-      "version": "0.24.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@lexical/react": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/react": "0.29.0",
+        "lexical": "0.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -790,38 +790,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -829,133 +832,143 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -964,61 +977,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1597,6 +1616,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -1633,14 +1653,16 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
+      "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -1752,9 +1774,10 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2034,9 +2057,10 @@
       "dev": true
     },
     "node_modules/yjs": {
-      "version": "13.6.23",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
-      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "version": "13.6.24",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
+      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
@@ -2510,227 +2534,225 @@
       }
     },
     "@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
       "requires": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
       "requires": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
       "requires": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
       "requires": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       }
     },
     "@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
       "requires": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
       "requires": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@rollup/rollup-android-arm-eabi": {
@@ -3135,14 +3157,14 @@
       "dev": true
     },
     "lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w=="
     },
     "lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
       "peer": true,
       "requires": {
         "isomorphic.js": "^0.2.4"
@@ -3207,9 +3229,9 @@
       }
     },
     "prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
     },
     "react": {
       "version": "18.2.0",
@@ -3367,9 +3389,9 @@
       "dev": true
     },
     "yjs": {
-      "version": "13.6.23",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
-      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "version": "13.6.24",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
+      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
       "peer": true,
       "requires": {
         "lib0": "^0.2.99"

--- a/examples/react-table/package-lock.json
+++ b/examples/react-table/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@lexical/react-table-example",
-  "version": "0.24.0",
+  "version": "0.29.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-table-example",
-      "version": "0.24.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@lexical/react": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/react": "0.29.0",
+        "lexical": "0.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -790,38 +790,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -829,133 +832,143 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -964,61 +977,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1597,6 +1616,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -1633,14 +1653,16 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
+      "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -1752,9 +1774,10 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2034,9 +2057,10 @@
       "dev": true
     },
     "node_modules/yjs": {
-      "version": "13.6.23",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
-      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "version": "13.6.24",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
+      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
@@ -2510,227 +2534,225 @@
       }
     },
     "@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
       "requires": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
       "requires": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
       "requires": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
       "requires": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       }
     },
     "@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
       "requires": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
       "requires": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@rollup/rollup-android-arm-eabi": {
@@ -3135,14 +3157,14 @@
       "dev": true
     },
     "lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w=="
     },
     "lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
       "peer": true,
       "requires": {
         "isomorphic.js": "^0.2.4"
@@ -3207,9 +3229,9 @@
       }
     },
     "prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
     },
     "react": {
       "version": "18.2.0",
@@ -3367,9 +3389,9 @@
       "dev": true
     },
     "yjs": {
-      "version": "13.6.23",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
-      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "version": "13.6.24",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
+      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
       "peer": true,
       "requires": {
         "lib0": "^0.2.99"

--- a/package-lock.json
+++ b/package-lock.json
@@ -836,25 +836,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2352,9 +2352,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.9.tgz",
-      "integrity": "sha512-5EVjbTegqN7RSJle6hMWYxO4voo4rI+9krITk+DWR+diJgGrjZjrIBnJhjrHYYQsFgI7j1w1QnrvV7YSKBfYGg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.27.0.tgz",
+      "integrity": "sha512-UWjX6t+v+0ckwZ50Y5ShZLnlk95pP5MyW/pon9tiYzl3+18pkTHTFNTKr7rQbfRXPkowt2QAn30o1b6oswszew==",
       "license": "MIT",
       "dependencies": {
         "core-js-pure": "^3.30.2",
@@ -2365,14 +2365,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2397,9 +2397,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -42330,20 +42330,20 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "requires": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "requires": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
@@ -43250,22 +43250,22 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.9.tgz",
-      "integrity": "sha512-5EVjbTegqN7RSJle6hMWYxO4voo4rI+9krITk+DWR+diJgGrjZjrIBnJhjrHYYQsFgI7j1w1QnrvV7YSKBfYGg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.27.0.tgz",
+      "integrity": "sha512-UWjX6t+v+0ckwZ50Y5ShZLnlk95pP5MyW/pon9tiYzl3+18pkTHTFNTKr7rQbfRXPkowt2QAn30o1b6oswszew==",
       "requires": {
         "core-js-pure": "^3.30.2",
         "regenerator-runtime": "^0.14.0"
       }
     },
     "@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "requires": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/traverse": {
@@ -43283,9 +43283,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "requires": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package-lock.json
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package-lock.json
@@ -1,27 +1,24 @@
 {
   "name": "lexical-esm-astro-react",
-  "version": "0.24.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexical-esm-astro-react",
-      "version": "0.24.0",
+      "version": "0.29.0",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@astrojs/react": "^4.2.0",
-        "@lexical/react": "0.24.0",
-        "@lexical/utils": "0.24.0",
+        "@lexical/react": "0.29.0",
+        "@lexical/utils": "0.29.0",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "astro": "^5.3.0",
-        "lexical": "0.24.0",
+        "lexical": "0.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "^5.4.2"
-      },
-      "devDependencies": {
-        "@playwright/test": "^1.43.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -344,23 +341,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -398,9 +397,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -409,13 +409,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -439,9 +440,10 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -1289,38 +1291,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -1328,133 +1333,143 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -1463,61 +1478,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1560,21 +1581,6 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.1.tgz",
-      "integrity": "sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==",
-      "dev": true,
-      "dependencies": {
-        "playwright": "1.43.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
@@ -3502,6 +3508,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -3565,14 +3572,16 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
+      "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -4490,15 +4499,16 @@
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4726,54 +4736,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
-      "integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.43.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
-      "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
-      "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -4788,6 +4754,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -4811,24 +4778,27 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -5888,12 +5858,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
-      "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.24.2",
-        "postcss": "^8.5.1",
+        "esbuild": "^0.25.0",
+        "postcss": "^8.5.3",
         "rollup": "^4.30.1"
       },
       "bin": {
@@ -5955,6 +5926,446 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz",
+      "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.1.tgz",
+      "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz",
+      "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.1.tgz",
+      "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz",
+      "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz",
+      "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz",
+      "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz",
+      "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz",
+      "integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz",
+      "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz",
+      "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz",
+      "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz",
+      "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz",
+      "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz",
+      "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz",
+      "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz",
+      "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz",
+      "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz",
+      "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz",
+      "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz",
+      "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz",
+      "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz",
+      "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.1",
+        "@esbuild/android-arm": "0.25.1",
+        "@esbuild/android-arm64": "0.25.1",
+        "@esbuild/android-x64": "0.25.1",
+        "@esbuild/darwin-arm64": "0.25.1",
+        "@esbuild/darwin-x64": "0.25.1",
+        "@esbuild/freebsd-arm64": "0.25.1",
+        "@esbuild/freebsd-x64": "0.25.1",
+        "@esbuild/linux-arm": "0.25.1",
+        "@esbuild/linux-arm64": "0.25.1",
+        "@esbuild/linux-ia32": "0.25.1",
+        "@esbuild/linux-loong64": "0.25.1",
+        "@esbuild/linux-mips64el": "0.25.1",
+        "@esbuild/linux-ppc64": "0.25.1",
+        "@esbuild/linux-riscv64": "0.25.1",
+        "@esbuild/linux-s390x": "0.25.1",
+        "@esbuild/linux-x64": "0.25.1",
+        "@esbuild/netbsd-arm64": "0.25.1",
+        "@esbuild/netbsd-x64": "0.25.1",
+        "@esbuild/openbsd-arm64": "0.25.1",
+        "@esbuild/openbsd-x64": "0.25.1",
+        "@esbuild/sunos-x64": "0.25.1",
+        "@esbuild/win32-arm64": "0.25.1",
+        "@esbuild/win32-ia32": "0.25.1",
+        "@esbuild/win32-x64": "0.25.1"
       }
     },
     "node_modules/vitefu": {
@@ -6303,6 +6714,22 @@
         "prettier": "2.8.7"
       }
     },
+    "node_modules/yaml-language-server/node_modules/prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/yaml-language-server/node_modules/request-light": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
@@ -6412,9 +6839,10 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.23",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
-      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "version": "13.6.24",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
+      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"

--- a/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/package-lock.json
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "lexical-esm-nextjs",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexical-esm-nextjs",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@lexical/plain-text": "0.28.0",
-        "@lexical/react": "0.28.0",
-        "lexical": "0.28.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/react": "0.29.0",
+        "lexical": "0.29.0",
         "next": "^14.2.1",
         "react": "^18",
         "react-dom": "^18"
@@ -39,9 +39,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -142,41 +143,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.28.0.tgz",
-      "integrity": "sha512-LYqion+kAwFQJStA37JAEMxTL/m1WlZbotDfM/2WuONmlO0yWxiyRDI18oeCwhBD6LQQd9c3Ccxp9HFwUG1AVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.28.0",
-        "@lexical/list": "0.28.0",
-        "@lexical/selection": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.28.0.tgz",
-      "integrity": "sha512-9LOKSWdRhxqAKRq5yveNC21XKtW4h2rmFNTucwMWZ9vLu9xteOHEwZdO1Qv82PFUmgCpAhg6EntmnZu9xD3K7Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.28.0.tgz",
-      "integrity": "sha512-Fk4itAjZ+MqTYXN84aE5RDf+wQX67N5nyo3JVxQTFZGAghx7Ux1xLWHB25zzD0YfjMtJ0NQROAbE3xdecZzxcQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.28.0",
-        "@lexical/link": "0.28.0",
-        "@lexical/mark": "0.28.0",
-        "@lexical/table": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -184,143 +185,143 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.28.0.tgz",
-      "integrity": "sha512-T6T8YaHnhU863ruuqmRHTLUYa8sfg/ArYcrnNGZGfpvvFTfFjpWb/ELOvOWo8N6Y/4fnSLjQ20aXexVW1KcTBQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.28.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.28.0.tgz",
-      "integrity": "sha512-zcqX9Qna4lj96bAUfwSQSVEhYQ0O5erSjrIhOVqEgeQ5ubz0EvqnnMbbwNHIb2n6jzSwAvpD/3UZJZtolh+zVg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.28.0.tgz",
-      "integrity": "sha512-CHzDxaGDn6qCFFhU0YKP1B8sgEb++0Ksqsj6BfDL/6TMxoLNQwRQhP3BUNNXl1kvUhxTQZgk3b9MjJZRaFKG9Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.28.0.tgz",
-      "integrity": "sha512-ayb0FPxr55Ko99/d9ewbfrApul4L0z+KpU2ZG03im7EvUPVLyIGLx4S0QguMDvQh0Vu+eJ7/EESuonDs5BCe3A==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.28.0.tgz",
-      "integrity": "sha512-T5VKxpOnML5DcXv2lW3Le0vjNlcbdohZjS9f6PAvm6eX8EzBKDpLQCopr1/0KGdlLd1QrzQsykQrdU7ieC4LRg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.28.0.tgz",
-      "integrity": "sha512-3a8QcZ75n2TLxP+xkSPJ2V15jsysMLMe0YoObG+ew/sioVelIU8GciYsWBo5GgQmwSzJNQJeK5cJ9p1b71z2cg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.28.0.tgz",
-      "integrity": "sha512-v5PzmTACsJrw3GvNZy2rgPxrNn9InLvLFoKqrSlNhhyvYNIAcuC4KVy00LKLja43Gw/fuB3QwKohYfAtM3yR3g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.28.0.tgz",
-      "integrity": "sha512-F3JXClqN4cjmXYLDK0IztxkbZuqkqS/AVbxnhGvnDYHQ9Gp8l7BonczhOiPwmJCDubJrAACP0L9LCqyt0jDRFw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.28.0",
-        "@lexical/link": "0.28.0",
-        "@lexical/list": "0.28.0",
-        "@lexical/rich-text": "0.28.0",
-        "@lexical/text": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.28.0.tgz",
-      "integrity": "sha512-/SMDQgBPeWM936t04mtH6UAn3xAjP/meu9q136bcT3S7p7V8ew9JfNp9aznTPTx+2W3brJORAvUow7Xn1fSHmw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.28.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.28.0.tgz",
-      "integrity": "sha512-ppmhHXEZVicBm05w9EVflzwFavTVNAe4q0bkabWUeW0IoCT3Vg2A3JT7PC9ypmp+mboUD195foFEr1BBSv1Y8Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.28.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.28.0.tgz",
-      "integrity": "sha512-Jj2dCMDEfRuVetfDKcUes8J5jvAfZrLnILFlHxnu7y+lC+7R/NR403DYb3NJ8H7+lNiH1K15+U2K7ewbjxS6KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.28.0",
-        "@lexical/selection": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.28.0.tgz",
-      "integrity": "sha512-dWPnxrKrbQFjNqExqnaAsV0UEUgw/5M1ZYRWd5FGBGjHqVTCaX2jNHlKLMA68Od0VPIoOX2Zy1TYZ8ZKtsj5Dg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/devtools-core": "0.28.0",
-        "@lexical/dragon": "0.28.0",
-        "@lexical/hashtag": "0.28.0",
-        "@lexical/history": "0.28.0",
-        "@lexical/link": "0.28.0",
-        "@lexical/list": "0.28.0",
-        "@lexical/mark": "0.28.0",
-        "@lexical/markdown": "0.28.0",
-        "@lexical/overflow": "0.28.0",
-        "@lexical/plain-text": "0.28.0",
-        "@lexical/rich-text": "0.28.0",
-        "@lexical/table": "0.28.0",
-        "@lexical/text": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "@lexical/yjs": "0.28.0",
-        "lexical": "0.28.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -329,67 +330,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.28.0.tgz",
-      "integrity": "sha512-y+vUWI+9uFupIb9UvssKU/DKcT9dFUZuQBu7utFkLadxCNyXQHeRjxzjzmvFiM3DBV0guPUDGu5VS5TPnIA+OA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.28.0",
-        "@lexical/selection": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.28.0.tgz",
-      "integrity": "sha512-AJDi67Nsexyejzp4dEQSVoPov4P+FJ0t1v6DxUU+YmcvV56QyJQi6ue0i/xd8unr75ZufzLsAC0cDJJCEI7QDA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.28.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.28.0.tgz",
-      "integrity": "sha512-HMPCwXdj0sRWdlDzsHcNWRgbeKbEhn3L8LPhFnTq7q61gZ4YW2umdmuvQFKnIBcKq49drTH8cUwZoIwI8+AEEw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.28.0.tgz",
-      "integrity": "sha512-PT/A2RZv+ktn7SG/tJkOpGlYE6zjOND59VtRHnV/xciZ+jEJVaqAHtWjhbWibAIZQAkv/O7UouuDqzDaNTSGAA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.28.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.28.0.tgz",
-      "integrity": "sha512-Qw00DjkS1nRK7DLSgqJpJ77Ti2AuiOQ6m5eM38YojoWXkVmoxqKAUMaIbVNVKqjFgrQvKFF46sXxIJPbUQkB0w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.28.0",
-        "@lexical/selection": "0.28.0",
-        "@lexical/table": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.28.0.tgz",
-      "integrity": "sha512-rKHpUEd3nrvMY7ghmOC0AeGSYT7YIviba+JViaOzrCX4/Wtv5C/3Sl7Io12Z9k+s1BKmy7C28bOdQHvRWaD7vQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.28.0",
-        "@lexical/selection": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1268,15 +1269,15 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/lexical": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.28.0.tgz",
-      "integrity": "sha512-dLE3O1PZg0TlZxRQo9YDpjCjDUj8zluGyBO9MHdjo21qZmMUNrxQPeCRt8fn2s5l4HKYFQ1YNgl7k1pOJB/vZQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
       "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.100",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.100.tgz",
-      "integrity": "sha512-ACQmtZ8cRD7/SpBEzBP88KrgrjOnhfcOANhhk8ASv+HFEvBSHOprxur3vuhmNw4YLq29y4Yen4jU0jHpIqVYWw==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
## Description
GitHub detected  vulnerabilities in these dependencies:
* @babel/runtime-corejs3 
* vite
* prismjs
* @babel/helpers
* @babel/runtime-corejs3 

## Test plan
existing test cases
