### PR TITLE
[lexical] Chore: Update KEY_ENTER_COMMAND API docs

### DIFF
--- a/packages/lexical/src/LexicalCommands.ts
+++ b/packages/lexical/src/LexicalCommands.ts
@@ -125,7 +125,8 @@ export const KEY_ARROW_DOWN_COMMAND: LexicalCommand<KeyboardEvent> =
   createCommand('KEY_ARROW_DOWN_COMMAND');
 /**
  * Dispatched when the enter key is pressed, may also be called with a null
- * payload when the intent is to insert a newline.
+ * payload when the intent is to insert a newline. The shift modifier key
+ * must be down, any other modifier keys may also be down.
  */
 export const KEY_ENTER_COMMAND: LexicalCommand<KeyboardEvent | null> =
   createCommand('KEY_ENTER_COMMAND');


### PR DESCRIPTION
## Description

Update KEY_ENTER_COMMAND API docs to reflect current semantics (as of #7479, and prior to #7443)

## Test plan

No runtime code changes