### PR TITLE
[lexical-playground] Feature: clear blockelement formatting along with textNode, even when #7383

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
@@ -276,7 +276,11 @@ export const clearFormatting = (editor: LexicalEditor) => {
           }
           if (textNode.__format !== 0) {
             textNode.setFormat(0);
-            $getNearestBlockElementAncestorOrThrow(textNode).setFormat('');
+          }
+          const nearestBlockElement =
+            $getNearestBlockElementAncestorOrThrow(textNode);
+          if (nearestBlockElement.__format !== 0) {
+            nearestBlockElement.setFormat('');
           }
           node = textNode;
         } else if ($isHeadingNode(node) || $isQuoteNode(node)) {


### PR DESCRIPTION

## Steps To Reproduce

1. Add any text to playground
2. right align it, without any other formatting like bold, font-size, etc
3. now try to do clear formatting





## The current behavior
pressing `cmd+\` do left align text until bold or any other formatting is applied to text.

https://github.com/user-attachments/assets/61607411-d177-4f3c-9caf-2db195b99f43

## The expected behavior
pressing `cmd+\` clears right align and text is left aligned

https://github.com/user-attachments/assets/aef76a8b-ff17-4c7b-a098-92e2d8340b00

## Impact of fix
clear formatting will be improved and cover wider range

