### PR TITLE
[lexical] Feature: Add text-transform styles to exported HTML

### DIFF
--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -645,6 +645,16 @@ export class TextNode extends LexicalNode {
       'Expected TextNode createDOM to always return a HTMLElement',
     );
     element.style.whiteSpace = 'pre-wrap';
+
+    // Add text-transform styles for capitalization formats
+    if (this.hasFormat('lowercase')) {
+      element.style.textTransform = 'lowercase';
+    } else if (this.hasFormat('uppercase')) {
+      element.style.textTransform = 'uppercase';
+    } else if (this.hasFormat('capitalize')) {
+      element.style.textTransform = 'capitalize';
+    }
+
     // This is the only way to properly add support for most clients,
     // even if it's semantically incorrect to have to resort to using
     // <b>, <u>, <s>, <i> elements.

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -867,6 +867,57 @@ describe('LexicalTextNode tests', () => {
     );
   });
 
+  describe('exportDOM()', () => {
+    test.each([
+      [
+        'lowercase format',
+        IS_LOWERCASE,
+        'Sample Text',
+        (element: HTMLElement) => {
+          expect(element.style.textTransform).toBe('lowercase');
+        },
+      ],
+      [
+        'uppercase format',
+        IS_UPPERCASE,
+        'Sample Text',
+        (element: HTMLElement) => {
+          expect(element.style.textTransform).toBe('uppercase');
+        },
+      ],
+      [
+        'capitalize format',
+        IS_CAPITALIZE,
+        'Sample Text',
+        (element: HTMLElement) => {
+          expect(element.style.textTransform).toBe('capitalize');
+        },
+      ],
+      [
+        'combined bold and lowercase format',
+        IS_BOLD | IS_LOWERCASE,
+        'Sample Text',
+        (element: HTMLElement) => {
+          expect(element.tagName.toLowerCase()).toBe('b');
+          // We need to check the child element for the style
+          const childElement = element.firstChild as HTMLElement;
+          expect(childElement.style.textTransform).toBe('lowercase');
+        },
+      ],
+    ])('%s', async (_type, format, contents, elementCheck) => {
+      await update(() => {
+        const textNode = $createTextNode(contents);
+        textNode.setFormat(format);
+        const {element} = textNode.exportDOM(editor);
+
+        expect(element).not.toBeNull();
+        if (element !== null) {
+          elementCheck(element as HTMLElement);
+        }
+      });
+    });
+  });
+
   test('mergeWithSibling', async () => {
     await update(() => {
       const paragraph = $getRoot().getFirstChild<ElementNode>()!;


### PR DESCRIPTION
## Description

### Current behavior:
When using text formatting options like lowercase, uppercase, and capitalize, Lexical only adds CSS classes to the exported HTML without the necessary inline styles. This means the formatting doesn't work when the content is viewed outside of Lexical's CSS context.

### Changes in this PR:
- This PR adds inline `text-transform` styles to the HTML elements during export via `TextNode.exportDOM()`. Now when users export content with these text transformations, the formatted text will maintain its appearance even when viewed without the Lexical CSS classes.
- Unit tests have been added to verify that the exported HTML contains the correct text-transform styles for all capitalization formats (lowercase, uppercase, and capitalize).

Closes #7328

## Test plan

### Before
When applying uppercase, lowercase, or capitalize to text and exporting the HTML, the elements only had CSS classes but no inline styles. The exported HTML looked like:
```html
<span class="PlaygroundEditorTheme__textUppercase">TEXT</span>
```
This formatting was lost when viewed outside of Lexical's styling context.


### After
Now when exporting text with capitalization formats, the exported HTML includes the appropriate inline style:
```html
<span class="PlaygroundEditorTheme__textUppercase" style="text-transform: uppercase;">TEXT</span>
```
This ensures the text transformation is preserved even without Lexical's CSS classes.