### PR TITLE
[lexical][lexical-playground] Chore: Deprecate KEY_MODIFIER_COMMAND and use KEY_DOWN_COMMAND for playground shortcuts

### DIFF
--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/index.tsx
@@ -13,7 +13,8 @@ import {
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
   INDENT_CONTENT_COMMAND,
-  KEY_MODIFIER_COMMAND,
+  isModifierMatch,
+  KEY_DOWN_COMMAND,
   LexicalEditor,
   OUTDENT_CONTENT_COMMAND,
 } from 'lexical';
@@ -72,104 +73,82 @@ export default function ShortcutsPlugin({
   const {toolbarState} = useToolbarState();
 
   useEffect(() => {
-    const keyboardShortcutsHandler = (payload: KeyboardEvent) => {
-      const event: KeyboardEvent = payload;
-
-      if (isFormatParagraph(event)) {
-        event.preventDefault();
+    const keyboardShortcutsHandler = (event: KeyboardEvent) => {
+      // Short-circuit, a least one modifier must be set
+      if (isModifierMatch(event, {})) {
+        return false;
+      } else if (isFormatParagraph(event)) {
         formatParagraph(editor);
       } else if (isFormatHeading(event)) {
-        event.preventDefault();
         const {code} = event;
         const headingSize = `h${code[code.length - 1]}` as HeadingTagType;
         formatHeading(editor, toolbarState.blockType, headingSize);
       } else if (isFormatBulletList(event)) {
-        event.preventDefault();
         formatBulletList(editor, toolbarState.blockType);
       } else if (isFormatNumberedList(event)) {
-        event.preventDefault();
         formatNumberedList(editor, toolbarState.blockType);
       } else if (isFormatCheckList(event)) {
-        event.preventDefault();
         formatCheckList(editor, toolbarState.blockType);
       } else if (isFormatCode(event)) {
-        event.preventDefault();
         formatCode(editor, toolbarState.blockType);
       } else if (isFormatQuote(event)) {
-        event.preventDefault();
         formatQuote(editor, toolbarState.blockType);
       } else if (isStrikeThrough(event)) {
-        event.preventDefault();
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough');
       } else if (isLowercase(event)) {
-        event.preventDefault();
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'lowercase');
       } else if (isUppercase(event)) {
-        event.preventDefault();
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'uppercase');
       } else if (isCapitalize(event)) {
-        event.preventDefault();
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'capitalize');
       } else if (isIndent(event)) {
-        event.preventDefault();
         editor.dispatchCommand(INDENT_CONTENT_COMMAND, undefined);
       } else if (isOutdent(event)) {
-        event.preventDefault();
         editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
       } else if (isCenterAlign(event)) {
-        event.preventDefault();
         editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'center');
       } else if (isLeftAlign(event)) {
-        event.preventDefault();
         editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left');
       } else if (isRightAlign(event)) {
-        event.preventDefault();
         editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'right');
       } else if (isJustifyAlign(event)) {
-        event.preventDefault();
         editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'justify');
       } else if (isSubscript(event)) {
-        event.preventDefault();
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'subscript');
       } else if (isSuperscript(event)) {
-        event.preventDefault();
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'superscript');
       } else if (isInsertCodeBlock(event)) {
-        event.preventDefault();
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
       } else if (isIncreaseFontSize(event)) {
-        event.preventDefault();
         updateFontSize(
           editor,
           UpdateFontSizeType.increment,
           toolbarState.fontSizeInputValue,
         );
       } else if (isDecreaseFontSize(event)) {
-        event.preventDefault();
         updateFontSize(
           editor,
           UpdateFontSizeType.decrement,
           toolbarState.fontSizeInputValue,
         );
       } else if (isClearFormatting(event)) {
-        event.preventDefault();
         clearFormatting(editor);
       } else if (isInsertLink(event)) {
-        event.preventDefault();
         const url = toolbarState.isLink ? null : sanitizeUrl('https://');
         setIsLinkEditMode(!toolbarState.isLink);
-
         editor.dispatchCommand(TOGGLE_LINK_COMMAND, url);
       } else if (isAddComment(event)) {
-        event.preventDefault();
         editor.dispatchCommand(INSERT_INLINE_COMMAND, undefined);
+      } else {
+        // No match for any of the event handlers
+        return false;
       }
