### PR TITLE
[lexical-link] Feature: Move URL formatting from #7499 to LinkNode sanitizeUrl

### DIFF
--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -96,3 +96,4 @@ declare export function $toggleLink(
 ): void;
 /** @deprecated renamed to {@link $toggleLink} by @lexical/eslint-plugin rules-of-lexical */
 declare const toggleLink: typeof $toggleLink;
+declare export function formatUrl(url: string): string;

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -542,7 +542,7 @@ describe('Markdown', () => {
     },
     {
       customTransformers: [SIMPLE_INLINE_JSX_MATCHER],
-      html: '<p><span style="white-space: pre-wrap;">Hello </span><a href="simple-jsx"><span style="white-space: pre-wrap;">One &lt;MyTag&gt;Two&lt;/MyTag&gt;</span></a><span style="white-space: pre-wrap;"> there</span></p>',
+      html: '<p><span style="white-space: pre-wrap;">Hello </span><a href="https://simple-jsx"><span style="white-space: pre-wrap;">One &lt;MyTag&gt;Two&lt;/MyTag&gt;</span></a><span style="white-space: pre-wrap;"> there</span></p>',
       md: 'Hello <MyTag>One <MyTag>Two</MyTag></MyTag> there',
       skipExport: true,
     },


### PR DESCRIPTION
## Description

The URL formatting added to the markdown transform in #7499 was reverted in #7560 because it changed the document model in ways that were incompatible with some uses at Meta, such as using a handlebar style `{{variable}}` as the URL.

This PR takes the `formatUrl` implemented in the original PR and moves it to lexical-link where it is used only in rendering the href of the anchor tag, which solves the use case of having link click have the expected behavior but without changing anything at in the document model (the exact href will round-trip).


## Test plan

Unit tests