### PR TITLE
[lexical][lexical-playground] Bug Fix: Support Apple Pencil

### DIFF
--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
@@ -65,7 +65,7 @@ export function isFormatParagraph(event: KeyboardEvent): boolean {
 export function isFormatHeading(event: KeyboardEvent): boolean {
   const {code} = event;
 
-  // Apple pencil keyboard events doesnt have a code property
+  // Apple pencil keyboard events don't have a code property
   if (!code) {
     return false;
   }

--- a/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
+++ b/packages/lexical-playground/src/plugins/ShortcutsPlugin/shortcuts.ts
@@ -64,6 +64,12 @@ export function isFormatParagraph(event: KeyboardEvent): boolean {
 
 export function isFormatHeading(event: KeyboardEvent): boolean {
   const {code} = event;
+
+  // Apple pencil keyboard events doesnt have a code property
+  if (!code) {
+    return false;
+  }
+
   const keyNumber = code[code.length - 1];
 
   return (

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -514,8 +514,8 @@ function onClick(event: PointerEvent, editor: LexicalEditor): void {
             }
           }
         }
-      } else if (event.pointerType === 'touch') {
-        // This is used to update the selection on touch devices when the user clicks on text after a
+      } else if (event.pointerType === 'touch' || event.pointerType === 'pen') {
+        // This is used to update the selection on touch devices (including Apple Pencil) when the user clicks on text after a
         // node selection. See isSelectionChangeFromMouseDown for the inverse
         const domAnchorNode = domSelection.anchorNode;
         // If the user is attempting to click selection back onto text, then
@@ -542,7 +542,7 @@ function onPointerDown(event: PointerEvent, editor: LexicalEditor) {
   // TODO implement text drag & drop
   const target = event.target;
   const pointerType = event.pointerType;
-  if (isDOMNode(target) && pointerType !== 'touch' && event.button === 0) {
+  if (isDOMNode(target) && pointerType !== 'touch' && pointerType !== 'pen' && event.button === 0) {
     updateEditorSync(editor, () => {
       // Drag & drop should not recompute selection until mouse up; otherwise the initially
       // selected content is lost.

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -542,7 +542,12 @@ function onPointerDown(event: PointerEvent, editor: LexicalEditor) {
   // TODO implement text drag & drop
   const target = event.target;
   const pointerType = event.pointerType;
-  if (isDOMNode(target) && pointerType !== 'touch' && pointerType !== 'pen' && event.button === 0) {
+  if (
+    isDOMNode(target) &&
+    pointerType !== 'touch' &&
+    pointerType !== 'pen' &&
+    event.button === 0
+  ) {
     updateEditorSync(editor, () => {
       // Drag & drop should not recompute selection until mouse up; otherwise the initially
       // selected content is lost.


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
Currently Apple Pencil inputs effectively breaks the editor because pen inputs do not update the selection state. This PR ensures pen input events update the selection state in the same way as touch input events.

Apple pencil inputs also create keyboard events when making scribbles. The key property for these events are undefined and broke the shortcuts plugin. This PR also fixes that.

Closes #7542