### PR TITLE
[lexical-rich-text] Bug Fix: Fix right and up arrow key navigation with decorator nodes

### DIFF
--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -747,10 +747,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
       KEY_ARROW_UP_COMMAND,
       (event) => {
         const selection = $getSelection();
-        if (
-          $isNodeSelection(selection) &&
-          !$isTargetWithinDecorator(event.target as HTMLElement)
-        ) {
+        if ($isNodeSelection(selection)) {
           // If selection is on a node, let's try and move selection
           // back to being a range selection.
           const nodes = selection.getNodes();

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -839,10 +839,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
       KEY_ARROW_RIGHT_COMMAND,
       (event) => {
         const selection = $getSelection();
-        if (
-          $isNodeSelection(selection) &&
-          !$isTargetWithinDecorator(event.target as HTMLElement)
-        ) {
+        if ($isNodeSelection(selection)) {
           // If selection is on a node, let's try and move selection
           // back to being a range selection.
           const nodes = selection.getNodes();


### PR DESCRIPTION
## Description

### Current behavior:
- When clicking on an Excalidraw decorator, the button becomes active and becomes the target of keyboard events
- The right arrow key handler checks if the target is inside a decorator (`!$isTargetWithinDecorator`) and ignores the event
- This check was originally added in PR #2895 for all arrow keys to fix keyboard controls on internal decorators
- Later, PR #2929 removed this check from left arrow key, but it remained for right arrow key
- This creates an inconsistent behavior where right arrow doesn't work initially, but works after pressing left arrow

### Changes in this PR:
- Remove the `!$isTargetWithinDecorator` check from `KEY_ARROW_RIGHT_COMMAND` to match the behavior of `KEY_ARROW_LEFT_COMMAND`
- This allows consistent bi-directional arrow key navigation when decorator nodes are selected
- The change follows the same pattern as PR #2929 which successfully removed this check from left arrow key

Closes #7392

## Test plan

### Before
1. Add an Excalidraw node to the editor
2. Click to select the Excalidraw node
3. Press right arrow key - nothing happens
4. Press left arrow key - selection moves left
5. Press right arrow key - now it works

https://github.com/user-attachments/assets/75640105-e8c5-429f-91be-6cd5baafbb0a

### After
1. Add an Excalidraw node to the editor
2. Click to select the Excalidraw node
3. Press right arrow key - selection moves right
4. Press left arrow key - selection moves left
5. Both arrow keys work consistently in either direction

https://github.com/user-attachments/assets/82eaa525-184f-4d45-b854-489cbdd3ea83
