### PR TITLE
[lexical-playground] Bug Fix: Update alignment state for image selection

### DIFF
--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -658,6 +658,13 @@ export default function ToolbarPlugin({
           const selectedElement = $findTopLevelElement(selectedNode);
           $handleHeadingNode(selectedElement);
           $handleCodeNode(selectedElement);
+          // Update elementFormat for node selection (e.g., images)
+          if ($isElementNode(selectedElement)) {
+            updateToolbarState(
+              'elementFormat',
+              selectedElement.getFormatType(),
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
**Current behavior:**  
When an image is selected in the editor, changing its alignment using the toolbar does not update the alignment button in the toolbar. The alignment state only updates correctly for text selections.

**Behavior after this PR:**  
The toolbar alignment button now correctly reflects the current alignment of the selected image. When an image is selected and its alignment is changed, the toolbar updates to show the new alignment, consistent with how it works for text.

Closes #7622

## Test plan

### Before
- Select an image in the editor.
- Change its alignment using the toolbar.
- The alignment button in the toolbar does **not** update to reflect the new alignment.
![image](https://github.com/user-attachments/assets/a26bb3ed-d939-4265-8895-83b2cfb48172)


### After
- Select an image in the editor.
- Change its alignment using the toolbar.
- The alignment button in the toolbar **does** update to reflect the new alignment.
![image](https://github.com/user-attachments/assets/74a95aef-0164-404b-a0cf-97ef4cd279e6)
