### PR TITLE
[lexical-react] Feature: Add option to disable first item auto-selection in menus

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -199,6 +199,7 @@ export type TypeaheadMenuPluginProps<TOption extends MenuOption> = {
   anchorClassName?: string;
   commandPriority?: CommandListenerPriority;
   parent?: HTMLElement;
+  autoSelectFirstItem?: boolean;
 };
 
 export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
@@ -212,6 +213,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
   anchorClassName,
   commandPriority = COMMAND_PRIORITY_LOW,
   parent,
+  autoSelectFirstItem = true,
 }: TypeaheadMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
@@ -326,6 +328,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
       shouldSplitNodeWithQuery={true}
       onSelectOption={onSelectOption}
       commandPriority={commandPriority}
+      autoSelectFirstItem={autoSelectFirstItem}
     />
   );
 }

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -199,7 +199,7 @@ export type TypeaheadMenuPluginProps<TOption extends MenuOption> = {
   anchorClassName?: string;
   commandPriority?: CommandListenerPriority;
   parent?: HTMLElement;
-  autoSelectFirstItem?: boolean;
+  preselectFirstItem?: boolean;
 };
 
 export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
@@ -213,7 +213,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
   anchorClassName,
   commandPriority = COMMAND_PRIORITY_LOW,
   parent,
-  autoSelectFirstItem = true,
+  preselectFirstItem = true,
 }: TypeaheadMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
@@ -328,7 +328,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
       shouldSplitNodeWithQuery={true}
       onSelectOption={onSelectOption}
       commandPriority={commandPriority}
-      autoSelectFirstItem={autoSelectFirstItem}
+      preselectFirstItem={preselectFirstItem}
     />
   );
 }

--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -267,7 +267,7 @@ export function LexicalMenu<TOption extends MenuOption>({
   onSelectOption,
   shouldSplitNodeWithQuery = false,
   commandPriority = COMMAND_PRIORITY_LOW,
-  autoSelectFirstItem = true,
+  preselectFirstItem = true,
 }: {
   close: () => void;
   editor: LexicalEditor;
@@ -283,17 +283,17 @@ export function LexicalMenu<TOption extends MenuOption>({
     matchingString: string,
   ) => void;
   commandPriority?: CommandListenerPriority;
-  autoSelectFirstItem?: boolean;
+  preselectFirstItem?: boolean;
 }): JSX.Element | null {
   const [selectedIndex, setHighlightedIndex] = useState<null | number>(null);
 
   const matchingString = resolution.match && resolution.match.matchingString;
 
   useEffect(() => {
-    if (autoSelectFirstItem) {
+    if (preselectFirstItem) {
       setHighlightedIndex(0);
     }
-  }, [matchingString, autoSelectFirstItem]);
+  }, [matchingString, preselectFirstItem]);
 
   const selectOptionAndCleanUp = useCallback(
     (selectedEntry: TOption) => {
@@ -340,10 +340,10 @@ export function LexicalMenu<TOption extends MenuOption>({
   useLayoutEffect(() => {
     if (options === null) {
       setHighlightedIndex(null);
-    } else if (selectedIndex === null && autoSelectFirstItem) {
+    } else if (selectedIndex === null && preselectFirstItem) {
       updateSelectedIndex(0);
     }
-  }, [options, selectedIndex, updateSelectedIndex, autoSelectFirstItem]);
+  }, [options, selectedIndex, updateSelectedIndex, preselectFirstItem]);
 
   useEffect(() => {
     return mergeRegister(

--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -267,6 +267,7 @@ export function LexicalMenu<TOption extends MenuOption>({
   onSelectOption,
   shouldSplitNodeWithQuery = false,
   commandPriority = COMMAND_PRIORITY_LOW,
+  autoSelectFirstItem = true,
 }: {
   close: () => void;
   editor: LexicalEditor;
@@ -282,14 +283,17 @@ export function LexicalMenu<TOption extends MenuOption>({
     matchingString: string,
   ) => void;
   commandPriority?: CommandListenerPriority;
+  autoSelectFirstItem?: boolean;
 }): JSX.Element | null {
   const [selectedIndex, setHighlightedIndex] = useState<null | number>(null);
 
   const matchingString = resolution.match && resolution.match.matchingString;
 
   useEffect(() => {
-    setHighlightedIndex(0);
-  }, [matchingString]);
+    if (autoSelectFirstItem) {
+      setHighlightedIndex(0);
+    }
+  }, [matchingString, autoSelectFirstItem]);
 
   const selectOptionAndCleanUp = useCallback(
     (selectedEntry: TOption) => {
@@ -336,10 +340,10 @@ export function LexicalMenu<TOption extends MenuOption>({
   useLayoutEffect(() => {
     if (options === null) {
       setHighlightedIndex(null);
-    } else if (selectedIndex === null) {
+    } else if (selectedIndex === null && autoSelectFirstItem) {
       updateSelectedIndex(0);
     }
-  }, [options, selectedIndex, updateSelectedIndex]);
+  }, [options, selectedIndex, updateSelectedIndex, autoSelectFirstItem]);
 
   useEffect(() => {
     return mergeRegister(
@@ -364,9 +368,13 @@ export function LexicalMenu<TOption extends MenuOption>({
         KEY_ARROW_DOWN_COMMAND,
         (payload) => {
           const event = payload;
-          if (options !== null && options.length && selectedIndex !== null) {
+          if (options !== null && options.length) {
             const newSelectedIndex =
-              selectedIndex !== options.length - 1 ? selectedIndex + 1 : 0;
+              selectedIndex === null
+                ? 0
+                : selectedIndex !== options.length - 1
+                ? selectedIndex + 1
+                : 0;
             updateSelectedIndex(newSelectedIndex);
             const option = options[newSelectedIndex];
             if (option.ref != null && option.ref.current) {
@@ -389,9 +397,13 @@ export function LexicalMenu<TOption extends MenuOption>({
         KEY_ARROW_UP_COMMAND,
         (payload) => {
           const event = payload;
-          if (options !== null && options.length && selectedIndex !== null) {
+          if (options !== null && options.length) {
             const newSelectedIndex =
-              selectedIndex !== 0 ? selectedIndex - 1 : options.length - 1;
+              selectedIndex === null
+                ? options.length - 1
+                : selectedIndex !== 0
+                ? selectedIndex - 1
+                : options.length - 1;
             updateSelectedIndex(newSelectedIndex);
             const option = options[newSelectedIndex];
             if (option.ref != null && option.ref.current) {


### PR DESCRIPTION
## Description

### Current behavior:
- LexicalMenu and LexicalTypeaheadMenuPlugin automatically select the first menu item when rendered
- Users have to work around this by creating a hidden no-op first option
- No built-in way to disable the auto-selection behavior

### Changes in this PR:
- Added new `autoSelectFirstItem` prop (defaults to true for backward compatibility)
- When set to false, no menu item is selected on initial render
- Improved keyboard navigation to handle unselected state:
  - Arrow down selects first item
  - Arrow up selects last item
  - Once an item is selected, maintains existing cycling behavior
- Added TypeScript types and prop interfaces for better type safety

Closes #7364

## Test plan

### Before

When opening any menu (e.g., component picker with "/"), the first item is always automatically selected

### After

When `autoSelectFirstItem={false}`:
- Menu opens with no item selected
- Arrow keys work as expected to select first/last items
- All other menu functionality remains unchanged


https://github.com/user-attachments/assets/6a212a76-c9cb-4733-a950-c9d6bdd10e00

