### PR TITLE
[RFC][lexical-markdown] Replace whitespace with &#160 when the string consists only of whitespace.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @zurfyx @fantactuka @acywatson @Fetz @ivailop7 @Sahejkm @potatowagon
+* @zurfyx @fantactuka @acywatson @Fetz @ivailop7 @Sahejkm @potatowagon @lilshady @takuyakanbr

--- a/examples/react-plain-text/package-lock.json
+++ b/examples/react-plain-text/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@lexical/react-plain-text-example",
-  "version": "0.24.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-plain-text-example",
-      "version": "0.24.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@lexical/react": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/react": "0.29.0",
+        "lexical": "0.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -790,38 +790,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -829,133 +832,143 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -964,61 +977,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1590,6 +1609,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -1626,14 +1646,16 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
+      "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -1745,9 +1767,10 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2027,9 +2050,10 @@
       "dev": true
     },
     "node_modules/yjs": {
-      "version": "13.6.23",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
-      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "version": "13.6.24",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
+      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"

--- a/examples/react-rich-collab/package-lock.json
+++ b/examples/react-rich-collab/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@lexical/react-rich-collab-example",
-  "version": "0.24.0",
+  "version": "0.29.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-rich-collab-example",
-      "version": "0.24.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@lexical/react": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/react": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "y-webrtc": "^10.3.0",
@@ -795,38 +795,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -834,133 +837,143 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -969,61 +982,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -2050,9 +2069,10 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
+      "license": "MIT"
     },
     "node_modules/lib0": {
       "version": "0.2.93",
@@ -2201,9 +2221,10 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3374,227 +3395,225 @@
       }
     },
     "@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
       "requires": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
       "requires": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
       "requires": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
       "requires": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       }
     },
     "@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
       "requires": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
       "requires": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@rollup/rollup-android-arm-eabi": {
@@ -4291,9 +4310,9 @@
       }
     },
     "lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w=="
     },
     "lib0": {
       "version": "0.2.93",
@@ -4390,9 +4409,9 @@
       }
     },
     "prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
     },
     "prr": {
       "version": "1.0.1",

--- a/examples/react-rich/package-lock.json
+++ b/examples/react-rich/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@lexical/react-rich-example",
-  "version": "0.24.0",
+  "version": "0.29.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-rich-example",
-      "version": "0.24.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@lexical/react": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/react": "0.29.0",
+        "lexical": "0.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -790,38 +790,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -829,133 +832,143 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -964,61 +977,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1597,6 +1616,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -1633,14 +1653,16 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
+      "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -1752,9 +1774,10 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2034,9 +2057,10 @@
       "dev": true
     },
     "node_modules/yjs": {
-      "version": "13.6.23",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
-      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "version": "13.6.24",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
+      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
@@ -2510,227 +2534,225 @@
       }
     },
     "@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
       "requires": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
       "requires": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
       "requires": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
       "requires": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       }
     },
     "@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
       "requires": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
       "requires": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@rollup/rollup-android-arm-eabi": {
