### PR TITLE
[lexical][lexical-selection] Bug Fix: Treat all TabNode as if they are in token mode

### DIFF
--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -80,9 +80,10 @@ export function $sliceSelectedTextNodeContent(
         endOffset = offset;
       }
 
-      return textNode.setTextContent(
-        textNode.__text.slice(startOffset, endOffset),
-      );
+      // NOTE: This mutates __text directly because the primary use case is to
+      // modify a $cloneWithProperties node that should never be added
+      // to the EditorState so we must not call getWritable via setTextContent
+      textNode.__text = textNode.__text.slice(startOffset, endOffset);
     }
   }
   return textNode;

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -49,8 +49,7 @@ export function $sliceSelectedTextNodeContent(
   const anchorAndFocus = selection.getStartEndPoints();
   if (
     textNode.isSelected(selection) &&
-    !textNode.isSegmented() &&
-    !textNode.isToken() &&
+    !$isTokenOrSegmented(textNode) &&
     anchorAndFocus !== null
   ) {
     const [anchor, focus] = anchorAndFocus;

--- a/packages/lexical-selection/src/lexical-node.ts
+++ b/packages/lexical-selection/src/lexical-node.ts
@@ -80,8 +80,9 @@ export function $sliceSelectedTextNodeContent(
         endOffset = offset;
       }
 
-      textNode.__text = textNode.__text.slice(startOffset, endOffset);
-      return textNode;
+      return textNode.setTextContent(
+        textNode.__text.slice(startOffset, endOffset),
+      );
     }
   }
   return textNode;

--- a/packages/lexical-yjs/src/CollabTextNode.ts
+++ b/packages/lexical-yjs/src/CollabTextNode.ts
@@ -155,8 +155,7 @@ export class CollabTextNode {
     const collabText = this._text;
 
     if (lexicalNode.__text !== collabText) {
-      const writable = lexicalNode.getWritable();
-      writable.__text = collabText;
+      lexicalNode.setTextContent(collabText);
     }
   }
 

