### PR TITLE
[lexical-devtools-core] Bug Fix: Allow CustomPrintNodeFn to return undefined

### DIFF
--- a/packages/lexical-devtools-core/src/generateContent.ts
+++ b/packages/lexical-devtools-core/src/generateContent.ts
@@ -35,7 +35,7 @@ import {LexicalCommandLog} from './useLexicalCommandsLog';
 export type CustomPrintNodeFn = (
   node: LexicalNode,
   obfuscateText?: boolean,
-) => string;
+) => string | undefined;
 
 const NON_SINGLE_WIDTH_CHARS_REPLACEMENT: Readonly<Record<string, string>> =
   Object.freeze({


### PR DESCRIPTION
## Description

- The current behavior is that the `CustomPrintNodeFn` type is strictly typed to return `string`. This causes a TypeScript error if your provided function returns `undefined` to fall back to the default node printing logic, even though the runtime code handles this scenario.
- This PR modifies the `CustomPrintNodeFn` type definition to be `string | undefined`. This aligns the type with the existing runtime behavior and resolves the TypeScript error.

Closes #7612

## Test plan

### Before

If you provided a `customPrintNode` function like this, you would encounter a TypeScript error:

```typescript
const myCustomPrintNode: CustomPrintNodeFn = (node) => {
  if (node.getType() === 'custom') {
    return 'Custom node representation';
  }
  return undefined; // TypeScript error: Type 'undefined' is not assignable to type 'string'.
};
```

### After

With the updated type definition, the above code will no longer produce a TypeScript error. The type checking will succeed, reflecting the actual supported behavior of the `generateContent` function in `lexical-devtools-core`.