### PR TITLE
[lexical-rich-text] Bug Fix: Prevent indentation from becoming negative

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Indentation.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Indentation.spec.mjs
@@ -14,6 +14,7 @@ import {
   html,
   initialize,
   insertTable,
+  pasteFromClipboard,
   selectFromAlignDropdown,
   test,
 } from '../utils/index.mjs';
@@ -26,6 +27,12 @@ async function toggleBulletList(page) {
 async function clickIndentButton(page, times = 1) {
   for (let i = 0; i < times; i++) {
     await selectFromAlignDropdown(page, '.indent');
+  }
+}
+
+async function clickOutdentButton(page, times = 1) {
+  for (let i = 0; i < times; i++) {
+    await selectFromAlignDropdown(page, '.outdent');
   }
 }
 
@@ -599,6 +606,51 @@ test.describe('Identation', () => {
     await assertHTML(
       page,
       '<ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"><ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"><ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"><ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">from</span></li><li value="2" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"><ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">the</span></li><li value="2" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"><ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">other</span></li><li value="2" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"><ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">side</span></li><li value="2" class="PlaygroundEditorTheme__listItem"><br></li></ul></li></ul></li></ul></li></ul></li></ul></li></ul></li></ul>',
+    );
+  });
+
+  test(`Cannot have negative indents (#7410)`, async ({page, isPlainText}) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+
+    await pasteFromClipboard(page, {
+      'text/html': html`
+        <p style="padding-inline-start: 1px">hello1</p>
+        <p style="padding-inline-start: 2px">hello2</p>
+        <p style="padding-inline-start: 3px">hello3</p>
+      `,
+    });
+
+    await selectAll(page);
+    await clickOutdentButton(page, 2);
+
+    await click(page, '.block-controls');
+    await click(page, '.dropdown .icon.bullet-list');
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="1">
+            <span data-lexical-text="true">hello1</span>
+          </li>
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="2">
+            <span data-lexical-text="true">hello2</span>
+          </li>
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+            dir="ltr"
+            value="3">
+            <span data-lexical-text="true">hello3</span>
+          </li>
+        </ul>
+      `,
     );
   });
 });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -737,7 +737,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
         return $handleIndentAndOutdent((block) => {
           const indent = block.getIndent();
           if (indent > 0) {
-            block.setIndent(indent - 1);
+            block.setIndent(Math.max(0, indent - 1));
           }
         });
       },

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -1971,7 +1971,7 @@ export function setNodeIndentFromDOM(
   elementNode: ElementNode,
 ) {
   const indentSize = parseInt(elementDom.style.paddingInlineStart, 10) || 0;
-  const indent = indentSize / 40;
+  const indent = Math.round(indentSize / 40);
   elementNode.setIndent(indent);
 }
 


### PR DESCRIPTION
## Description

Prevent paragraph indentation from becoming negative, which can trigger an invariant when converting to list nodes.

Closes #7410

## Test plan

`npm run test-e2e-chromium Indentation`