### PR TITLE
[lexical-playground] Feature: Add keyboard shortcut for comments

### DIFF
--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/index.tsx
@@ -21,6 +21,7 @@ import {Dispatch, useEffect} from 'react';
 
 import {useToolbarState} from '../../context/ToolbarContext';
 import {sanitizeUrl} from '../../utils/url';
+import {INSERT_INLINE_COMMAND} from '../CommentPlugin';
 import {
   clearFormatting,
   formatBulletList,
@@ -34,6 +35,7 @@ import {
   UpdateFontSizeType,
 } from '../ToolbarPlugin/utils';
 import {
+  isAddComment,
   isCapitalize,
   isCenterAlign,
   isClearFormatting,
@@ -158,6 +160,9 @@ export default function ShortcutsPlugin({
         setIsLinkEditMode(!toolbarState.isLink);
 
         editor.dispatchCommand(TOGGLE_LINK_COMMAND, url);
+      } else if (isAddComment(event)) {
+        event.preventDefault();
+        editor.dispatchCommand(INSERT_INLINE_COMMAND, undefined);
       }
 
       return false;

--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
@@ -21,6 +21,7 @@ export const SHORTCUTS = Object.freeze({
   CHECK_LIST: IS_APPLE ? '⌘+Opt+6' : 'Ctrl+Alt+6',
   CODE_BLOCK: IS_APPLE ? '⌘+Opt+C' : 'Ctrl+Alt+C',
   QUOTE: IS_APPLE ? '⌘+Opt+Q' : 'Ctrl+Alt+Q',
+  ADD_COMMENT: IS_APPLE ? '⌘+Opt+M' : 'Ctrl+Alt+M',
 
   // (Ctrl|⌘) + Shift + <key> shortcuts
   INCREASE_FONT_SIZE: IS_APPLE ? '⌘+Shift+.' : 'Ctrl+Shift+.',
@@ -254,5 +255,12 @@ export function isInsertLink(event: KeyboardEvent): boolean {
   const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
   return (
     code === 'KeyK' && !shiftKey && !altKey && controlOrMeta(metaKey, ctrlKey)
+  );
+}
+
+export function isAddComment(event: KeyboardEvent): boolean {
+  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  return (
+    code === 'KeyM' && !shiftKey && altKey && controlOrMeta(metaKey, ctrlKey)
   );
 }


### PR DESCRIPTION
## Description

### What is the current behavior that you are modifying?
Currently, comments can only be added through the UI button that appears when text is selected in the Lexical editor.

### What are the behavior or changes that are being added by this PR?
This PR adds keyboard shortcut support (⌘+Option+M on Mac, Ctrl+Alt+M on Windows/Linux) for adding comments, similar to Google Docs. The changes include:
1. Adding a new `ADD_COMMENT` constant to the `SHORTCUTS` object
2. Adding `isAddComment` helper function to detect the shortcut
3. Updating `ShortcutsPlugin` to handle the comment shortcut using `INSERT_INLINE_COMMAND`

Closes #7463

## Test plan

### Before

Currently, users can only add comments by:
1. Selecting text in the editor
2. Clicking on the comment button that appears in the UI
3. No keyboard shortcut support exists

### After
Users can now:
1. Select text in the editor
2. Press ⌘+Option+M (Mac) or Ctrl+Alt+M (Windows/Linux) to add a comment
3. The comment input box appears immediately, matching Google Docs behavior


https://github.com/user-attachments/assets/13687150-8652-470c-ba26-8d3178f4fac7

