### PR TITLE
[lexical-playground] Bug: clear formatting should also clear any indent/outdent if applied

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
@@ -7,9 +7,9 @@
  */
 
 import {
+  centerAlign,
   indent,
   outdent,
-  centerAlign,
   rightAlign,
   selectAll,
   toggleBold,

--- a/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/ClearFormatting.spec.mjs
@@ -7,6 +7,9 @@
  */
 
 import {
+  indent,
+  outdent,
+  rightAlign,
   selectAll,
   toggleBold,
   toggleItalic,
@@ -192,4 +195,58 @@ test.describe('Clear All Formatting', () => {
       );
     },
   );
+
+  test(`Can clear when only indent/outdent alignment is applied`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    await page.keyboard.type('Hello World');
+    await indent(page);
+    await page.keyboard.type(' Test');
+    await indent(page);
+    await selectAll(page);
+    await selectFromAdditionalStylesDropdown(page, '.clear');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr"
+          style="">
+          <span data-lexical-text="true">Hello World Test</span>
+        </p>
+      `,
+    );
+  });
+
+  test(`Can clear indent/outdent alignment when other formatting options like BIU or left/right/center align are also applied`, async ({
+    page,
+  }) => {
+    await focusEditor(page);
+
+    await page.keyboard.type('Hello');
+    await toggleBold(page);
+    await toggleItalic(page);
+    await page.keyboard.type(' World');
+    await indent(page);
+    await indent(page);
+    await indent(page);
+    await rightAlign(page);
+    await page.keyboard.type(' Test');
+    await outdent(page);
+    await selectAll(page);
+    await selectFromAdditionalStylesDropdown(page, '.clear');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr"
+          style="">
+          <span data-lexical-text="true">Hello World Test</span>
+        </p>
+      `,
+    );
+  });
 });

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
@@ -276,7 +276,14 @@ export const clearFormatting = (editor: LexicalEditor) => {
           }
           if (textNode.__format !== 0) {
             textNode.setFormat(0);
-            $getNearestBlockElementAncestorOrThrow(textNode).setFormat('');
+          }
+          const nearestBlockElement =
+            $getNearestBlockElementAncestorOrThrow(textNode);
+          if (nearestBlockElement.__format !== 0) {
+            nearestBlockElement.setFormat('');
+          }
+          if (nearestBlockElement.__indent !== 0) {
+            nearestBlockElement.setIndent(0);
           }
           node = textNode;
         } else if ($isHeadingNode(node) || $isQuoteNode(node)) {


### PR DESCRIPTION


## Description
## Steps To Reproduce

1. Add any text 
2. Select added text and try indent/outdent selected text
3. Now while keeping selection try `clear-formatting` it won't have any effect

<!--
  Your bug will get fixed much faster if we can run your code and it doesn't
  have dependencies other than Lexical. Issues without reproduction steps or
  code examples may be closed as not actionable.
-->


<!--
  Please provide a CodeSandbox (https://codesandbox.io/s/new) or (https://stackblitz.com/github/facebook/lexical/tree/main/examples/react-plain-text?embed=1&file=src%2FApp.tsx&terminalHeight=0&ctl=1&showSidebar=0&devtoolsheight=0&view=preview), a link to a
  repository on GitHub, or provide a minimal code example that reproduces the
  problem. You may provide a screenshot of the application if you think it is
  relevant to your bug report. Here are some tips for providing a minimal
  example: https://stackoverflow.com/help/mcve.
-->

### Before

https://github.com/user-attachments/assets/5f19a594-c28f-4463-a644-713235bb0306


### After

https://github.com/user-attachments/assets/9388792e-1cf0-4b22-abc0-662bbfdc024f

### Impact of fix
clear formatting will be improved and cover wider range