@@ -3135,14 +3157,14 @@
       "dev": true
     },
     "lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w=="
     },
     "lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
       "peer": true,
       "requires": {
         "isomorphic.js": "^0.2.4"
@@ -3207,9 +3229,9 @@
       }
     },
     "prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
     },
     "react": {
       "version": "18.2.0",
@@ -3367,9 +3389,9 @@
       "dev": true
     },
     "yjs": {
-      "version": "13.6.23",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
-      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "version": "13.6.24",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
+      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
       "peer": true,
       "requires": {
         "lib0": "^0.2.99"

--- a/examples/react-table/package-lock.json
+++ b/examples/react-table/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@lexical/react-table-example",
-  "version": "0.24.0",
+  "version": "0.29.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-table-example",
-      "version": "0.24.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@lexical/react": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/react": "0.29.0",
+        "lexical": "0.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -790,38 +790,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -829,133 +832,143 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -964,61 +977,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1597,6 +1616,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -1633,14 +1653,16 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
+      "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -1752,9 +1774,10 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2034,9 +2057,10 @@
       "dev": true
     },
     "node_modules/yjs": {
-      "version": "13.6.23",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
-      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "version": "13.6.24",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
+      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
@@ -2510,227 +2534,225 @@
       }
     },
     "@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
       "requires": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
       "requires": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
       "requires": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
       "requires": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
       "requires": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       }
     },
     "@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
       "requires": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
       "requires": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
       "requires": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
       "requires": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "@rollup/rollup-android-arm-eabi": {
@@ -3135,14 +3157,14 @@
       "dev": true
     },
     "lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w=="
     },
     "lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
       "peer": true,
       "requires": {
         "isomorphic.js": "^0.2.4"
@@ -3207,9 +3229,9 @@
       }
     },
     "prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
     },
     "react": {
       "version": "18.2.0",
@@ -3367,9 +3389,9 @@
       "dev": true
     },
     "yjs": {
-      "version": "13.6.23",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
-      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "version": "13.6.24",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
+      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
       "peer": true,
       "requires": {
         "lib0": "^0.2.99"

--- a/package-lock.json
+++ b/package-lock.json
@@ -836,25 +836,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2352,9 +2352,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.9.tgz",
-      "integrity": "sha512-5EVjbTegqN7RSJle6hMWYxO4voo4rI+9krITk+DWR+diJgGrjZjrIBnJhjrHYYQsFgI7j1w1QnrvV7YSKBfYGg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.27.0.tgz",
+      "integrity": "sha512-UWjX6t+v+0ckwZ50Y5ShZLnlk95pP5MyW/pon9tiYzl3+18pkTHTFNTKr7rQbfRXPkowt2QAn30o1b6oswszew==",
       "license": "MIT",
       "dependencies": {
         "core-js-pure": "^3.30.2",
@@ -2365,14 +2365,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2397,9 +2397,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -42330,20 +42330,20 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "requires": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "requires": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
@@ -43250,22 +43250,22 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.9.tgz",
-      "integrity": "sha512-5EVjbTegqN7RSJle6hMWYxO4voo4rI+9krITk+DWR+diJgGrjZjrIBnJhjrHYYQsFgI7j1w1QnrvV7YSKBfYGg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.27.0.tgz",
+      "integrity": "sha512-UWjX6t+v+0ckwZ50Y5ShZLnlk95pP5MyW/pon9tiYzl3+18pkTHTFNTKr7rQbfRXPkowt2QAn30o1b6oswszew==",
       "requires": {
         "core-js-pure": "^3.30.2",
         "regenerator-runtime": "^0.14.0"
       }
     },
     "@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "requires": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/traverse": {
@@ -43283,9 +43283,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "requires": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -25,6 +25,7 @@ import {
 } from './MarkdownTransformers';
 import {isEmptyParagraph, transformersByType} from './utils';
 
+const WHITESPACE_CHAR = '&#160;';
 /**
  * Renders string from markdown. The selection is moved to the start after the operation.
  */
@@ -205,14 +206,19 @@ function exportTextFormat(
   // Where it would be invalid markdown to generate: "**   foo   **"
   // We instead want to trim the whitespace out, apply formatting, and then
   // bring the whitespace back. So our returned string looks like this: "   **foo**   "
+  // for whitespace only string case like: "  ", we replace the whitespace with &#160;
   const frozenString = textContent.trim();
   let output = frozenString;
+  const isWhitespaceOnly = frozenString.length === 0;
+
+  if (isWhitespaceOnly) {
+    output = textContent.replace(/\s/g, WHITESPACE_CHAR);
+  }
 
   if (!node.hasFormat('code')) {
     // Escape any markdown characters in the text content
     output = output.replace(/([*_`~\\])/g, '\\$1');
   }
-
   // the opening tags to be added to the result
   let openingTags = '';
   // the closing tags to be added to the result
@@ -286,6 +292,9 @@ function exportTextFormat(
   }
 
   output = openingTags + output + closingTagsAfter;
+  if (isWhitespaceOnly) {
+    return closingTagsBefore + output;
+  }
   // Replace trimmed version of textContent ensuring surrounding whitespace is not modified
   return closingTagsBefore + textContent.replace(frozenString, () => output);
 }

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -209,9 +209,10 @@ function exportTextFormat(
   // for whitespace only string case like: "  ", we replace the whitespace with &#160;
   const frozenString = textContent.trim();
   let output = frozenString;
-  const isWhitespaceOnly = frozenString.length === 0;
+  const isFormattedWhitespace =
+    frozenString.length === 0 && node.getFormat() !== 0;
 
-  if (isWhitespaceOnly) {
+  if (isFormattedWhitespace) {
     output = textContent.replace(/\s/g, WHITESPACE_CHAR);
   }
 
@@ -292,7 +293,7 @@ function exportTextFormat(
   }
 
   output = openingTags + output + closingTagsAfter;
-  if (isWhitespaceOnly) {
+  if (isFormattedWhitespace) {
     return closingTagsBefore + output;
   }
   // Replace trimmed version of textContent ensuring surrounding whitespace is not modified

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -214,7 +214,7 @@ function exportTextFormat(
   if (isFormattedWhitespace) {
     // Convert whitespaces to the code entity
     output = [...textContent]
-      .map((char) => '&#' + char.charCodeAt(0) + ';')
+      .map((char) => '&#' + char.codePointAt(0) + ';')
       .join('');
   }
 

--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -25,7 +25,6 @@ import {
 } from './MarkdownTransformers';
 import {isEmptyParagraph, transformersByType} from './utils';
 
-const WHITESPACE_CHAR = '&#160;';
 /**
  * Renders string from markdown. The selection is moved to the start after the operation.
  */
@@ -213,7 +212,10 @@ function exportTextFormat(
     frozenString.length === 0 && node.getFormat() !== 0;
 
   if (isFormattedWhitespace) {
-    output = textContent.replace(/\s/g, WHITESPACE_CHAR);
+    // Convert whitespaces to the code entity
+    output = [...textContent]
+      .map((char) => '&#' + char.charCodeAt(0) + ';')
+      .join('');
   }
 
   if (!node.hasFormat('code')) {

--- a/packages/lexical-markdown/src/MarkdownImport.ts
+++ b/packages/lexical-markdown/src/MarkdownImport.ts
@@ -79,6 +79,7 @@ export function createMarkdownImport(
         byType.element,
         textFormatTransformersIndex,
         byType.textMatch,
+        shouldPreserveNewLines,
       );
     }
 
@@ -224,6 +225,7 @@ function $importBlocks(
   elementTransformers: Array<ElementTransformer>,
   textFormatTransformersIndex: TextFormatTransformersIndex,
   textMatchTransformers: Array<TextMatchTransformer>,
+  shouldPreserveNewLines: boolean,
 ) {
   const textNode = $createTextNode(lineText);
   const elementNode = $createParagraphNode();
@@ -253,9 +255,10 @@ function $importBlocks(
   if (elementNode.isAttached() && lineText.length > 0) {
     const previousNode = elementNode.getPreviousSibling();
     if (
-      $isParagraphNode(previousNode) ||
-      $isQuoteNode(previousNode) ||
-      $isListNode(previousNode)
+      !shouldPreserveNewLines && // Only append if we're not preserving newlines
+      ($isParagraphNode(previousNode) ||
+        $isQuoteNode(previousNode) ||
+        $isListNode(previousNode))
     ) {
       let targetNode: typeof previousNode | ListItemNode | null = previousNode;
 

--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -254,6 +254,9 @@ function $runTextFormatTransformers(
       }
 
       if ($isTextNode(sibling)) {
+        if (sibling.hasFormat('code')) {
+          continue;
+        }
         const siblingTextContent = sibling.getTextContent();
         openNode = sibling;
         openTagStartIndex = getOpenTagStartIndex(

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -359,15 +359,15 @@ describe('Markdown', () => {
     },
     {
       html: '<p><b><strong style="white-space: pre-wrap;">Hello </strong></b><s><b><strong style="white-space: pre-wrap;">world</strong></b></s><span style="white-space: pre-wrap;">!</span></p>',
-      md: '**Hello ~~world~~**!',
+      md: '**Hello&#32;~~world~~**!',
     },
     {
       html: '<p><s><b><strong style="white-space: pre-wrap;">Hello </strong></b></s><s><i><b><strong style="white-space: pre-wrap;">world</strong></b></i></s><s><span style="white-space: pre-wrap;">!</span></s></p>',
-      md: '**~~Hello *world*~~**~~!~~',
+      md: '**~~Hello&#32;*world*~~**~~!~~',
     },
     {
       html: '<p><i><em style="white-space: pre-wrap;">Hello </em></i><i><b><strong style="white-space: pre-wrap;">world</strong></b></i><i><em style="white-space: pre-wrap;">!</em></i></p>',
-      md: '*Hello **world**!*',
+      md: '*Hello&#32;**world**!*',
     },
     {
       html: '<p><span style="white-space: pre-wrap;">helloworld</span></p>',
@@ -547,21 +547,23 @@ describe('Markdown', () => {
     },
     {
       html: '<p><span style="white-space: pre-wrap;">Text </span><b><strong style="white-space: pre-wrap;">boldstart </strong></b><a href="https://lexical.dev"><b><strong style="white-space: pre-wrap;">text</strong></b></a><b><strong style="white-space: pre-wrap;"> boldend</strong></b><span style="white-space: pre-wrap;"> text</span></p>',
-      md: 'Text **boldstart [text](https://lexical.dev) boldend** text',
+      md: 'Text **boldstart&#32;[text](https://lexical.dev)&#32;boldend** text',
     },
     {
       html: '<p><span style="white-space: pre-wrap;">Text </span><b><strong style="white-space: pre-wrap;">boldstart </strong></b><a href="https://lexical.dev"><b><code spellcheck="false" style="white-space: pre-wrap;"><strong>text</strong></code></b></a><b><strong style="white-space: pre-wrap;"> boldend</strong></b><span style="white-space: pre-wrap;"> text</span></p>',
-      md: 'Text **boldstart [`text`](https://lexical.dev) boldend** text',
+      md: 'Text **boldstart&#32;[`text`](https://lexical.dev)&#32;boldend** text',
     },
     {
       html: '<p><span style="white-space: pre-wrap;">It </span><s><i><b><strong style="white-space: pre-wrap;">works </strong></b></i></s><a href="https://lexical.io"><s><i><b><strong style="white-space: pre-wrap;">with links</strong></b></i></s></a><span style="white-space: pre-wrap;"> too</span></p>',
       md: 'It ~~___works [with links](https://lexical.io)___~~ too',
-      mdAfterExport: 'It ***~~works [with links](https://lexical.io)~~*** too',
+      mdAfterExport:
+        'It ***~~works&#32;[with links](https://lexical.io)~~*** too',
     },
     {
       html: '<p><span style="white-space: pre-wrap;">It </span><s><i><b><strong style="white-space: pre-wrap;">works </strong></b></i></s><a href="https://lexical.io"><s><i><b><strong style="white-space: pre-wrap;">with links</strong></b></i></s></a><s><i><b><strong style="white-space: pre-wrap;"> too</strong></b></i></s><span style="white-space: pre-wrap;">!</span></p>',
       md: 'It ~~___works [with links](https://lexical.io) too___~~!',
-      mdAfterExport: 'It ***~~works [with links](https://lexical.io) too~~***!',
+      mdAfterExport:
+        'It ***~~works&#32;[with links](https://lexical.io)&#32;too~~***!',
     },
     {
       html: '<p><a href="https://lexical.dev"><span style="white-space: pre-wrap;">link</span></a><a href="https://lexical.dev"><span style="white-space: pre-wrap;">link2</span></a></p>',

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -609,6 +609,11 @@ describe('Markdown', () => {
       html: '<p><span style="white-space: pre-wrap;">*Hello* world</span></p>',
       md: '\\*Hello\\* world',
     },
+    {
+      html: '<p><b><strong style="white-space: pre-wrap;">&nbsp;</strong></b></p>',
+      md: '**&#160;**',
+      mdAfterExport: '**&#160;**',
+    },
   ];
 
   const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -381,7 +381,7 @@ describe('Markdown', () => {
       shouldMergeAdjacentLines: false,
     },
     {
-      html: '<p><span style="white-space: pre-wrap;">hello</span><br><span style="white-space: pre-wrap;">world</span></p>',
+      html: '<p><span style="white-space: pre-wrap;">hello</span></p><p><span style="white-space: pre-wrap;">world</span></p>',
       md: 'hello\nworld',
       shouldPreserveNewLines: true,
     },

--- a/packages/lexical-markdown/src/importTextTransformers.ts
+++ b/packages/lexical-markdown/src/importTextTransformers.ts
@@ -136,7 +136,7 @@ export function importTextTransformers(
   const escapedText = textContent
     .replace(/\\([*_`~])/g, '$1')
     .replace(/&#(\d+);/g, (_, codePoint) => {
-      return String.fromCharCode(codePoint);
+      return String.fromCodePoint(codePoint);
     });
   textNode.setTextContent(escapedText);
 }

--- a/packages/lexical-markdown/src/importTextTransformers.ts
+++ b/packages/lexical-markdown/src/importTextTransformers.ts
@@ -133,6 +133,10 @@ export function importTextTransformers(
 
   // Handle escape characters
   const textContent = textNode.getTextContent();
-  const escapedText = textContent.replace(/\\([*_`~])/g, '$1');
+  const escapedText = textContent
+    .replace(/\\([*_`~])/g, '$1')
+    .replace(/&#(\d+);/g, (_, codePoint) => {
+      return String.fromCharCode(codePoint);
+    });
   textNode.setTextContent(escapedText);
 }

--- a/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
@@ -7,6 +7,8 @@
  */
 
 import {
+  centerAlign,
+  rightAlign,
   selectAll,
   toggleBold,
   toggleItalic,
@@ -192,4 +194,53 @@ test.describe('Clear All Formatting', () => {
       );
     },
   );
+
+  test(`Can clear left/center/right alignment when BIU formatting already applied`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    await page.keyboard.type('Hello');
+    await toggleBold(page);
+    await page.keyboard.type(' World');
+    await rightAlign(page);
+    await page.keyboard.type(' Test');
+    await selectAll(page);
+    await selectFromAdditionalStylesDropdown(page, '.clear');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr"
+          style="">
+          <span data-lexical-text="true">Hello World Test</span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Can clear left/center/right alignment when BIU formatting not applied`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    await page.keyboard.type('Hello World');
+    await rightAlign(page);
+    await page.keyboard.type(' Test');
+    await centerAlign(page);
+    await selectAll(page);
+    await selectFromAdditionalStylesDropdown(page, '.clear');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr"
+          style="">
+          <span data-lexical-text="true">Hello World Test</span>
+        </p>
+      `,
+    );
+  });
 });

