### PR TITLE
[lexical-rich-text] Bug Fix: Backspace should only dedent at first descendant of indented block

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -32,6 +32,7 @@ import {
   focusEditor,
   html,
   initialize,
+  insertSampleImage,
   pasteFromClipboard,
   repeat,
   selectFromAlignDropdown,
@@ -161,6 +162,74 @@ test.describe.parallel('Nested List', () => {
     await assertHTML(
       page,
       '<ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true">Hello</span></li><li value="2" class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"><ul class="PlaygroundEditorTheme__ul"><li value="1" class="PlaygroundEditorTheme__listItem"><br></li></ul></li></ul>',
+    );
+  });
+
+  test('Should outdent if indented when the backspace key is pressed only at the front', async ({
+    page,
+  }) => {
+    // repro for #7514
+    await focusEditor(page);
+    await toggleBulletList(page);
+
+    await insertSampleImage(page);
+    await page.keyboard.type('x');
+    await moveLeft(page, 1);
+
+    await clickIndentButton(page, 1);
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"
+            value="1">
+            <ul class="PlaygroundEditorTheme__ul">
+              <li
+                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                value="1">
+                <span
+                  class="editor-image"
+                  contenteditable="false"
+                  data-lexical-decorator="true">
+                  <div draggable="false">
+                    <img
+                      alt="Yellow flower in tilt shift lens"
+                      draggable="false"
+                      src="/src/images/yellow-flower.jpg"
+                      style="height: inherit; max-width: 500px; width: inherit" />
+                  </div>
+                </span>
+                <span data-lexical-text="true">x</span>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      `,
+    );
+
+    await page.keyboard.press('Backspace');
+
+    await assertHTML(
+      page,
+      html`
+        <ul class="PlaygroundEditorTheme__ul">
+          <li
+            class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__nestedListItem"
+            value="1">
+            <ul class="PlaygroundEditorTheme__ul">
+              <li
+                class="PlaygroundEditorTheme__listItem PlaygroundEditorTheme__ltr"
+                dir="ltr"
+                value="1">
+                <span data-lexical-text="true">x</span>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      `,
     );
   });
 

--- a/packages/lexical-playground/__tests__/e2e/List.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/List.spec.mjs
@@ -35,6 +35,7 @@ import {
   insertSampleImage,
   pasteFromClipboard,
   repeat,
+  SAMPLE_IMAGE_URL,
   selectFromAlignDropdown,
   selectFromColorPicker,
   selectFromFormatDropdown,
@@ -198,7 +199,7 @@ test.describe.parallel('Nested List', () => {
                     <img
                       alt="Yellow flower in tilt shift lens"
                       draggable="false"
-                      src="/src/images/yellow-flower.jpg"
+                      src="${SAMPLE_IMAGE_URL}"
                       style="height: inherit; max-width: 500px; width: inherit" />
                   </div>
                 </span>

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -549,6 +549,27 @@ function $isSelectionAtEndOfRoot(selection: RangeSelection) {
   return focus.key === 'root' && focus.offset === $getRoot().getChildrenSize();
 }
 
+function $isSelectionCollapsedAtFrontOfIndentedBlock(
+  selection: RangeSelection,
+): boolean {
+  if (!selection.isCollapsed()) {
+    return false;
+  }
+  const {anchor} = selection;
+  if (anchor.offset !== 0) {
+    return false;
+  }
+  const anchorNode = anchor.getNode();
+  if ($isRootNode(anchorNode)) {
+    return false;
+  }
+  const element = $getNearestBlockElementAncestorOrThrow(anchorNode);
+  return (
+    element.getIndent() > 0 &&
+    (element.is(anchorNode) || anchorNode.is(element.getFirstDescendant()))
+  );
+}
+
 /**
  * Resets the capitalization of the selection to default.
  * Called when the user presses space, tab, or enter key.
@@ -868,21 +889,10 @@ export function registerRichText(editor: LexicalEditor): () => void {
         }
         const selection = $getSelection();
         if ($isRangeSelection(selection)) {
-          const {anchor} = selection;
-          const anchorNode = anchor.getNode();
-
-          if (
-            selection.isCollapsed() &&
-            anchor.offset === 0 &&
-            !$isRootNode(anchorNode)
-          ) {
-            const element = $getNearestBlockElementAncestorOrThrow(anchorNode);
-            if (element.getIndent() > 0) {
-              event.preventDefault();
-              return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
-            }
+          if ($isSelectionCollapsedAtFrontOfIndentedBlock(selection)) {
+            event.preventDefault();
+            return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
           }
-
           // Exception handling for iOS native behavior instead of Lexical's behavior when using Korean on iOS devices.
           // more details - https://github.com/facebook/lexical/issues/5841
           if (IS_IOS && navigator.language === 'ko-KR') {


### PR DESCRIPTION
## Description

The dedent-on-backspace heuristic in lexical-rich-text only checked if the selection was collapsed at the start of a node in an indented block, so it could trigger in situations where the selection was nested anywhere in an indented block. The intent is that this behavior should only happen at the first caret position in the block, so now it checks that the selection is at the first descendant of the block.

Closes #7515
Closes #7514

## Test plan

e2e test to confirm that dedent does not happen if the selection is at the beginning of a TextNode that occurs after a DecoratorNode in an indented list. All other e2e tests should pass.
