### PR TITLE
[lexical-playground] Bug Fix: Fix typeahead menu positioning during scroll

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -264,7 +264,6 @@ pre::-webkit-scrollbar-thumb {
   box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.3);
   border-radius: 8px;
   position: absolute;
-  z-index: 1000;
 }
 
 .typeahead-popover-container {

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -263,7 +263,12 @@ pre::-webkit-scrollbar-thumb {
   background: #fff;
   box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.3);
   border-radius: 8px;
-  position: fixed;
+  position: absolute;
+  z-index: 1000;
+}
+
+.typeahead-popover-container {
+  position: relative;
 }
 
 .typeahead-popover ul {

--- a/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutoEmbedPlugin/index.tsx
@@ -327,26 +327,31 @@ export default function AutoEmbedPlugin(): JSX.Element {
         ) =>
           anchorElementRef.current
             ? ReactDOM.createPortal(
-                <div
-                  className="typeahead-popover auto-embed-menu"
-                  style={{
-                    marginLeft: `${Math.max(
-                      parseFloat(anchorElementRef.current.style.width) - 200,
-                      0,
-                    )}px`,
-                    width: 200,
-                  }}>
-                  <AutoEmbedMenu
-                    options={options}
-                    selectedItemIndex={selectedIndex}
-                    onOptionClick={(option: AutoEmbedOption, index: number) => {
-                      setHighlightedIndex(index);
-                      selectOptionAndCleanUp(option);
-                    }}
-                    onOptionMouseEnter={(index: number) => {
-                      setHighlightedIndex(index);
-                    }}
-                  />
+                <div className="typeahead-popover-container">
+                  <div
+                    className="typeahead-popover auto-embed-menu"
+                    style={{
+                      marginLeft: `${Math.max(
+                        parseFloat(anchorElementRef.current.style.width) - 200,
+                        0,
+                      )}px`,
+                      width: 200,
+                    }}>
+                    <AutoEmbedMenu
+                      options={options}
+                      selectedItemIndex={selectedIndex}
+                      onOptionClick={(
+                        option: AutoEmbedOption,
+                        index: number,
+                      ) => {
+                        setHighlightedIndex(index);
+                        selectOptionAndCleanUp(option);
+                      }}
+                      onOptionMouseEnter={(index: number) => {
+                        setHighlightedIndex(index);
+                      }}
+                    />
+                  </div>
                 </div>,
                 anchorElementRef.current,
               )

--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -373,24 +373,26 @@ export default function ComponentPickerMenuPlugin(): JSX.Element {
         ) =>
           anchorElementRef.current && options.length
             ? ReactDOM.createPortal(
-                <div className="typeahead-popover component-picker-menu">
-                  <ul>
-                    {options.map((option, i: number) => (
-                      <ComponentPickerMenuItem
-                        index={i}
-                        isSelected={selectedIndex === i}
-                        onClick={() => {
-                          setHighlightedIndex(i);
-                          selectOptionAndCleanUp(option);
-                        }}
-                        onMouseEnter={() => {
-                          setHighlightedIndex(i);
-                        }}
-                        key={option.key}
-                        option={option}
-                      />
-                    ))}
-                  </ul>
+                <div className="typeahead-popover-container">
+                  <div className="typeahead-popover component-picker-menu">
+                    <ul>
+                      {options.map((option, i: number) => (
+                        <ComponentPickerMenuItem
+                          index={i}
+                          isSelected={selectedIndex === i}
+                          onClick={() => {
+                            setHighlightedIndex(i);
+                            selectOptionAndCleanUp(option);
+                          }}
+                          onMouseEnter={() => {
+                            setHighlightedIndex(i);
+                          }}
+                          key={option.key}
+                          option={option}
+                        />
+                      ))}
+                    </ul>
+                  </div>
                 </div>,
                 anchorElementRef.current,
               )

--- a/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
@@ -252,25 +252,30 @@ export default function ContextMenuPlugin(): JSX.Element {
       ) =>
         anchorElementRef.current
           ? ReactDOM.createPortal(
-              <div
-                className="typeahead-popover auto-embed-menu"
-                style={{
-                  marginLeft: anchorElementRef.current.style.width,
-                  userSelect: 'none',
-                  width: 200,
-                }}
-                ref={setMenuRef}>
-                <ContextMenu
-                  options={options}
-                  selectedItemIndex={selectedIndex}
-                  onOptionClick={(option: ContextMenuOption, index: number) => {
-                    setHighlightedIndex(index);
-                    selectOptionAndCleanUp(option);
+              <div className="typeahead-popover-container">
+                <div
+                  className="typeahead-popover auto-embed-menu"
+                  style={{
+                    marginLeft: anchorElementRef.current.style.width,
+                    userSelect: 'none',
+                    width: 200,
                   }}
-                  onOptionMouseEnter={(index: number) => {
-                    setHighlightedIndex(index);
-                  }}
-                />
+                  ref={setMenuRef}>
+                  <ContextMenu
+                    options={options}
+                    selectedItemIndex={selectedIndex}
+                    onOptionClick={(
+                      option: ContextMenuOption,
+                      index: number,
+                    ) => {
+                      setHighlightedIndex(index);
+                      selectOptionAndCleanUp(option);
+                    }}
+                    onOptionMouseEnter={(index: number) => {
+                      setHighlightedIndex(index);
+                    }}
+                  />
+                </div>
               </div>,
               anchorElementRef.current,
             )

--- a/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
@@ -170,24 +170,26 @@ export default function EmojiPickerPlugin() {
 
         return anchorElementRef.current && options.length
           ? ReactDOM.createPortal(
-              <div className="typeahead-popover emoji-menu">
-                <ul>
-                  {options.map((option: EmojiOption, index) => (
-                    <EmojiMenuItem
-                      key={option.key}
-                      index={index}
-                      isSelected={selectedIndex === index}
-                      onClick={() => {
-                        setHighlightedIndex(index);
-                        selectOptionAndCleanUp(option);
-                      }}
-                      onMouseEnter={() => {
-                        setHighlightedIndex(index);
-                      }}
-                      option={option}
-                    />
-                  ))}
-                </ul>
+              <div className="typeahead-popover-container">
+                <div className="typeahead-popover emoji-menu">
+                  <ul>
+                    {options.map((option: EmojiOption, index) => (
+                      <EmojiMenuItem
+                        key={option.key}
+                        index={index}
+                        isSelected={selectedIndex === index}
+                        onClick={() => {
+                          setHighlightedIndex(index);
+                          selectOptionAndCleanUp(option);
+                        }}
+                        onMouseEnter={() => {
+                          setHighlightedIndex(index);
+                        }}
+                        option={option}
+                      />
+                    ))}
+                  </ul>
+                </div>
               </div>,
               anchorElementRef.current,
             )

--- a/packages/lexical-playground/src/plugins/MentionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/MentionsPlugin/index.tsx
@@ -670,24 +670,26 @@ export default function NewMentionsPlugin(): JSX.Element | null {
       ) =>
         anchorElementRef.current && results.length
           ? ReactDOM.createPortal(
-              <div className="typeahead-popover mentions-menu">
-                <ul>
-                  {options.map((option, i: number) => (
-                    <MentionsTypeaheadMenuItem
-                      index={i}
-                      isSelected={selectedIndex === i}
-                      onClick={() => {
-                        setHighlightedIndex(i);
-                        selectOptionAndCleanUp(option);
-                      }}
-                      onMouseEnter={() => {
-                        setHighlightedIndex(i);
-                      }}
-                      key={option.key}
-                      option={option}
-                    />
-                  ))}
-                </ul>
+              <div className="typeahead-popover-container">
+                <div className="typeahead-popover mentions-menu">
+                  <ul>
+                    {options.map((option, i: number) => (
+                      <MentionsTypeaheadMenuItem
+                        index={i}
+                        isSelected={selectedIndex === i}
+                        onClick={() => {
+                          setHighlightedIndex(i);
+                          selectOptionAndCleanUp(option);
+                        }}
+                        onMouseEnter={() => {
+                          setHighlightedIndex(i);
+                        }}
+                        key={option.key}
+                        option={option}
+                      />
+                    ))}
+                  </ul>
+                </div>
               </div>,
               anchorElementRef.current,
             )


### PR DESCRIPTION
## Description
### Current behavior:
- The typeahead menus (slash menu, emoji picker, mentions, etc.) disappear when scrolling down in the editor
- This occurs because the menu uses `position: fixed` without proper positioning values
- The menu stays in its initial position relative to the viewport instead of moving with the cursor

### Changes being added:
- Changed typeahead popover positioning from `fixed` to `absolute`
- Added positioning context container with `position: relative`
- Updated all typeahead menu implementations (ComponentPicker, EmojiPicker, Mentions, AutoEmbed, ContextMenu) to use the new container

Closes #7430

## Test plan

### Before
The slash menu and other typeahead menus disappear when scrolling down:

https://github.com/user-attachments/assets/2a6acc69-38db-4a84-bc74-ef80887a1b4a

### After
The menus stay properly positioned relative to their trigger points during scrolling:

https://github.com/user-attachments/assets/25dfd844-4e9f-418c-92b3-f0e7885ef512

Tested the following scenarios:
1. ComponentPickerPlugin
   - Type "/" at various scroll positions
   - Menu stays visible and properly positioned
2. Emoji picker
   - Type ":" at various scroll positions
   - Menu stays visible and follows cursor
3. Mentions plugin
   - Type "@" at various scroll positions
   - Menu stays visible and follows cursor
4. AutoEmbed plugin
   - Enter URL at various scroll positions
   - Menu stays visible
5. Context menu
   - Right-click on text at various scroll positions
   - Menu appears at correct position