### PR TITLE
[lexical-react] Chore: Remove confusing return value

### DIFF
--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -492,7 +492,8 @@ function useAutoLink(
             return false;
           }
           const nodes = selection.extract();
-          nodes.forEach((node) => {
+          for (let i = 0; i < nodes.length; i++) {
+            const node = nodes[i];
             const parent = node.getParent();
 
             if ($isAutoLinkNode(parent)) {
@@ -501,7 +502,7 @@ function useAutoLink(
               parent.markDirty();
               return true;
             }
-          });
+          }
           return false;
         },
         COMMAND_PRIORITY_LOW,

--- a/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
+++ b/packages/lexical-react/src/LexicalAutoLinkPlugin.ts
@@ -492,17 +492,15 @@ function useAutoLink(
             return false;
           }
           const nodes = selection.extract();
-          for (let i = 0; i < nodes.length; i++) {
-            const node = nodes[i];
+          nodes.forEach((node) => {
             const parent = node.getParent();
 
             if ($isAutoLinkNode(parent)) {
               // invert the value
               parent.setIsUnlinked(!parent.getIsUnlinked());
               parent.markDirty();
-              return true;
             }
-          }
+          });
           return false;
         },
         COMMAND_PRIORITY_LOW,


### PR DESCRIPTION
## Description
- What is the current behavior that you are modifying?
In the AutoLinkPlugin, specifically in the `TOGGLE_LINK_COMMAND` handler, a value is returned from a `forEach` loop, which has no effect, is confusing and doesn't make much sense.
- What are the behavior or changes that are being added by this PR?
The return value was removed.