### PR TITLE
[lexical-markdown]: Do not export auto-link nodes

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -10,7 +10,12 @@ import type {ListType} from '@lexical/list';
 import type {HeadingTagType} from '@lexical/rich-text';
 
 import {$createCodeNode, $isCodeNode, CodeNode} from '@lexical/code';
-import {$createLinkNode, $isLinkNode, LinkNode} from '@lexical/link';
+import {
+  $createLinkNode,
+  $isAutoLinkNode,
+  $isLinkNode,
+  LinkNode,
+} from '@lexical/link';
 import {
   $createListItemNode,
   $createListNode,
@@ -542,7 +547,7 @@ export const ITALIC_UNDERSCORE: TextFormatTransformer = {
 export const LINK: TextMatchTransformer = {
   dependencies: [LinkNode],
   export: (node, exportChildren, exportFormat) => {
-    if (!$isLinkNode(node)) {
+    if (!$isLinkNode(node) || !$isAutoLinkNode(node)) {
       return null;
     }
     const title = node.getTitle();


### PR DESCRIPTION
## Description

When using auto-link plugin, once exporting state to text (Markdown), auto-links are rendered as Markdown links, witch is unexpected since auto-links should be during render only

Closes: https://github.com/facebook/lexical/issues/7329

## Test plan

### Before

```
Check this: https://example.com
```

Becomes:

```
Check this: [https://example.com](https://example.com)
```

### After

```
Check this: https://example.com
```

Becomes:

```
Check this: https://example.com
```

