### PR TITLE
[lexical-playground] Bug Fix: Preserve row striping in frozen table columns

### DIFF
--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -249,18 +249,13 @@
   width: 100%;
   border-bottom: 1px solid #bbb;
 }
-.PlaygroundEditorTheme__tableFrozenColumn tr:nth-child(odd) > td:first-child {
+.PlaygroundEditorTheme__tableFrozenColumn tr > td:first-child {
   background-color: #ffffff;
   position: sticky;
   z-index: 2;
   left: 0;
 }
-.PlaygroundEditorTheme__tableFrozenColumn tr:nth-child(even) > td:first-child {
-  background-color: #f2f5fb;
-  position: sticky;
-  z-index: 2;
-  left: 0;
-}
+
 .PlaygroundEditorTheme__tableFrozenColumn tr > th:first-child {
   background-color: #f2f3f5;
   position: sticky;
@@ -276,7 +271,11 @@
   height: 100%;
   border-right: 1px solid #bbb;
 }
-.PlaygroundEditorTheme__tableRowStriping tr:nth-child(even) {
+.PlaygroundEditorTheme__tableRowStriping tr:nth-child(even),
+.PlaygroundEditorTheme__tableFrozenColumn
+  .PlaygroundEditorTheme__table.PlaygroundEditorTheme__tableRowStriping
+  tr:nth-child(even)
+  > td:first-child {
   background-color: #f2f5fb;
 }
 .PlaygroundEditorTheme__tableSelection *::selection {

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -255,7 +255,6 @@
   z-index: 2;
   left: 0;
 }
-
 .PlaygroundEditorTheme__tableFrozenColumn tr > th:first-child {
   background-color: #f2f3f5;
   position: sticky;

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -249,8 +249,14 @@
   width: 100%;
   border-bottom: 1px solid #bbb;
 }
-.PlaygroundEditorTheme__tableFrozenColumn tr > td:first-child {
+.PlaygroundEditorTheme__tableFrozenColumn tr:nth-child(odd) > td:first-child {
   background-color: #ffffff;
+  position: sticky;
+  z-index: 2;
+  left: 0;
+}
+.PlaygroundEditorTheme__tableFrozenColumn tr:nth-child(even) > td:first-child {
+  background-color: #f2f5fb;
   position: sticky;
   z-index: 2;
   left: 0;


### PR DESCRIPTION
## Description

Currently, when a table column is frozen using the "Freeze First Column" option, the row striping (alternating row background colors) disappears for the frozen column. This happens because the frozen column cells have a hardcoded white background that overrides the row striping styles.

This PR fixes the issue by:
- Maintaining row striping in frozen columns by explicitly setting background colors for odd/even rows

Closes #7571

## Test plan

### Before

![image](https://github.com/user-attachments/assets/3ebd48ba-8770-4172-9e23-d79e0fb8e8b5)

- Create a table with multiple rows and columns
- Right click the first column -> Remove Column Header
- Right click -> Toggle Row Striping
- Right click -> Freeze First Column
- Notice that the frozen column loses its row striping, showing only white background

### After

https://github.com/user-attachments/assets/23b56670-f1ca-4c28-8144-fe1c8875a547



- Create a table with multiple rows and columns
- For the first column -> Remove Column Header
- Apply row striping using "Toggle Row Striping"
- Freeze the first column using "Freeze First Column"
- Verify that the frozen column maintains the same striping pattern as non-frozen columns

Additional tests done:
- Scroll horizontally to verify the right border remains visible on the frozen column
- Check that the frozen column properly overlays content while scrolling