### PR TITLE
[lexical-playground] Bug Fix: Stabilize text format dropdown width in toolbar

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1803,3 +1803,17 @@ button.item.dropdown-item-active i {
   margin-bottom: 10px;
   width: 100%;
 }
+
+.toolbar .block-controls {
+  display: flex;
+  align-items: center;
+}
+
+.toolbar .block-controls .dropdown-button-text {
+  width: 7em;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+}


### PR DESCRIPTION
## Description

### Current behavior:
- The text format dropdown button width changes dynamically based on the selected format text (e.g., "Normal", "Heading 1")
- This causes other toolbar buttons to shift position when switching formats
- Creates a jarring visual experience and poor UX

### Changes made:
- Added fixed width (7em) to dropdown button text
- Added text overflow handling with ellipsis for longer format names
- Ensured proper text alignment and spacing
- Fixed visual disruption when switching between text formats

Closes #7461

## Test plan

### Before

https://github.com/user-attachments/assets/23ae3b6c-9ed7-4873-92fa-a9c80a9d5438

### After

https://github.com/user-attachments/assets/b5c90954-c993-4526-a7b8-280d8a5125b4


The changes can be tested by:
1. Opening the Lexical playground preview for this PR
2. Clicking on the text format dropdown (shows "Normal" by default)
3. Selecting "Heading 1" from the dropdown
4. Switching back to "Normal"
5. Verifying that toolbar buttons maintain stable positions
6. Checking that longer format names are properly truncated with ellipsis