### PR TITLE
[lexical-playground] Feature: Add zoom functionality to editor

### DIFF
--- a/packages/lexical-playground/src/context/ToolbarContext.tsx
+++ b/packages/lexical-playground/src/context/ToolbarContext.tsx
@@ -73,6 +73,8 @@ const INITIAL_TOOLBAR_STATE = {
   isUppercase: false,
   isCapitalize: false,
   rootType: 'root' as keyof typeof rootTypeToRootName,
+  // Zoom level in percentage or 'Fit'
+  zoomLevel: 100 as number | 'Fit',
 };
 
 type ToolbarState = typeof INITIAL_TOOLBAR_STATE;

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1803,3 +1803,28 @@ button.item.dropdown-item-active i {
   margin-bottom: 10px;
   width: 100%;
 }
+
+.zoom-menu {
+  min-width: 45px;
+}
+
+.toolbar .toolbar-item.zoom-menu .icon {
+  display: none;
+}
+
+.zoom-menu .text {
+  min-width: 35px;
+}
+
+/* Show zoom level in mobile */
+@media (max-width: 480px) {
+  .zoom-menu {
+    display: flex;
+    align-items: center;
+  }
+
+  .zoom-menu .text {
+    display: inline-block !important;
+    width: auto !important;
+  }
+}

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -93,6 +93,7 @@ import {
   formatParagraph,
   formatQuote,
 } from './utils';
+import Zoom from './zoom';
 
 const rootTypeToRootName = {
   root: 'Root',
@@ -1194,6 +1195,8 @@ export default function ToolbarPlugin({
         editor={activeEditor}
         isRTL={toolbarState.isRTL}
       />
+      <Divider />
+      <Zoom editor={editor} disabled={!isEditable} />
 
       {modal}
     </div>

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/zoom.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/zoom.tsx
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {LexicalEditor} from 'lexical';
+
+import * as React from 'react';
+import {useCallback} from 'react';
+
+import {useToolbarState} from '../../context/ToolbarContext';
+import DropDown, {DropDownItem} from '../../ui/DropDown';
+
+const ZOOM_LEVELS = ['Fit', 50, 75, 90, 100, 125, 150, 200] as const;
+type ZoomLevel = (typeof ZOOM_LEVELS)[number];
+
+export default function Zoom({
+  editor,
+  disabled = false,
+}: {
+  editor: LexicalEditor;
+  disabled?: boolean;
+}): JSX.Element {
+  const {toolbarState, updateToolbarState} = useToolbarState();
+  const {zoomLevel} = toolbarState;
+
+  const handleZoomChange = useCallback(
+    (newZoom: ZoomLevel) => {
+      // Apply zoom to editor container
+      const editorElement = editor.getRootElement()?.parentElement;
+      if (editorElement) {
+        if (newZoom === 'Fit') {
+          // Reset zoom temporarily to get actual content width
+          editorElement.style.zoom = '100%';
+
+          // Calculate zoom level to fit content width
+          const containerWidth = editorElement.parentElement?.clientWidth || 0;
+          const contentWidth = editorElement.scrollWidth;
+
+          const fitZoom = Math.min(
+            100,
+            Math.floor((containerWidth / contentWidth) * 100),
+          );
+
+          // Apply the calculated fit zoom
+          editorElement.style.zoom = `${fitZoom}%`;
+          updateToolbarState('zoomLevel', 'Fit');
+        } else {
+          editorElement.style.zoom = `${newZoom}%`;
+          updateToolbarState('zoomLevel', newZoom);
+        }
+      }
+    },
+    [editor, updateToolbarState],
+  );
+
+  const isCurrentZoomLevel = (level: ZoomLevel) => {
+    if (level === 'Fit' && zoomLevel === 'Fit') {
+      return true;
+    }
+    if (typeof level === 'number' && typeof zoomLevel === 'number') {
+      return level === zoomLevel;
+    }
+    return false;
+  };
+
+  return (
+    <DropDown
+      disabled={disabled}
+      buttonClassName="toolbar-item zoom-menu"
+      buttonLabel={zoomLevel === 'Fit' ? 'Fit' : `${zoomLevel}%`}
+      buttonIconClassName="icon"
+      buttonAriaLabel="Formatting options for zoom level">
+      <DropDownItem
+        key="fit"
+        className={'item ' + (isCurrentZoomLevel('Fit') ? 'active' : '')}
+        onClick={() => handleZoomChange('Fit')}>
+        <span className="text">Fit</span>
+      </DropDownItem>
+      <div className="divider" />
+      {ZOOM_LEVELS.slice(1).map((level) => (
+        <DropDownItem
+          key={level}
+          className={'item ' + (isCurrentZoomLevel(level) ? 'active' : '')}
+          onClick={() => handleZoomChange(level)}>
+          <span className="text">{level}%</span>
+        </DropDownItem>
+      ))}
+    </DropDown>
+  );
+}


### PR DESCRIPTION
## Description
### Current Behvior:
The playground editor doesn't have any zoom functionality, making it difficult for users to adjust content size for better readability or detailed editing.

### This PR adds:
- A new zoom dropdown in the toolbar with options: Fit, 50%, 75%, 90%, 100%, 125%, 150%, 200%
- Simple zoom implementation using CSS zoom property
- "Fit" option that automatically calculates and applies zoom to fit content width
- Mobile-responsive zoom display that shows current zoom level
- Styling that matches existing Lexical toolbar dropdowns
- Zoom state management through ToolbarContext

Closes #7467

## Test plan

### Before

No Zoom functionality

### After

Desktop:

https://github.com/user-attachments/assets/ac5d6756-8aa5-4798-8aa8-e6c1b774b797

Mobie:

![image](https://github.com/user-attachments/assets/7a955083-311b-4553-92d8-e819578c68d8)


1. Toolbar with new zoom dropdown
2. Dropdown expanded showing all zoom options with separator
3. Mobile view showing zoom level
4. Editor at different zoom levels (ex: 100%, 200%, Fit)