### PR TITLE
[lexical-react][lexical-table] Bug Fix: Re-render tables when the hasHorizontalScroll setting is changed

### DIFF
--- a/packages/lexical-react/src/LexicalTablePlugin.ts
+++ b/packages/lexical-react/src/LexicalTablePlugin.ts
@@ -10,11 +10,13 @@ import type {JSX} from 'react';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
+  $isScrollableTablesActive,
   registerTableCellUnmergeTransform,
   registerTablePlugin,
   registerTableSelectionObserver,
   setScrollableTablesActive,
   TableCellNode,
+  TableNode,
 } from '@lexical/table';
 import {useEffect} from 'react';
 
@@ -53,7 +55,13 @@ export function TablePlugin({
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    setScrollableTablesActive(editor, hasHorizontalScroll);
+    const hadHorizontalScroll = $isScrollableTablesActive(editor);
+    if (hadHorizontalScroll !== hasHorizontalScroll) {
+      setScrollableTablesActive(editor, hasHorizontalScroll);
+      // Registering the transform has the side-effect of marking all existing
+      // TableNodes as dirty. The handler is immediately unregistered.
+      editor.registerNodeTransform(TableNode, () => {})();
+    }
   }, [editor, hasHorizontalScroll]);
 
   useEffect(() => registerTablePlugin(editor), [editor]);

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -337,11 +337,15 @@ export class TableNode extends ElementNode {
   }
 
   updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
-    const tableElement = this.getDOMSlot(dom).element;
+    const slot = this.getDOMSlot(dom);
+    const tableElement = slot.element;
+    if ((dom === tableElement) === $isScrollableTablesActive()) {
+      return true;
+    }
     if (isHTMLDivElement(dom)) {
       this.updateTableWrapper(prevNode, dom, tableElement, config);
     }
-    this.updateTableElement(prevNode, this.getDOMSlot(dom).element, config);
+    this.updateTableElement(prevNode, tableElement, config);
     return false;
   }
 

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -1822,12 +1822,6 @@ describe('LexicalTableNode tests', () => {
   });
 
   describe(`hasHorizontalScroll false -> true`, () => {
-    // function expectTableHtmlToBeEqual(actual: string, expected: string): void {
-    //   return expectHtmlToBeEqual(
-    //     actual,
-    //     hasHorizontalScroll ? wrapTableHtml(expected) : expected,
-    //   );
-    // }
     let hasHorizontalScroll = false;
     let setHasHorizontalScroll: (
       _hasHorizontalScroll: boolean,
@@ -1907,6 +1901,39 @@ describe('LexicalTableNode tests', () => {
                   </tr>
                 </table>
               </div>
+            `,
+          );
+          act(() => {
+            expect(testEnv.editor.read($isScrollableTablesActive)).toBe(true);
+            setHasHorizontalScroll(false);
+          });
+          await Promise.resolve().then();
+          expect(testEnv.editor.read($isScrollableTablesActive)).toBe(false);
+          expectHtmlToBeEqual(
+            testEnv.innerHTML,
+            html`
+              <table class="test-table-class">
+                <colgroup>
+                  <col />
+                  <col />
+                </colgroup>
+                <tr>
+                  <th>
+                    <p><br /></p>
+                  </th>
+                  <th>
+                    <p><br /></p>
+                  </th>
+                </tr>
+                <tr>
+                  <th>
+                    <p><br /></p>
+                  </th>
+                  <td>
+                    <p><br /></p>
+                  </td>
+                </tr>
+              </table>
             `,
           );
         });


### PR DESCRIPTION
## Description

When the `TablePlugin` initializes its `setScrollableTablesActive` effect after the editor has already rendered some tables there may be a mismatch. This change forces all existing tables to re-render when a change in `hasHorizontalScroll` is detected. In order to perform this update efficiently it marks table nodes as dirty by temporarily registering a no-op transform on TableNode, and its updateDOM implementation was changed to detect when the presence of a wrapper does not match the `$isScrollableTablesActive` setting.

Closes #7445

## Test plan

Unit test coverage