### PR TITLE
[lexical] Bug Fix: Fix loop in indexPath

### DIFF
--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -286,7 +286,7 @@ export class ElementDOMSlot<T extends HTMLElement = HTMLElement> {
   }
 }
 
-function indexPath(root: HTMLElement, child: Node): number[] {
+export function indexPath(root: HTMLElement, child: Node): number[] {
   const path: number[] = [];
   let node: Node | null = child;
   for (; node !== root && node !== null; node = node.parentNode) {

--- a/packages/lexical/src/nodes/LexicalElementNode.ts
+++ b/packages/lexical/src/nodes/LexicalElementNode.ts
@@ -289,7 +289,7 @@ export class ElementDOMSlot<T extends HTMLElement = HTMLElement> {
 function indexPath(root: HTMLElement, child: Node): number[] {
   const path: number[] = [];
   let node: Node | null = child;
-  for (; node !== root && node !== null; node = child.parentNode) {
+  for (; node !== root && node !== null; node = node.parentNode) {
     let i = 0;
     for (
       let sibling = node.previousSibling;

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -28,7 +28,7 @@ import {
   $createTestElementNode,
   createTestEditor,
 } from '../../../__tests__/utils';
-import {SerializedElementNode} from '../../LexicalElementNode';
+import {indexPath, SerializedElementNode} from '../../LexicalElementNode';
 
 describe('LexicalElementNode tests', () => {
   let container: HTMLElement;
@@ -719,5 +719,38 @@ describe('getDOMSlot tests', () => {
       {discrete: true},
     );
     expect(container.innerHTML).toBe(`<main><section><br></section></main>`);
+  });
+});
+
+describe('indexPath', () => {
+  test('no path', () => {
+    const root = document.createElement('div');
+    expect(indexPath(root, root)).toEqual([]);
+  });
+  test('only child', () => {
+    const root = document.createElement('div');
+    const child = document.createElement('div');
+    root.appendChild(child);
+    expect(indexPath(root, child)).toEqual([0]);
+  });
+  test('nested child', () => {
+    const root = document.createElement('div');
+    const parent = document.createElement('div');
+    const child = document.createElement('div');
+    root.appendChild(parent);
+    parent.appendChild(child);
+    expect(indexPath(root, child)).toEqual([0, 0]);
+  });
+  test('nested child with siblings', () => {
+    const root = document.createElement('div');
+    const parent = document.createElement('div');
+    const child = document.createElement('div');
+    root.appendChild(document.createElement('span'));
+    root.appendChild(parent);
+    root.appendChild(document.createElement('span'));
+    parent.appendChild(document.createElement('span'));
+    parent.appendChild(child);
+    parent.appendChild(document.createElement('span'));
+    expect(indexPath(root, child)).toEqual([1, 1]);
   });
 });


### PR DESCRIPTION
## Description

The "afterthought" (third expression) of the outer for loop in indexPath was constant and would never terminate in some scenarios, referencing child instead of node.

Closes #7548

## Test plan

New unit test coverage