### PR TITLE
[Lexical] Type: Add flow export type for `UpdateTag`

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -900,8 +900,8 @@ declare export function $isParagraphNode(
  * LexicalUtils
  */
 export type EventHandler = (event: Event, editor: LexicalEditor) => void;
-declare export function $hasUpdateTag(tag: string): boolean;
-declare export function $addUpdateTag(tag: string): void;
+declare export function $hasUpdateTag(tag: UpdateTag): boolean;
+declare export function $addUpdateTag(tag: UpdateTag): void;
 declare export function $onUpdate(updateFn: () => void): void;
 declare export function getNearestEditorFromDOMNode(
   node: Node | null,
@@ -1259,3 +1259,25 @@ declare export function $splitAtPointCaretNext(
   pointCaret: PointCaret<'next'>,
   options?: SplitAtPointCaretNextOptions,
 ): null | NodeCaret<'next'>;
+
+/**
+ * LexicalUpdateTags
+ */
+declare export var COLLABORATION_TAG: 'collaboration';
+declare export var HISTORIC_TAG: 'historic';
+declare export var HISTORY_MERGE_TAG: 'history-merge';
+declare export var HISTORY_PUSH_TAG: 'history-push';
+declare export var PASTE_TAG: 'paste';
+declare export var SKIP_COLLAB_TAG: 'skip-collab';
+declare export var SKIP_DOM_SELECTION_TAG: 'skip-dom-selection';
+declare export var SKIP_SCROLL_INTO_VIEW_TAG: 'skip-scroll-into-view';
+export type UpdateTag =
+  typeof COLLABORATION_TAG
+  | typeof HISTORIC_TAG
+  | typeof HISTORY_MERGE_TAG
+  | typeof HISTORY_PUSH_TAG
+  | typeof PASTE_TAG
+  | typeof SKIP_COLLAB_TAG
+  | typeof SKIP_DOM_SELECTION_TAG
+  | typeof SKIP_SCROLL_INTO_VIEW_TAG
+  | string;

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -66,7 +66,6 @@ export {
   $updateRangeSelectionFromCaretRange,
   type SplitAtPointCaretNextOptions,
 } from './caret/LexicalCaretUtils';
-export type {PasteCommandType} from './LexicalCommands';
 export {
   BLUR_COMMAND,
   CAN_REDO_COMMAND,
@@ -108,6 +107,7 @@ export {
   MOVE_TO_START,
   OUTDENT_CONTENT_COMMAND,
   PASTE_COMMAND,
+  type PasteCommandType,
   REDO_COMMAND,
   REMOVE_TEXT_COMMAND,
   SELECT_ALL_COMMAND,


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

This Pr is to add  flow export type  for `update tag`, which is an export type in Javascript, but not in flow. We have to declare that in the type declaration file.

Closes #<!-- issue number -->

## Test plan

Pass CI - just updating type declarations, not other things are impacted

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*