### PR TITLE
[lexical-markdown] Bug Fix: Add import support for backslash escape sequences

### DIFF
--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -581,6 +581,10 @@ describe('Markdown', () => {
       md: '**`Bold Code`**',
     },
     {
+      html: '<p><span style="white-space: pre-wrap;">This is a backslash: \\</span></p>',
+      md: 'This is a backslash: \\\\',
+    },
+    {
       html: '<p><span style="white-space: pre-wrap;">This is an asterisk: *</span></p>',
       md: 'This is an asterisk: \\*',
     },

--- a/packages/lexical-markdown/src/importTextTransformers.ts
+++ b/packages/lexical-markdown/src/importTextTransformers.ts
@@ -134,7 +134,7 @@ export function importTextTransformers(
   // Handle escape characters
   const textContent = textNode.getTextContent();
   const escapedText = textContent
-    .replace(/\\([*_`~])/g, '$1')
+    .replace(/\\([*_`~\\])/g, '$1')
     .replace(/&#(\d+);/g, (_, codePoint) => {
       return String.fromCodePoint(codePoint);
     });


### PR DESCRIPTION
## Description

Addresses markdown backslash escape sequence regression introduced by #7353. The escape sequence was exported but not correctly imported.

Closes #7473

## Test plan

Unit test coverage