### PR TITLE
[lexical] Bug Fix: synced the export html output with import DOM expectations and browser DOM

### DIFF
--- a/packages/lexical/src/nodes/LexicalLineBreakNode.ts
+++ b/packages/lexical/src/nodes/LexicalLineBreakNode.ts
@@ -6,10 +6,11 @@
  *
  */
 
-import type {KlassConstructor} from '../LexicalEditor';
+import type {KlassConstructor, LexicalEditor} from '../LexicalEditor';
 import type {
   DOMConversionMap,
   DOMConversionOutput,
+  DOMExportOutput,
   NodeKey,
   SerializedLexicalNode,
 } from '../LexicalNode';
@@ -48,6 +49,18 @@ export class LineBreakNode extends LexicalNode {
 
   updateDOM(): false {
     return false;
+  }
+
+  override exportDOM(editor: LexicalEditor): DOMExportOutput {
+    const {element} = super.exportDOM(editor);
+    if (this.getNextSibling() !== null) {
+      return {element};
+    }
+    const documentFragment = document.createDocumentFragment();
+    const extraLineBreakElement = this.createDOM();
+    documentFragment.appendChild(element as HTMLElement);
+    documentFragment.appendChild(extraLineBreakElement);
+    return {element: documentFragment};
   }
 
   isInline(): true {


### PR DESCRIPTION
## Description

**Context:**
Currently the Lexical reconciler adds an extra `br` tag in the DOM to ensure the br tag added by us is not ignored by the parent block element.
So if there are n consecutive LB nodes in a block node, there will be n+1 `br` elements in the DOM. This hold true only if the last element of the block node is LB node.
This is handled by `reconcileElementTerminatingLineBreak` helper present in `packages/lexical/src/LexicalReconciler.ts`

In order to handle this, the importDOM method of the lineBreak node, ignores the last br node present in the imported HTML to avoid adding extra line breaks.

**Issue:**
The export DOM method does not export the extra br tag, which is anticipated to be present in the output by the import method, hence if we have 3 LB nodes added, there will be 4 br elements in the DOM. but the exported output will only have 3 LB nodes.
If we try to parse the same HTML output in our editor, we will trim away the last LB node, leading to only 2 line breaks in the given output which leads to a discrepancy.

I logged the HTML output in our plaground, attaching screenshots below
Before:
Here there are 2 nodes inserted in the video, 3 BR elements in the DOM but only 2 br elements are exported


https://github.com/user-attachments/assets/67b8fa78-4c3d-4192-8a52-e3e8cb897a48


After:
Here there are 2 nodes inserted in the video, 3 BR elements in the DOM but 3 br elements are exported

<img width="1728" alt="Screenshot 2025-06-03 at 4 44 00 PM" src="https://github.com/user-attachments/assets/fb4068b1-3c7d-40ba-a3ca-3dac31bff2c7" />


https://github.com/user-attachments/assets/5977dac1-d93e-4ffd-ba60-274b0cd23cce



Closes #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*