### PR TITLE
[lexical-playground] Bug Fix: Floating toolbar position for end-aligned text

### DIFF
--- a/packages/lexical-playground/src/utils/setFloatingElemPosition.ts
+++ b/packages/lexical-playground/src/utils/setFloatingElemPosition.ts
@@ -31,6 +31,25 @@ export function setFloatingElemPosition(
   let top = targetRect.top - floatingElemRect.height - verticalGap;
   let left = targetRect.left - horizontalOffset;
 
+  // Check if text is end-aligned
+  const selection = window.getSelection();
+  if (selection && selection.rangeCount > 0) {
+    const range = selection.getRangeAt(0);
+    const textNode = range.startContainer;
+    if (textNode.nodeType === Node.ELEMENT_NODE || textNode.parentElement) {
+      const textElement =
+        textNode.nodeType === Node.ELEMENT_NODE
+          ? (textNode as Element)
+          : (textNode.parentElement as Element);
+      const textAlign = window.getComputedStyle(textElement).textAlign;
+
+      if (textAlign === 'right' || textAlign === 'end') {
+        // For end-aligned text, position the toolbar relative to the text end
+        left = targetRect.right - floatingElemRect.width + horizontalOffset;
+      }
+    }
+  }
+
   if (top < editorScrollerRect.top) {
     // adjusted height for link element if the element is at top
     top +=
@@ -41,6 +60,10 @@ export function setFloatingElemPosition(
 
   if (left + floatingElemRect.width > editorScrollerRect.right) {
     left = editorScrollerRect.right - floatingElemRect.width - horizontalOffset;
+  }
+
+  if (left < editorScrollerRect.left) {
+    left = editorScrollerRect.left + horizontalOffset;
   }
 
   top -= anchorElementRect.top;


### PR DESCRIPTION
## Description

### Current behavior:
When text is end-aligned, the floating text format toolbar appears correctly above the first two lines but shifts to the leftmost position when selecting text on the third line and beyond. This inconsistent positioning creates a poor user experience and makes it difficult to format end-aligned text.

### Changes in this PR:
- Added detection of text alignment using computed styles to determine text positioning
- Modified the floating toolbar position calculation to be relative to text end for right/end-aligned content
- Added boundary checks to ensure the toolbar stays within editor bounds
- Improved horizontal positioning logic to maintain consistent toolbar placement regardless of text alignment

Closes #7114

## Test plan

### Before
The floating toolbar jumps to the leftmost position when selecting text on the third line of end-aligned content.

![image](https://github.com/user-attachments/assets/09e5821b-7a37-4f95-ae54-254331cdc242)

### After
1. Add 3-4 lines of text in the editor
2. Set text alignment to "end" or "right"
3. Select text on different lines
4. Verify toolbar appears consistently above selected text
5. Verify toolbar stays within editor boundaries
6. Test with different text alignments (left, center, right)

![image](https://github.com/user-attachments/assets/340212da-84b3-4929-ae15-9ba68ab29d48)
