### PR TITLE
[lexical-table] Feature: Improve logic for pasting table into table

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -16,6 +16,7 @@ import {
   pressBackspace,
   selectAll,
   selectCharacters,
+  undo,
 } from '../keyboardShortcuts/index.mjs';
 import {
   assertSelection,
@@ -45,6 +46,7 @@ import {
   mergeTableCells,
   pasteFromClipboard,
   SAMPLE_IMAGE_URL,
+  selectCellFromTableCoord,
   selectCellsFromTableCords,
   selectFromAdditionalStylesDropdown,
   selectFromAlignDropdown,
@@ -6237,4 +6239,657 @@ test.describe.parallel('Tables', () => {
 
     expect(menuHidden).toBe(true);
   });
+
+  test(`Can expand table to fit content when pasting table into table`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
+    await focusEditor(page);
+
+    await pasteFromClipboard(page, {'text/html': TABLE_WITH_MERGED_CELLS});
+
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 0},
+      {x: 2, y: 1},
+      false,
+      false,
+    );
+
+    await withExclusiveClipboardAccess(async () => {
+      const clipboard = await copyToClipboard(page);
+
+      await selectCellFromTableCoord(page, {x: 0, y: 2});
+
+      await pasteFromClipboard(page, clipboard);
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a3</span>
+              </p>
+            </td>
+          </tr>
+          <tr style="height: 38px">
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              rowspan="2"
+              style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b3</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a3</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b3</span>
+              </p>
+            </td>
+          </tr>
+        </table>
+      `,
+    );
+
+    await undo(page);
+
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 0},
+      {x: 2, y: 1},
+      false,
+      false,
+    );
+
+    await withExclusiveClipboardAccess(async () => {
+      const clipboard = await copyToClipboard(page);
+
+      await selectCellFromTableCoord(page, {x: 2, y: 1});
+
+      await pasteFromClipboard(page, clipboard);
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a3</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr style="height: 38px">
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              rowspan="2"
+              style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a3</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">c2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b3</span>
+              </p>
+            </td>
+          </tr>
+        </table>
+      `,
+    );
+  });
+
+  test(`Can paste table containing merged cells into table`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
+    await focusEditor(page);
+
+    await pasteFromClipboard(page, {'text/html': TABLE_WITH_MERGED_CELLS});
+
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 1},
+      {x: 0, y: 2},
+      false,
+      false,
+    );
+
+    await withExclusiveClipboardAccess(async () => {
+      const clipboard = await copyToClipboard(page);
+
+      await selectCellFromTableCoord(page, {x: 0, y: 2});
+
+      await pasteFromClipboard(page, clipboard);
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a3</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr style="height: 38px">
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              rowspan="2"
+              style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b3</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+          </tr>
+          <tr>
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              rowspan="2"
+              style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b3</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" colspan="2">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">c2</span>
+              </p>
+            </td>
+          </tr>
+        </table>
+      `,
+    );
+
+    await undo(page);
+
+    await selectCellsFromTableCords(
+      page,
+      {x: 0, y: 1},
+      {x: 0, y: 2},
+      false,
+      false,
+    );
+
+    await withExclusiveClipboardAccess(async () => {
+      const clipboard = await copyToClipboard(page);
+
+      await selectCellFromTableCoord(page, {x: 0, y: 0});
+
+      await pasteFromClipboard(page, clipboard);
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr>
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              rowspan="2"
+              style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b3</span>
+              </p>
+            </td>
+          </tr>
+          <tr style="height: 38px">
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              colspan="2"
+              style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">c2</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+            </td>
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              colspan="2"
+              style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">c2</span>
+              </p>
+            </td>
+          </tr>
+        </table>
+      `,
+    );
+  });
+
+  test(`Can paste table into table while having table selection`, async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText);
+    await initialize({isCollab, page});
+    await focusEditor(page);
+
+    await pasteFromClipboard(page, {'text/html': TABLE_WITH_MERGED_CELLS});
+
+    await selectCellsFromTableCords(
+      page,
+      {x: 1, y: 1},
+      {x: 0, y: 2},
+      false,
+      false,
+    );
+
+    await pasteFromClipboard(page, {'text/html': TABLE_WITH_MERGED_CELLS});
+
+    await assertHTML(
+      page,
+      html`
+        <table class="PlaygroundEditorTheme__table">
+          <colgroup>
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+            <col style="width: 92px" />
+          </colgroup>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a2</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a3</span>
+              </p>
+            </td>
+          </tr>
+          <tr style="height: 38px">
+            <td
+              class="PlaygroundEditorTheme__tableCell"
+              rowspan="2"
+              style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">a2</span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="PlaygroundEditorTheme__tableCell" style="width: 75px">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b1</span>
+              </p>
+            </td>
+            <td class="PlaygroundEditorTheme__tableCell">
+              <p
+                class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                style="text-align: start">
+                <span data-lexical-text="true">b2</span>
+              </p>
+            </td>
+          </tr>
+        </table>
+      `,
+    );
+  });
 });
