### PR TITLE
Chore: migrate string literals to update tag constants

### DIFF
--- a/examples/vanilla-js-iframe/src/main.ts
+++ b/examples/vanilla-js-iframe/src/main.ts
@@ -11,7 +11,7 @@ import {registerDragonSupport} from '@lexical/dragon';
 import {createEmptyHistoryState, registerHistory} from '@lexical/history';
 import {HeadingNode, QuoteNode, registerRichText} from '@lexical/rich-text';
 import {mergeRegister} from '@lexical/utils';
-import {createEditor} from 'lexical';
+import {createEditor, HISTORY_MERGE_TAG} from 'lexical';
 
 import prepopulatedRichText from './prepopulatedRichText';
 
@@ -45,7 +45,7 @@ mergeRegister(
   registerHistory(editor, createEmptyHistoryState(), 300),
 );
 
-editor.update(prepopulatedRichText, {tag: 'history-merge'});
+editor.update(prepopulatedRichText, {tag: HISTORY_MERGE_TAG});
 
 editor.registerUpdateListener(({editorState}) => {
   stateRef!.value = JSON.stringify(editorState.toJSON(), undefined, 2);

--- a/examples/vanilla-js-plugin/src/main.ts
+++ b/examples/vanilla-js-plugin/src/main.ts
@@ -11,7 +11,7 @@ import {registerDragonSupport} from '@lexical/dragon';
 import {createEmptyHistoryState, registerHistory} from '@lexical/history';
 import {HeadingNode, QuoteNode, registerRichText} from '@lexical/rich-text';
 import {mergeRegister} from '@lexical/utils';
-import {createEditor} from 'lexical';
+import {createEditor, HISTORY_MERGE_TAG} from 'lexical';
 
 import {EmojiNode} from './emoji-plugin/EmojiNode';
 import {registerEmoji} from './emoji-plugin/EmojiPlugin';
@@ -51,7 +51,7 @@ mergeRegister(
   registerEmoji(editor),
 );
 
-editor.update(prepopulatedRichText, {tag: 'history-merge'});
+editor.update(prepopulatedRichText, {tag: HISTORY_MERGE_TAG});
 
 editor.registerUpdateListener(({editorState}) => {
   stateRef!.value = JSON.stringify(editorState.toJSON(), undefined, 2);

--- a/examples/vanilla-js/src/main.ts
+++ b/examples/vanilla-js/src/main.ts
@@ -11,7 +11,7 @@ import {registerDragonSupport} from '@lexical/dragon';
 import {createEmptyHistoryState, registerHistory} from '@lexical/history';
 import {HeadingNode, QuoteNode, registerRichText} from '@lexical/rich-text';
 import {mergeRegister} from '@lexical/utils';
-import {createEditor} from 'lexical';
+import {createEditor, HISTORY_MERGE_TAG} from 'lexical';
 
 import prepopulatedRichText from './prepopulatedRichText';
 
@@ -52,7 +52,7 @@ mergeRegister(
   registerHistory(editor, createEmptyHistoryState(), 300),
 );
 
-editor.update(prepopulatedRichText, {tag: 'history-merge'});
+editor.update(prepopulatedRichText, {tag: HISTORY_MERGE_TAG});
 
 editor.registerUpdateListener(({editorState}) => {
   stateRef!.value = JSON.stringify(editorState.toJSON(), undefined, 2);

--- a/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
+++ b/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
@@ -28,6 +28,7 @@ import {
   $isTabNode,
   $isTextNode,
   $setSelection,
+  HISTORY_MERGE_TAG,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ARROW_UP_COMMAND,
   KEY_TAB_COMMAND,
@@ -869,7 +870,7 @@ describe('LexicalCodeNode tests', () => {
             );
             root.append(codeBlock);
           },
-          {tag: 'history-merge'},
+          {tag: HISTORY_MERGE_TAG},
         );
         // before transform
         expect(testEnv.innerHTML).toBe(

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -30,6 +30,7 @@ import {
   CAN_UNDO_COMMAND,
   CLEAR_HISTORY_COMMAND,
   COMMAND_PRIORITY_CRITICAL,
+  HISTORY_MERGE_TAG,
   type KlassConstructor,
   LexicalEditor,
   LexicalNode,
@@ -362,7 +363,7 @@ describe('LexicalHistory tests', () => {
         paragraph.selectEnd();
       },
       {
-        tag: 'history-merge',
+        tag: HISTORY_MERGE_TAG,
       },
     );
     nestedEditor._parentEditor = editor_;

--- a/packages/lexical-history/src/index.ts
+++ b/packages/lexical-history/src/index.ts
@@ -18,6 +18,9 @@ import {
   CLEAR_EDITOR_COMMAND,
   CLEAR_HISTORY_COMMAND,
   COMMAND_PRIORITY_EDITOR,
+  HISTORIC_TAG,
+  HISTORY_MERGE_TAG,
+  HISTORY_PUSH_TAG,
   REDO_COMMAND,
   UNDO_COMMAND,
 } from 'lexical';
@@ -244,7 +247,7 @@ function createMergeActionGetter(
 
     // If applying changes from history stack there's no need
     // to run history logic again, as history entries already calculated
-    if (tags.has('historic')) {
+    if (tags.has(HISTORIC_TAG)) {
       prevChangeType = OTHER;
       prevChangeTime = changeTime;
       return DISCARD_HISTORY_CANDIDATE;
@@ -261,9 +264,9 @@ function createMergeActionGetter(
     const mergeAction = (() => {
       const isSameEditor =
         currentHistoryEntry === null || currentHistoryEntry.editor === editor;
-      const shouldPushHistory = tags.has('history-push');
+      const shouldPushHistory = tags.has(HISTORY_PUSH_TAG);
       const shouldMergeHistory =
-        !shouldPushHistory && isSameEditor && tags.has('history-merge');
+        !shouldPushHistory && isSameEditor && tags.has(HISTORY_MERGE_TAG);
 
       if (shouldMergeHistory) {
         return HISTORY_MERGE;
@@ -337,7 +340,7 @@ function redo(editor: LexicalEditor, historyState: HistoryState): void {
 
     if (historyStateEntry) {
       historyStateEntry.editor.setEditorState(historyStateEntry.editorState, {
-        tag: 'historic',
+        tag: HISTORIC_TAG,
       });
     }
   }
@@ -365,7 +368,7 @@ function undo(editor: LexicalEditor, historyState: HistoryState): void {
 
     if (historyStateEntry) {
       historyStateEntry.editor.setEditorState(historyStateEntry.editorState, {
-        tag: 'historic',
+        tag: HISTORIC_TAG,
       });
     }
   }

--- a/packages/lexical-markdown/src/MarkdownShortcuts.ts
+++ b/packages/lexical-markdown/src/MarkdownShortcuts.ts
@@ -24,6 +24,8 @@ import {
   $isRootOrShadowRoot,
   $isTextNode,
   $setSelection,
+  COLLABORATION_TAG,
+  HISTORIC_TAG,
 } from 'lexical';
 import invariant from 'shared/invariant';
 
@@ -472,7 +474,7 @@ export function registerMarkdownShortcuts(
   return editor.registerUpdateListener(
     ({tags, dirtyLeaves, editorState, prevEditorState}) => {
       // Ignore updates from collaboration and undo/redo (as changes already calculated)
-      if (tags.has('collaboration') || tags.has('historic')) {
+      if (tags.has(COLLABORATION_TAG) || tags.has(HISTORIC_TAG)) {
         return;
       }
 

--- a/packages/lexical-plain-text/src/index.ts
+++ b/packages/lexical-plain-text/src/index.ts
@@ -38,6 +38,7 @@ import {
   KEY_DELETE_COMMAND,
   KEY_ENTER_COMMAND,
   PASTE_COMMAND,
+  PASTE_TAG,
   REMOVE_TEXT_COMMAND,
   SELECT_ALL_COMMAND,
 } from 'lexical';
@@ -89,7 +90,7 @@ function onPasteForPlainText(
       }
     },
     {
-      tag: 'paste',
+      tag: PASTE_TAG,
     },
   );
 }

--- a/packages/lexical-playground/esm/index.mjs
+++ b/packages/lexical-playground/esm/index.mjs
@@ -10,7 +10,7 @@ import {registerDragonSupport} from '@lexical/dragon';
 import {createEmptyHistoryState, registerHistory} from '@lexical/history';
 import {HeadingNode, QuoteNode, registerRichText} from '@lexical/rich-text';
 import {mergeRegister} from '@lexical/utils';
-import {createEditor} from 'lexical';
+import {createEditor, HISTORY_MERGE_TAG} from 'lexical';
 
 import prepopulatedRichText from './prepopulatedRichText.mjs';
 
@@ -39,7 +39,7 @@ mergeRegister(
   registerHistory(editor, createEmptyHistoryState(), 300),
 );
 
-editor.update(prepopulatedRichText, {tag: 'history-merge'});
+editor.update(prepopulatedRichText, {tag: HISTORY_MERGE_TAG});
 
 editor.registerUpdateListener(({editorState}) => {
   stateRef.value = JSON.stringify(editorState.toJSON(), undefined, 2);

--- a/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx
@@ -31,7 +31,9 @@ import {
   $isParagraphNode,
   CLEAR_EDITOR_COMMAND,
   CLEAR_HISTORY_COMMAND,
+  COLLABORATION_TAG,
   COMMAND_PRIORITY_EDITOR,
+  HISTORIC_TAG,
 } from 'lexical';
 import {useCallback, useEffect, useState} from 'react';
 
@@ -143,8 +145,8 @@ export default function ActionsPlugin({
         if (
           !isEditable &&
           dirtyElements.size > 0 &&
-          !tags.has('historic') &&
-          !tags.has('collaboration')
+          !tags.has(HISTORIC_TAG) &&
+          !tags.has(COLLABORATION_TAG)
         ) {
           validateEditorState(editor);
         }

--- a/packages/lexical-playground/src/plugins/AutocompletePlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutocompletePlugin/index.tsx
@@ -21,6 +21,7 @@ import {
   $isTextNode,
   $setSelection,
   COMMAND_PRIORITY_LOW,
+  HISTORY_MERGE_TAG,
   KEY_ARROW_RIGHT_COMMAND,
   KEY_TAB_COMMAND,
 } from 'lexical';
@@ -33,7 +34,7 @@ import {
 } from '../../nodes/AutocompleteNode';
 import {addSwipeRightListener} from '../../utils/swipe';
 
-const HISTORY_MERGE = {tag: 'history-merge'};
+const HISTORY_MERGE = {tag: HISTORY_MERGE_TAG};
 
 declare global {
   interface Navigator {

--- a/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/CommentPlugin/index.tsx
@@ -46,6 +46,7 @@ import {
   $isRangeSelection,
   $isTextNode,
   CLEAR_EDITOR_COMMAND,
+  COLLABORATION_TAG,
   COMMAND_PRIORITY_EDITOR,
   createCommand,
   getDOMSelection,
@@ -923,7 +924,7 @@ export default function CommentPlugin({
           if (!hasAnchorKey) {
             setActiveAnchorKey(null);
           }
-          if (!tags.has('collaboration') && $isRangeSelection(selection)) {
+          if (!tags.has(COLLABORATION_TAG) && $isRangeSelection(selection)) {
             setShowCommentInput(false);
           }
         });

--- a/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
+++ b/packages/lexical-playground/src/plugins/TableCellResizer/index.tsx
@@ -24,7 +24,11 @@ import {
   TableNode,
 } from '@lexical/table';
 import {calculateZoomLevel, mergeRegister} from '@lexical/utils';
-import {$getNearestNodeFromDOMNode, isHTMLElement} from 'lexical';
+import {
+  $getNearestNodeFromDOMNode,
+  isHTMLElement,
+  SKIP_SCROLL_INTO_VIEW_TAG,
+} from 'lexical';
 import * as React from 'react';
 import {
   CSSProperties,
@@ -240,7 +244,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
           const newHeight = Math.max(height + heightChange, MIN_ROW_HEIGHT);
           tableRow.setHeight(newHeight);
         },
-        {tag: 'skip-scroll-into-view'},
+        {tag: SKIP_SCROLL_INTO_VIEW_TAG},
       );
     },
     [activeCell, editor],
@@ -303,7 +307,7 @@ function TableCellResizer({editor}: {editor: LexicalEditor}): JSX.Element {
           newColWidths[columnIndex] = newWidth;
           tableNode.setColWidths(newColWidths);
         },
-        {tag: 'skip-scroll-into-view'},
+        {tag: SKIP_SCROLL_INTO_VIEW_TAG},
       );
     },
     [activeCell, editor],

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -45,6 +45,7 @@ import {
   ElementFormatType,
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
+  HISTORIC_TAG,
   INDENT_CONTENT_COMMAND,
   LexicalEditor,
   NodeKey,
@@ -680,7 +681,7 @@ export default function ToolbarPlugin({
             $patchStyleText(selection, styles);
           }
         },
-        skipHistoryStack ? {tag: 'historic'} : {},
+        skipHistoryStack ? {tag: HISTORIC_TAG} : {},
       );
     },
     [activeEditor],

--- a/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
+++ b/packages/lexical-react/src/LexicalAutoEmbedPlugin.tsx
@@ -29,6 +29,7 @@ import {
   LexicalCommand,
   LexicalEditor,
   NodeKey,
+  PASTE_TAG,
   TextNode,
 } from 'lexical';
 import {useCallback, useEffect, useMemo, useState} from 'react';
@@ -135,7 +136,7 @@ export function LexicalAutoEmbedPlugin<TEmbedConfig extends EmbedConfig>({
       for (const [key, mutation] of nodeMutations) {
         if (
           mutation === 'created' &&
-          updateTags.has('paste') &&
+          updateTags.has(PASTE_TAG) &&
           dirtyLeaves.size <= 3
         ) {
           checkIfLinkNodeIsEmbeddable(key);

--- a/packages/lexical-react/src/LexicalComposer.tsx
+++ b/packages/lexical-react/src/LexicalComposer.tsx
@@ -20,6 +20,7 @@ import {
   createEditor,
   EditorState,
   EditorThemeClasses,
+  HISTORY_MERGE_TAG,
   HTMLConfig,
   Klass,
   LexicalEditor,
@@ -31,7 +32,7 @@ import * as React from 'react';
 import {CAN_USE_DOM} from 'shared/canUseDOM';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
-const HISTORY_MERGE_OPTIONS = {tag: 'history-merge'};
+const HISTORY_MERGE_OPTIONS = {tag: HISTORY_MERGE_TAG};
 
 export type InitialEditorStateType =
   | null

--- a/packages/lexical-react/src/LexicalOnChangePlugin.ts
+++ b/packages/lexical-react/src/LexicalOnChangePlugin.ts
@@ -9,6 +9,7 @@
 import type {EditorState, LexicalEditor} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {HISTORY_MERGE_TAG} from 'lexical';
 import useLayoutEffect from 'shared/useLayoutEffect';
 
 export function OnChangePlugin({
@@ -34,7 +35,7 @@ export function OnChangePlugin({
             (ignoreSelectionChange &&
               dirtyElements.size === 0 &&
               dirtyLeaves.size === 0) ||
-            (ignoreHistoryMergeTagChange && tags.has('history-merge')) ||
+            (ignoreHistoryMergeTagChange && tags.has(HISTORY_MERGE_TAG)) ||
             prevEditorState.isEmpty()
           ) {
             return;

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -24,6 +24,7 @@ import {
   $setSelection,
   COMMAND_PRIORITY_LOW,
   DELETE_CHARACTER_COMMAND,
+  HISTORY_MERGE_TAG,
 } from 'lexical';
 import {useEffect} from 'react';
 import invariant from 'shared/invariant';
@@ -88,7 +89,7 @@ export function useCharacterLimit(
               $wrapOverflowedNodes(offset);
             },
             {
-              tag: 'history-merge',
+              tag: HISTORY_MERGE_TAG,
             },
           );
         }

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -30,7 +30,9 @@ import {
   CAN_UNDO_COMMAND,
   COMMAND_PRIORITY_EDITOR,
   FOCUS_COMMAND,
+  HISTORY_MERGE_TAG,
   REDO_COMMAND,
+  SKIP_COLLAB_TAG,
   UNDO_COMMAND,
 } from 'lexical';
 import * as React from 'react';
@@ -144,7 +146,7 @@ export function useYjsCollaboration(
         normalizedNodes,
         tags,
       }) => {
-        if (tags.has('skip-collab') === false) {
+        if (tags.has(SKIP_COLLAB_TAG) === false) {
           syncLexicalUpdateToYjs(
             binding,
             provider,
@@ -346,11 +348,15 @@ function initializeEditor(
             case 'string': {
               const parsedEditorState =
                 editor.parseEditorState(initialEditorState);
-              editor.setEditorState(parsedEditorState, {tag: 'history-merge'});
+              editor.setEditorState(parsedEditorState, {
+                tag: HISTORY_MERGE_TAG,
+              });
               break;
             }
             case 'object': {
-              editor.setEditorState(initialEditorState, {tag: 'history-merge'});
+              editor.setEditorState(initialEditorState, {
+                tag: HISTORY_MERGE_TAG,
+              });
               break;
             }
             case 'function': {
@@ -361,7 +367,7 @@ function initializeEditor(
                     initialEditorState(editor);
                   }
                 },
-                {tag: 'history-merge'},
+                {tag: HISTORY_MERGE_TAG},
               );
               break;
             }
@@ -382,7 +388,7 @@ function initializeEditor(
       }
     },
     {
-      tag: 'history-merge',
+      tag: HISTORY_MERGE_TAG,
     },
   );
 }
@@ -396,7 +402,7 @@ function clearEditorSkipCollab(editor: LexicalEditor, binding: Binding) {
       root.select();
     },
     {
-      tag: 'skip-collab',
+      tag: SKIP_COLLAB_TAG,
     },
   );
 

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -94,6 +94,7 @@ import {
   KEY_TAB_COMMAND,
   OUTDENT_CONTENT_COMMAND,
   PASTE_COMMAND,
+  PASTE_TAG,
   REMOVE_TEXT_COMMAND,
   SELECT_ALL_COMMAND,
   setNodeIndentFromDOM,
@@ -459,7 +460,7 @@ function onPasteForRichText(
       }
     },
     {
-      tag: 'paste',
+      tag: PASTE_TAG,
     },
   );
 }

--- a/packages/lexical-website/docs/concepts/selection.md
+++ b/packages/lexical-website/docs/concepts/selection.md
@@ -1,5 +1,3 @@
-
-
 # Selection
 
 ## Types of selection
@@ -127,12 +125,12 @@ selection is reconciled to the DOM selection during reconciliation,
 and the browser's focus follows its DOM selection.
 
 If you want to make updates or dispatch commands to the editor without
-changing the selection, can use the `'skip-dom-selection'` update tag
+changing the selection, can use the `SKIP_DOM_SELECTION_TAG` update tag
 (added in v0.22.0):
 
 ```js
 // Call this from an editor.update or command listener
-$addUpdateTag('skip-dom-selection');
+$addUpdateTag(SKIP_DOM_SELECTION_TAG);
 ```
 
 If you want to add this tag during processing of a `dispatchCommand`,
@@ -144,7 +142,7 @@ you can wrap it in an `editor.update`:
 //       confusing semantics (dispatchCommand will re-use the
 //       current update without nesting)
 editor.update(() => {
-  $addUpdateTag('skip-dom-selection');
+  $addUpdateTag(SKIP_DOM_SELECTION_TAG);
   editor.dispatchCommand(/* … */);
 });
 ```

--- a/packages/lexical-yjs/src/SyncEditorStates.ts
+++ b/packages/lexical-yjs/src/SyncEditorStates.ts
@@ -17,6 +17,9 @@ import {
   $getWritableNodeState,
   $isRangeSelection,
   $isTextNode,
+  COLLABORATION_TAG,
+  HISTORIC_TAG,
+  SKIP_SCROLL_INTO_VIEW_TAG,
 } from 'lexical';
 import invariant from 'shared/invariant';
 import {
@@ -176,7 +179,7 @@ export function syncYjsChangesToLexical(
       if (!isFromUndoManger) {
         // If it is an external change, we don't want the current scroll position to get changed
         // since the user might've intentionally scrolled somewhere else in the document.
-        $addUpdateTag('skip-scroll-into-view');
+        $addUpdateTag(SKIP_SCROLL_INTO_VIEW_TAG);
       }
     },
     {
@@ -192,7 +195,7 @@ export function syncYjsChangesToLexical(
         });
       },
       skipTransforms: true,
-      tag: isFromUndoManger ? 'historic' : 'collaboration',
+      tag: isFromUndoManger ? HISTORIC_TAG : COLLABORATION_TAG,
     },
   );
 }
@@ -269,7 +272,7 @@ export function syncLexicalUpdateToYjs(
       // types a character and we get it, we don't want to then insert
       // the same character again. The exception to this heuristic is
       // when we need to handle normalization merge conflicts.
-      if (tags.has('collaboration') || tags.has('historic')) {
+      if (tags.has(COLLABORATION_TAG) || tags.has(HISTORIC_TAG)) {
         if (normalizedNodes.size > 0) {
           $handleNormalizationMergeConflicts(binding, normalizedNodes);
         }

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -31,6 +31,7 @@ import {
   updateEditor,
   updateEditorSync,
 } from './LexicalUpdates';
+import {HISTORY_MERGE_TAG} from './LexicalUpdateTags';
 import {
   $addUpdateTag,
   $onUpdate,
@@ -1126,7 +1127,7 @@ export class LexicalEditor {
         this._dirtyType = FULL_RECONCILE;
         initMutationObserver(this);
 
-        this._updateTags.add('history-merge');
+        this._updateTags.add(HISTORY_MERGE_TAG);
 
         $commitPendingUpdates(this);
 
@@ -1158,7 +1159,7 @@ export class LexicalEditor {
         // using a commit we preserve the readOnly invariant
         // for editor.getEditorState().
         this._window = null;
-        this._updateTags.add('history-merge');
+        this._updateTags.add(HISTORY_MERGE_TAG);
         $commitPendingUpdates(this);
       }
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -45,8 +45,10 @@ import {
   $updateRangeSelectionFromCaretRange,
   CaretRange,
   ChildCaret,
+  COLLABORATION_TAG,
   NodeCaret,
   PointCaret,
+  SKIP_SCROLL_INTO_VIEW_TAG,
   TextNode,
 } from '.';
 import {TEXT_TYPE_TO_FORMAT} from './LexicalConstants';
@@ -2955,7 +2957,7 @@ export function updateDOMSelection(
   // TODO: make this not hard-coded, and add another config option
   // that makes this configurable.
   if (
-    (tags.has('collaboration') && activeElement !== rootElement) ||
+    (tags.has(COLLABORATION_TAG) && activeElement !== rootElement) ||
     (activeElement !== null &&
       isSelectionCapturedInDecoratorInput(activeElement))
   ) {
@@ -3064,7 +3066,7 @@ export function updateDOMSelection(
     nextFocusOffset,
   );
   if (
-    !tags.has('skip-scroll-into-view') &&
+    !tags.has(SKIP_SCROLL_INTO_VIEW_TAG) &&
     nextSelection.isCollapsed() &&
     rootElement !== null &&
     rootElement === document.activeElement

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -11,7 +11,12 @@ import type {LexicalNode, SerializedLexicalNode} from './LexicalNode';
 
 import invariant from 'shared/invariant';
 
-import {$isElementNode, $isTextNode, SELECTION_CHANGE_COMMAND} from '.';
+import {
+  $isElementNode,
+  $isTextNode,
+  SELECTION_CHANGE_COMMAND,
+  SKIP_DOM_SELECTION_TAG,
+} from '.';
 import {FULL_RECONCILE, NO_DIRTY_NODES} from './LexicalConstants';
 import {
   CommandPayloadType,
@@ -618,7 +623,7 @@ export function $commitPendingUpdates(
     domSelection !== null &&
     (needsUpdate || pendingSelection === null || pendingSelection.dirty) &&
     rootElement !== null &&
-    !tags.has('skip-dom-selection')
+    !tags.has(SKIP_DOM_SELECTION_TAG)
   ) {
     activeEditor = editor;
     activeEditorState = pendingEditorState;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -51,6 +51,7 @@ import {
   $isTextNode,
   DecoratorNode,
   ElementNode,
+  HISTORY_MERGE_TAG,
   LineBreakNode,
 } from '.';
 import {
@@ -555,7 +556,7 @@ export function markNodesWithTypesAsDirty(
     },
     editor._pendingEditorState === null
       ? {
-          tag: 'history-merge',
+          tag: HISTORY_MERGE_TAG,
         }
       : undefined,
   );

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -51,12 +51,14 @@ import {
   EditorState,
   ElementNode,
   getDOMSelection,
+  HISTORY_MERGE_TAG,
   type Klass,
   type LexicalEditor,
   type LexicalNode,
   type LexicalNodeReplacement,
   ParagraphNode,
   RootNode,
+  SKIP_DOM_SELECTION_TAG,
   TextNode,
   UpdateListenerPayload,
 } from 'lexical';
@@ -3237,7 +3239,7 @@ describe('LexicalEditor tests', () => {
           $getRoot().append($createParagraphNode().append(textNode));
           textNode.select();
         },
-        {tag: 'history-merge'},
+        {tag: HISTORY_MERGE_TAG},
       );
       await newEditor.setRootElement(container);
       const domText = newEditor.getElementByKey(textNode.getKey())
@@ -3279,7 +3281,7 @@ describe('LexicalEditor tests', () => {
           $getRoot().append($createParagraphNode().append(textNode));
           textNode.select();
         },
-        {tag: 'history-merge'},
+        {tag: HISTORY_MERGE_TAG},
       );
       await newEditor.setRootElement(container);
       const domText = newEditor.getElementByKey(textNode.getKey())
@@ -3298,7 +3300,7 @@ describe('LexicalEditor tests', () => {
         () => {
           textNode.select(0);
         },
-        {tag: 'skip-dom-selection'},
+        {tag: SKIP_DOM_SELECTION_TAG},
       );
       selection = getDOMSelection(newEditor._window || window) as Selection;
       expect(selection).not.toBe(null);

--- a/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/src/routes/+page.svelte
+++ b/scripts/__tests__/integration/fixtures/lexical-esm-sveltekit-vanilla-js/src/routes/+page.svelte
@@ -11,7 +11,7 @@
 	import { createEmptyHistoryState, registerHistory } from '@lexical/history';
 	import { HeadingNode, QuoteNode, registerRichText } from '@lexical/rich-text';
 	import { mergeRegister } from '@lexical/utils';
-	import { createEditor } from 'lexical';
+	import { createEditor, HISTORY_MERGE_TAG } from 'lexical';
 
 	import prepopulatedRichText from '$lib/prepopulatedRichText';
 	import { onMount } from 'svelte';
@@ -42,7 +42,7 @@
 			registerHistory(editor, createEmptyHistoryState(), 300)
 		);
 
-		editor.update(prepopulatedRichText, { tag: 'history-merge' });
+		editor.update(prepopulatedRichText, { tag: HISTORY_MERGE_TAG });
 
 		editor.registerUpdateListener(({ editorState }) => {
 			stateRef!.value = JSON.stringify(editorState.toJSON(), undefined, 2);


### PR DESCRIPTION
## Description
### Current behavior:
Currently, string literals are being used directly for update tags in documentation and code (e.g., 'skip-dom-selection', 'history-merge'). This makes the code prone to typos and lacks proper TypeScript type checking.

### Changes in this PR:
This PR replaces string literal update tags with their corresponding exported constants from LexicalUpdateTags.ts. 

These changes improve:
- Type safety through TypeScript validation
- Code maintainability
- IDE support with autocomplete
- Consistency between documentation and implementation

Closes #7446

## Test plan

### Before

Documentation and code use string literals:
```js
$addUpdateTag('skip-dom-selection');
editor.update(prepopulatedRichText, { tag: 'history-merge' });
```


### After

```js
$addUpdateTag(SKIP_DOM_SELECTION_TAG);
editor.update(prepopulatedRichText, { tag: HISTORY_MERGE_TAG });
```