### PR TITLE
[lexical-list] Bug Fix: Inherit marker styles when indenting list items

### DIFF
--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
@@ -25,6 +25,7 @@ import {
   ListItemNode,
   ListNode,
 } from '../..';
+import {$handleIndent} from '../../formatList';
 
 const editorConfig = Object.freeze({
   namespace: '',
@@ -1512,6 +1513,33 @@ describe('LexicalListItemNode tests', () => {
             </div>
           `,
         );
+      });
+    });
+
+    test('ListItemNode marker style inheritance on indent', async () => {
+      const {editor} = testEnv;
+
+      await editor.update(() => {
+        const root = $getRoot();
+        const listNode = $createListNode('bullet');
+        const listItem1 = $createListItemNode();
+        const listItem2 = $createListItemNode();
+
+        // Set marker style on listItem2
+        listItem2.__textStyle = 'font-size: 19px;';
+
+        listNode.append(listItem1, listItem2);
+        root.append(listNode);
+
+        // Indent listItem2
+        $handleIndent(listItem2);
+
+        // Get the parent list item after indent
+        const parentListItem = listItem2.getParentOrThrow().getParentOrThrow();
+        expect($isListItemNode(parentListItem)).toBe(true);
+
+        // Check if marker style was inherited
+        expect(parentListItem.__textStyle).toBe('font-size: 19px;');
       });
     });
   });

--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
@@ -1526,7 +1526,7 @@ describe('LexicalListItemNode tests', () => {
         const listItem2 = $createListItemNode();
 
         // Set marker style on listItem2
-        listItem2.__textStyle = 'font-size: 19px;';
+        listItem2.setTextStyle('font-size: 19px;');
 
         listNode.append(listItem1, listItem2);
         root.append(listNode);
@@ -1539,7 +1539,7 @@ describe('LexicalListItemNode tests', () => {
         expect($isListItemNode(parentListItem)).toBe(true);
 
         // Check if marker style was inherited
-        expect(parentListItem.__textStyle).toBe('font-size: 19px;');
+        expect(parentListItem.getTextStyle()).toBe('font-size: 19px;');
       });
     });
   });

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -400,6 +400,8 @@ export function $handleIndent(listItemNode: ListItemNode): void {
       const newListItem = $createListItemNode()
         .setTextFormat(parent.getTextFormat())
         .setTextStyle(parent.getTextStyle());
+      // Copy the text style from the list item being indented to preserve marker styles
+      newListItem.__textStyle = listItemNode.__textStyle;
       const newList = $createListNode(parent.getListType())
         .setTextFormat(parent.getTextFormat())
         .setTextStyle(parent.getTextStyle());

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -398,10 +398,8 @@ export function $handleIndent(listItemNode: ListItemNode): void {
 
     if ($isListNode(parent)) {
       const newListItem = $createListItemNode()
-        .setTextFormat(parent.getTextFormat())
-        .setTextStyle(parent.getTextStyle());
-      // Copy the text style from the list item being indented to preserve marker styles
-      newListItem.setTextStyle(listItemNode.getTextStyle());
+        .setTextFormat(listItemNode.getTextFormat())
+        .setTextStyle(listItemNode.getTextStyle());
       const newList = $createListNode(parent.getListType())
         .setTextFormat(parent.getTextFormat())
         .setTextStyle(parent.getTextStyle());

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -401,7 +401,7 @@ export function $handleIndent(listItemNode: ListItemNode): void {
         .setTextFormat(parent.getTextFormat())
         .setTextStyle(parent.getTextStyle());
       // Copy the text style from the list item being indented to preserve marker styles
-      newListItem.__textStyle = listItemNode.__textStyle;
+      newListItem.setTextStyle(listItemNode.getTextStyle());
       const newList = $createListNode(parent.getListType())
         .setTextFormat(parent.getTextFormat())
         .setTextStyle(parent.getTextStyle());


### PR DESCRIPTION
## Description
### Current Behavior:
Currently, when a list item with marker styles (like `--listitem-marker-font-size`) is indented, the parent list item that gets created does not inherit these styles. This causes inconsistent marker styling when indenting list items.

### Changes in this PR:
1. Modified `$handleIndent` in `formatList.ts` to copy the text style from the list item being indented to the newly created parent list item
2. Added unit tests to verify the marker style inheritance behavior

Closes #7491

## Test plan

### Before

![lexical-bug-7491](https://github.com/user-attachments/assets/11721cbd-89ea-44ad-8bed-b4ff85f37dab)

When a list item with custom marker styles is indented, the parent list item loses those styles:
```html
<li><!-- Parent loses the marker style -->
  <ul>
    <li style="--listitem-marker-font-size: 60px;">Child item</li>
  </ul>
</li>
```

### After

https://github.com/user-attachments/assets/2ce40bd5-4eb4-4807-a5be-252a0688d958

The parent list item now inherits the marker styles when a child is indented:
```html
<li style="--listitem-marker-font-size: 60px;">
  <ul>
    <li style="--listitem-marker-font-size: 60px;">Child item</li>
  </ul>
</li>
```