### PR TITLE
[lexical-react][lexical-playground] Feature: allow whitespaces in search keyword in useBasicTypeaheadTriggerMatch 

### DIFF
--- a/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ComponentPickerPlugin/index.tsx
@@ -34,7 +34,6 @@ import {
   TextNode,
 } from 'lexical';
 import {useCallback, useMemo, useState} from 'react';
-import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import useModal from '../../hooks/useModal';
@@ -321,6 +320,7 @@ export default function ComponentPickerMenuPlugin(): JSX.Element {
   const [queryString, setQueryString] = useState<string | null>(null);
 
   const checkForTriggerMatch = useBasicTypeaheadTriggerMatch('/', {
+    allowWhitespace: true,
     minLength: 0,
   });
 

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -189,7 +189,7 @@ export function useBasicTypeaheadTriggerMatch(
       }
       return null;
     },
-    [maxLength, minLength, trigger, punctuation],
+    [allowWhitespace, trigger, punctuation, maxLength, minLength],
   );
 }
 

--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -29,7 +29,6 @@ import {
   TextNode,
 } from 'lexical';
 import {useCallback, useEffect, useState} from 'react';
-import * as React from 'react';
 import {startTransition} from 'shared/reactPatches';
 
 import {LexicalMenu, MenuOption, useMenuAnchorRef} from './shared/LexicalMenu';
@@ -152,11 +151,18 @@ export function useBasicTypeaheadTriggerMatch(
     minLength = 1,
     maxLength = 75,
     punctuation = PUNCTUATION,
-  }: {minLength?: number; maxLength?: number; punctuation?: string},
+    allowWhitespace = false,
+  }: {
+    minLength?: number;
+    maxLength?: number;
+    punctuation?: string;
+    allowWhitespace?: boolean;
+  },
 ): TriggerFn {
   return useCallback(
     (text: string) => {
-      const validChars = '[^' + trigger + punctuation + '\\s]';
+      const validCharsSuffix = allowWhitespace ? '' : '\\s';
+      const validChars = '[^' + trigger + punctuation + validCharsSuffix + ']';
       const TypeaheadTriggerRegex = new RegExp(
         '(^|\\s|\\()(' +
           '[' +


### PR DESCRIPTION

<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
- Currently, there is support for adding custom punctuation in search keywords, but it’s not possible to search multiple words.
- After this feature, simple use cases related to the LexicalTypeahead Plugin that allow white spaces will be greatly simplified.

*Describe the changes in this pull request*
I have added an allowWhitespace prop in useBasicTypeaheadTriggerMatch, and based on its value, it will control whether to exclude whitespaces or not.

Closes #7583

## Test plan

### Before

Not able to type "Heading 1" as search keyword

https://github.com/user-attachments/assets/756a3266-619d-4d3a-b4c8-adca2e3dd01b



### After

By adding `allowWhitespace: true` it would be possible to search "Heading 1"

https://github.com/user-attachments/assets/9318db49-8756-4cd1-889c-3498cb1e55d6

