### PR TITLE
[lexical-react] Bug Fix: page freezes when typing a link in an overflow area

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CharacterLimit.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CharacterLimit.spec.mjs
@@ -79,16 +79,11 @@ function testSuite(charset) {
     });
   });
 
-  test('displays overflow on token nodes', async ({page, isCollab}) => {
-    // The smile emoji (S) is length 2, so for 1234S56:
-    // - 1234 is non-overflow text
-    // - S takes characters 5 and 6, since it's a token and can't be split we count the whole
-    //   node as overflowed
-    // - 56 is overflowed
+  test('handles auto link nodes', async ({page, isCollab}) => {
     test.skip(isCollab);
     await page.focus('div[contenteditable="true"]');
 
-    await page.keyboard.type('1234:)56');
+    await page.keyboard.type('1234:)56 www.example.com');
     await assertHTML(
       page,
       html`
@@ -101,6 +96,12 @@ function testSuite(charset) {
               <span class="emoji-inner">🙂</span>
             </span>
             <span data-lexical-text="true">56</span>
+            <a
+              class="PlaygroundEditorTheme__link PlaygroundEditorTheme__ltr"
+              dir="ltr"
+              href="https://www.example.com">
+              <span data-lexical-text="true">www.example.com</span>
+            </a>
           </span>
         </p>
       `,
@@ -112,6 +113,14 @@ function testSuite(charset) {
       html`
         <p class="PlaygroundEditorTheme__paragraph">
           <span data-lexical-text="true">1234</span>
+          <span
+            class="PlaygroundEditorTheme__characterLimit PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span class="emoji happysmile" data-lexical-text="true">
+              <span class="emoji-inner">🙂</span>
+            </span>
+            <span data-lexical-text="true">56 www.example.</span>
+          </span>
         </p>
       `,
     );

--- a/packages/lexical-playground/__tests__/e2e/CharacterLimit.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CharacterLimit.spec.mjs
@@ -126,6 +126,44 @@ function testSuite(charset) {
     );
   });
 
+  test('displays overflow on token nodes', async ({page, isCollab}) => {
+    // The smile emoji (S) is length 2, so for 1234S56:
+    // - 1234 is non-overflow text
+    // - S takes characters 5 and 6, since it's a token and can't be split we count the whole
+    //   node as overflowed
+    // - 56 is overflowed
+    test.skip(isCollab);
+    await page.focus('div[contenteditable="true"]');
+
+    await page.keyboard.type('1234:)56');
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span data-lexical-text="true">1234</span>
+          <span
+            class="PlaygroundEditorTheme__characterLimit PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span class="emoji happysmile" data-lexical-text="true">
+              <span class="emoji-inner">🙂</span>
+            </span>
+            <span data-lexical-text="true">56</span>
+          </span>
+        </p>
+      `,
+    );
+
+    await pressBackspace(page, 3);
+    await assertHTML(
+      page,
+      html`
+        <p class="PlaygroundEditorTheme__paragraph">
+          <span data-lexical-text="true">1234</span>
+        </p>
+      `,
+    );
+  });
+
   test('can type new lines inside overflow', async ({
     page,
     isRichText,

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -173,6 +173,9 @@ function $wrapOverflowedNodes(offset: number): void {
 
   for (let i = 0; i < dfsNodesLength; i += 1) {
     const {node} = dfsNodes[i];
+    const hasOverflowParent = !!node
+      .getParents()
+      .find((p) => p instanceof OverflowNode);
 
     if ($isOverflowNode(node)) {
       const previousLength = accumulatedLength;
@@ -215,7 +218,7 @@ function $wrapOverflowedNodes(offset: number): void {
           $unwrapNode(node);
         }
       }
-    } else if ($isLeafNode(node)) {
+    } else if ($isLeafNode(node) && !hasOverflowParent) {
       const previousAccumulatedLength = accumulatedLength;
       accumulatedLength += node.getTextContentSize();
 

--- a/packages/lexical-react/src/shared/useCharacterLimit.ts
+++ b/packages/lexical-react/src/shared/useCharacterLimit.ts
@@ -14,7 +14,12 @@ import {
   OverflowNode,
 } from '@lexical/overflow';
 import {$rootTextContent} from '@lexical/text';
-import {$dfs, $unwrapNode, mergeRegister} from '@lexical/utils';
+import {
+  $dfs,
+  $findMatchingParent,
+  $unwrapNode,
+  mergeRegister,
+} from '@lexical/utils';
 import {
   $getSelection,
   $isElementNode,
@@ -173,9 +178,9 @@ function $wrapOverflowedNodes(offset: number): void {
 
   for (let i = 0; i < dfsNodesLength; i += 1) {
     const {node} = dfsNodes[i];
-    const hasOverflowParent = !!node
-      .getParents()
-      .find((p) => p instanceof OverflowNode);
+
+    const needsOverflowParent =
+      $isLeafNode(node) && !$findMatchingParent(node, $isOverflowNode);
 
     if ($isOverflowNode(node)) {
       const previousLength = accumulatedLength;
@@ -218,7 +223,7 @@ function $wrapOverflowedNodes(offset: number): void {
           $unwrapNode(node);
         }
       }
-    } else if ($isLeafNode(node) && !hasOverflowParent) {
+    } else if (needsOverflowParent) {
       const previousAccumulatedLength = accumulatedLength;
       accumulatedLength += node.getTextContentSize();
 


### PR DESCRIPTION
## Description
Fix for an infinite loop bug caused by auto link plugin and overflow that were wrapping each other indefinitely.
Added an additional check within $wrapOverflowedNodes function that skips leaf nodes that already have an overflow parent.

Closes #7474
Closes #6662 
Closes #6668

### Before

When typing in an autolink with a character limit on, page freezes


### After

Page doesn't freeze anymore


https://github.com/user-attachments/assets/07db956b-d9a2-46ab-b2b8-e000f09d64b7

