### PR TITLE
[lexical-playground] Bug: bullet points do not follow list's left/center/right alignment

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -416,36 +416,36 @@
 .PlaygroundEditorTheme__ol1 {
   padding: 0;
   margin: 0;
-  list-style-position: outside;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol2 {
   padding: 0;
   margin: 0;
   list-style-type: upper-alpha;
-  list-style-position: outside;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol3 {
   padding: 0;
   margin: 0;
   list-style-type: lower-alpha;
-  list-style-position: outside;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol4 {
   padding: 0;
   margin: 0;
   list-style-type: upper-roman;
-  list-style-position: outside;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ol5 {
   padding: 0;
   margin: 0;
   list-style-type: lower-roman;
-  list-style-position: outside;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__ul {
   padding: 0;
   margin: 0;
-  list-style-position: outside;
+  list-style-position: inside;
 }
 .PlaygroundEditorTheme__listItem {
   margin: 0 32px;


### PR DESCRIPTION
similar to google docs






## Description
Bullet points should follow list's `text-alignment`





Closes #7426 



### Before


https://github.com/user-attachments/assets/b2364c64-3917-4629-8860-ac35335b604b




### After

https://github.com/user-attachments/assets/e569f487-0824-4778-8abc-de10c72c6735

