### PR TITLE
[lexical-devtools-core] Bug Fix: Update debug view to show KEY_ESCAPE_COMMAND immediately

### DIFF
--- a/packages/lexical-devtools-core/src/TreeView.tsx
+++ b/packages/lexical-devtools-core/src/TreeView.tsx
@@ -93,7 +93,7 @@ export const TreeView = forwardRef<
       }
     }
 
-    // Force generation when the editor state changes
+    // Force generation when the editor state changes or when new commands are logged
     const shouldRegenerateTree = lastEditorStateRef.current !== editorState;
     if (shouldRegenerateTree) {
       lastEditorStateRef.current = editorState;
@@ -105,24 +105,24 @@ export const TreeView = forwardRef<
           [Date.now(), editorState],
         ]);
       }
-    } else {
-      // This will check if there are new commands to render even when the editor state hasn't changed
-      generateContent(showExportDOM)
-        .then((treeText) => {
-          const commandsLogStartIndex = treeText.indexOf('\n\n commands:');
-          if (commandsLogStartIndex !== -1) {
-            const commandsLogPart = treeText.substring(commandsLogStartIndex);
-            if (commandsLogPart !== lastCommandsLogRef.current) {
-              // Commands log has changed, update the content
-              setContent(treeText);
-              lastCommandsLogRef.current = commandsLogPart;
-            }
-          }
-        })
-        .catch(() => {
-          // Silently ignore errors here, as the regular update will handle them
-        });
     }
+
+    // This will check if there are new commands to render even when the editor state hasn't changed
+    generateContent(showExportDOM)
+      .then((treeText) => {
+        const commandsLogStartIndex = treeText.indexOf('\n\n commands:');
+        if (commandsLogStartIndex !== -1) {
+          const commandsLogPart = treeText.substring(commandsLogStartIndex);
+          if (commandsLogPart !== lastCommandsLogRef.current) {
+            // Commands log has changed, update the content
+            setContent(treeText);
+            lastCommandsLogRef.current = commandsLogPart;
+          }
+        }
+      })
+      .catch(() => {
+        // Silently ignore errors here, as the regular update will handle them
+      });
   }, [
     editorState,
     generateTree,


### PR DESCRIPTION
## Description

### Current behavior:
Currently, the TreeView component in the debug view only updates its content when the editor state changes. This causes commands that don't modify the editor state (like `KEY_ESCAPE_COMMAND`) to not appear in the debug view until the editor regains focus.

Changes in this PR:
The TreeView component now checks for and displays new commands on every render, regardless of whether the editor state has changed. This ensures that all commands, including KEY_ESCAPE_COMMAND, are logged immediately in the playground debugger when they occur, without requiring the editor to regain focus.

- Modified the TreeView component's useEffect hook to check for new commands independently of editor state changes
- Moved the command log check outside the `shouldRegenerateTree` condition

Closes #7379

## Test plan

### Before

1. Open the Playground
2. Click/focus the editor
3. Press Escape
4. KEY_ESCAPE_COMMAND is not logged in the debug view
5. Click outside the editor and back in
6. Only then does KEY_ESCAPE_COMMAND appear in the debug view


### After

1. Open the Playground
2. Click/focus the editor
3. Press Escape
4. KEY_ESCAPE_COMMAND is immediately logged in the debug view
5. No need to click outside and back in to see the command


https://github.com/user-attachments/assets/8d8a8b9a-65a4-42b0-95ec-e6796bc842e6

