### PR TITLE
[lexical-playground] Bug Fix: bullet, strikethrough and quoteblock shortcuts updated 

### DIFF
--- a/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
+++ b/packages/lexical-playground/__tests__/keyboardShortcuts/index.mjs
@@ -306,7 +306,7 @@ export async function toggleCapitalize(page) {
 export async function toggleStrikethrough(page) {
   await keyDownCtrlOrMeta(page);
   await page.keyboard.down('Shift');
-  await page.keyboard.press('s');
+  await page.keyboard.press('x');
   await keyUpCtrlOrMeta(page);
   await page.keyboard.up('Shift');
 }
@@ -431,34 +431,34 @@ export async function applyHeading(page, level) {
 
 export async function toggleBulletList(page) {
   await keyDownCtrlOrMeta(page);
-  await page.keyboard.down('Alt');
-  await page.keyboard.press('4');
+  await page.keyboard.down('Shift');
+  await page.keyboard.press('8');
   await keyUpCtrlOrMeta(page);
-  await page.keyboard.up('Alt');
+  await page.keyboard.up('Shift');
 }
 
 export async function toggleNumberedList(page) {
   await keyDownCtrlOrMeta(page);
-  await page.keyboard.down('Alt');
-  await page.keyboard.press('5');
+  await page.keyboard.down('Shift');
+  await page.keyboard.press('7');
   await keyUpCtrlOrMeta(page);
-  await page.keyboard.up('Alt');
+  await page.keyboard.up('Shift');
 }
 
 export async function toggleChecklist(page) {
   await keyDownCtrlOrMeta(page);
-  await page.keyboard.down('Alt');
-  await page.keyboard.press('6');
+  await page.keyboard.down('Shift');
+  await page.keyboard.press('9');
   await keyUpCtrlOrMeta(page);
-  await page.keyboard.up('Alt');
+  await page.keyboard.up('Shift');
 }
 
 export async function applyQuoteBlock(page) {
-  await keyDownCtrlOrMeta(page);
-  await page.keyboard.down('Alt');
+  await page.keyboard.down('Control');
+  await page.keyboard.down('Shift');
   await page.keyboard.press('q');
-  await keyUpCtrlOrMeta(page);
-  await page.keyboard.up('Alt');
+  await page.keyboard.up('Control');
+  await page.keyboard.up('Shift');
 }
 
 export async function applyCodeBlock(page) {

--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
@@ -17,18 +17,18 @@ export const SHORTCUTS = Object.freeze({
   HEADING1: IS_APPLE ? '⌘+Opt+1' : 'Ctrl+Alt+1',
   HEADING2: IS_APPLE ? '⌘+Opt+2' : 'Ctrl+Alt+2',
   HEADING3: IS_APPLE ? '⌘+Opt+3' : 'Ctrl+Alt+3',
-  BULLET_LIST: IS_APPLE ? '⌘+Opt+4' : 'Ctrl+Alt+4',
-  NUMBERED_LIST: IS_APPLE ? '⌘+Opt+5' : 'Ctrl+Alt+5',
-  CHECK_LIST: IS_APPLE ? '⌘+Opt+6' : 'Ctrl+Alt+6',
+  NUMBERED_LIST: IS_APPLE ? '⌘+Shift+7' : 'Ctrl+Shift+7',
+  BULLET_LIST: IS_APPLE ? '⌘+Shift+8' : 'Ctrl+Shift+8',
+  CHECK_LIST: IS_APPLE ? '⌘+Shift+9' : 'Ctrl+Shift+9',
   CODE_BLOCK: IS_APPLE ? '⌘+Opt+C' : 'Ctrl+Alt+C',
-  QUOTE: IS_APPLE ? '⌘+Opt+Q' : 'Ctrl+Alt+Q',
+  QUOTE: IS_APPLE ? '⌃+Shift+Q' : 'Ctrl+Shift+Q',
   ADD_COMMENT: IS_APPLE ? '⌘+Opt+M' : 'Ctrl+Alt+M',
 
   // (Ctrl|⌘) + Shift + <key> shortcuts
   INCREASE_FONT_SIZE: IS_APPLE ? '⌘+Shift+.' : 'Ctrl+Shift+.',
   DECREASE_FONT_SIZE: IS_APPLE ? '⌘+Shift+,' : 'Ctrl+Shift+,',
   INSERT_CODE_BLOCK: IS_APPLE ? '⌘+Shift+C' : 'Ctrl+Shift+C',
-  STRIKETHROUGH: IS_APPLE ? '⌘+Shift+S' : 'Ctrl+Shift+S',
+  STRIKETHROUGH: IS_APPLE ? '⌘+Shift+X' : 'Ctrl+Shift+X',
   LOWERCASE: IS_APPLE ? '⌃+Shift+1' : 'Ctrl+Shift+1',
   UPPERCASE: IS_APPLE ? '⌃+Shift+2' : 'Ctrl+Shift+2',
   CAPITALIZE: IS_APPLE ? '⌃+Shift+3' : 'Ctrl+Shift+3',
@@ -75,24 +75,24 @@ export function isFormatHeading(event: KeyboardEvent): boolean {
 export function isFormatBulletList(event: KeyboardEvent): boolean {
   const {code} = event;
   return (
-    (code === 'Numpad4' || code === 'Digit4') &&
-    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
+    (code === 'Numpad8' || code === 'Digit8') &&
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isFormatNumberedList(event: KeyboardEvent): boolean {
   const {code} = event;
   return (
-    (code === 'Numpad5' || code === 'Digit5') &&
-    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
+    (code === 'Numpad7' || code === 'Digit7') &&
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
 export function isFormatCheckList(event: KeyboardEvent): boolean {
   const {code} = event;
   return (
-    (code === 'Numpad6' || code === 'Digit6') &&
-    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
+    (code === 'Numpad9' || code === 'Digit9') &&
+    isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }
 
@@ -108,7 +108,10 @@ export function isFormatQuote(event: KeyboardEvent): boolean {
   const {code} = event;
   return (
     code === 'KeyQ' &&
-    isModifierMatch(event, {...CONTROL_OR_META, altKey: true})
+    isModifierMatch(event, {
+      ctrlKey: true,
+      shiftKey: true,
+    })
   );
 }
 
@@ -139,7 +142,7 @@ export function isCapitalize(event: KeyboardEvent): boolean {
 export function isStrikeThrough(event: KeyboardEvent): boolean {
   const {code} = event;
   return (
-    code === 'KeyS' &&
+    code === 'KeyX' &&
     isModifierMatch(event, {...CONTROL_OR_META, shiftKey: true})
   );
 }


### PR DESCRIPTION

<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
I found that keyboard shortcuts for Bullet list, Strikethrough and Quote block formatting were conflicting with some existing shortcut combinations on Windows machine. So while updating to these new shortcuts I've tried to mimic what google docs does along with aim to have somewhat similar key combinations for both Mac and Windows devices

Closes #7535 

## Test plan
updated relevant tests
### Before
| Action | Mac | Windows |
|--------|--------|--------|
| Numbered List | ⌘+Opt+5 | Ctrl+Alt+5 |
| Bullet List | ⌘+Opt+4 | Ctrl+Alt+4 |
| Check List | ⌘+Opt+6 | Ctrl+Alt+6 |
| Strikethrough | ⌘+Shift+S | Ctrl+Shift+S |
| Quote Block | ⌘+Opt+Q |  Ctrl+Alt+Q |


### After

| Action | Mac | Windows |
|--------|--------|--------|
| Numbered List | ⌘+Shift+7 | Ctrl+Shift+7 |
| Bullet List | ⌘+Shift+8 | Ctrl+Shift+8 |
| Check List | ⌘+Shift+9 | Ctrl+Shift+9 |
| Strikethrough | ⌘+Shift+X | Ctrl+Shift+X |
| Quote Block | ⌃+Shift+Q |  Ctrl+Shift+Q |

