### PR TITLE
[lexical-playground] Bug Fix: Use natural dimensions for inherited image size

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -418,7 +418,7 @@ test.describe('Images', () => {
                 alt="lexical logo"
                 draggable="false"
                 src="https://lexical.dev/img/logo.svg"
-                style="height: inherit; max-width: 500px; width: inherit;" />
+                style="height: 112px; max-width: 500px; width: 500px" />
             </div>
           </span>
           <span
@@ -783,6 +783,59 @@ test.describe('Images', () => {
                 draggable="false"
                 src="${SAMPLE_IMAGE_URL}"
                 style="height: inherit; max-width: 500px; width: inherit" />
+            </div>
+          </span>
+          <br />
+        </p>
+      `,
+    );
+  });
+
+  test(`Verifies image dimensions are properly calculated for both SVG and JPG formats`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    // Insert an SVG image using the Lexical logo
+    await insertUrlImage(
+      page,
+      'https://lexical.dev/img/logo.svg',
+      'lexical logo',
+    );
+
+    // Insert a JPG image
+    await insertUrlImage(page, SAMPLE_IMAGE_URL, 'sample image');
+
+    // Wait for the images to load
+    await waitForSelector(page, '.editor-image img');
+
+    // Verify both images are inserted with proper dimensions and styling
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="false">
+              <img
+                alt="lexical logo"
+                draggable="false"
+                src="https://lexical.dev/img/logo.svg"
+                style="height: 112px; max-width: 500px; width: 500px" />
+            </div>
+          </span>
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="false">
+              <img
+                alt="sample image"
+                draggable="false"
+                src="${SAMPLE_IMAGE_URL}"
+                style="height: inherit; max-width: 500px; width: inherit;" />
             </div>
           </span>
           <br />

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -388,8 +388,12 @@ test.describe('Images', () => {
     });
   });
 
-  test('Can add images by arbitrary URL', async ({page, isPlainText}) => {
-    test.skip(isPlainText);
+  test('Can add images by arbitrary URL', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab, 'Skip in plain text and collab mode');
 
     await focusEditor(page);
 
@@ -793,7 +797,11 @@ test.describe('Images', () => {
 
   test(`Verifies image dimensions are properly calculated for both SVG and JPG formats`, async ({
     page,
+    isPlainText,
+    isCollab,
   }) => {
+    test.skip(isPlainText || isCollab, 'Skip in plain text and collab mode');
+
     await focusEditor(page);
 
     // Insert an SVG image using the Lexical logo
@@ -805,9 +813,6 @@ test.describe('Images', () => {
 
     // Insert a JPG image
     await insertUrlImage(page, SAMPLE_IMAGE_URL, 'sample image');
-
-    // Wait for the images to load
-    await waitForSelector(page, '.editor-image img');
 
     // Verify both images are inserted with proper dimensions and styling
     await assertHTML(


### PR DESCRIPTION
## Description

### Current Behavior
Currently, when an image is inserted with 'inherit' dimensions in the Lexical playground, it defaults to arbitrary 200x200 dimensions without considering the image's natural size. This causes visual inconsistency and incorrect image rendering on initial load.

### Changes in this PR
1. Using the image's natural dimensions (naturalWidth/naturalHeight) when width/height is set to 'inherit'
2. Maintaining proper aspect ratio during scaling
3. Adding proper dimension detection on both initial mount and image load
4. Keeping the existing maxWidth and maxHeight (500px) constraints for editor usability
5. Using fallback dimensions (200x200) only while the image is loading

Closes #7376

## Test plan

### Before

![image](https://github.com/user-attachments/assets/171c8346-c638-4016-b724-264aaab0c74a)

### After

![image](https://github.com/user-attachments/assets/867f22a2-6891-443e-9a6c-1aebcadaebe4)
