### PR TITLE
[lexical-table] Bug Fix: Add missing DOM import for TableNode frozen rows and columns

### DIFF
--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -610,10 +610,20 @@ export function $getElementForTableNode(
 export function $convertTableElement(
   domNode: HTMLElement,
 ): DOMConversionOutput {
-  const tableNode = $createTableNode();
+  const tableNode = $createTableNode(); // VADIM: no access to domNode here, and we want to set frozen things from domNode
   if (domNode.hasAttribute('data-lexical-row-striping')) {
     tableNode.setRowStriping(true);
   }
+  const frozenColumnCount = domNode.getAttribute('data-lexical-frozen-column');
+  if (frozenColumnCount) {
+    tableNode.setFrozenColumns(Number(frozenColumnCount));
+  }
+  const frozenRowCount = domNode.getAttribute('data-lexical-frozen-row');
+  if (frozenRowCount) {
+    tableNode.setFrozenRows(Number(frozenRowCount));
+  }
+  console.log('TableNode: frozenColumnCount', frozenColumnCount);
+  console.log('TableNode: frozenRowCount', frozenRowCount);
   const colGroup = domNode.querySelector(':scope > colgroup');
   if (colGroup) {
     let columns: number[] | undefined = [];

--- a/packages/lexical-table/src/LexicalTableNode.ts
+++ b/packages/lexical-table/src/LexicalTableNode.ts
@@ -610,20 +610,16 @@ export function $getElementForTableNode(
 export function $convertTableElement(
   domNode: HTMLElement,
 ): DOMConversionOutput {
-  const tableNode = $createTableNode(); // VADIM: no access to domNode here, and we want to set frozen things from domNode
+  const tableNode = $createTableNode();
   if (domNode.hasAttribute('data-lexical-row-striping')) {
     tableNode.setRowStriping(true);
   }
-  const frozenColumnCount = domNode.getAttribute('data-lexical-frozen-column');
-  if (frozenColumnCount) {
-    tableNode.setFrozenColumns(Number(frozenColumnCount));
+  if (domNode.hasAttribute('data-lexical-frozen-column')) {
+    tableNode.setFrozenColumns(1);
   }
-  const frozenRowCount = domNode.getAttribute('data-lexical-frozen-row');
-  if (frozenRowCount) {
-    tableNode.setFrozenRows(Number(frozenRowCount));
+  if (domNode.hasAttribute('data-lexical-frozen-row')) {
+    tableNode.setFrozenRows(1);
   }
-  console.log('TableNode: frozenColumnCount', frozenColumnCount);
-  console.log('TableNode: frozenRowCount', frozenRowCount);
   const colGroup = domNode.querySelector(':scope > colgroup');
   if (colGroup) {
     let columns: number[] | undefined = [];


### PR DESCRIPTION
## Description
Currently the table node does not set frozen columns and frozen rows on conversion. Since a replacement `TableNode` has no access to the `domNode` in `$convertTableElement`, only row striping is correctly set on the node. 