### PR TITLE
[lexical] Chore: Update internalMarkNodeAsDirty TODO comment

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -407,7 +407,6 @@ export function internalMarkNodeAsDirty(node: LexicalNode): void {
   if ($isElementNode(node)) {
     dirtyElements.set(key, true);
   } else {
-    // TODO split internally MarkNodeAsDirty into two dedicated Element/leave functions
     editor._dirtyLeaves.add(key);
   }
 }


### PR DESCRIPTION
## Description

### Current behavior:
- `internalMarkNodeAsDirty` has a TODO comment suggesting to split it into separate element/leaf functions
- After analysis and review feedback, the current single-function implementation is actually preferred

### Changes being made:
1. Remove the outdated TODO comment as the current implementation is better because:
   - Avoids unnecessary code duplication
   - Maintains better performance
   - Keeps code size minimal
   - Improves maintainability

The change is minimal but important - removing an outdated TODO comment that would lead developers down a suboptimal path. The current implementation is more maintainable and efficient than splitting it would be.

Closes #7456