-
-      return false;
+      event.preventDefault();
+      return true;
     };
 
     return editor.registerCommand(
-      KEY_MODIFIER_COMMAND,
+      KEY_DOWN_COMMAND,
       keyboardShortcutsHandler,
       COMMAND_PRIORITY_NORMAL,
     );

--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
@@ -7,6 +7,7 @@
  */
 
 import {IS_APPLE} from '@lexical/utils';
+import {isModifierMatch} from 'lexical';
 
 //disable eslint sorting rule for quick reference to shortcuts
 /* eslint-disable sort-keys-fix/sort-keys-fix */
@@ -50,217 +51,189 @@ export const SHORTCUTS = Object.freeze({
   INSERT_LINK: IS_APPLE ? '⌘+K' : 'Ctrl+K',
 });
 
-export function controlOrMeta(metaKey: boolean, ctrlKey: boolean): boolean {
-  return IS_APPLE ? metaKey : ctrlKey;
-}
+const CONTROL_OR_META = {ctrlKey: !IS_APPLE, metaKey: IS_APPLE};
 
 export function isFormatParagraph(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
 
   return (
     (code === 'Numpad0' || code === 'Digit0') &&
-    !shiftKey &&
-    altKey &&
-    controlOrMeta(metaKey, ctrlKey)
+    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
   );
 }
 
 export function isFormatHeading(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   const keyNumber = code[code.length - 1];
 
   return (
     ['1', '2', '3'].includes(keyNumber) &&
-    !shiftKey &&
-    altKey &&
-    controlOrMeta(metaKey, ctrlKey)
+    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
   );
 }
 
 export function isFormatBulletList(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
     (code === 'Numpad4' || code === 'Digit4') &&
-    !shiftKey &&
-    altKey &&
-    controlOrMeta(metaKey, ctrlKey)
+    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
   );
 }
 
 export function isFormatNumberedList(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
     (code === 'Numpad5' || code === 'Digit5') &&
-    !shiftKey &&
-    altKey &&
-    controlOrMeta(metaKey, ctrlKey)
+    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
   );
 }
 
 export function isFormatCheckList(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
     (code === 'Numpad6' || code === 'Digit6') &&
-    !shiftKey &&
-    altKey &&
-    controlOrMeta(metaKey, ctrlKey)
+    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
   );
 }
 
 export function isFormatCode(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
-    code === 'KeyC' && !shiftKey && altKey && controlOrMeta(metaKey, ctrlKey)
+    code === 'KeyC' &&
+    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
   );
 }
 
 export function isFormatQuote(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
-    code === 'KeyQ' && !shiftKey && altKey && controlOrMeta(metaKey, ctrlKey)
+    code === 'KeyQ' &&
+    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
   );
 }
 
 export function isLowercase(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
     (code === 'Numpad1' || code === 'Digit1') &&
-    shiftKey &&
-    !altKey &&
-    controlOrMeta(metaKey, ctrlKey)
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isUppercase(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
     (code === 'Numpad2' || code === 'Digit2') &&
-    shiftKey &&
-    !altKey &&
-    controlOrMeta(metaKey, ctrlKey)
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isCapitalize(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
     (code === 'Numpad3' || code === 'Digit3') &&
-    shiftKey &&
-    !altKey &&
-    controlOrMeta(metaKey, ctrlKey)
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isStrikeThrough(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
-    code === 'KeyS' && shiftKey && !altKey && controlOrMeta(metaKey, ctrlKey)
+    code === 'KeyS' &&
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isIndent(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
-  return (
-    code === 'BracketRight' &&
-    !shiftKey &&
-    !altKey &&
-    controlOrMeta(metaKey, ctrlKey)
-  );
+  const {code} = event;
+  return code === 'BracketRight' && isModifierMatch(event, CONTROL_OR_META);
 }
 
 export function isOutdent(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
-  return (
-    code === 'BracketLeft' &&
-    !shiftKey &&
-    !altKey &&
-    controlOrMeta(metaKey, ctrlKey)
-  );
+  const {code} = event;
+  return code === 'BracketLeft' && isModifierMatch(event, CONTROL_OR_META);
 }
 
 export function isCenterAlign(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
-    code === 'KeyE' && shiftKey && !altKey && controlOrMeta(metaKey, ctrlKey)
+    code === 'KeyE' &&
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isLeftAlign(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
-    code === 'KeyL' && shiftKey && !altKey && controlOrMeta(metaKey, ctrlKey)
+    code === 'KeyL' &&
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isRightAlign(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
-    code === 'KeyR' && shiftKey && !altKey && controlOrMeta(metaKey, ctrlKey)
+    code === 'KeyR' &&
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isJustifyAlign(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
-    code === 'KeyJ' && shiftKey && !altKey && controlOrMeta(metaKey, ctrlKey)
+    code === 'KeyJ' &&
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isSubscript(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
-  return (
-    code === 'Comma' && !shiftKey && !altKey && controlOrMeta(metaKey, ctrlKey)
-  );
+  const {code} = event;
+  return code === 'Comma' && isModifierMatch(event, CONTROL_OR_META);
 }
 
 export function isSuperscript(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
-  return (
-    code === 'Period' && !shiftKey && !altKey && controlOrMeta(metaKey, ctrlKey)
-  );
+  const {code} = event;
+  return code === 'Period' && isModifierMatch(event, CONTROL_OR_META);
 }
 
 export function isInsertCodeBlock(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
-    code === 'KeyC' && shiftKey && !altKey && controlOrMeta(metaKey, ctrlKey)
+    code === 'KeyC' &&
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isIncreaseFontSize(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
-    code === 'Period' && shiftKey && !altKey && controlOrMeta(metaKey, ctrlKey)
+    code === 'Period' &&
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isDecreaseFontSize(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
-    code === 'Comma' && shiftKey && !altKey && controlOrMeta(metaKey, ctrlKey)
+    code === 'Comma' &&
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isClearFormatting(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
-  return (
-    code === 'Backslash' &&
-    !shiftKey &&
-    !altKey &&
-    controlOrMeta(metaKey, ctrlKey)
-  );
+  const {code} = event;
+  return code === 'Backslash' && isModifierMatch(event, CONTROL_OR_META);
 }
 
 export function isInsertLink(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
-  return (
-    code === 'KeyK' && !shiftKey && !altKey && controlOrMeta(metaKey, ctrlKey)
-  );
+  const {code} = event;
+  return code === 'KeyK' && isModifierMatch(event, CONTROL_OR_META);
 }
 
 export function isAddComment(event: KeyboardEvent): boolean {
-  const {code, shiftKey, altKey, metaKey, ctrlKey} = event;
+  const {code} = event;
   return (
-    code === 'KeyM' && !shiftKey && altKey && controlOrMeta(metaKey, ctrlKey)
+    code === 'KeyM' &&
+    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
   );
 }

--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -210,5 +210,11 @@ export const FOCUS_COMMAND: LexicalCommand<FocusEvent> =
   createCommand('FOCUS_COMMAND');
 export const BLUR_COMMAND: LexicalCommand<FocusEvent> =
   createCommand('BLUR_COMMAND');
+/**
+ * @deprecated in v0.31.0, use KEY_DOWN_COMMAND and check for modifiers
+ * directly.
+ *
+ * Dispatched after any KeyboardEvent when modifiers are pressed
+ */
 export const KEY_MODIFIER_COMMAND: LexicalCommand<KeyboardEvent> =
   createCommand('KEY_MODIFIER_COMMAND');


### PR DESCRIPTION
## Description

While reviewing #7443 it was discovered that we have this `KEY_MODIFIER_COMMAND` that is hard to use correctly and not particularly useful when `KEY_DOWN_COMMAND` can be used instead with a small check to verify that some modifier is pressed.

This PR deprecates this `KEY_MODIFIER_COMMAND` and refactors the playground's keyboard shortcuts to use the new `isModifierMatch` function in combination with `KEY_DOWN_COMMAND`.

## Test plan

Existing e2e tests for playground shortcuts continue to work