### PR TITLE
[lexical-playground] Bug Fix: Checklist Checkbox Now Scales Dynamically with Font Size

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -459,10 +459,10 @@
 .PlaygroundEditorTheme__listItemChecked,
 .PlaygroundEditorTheme__listItemUnchecked {
   position: relative;
-  margin-left: 8px;
-  margin-right: 8px;
-  padding-left: 24px;
-  padding-right: 24px;
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+  padding-left: 1.5em;
+  padding-right: 1.5em;
   list-style-type: none;
   outline: none;
 }
@@ -472,9 +472,9 @@
 .PlaygroundEditorTheme__listItemUnchecked:before,
 .PlaygroundEditorTheme__listItemChecked:before {
   content: '';
-  width: 16px;
-  height: 16px;
-  top: 2px;
+  width: 1em;
+  height: 1em;
+  top: 0.125em;
   left: 0;
   cursor: pointer;
   display: block;
@@ -508,11 +508,10 @@
   border-style: solid;
   position: absolute;
   display: block;
-  top: 6px;
-  width: 3px;
-  left: 7px;
-  right: 7px;
-  height: 6px;
+  top: 0.375em;
+  width: 0.1875em;
+  left: 0.4375em;
+  height: 0.375em;
   transform: rotate(45deg);
   border-width: 0 2px 2px 0;
 }


### PR DESCRIPTION
**Current behavior:**

When increasing the font size of a checklist item in the Lexical Playground, the checkbox icon (checklist marker) does not scale proportionally—it remains the same size, which can lead to inconsistent appearance and accessibility issues.

**Changes introduced by this PR:**

Updated the checklist checkbox styles in [PlaygroundEditorTheme.css] to use relative units (em) for width, height, and positioning.
Now, when the font size of a checklist item is increased, the checkbox icon will scale accordingly and always match the text size.
This change improves visual consistency and accessibility for users who adjust font sizes.



Closes #7554

