### PR TITLE
[lexical-playground] Bug Fix: Use babel MatchPatterns that work correctly on windows

### DIFF
--- a/packages/lexical-devtools/wxt.config.ts
+++ b/packages/lexical-devtools/wxt.config.ts
@@ -121,7 +121,7 @@ export default defineConfig({
           babelHelpers: 'bundled',
           babelrc: false,
           configFile: false,
-          exclude: '/**/node_modules/**',
+          exclude: '**/node_modules/**',
           extensions: ['jsx', 'js', 'ts', 'tsx', 'mjs'],
           plugins: [
             '@babel/plugin-transform-flow-strip-types',

--- a/packages/lexical-playground/vite.config.ts
+++ b/packages/lexical-playground/vite.config.ts
@@ -50,7 +50,7 @@ export default defineConfig(({mode}) => ({
       babelHelpers: 'bundled',
       babelrc: false,
       configFile: false,
-      exclude: '/**/node_modules/**',
+      exclude: '**/node_modules/**',
       extensions: ['jsx', 'js', 'ts', 'tsx', 'mjs'],
       plugins: [
         '@babel/plugin-transform-flow-strip-types',

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -197,7 +197,7 @@ async function build(
         babelHelpers: 'bundled',
         babelrc: false,
         configFile: false,
-        exclude: '/**/node_modules/**',
+        exclude: '**/node_modules/**',
         extensions,
         plugins: [
           [


### PR DESCRIPTION
## Description

Presumably the babel normalized windows paths must not start with a / (e.g. `c:/` or something). The `/` at the beginning is redundant on all platforms anyway, and removing it seems to fix it on Windows (reportedly).

## Test plan

### Before

https://discord.com/channels/953974421008293909/953974421486436393/1371755536587948172

### After

https://discord.com/channels/953974421008293909/953974421486436393/1371912767992238211