### PR TITLE
[RFC][lexical-markdown] Replace whitespace with &#160 when the string consists only of whitespace.

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -25,6 +25,7 @@ import {
 } from './MarkdownTransformers';
 import {isEmptyParagraph, transformersByType} from './utils';
 
+const WHITESPACE_CHAR = '&#160;';
 /**
  * Renders string from markdown. The selection is moved to the start after the operation.
  */
@@ -205,14 +206,19 @@ function exportTextFormat(
   // Where it would be invalid markdown to generate: "**   foo   **"
   // We instead want to trim the whitespace out, apply formatting, and then
   // bring the whitespace back. So our returned string looks like this: "   **foo**   "
+  // for whitespace only string case like: "  ", we replace the whitespace with &#160;
   const frozenString = textContent.trim();
   let output = frozenString;
+  const isWhitespaceOnly = frozenString.length === 0;
+
+  if (isWhitespaceOnly) {
+    output = textContent.replace(/\s/g, WHITESPACE_CHAR);
+  }
 
   if (!node.hasFormat('code')) {
     // Escape any markdown characters in the text content
     output = output.replace(/([*_`~\\])/g, '\\$1');
   }
-
   // the opening tags to be added to the result
   let openingTags = '';
   // the closing tags to be added to the result
@@ -286,6 +292,9 @@ function exportTextFormat(
   }
 
   output = openingTags + output + closingTagsAfter;
+  if (isWhitespaceOnly) {
+    return closingTagsBefore + output;
+  }
   // Replace trimmed version of textContent ensuring surrounding whitespace is not modified
   return closingTagsBefore + textContent.replace(frozenString, () => output);
 }

--- a/packages/lexical-markdown/src/importTextTransformers.ts
+++ b/packages/lexical-markdown/src/importTextTransformers.ts
@@ -133,6 +133,10 @@ export function importTextTransformers(
 
   // Handle escape characters
   const textContent = textNode.getTextContent();
-  const escapedText = textContent.replace(/\\([*_`~])/g, '$1');
+  const escapedText = textContent
+    .replace(/\\([*_`~])/g, '$1')
+    .replace(/&#(\d+);/g, (_, codePoint) => {
+      return String.fromCharCode(codePoint);
+    });
   textNode.setTextContent(escapedText);
 }


### PR DESCRIPTION
## Description
Currently, `exportTextFormat` in `MardownExports` trim the input first to handle the case looking like `**   foo   **`
An edge case here is if the string consists only of whitespaces, the trimmed string will be empty.
Based on the discussion [here](https://github.com/facebook/lexical/issues/6526#issuecomment-2725146825), one possible solution is replacing the whitespace with &#160;, which is also compatible with CommonMark.

Closes #6526 

## Test plan

### Before


https://github.com/user-attachments/assets/8a8882e7-db70-4401-9461-31db07fc5b88




### After


https://github.com/user-attachments/assets/fb7b844e-2c53-40bc-b604-cd427b50459d



