### PR TITLE
[lexical-devtools] Bug Fix: Update devtools vite config for process.env.LEXICAL_VERSION

### DIFF
--- a/packages/lexical-devtools/wxt.config.ts
+++ b/packages/lexical-devtools/wxt.config.ts
@@ -8,7 +8,6 @@
 import type {Alias} from 'vite';
 
 import babel from '@rollup/plugin-babel';
-import replace from '@rollup/plugin-replace';
 import react from '@vitejs/plugin-react';
 import fs from 'fs';
 import * as path from 'path';
@@ -111,6 +110,12 @@ export default defineConfig({
     );
 
     return {
+      define: {
+        __DEV__: !isProd,
+        'process.env.LEXICAL_VERSION': JSON.stringify(
+          `${version}+${isProd ? 'prod' : 'dev'}.devtools`,
+        ),
+      },
       plugins: [
         babel({
           babelHelpers: 'bundled',
@@ -128,16 +133,6 @@ export default defineConfig({
             ],
           ],
           presets: [['@babel/preset-react', {runtime: 'automatic'}]],
-        }),
-        replace({
-          delimiters: ['', ''],
-          preventAssignment: true,
-          values: {
-            __DEV__: isProd ? 'false' : 'true',
-            'process.env.LEXICAL_VERSION': JSON.stringify(
-              `${version}+${isProd ? 'prod' : 'dev'}.devtools`,
-            ),
-          },
         }),
         react(),
       ],

--- a/packages/lexical-devtools/wxt.config.ts
+++ b/packages/lexical-devtools/wxt.config.ts
@@ -8,6 +8,7 @@
 import type {Alias} from 'vite';
 
 import babel from '@rollup/plugin-babel';
+import replace from '@rollup/plugin-replace';
 import react from '@vitejs/plugin-react';
 import fs from 'fs';
 import * as path from 'path';
@@ -101,45 +102,61 @@ export default defineConfig({
     ],
   },
   srcDir: './src',
-  vite: (configEnv) => ({
-    define: {
-      __DEV__: configEnv.mode === 'development',
-    },
-    plugins: [
-      babel({
-        babelHelpers: 'bundled',
-        babelrc: false,
-        configFile: false,
-        exclude: '/**/node_modules/**',
-        extensions: ['jsx', 'js', 'ts', 'tsx', 'mjs'],
-        plugins: [
-          '@babel/plugin-transform-flow-strip-types',
-          [
-            require('../../scripts/error-codes/transform-error-messages'),
-            {
-              noMinify: true,
-            },
-          ],
-        ],
-        presets: [['@babel/preset-react', {runtime: 'automatic'}]],
+  vite: (configEnv) => {
+    const isProd = configEnv.mode !== 'development';
+    const {version} = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, 'package.json'), {
+        encoding: 'utf8',
       }),
-      react(),
-    ],
-    resolve: {
-      alias: [
-        // See lexicalForExtension.ts for more details
-        {
-          find: /lexical$/,
-          replacement: path.resolve('./src/lexicalForExtension.ts'),
-        },
-        {
-          find: 'lexicalOriginal',
-          replacement: path.resolve('../lexical/src/index.ts'),
-        },
-        ...(moduleResolution('source') as Alias[]),
+    );
+
+    return {
+      plugins: [
+        babel({
+          babelHelpers: 'bundled',
+          babelrc: false,
+          configFile: false,
+          exclude: '/**/node_modules/**',
+          extensions: ['jsx', 'js', 'ts', 'tsx', 'mjs'],
+          plugins: [
+            '@babel/plugin-transform-flow-strip-types',
+            [
+              require('../../scripts/error-codes/transform-error-messages'),
+              {
+                noMinify: true,
+              },
+            ],
+          ],
+          presets: [['@babel/preset-react', {runtime: 'automatic'}]],
+        }),
+        replace({
+          delimiters: ['', ''],
+          preventAssignment: true,
+          values: {
+            __DEV__: isProd ? 'false' : 'true',
+            'process.env.LEXICAL_VERSION': JSON.stringify(
+              `${version}+${isProd ? 'prod' : 'dev'}.devtools`,
+            ),
+          },
+        }),
+        react(),
       ],
-    },
-  }),
+      resolve: {
+        alias: [
+          // See lexicalForExtension.ts for more details
+          {
+            find: /lexical$/,
+            replacement: path.resolve('./src/lexicalForExtension.ts'),
+          },
+          {
+            find: 'lexicalOriginal',
+            replacement: path.resolve('../lexical/src/index.ts'),
+          },
+          ...(moduleResolution('source') as Alias[]),
+        ],
+      },
+    };
+  },
   zip: {
     sourcesRoot: path.resolve('../..'),
   },


### PR DESCRIPTION
## Description

When process.env.LEXICAL_VERSION was added to the build, the devtools config wasn't also updated

Closes #7524

## Test plan

### Before

The latest lexical devtools extension doesn't work with an error message related to process.env.LEXICAL_VERSION
https://discord.com/channels/953974421008293909/953974421486436393/1370450398522904750

### After

The devtools builds and runs

```
npm run -w packages/lexical-devtools dev
```