### PR TITLE
[WIP][lexical] Bug Fix: Preserve empty first paragraph on backspace

### DIFF
--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -31,6 +31,7 @@ import {
   setNodeIndentFromDOM,
 } from '../LexicalUtils';
 import {ElementNode} from './LexicalElementNode';
+import {$isRootNode} from './LexicalRootNode';
 import {$isTextNode} from './LexicalTextNode';
 
 export type SerializedParagraphNode = Spread<
@@ -132,10 +133,16 @@ export class ParagraphNode extends ElementNode {
     const children = this.getChildren();
     // If we have an empty (trimmed) first paragraph and try and remove it,
     // delete the paragraph as long as we have another sibling to go to
+    // AND we're not the first node in the editor
     if (
       children.length === 0 ||
       ($isTextNode(children[0]) && children[0].getTextContent().trim() === '')
     ) {
+      const parent = this.getParent();
+      // Don't delete if we're the first node in the editor
+      if ($isRootNode(parent) && this.getPreviousSibling() === null) {
+        return false;
+      }
       const nextSibling = this.getNextSibling();
       if (nextSibling !== null) {
         this.selectNext();


### PR DESCRIPTION
## Description

### Current behavior:
Currently, when pressing backspace in an empty first paragraph with non-empty nodes below it, the paragraph gets deleted. This behavior is inconsistent with standard text editors which preserve the empty first paragraph.

### Changes in this PR:
This PR modifies the `ParagraphNode`'s `collapseAtStart` method to prevent deletion of empty first paragraph when it's the first node in the editor (direct child of root with no previous siblings). The behavior now matches standard text editors where backspace in an empty first paragraph does nothing.

Closes #6570

## Test plan

### Before
When pressing backspace in an empty first paragraph:
- The empty paragraph gets deleted
- Selection moves to the next non-empty node
- This creates a jarring experience as users expect the first paragraph to be preserved

### After
When pressing backspace in an empty first paragraph:
- The empty paragraph is preserved
- Selection stays at the start of the paragraph
- Matches the behavior of standard text editors


https://github.com/user-attachments/assets/cecff035-042c-4f20-9668-eacb5aee7e4f

