### PR TITLE
[lexical-list] Feature: Enforce strict list indentation

### DIFF
--- a/packages/lexical-list/src/__tests__/unit/registerListStrictIndentTransform.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/registerListStrictIndentTransform.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
+import {$getRoot} from 'lexical';
+import {
+  expectHtmlToBeEqual,
+  html,
+  initializeUnitTest,
+} from 'lexical/src/__tests__/utils';
+
+import {registerListStrictIndentTransform} from '../../index';
+
+describe('Lexical List StrictIndentTransform tests', () => {
+  initializeUnitTest((testEnv) => {
+    beforeEach(() => {
+      const {editor} = testEnv;
+      registerListStrictIndentTransform(editor);
+    });
+
+    test('applyStrictListIndentation', async () => {
+      const {editor} = testEnv;
+      const parser = new DOMParser();
+
+      const output = html`
+        <ul>
+          <li value="1">
+            <span style="white-space: pre-wrap;">0</span>
+          </li>
+          <li value="2">
+            <ul>
+              <li value="1">
+                <!-- Indent: 1 -->
+                <span style="white-space: pre-wrap;">1</span>
+              </li>
+              <li value="2">
+                <ul>
+                  <li value="1">
+                    <!-- Indent: 2 -->
+                    <span style="white-space: pre-wrap;">2</span>
+                  </li>
+                  <li value="2">
+                    <ul>
+                      <li value="1">
+                        <!-- Indent: 3 -->
+                        <span style="white-space: pre-wrap;">3</span>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      `;
+
+      const cases: string[] = [
+        html`
+          <ul>
+            <li>
+              <span style="white-space: pre-wrap;">0</span>
+            </li>
+            <li>
+              <ul>
+                <li>
+                  <ul>
+                    <li>
+                      <ul>
+                        <li>
+                          <!-- Indent: 3 -->
+                          <span style="white-space: pre-wrap;">1</span>
+                        </li>
+                      </ul>
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <ul>
+                    <li>
+                      <!-- Indent: 2 -->
+                      <span style="white-space: pre-wrap;">2</span>
+                    </li>
+                    <li>
+                      <ul>
+                        <li>
+                          <!-- Indent: 3 -->
+                          <span style="white-space: pre-wrap;">3</span>
+                        </li>
+                      </ul>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        `,
+        html`
+          <ul>
+            <li>
+              <span style="white-space: pre-wrap;">0</span>
+            </li>
+            <li>
+              <ul>
+                <li>
+                  <ul>
+                    <li>
+                      <!-- Indent: 2 -->
+                      <span style="white-space: pre-wrap;">1</span>
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <ul>
+                    <li>
+                      <ul>
+                        <li>
+                          <ul>
+                            <li>
+                              <!-- Indent: 4 -->
+                              <span style="white-space: pre-wrap;">2</span>
+                            </li>
+                          </ul>
+                        </li>
+                      </ul>
+                    </li>
+                    <li>
+                      <ul>
+                        <li>
+                          <!-- Indent: 3 -->
+                          <span style="white-space: pre-wrap;">3</span>
+                        </li>
+                      </ul>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        `,
+        html`
+          <ul>
+            <li>
+              <span style="white-space: pre-wrap;">0</span>
+            </li>
+            <li>
+              <ul>
+                <li>
+                  <ul>
+                    <li>
+                      <!-- Indent: 2 -->
+                      <span style="white-space: pre-wrap;">1</span>
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <ul>
+                    <li>
+                      <ul>
+                        <li>
+                          <ul>
+                            <li>
+                              <!-- Indent: 4 -->
+                              <span style="white-space: pre-wrap;">2</span>
+                            </li>
+                          </ul>
+                        </li>
+                      </ul>
+                    </li>
+                    <li>
+                      <ul>
+                        <li>
+                          <ul>
+                            <li>
+                              <ul>
+                                <li>
+                                  <!-- Indent: 5 -->
+                                  <span style="white-space: pre-wrap;">3</span>
+                                </li>
+                              </ul>
+                            </li>
+                          </ul>
+                        </li>
+                      </ul>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        `,
+      ];
+
+      for (const input of cases) {
+        await editor.update(() => {
+          const root = $getRoot();
+          root.clear();
+
+          const dom = parser.parseFromString(input, 'text/html');
+          const nodes = $generateNodesFromDOM(editor, dom);
+          root.append(...nodes);
+        });
+
+        editor.read(() => {
+          expectHtmlToBeEqual($generateHtmlFromNodes(editor), output);
+        });
+      }
+    });
+  });
+});

