### PR TITLE
[lexical] Bug Fix: Fix forward line deletion when using control+K

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -259,6 +259,62 @@ test.describe.parallel('Selection', () => {
     await assertHTML(page, lines(''));
   });
 
+  test('can delete text by line forwards with control+K', async ({
+    page,
+    isPlainText,
+  }) => {
+    const deleteLineForwardWithControlK = async () => {
+      await page.keyboard.down('Control');
+      await page.keyboard.press('k');
+      await page.keyboard.up('Control');
+    };
+
+    test.skip(isPlainText || !IS_MAC);
+    await focusEditor(page);
+    await page.keyboard.type('One');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Two');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Three');
+
+    const p = (text) =>
+      text
+        ? html`
+            <p
+              class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+              dir="ltr">
+              <span data-lexical-text="true">${text}</span>
+            </p>
+          `
+        : html`
+            <p class="PlaygroundEditorTheme__paragraph"><br /></p>
+          `;
+    const lines = (...args) => html`
+      ${args.map(p).join('')}
+    `;
+    await assertHTML(page, lines('One', 'Two', '', 'Three'));
+    // Move to the end of the line of 'Two'
+    await moveUp(page, 2);
+    await deleteLineForwardWithControlK(page);
+    await assertHTML(page, lines('One', 'Two', 'Three'));
+    await deleteLineForwardWithControlK(page);
+    await assertHTML(page, lines('One', 'TwoThree'));
+    await deleteLineForwardWithControlK(page);
+    await assertHTML(page, lines('One', 'Two'));
+    await deleteLineForwardWithControlK(page);
+    await assertHTML(page, lines('One', 'Two'));
+    await moveToEditorBeginning(page);
+    await deleteLineForwardWithControlK(page);
+    await assertHTML(page, lines('', 'Two'));
+    await deleteLineForwardWithControlK(page);
+    await assertHTML(page, lines('Two'));
+    await deleteLineForwardWithControlK(page);
+    await assertHTML(page, lines(''));
+    await deleteLineForwardWithControlK(page);
+    await assertHTML(page, lines(''));
+  });
+
   test('can delete line which ends with element backwards with CMD+delete', async ({
     page,
     isPlainText,

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -1178,7 +1178,7 @@ function onKeyDown(event: KeyboardEvent, editor: LexicalEditor): void {
   } else if (isDeleteLineBackward(key, metaKey)) {
     event.preventDefault();
     dispatchCommand(editor, DELETE_LINE_COMMAND, true);
-  } else if (isDeleteLineForward(key, metaKey)) {
+  } else if (isDeleteLineForward(key, metaKey, ctrlKey)) {
     event.preventDefault();
     dispatchCommand(editor, DELETE_LINE_COMMAND, false);
   } else if (isBold(key, altKey, metaKey, ctrlKey)) {

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -911,8 +911,15 @@ export function isDeleteLineBackward(key: string, metaKey: boolean): boolean {
   return IS_APPLE && metaKey && isBackspace(key);
 }
 
-export function isDeleteLineForward(key: string, metaKey: boolean): boolean {
-  return IS_APPLE && metaKey && isDelete(key);
+export function isDeleteLineForward(
+  key: string,
+  metaKey: boolean,
+  ctrlKey: boolean,
+): boolean {
+  return (
+    IS_APPLE &&
+    ((metaKey && isDelete(key)) || (ctrlKey && key.toLowerCase() === 'k'))
+  );
 }
 
 export function isDeleteBackward(


### PR DESCRIPTION
Fix forward line deletion when using control+K on Mac.

On the Mac, control+K [performs forward line deletion](https://support.apple.com/en-sg/102650#:~:text=Control%2DK%3A%20delete%20the%20text%20between%20the%20insertion%20point%20and%20the%20end%20of%20the%20line%20or%20paragraph.), which is the same function that Lexical already supports / handles via cmd+fn+delete. We're not currently explicitly handling the control+K key combination in Lexical, resulting in unexpected behavior when it is performed.

(Fixes an internally-reported bug: T193999537.)

## Test plan

Added a test to `Selection.mjs.spec`:
`npm run test-e2e-chromium Selection`

### Before

https://github.com/user-attachments/assets/72fad707-5bcc-4241-b59d-b5bbe5b29a23

### After

https://github.com/user-attachments/assets/825df656-1906-4fca-866a-1a0d1c1f494a