### PR TITLE
[lexical-yjs] Bug Fix: Fix scroll position getting changed when someone else makes a change in collab

### DIFF
--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -9,6 +9,7 @@
 import type {EditorState, NodeKey} from 'lexical';
 
 import {
+  $addUpdateTag,
   $createParagraphNode,
   $getNodeByKey,
   $getRoot,
@@ -170,6 +171,12 @@ export function syncYjsChangesToLexical(
         } else {
           $syncLocalCursorPosition(binding, provider);
         }
+      }
+
+      if (!isFromUndoManger) {
+        // If it is an external change, we don't want the current scroll position to get changed
+        // since the user might've intentionally scrolled somewhere else in the document.
+        $addUpdateTag('skip-scroll-into-view');
       }
     },
     {


### PR DESCRIPTION
## Description

This MR fixes an issue where your cursor would get scrolled back into view in a collab editor if your cursor was not in view and someone else made a change anywhere else in the state.

## Test plan

### Before

https://github.com/user-attachments/assets/69ea0e7d-de6d-4daa-8122-8646f43c9233

### After

https://github.com/user-attachments/assets/2ca0f01e-b564-40eb-b21d-9cc033065256