--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -85,6 +85,7 @@ import {
   $getNodeByKey,
   $isSelectionCapturedInDecorator,
   $isTokenOrSegmented,
+  $isTokenOrTab,
   $setSelection,
   $shouldInsertTextAfterOrBeforeTextNode,
   $updateSelectedTextFromDOM,
@@ -577,8 +578,8 @@ function $canRemoveText(
     anchorNode !== focusNode ||
     $isElementNode(anchorNode) ||
     $isElementNode(focusNode) ||
-    !anchorNode.isToken() ||
-    !focusNode.isToken()
+    !$isTokenOrTab(anchorNode) ||
+    !$isTokenOrTab(focusNode)
   );
 }
 

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -74,6 +74,7 @@ import {
   $hasAncestor,
   $isRootOrShadowRoot,
   $isTokenOrSegmented,
+  $isTokenOrTab,
   $setCompositionKey,
   doesContainSurrogatePair,
   getDOMSelection,
@@ -841,8 +842,7 @@ export class RangeSelection implements BaseSelection {
     if (
       this.isCollapsed() &&
       startOffset === firstNodeTextLength &&
-      (firstNode.isSegmented() ||
-        firstNode.isToken() ||
+      ($isTokenOrSegmented(firstNode) ||
         !firstNode.canInsertTextAfter() ||
         (!firstNodeParent.canInsertTextAfter() &&
           firstNode.getNextSibling() === null))
@@ -871,8 +871,7 @@ export class RangeSelection implements BaseSelection {
     } else if (
       this.isCollapsed() &&
       startOffset === 0 &&
-      (firstNode.isSegmented() ||
-        firstNode.isToken() ||
+      ($isTokenOrSegmented(firstNode) ||
         !firstNode.canInsertTextBefore() ||
         (!firstNodeParent.canInsertTextBefore() &&
           firstNode.getPreviousSibling() === null))
@@ -920,7 +919,7 @@ export class RangeSelection implements BaseSelection {
     }
 
     if (selectedNodesLength === 1) {
-      if (firstNode.isToken()) {
+      if ($isTokenOrTab(firstNode)) {
         const textNode = $createTextNode(text);
         textNode.select();
         firstNode.replace(textNode);
@@ -1016,7 +1015,7 @@ export class RangeSelection implements BaseSelection {
       ) {
         if (
           $isTextNode(lastNode) &&
-          !lastNode.isToken() &&
+          !$isTokenOrTab(lastNode) &&
           endOffset !== lastNode.getTextContentSize()
         ) {
           if (lastNode.isSegmented()) {
@@ -1109,7 +1108,7 @@ export class RangeSelection implements BaseSelection {
 
       // Ensure we do splicing after moving of nodes, as splicing
       // can have side-effects (in the case of hashtags).
-      if (!firstNode.isToken()) {
+      if (!$isTokenOrTab(firstNode)) {
         firstNode = firstNode.spliceText(
           startOffset,
           firstNodeTextLength - startOffset,

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -48,6 +48,7 @@ import {
   $isLineBreakNode,
   $isRangeSelection,
   $isRootNode,
+  $isTabNode,
   $isTextNode,
   DecoratorNode,
   ElementNode,
@@ -194,8 +195,18 @@ export function getTextDirection(text: string): 'ltr' | 'rtl' | null {
   return null;
 }
 
+/**
+ * Return true if the TextNode is a TabNode or is in token mode.
+ */
+export function $isTokenOrTab(node: TextNode): boolean {
+  return $isTabNode(node) || node.isToken();
+}
+
+/**
+ * Return true if the TextNode is a TabNode, or is in token or segmented mode.
+ */
 export function $isTokenOrSegmented(node: TextNode): boolean {
-  return node.isToken() || node.isSegmented();
+  return $isTokenOrTab(node) || node.isSegmented();
 }
 
 /**
@@ -816,7 +827,7 @@ export function $shouldInsertTextAfterOrBeforeTextNode(
   }
   const offset = selection.anchor.offset;
   const parent = node.getParentOrThrow();
-  const isToken = node.isToken();
+  const isToken = $isTokenOrTab(node);
   if (offset === 0) {
     return (
       !node.canInsertTextBefore() ||

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -238,6 +238,7 @@ export {
   $isLeafNode,
   $isRootOrShadowRoot,
   $isTokenOrSegmented,
+  $isTokenOrTab,
   $nodesOfType,
   $onUpdate,
   $selectAll,

--- a/packages/lexical/src/nodes/LexicalTabNode.ts
+++ b/packages/lexical/src/nodes/LexicalTabNode.ts
@@ -62,7 +62,21 @@ export class TabNode extends TextNode {
       text === '\t' || text === '',
       'TabNode does not support setTextContent',
     );
-    return super.setTextContent(text);
+    return super.setTextContent('\t');
+  }
+
+  spliceText(
+    offset: number,
+    delCount: number,
+    newText: string,
+    moveSelection?: boolean,
+  ): TextNode {
+    invariant(
+      (newText === '' && delCount === 0) ||
+        (newText === '\t' && delCount === 1),
+      'TabNode does not support spliceText',
+    );
+    return this;
   }
 
   setDetail(detail: TextDetailType | number): this {

--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -1010,8 +1010,7 @@ export class TextNode extends LexicalNode {
       hasReplacedSelf = true;
     } else {
       // For the first part, update the existing node
-      writableNode = self.getWritable();
-      writableNode.__text = firstPart;
+      writableNode = self.setTextContent(firstPart);
     }
 
     // Then handle all other parts


### PR DESCRIPTION
## Description

For legacy reasons TabNode is a 'normal' mode TextNode with the `IS_UNMERGEABLE` detail flag (used only in the reconciler's normalization), but the conditions in the rest of the core used `node.isToken()` to determine if the node should be modified or replaced without checking the `IS_UNMERGEABLE` flag.

To keep legacy serialization as-is, this PR changes the core to use `$isTokenOrTab` (new) and `$isTokenOrSegmented` functions instead of calling the `TextNode.isToken` method directly, and these functions both now check `$isTabNode` as part of their condition.

This also changes all property setters of `__text` to go through the `setTextContent` method (except for `@lexical/selection`'s `$sliceSelectedTextNodeContent` which is used in an unusual "read-only" way), and adds an additional invariant to `TabNode.spliceText` to ensure that it is not modified by that either.

Closes #7601

## Test plan

Unit tests to confirm that `TabNode` is not modified in the scenarios from #7601