### PR TITLE
[Breaking Change][lexical-markdown] Bug Fix: Preserve paragraph separation after block elements

### DIFF
--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -79,6 +79,7 @@ export function createMarkdownImport(
         byType.element,
         textFormatTransformersIndex,
         byType.textMatch,
+        shouldPreserveNewLines,
       );
     }
 
@@ -224,6 +225,7 @@ function $importBlocks(
   elementTransformers: Array<ElementTransformer>,
   textFormatTransformersIndex: TextFormatTransformersIndex,
   textMatchTransformers: Array<TextMatchTransformer>,
+  shouldPreserveNewLines: boolean,
 ) {
   const textNode = $createTextNode(lineText);
   const elementNode = $createParagraphNode();
@@ -253,9 +255,10 @@ function $importBlocks(
   if (elementNode.isAttached() && lineText.length > 0) {
     const previousNode = elementNode.getPreviousSibling();
     if (
-      $isParagraphNode(previousNode) ||
-      $isQuoteNode(previousNode) ||
-      $isListNode(previousNode)
+      !shouldPreserveNewLines && // Only append if we're not preserving newlines
+      ($isParagraphNode(previousNode) ||
+        $isQuoteNode(previousNode) ||
+        $isListNode(previousNode))
     ) {
       let targetNode: typeof previousNode | ListItemNode | null = previousNode;
 

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -381,7 +381,7 @@ describe('Markdown', () => {
       shouldMergeAdjacentLines: false,
     },
     {
-      html: '<p><span style="white-space: pre-wrap;">hello</span><br><span style="white-space: pre-wrap;">world</span></p>',
+      html: '<p><span style="white-space: pre-wrap;">hello</span></p><p><span style="white-space: pre-wrap;">world</span></p>',
       md: 'hello\nworld',
       shouldPreserveNewLines: true,
     },


### PR DESCRIPTION
## Description
### Current Behavior
Currently, when `shouldPreserveNewLines` is enabled, paragraphs after block elements (lists, quotes, and paragraphs) are incorrectly merged into the block. This causes issues with markdown formatting where new paragraphs are unintentionally becoming part of the previous block element.

### Changes in this PR
This PR modifies the paragraph merging logic to respect the `shouldPreserveNewLines` setting. When enabled, paragraphs will maintain their separation from previous block elements, aligning with GitHub's markdown editor behavior for list and common markdown formatting expectations as discussed here: https://github.com/facebook/lexical/issues/6606.

- Updates the merging logic in `$importBlocks` to properly handle paragraph separation when `shouldPreserveNewLines` is true
- Updates test case to expect separate paragraphs with `shouldPreserveNewLines` enabled
- Maintains backward compatibility when `shouldPreserveNewLines` is false
- Fixes paragraph merging behavior for all block elements (lists, quotes, and paragraphs)

Closes #6606

## Test plan

### Before

Issue with list:

https://github.com/user-attachments/assets/2f48f6d3-f7bd-4c2d-a9cc-45b4ed1b7876

Issue with Quote:

https://github.com/user-attachments/assets/c6b43091-af64-494c-b2ad-e89f1490d3c0

### After

https://github.com/user-attachments/assets/d966d8d4-2494-446a-90d1-4950abbd130f