--- a/packages/lexical-list/src/__tests__/unit/registerListStrictIndentTransform.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/registerListStrictIndentTransform.test.ts
@@ -34,19 +34,16 @@ describe('Lexical List StrictIndentTransform tests', () => {
           <li value="2">
             <ul>
               <li value="1">
-                <!-- Indent: 1 -->
                 <span style="white-space: pre-wrap;">1</span>
               </li>
               <li value="2">
                 <ul>
                   <li value="1">
-                    <!-- Indent: 2 -->
                     <span style="white-space: pre-wrap;">2</span>
                   </li>
                   <li value="2">
                     <ul>
                       <li value="1">
-                        <!-- Indent: 3 -->
                         <span style="white-space: pre-wrap;">3</span>
                       </li>
                     </ul>

--- a/packages/lexical-list/src/index.ts
+++ b/packages/lexical-list/src/index.ts
@@ -175,7 +175,7 @@ export function registerListStrictIndentTransform(
           const prevDepth = $getListDepth(endListNode);
           const depth = $getListDepth(listNode);
 
-          if (prevDepth < depth) {
+          if (prevDepth + 1 < depth) {
             listItemNode.setIndent(prevDepth);
           }
         }

--- a/packages/lexical-list/src/index.ts
+++ b/packages/lexical-list/src/index.ts
@@ -184,10 +184,10 @@ export function registerListStrictIndentTransform(
   };
 
   const $processListWithStrictIndent = (listNode: ListNode): void => {
-    const stack: ListNode[] = [listNode];
+    const queue: ListNode[] = [listNode];
 
-    while (stack.length > 0) {
-      const node = stack.pop();
+    while (queue.length > 0) {
+      const node = queue.shift();
       if (!$isListNode(node)) {
         continue;
       }
@@ -198,7 +198,7 @@ export function registerListStrictIndentTransform(
 
           const firstChild = child.getFirstChild();
           if ($isListNode(firstChild)) {
-            stack.push(firstChild);
+            queue.push(firstChild);
           }
         }
       }

--- a/packages/lexical-list/src/index.ts
+++ b/packages/lexical-list/src/index.ts
@@ -184,13 +184,22 @@ export function registerListStrictIndentTransform(
   };
 
   const $processListWithStrictIndent = (listNode: ListNode): void => {
-    for (const child of listNode.getChildren()) {
-      if ($isListItemNode(child)) {
-        $formatListIndentStrict(child);
+    const stack: ListNode[] = [listNode];
 
-        const firstChild = child.getFirstChild();
-        if ($isListNode(firstChild)) {
-          $processListWithStrictIndent(firstChild);
+    while (stack.length > 0) {
+      const node = stack.pop();
+      if (!$isListNode(node)) {
+        continue;
+      }
+
+      for (const child of node.getChildren()) {
+        if ($isListItemNode(child)) {
+          $formatListIndentStrict(child);
+
+          const firstChild = child.getFirstChild();
+          if ($isListNode(firstChild)) {
+            stack.push(firstChild);
+          }
         }
       }
     }
@@ -202,16 +211,21 @@ export function registerListStrictIndentTransform(
 function $findChildrenEndListItemNode(
   listItemNode: ListItemNode,
 ): ListItemNode {
-  const firstChild = listItemNode.getFirstChild();
-  if ($isListNode(firstChild)) {
+  let current = listItemNode;
+  let firstChild = current.getFirstChild();
+
+  while ($isListNode(firstChild)) {
     const lastChild = firstChild.getLastChild();
 
     if ($isListItemNode(lastChild)) {
-      return $findChildrenEndListItemNode(lastChild);
+      current = lastChild;
+      firstChild = current.getFirstChild();
+    } else {
+      break;
     }
   }
 
-  return listItemNode;
+  return current;
 }
 
 /**

--- a/packages/lexical-list/src/index.ts
+++ b/packages/lexical-list/src/index.ts
@@ -162,7 +162,7 @@ export function registerListStrictIndentTransform(
         $isListItemNode(node.getPreviousSibling()),
     );
 
-    if (startingListItemNode === null) {
+    if (startingListItemNode === null && listItemNode.getIndent() > 0) {
       listItemNode.setIndent(0);
     } else if ($isListItemNode(startingListItemNode)) {
       const prevListItemNode = startingListItemNode.getPreviousSibling();

--- a/packages/lexical-playground/src/Editor.tsx
+++ b/packages/lexical-playground/src/Editor.tsx
@@ -100,6 +100,7 @@ export default function Editor(): JSX.Element {
       tableHorizontalScroll,
       shouldAllowHighlightingWithBrackets,
       selectionAlwaysOnDisplay,
+      listStrictIndent,
     },
   } = useSettings();
   const isEditable = useLexicalEditable();
@@ -199,7 +200,7 @@ export default function Editor(): JSX.Element {
             />
             <MarkdownShortcutPlugin />
             <CodeHighlightPlugin />
-            <ListPlugin />
+            <ListPlugin hasStrictIndent={listStrictIndent} />
             <CheckListPlugin />
             <TablePlugin
               hasCellMerge={tableCellMerge}

--- a/packages/lexical-playground/src/appSettings.ts
+++ b/packages/lexical-playground/src/appSettings.ts
@@ -21,6 +21,7 @@ export const DEFAULT_SETTINGS = {
   isCollab: false,
   isMaxLength: false,
   isRichText: true,
+  listStrictIndent: false,
   measureTypingPerf: false,
   selectionAlwaysOnDisplay: false,
   shouldAllowHighlightingWithBrackets: false,

--- a/packages/lexical-react/src/LexicalListPlugin.ts
+++ b/packages/lexical-react/src/LexicalListPlugin.ts
@@ -24,9 +24,7 @@ export interface ListPluginProps {
   hasStrictIndent?: boolean;
 }
 
-export function ListPlugin({
-  hasStrictIndent = false,
-}: ListPluginProps = {}): null {
+export function ListPlugin({hasStrictIndent = false}: ListPluginProps): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {

--- a/packages/lexical-react/src/LexicalListPlugin.ts
+++ b/packages/lexical-react/src/LexicalListPlugin.ts
@@ -6,13 +6,27 @@
  *
  */
 
-import {ListItemNode, ListNode} from '@lexical/list';
+import {
+  ListItemNode,
+  ListNode,
+  registerListStrictIndentTransform,
+} from '@lexical/list';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
 
 import {useList} from './shared/useList';
 
-export function ListPlugin(): null {
+export interface ListPluginProps {
+  /**
+   * When `true`, enforces strict indentation rules for list items, ensuring consistent structure.
+   * When `false` (default), indentation is more flexible.
+   */
+  hasStrictIndent?: boolean;
+}
+
+export function ListPlugin({
+  hasStrictIndent = false,
+}: ListPluginProps = {}): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
@@ -22,6 +36,14 @@ export function ListPlugin(): null {
       );
     }
   }, [editor]);
+
+  useEffect(() => {
+    if (!hasStrictIndent) {
+      return;
+    }
+
+    return registerListStrictIndentTransform(editor);
+  }, [editor, hasStrictIndent]);
 
   useList(editor);
 


### PR DESCRIPTION
## Description

We are adding a strict indent feature for lists.
This feature helps in creating an accurate Markdown converter.
Additionally, it can be optionally enabled as needed.

## Test plan

### Before

https://github.com/user-attachments/assets/75fd4f1f-7b1c-49e3-96f2-fc7748b0c567

### After

https://github.com/user-attachments/assets/e1235286-b37a-4ca8-bd35-ee08439a576d
