### PR TITLE
[tests] Chore: Update table test to use locator API instead of page.evaluate

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Tables.spec.mjs
@@ -6791,13 +6791,8 @@ test.describe.parallel('Tables', () => {
     await click(page, 'th >> nth=1');
 
     // Check that the action menu button is visible when no overflow
-    const menuVisible = await page.evaluate(() => {
-      const button = document.querySelector('.table-cell-action-button');
-      // If button exists, menu is visible
-      return !!button;
-    });
-
-    expect(menuVisible).toBe(true);
+    // If button exists, menu is visible
+    await expect(page.locator('.table-cell-action-button')).toBeVisible();
 
     // Make the column very wide to ensure overflow
     await page.mouse.move(
@@ -6814,13 +6809,8 @@ test.describe.parallel('Tables', () => {
     // Click the cell
     await click(page, 'th >> nth=0');
 
-    const menuHidden = await page.evaluate(() => {
-      const button = document.querySelector('.table-cell-action-button');
-      // If button doesn't exist, menu is hidden
-      return !button;
-    });
-
-    expect(menuHidden).toBe(true);
+    // If button doesn't exist, menu is hidden
+    await expect(page.locator('.table-cell-action-button')).toBeHidden();
   });
 
   test(`Can expand table to fit content when pasting table into table`, async ({


### PR DESCRIPTION
## Description

I noticed that this table test failed for no particular reason and saw that it was using an awkward API to check its condition. Using locators and the playwright expect API should be a bit more resilient. I didn't see any other usage of `page.evaluate` that looked suspect.

```
  1 failed
    [chromium] › packages/lexical-playground/__tests__/e2e/Tables.spec.mjs:6770:3 › Tables › Table action menu is hidden when cell overflows 
```

## Test plan

### Before

Test sometimes fails

### After

Hopefully it fails less