### PR TITLE
[lexical] Chore: Revert Enter command to use inexact matching

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -926,11 +926,20 @@ export function isUnderline(event: KeyboardEventModifiers): boolean {
 }
 
 export function isParagraph(event: KeyboardEventModifiers): boolean {
-  return isExactShortcutMatch(event, 'Enter', {});
+  return isExactShortcutMatch(event, 'Enter', {
+    altKey: 'any',
+    ctrlKey: 'any',
+    metaKey: 'any',
+  });
 }
 
 export function isLineBreak(event: KeyboardEventModifiers): boolean {
-  return isExactShortcutMatch(event, 'Enter', {shiftKey: true});
+  return isExactShortcutMatch(event, 'Enter', {
+    altKey: 'any',
+    ctrlKey: 'any',
+    metaKey: 'any',
+    shiftKey: true,
+  });
 }
 
 // Inserts a new line after the selection
@@ -1043,10 +1052,6 @@ export function controlOrMeta(metaKey: boolean, ctrlKey: boolean): boolean {
     return metaKey;
   }
   return ctrlKey;
-}
-
-export function isReturn(event: KeyboardEventModifiers): boolean {
-  return event.key === 'Enter';
 }
 
 export function isBackspace(event: KeyboardEventModifiers): boolean {


### PR DESCRIPTION
## Description

#7443 modified built-in keyboard shortcuts (including Enter and Shift+Enter) to use exact modifier matching. Unfortunately internally we have a decent amount of plugins relying on the old inexact matching to handle the Enter key (with various modifiers), across both public and internal products. This PR reverts the triggering of `KEY_ENTER_COMMAND` to the state before #7443, to give us time to migrate our plugins to use `KEY_DOWN_COMMAND` instead (if we want to move ahead with exact-matching for the Enter command).

## Test plan

Existing tests