### PR TITLE
[lexical-playground] Chore: source command priority from package

### DIFF
--- a/packages/lexical-playground/src/plugins/TabFocusPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TabFocusPlugin/index.tsx
@@ -12,10 +12,10 @@ import {
   $isRangeSelection,
   $setSelection,
   FOCUS_COMMAND,
+  COMMAND_PRIORITY_LOW,
 } from 'lexical';
 import {useEffect} from 'react';
 
-const COMMAND_PRIORITY_LOW = 1;
 const TAB_TO_FOCUS_INTERVAL = 100;
 
 let lastTabKeyDownTimestamp = 0;

--- a/packages/lexical-playground/src/plugins/TabFocusPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/TabFocusPlugin/index.tsx
@@ -11,8 +11,8 @@ import {
   $getSelection,
   $isRangeSelection,
   $setSelection,
-  FOCUS_COMMAND,
   COMMAND_PRIORITY_LOW,
+  FOCUS_COMMAND,
 } from 'lexical';
 import {useEffect} from 'react';
 


### PR DESCRIPTION
## Description
- What is the current behavior that you are modifying? 
`COMMAND_PRIORITY_LOW` was re-defined in the plugin file.
- What are the behavior or changes that are being added by this PR?
`COMMAND_PRIORITY_LOW` is now sourced from the `lexical` package
