### PR TITLE
[Bug Fix] Clone a node and use  `$setSelection` instead of assigning dirty to true directly. 

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -34,6 +34,7 @@ import {
 import {
   $addUpdateTag,
   $onUpdate,
+  $setSelection,
   createUID,
   dispatchCommand,
   getCachedClassNameArray,
@@ -1302,17 +1303,12 @@ export class LexicalEditor {
       // This ensures that iOS does not trigger caps lock upon focus
       rootElement.setAttribute('autocapitalize', 'off');
       updateEditorSync(this, () => {
-        let selection = $getSelection();
+        const selection = $getSelection();
         const root = $getRoot();
         if (selection !== null) {
           // Marking the selection dirty will force the selection back to it
-          // In DEV mode, we freeze the selection in $commitPendingUpdates
-          // so clone a node here to prevent an error.
-          if (__DEV__ && Object.isFrozen(selection)) {
-            selection = selection.clone();
-          }
           if (!selection.dirty) {
-            selection.dirty = true;
+            $setSelection(selection.clone());
           }
         } else if (root.getChildrenSize() !== 0) {
           if (options.defaultSelection === 'rootStart') {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1305,6 +1305,7 @@ export class LexicalEditor {
       updateEditorSync(this, () => {
         const selection = $getSelection();
         const root = $getRoot();
+
         if (selection !== null) {
           // Marking the selection dirty will force the selection back to it
           if (!selection.dirty) {

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -1302,12 +1302,18 @@ export class LexicalEditor {
       // This ensures that iOS does not trigger caps lock upon focus
       rootElement.setAttribute('autocapitalize', 'off');
       updateEditorSync(this, () => {
-        const selection = $getSelection();
+        let selection = $getSelection();
         const root = $getRoot();
-
         if (selection !== null) {
           // Marking the selection dirty will force the selection back to it
-          selection.dirty = true;
+          // In DEV mode, we freeze the selection in $commitPendingUpdates
+          // so clone a node here to prevent an error.
+          if (__DEV__ && Object.isFrozen(selection)) {
+            selection = selection.clone();
+          }
+          if (!selection.dirty) {
+            selection.dirty = true;
+          }
         } else if (root.getChildrenSize() !== 0) {
           if (options.defaultSelection === 'rootStart') {
             root.selectStart();


### PR DESCRIPTION
## Description
Currently, we mark the selection dirty and force the selection back to it.
We freeze the selection object in `LexicalUpdates::$commitPendingUpdates` when in `DEV` mode for performance reasons
```javascript
 if (!pendingEditorState._readOnly) {
    pendingEditorState._readOnly = true;
    if (__DEV__) {
      handleDEVOnlyPendingUpdateGuarantees(pendingEditorState);
      if ($isRangeSelection(pendingSelection)) {
        Object.freeze(pendingSelection.anchor);
        Object.freeze(pendingSelection.focus);
      }
      Object.freeze(pendingSelection);
    }
  }
```
In some cases, we have observed this error:
```
Uncaught TypeError: Cannot assign to read only property 'dirty' of object '#<RangeSelection>'
```
To prevent this, we can clone a node and use  `$setSelection` instead of assigning dirty to true directly. 

## Test plan
existing tests.

### Before
Have seen the error above in console when in dev mode
### After
The error disappears. 