### PR TITLE
[lexical] Bug Fix : Prevent from adding element.style.textAlign when formatType is unset

### DIFF
--- a/packages/lexical-list/src/LexicalListItemNode.ts
+++ b/packages/lexical-list/src/LexicalListItemNode.ts
@@ -173,11 +173,17 @@ export class ListItemNode extends ElementNode {
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
     const element = this.createDOM(editor._config);
-    element.style.textAlign = this.getFormatType();
+
+    const formatType = this.getFormatType();
+    if (formatType) {
+      element.style.textAlign = formatType;
+    }
+
     const direction = this.getDirection();
     if (direction) {
       element.dir = direction;
     }
+
     return {
       element,
     };

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -159,7 +159,9 @@ export class QuoteNode extends ElementNode {
       }
 
       const formatType = this.getFormatType();
-      element.style.textAlign = formatType;
+      if (formatType) {
+        element.style.textAlign = formatType;
+      }
 
       const direction = this.getDirection();
       if (direction) {
@@ -320,7 +322,9 @@ export class HeadingNode extends ElementNode {
       }
 
       const formatType = this.getFormatType();
-      element.style.textAlign = formatType;
+      if (formatType) {
+        element.style.textAlign = formatType;
+      }
 
       const direction = this.getDirection();
       if (direction) {

--- a/packages/lexical/src/nodes/LexicalParagraphNode.ts
+++ b/packages/lexical/src/nodes/LexicalParagraphNode.ts
@@ -90,7 +90,9 @@ export class ParagraphNode extends ElementNode {
       }
 
       const formatType = this.getFormatType();
-      element.style.textAlign = formatType;
+      if (formatType) {
+        element.style.textAlign = formatType;
+      }
     }
 
     return {


### PR DESCRIPTION
## Description

There is a small bug in exportDOM functions on
- ListNode
- ParagraphNode
- HeadingNode
- QuoteNode

style text-align gets added in any case, even if getFormat is unset. While it's not a big deal on most dom implementations, we can end up with :

```
<li style="text-align: ">Value</li>
```

## Test plan

### Before

```
<li style="text-align: ">Value</li>
```

### After

```
<li>Value</li>
```
