### PR TITLE
[lexical-react][lexical-playground] Bug Fix: Make typeahead punctuation configurable; allow underscores and dashes in emoji queries 

### DIFF
--- a/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/EmojiPickerPlugin/index.tsx
@@ -112,6 +112,7 @@ export default function EmojiPickerPlugin() {
 
   const checkForTriggerMatch = useBasicTypeaheadTriggerMatch(':', {
     minLength: 0,
+    punctuation: '\\.,\\+\\*\\?\\$\\@\\|#{}\\(\\)\\^\\[\\]\\\\/!%\'"~=<>:;', // allow _ and -
   });
 
   const options: Array<EmojiOption> = useMemo(() => {

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -35,7 +35,7 @@ import {startTransition} from 'shared/reactPatches';
 import {LexicalMenu, MenuOption, useMenuAnchorRef} from './shared/LexicalMenu';
 
 export const PUNCTUATION =
-  '\\.,\\+\\*\\?\\$\\@\\|#{}\\(\\)\\^\\-\\[\\]\\\\/!%\'"~=<>_:;';
+  '\\.,\\+\\*\\?\\$\\@\\|#{}\\(\\)\\^\\[\\]\\\\/!%\'"~=<>:;';
 
 function getTextUpToAnchor(selection: RangeSelection): string | null {
   const anchor = selection.anchor;

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -35,7 +35,7 @@ import {startTransition} from 'shared/reactPatches';
 import {LexicalMenu, MenuOption, useMenuAnchorRef} from './shared/LexicalMenu';
 
 export const PUNCTUATION =
-  '\\.,\\+\\*\\?\\$\\@\\|#{}\\(\\)\\^\\[\\]\\\\/!%\'"~=<>:;';
+  '\\.,\\+\\*\\?\\$\\@\\|#{}\\(\\)\\^\\-\\[\\]\\\\/!%\'"~=<>_:;';
 
 function getTextUpToAnchor(selection: RangeSelection): string | null {
   const anchor = selection.anchor;
@@ -148,11 +148,15 @@ export const SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND: LexicalCommand<{
 
 export function useBasicTypeaheadTriggerMatch(
   trigger: string,
-  {minLength = 1, maxLength = 75}: {minLength?: number; maxLength?: number},
+  {
+    minLength = 1,
+    maxLength = 75,
+    punctuation = PUNCTUATION,
+  }: {minLength?: number; maxLength?: number; punctuation?: string},
 ): TriggerFn {
   return useCallback(
     (text: string) => {
-      const validChars = '[^' + trigger + PUNCTUATION + '\\s]';
+      const validChars = '[^' + trigger + punctuation + '\\s]';
       const TypeaheadTriggerRegex = new RegExp(
         '(^|\\s|\\()(' +
           '[' +
@@ -179,7 +183,7 @@ export function useBasicTypeaheadTriggerMatch(
       }
       return null;
     },
-    [maxLength, minLength, trigger],
+    [maxLength, minLength, trigger, punctuation],
   );
 }
 


### PR DESCRIPTION
## Description
### Current behavior:
The typeahead menu does not recognize queries containing underscores (`_`) or dashes (`-`). For example, typing `:man_beard` or `:t-rex` does not trigger the typeahead menu as expected.

### Change introduced:  
This PR makes the punctuation set for typeahead queries configurable via an optional parameter in `useBasicTypeaheadTriggerMatch`.

- The default punctuation set is restored for backwards compatibility.
- The emoji plugin now passes a custom punctuation set, allowing underscores and dashes in emoji queries.

This enables the typeahead menu to correctly match and display suggestions for queries like `:man_beard` and `:t-rex` in the emoji picker, without affecting other typeahead usages.

Closes #7519

## Test plan

### Before

https://github.com/user-attachments/assets/69979fde-8946-4aa0-b529-91000429490e

### After

![image](https://github.com/user-attachments/assets/7a353604-8fa2-469a-98c8-fa5886553ede)

![image](https://github.com/user-attachments/assets/7d6a0130-2c90-4307-b15e-0ab2abf8d436)
