### PR TITLE
Revert "[lexical-markdown] Bug Fix: Link Transformer URL Protocol Han…

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -42,8 +42,6 @@ import {
   TextNode,
 } from 'lexical';
 
-import {formatUrl} from './utils';
-
 export type Transformer =
   | ElementTransformer
   | MultilineElementTransformer
@@ -566,8 +564,7 @@ export const LINK: TextMatchTransformer = {
     /(?:\[([^[]+)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))$/,
   replace: (textNode, match) => {
     const [, linkText, linkUrl, linkTitle] = match;
-    const formattedUrl = formatUrl(linkUrl);
-    const linkNode = $createLinkNode(formattedUrl, {title: linkTitle});
+    const linkNode = $createLinkNode(linkUrl, {title: linkTitle});
     const linkTextNode = $createTextNode(linkText);
     linkTextNode.setFormat(textNode.getFormat());
     linkNode.append(linkTextNode);

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -27,7 +27,6 @@ import {
   MultilineElementTransformer,
   normalizeMarkdown,
 } from '../../MarkdownTransformers';
-import {formatUrl} from '../../utils';
 
 const SIMPLE_INLINE_JSX_MATCHER: TextMatchTransformer = {
   dependencies: [LinkNode],
@@ -887,41 +886,5 @@ E3
 | c | d |
 `;
     expect(normalizeMarkdown(markdown, false)).toBe(markdown);
-  });
-});
-
-describe('formatUrl', () => {
-  it('should not modify URLs with protocols', () => {
-    expect(formatUrl('https://example.com')).toBe('https://example.com');
-    expect(formatUrl('http://example.com')).toBe('http://example.com');
-    expect(formatUrl('mailto:user@example.com')).toBe(
-      'mailto:user@example.com',
-    );
-    expect(formatUrl('tel:+1234567890')).toBe('tel:+1234567890');
-  });
-
-  it('should not modify relative paths', () => {
-    expect(formatUrl('/path/to/resource')).toBe('/path/to/resource');
-    expect(formatUrl('/index.html')).toBe('/index.html');
-  });
-
-  it('should add mailto: to email addresses', () => {
-    expect(formatUrl('user@example.com')).toBe('mailto:user@example.com');
-    expect(formatUrl('name.lastname@domain.co.uk')).toBe(
-      'mailto:name.lastname@domain.co.uk',
-    );
-  });
-
-  it('should add tel: to phone numbers', () => {
-    expect(formatUrl('+1234567890')).toBe('tel:+1234567890');
-    expect(formatUrl('123-456-7890')).toBe('tel:123-456-7890');
-  });
-
-  it('should add https:// to URLs without protocols', () => {
-    expect(formatUrl('www.example.com')).toBe('https://www.example.com');
-    expect(formatUrl('example.com')).toBe('https://example.com');
-    expect(formatUrl('subdomain.example.com/path')).toBe(
-      'https://subdomain.example.com/path',
-    );
   });
 });

--- a/packages/lexical-markdown/src/utils.ts
+++ b/packages/lexical-markdown/src/utils.ts
@@ -460,37 +460,3 @@ export function isEmptyParagraph(node: LexicalNode): boolean {
       MARKDOWN_EMPTY_LINE_REG_EXP.test(firstChild.getTextContent()))
   );
 }
-
-export const PHONE_NUMBER_REGEX = /^\+?[0-9\s()-]{5,}$/;
-
-/**
- * Formats a URL string by adding appropriate protocol if missing
- *
- * @param url - URL to format
- * @returns Formatted URL with appropriate protocol
- */
-export function formatUrl(url: string): string {
-  // Check if URL already has a protocol
-  if (url.match(/^[a-z][a-z0-9+.-]*:/i)) {
-    // URL already has a protocol, leave it as is
-    return url;
-  }
-  // Check if it's a relative path (starting with '/', '.', or '#')
-  else if (url.match(/^[/#.]/)) {
-    // Relative path, leave it as is
-    return url;
-  }
-
-  // Check for email address
-  else if (url.includes('@')) {
-    return `mailto:${url}`;
-  }
-
-  // Check for phone number
-  else if (PHONE_NUMBER_REGEX.test(url)) {
-    return `tel:${url}`;
-  }
-
-  // For everything else, return with https:// prefix
-  return `https://${url}`;
-}


### PR DESCRIPTION
Despite this a fine PR, this was introduced a breaking change that happens to break product code assumptions for already existing code. 

For the most part this PR can reused, let's republish it with this small tweaks https://github.com/facebook/lexical/pull/7499/files#r2100392931 @aashishr-meelance

---


Revert "[lexical-markdown] Bug Fix: Link Transformer URL Protocol Handling (#7499)"

This reverts commit 0aa2d5aa737ae116a82912fac36e715c54c3b8ef.
