### PR TITLE
[lexical-playground] Bug Fix: Immediate broken image display on load failure

### DIFF
--- a/packages/lexical-playground/src/nodes/ImageComponent.tsx
+++ b/packages/lexical-playground/src/nodes/ImageComponent.tsx
@@ -124,8 +124,14 @@ function LazyImage({
   }, [imageRef, isSVGImage]);
 
   const hasError = useSuspenseImage(src);
+
+  useEffect(() => {
+    if (hasError) {
+      onError();
+    }
+  }, [hasError, onError]);
+
   if (hasError) {
-    onError();
     return <BrokenImage />;
   }
 


### PR DESCRIPTION
## Description
### Current behavior:
- When an image fails to load in the Lexical editor, the fallback image-broken.svg does not display immediately
- The fallback image only appears after making changes to the editor (like typing)
- The image-broken.svg fails to load because it's trying to load from the wrong path

### Changes in this PR:
- Improved error handling in `useSuspenseImage` hook to properly handle image loading failures
- Modified LazyImage component to maintain proper error state and show fallback immediately
- Ensured failed images aren't cached to allow retry attempts

Closes #7387

## Test plan

### Before
- Try to load an invalid image URL in the editor
- Observe that the broken image fallback doesn't appear immediately
- Need to make changes to the editor to see the fallback

https://github.com/user-attachments/assets/74df4cdf-acb9-4aad-baf9-9b370035ecdc

### After

- Load an invalid image URL in the editor
- Broken image fallback appears immediately
- No need to make additional changes to see the fallback
- Verify that retrying with a valid URL works


https://github.com/user-attachments/assets/c19a74e1-8526-4b16-968e-beb33c5716a7