+
+const TABLE_WITH_MERGED_CELLS = `
+<table class="PlaygroundEditorTheme__table">
+  <colgroup>
+    <col style="width: 92px;">
+    <col style="width: 92px;">
+    <col style="width: 92px;">
+  </colgroup>
+  <tbody>
+    <tr dir="ltr">
+      <td class="PlaygroundEditorTheme__tableCell" dir="ltr" style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start;">
+        <p class="PlaygroundEditorTheme__paragraph" dir="ltr">
+          <span style="white-space: pre-wrap;">a1</span>
+        </p>
+      </td>
+      <td class="PlaygroundEditorTheme__tableCell" dir="ltr" style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start;">
+        <p class="PlaygroundEditorTheme__paragraph" dir="ltr">
+          <span style="white-space: pre-wrap;">a2</span>
+        </p>
+      </td>
+      <td class="PlaygroundEditorTheme__tableCell" dir="ltr" style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start;">
+        <p class="PlaygroundEditorTheme__paragraph" dir="ltr">
+          <span style="white-space: pre-wrap;">a3</span>
+        </p>
+      </td>
+    </tr>
+    <tr style="height: 38px;">
+      <td rowspan="2" class="PlaygroundEditorTheme__tableCell" dir="ltr" style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start;">
+        <p class="PlaygroundEditorTheme__paragraph" dir="ltr">
+          <span style="white-space: pre-wrap;">b1</span>
+        </p>
+      </td>
+      <td class="PlaygroundEditorTheme__tableCell" dir="ltr" style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start;">
+        <p class="PlaygroundEditorTheme__paragraph" dir="ltr">
+          <span style="white-space: pre-wrap;">b2</span>
+        </p>
+      </td>
+      <td class="PlaygroundEditorTheme__tableCell" dir="ltr" style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start;">
+        <p class="PlaygroundEditorTheme__paragraph" dir="ltr">
+          <span style="white-space: pre-wrap;">b3</span>
+        </p>
+      </td>
+    </tr>
+    <tr dir="ltr">
+      <td colspan="2" class="PlaygroundEditorTheme__tableCell" dir="ltr" style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start;">
+        <p class="PlaygroundEditorTheme__paragraph" dir="ltr">
+          <span style="white-space: pre-wrap;">c2</span>
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>`;

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -916,6 +916,20 @@ export async function insertCollapsible(page) {
   await selectFromInsertDropdown(page, '.item .caret-right');
 }
 
