### PR TITLE
[lexical-devtools-core] Bug Fix: Update debug view to show KEY_ESCAPE_COMMAND immediately

### DIFF
--- a/packages/lexical-devtools-core/src/TreeView.tsx
+++ b/packages/lexical-devtools-core/src/TreeView.tsx
@@ -95,11 +95,15 @@ export const TreeView = forwardRef<
       lastCommandsLogRef.current !== commandsLog;
 
     if (shouldUpdate) {
+      // Check if it's a real editor state change
+      const isEditorStateChange = lastEditorStateRef.current !== editorState;
+
       lastEditorStateRef.current = editorState;
       lastCommandsLogRef.current = commandsLog;
       generateTree(showExportDOM);
 
-      if (!timeTravelEnabled && lastEditorStateRef.current !== editorState) {
+      // Only record in time travel if there was an actual editor state change
+      if (!timeTravelEnabled && isEditorStateChange) {
         setTimeStampedEditorStates((currentEditorStates) => [
           ...currentEditorStates,
           [Date.now(), editorState],

--- a/packages/lexical-devtools-core/src/TreeView.tsx
+++ b/packages/lexical-devtools-core/src/TreeView.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import type {LexicalCommandLog} from './useLexicalCommandsLog';
 import type {EditorSetOptions, EditorState} from 'lexical';
 import type {JSX} from 'react';
 
@@ -27,7 +28,7 @@ export const TreeView = forwardRef<
     generateContent: (exportDOM: boolean) => Promise<string>;
     setEditorState: (state: EditorState, options?: EditorSetOptions) => void;
     setEditorReadOnly: (isReadonly: boolean) => void;
-    commandsLog?: string[];
+    commandsLog?: LexicalCommandLog;
   }
 >(function TreeViewWrapped(
   {
@@ -57,7 +58,7 @@ export const TreeView = forwardRef<
   const [isLimited, setIsLimited] = useState(false);
   const [showLimited, setShowLimited] = useState(false);
   const lastEditorStateRef = useRef<null | EditorState>();
-  const lastCommandsLogRef = useRef<string[]>([]);
+  const lastCommandsLogRef = useRef<LexicalCommandLog>([]);
   const lastGenerationID = useRef(0);
 
   const generateTree = useCallback(

--- a/packages/lexical-react/src/LexicalTreeView.tsx
+++ b/packages/lexical-react/src/LexicalTreeView.tsx
@@ -122,6 +122,7 @@ export function TreeView({
         return generateContent(editor, commandsLog, exportDOM, customPrintNode);
       }}
       ref={treeElementRef}
+      commandsLog={commandsLog}
     />
   );
 }


### PR DESCRIPTION
## Description

### Current behavior:
- The debug view in TreeView component only updates when the editor state changes
- Commands that don't modify state (like KEY_ESCAPE_COMMAND) are not displayed until the editor regains focus
- This creates confusion for developers trying to debug command interactions

### Changes in this PR:
- Added a new `commandsLog` prop to TreeView to track commands independently of state changes
- Modified the update logic to trigger view refresh when either editor state or commands log changes
- Preserved existing time-travel functionality by only recording state changes in timeline

Closes #7379

## Test plan

### Before

1. Open the Playground
2. Click/focus the editor
3. Press Escape
4. KEY_ESCAPE_COMMAND is not logged in the debug view
5. Click outside the editor and back in
6. Only then does KEY_ESCAPE_COMMAND appear in the debug view


### After

1. Open the Playground
2. Click/focus the editor
3. Press Escape
4. KEY_ESCAPE_COMMAND is immediately logged in the debug view
5. No need to click outside and back in to see the command


https://github.com/user-attachments/assets/8d8a8b9a-65a4-42b0-95ec-e6796bc842e6

