### PR TITLE
[lexical-playground] [lexical-richtext] BugFix Deleting Last Character of Link Inside Brackets Reduces Indentation Level

### DIFF
--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -876,6 +876,10 @@ export function registerRichText(editor: LexicalEditor): () => void {
             anchor.offset === 0 &&
             !$isRootNode(anchorNode)
           ) {
+            const prevNode = anchorNode.getPreviousSibling();
+            if (prevNode && prevNode.__type === 'link') {
+              return false;
+            }
             const element = $getNearestBlockElementAncestorOrThrow(anchorNode);
             if (element.getIndent() > 0) {
               event.preventDefault();


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

This PR addresses an edge case where deleting a character at the end of a link text incorrectly removes the indent. To resolve this issue, we've added a check to verify if the node preceding the cursor is a link. If it is, we skip the OUTDENT_CONTENT_COMMAND, ensuring that the indent remains intact.

Closes https://github.com/facebook/lexical/issues/7514

## Test plan

### Before

https://github.com/user-attachments/assets/442f0bc9-77f2-4db0-a78e-94482d36a6a7

### After

https://github.com/user-attachments/assets/4891d477-f2ff-4c7c-8439-2a0cf22671b2
