### PR TITLE
[lexical-react] Feature: make check for entity boundary configurable in LexicalTypeaheadMenuPlugin

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -306,6 +306,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
     resolution,
     closeTypeahead,
     openTypeahead,
+    ignoreEntityBoundary,
   ]);
 
   useEffect(

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -200,6 +200,7 @@ export type TypeaheadMenuPluginProps<TOption extends MenuOption> = {
   commandPriority?: CommandListenerPriority;
   parent?: HTMLElement;
   preselectFirstItem?: boolean;
+  ignoreEntityBoundary?: boolean;
 };
 
 export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
@@ -214,6 +215,7 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
   commandPriority = COMMAND_PRIORITY_LOW,
   parent,
   preselectFirstItem = true,
+  ignoreEntityBoundary = false,
 }: TypeaheadMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
@@ -270,7 +272,8 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
 
         if (
           match !== null &&
-          !isSelectionOnEntityBoundary(editor, match.leadOffset)
+          (ignoreEntityBoundary ||
+            !isSelectionOnEntityBoundary(editor, match.leadOffset))
         ) {
           const isRangePositioned = tryToPositionRange(
             match.leadOffset,


### PR DESCRIPTION
## Description

### What is the current behavior that you are modifying?
LexicalTypeaheadMenuPlugin can only be triggered if there is no TextNode before trigger, i.e. whitespace or a paragraph and there is no way to configure this behaviour, i.e.
- @Bob@B - won't trigger menu

### What are the behavior or changes that are being added by this PR?
Make this behaviour configurable by ignoring element boundary check