### PR TITLE
[lexical-markdown] Bug Fix: Link Transformer URL Protocol Handling

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -37,6 +37,8 @@ import {
   TextNode,
 } from 'lexical';
 
+import {formatUrl} from './utils';
+
 export type Transformer =
   | ElementTransformer
   | MultilineElementTransformer
@@ -559,7 +561,8 @@ export const LINK: TextMatchTransformer = {
     /(?:\[([^[]+)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))$/,
   replace: (textNode, match) => {
     const [, linkText, linkUrl, linkTitle] = match;
-    const linkNode = $createLinkNode(linkUrl, {title: linkTitle});
+    const formattedUrl = formatUrl(linkUrl);
+    const linkNode = $createLinkNode(formattedUrl, {title: linkTitle});
     const linkTextNode = $createTextNode(linkText);
     linkTextNode.setFormat(textNode.getFormat());
     linkNode.append(linkTextNode);

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -27,6 +27,7 @@ import {
   MultilineElementTransformer,
   normalizeMarkdown,
 } from '../../MarkdownTransformers';
+import {formatUrl} from '../../utils';
 
 const SIMPLE_INLINE_JSX_MATCHER: TextMatchTransformer = {
   dependencies: [LinkNode],
@@ -886,5 +887,41 @@ E3
 | c | d |
 `;
     expect(normalizeMarkdown(markdown, false)).toBe(markdown);
+  });
+});
+
+describe('formatUrl', () => {
+  it('should not modify URLs with protocols', () => {
+    expect(formatUrl('https://example.com')).toBe('https://example.com');
+    expect(formatUrl('http://example.com')).toBe('http://example.com');
+    expect(formatUrl('mailto:user@example.com')).toBe(
+      'mailto:user@example.com',
+    );
+    expect(formatUrl('tel:+1234567890')).toBe('tel:+1234567890');
+  });
+
+  it('should not modify relative paths', () => {
+    expect(formatUrl('/path/to/resource')).toBe('/path/to/resource');
+    expect(formatUrl('/index.html')).toBe('/index.html');
+  });
+
+  it('should add mailto: to email addresses', () => {
+    expect(formatUrl('user@example.com')).toBe('mailto:user@example.com');
+    expect(formatUrl('name.lastname@domain.co.uk')).toBe(
+      'mailto:name.lastname@domain.co.uk',
+    );
+  });
+
+  it('should add tel: to phone numbers', () => {
+    expect(formatUrl('+1234567890')).toBe('tel:+1234567890');
+    expect(formatUrl('123-456-7890')).toBe('tel:123-456-7890');
+  });
+
+  it('should add https:// to URLs without protocols', () => {
+    expect(formatUrl('www.example.com')).toBe('https://www.example.com');
+    expect(formatUrl('example.com')).toBe('https://example.com');
+    expect(formatUrl('subdomain.example.com/path')).toBe(
+      'https://subdomain.example.com/path',
+    );
   });
 });

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -460,3 +460,43 @@ export function isEmptyParagraph(node: LexicalNode): boolean {
       MARKDOWN_EMPTY_LINE_REG_EXP.test(firstChild.getTextContent()))
   );
 }
+
+// URL validation patterns
+export const EMAIL_REGEX =
+  /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
+
+export const PHONE_NUMBER_REGEX = /^\+?[0-9\s()-]{5,}$/;
+
+/**
+ * Formats a URL string by adding appropriate protocol if missing
+ *
+ * @param url - URL to format
+ * @returns Formatted URL with appropriate protocol
+ */
+export function formatUrl(url: string): string {
+  // Check if URL already has a protocol
+  if (url.match(/^[a-z]+:/i)) {
+    // URL already has a protocol, leave it as is
+    return url;
+  }
+  // Check if it's a relative path
+  else if (url.startsWith('/')) {
+    // Relative path, leave it as is
+    return url;
+  }
+  // Check for email address
+  else if (EMAIL_REGEX.test(url)) {
+    return `mailto:${url}`;
+  }
+  // Check for phone number
+  else if (PHONE_NUMBER_REGEX.test(url)) {
+    return `tel:${url}`;
+  }
+  // For everything else that looks like a URL (starting with www. or containing dots)
+  else if (/^www\.|(\.[a-z]{2,})/i.test(url)) {
+    return `https://${url}`;
+  }
+
+  // If nothing matches, return the original URL
+  return url;
+}

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -476,18 +476,13 @@ export function formatUrl(url: string): string {
     return url;
   }
   // Check if it's a relative path (starting with '/', '.', or '#')
-  else if (url.startsWith('/') || url.startsWith('.') || url.startsWith('#')) {
+  else if (url.match(/^[/#.]/)) {
     // Relative path, leave it as is
     return url;
   }
 
-  // Check for email address - ensure it has exactly one '@' with non-empty username and domain portions
-  else if (
-    url.includes('@') &&
-    url.split('@').length === 2 &&
-    url.split('@')[0].length > 0 &&
-    url.split('@')[1].length > 0
-  ) {
+  // Check for email address
+  else if (url.includes('@')) {
     return `mailto:${url}`;
   }
 
@@ -495,11 +490,7 @@ export function formatUrl(url: string): string {
   else if (PHONE_NUMBER_REGEX.test(url)) {
     return `tel:${url}`;
   }
-  // For everything else that looks like a URL (starting with www. or containing dots)
-  else if (/^www\.|(\.[a-z]{2,})/i.test(url)) {
-    return `https://${url}`;
-  }
 
-  // If nothing matches, return the original URL
-  return url;
+  // For everything else, return with https:// prefix
+  return `https://${url}`;
 }

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -481,8 +481,13 @@ export function formatUrl(url: string): string {
     return url;
   }
 
-  // Check for email address
-  else if (url.includes('@')) {
+  // Check for email address - ensure it has exactly one '@' with non-empty username and domain portions
+  else if (
+    url.includes('@') &&
+    url.split('@').length === 2 &&
+    url.split('@')[0].length > 0 &&
+    url.split('@')[1].length > 0
+  ) {
     return `mailto:${url}`;
   }
 

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -461,10 +461,6 @@ export function isEmptyParagraph(node: LexicalNode): boolean {
   );
 }
 
-// URL validation patterns
-export const EMAIL_REGEX =
-  /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
-
 export const PHONE_NUMBER_REGEX = /^\+?[0-9\s()-]{5,}$/;
 
 /**
@@ -475,19 +471,21 @@ export const PHONE_NUMBER_REGEX = /^\+?[0-9\s()-]{5,}$/;
  */
 export function formatUrl(url: string): string {
   // Check if URL already has a protocol
-  if (url.match(/^[a-z]+:/i)) {
+  if (url.match(/^[a-z][a-z0-9+.-]*:/i)) {
     // URL already has a protocol, leave it as is
     return url;
   }
-  // Check if it's a relative path
-  else if (url.startsWith('/')) {
+  // Check if it's a relative path (starting with '/', '.', or '#')
+  else if (url.startsWith('/') || url.startsWith('.') || url.startsWith('#')) {
     // Relative path, leave it as is
     return url;
   }
+
   // Check for email address
-  else if (EMAIL_REGEX.test(url)) {
+  else if (url.includes('@')) {
     return `mailto:${url}`;
   }
+
   // Check for phone number
   else if (PHONE_NUMBER_REGEX.test(url)) {
     return `tel:${url}`;


### PR DESCRIPTION
## Description

Currently, when creating links without protocols (like `[youtube](www.youtube.com)`) using the Link transformer, they're treated as relative paths instead of external URLs. This causes links to navigate to incorrect destinations (e.g., https://playground.lexical.dev/www.youtube.com instead of https://www.youtube.com).

This PR:
1. Adds URL handling utility functions to detect and format different types of URLs
2. Updates the LINK transformer to use these utilities
3. Adds tests to ensure the behavior works correctly

The fix improves the user experience for content creators by:
- Adding https:// to common URLs without protocols
- Adding mailto: to email addresses
- Adding tel: to phone numbers
- Preserving relative URLs


Closes #7497

## Test plan

### Before
When clicking a link created as `[YouTube](www.youtube.com)`, the browser navigates to a relative URL like `https://playground.lexical.dev/www.youtube.com` instead of `https://www.youtube.com`.




https://github.com/user-attachments/assets/f2361acd-901c-4d53-b32f-57731f29ce73



### After
When clicking a link created as `[YouTube](www.youtube.com)`, the browser correctly navigates to `https://www.youtube.com`.



https://github.com/user-attachments/assets/054ab3ac-2c47-4689-ab0e-8ddac6d26554




