### PR TITLE
[lexical-yjs][lexical] Refactor: Simplify removeFromParent internal operations

### DIFF
--- a/packages/lexical-yjs/src/CollabElementNode.ts
+++ b/packages/lexical-yjs/src/CollabElementNode.ts
@@ -17,6 +17,7 @@ import {
   $isDecoratorNode,
   $isElementNode,
   $isTextNode,
+  removeFromParent,
 } from 'lexical';
 import invariant from 'shared/invariant';
 
@@ -29,7 +30,6 @@ import {
   $syncPropertiesFromYjs,
   createLexicalNodeFromCollabNode,
   getPositionFromElementAndOffset,
-  removeFromParent,
   spliceString,
   syncPropertiesFromLexical,
 } from './Utils';

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -566,47 +566,38 @@ export function removeFromParent(node: LexicalNode): void {
     const writableParent = oldParent.getWritable();
     const prevSibling = node.getPreviousSibling();
     const nextSibling = node.getNextSibling();
-    // TODO: this function duplicates a bunch of operations, can be simplified.
+
+    // Get writable siblings once
+    const writablePrevSibling =
+      prevSibling !== null ? prevSibling.getWritable() : null;
+    const writableNextSibling =
+      nextSibling !== null ? nextSibling.getWritable() : null;
+
+    // Update parent's first/last pointers
     if (prevSibling === null) {
-      if (nextSibling !== null) {
-        const writableNextSibling = nextSibling.getWritable();
-        writableParent.__first = nextSibling.__key;
-        writableNextSibling.__prev = null;
-      } else {
-        writableParent.__first = null;
-      }
-    } else {
-      const writablePrevSibling = prevSibling.getWritable();
-      if (nextSibling !== null) {
-        const writableNextSibling = nextSibling.getWritable();
-        writableNextSibling.__prev = writablePrevSibling.__key;
-        writablePrevSibling.__next = writableNextSibling.__key;
-      } else {
-        writablePrevSibling.__next = null;
-      }
-      writableNode.__prev = null;
+      writableParent.__first = nextSibling !== null ? nextSibling.__key : null;
     }
     if (nextSibling === null) {
-      if (prevSibling !== null) {
-        const writablePrevSibling = prevSibling.getWritable();
-        writableParent.__last = prevSibling.__key;
-        writablePrevSibling.__next = null;
-      } else {
-        writableParent.__last = null;
-      }
-    } else {
-      const writableNextSibling = nextSibling.getWritable();
-      if (prevSibling !== null) {
-        const writablePrevSibling = prevSibling.getWritable();
-        writablePrevSibling.__next = writableNextSibling.__key;
-        writableNextSibling.__prev = writablePrevSibling.__key;
-      } else {
-        writableNextSibling.__prev = null;
-      }
-      writableNode.__next = null;
+      writableParent.__last = prevSibling !== null ? prevSibling.__key : null;
     }
-    writableParent.__size--;
+
+    // Update sibling links
+    if (writablePrevSibling !== null) {
+      writablePrevSibling.__next =
+        nextSibling !== null ? nextSibling.__key : null;
+    }
+    if (writableNextSibling !== null) {
+      writableNextSibling.__prev =
+        prevSibling !== null ? prevSibling.__key : null;
+    }
+
+    // Clear node's links
+    writableNode.__prev = null;
+    writableNode.__next = null;
     writableNode.__parent = null;
+
+    // Update parent size
+    writableParent.__size--;
   }
 }
 

--- a/packages/lexical-yjs/src/Utils.ts
+++ b/packages/lexical-yjs/src/Utils.ts
@@ -559,48 +559,6 @@ export function syncWithTransaction(binding: Binding, fn: () => void): void {
   binding.doc.transact(fn, binding);
 }
 
