### PR TITLE
[lexical-react][lexical-yjs] Feature: Add cursor filters

### DIFF
--- a/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
@@ -17,11 +17,14 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
   Binding,
   createBinding,
+  type CursorFilter,
   ExcludedProperties,
   Provider,
+  syncCursorPositions,
+  SyncCursorPositionsFn,
 } from '@lexical/yjs';
 import {LexicalEditor} from 'lexical';
-import {useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 
 import {InitialEditorStateType} from './LexicalComposer';
 import {
@@ -46,6 +49,7 @@ type Props = {
   excludedProperties?: ExcludedProperties;
   // `awarenessData` parameter allows arbitrary data to be added to the awareness.
   awarenessData?: object;
+  cursorFilter?: CursorFilter;
 };
 
 export function CollaborationPlugin({
@@ -58,6 +62,7 @@ export function CollaborationPlugin({
   initialEditorState,
   excludedProperties,
   awarenessData,
+  cursorFilter,
 }: Props): JSX.Element {
   const isBindingInitialized = useRef(false);
   const isProviderInitialized = useRef(false);
@@ -145,6 +150,7 @@ export function CollaborationPlugin({
       setDoc={setDoc}
       shouldBootstrap={shouldBootstrap}
       yjsDocMap={yjsDocMap}
+      cursorFilter={cursorFilter}
     />
   );
 }
@@ -163,6 +169,7 @@ function YjsCollaborationCursors({
   collabContext,
   binding,
   setDoc,
+  cursorFilter,
 }: {
   editor: LexicalEditor;
   id: string;
@@ -177,7 +184,15 @@ function YjsCollaborationCursors({
   initialEditorState?: InitialEditorStateType | undefined;
   awarenessData?: object;
   collabContext: CollaborationContextType;
+  cursorFilter?: CursorFilter;
 }) {
+  const syncCursorPositionsFn: SyncCursorPositionsFn = useCallback(
+    (_binding, _provider) => {
+      syncCursorPositions(_binding, _provider, cursorFilter);
+    },
+    [cursorFilter],
+  );
+
   const cursors = useYjsCollaboration(
     editor,
     id,
@@ -188,6 +203,7 @@ function YjsCollaborationCursors({
     shouldBootstrap,
     binding,
     setDoc,
+    syncCursorPositionsFn,
     cursorsContainerRef,
     initialEditorState,
     awarenessData,

--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -16,7 +16,6 @@ import {
   createUndoManager,
   initLocalState,
   setLocalStateFocus,
-  syncCursorPositions,
   syncLexicalUpdateToYjs,
   syncYjsChangesToLexical,
   TOGGLE_CONNECT_COMMAND,
@@ -54,10 +53,10 @@ export function useYjsCollaboration(
   shouldBootstrap: boolean,
   binding: Binding,
   setDoc: React.Dispatch<React.SetStateAction<Doc | undefined>>,
+  syncCursorPositionsFn: SyncCursorPositionsFn,
   cursorsContainerRef?: CursorsContainerRef,
   initialEditorState?: InitialEditorStateType,
   awarenessData?: object,
-  syncCursorPositionsFn: SyncCursorPositionsFn = syncCursorPositions,
 ): JSX.Element {
   const isReloadingDoc = useRef(false);
 

--- a/packages/lexical-yjs/src/SyncCursors.ts
+++ b/packages/lexical-yjs/src/SyncCursors.ts
@@ -410,14 +410,18 @@ function getCollabNodeAndOffset(
   return [null, 0];
 }
 
+export type CursorFilter = (clientID: number, awareness: UserState) => boolean;
+
 export type SyncCursorPositionsFn = (
   binding: Binding,
   provider: Provider,
+  cursorFilter?: CursorFilter,
 ) => void;
 
 export function syncCursorPositions(
   binding: Binding,
   provider: Provider,
+  cursorFilter?: CursorFilter,
 ): void {
   const awarenessStates = Array.from(provider.awareness.getStates());
   const localClientID = binding.clientID;
@@ -429,8 +433,9 @@ export function syncCursorPositions(
   for (let i = 0; i < awarenessStates.length; i++) {
     const awarenessState = awarenessStates[i];
     const [clientID, awareness] = awarenessState;
+    const filtered = cursorFilter ? cursorFilter(clientID, awareness) : true;
 
-    if (clientID !== localClientID) {
+    if (clientID !== localClientID && filtered) {
       visitedClientIDs.add(clientID);
       const {name, color, focusing} = awareness;
       let selection = null;

--- a/packages/lexical-yjs/src/index.ts
+++ b/packages/lexical-yjs/src/index.ts
@@ -112,6 +112,7 @@ export function setLocalStateFocus(
   awareness.setLocalState(localState);
 }
 export {
+  type CursorFilter,
   getAnchorAndFocusCollabNodesForUserState,
   syncCursorPositions,
   type SyncCursorPositionsFn,


### PR DESCRIPTION
Added a new optional `cursorFilter` parameter to the `syncCursorPositions` function and exposed it as a `LexicalCollaborationPlugin`’s prop.

The function is defined as `(clientID: number, awareness: UserState) => boolean` and is useful for hiding cursors without impacting awareness data.

## Motivation

Let’s consider an editor with 3 active presences:
- User A
- User B
- User B, in another tab (or side-by-side window)

So we have 3 different client IDs, and each user can see up to two cursors. It’s not necessarily a problem that User B can see the cursor state from the other tab/window, but it can cause issues when you start to consider refreshes and failures of the provider to push the new awareness state when the tab is closed. In the worst case, you have to wait for the timeout to see the old cursors get “garbage collected,” and during this time, a new cursor can appear with each refresh (which will still be automatically deleted after, say, 30 seconds).

In the attached video, I show this scenario with a custom provider that doesn’t include the listener recommended by Yjs
```ts
window.addEventListener('beforeunload', () => {
  awarenessProtocol.removeAwarenessStates(
    this.awareness, [doc.clientID], 'window unload'
  )
})
```

We can easily solve this problem by hiding, only for User B, the cursor from the other tab. Hence the `cursorFilter` addition.


https://github.com/user-attachments/assets/1ba0aa93-dec0-49f3-94d7-35589427f8fc