--- a/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Images.spec.mjs
@@ -388,8 +388,12 @@ test.describe('Images', () => {
     });
   });
 
-  test('Can add images by arbitrary URL', async ({page, isPlainText}) => {
-    test.skip(isPlainText);
+  test('Can add images by arbitrary URL', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab, 'Skip in plain text and collab mode');
 
     await focusEditor(page);
 
@@ -418,7 +422,7 @@ test.describe('Images', () => {
                 alt="lexical logo"
                 draggable="false"
                 src="https://lexical.dev/img/logo.svg"
-                style="height: inherit; max-width: 500px; width: inherit;" />
+                style="height: 112px; max-width: 500px; width: 500px" />
             </div>
           </span>
           <span
@@ -783,6 +787,60 @@ test.describe('Images', () => {
                 draggable="false"
                 src="${SAMPLE_IMAGE_URL}"
                 style="height: inherit; max-width: 500px; width: inherit" />
+            </div>
+          </span>
+          <br />
+        </p>
+      `,
+    );
+  });
+
+  test(`Verifies image dimensions are properly calculated for both SVG and JPG formats`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab, 'Skip in plain text and collab mode');
+
+    await focusEditor(page);
+
+    // Insert an SVG image using the Lexical logo
+    await insertUrlImage(
+      page,
+      'https://lexical.dev/img/logo.svg',
+      'lexical logo',
+    );
+
+    // Insert a JPG image
+    await insertUrlImage(page, SAMPLE_IMAGE_URL, 'sample image');
+
+    // Verify both images are inserted with proper dimensions and styling
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="false">
+              <img
+                alt="lexical logo"
+                draggable="false"
+                src="https://lexical.dev/img/logo.svg"
+                style="height: 112px; max-width: 500px; width: 500px" />
+            </div>
+          </span>
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="false">
+              <img
+                alt="sample image"
+                draggable="false"
+                src="${SAMPLE_IMAGE_URL}"
+                style="height: inherit; max-width: 500px; width: inherit;" />
             </div>
           </span>
           <br />

--- a/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Links.spec.mjs
@@ -26,9 +26,11 @@ import {
   focusEditor,
   html,
   initialize,
+  insertSampleImage,
   keyDownCtrlOrMeta,
   keyUpCtrlOrMeta,
   pasteFromClipboard,
+  SAMPLE_IMAGE_URL,
   test,
   withExclusiveClipboardAccess,
 } from '../utils/index.mjs';
@@ -2122,6 +2124,412 @@ test.describe.parallel('Links', () => {
       `,
       undefined,
       {ignoreClasses: true},
+    );
+  });
+
+  test('Can add, edit and remove links on images', async ({
+    page,
+    isCollab,
+    browserName,
+  }) => {
+    // Skip for collaborative mode and Firefox on Linux
+    test.skip(
+      isCollab || (browserName === 'firefox' && process.platform === 'linux'),
+    );
+    await focusEditor(page);
+
+    // Insert image
+    await insertSampleImage(page);
+
+    // Add link to image
+    await click(page, '.editor-image img');
+    await click(page, '.link');
+    await focus(page, '.link-input');
+    await page.keyboard.type('lexical.dev');
+    await click(page, '.link-confirm');
+
+    // Verify link was added
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://lexical.dev"
+            rel="noreferrer">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="true">
+                <img
+                  class="focused draggable"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="${SAMPLE_IMAGE_URL}"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+              <div>
+                <button class="image-caption-button">Add Caption</button>
+                <div class="image-resizer image-resizer-n"></div>
+                <div class="image-resizer image-resizer-ne"></div>
+                <div class="image-resizer image-resizer-e"></div>
+                <div class="image-resizer image-resizer-se"></div>
+                <div class="image-resizer image-resizer-s"></div>
+                <div class="image-resizer image-resizer-sw"></div>
+                <div class="image-resizer image-resizer-w"></div>
+                <div class="image-resizer image-resizer-nw"></div>
+              </div>
+            </span>
+          </a>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: false},
+    );
+
+    // Edit link
+    await click(page, '.editor-image img');
+    await click(page, '.link-edit');
+    await focus(page, '.link-input');
+    await selectAll(page);
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type('https://github.com/facebook/lexical');
+    await click(page, '.link-confirm');
+
+    // Verify link was updated
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://github.com/facebook/lexical"
+            rel="noreferrer">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="true">
+                <img
+                  class="focused draggable"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="${SAMPLE_IMAGE_URL}"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+              <div>
+                <button class="image-caption-button">Add Caption</button>
+                <div class="image-resizer image-resizer-n"></div>
+                <div class="image-resizer image-resizer-ne"></div>
+                <div class="image-resizer image-resizer-e"></div>
+                <div class="image-resizer image-resizer-se"></div>
+                <div class="image-resizer image-resizer-s"></div>
+                <div class="image-resizer image-resizer-sw"></div>
+                <div class="image-resizer image-resizer-w"></div>
+                <div class="image-resizer image-resizer-nw"></div>
+              </div>
+            </span>
+          </a>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: false},
+    );
+
+    // Remove link
+    await click(page, '.editor-image img');
+    await click(page, '.link-trash');
+
+    // Verify link was removed but image remains
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="true">
+              <img
+                class="focused draggable"
+                alt="Yellow flower in tilt shift lens"
+                draggable="false"
+                src="${SAMPLE_IMAGE_URL}"
+                style="height: inherit; max-width: 500px; width: inherit" />
+            </div>
+            <div>
+              <button class="image-caption-button">Add Caption</button>
+              <div class="image-resizer image-resizer-n"></div>
+              <div class="image-resizer image-resizer-ne"></div>
+              <div class="image-resizer image-resizer-e"></div>
+              <div class="image-resizer image-resizer-se"></div>
+              <div class="image-resizer image-resizer-s"></div>
+              <div class="image-resizer image-resizer-sw"></div>
+              <div class="image-resizer image-resizer-w"></div>
+              <div class="image-resizer image-resizer-nw"></div>
+            </div>
+          </span>
+          <br />
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: false},
+    );
+  });
+
+  test('Can add, edit and remove links on multiple selected images', async ({
+    page,
+    isCollab,
+    browserName,
+  }) => {
+    // Skip for collaborative mode and Firefox on Linux
+    test.skip(
+      isCollab || (browserName === 'firefox' && process.platform === 'linux'),
+    );
+    await focusEditor(page);
+
+    // Insert first image
+    await insertSampleImage(page);
+    await page.keyboard.press('Enter');
+
+    // Insert second image
+    await insertSampleImage(page);
+
+    // Select both images
+    await click(page, 'p:nth-child(1) .editor-image img');
+    await page.keyboard.down('Shift');
+    await click(page, 'p:nth-child(2) .editor-image img');
+    await page.keyboard.up('Shift');
+
+    // Add link to both images
+    await click(page, '.link');
+    await focus(page, '.link-input');
+    await page.keyboard.type('lexical.dev');
+    await click(page, '.link-confirm');
+
+    // Verify both images are linked
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://lexical.dev"
+            rel="noreferrer">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="true">
+                <img
+                  class="focused draggable"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="${SAMPLE_IMAGE_URL}"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+              <div>
+                <button class="image-caption-button">Add Caption</button>
+                <div class="image-resizer image-resizer-n"></div>
+                <div class="image-resizer image-resizer-ne"></div>
+                <div class="image-resizer image-resizer-e"></div>
+                <div class="image-resizer image-resizer-se"></div>
+                <div class="image-resizer image-resizer-s"></div>
+                <div class="image-resizer image-resizer-sw"></div>
+                <div class="image-resizer image-resizer-w"></div>
+                <div class="image-resizer image-resizer-nw"></div>
+              </div>
+            </span>
+          </a>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://lexical.dev"
+            rel="noreferrer">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="true">
+                <img
+                  class="focused draggable"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="${SAMPLE_IMAGE_URL}"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+              <div>
+                <button class="image-caption-button">Add Caption</button>
+                <div class="image-resizer image-resizer-n"></div>
+                <div class="image-resizer image-resizer-ne"></div>
+                <div class="image-resizer image-resizer-e"></div>
+                <div class="image-resizer image-resizer-se"></div>
+                <div class="image-resizer image-resizer-s"></div>
+                <div class="image-resizer image-resizer-sw"></div>
+                <div class="image-resizer image-resizer-w"></div>
+                <div class="image-resizer image-resizer-nw"></div>
+              </div>
+            </span>
+          </a>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: false},
+    );
+
+    // Edit link for both images
+    await click(page, 'p:nth-child(1) .editor-image img');
+    await page.keyboard.down('Shift');
+    await click(page, 'p:nth-child(2) .editor-image img');
+    await page.keyboard.up('Shift');
+    await click(page, '.link-edit');
+    await focus(page, '.link-input');
+    await selectAll(page);
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type('https://github.com/facebook/lexical');
+    await click(page, '.link-confirm');
+
+    // Verify both links were updated
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://github.com/facebook/lexical"
+            rel="noreferrer">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="true">
+                <img
+                  class="focused draggable"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="${SAMPLE_IMAGE_URL}"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+              <div>
+                <button class="image-caption-button">Add Caption</button>
+                <div class="image-resizer image-resizer-n"></div>
+                <div class="image-resizer image-resizer-ne"></div>
+                <div class="image-resizer image-resizer-e"></div>
+                <div class="image-resizer image-resizer-se"></div>
+                <div class="image-resizer image-resizer-s"></div>
+                <div class="image-resizer image-resizer-sw"></div>
+                <div class="image-resizer image-resizer-w"></div>
+                <div class="image-resizer image-resizer-nw"></div>
+              </div>
+            </span>
+          </a>
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph">
+          <a
+            class="PlaygroundEditorTheme__link"
+            href="https://github.com/facebook/lexical"
+            rel="noreferrer">
+            <span
+              class="editor-image"
+              contenteditable="false"
+              data-lexical-decorator="true">
+              <div draggable="true">
+                <img
+                  class="focused draggable"
+                  alt="Yellow flower in tilt shift lens"
+                  draggable="false"
+                  src="${SAMPLE_IMAGE_URL}"
+                  style="height: inherit; max-width: 500px; width: inherit" />
+              </div>
+              <div>
+                <button class="image-caption-button">Add Caption</button>
+                <div class="image-resizer image-resizer-n"></div>
+                <div class="image-resizer image-resizer-ne"></div>
+                <div class="image-resizer image-resizer-e"></div>
+                <div class="image-resizer image-resizer-se"></div>
+                <div class="image-resizer image-resizer-s"></div>
+                <div class="image-resizer image-resizer-sw"></div>
+                <div class="image-resizer image-resizer-w"></div>
+                <div class="image-resizer image-resizer-nw"></div>
+              </div>
+            </span>
+          </a>
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: false},
+    );
+
+    // Remove links from both images
+    await click(page, 'p:nth-child(1) .editor-image img');
+    await page.keyboard.down('Shift');
+    await click(page, 'p:nth-child(2) .editor-image img');
+    await page.keyboard.up('Shift');
+    await click(page, '.link-trash');
+
+    // Verify links were removed but images remain
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="true">
+              <img
+                class="focused draggable"
+                alt="Yellow flower in tilt shift lens"
+                draggable="false"
+                src="${SAMPLE_IMAGE_URL}"
+                style="height: inherit; max-width: 500px; width: inherit" />
+            </div>
+            <div>
+              <button class="image-caption-button">Add Caption</button>
+              <div class="image-resizer image-resizer-n"></div>
+              <div class="image-resizer image-resizer-ne"></div>
+              <div class="image-resizer image-resizer-e"></div>
+              <div class="image-resizer image-resizer-se"></div>
+              <div class="image-resizer image-resizer-s"></div>
+              <div class="image-resizer image-resizer-sw"></div>
+              <div class="image-resizer image-resizer-w"></div>
+              <div class="image-resizer image-resizer-nw"></div>
+            </div>
+          </span>
+          <br />
+        </p>
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span
+            class="editor-image"
+            contenteditable="false"
+            data-lexical-decorator="true">
+            <div draggable="true">
+              <img
+                class="focused draggable"
+                alt="Yellow flower in tilt shift lens"
+                draggable="false"
+                src="${SAMPLE_IMAGE_URL}"
+                style="height: inherit; max-width: 500px; width: inherit" />
+            </div>
+            <div>
+              <button class="image-caption-button">Add Caption</button>
+              <div class="image-resizer image-resizer-n"></div>
+              <div class="image-resizer image-resizer-ne"></div>
+              <div class="image-resizer image-resizer-e"></div>
+              <div class="image-resizer image-resizer-se"></div>
+              <div class="image-resizer image-resizer-s"></div>
+              <div class="image-resizer image-resizer-sw"></div>
+              <div class="image-resizer image-resizer-w"></div>
+              <div class="image-resizer image-resizer-nw"></div>
+            </div>
+          </span>
+          <br />
+        </p>
+      `,
+      undefined,
+      {ignoreClasses: false},
     );
   });
 });

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -1047,6 +1047,29 @@ test.describe.parallel('Markdown', () => {
     );
   });
 
+  test('does not use code-formatted text in text format transformers (#7349)', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('`void*` or `int*`');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <code spellcheck="false" data-lexical-text="true">
+            <span class="PlaygroundEditorTheme__textCode">void*</span>
+          </code>
+          <span data-lexical-text="true">or</span>
+          <code spellcheck="false" data-lexical-text="true">
+            <span class="PlaygroundEditorTheme__textCode">int*</span>
+          </code>
+        </p>
+      `,
+    );
+  });
+
   test('can adjust selection after text match transformer', async ({page}) => {
     await focusEditor(page);
     await page.keyboard.type('Hello  world');

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -1233,21 +1233,21 @@ test.describe.parallel('Tables', () => {
               <p dir="ltr"><span data-lexical-text="true">aa</span></p>
             </th>
             <th>
-              <p><span data-lexical-text="true">bb</span></p>
+              <p dir="ltr"><span data-lexical-text="true">bb</span></p>
             </th>
             <th>
-              <p><span data-lexical-text="true">cc</span></p>
+              <p dir="ltr"><span data-lexical-text="true">cc</span></p>
             </th>
           </tr>
           <tr>
             <th>
-              <p><span data-lexical-text="true">d</span></p>
+              <p dir="ltr"><span data-lexical-text="true">d</span></p>
             </th>
             <td>
-              <p><span data-lexical-text="true">e</span></p>
+              <p dir="ltr"><span data-lexical-text="true">e</span></p>
             </td>
             <td>
-              <p><span data-lexical-text="true">f</span></p>
+              <p dir="ltr"><span data-lexical-text="true">f</span></p>
             </td>
           </tr>
         </table>

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
@@ -276,7 +276,11 @@ export const clearFormatting = (editor: LexicalEditor) => {
           }
           if (textNode.__format !== 0) {
             textNode.setFormat(0);
-            $getNearestBlockElementAncestorOrThrow(textNode).setFormat('');
+          }
+          const nearestBlockElement =
+            $getNearestBlockElementAncestorOrThrow(textNode);
+          if (nearestBlockElement.__format !== 0) {
+            nearestBlockElement.setFormat('');
           }
           node = textNode;
         } else if ($isHeadingNode(node) || $isQuoteNode(node)) {

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -747,10 +747,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
       KEY_ARROW_UP_COMMAND,
       (event) => {
         const selection = $getSelection();
-        if (
-          $isNodeSelection(selection) &&
-          !$isTargetWithinDecorator(event.target as HTMLElement)
-        ) {
+        if ($isNodeSelection(selection)) {
           // If selection is on a node, let's try and move selection
           // back to being a range selection.
           const nodes = selection.getNodes();
@@ -839,10 +836,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
       KEY_ARROW_RIGHT_COMMAND,
       (event) => {
         const selection = $getSelection();
-        if (
-          $isNodeSelection(selection) &&
-          !$isTargetWithinDecorator(event.target as HTMLElement)
-        ) {
+        if ($isNodeSelection(selection)) {
           // If selection is on a node, let's try and move selection
           // back to being a range selection.
           const nodes = selection.getNodes();

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -9,6 +9,7 @@
 import type {EditorState, NodeKey} from 'lexical';
 
 import {
+  $addUpdateTag,
   $createParagraphNode,
   $getNodeByKey,
   $getRoot,
@@ -170,6 +171,12 @@ export function syncYjsChangesToLexical(
         } else {
           $syncLocalCursorPosition(binding, provider);
         }
+      }
+
+      if (!isFromUndoManger) {
+        // If it is an external change, we don't want the current scroll position to get changed
+        // since the user might've intentionally scrolled somewhere else in the document.
+        $addUpdateTag('skip-scroll-into-view');
       }
     },
     {

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -51,6 +51,7 @@ const elementExcludedProperties = new Set<string>([
   '__first',
   '__last',
   '__size',
+  '__dir',
 ]);
 const rootExcludedProperties = new Set<string>(['__cachedText']);
 const textExcludedProperties = new Set<string>(['__text']);

--- a/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  $createLineBreakNode,
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  ParagraphNode,
+} from 'lexical';
+
+import {initializeUnitTest} from '../utils';
+
+describe('LexicalReconciler', () => {
+  initializeUnitTest((testEnv) => {
+    test('Should use activeEditorDirection as the direction for a node with no directioned text', async () => {
+      const {editor} = testEnv;
+
+      editor.update(() => {
+        const root = $getRoot().clear();
+        root.append(
+          $createParagraphNode().append($createTextNode('فرعي')),
+          $createParagraphNode().append($createTextNode('Hello')),
+          $createParagraphNode().append($createLineBreakNode()),
+        );
+      });
+
+      // The third paragraph has no directioned text, so it should be set to the direction of the previous sibling.
+      let para3Dir = editor.read(() => {
+        return $getRoot().getChildAtIndex<ParagraphNode>(2)!.getDirection();
+      });
+      expect(para3Dir).toEqual('ltr');
+
+      // Mark the first and third paragraphs as dirty to force the reconciler to run.
+      editor.update(() => {
+        $getRoot().getChildAtIndex<ParagraphNode>(0)!.markDirty();
+        $getRoot().getChildAtIndex<ParagraphNode>(2)!.markDirty();
+      });
+
+      // Note: this is arguably a bug. It would be preferable for the node to keep its LTR direction. Added as a
+      // test so that the behaviour is at least documented.
+      para3Dir = editor.read(() => {
+        return $getRoot().getChildAtIndex<ParagraphNode>(2)!.getDirection();
+      });
+      expect(para3Dir).toEqual('rtl');
+    });
+  });
+});

--- a/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package-lock.json
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-astro-react/package-lock.json
@@ -1,27 +1,24 @@
 {
   "name": "lexical-esm-astro-react",
-  "version": "0.24.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexical-esm-astro-react",
-      "version": "0.24.0",
+      "version": "0.29.0",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@astrojs/react": "^4.2.0",
-        "@lexical/react": "0.24.0",
-        "@lexical/utils": "0.24.0",
+        "@lexical/react": "0.29.0",
+        "@lexical/utils": "0.29.0",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "astro": "^5.3.0",
-        "lexical": "0.24.0",
+        "lexical": "0.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "^5.4.2"
-      },
-      "devDependencies": {
-        "@playwright/test": "^1.43.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -344,23 +341,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -398,9 +397,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -409,13 +409,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -439,9 +440,10 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -1289,38 +1291,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.24.0.tgz",
-      "integrity": "sha512-DPrDsQ/ZOwcnr92rcSIRkoQ9LWT2285ilZRoD5w9/+LdXn9/2/CBlrt/2guQKb3E2ErfOoxNpDBA6SLOtQB4nQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.24.0.tgz",
-      "integrity": "sha512-RjgpTSiTKRDH+BDSuLCwzc/UXljkKwfSW4nKZXKQ6swUBYnRfxQchjtgOERXVWNs33mgWx+sNGWE4y47zd50QA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0",
-        "prismjs": "^1.27.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
+        "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.24.0.tgz",
-      "integrity": "sha512-hSpyt3aqzmyVxlnjyiDHps710AdI3NGWKvc5R29F5Y6XNPtrvDpsG3l47HqMmp3DvC+cPlKtTgil02Nla9d5KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -1328,133 +1333,143 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.24.0.tgz",
-      "integrity": "sha512-CHfUQoC7qFWywRhqyXb6s0lA7hHrpaPCLNl7m7Fb15k7YIT7z88UTjopQNzi43ZSKqkhawUhaFgBexyuX1E3/w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.24.0.tgz",
-      "integrity": "sha512-Q1FqZjOagrFJ+mOsMnHSEWrrFjxABe5mFzU++jNDwXFrRs2qb24PeRePu1EaVi+PksUOgn3Q/ZurCAFa+f3wzg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.24.0.tgz",
-      "integrity": "sha512-R3LRnckB3NAYK10y5hC946L2gCgnlfzFeQfhRSj8SZRgvOtd3eXYIhXzeO1WJbedLajy+zmddcPGrzBIeRFpOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.24.0.tgz",
-      "integrity": "sha512-UQkn+NR1+wNE7zlDmi4UcZRoQ7w5bTw427VJWiY3/vJTSZpjWaK48+llPtkj7OwwoQUu42ihZFXrEOizCdTVDw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.24.0.tgz",
-      "integrity": "sha512-x94RvIymB4FdkYX0kA0F1M58CpqLseMhz3PypZ6TXj5mB+shk0RFh5xYfEIXS9AvHnhTd1xjp+skOc3NvsCoOw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.24.0.tgz",
-      "integrity": "sha512-/wk/L8S8Jg+AghgpVAJ1hqSvk+4Fn4oYcihoyjmB0b+ZEIRS38aCdAn1LSH3BjWUbBM+fBMwAgsg8IWFDddYLg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.24.0.tgz",
-      "integrity": "sha512-wO2rB+HKukqFUy8dVLz+Y1BB0RzL4fv0ag0Cm0skNhxKYcPC/sDJBHmL8793DVQTGcloAdNrthCkRq3ufPUb4w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.24.0.tgz",
-      "integrity": "sha512-0+aSd090qwlD9lL3aGHDEygnbNa1UXM9ACRqPvxOwSmFBnCLceIelAePTFjnxUNs0hlp7nxPAulmO6ae5w2+eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.24.0.tgz",
-      "integrity": "sha512-wgRZQhh4tuDvtW+9bwSJphOE9BsU6xr1wplw/rPNKSKSEVcjkOJ5Ekjtp2BIgBmAfbbEtyTtjdhaY+NMFeY2yg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.24.0.tgz",
-      "integrity": "sha512-s/s9eICDqEZa1Ae/Q7BbA82LHmuV/FsBjWO+daSc6sOl/cKYItz9OJ6uVjv4mp+klaIYH6w+YwR2u/fiksJ2eg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.24.0.tgz",
-      "integrity": "sha512-Fd34JYBpVSwKckxJIXlfpj9QE2+G7wO26IyOMhE6kmsAxyjwEIeE1UTYgv/VfP61/EVRv924fBMMb1q22AJJ1g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.24.0.tgz",
-      "integrity": "sha512-OUgV+pVb1P3OrnoiW1Th6lWnfHFO/P1Lc6s7uzEQAgR8BzpJ+BGzXvKNYMX8DL98DWOAXCHOgCzm8rjTz9URcA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/code": "0.24.0",
-        "@lexical/devtools-core": "0.24.0",
-        "@lexical/dragon": "0.24.0",
-        "@lexical/hashtag": "0.24.0",
-        "@lexical/history": "0.24.0",
-        "@lexical/link": "0.24.0",
-        "@lexical/list": "0.24.0",
-        "@lexical/mark": "0.24.0",
-        "@lexical/markdown": "0.24.0",
-        "@lexical/overflow": "0.24.0",
-        "@lexical/plain-text": "0.24.0",
-        "@lexical/rich-text": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "@lexical/text": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "@lexical/yjs": "0.24.0",
-        "lexical": "0.24.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -1463,61 +1478,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.24.0.tgz",
-      "integrity": "sha512-pOqI13Rwekujc+eUAJ2LUvp9Lv2gFiwLcIYrk1B1JpY/rT0s2U1RRwIgt2YEAPK4sedF5twcFsJvf2tswEIpIw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.24.0.tgz",
-      "integrity": "sha512-dZd2bTbKvjnumx9cJdQrchT5EbEfND7u4eBi6fdS38xj3Njcj5Epdk5xGdlJYGC9iMaHlhNQSzogZaWJYt9MsA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.24.0.tgz",
-      "integrity": "sha512-RmmDHRaW6y8/5f5OFWd2JQ89+2/NF1Y3KGwCjn5kaOehTyUD7lpJOblyAjloviRfUaNxpJB+8Co/9iATj9e5qA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.24.0",
-        "@lexical/utils": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.24.0.tgz",
-      "integrity": "sha512-+cXFdT3dYHUeDMo3+lnSZOQoC3QEMf2MKsk1Gt4dFyVURWYd6u/hyXdOHIEeKfv8ktazDMWoKTZmrfAycZBcXg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
+      "license": "MIT",
       "dependencies": {
-        "lexical": "0.24.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.24.0.tgz",
-      "integrity": "sha512-Qo2AB9iMtagHa7fjzrCyOV0dHnXekF0pcH4WZIKemAPagfLytDKDGamHXQUIFQ23CoDkprGLfM4mdJxQiZXH/Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "@lexical/table": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.24.0.tgz",
-      "integrity": "sha512-RpG9wZgzc/0DCuEOQwDSvLqO2wnC1f2+Hq0oG0GsRNSiI1daRUbf6sgbontupqwUUQsJ2tjWhGp9ZVyOIpIbVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
+      "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.24.0",
-        "@lexical/selection": "0.24.0",
-        "lexical": "0.24.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1560,21 +1581,6 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.1.tgz",
-      "integrity": "sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==",
-      "dev": true,
-      "dependencies": {
-        "playwright": "1.43.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
@@ -3502,6 +3508,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -3565,14 +3572,16 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.24.0.tgz",
-      "integrity": "sha512-0qEyd7pl6v48JZhrd1+LfP4ZGSYJ8RSfk75RaPyTWNibi/oA0Ob0Fqb/Hl1hqMLzAM9shgZvY6HXOV0iW/HfiQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
+      "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -4490,15 +4499,16 @@
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4726,54 +4736,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
-      "integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.43.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
-      "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
-      "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -4788,6 +4754,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -4811,24 +4778,27 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -5888,12 +5858,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
-      "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.24.2",
-        "postcss": "^8.5.1",
+        "esbuild": "^0.25.0",
+        "postcss": "^8.5.3",
         "rollup": "^4.30.1"
       },
       "bin": {
@@ -5955,6 +5926,446 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz",
+      "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.1.tgz",
+      "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz",
+      "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.1.tgz",
+      "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz",
+      "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz",
+      "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz",
+      "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz",
+      "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz",
+      "integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz",
+      "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz",
+      "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz",
+      "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz",
+      "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz",
+      "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz",
+      "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz",
+      "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz",
+      "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz",
+      "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz",
+      "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz",
+      "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz",
+      "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz",
+      "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz",
+      "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.1",
+        "@esbuild/android-arm": "0.25.1",
+        "@esbuild/android-arm64": "0.25.1",
+        "@esbuild/android-x64": "0.25.1",
+        "@esbuild/darwin-arm64": "0.25.1",
+        "@esbuild/darwin-x64": "0.25.1",
+        "@esbuild/freebsd-arm64": "0.25.1",
+        "@esbuild/freebsd-x64": "0.25.1",
+        "@esbuild/linux-arm": "0.25.1",
+        "@esbuild/linux-arm64": "0.25.1",
+        "@esbuild/linux-ia32": "0.25.1",
+        "@esbuild/linux-loong64": "0.25.1",
+        "@esbuild/linux-mips64el": "0.25.1",
+        "@esbuild/linux-ppc64": "0.25.1",
+        "@esbuild/linux-riscv64": "0.25.1",
+        "@esbuild/linux-s390x": "0.25.1",
+        "@esbuild/linux-x64": "0.25.1",
+        "@esbuild/netbsd-arm64": "0.25.1",
+        "@esbuild/netbsd-x64": "0.25.1",
+        "@esbuild/openbsd-arm64": "0.25.1",
+        "@esbuild/openbsd-x64": "0.25.1",
+        "@esbuild/sunos-x64": "0.25.1",
+        "@esbuild/win32-arm64": "0.25.1",
+        "@esbuild/win32-ia32": "0.25.1",
+        "@esbuild/win32-x64": "0.25.1"
       }
     },
     "node_modules/vitefu": {
@@ -6303,6 +6714,22 @@
         "prettier": "2.8.7"
       }
     },
+    "node_modules/yaml-language-server/node_modules/prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/yaml-language-server/node_modules/request-light": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
@@ -6412,9 +6839,10 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.23",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
-      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "version": "13.6.24",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
+      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"

--- a/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/package-lock.json
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-nextjs/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "lexical-esm-nextjs",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexical-esm-nextjs",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@lexical/plain-text": "0.28.0",
-        "@lexical/react": "0.28.0",
-        "lexical": "0.28.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/react": "0.29.0",
+        "lexical": "0.29.0",
         "next": "^14.2.1",
         "react": "^18",
         "react-dom": "^18"
@@ -39,9 +39,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -142,41 +143,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.28.0.tgz",
-      "integrity": "sha512-LYqion+kAwFQJStA37JAEMxTL/m1WlZbotDfM/2WuONmlO0yWxiyRDI18oeCwhBD6LQQd9c3Ccxp9HFwUG1AVw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
+      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.28.0",
-        "@lexical/list": "0.28.0",
-        "@lexical/selection": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.28.0.tgz",
-      "integrity": "sha512-9LOKSWdRhxqAKRq5yveNC21XKtW4h2rmFNTucwMWZ9vLu9xteOHEwZdO1Qv82PFUmgCpAhg6EntmnZu9xD3K7Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
+      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.28.0.tgz",
-      "integrity": "sha512-Fk4itAjZ+MqTYXN84aE5RDf+wQX67N5nyo3JVxQTFZGAghx7Ux1xLWHB25zzD0YfjMtJ0NQROAbE3xdecZzxcQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
+      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.28.0",
-        "@lexical/link": "0.28.0",
-        "@lexical/mark": "0.28.0",
-        "@lexical/table": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/html": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -184,143 +185,143 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.28.0.tgz",
-      "integrity": "sha512-T6T8YaHnhU863ruuqmRHTLUYa8sfg/ArYcrnNGZGfpvvFTfFjpWb/ELOvOWo8N6Y/4fnSLjQ20aXexVW1KcTBQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
+      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.28.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.28.0.tgz",
-      "integrity": "sha512-zcqX9Qna4lj96bAUfwSQSVEhYQ0O5erSjrIhOVqEgeQ5ubz0EvqnnMbbwNHIb2n6jzSwAvpD/3UZJZtolh+zVg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
+      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.28.0.tgz",
-      "integrity": "sha512-CHzDxaGDn6qCFFhU0YKP1B8sgEb++0Ksqsj6BfDL/6TMxoLNQwRQhP3BUNNXl1kvUhxTQZgk3b9MjJZRaFKG9Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
+      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.28.0.tgz",
-      "integrity": "sha512-ayb0FPxr55Ko99/d9ewbfrApul4L0z+KpU2ZG03im7EvUPVLyIGLx4S0QguMDvQh0Vu+eJ7/EESuonDs5BCe3A==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
+      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.28.0.tgz",
-      "integrity": "sha512-T5VKxpOnML5DcXv2lW3Le0vjNlcbdohZjS9f6PAvm6eX8EzBKDpLQCopr1/0KGdlLd1QrzQsykQrdU7ieC4LRg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
+      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.28.0.tgz",
-      "integrity": "sha512-3a8QcZ75n2TLxP+xkSPJ2V15jsysMLMe0YoObG+ew/sioVelIU8GciYsWBo5GgQmwSzJNQJeK5cJ9p1b71z2cg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
+      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.28.0.tgz",
-      "integrity": "sha512-v5PzmTACsJrw3GvNZy2rgPxrNn9InLvLFoKqrSlNhhyvYNIAcuC4KVy00LKLja43Gw/fuB3QwKohYfAtM3yR3g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
+      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.28.0.tgz",
-      "integrity": "sha512-F3JXClqN4cjmXYLDK0IztxkbZuqkqS/AVbxnhGvnDYHQ9Gp8l7BonczhOiPwmJCDubJrAACP0L9LCqyt0jDRFw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
+      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.28.0",
-        "@lexical/link": "0.28.0",
-        "@lexical/list": "0.28.0",
-        "@lexical/rich-text": "0.28.0",
-        "@lexical/text": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/code": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.28.0.tgz",
-      "integrity": "sha512-/SMDQgBPeWM936t04mtH6UAn3xAjP/meu9q136bcT3S7p7V8ew9JfNp9aznTPTx+2W3brJORAvUow7Xn1fSHmw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
+      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.28.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.28.0.tgz",
-      "integrity": "sha512-ppmhHXEZVicBm05w9EVflzwFavTVNAe4q0bkabWUeW0IoCT3Vg2A3JT7PC9ypmp+mboUD195foFEr1BBSv1Y8Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
+      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.28.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.28.0.tgz",
-      "integrity": "sha512-Jj2dCMDEfRuVetfDKcUes8J5jvAfZrLnILFlHxnu7y+lC+7R/NR403DYb3NJ8H7+lNiH1K15+U2K7ewbjxS6KQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
+      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.28.0",
-        "@lexical/selection": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.28.0.tgz",
-      "integrity": "sha512-dWPnxrKrbQFjNqExqnaAsV0UEUgw/5M1ZYRWd5FGBGjHqVTCaX2jNHlKLMA68Od0VPIoOX2Zy1TYZ8ZKtsj5Dg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
+      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/devtools-core": "0.28.0",
-        "@lexical/dragon": "0.28.0",
-        "@lexical/hashtag": "0.28.0",
-        "@lexical/history": "0.28.0",
-        "@lexical/link": "0.28.0",
-        "@lexical/list": "0.28.0",
-        "@lexical/mark": "0.28.0",
-        "@lexical/markdown": "0.28.0",
-        "@lexical/overflow": "0.28.0",
-        "@lexical/plain-text": "0.28.0",
-        "@lexical/rich-text": "0.28.0",
-        "@lexical/table": "0.28.0",
-        "@lexical/text": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "@lexical/yjs": "0.28.0",
-        "lexical": "0.28.0",
+        "@lexical/devtools-core": "0.29.0",
+        "@lexical/dragon": "0.29.0",
+        "@lexical/hashtag": "0.29.0",
+        "@lexical/history": "0.29.0",
+        "@lexical/link": "0.29.0",
+        "@lexical/list": "0.29.0",
+        "@lexical/mark": "0.29.0",
+        "@lexical/markdown": "0.29.0",
+        "@lexical/overflow": "0.29.0",
+        "@lexical/plain-text": "0.29.0",
+        "@lexical/rich-text": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "@lexical/text": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "@lexical/yjs": "0.29.0",
+        "lexical": "0.29.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -329,67 +330,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.28.0.tgz",
-      "integrity": "sha512-y+vUWI+9uFupIb9UvssKU/DKcT9dFUZuQBu7utFkLadxCNyXQHeRjxzjzmvFiM3DBV0guPUDGu5VS5TPnIA+OA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
+      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.28.0",
-        "@lexical/selection": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.28.0.tgz",
-      "integrity": "sha512-AJDi67Nsexyejzp4dEQSVoPov4P+FJ0t1v6DxUU+YmcvV56QyJQi6ue0i/xd8unr75ZufzLsAC0cDJJCEI7QDA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
+      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.28.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.28.0.tgz",
-      "integrity": "sha512-HMPCwXdj0sRWdlDzsHcNWRgbeKbEhn3L8LPhFnTq7q61gZ4YW2umdmuvQFKnIBcKq49drTH8cUwZoIwI8+AEEw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
+      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.28.0",
-        "@lexical/utils": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/clipboard": "0.29.0",
+        "@lexical/utils": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.28.0.tgz",
-      "integrity": "sha512-PT/A2RZv+ktn7SG/tJkOpGlYE6zjOND59VtRHnV/xciZ+jEJVaqAHtWjhbWibAIZQAkv/O7UouuDqzDaNTSGAA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
+      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.28.0"
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.28.0.tgz",
-      "integrity": "sha512-Qw00DjkS1nRK7DLSgqJpJ77Ti2AuiOQ6m5eM38YojoWXkVmoxqKAUMaIbVNVKqjFgrQvKFF46sXxIJPbUQkB0w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.28.0",
-        "@lexical/selection": "0.28.0",
-        "@lexical/table": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/list": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "@lexical/table": "0.29.0",
+        "lexical": "0.29.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.28.0.tgz",
-      "integrity": "sha512-rKHpUEd3nrvMY7ghmOC0AeGSYT7YIviba+JViaOzrCX4/Wtv5C/3Sl7Io12Z9k+s1BKmy7C28bOdQHvRWaD7vQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
+      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.28.0",
-        "@lexical/selection": "0.28.0",
-        "lexical": "0.28.0"
+        "@lexical/offset": "0.29.0",
+        "@lexical/selection": "0.29.0",
+        "lexical": "0.29.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1268,15 +1269,15 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/lexical": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.28.0.tgz",
-      "integrity": "sha512-dLE3O1PZg0TlZxRQo9YDpjCjDUj8zluGyBO9MHdjo21qZmMUNrxQPeCRt8fn2s5l4HKYFQ1YNgl7k1pOJB/vZQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
+      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
       "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.100",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.100.tgz",
-      "integrity": "sha512-ACQmtZ8cRD7/SpBEzBP88KrgrjOnhfcOANhhk8ASv+HFEvBSHOprxur3vuhmNw4YLq29y4Yen4jU0jHpIqVYWw==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
## Description
Currently, `exportTextFormat` in `MardownExports` trim the input first to handle the case looking like `**   foo   **`
An edge case here is if the string consists only of whitespaces, the trimmed string will be empty.
Based on the discussion [here](https://github.com/facebook/lexical/issues/6526#issuecomment-2725146825), one possible solution is replacing the whitespace with `&#160;`, which is also compatible with CommonMark.

Closes #6526 

## Test plan

### Add a new unit test


### Before


https://github.com/user-attachments/assets/8a8882e7-db70-4401-9461-31db07fc5b88




### After

https://github.com/user-attachments/assets/772fe8fa-634c-40ce-a217-3a8db2eca2e9

------------------
Test other whitespaces


https://github.com/user-attachments/assets/b0497b32-c613-42b7-a288-b4b026468fad




