### PR TITLE
[7507] capitalize shortcut not working in macos fix

### DIFF
--- a/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
+++ b/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
@@ -297,9 +297,15 @@ export async function toggleUppercase(page) {
 
 export async function toggleCapitalize(page) {
   await keyDownCtrlOrMeta(page);
+  if (IS_MAC) {
+    await page.keyboard.down('Alt');
+  }
   await page.keyboard.down('Shift');
   await page.keyboard.press('3');
   await keyUpCtrlOrMeta(page);
+  if (IS_MAC) {
+    await page.keyboard.up('Alt');
+  }
   await page.keyboard.up('Shift');
 }
 

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -779,13 +779,13 @@ i.page-break,
   background-color: #fff;
   border-radius: 8px;
   border: 0;
-  max-width: 250px;
+  max-width: 264px;
   min-width: 100px;
 }
 
 .dropdown .item.wide {
   align-items: center;
-  width: 248px;
+  width: 260px;
 }
 
 .dropdown .item.wide .icon-text-container {

--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
@@ -31,7 +31,7 @@ export const SHORTCUTS = Object.freeze({
   STRIKETHROUGH: IS_APPLE ? '⌘+Shift+S' : 'Ctrl+Shift+S',
   LOWERCASE: IS_APPLE ? '⌘+Shift+1' : 'Ctrl+Shift+1',
   UPPERCASE: IS_APPLE ? '⌘+Shift+2' : 'Ctrl+Shift+2',
-  CAPITALIZE: IS_APPLE ? '⌘+Shift+3' : 'Ctrl+Shift+3',
+  CAPITALIZE: IS_APPLE ? '⌘+Shift+Opt+3' : 'Ctrl+Shift+3',
   CENTER_ALIGN: IS_APPLE ? '⌘+Shift+E' : 'Ctrl+Shift+E',
   JUSTIFY_ALIGN: IS_APPLE ? '⌘+Shift+J' : 'Ctrl+Shift+J',
   LEFT_ALIGN: IS_APPLE ? '⌘+Shift+L' : 'Ctrl+Shift+L',
@@ -132,7 +132,11 @@ export function isCapitalize(event: KeyboardEvent): boolean {
   const {code} = event;
   return (
     (code === 'Numpad3' || code === 'Digit3') &&
-    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
+    isModifierMatch(event, {
+      ...CONTROL_OR_META,
+      shiftKey: true,
+      altKey: IS_APPLE,
+    })
   );
 }
 


### PR DESCRIPTION

<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
For macOs, modified shortcut to `⌘+Opt+Shift+3` instead of `⌘+Shift+3`

Closes #7507 


### Before

https://github.com/user-attachments/assets/c6fb6e64-a322-4181-802c-0591c677d353


### After

https://github.com/user-attachments/assets/1cd9e86f-01a5-4761-93b6-aecc86685e7e