-export function removeFromParent(node: LexicalNode): void {
-  const oldParent = node.getParent();
-  if (oldParent !== null) {
-    const writableNode = node.getWritable();
-    const writableParent = oldParent.getWritable();
-    const prevSibling = node.getPreviousSibling();
-    const nextSibling = node.getNextSibling();
-
-    // Get writable siblings once
-    const writablePrevSibling =
-      prevSibling !== null ? prevSibling.getWritable() : null;
-    const writableNextSibling =
-      nextSibling !== null ? nextSibling.getWritable() : null;
-
-    // Update parent's first/last pointers
-    if (prevSibling === null) {
-      writableParent.__first = nextSibling !== null ? nextSibling.__key : null;
-    }
-    if (nextSibling === null) {
-      writableParent.__last = prevSibling !== null ? prevSibling.__key : null;
-    }
-
-    // Update sibling links
-    if (writablePrevSibling !== null) {
-      writablePrevSibling.__next =
-        nextSibling !== null ? nextSibling.__key : null;
-    }
-    if (writableNextSibling !== null) {
-      writableNextSibling.__prev =
-        prevSibling !== null ? prevSibling.__key : null;
-    }
-
-    // Clear node's links
-    writableNode.__prev = null;
-    writableNode.__next = null;
-    writableNode.__parent = null;
-
-    // Update parent size
-    writableParent.__size--;
-  }
-}
-
 export function $moveSelectionToPreviousNode(
   anchorNodeKey: string,
   currentEditorState: EditorState,

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -353,6 +353,10 @@ export function removeFromParent(node: LexicalNode): void {
     const prevSibling = node.getPreviousSibling();
     const nextSibling = node.getNextSibling();
 
+    // Store sibling keys
+    const nextSiblingKey = nextSibling !== null ? nextSibling.__key : null;
+    const prevSiblingKey = prevSibling !== null ? prevSibling.__key : null;
+
     // Get writable siblings once
     const writablePrevSibling =
       prevSibling !== null ? prevSibling.getWritable() : null;
@@ -361,20 +365,18 @@ export function removeFromParent(node: LexicalNode): void {
 
     // Update parent's first/last pointers
     if (prevSibling === null) {
-      writableParent.__first = nextSibling !== null ? nextSibling.__key : null;
+      writableParent.__first = nextSiblingKey;
     }
     if (nextSibling === null) {
-      writableParent.__last = prevSibling !== null ? prevSibling.__key : null;
+      writableParent.__last = prevSiblingKey;
     }
 
     // Update sibling links
     if (writablePrevSibling !== null) {
-      writablePrevSibling.__next =
-        nextSibling !== null ? nextSibling.__key : null;
+      writablePrevSibling.__next = nextSiblingKey;
     }
     if (writableNextSibling !== null) {
-      writableNextSibling.__prev =
-        prevSibling !== null ? prevSibling.__key : null;
+      writableNextSibling.__prev = prevSiblingKey;
     }
 
     // Clear node's links

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -345,47 +345,38 @@ export function removeFromParent(node: LexicalNode): void {
     const writableParent = oldParent.getWritable();
     const prevSibling = node.getPreviousSibling();
     const nextSibling = node.getNextSibling();
-    // TODO: this function duplicates a bunch of operations, can be simplified.
+
+    // Get writable siblings once
+    const writablePrevSibling =
+      prevSibling !== null ? prevSibling.getWritable() : null;
+    const writableNextSibling =
+      nextSibling !== null ? nextSibling.getWritable() : null;
+
+    // Update parent's first/last pointers
     if (prevSibling === null) {
-      if (nextSibling !== null) {
-        const writableNextSibling = nextSibling.getWritable();
-        writableParent.__first = nextSibling.__key;
-        writableNextSibling.__prev = null;
-      } else {
-        writableParent.__first = null;
-      }
-    } else {
-      const writablePrevSibling = prevSibling.getWritable();
-      if (nextSibling !== null) {
-        const writableNextSibling = nextSibling.getWritable();
-        writableNextSibling.__prev = writablePrevSibling.__key;
-        writablePrevSibling.__next = writableNextSibling.__key;
-      } else {
-        writablePrevSibling.__next = null;
-      }
-      writableNode.__prev = null;
+      writableParent.__first = nextSibling !== null ? nextSibling.__key : null;
     }
     if (nextSibling === null) {
-      if (prevSibling !== null) {
-        const writablePrevSibling = prevSibling.getWritable();
-        writableParent.__last = prevSibling.__key;
-        writablePrevSibling.__next = null;
-      } else {
-        writableParent.__last = null;
-      }
-    } else {
-      const writableNextSibling = nextSibling.getWritable();
-      if (prevSibling !== null) {
-        const writablePrevSibling = prevSibling.getWritable();
-        writablePrevSibling.__next = writableNextSibling.__key;
-        writableNextSibling.__prev = writablePrevSibling.__key;
-      } else {
-        writableNextSibling.__prev = null;
-      }
-      writableNode.__next = null;
+      writableParent.__last = prevSibling !== null ? prevSibling.__key : null;
     }
-    writableParent.__size--;
+
+    // Update sibling links
+    if (writablePrevSibling !== null) {
+      writablePrevSibling.__next =
+        nextSibling !== null ? nextSibling.__key : null;
+    }
+    if (writableNextSibling !== null) {
+      writableNextSibling.__prev =
+        prevSibling !== null ? prevSibling.__key : null;
+    }
+
+    // Clear node's links
+    writableNode.__prev = null;
+    writableNode.__next = null;
     writableNode.__parent = null;
+
+    // Update parent size
+    writableParent.__size--;
   }
 }
 

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -338,6 +338,13 @@ function internalMarkParentElementsAsDirty(
 }
 
 // TODO #6031 this function or their callers have to adjust selection (i.e. insertBefore)
+/**
+ * Removes a node from its parent, updating all necessary pointers and links.
+ * @internal
+ *
+ * This function is for internal use of the library.
+ * Please do not use it as it may change in the future.
+ */
 export function removeFromParent(node: LexicalNode): void {
   const oldParent = node.getParent();
   if (oldParent !== null) {

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -262,6 +262,7 @@ export {
   isLexicalEditor,
   isSelectionCapturedInDecoratorInput,
   isSelectionWithinEditor,
+  removeFromParent,
   resetRandomKey,
   setDOMUnmanaged,
   setNodeIndentFromDOM,


### PR DESCRIPTION
## Description

### Current behavior:
- The removeFromParent function in both packages makes multiple separate getWritable() calls
- Has nested conditional logic for sibling pointer updates
- Contains repeated null checks and sibling key access operations
- Has a TODO comment noting operation duplication

### Changes being added:
- Batch all getWritable() calls at the start of the function
- Consolidate related pointer updates into cleaner blocks
- Simplify null checks and conditional logic
- Maintain identical functionality with improved code structure
- Remove the TODO comment as the operations are now optimized

Closes #7452

## Test plan

All existing tests should continue to pass as the functionality remains unchanged.