### PR TITLE
[lexical-markdown] Bug Fix: Prevent Markdown shortcuts from applying to code-formatted text

### DIFF
--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -254,6 +254,9 @@ function $runTextFormatTransformers(
       }
 
       if ($isTextNode(sibling)) {
+        if (sibling.hasFormat('code')) {
+          continue;
+        }
         const siblingTextContent = sibling.getTextContent();
         openNode = sibling;
         openTagStartIndex = getOpenTagStartIndex(

--- a/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Markdown.spec.mjs
@@ -1047,6 +1047,29 @@ test.describe.parallel('Markdown', () => {
     );
   });
 
+  test('does not use code-formatted text in text format transformers (#7349)', async ({
+    page,
+  }) => {
+    await focusEditor(page);
+    await page.keyboard.type('`void*` or `int*`');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <code spellcheck="false" data-lexical-text="true">
+            <span class="PlaygroundEditorTheme__textCode">void*</span>
+          </code>
+          <span data-lexical-text="true">or</span>
+          <code spellcheck="false" data-lexical-text="true">
+            <span class="PlaygroundEditorTheme__textCode">int*</span>
+          </code>
+        </p>
+      `,
+    );
+  });
+
   test('can adjust selection after text match transformer', async ({page}) => {
     await focusEditor(page);
     await page.keyboard.type('Hello  world');


### PR DESCRIPTION
## Description

Prevent text-format Markdown shortcuts from matching with text in code-formatted text nodes.

For example, this ensures that typing the following:
```
`void*` and `int*`
```
results in "<code>void*</code> and <code>int*</code>" instead of "<code>void</code><i> and <code>int</code></i>".

Closes #7349

## Test plan

Run E2E tests: `npm run test-e2e-chromium Markdown.spec`

### Before

https://github.com/user-attachments/assets/51f3483c-2fa8-419f-affb-2d1e00b2ccd4

### After

https://github.com/user-attachments/assets/134489a7-d770-48e5-b771-69351e9ddf4c