+export async function selectCellFromTableCoord(page, coord, isHeader = false) {
+  const leftFrame = getPageOrFrame(page);
+  if (IS_COLLAB) {
+    await focusEditor(page);
+  }
+
+  const cell = await leftFrame.locator(
+    `table:first-of-type > :nth-match(tr, ${coord.y + 1}) > ${
+      isHeader ? 'th' : 'td'
+    }:nth-child(${coord.x + 1})`,
+  );
+  await cell.click();
+}
+
 export async function selectCellsFromTableCords(
   page,
   firstCords,

--- a/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableActionMenuPlugin/index.tsx
@@ -24,6 +24,7 @@ import {
   $insertTableRow__EXPERIMENTAL,
   $isTableCellNode,
   $isTableSelection,
+  $mergeCells,
   $unmergeCell,
   getTableElement,
   getTableObserverFromTableElement,
@@ -34,10 +35,8 @@ import {
 } from '@lexical/table';
 import {mergeRegister} from '@lexical/utils';
 import {
-  $createParagraphNode,
   $getSelection,
   $isElementNode,
-  $isParagraphNode,
   $isRangeSelection,
   $isTextNode,
   $setSelection,
@@ -76,17 +75,6 @@ function $canUnmerge(): boolean {
   }
   const [cell] = $getNodeTriplet(selection.anchor);
   return cell.__colSpan > 1 || cell.__rowSpan > 1;
-}
-
-function $cellContainsEmptyParagraph(cell: TableCellNode): boolean {
-  if (cell.getChildrenSize() !== 1) {
-    return false;
-  }
-  const firstChild = cell.getFirstChildOrThrow();
-  if (!$isParagraphNode(firstChild) || !firstChild.isEmpty()) {
-    return false;
-  }
-  return true;
 }
 
 function $selectLastDescendant(node: ElementNode): void {
@@ -263,105 +251,15 @@ function TableActionMenu({
   const mergeTableCellsAtSelection = () => {
     editor.update(() => {
       const selection = $getSelection();
-      if ($isTableSelection(selection)) {
-        // Get all selected cells and compute the total area
-        const nodes = selection.getNodes();
-        const tableCells = nodes.filter($isTableCellNode);
+      if (!$isTableSelection(selection)) {
+        return;
+      }
 
-        if (tableCells.length === 0) {
-          return;
-        }
+      const nodes = selection.getNodes();
+      const tableCells = nodes.filter($isTableCellNode);
+      const targetCell = $mergeCells(tableCells);
 
-        // Find the table node
-        const tableNode = $getTableNodeFromLexicalNodeOrThrow(tableCells[0]);
-        const [gridMap] = $computeTableMapSkipCellCheck(tableNode, null, null);
-
-        // Find the boundaries of the selection including merged cells
-        let minRow = Infinity;
-        let maxRow = -Infinity;
-        let minCol = Infinity;
-        let maxCol = -Infinity;
-
-        // First pass: find the actual boundaries considering merged cells
-        const processedCells = new Set();
-        for (const row of gridMap) {
-          for (const mapCell of row) {
-            if (!mapCell || !mapCell.cell) {
-              continue;
-            }
-
-            const cellKey = mapCell.cell.getKey();
-            if (processedCells.has(cellKey)) {
-              continue;
-            }
-
-            if (tableCells.some((cell) => cell.is(mapCell.cell))) {
-              processedCells.add(cellKey);
-              // Get the actual position of this cell in the grid
-              const cellStartRow = mapCell.startRow;
-              const cellStartCol = mapCell.startColumn;
-              const cellRowSpan = mapCell.cell.__rowSpan || 1;
-              const cellColSpan = mapCell.cell.__colSpan || 1;
-
-              // Update boundaries considering the cell's actual position and span
-              minRow = Math.min(minRow, cellStartRow);
-              maxRow = Math.max(maxRow, cellStartRow + cellRowSpan - 1);
-              minCol = Math.min(minCol, cellStartCol);
-              maxCol = Math.max(maxCol, cellStartCol + cellColSpan - 1);
-            }
-          }
-        }
-
-        // Validate boundaries
-        if (minRow === Infinity || minCol === Infinity) {
-          return;
-        }
-
-        // The total span of the merged cell
-        const totalRowSpan = maxRow - minRow + 1;
-        const totalColSpan = maxCol - minCol + 1;
-
-        // Use the top-left cell as the target cell
-        const targetCellMap = gridMap[minRow][minCol];
-        if (!targetCellMap?.cell) {
-          return;
-        }
-        const targetCell = targetCellMap.cell;
-
-        // Set the spans for the target cell
-        targetCell.setColSpan(totalColSpan);
-        targetCell.setRowSpan(totalRowSpan);
-
-        // Move content from other cells to the target cell
-        const seenCells = new Set([targetCell.getKey()]);
-
-        // Second pass: merge content and remove other cells
-        for (let row = minRow; row <= maxRow; row++) {
-          for (let col = minCol; col <= maxCol; col++) {
-            const mapCell = gridMap[row][col];
-            if (!mapCell?.cell) {
-              continue;
-            }
-
-            const currentCell = mapCell.cell;
-            const key = currentCell.getKey();
-
-            if (!seenCells.has(key)) {
-              seenCells.add(key);
-              const isEmpty = $cellContainsEmptyParagraph(currentCell);
-              if (!isEmpty) {
-                targetCell.append(...currentCell.getChildren());
-              }
-              currentCell.remove();
-            }
-          }
-        }
-
-        // Ensure target cell has content
-        if (targetCell.getChildrenSize() === 0) {
-          targetCell.append($createParagraphNode());
-        }
-
+      if (targetCell) {
         $selectLastDescendant(targetCell);
         onClose();
       }

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -14,6 +14,7 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getSelection,
+  $isParagraphNode,
   $isRangeSelection,
   LexicalNode,
 } from 'lexical';
@@ -262,21 +263,45 @@ export function $insertTableRow__EXPERIMENTAL(
   const focus = selection.focus.getNode();
   const [anchorCell] = $getNodeTriplet(anchor);
   const [focusCell, , grid] = $getNodeTriplet(focus);
-  const [gridMap, focusCellMap, anchorCellMap] = $computeTableMap(
+  const [, focusCellMap, anchorCellMap] = $computeTableMap(
     grid,
     focusCell,
     anchorCell,
   );
-  const columnCount = gridMap[0].length;
   const {startRow: anchorStartRow} = anchorCellMap;
   const {startRow: focusStartRow} = focusCellMap;
+  if (insertAfter) {
+    return $insertTableRowAtNode(
+      anchorStartRow + anchorCell.__rowSpan >
+        focusStartRow + focusCell.__rowSpan
+        ? anchorCell
+        : focusCell,
+      true,
+    );
+  } else {
+    return $insertTableRowAtNode(
+      focusStartRow < anchorStartRow ? focusCell : anchorCell,
+      false,
+    );
+  }
+}
+
+/**
+ * Inserts a table row before or after the given cell node,
+ * taking into account any spans. If successful, returns the
+ * inserted table row node.
+ */
+export function $insertTableRowAtNode(
+  cellNode: TableCellNode,
+  insertAfter = true,
+): TableRowNode | null {
+  const [, , grid] = $getNodeTriplet(cellNode);
+  const [gridMap, cellMap] = $computeTableMap(grid, cellNode, cellNode);
+  const columnCount = gridMap[0].length;
+  const {startRow: cellStartRow} = cellMap;
   let insertedRow: TableRowNode | null = null;
   if (insertAfter) {
-    const insertAfterEndRow =
-      Math.max(
-        focusStartRow + focusCell.__rowSpan,
-        anchorStartRow + anchorCell.__rowSpan,
-      ) - 1;
+    const insertAfterEndRow = cellStartRow + cellNode.__rowSpan - 1;
     const insertAfterEndRowMap = gridMap[insertAfterEndRow];
     const newRow = $createTableRowNode();
     for (let i = 0; i < columnCount; i++) {
@@ -305,7 +330,7 @@ export function $insertTableRow__EXPERIMENTAL(
     insertAfterEndRowNode.insertAfter(newRow);
     insertedRow = newRow;
   } else {
-    const insertBeforeStartRow = Math.min(focusStartRow, anchorStartRow);
+    const insertBeforeStartRow = cellStartRow;
     const insertBeforeStartRowMap = gridMap[insertBeforeStartRow];
     const newRow = $createTableRowNode();
     for (let i = 0; i < columnCount; i++) {
@@ -413,17 +438,44 @@ export function $insertTableColumn__EXPERIMENTAL(
   const focus = selection.focus.getNode();
   const [anchorCell] = $getNodeTriplet(anchor);
   const [focusCell, , grid] = $getNodeTriplet(focus);
-  const [gridMap, focusCellMap, anchorCellMap] = $computeTableMap(
+  const [, focusCellMap, anchorCellMap] = $computeTableMap(
     grid,
     focusCell,
     anchorCell,
   );
+  const {startColumn: anchorStartColumn} = anchorCellMap;
+  const {startColumn: focusStartColumn} = focusCellMap;
+  if (insertAfter) {
+    return $insertTableColumnAtNode(
+      anchorStartColumn + anchorCell.__colSpan >
+        focusStartColumn + focusCell.__colSpan
+        ? anchorCell
+        : focusCell,
+      true,
+    );
+  } else {
+    return $insertTableColumnAtNode(
+      focusStartColumn < anchorStartColumn ? focusCell : anchorCell,
+      false,
+    );
+  }
+}
+
+/**
+ * Inserts a column before or after the given cell node,
+ * taking into account any spans. If successful, returns the
+ * first inserted cell node.
+ */
+export function $insertTableColumnAtNode(
+  cellNode: TableCellNode,
+  insertAfter = true,
+): TableCellNode | null {
+  const [, , grid] = $getNodeTriplet(cellNode);
+  const [gridMap, cellMap] = $computeTableMap(grid, cellNode, cellNode);
   const rowCount = gridMap.length;
-  const startColumn = insertAfter
-    ? Math.max(focusCellMap.startColumn, anchorCellMap.startColumn)
-    : Math.min(focusCellMap.startColumn, anchorCellMap.startColumn);
+  const {startColumn} = cellMap;
   const insertAfterColumn = insertAfter
-    ? startColumn + focusCell.__colSpan - 1
+    ? startColumn + cellNode.__colSpan - 1
     : startColumn - 1;
   const gridFirstChild = grid.getFirstChild();
   invariant(
@@ -725,6 +777,115 @@ function $insertFirst(parent: ElementNode, node: LexicalNode): void {
   }
 }
 
+export function $mergeCells(cellNodes: TableCellNode[]): TableCellNode | null {
+  if (cellNodes.length === 0) {
+    return null;
+  }
+
+  // Find the table node
+  const tableNode = $getTableNodeFromLexicalNodeOrThrow(cellNodes[0]);
+  const [gridMap] = $computeTableMapSkipCellCheck(tableNode, null, null);
+
+  // Find the boundaries of the selection including merged cells
+  let minRow = Infinity;
+  let maxRow = -Infinity;
+  let minCol = Infinity;
+  let maxCol = -Infinity;
+
+  // First pass: find the actual boundaries considering merged cells
+  const processedCells = new Set();
+  for (const row of gridMap) {
+    for (const mapCell of row) {
+      if (!mapCell || !mapCell.cell) {
+        continue;
+      }
+
+      const cellKey = mapCell.cell.getKey();
+      if (processedCells.has(cellKey)) {
+        continue;
+      }
+
+      if (cellNodes.some((cell) => cell.is(mapCell.cell))) {
+        processedCells.add(cellKey);
+        // Get the actual position of this cell in the grid
+        const cellStartRow = mapCell.startRow;
+        const cellStartCol = mapCell.startColumn;
+        const cellRowSpan = mapCell.cell.__rowSpan || 1;
+        const cellColSpan = mapCell.cell.__colSpan || 1;
+
+        // Update boundaries considering the cell's actual position and span
+        minRow = Math.min(minRow, cellStartRow);
+        maxRow = Math.max(maxRow, cellStartRow + cellRowSpan - 1);
+        minCol = Math.min(minCol, cellStartCol);
+        maxCol = Math.max(maxCol, cellStartCol + cellColSpan - 1);
+      }
+    }
+  }
+
+  // Validate boundaries
+  if (minRow === Infinity || minCol === Infinity) {
+    return null;
+  }
+
+  // The total span of the merged cell
+  const totalRowSpan = maxRow - minRow + 1;
+  const totalColSpan = maxCol - minCol + 1;
+
+  // Use the top-left cell as the target cell
+  const targetCellMap = gridMap[minRow][minCol];
+  if (!targetCellMap.cell) {
+    return null;
+  }
+  const targetCell = targetCellMap.cell;
+
+  // Set the spans for the target cell
+  targetCell.setColSpan(totalColSpan);
+  targetCell.setRowSpan(totalRowSpan);
+
+  // Move content from other cells to the target cell
+  const seenCells = new Set([targetCell.getKey()]);
+
+  // Second pass: merge content and remove other cells
+  for (let row = minRow; row <= maxRow; row++) {
+    for (let col = minCol; col <= maxCol; col++) {
+      const mapCell = gridMap[row][col];
+      if (!mapCell.cell) {
+        continue;
+      }
+
+      const currentCell = mapCell.cell;
+      const key = currentCell.getKey();
+
+      if (!seenCells.has(key)) {
+        seenCells.add(key);
+        const isEmpty = $cellContainsEmptyParagraph(currentCell);
+        if (!isEmpty) {
+          targetCell.append(...currentCell.getChildren());
+        }
+        currentCell.remove();
+      }
+    }
+  }
+
+  // Ensure target cell has content
+  if (targetCell.getChildrenSize() === 0) {
+    targetCell.append($createParagraphNode());
+  }
+
+  return targetCell;
+}
+
+function $cellContainsEmptyParagraph(cell: TableCellNode): boolean {
+  if (cell.getChildrenSize() !== 1) {
+    return false;
+  }
+  const firstChild = cell.getFirstChildOrThrow();
+  if (!$isParagraphNode(firstChild) || !firstChild.isEmpty()) {
+    return false;
+  }
+  return true;
+}
+
 export function $unmergeCell(): void {
   const selection = $getSelection();
   invariant(
@@ -732,7 +893,16 @@ export function $unmergeCell(): void {
     'Expected a RangeSelection or TableSelection',
   );
   const anchor = selection.anchor.getNode();
-  const [cell, row, grid] = $getNodeTriplet(anchor);
+  const cellNode = $findMatchingParent(anchor, $isTableCellNode);
+  invariant(
+    $isTableCellNode(cellNode),
+    'Expected to find a parent TableCellNode',
+  );
+  return $unmergeCellNode(cellNode);
+}
+
+export function $unmergeCellNode(cellNode: TableCellNode): void {
+  const [cell, row, grid] = $getNodeTriplet(cellNode);
   const colSpan = cell.__colSpan;
   const rowSpan = cell.__rowSpan;
   if (colSpan === 1 && rowSpan === 1) {

--- a/packages/lexical-table/src/LexicalTableUtils.ts
+++ b/packages/lexical-table/src/LexicalTableUtils.ts
@@ -469,6 +469,7 @@ export function $insertTableColumn__EXPERIMENTAL(
 export function $insertTableColumnAtNode(
   cellNode: TableCellNode,
   insertAfter = true,
+  shouldSetSelection = true,
 ): TableCellNode | null {
   const [, , grid] = $getNodeTriplet(cellNode);
   const [gridMap, cellMap] = $computeTableMap(grid, cellNode, cellNode);
@@ -550,7 +551,7 @@ export function $insertTableColumnAtNode(
       currentCell.setColSpan(currentCell.__colSpan + 1);
     }
   }
-  if (firstInsertedCell !== null) {
+  if (firstInsertedCell !== null && shouldSetSelection) {
     $moveSelectionToCell(firstInsertedCell);
   }
   const colWidths = grid.getColWidths();

--- a/packages/lexical-table/src/index.ts
+++ b/packages/lexical-table/src/index.ts
@@ -78,6 +78,7 @@ export {
   $insertTableColumn__EXPERIMENTAL,
   $insertTableRow,
   $insertTableRow__EXPERIMENTAL,
+  $mergeCells,
   $removeTableRowAtIndex,
   $unmergeCell,
 } from './LexicalTableUtils';


### PR DESCRIPTION
## Description

Improve how we handle pasting table into table:
- Properly account for merged cells in both tables. Presence of merged cells currently causes very buggy behavior when pasting (including the possibility of creating nested tables).
- If the current selection is a range selection, allow the table being modified to grow if necessary to contain the table being pasted. This is in line with GDocs behavior.
- If the current selection is a table selection, constrain the modifications to be within the selection boundary. This is in line with GDocs behavior.

Closes #7262
Closes #7263

## Test plan

Added E2E tests for table pasting: `npm run test-e2e-chromium Tables.spec`

### Before

https://github.com/user-attachments/assets/d2f03651-8149-4697-b1f5-b7a222d8e650

### After

https://github.com/user-attachments/assets/174211b4-c454-44e6-9e8b-c58b80fb39f5

## Additional notes

The new logic for pasting tables can be summarized as:
1. Unmerge all cells in affected area of the table being modified.
2. Expand the table being modified so that it can contain the table being pasted (if range selection).
3. Merge cells in the table being modified to match the table being pasted.
4. Set content in all affected cells to match the table being pasted.

To support the new logic, I've added a few additional table utils (in `lexical-table` package) that works on TableCellNode(s)—insert row, insert column, merge cells, unmerge cell. The logic for merging cells is taken from the `TableActionMenuPlugin` in `lexical-playground` package.

Some potential followups:
- I can't seem to be able to trigger pasting using cmd+V when there is a table selection (on Chrome). You can still use the browser context menu, but this should probably be fixed.
- Unlike GDocs, I'm not currently making multiple copies of the table being pasted when the selection boundary is larger than the size of the table being pasted. If there is interest in this, it could be a potential follow-up item.