### PR TITLE
[lexical-playground] Chore: Skip flaky autolinks test in collab

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs
@@ -488,7 +488,7 @@ test.describe('Auto Links', () => {
     );
   });
 
-  test('Can convert URLs into links', async ({page, isPlainText}) => {
+  test('Can convert URLs into links', async ({page, isPlainText, isCollab}) => {
     const testUrls = [
       // Basic URLs
       'http://example.com', // Standard HTTP URL
@@ -540,7 +540,7 @@ test.describe('Auto Links', () => {
       'https://foo.bar', // HTTPS minimal URL with uncommon TLD
     ];
 
-    test.skip(isPlainText);
+    test.skip(isPlainText || isCollab);
     await focusEditor(page);
     await page.keyboard.type(testUrls.join(' ') + ' ');
 


### PR DESCRIPTION
## Description

Skips this test in collab as it seems flaky in that environment. Primarily this test seems to be testing the regex so it doesn't seem particularly valuable to verify the collab behavior

```
1 failed
[1]     [chromium] › packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs:491:3 › Auto Links › Can convert URLs into links 
```

## Test plan

Removes a test from running in collab