### PR TITLE
[lexical-list] Bug Fix: Removed the hardcoded checkbox width in checklist onclick helper

### DIFF
--- a/packages/lexical-list/src/checkList.ts
+++ b/packages/lexical-list/src/checkList.ts
@@ -182,10 +182,14 @@ function handleCheckItemEvent(event: PointerEvent, callback: () => void) {
 
   const rect = target.getBoundingClientRect();
   const pageX = event.pageX / calculateZoomLevel(target);
+  const beforeStyles = window.getComputedStyle(target, '::before');
+
+  const beforeWidth = beforeStyles.width;
+  const beforeWidthInPixels = parseFloat(beforeWidth);
   if (
     target.dir === 'rtl'
-      ? pageX < rect.right && pageX > rect.right - 20
-      : pageX > rect.left && pageX < rect.left + 20
+      ? pageX < rect.right && pageX > rect.right - beforeWidthInPixels
+      : pageX > rect.left && pageX < rect.left + beforeWidthInPixels
   ) {
     callback();
   }


### PR DESCRIPTION
## Description
The checkbox onclick handler currently assumes the checkbox size to be 20px, which works for current scenarios as the checkbox doesnt grow with the font size.

instead of hardcoding the checkbox width, now we're using the calculated width of the checkbox

## Test plan

### Before

https://github.com/user-attachments/assets/cc88359f-b179-401a-a532-e1c981d93dc2




### After

https://github.com/user-attachments/assets/cb12f24e-d46e-4d35-a643-02279ac778d0


