### PR TITLE
[lexical-playground] Chore: Disable flaky "Can expand table to fit content when pasting table into table" in collab

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/ImageHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/ImageHTMLCopyAndPaste.spec.mjs
@@ -61,8 +61,12 @@ test.describe('HTML Image CopyAndPaste', () => {
     );
   });
 
-  test('Copy + paste + undo multiple image', async ({page, isPlainText}) => {
-    test.skip(isPlainText);
+  test('Copy + paste + undo multiple image', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
 
     await focusEditor(page);
 

--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -6245,7 +6245,7 @@ test.describe.parallel('Tables', () => {
     isPlainText,
     isCollab,
   }) => {
-    test.skip(isPlainText);
+    test.skip(isPlainText || isCollab);
     await initialize({isCollab, page});
     await focusEditor(page);
 


### PR DESCRIPTION
## Description

Disables a flaky "Can expand table to fit content when pasting table into table" test in collab. The functionality of this test is not particularly relevant to collab.

Also disables this test in collab:

```
[chromium] › packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/ImageHTMLCopyAndPaste.spec.mjs:64:3 › HTML Image CopyAndPaste › Copy + paste + undo multiple image 
```

## Test plan

### Before

Spurious test failures

### After

Fewer spurious test failures