### PR TITLE
[lexical-markdown] Bug Fix: Don't select nodes when importing

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -213,11 +213,13 @@ const TABLE_ROW_DIVIDER_REG_EXP = /^(\| ?:?-*:? ?)+\|\s?$/;
 const createBlockNode = (
   createNode: (match: Array<string>) => ElementNode,
 ): ElementTransformer['replace'] => {
-  return (parentNode, children, match) => {
+  return (parentNode, children, match, isImport) => {
     const node = createNode(match);
     node.append(...children);
     parentNode.replace(node);
-    node.select(0, 0);
+    if (!isImport) {
+      node.select(0, 0);
+    }
   };
 };
 
@@ -243,7 +245,7 @@ function getIndent(whitespaces: string): number {
 }
 
 const listReplace = (listType: ListType): ElementTransformer['replace'] => {
-  return (parentNode, children, match) => {
+  return (parentNode, children, match, isImport) => {
     const previousNode = parentNode.getPreviousSibling();
     const nextNode = parentNode.getNextSibling();
     const listItem = $createListItemNode(
@@ -273,7 +275,9 @@ const listReplace = (listType: ListType): ElementTransformer['replace'] => {
       parentNode.replace(list);
     }
     listItem.append(...children);
-    listItem.select(0, 0);
+    if (!isImport) {
+      listItem.select(0, 0);
+    }
     const indent = getIndent(match[1]);
     if (indent) {
       listItem.setIndent(indent);
@@ -354,7 +358,6 @@ export const QUOTE: ElementTransformer = {
           $createLineBreakNode(),
           ...children,
         ]);
-        previousNode.select(0, 0);
         parentNode.remove();
         return;
       }
@@ -363,7 +366,9 @@ export const QUOTE: ElementTransformer = {
     const node = $createQuoteNode();
     node.append(...children);
     parentNode.replace(node);
-    node.select(0, 0);
+    if (!isImport) {
+      node.select(0, 0);
+    }
   },
   type: 'element',
 };

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -756,6 +756,52 @@ describe('Markdown', () => {
       ).toBe(mdAfterExport ?? md);
     });
   }
+
+  for (const {
+    md,
+    skipImport,
+    shouldPreserveNewLines,
+    shouldMergeAdjacentLines,
+    customTransformers,
+  } of IMPORT_AND_EXPORT) {
+    if (skipImport) {
+      continue;
+    }
+
+    it(`should not select when importing "${md.replace(/\n/g, '\\n')}"`, () => {
+      const editor = createHeadlessEditor({
+        nodes: [
+          HeadingNode,
+          ListNode,
+          ListItemNode,
+          QuoteNode,
+          CodeNode,
+          LinkNode,
+        ],
+      });
+
+      editor.update(
+        () =>
+          $convertFromMarkdownString(
+            md,
+            [
+              ...(customTransformers || []),
+              ...TRANSFORMERS,
+              HIGHLIGHT_TEXT_MATCH_IMPORT,
+            ],
+            undefined,
+            shouldPreserveNewLines,
+            shouldMergeAdjacentLines,
+          ),
+        {
+          discrete: true,
+        },
+      );
+
+      expect(editor.getEditorState().read(() => $getSelection())).toBe(null);
+    });
+  }
+
   it('should not remove leading node and transform if replace returns false', () => {
     const editor = createHeadlessEditor({
       nodes: [


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
Currently, some nodes are selected in markdown transformers in their replace call. This changes this select to only occur when not importing. This prevents the editor from being focused inadvertently when importing.

Closes #7576 

## Test plan

### Before
Using the code from original stackblitz: https://stackblitz.com/edit/facebook-lexical-i9kn8h4q?file=src%2FApp.tsx

https://github.com/user-attachments/assets/5b754cb9-02ad-4fbb-ae1f-df5667a2c4b2

### After
With the markdown import overridden to use my fork.

https://github.com/user-attachments/assets/86b9d451-7e3a-4be1-bcf7-8264553eb817