### PR TITLE
RFC [lexical] Fix: propagate directioned text up the tree in reconciler

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -83,7 +83,6 @@ export interface LexicalPrivateDOM {
   __lexicalTextContent?: string | undefined | null;
   __lexicalLineBreak?: HTMLBRElement | HTMLImageElement | undefined | null;
   __lexicalDirTextContent?: string | undefined | null;
-  __lexicalDir?: 'ltr' | 'rtl' | null | undefined;
   __lexicalUnmanaged?: boolean | undefined;
 }
 

--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -256,7 +256,8 @@ function $createChildrenWithDirection(
   subTreeDirectionedTextContent = '';
   $createChildren(children, element, 0, endIndex, element.getDOMSlot(dom));
   reconcileBlockDirection(element, dom);
-  subTreeDirectionedTextContent = previousSubTreeDirectionedTextContent;
+  subTreeDirectionedTextContent =
+    previousSubTreeDirectionedTextContent + subTreeDirectionedTextContent;
 }
 
 function $createChildren(
@@ -357,7 +358,7 @@ function reconcileBlockDirection(
 ): void {
   const previousSubTreeDirectionTextContent: string =
     dom.__lexicalDirTextContent || '';
-  const previousDirection: string = dom.__lexicalDir || '';
+  const previousDirection: string | null = dom.dir || null;
 
   if (
     previousSubTreeDirectionTextContent !== subTreeDirectionedTextContent ||
@@ -371,20 +372,21 @@ function reconcileBlockDirection(
     if (direction !== previousDirection) {
       const classList = dom.classList;
       const theme = activeEditorConfig.theme;
-      let previousDirectionTheme =
-        previousDirection !== null ? theme[previousDirection] : undefined;
       let nextDirectionTheme =
         direction !== null ? theme[direction] : undefined;
 
-      // Remove the old theme classes if they exist
-      if (previousDirectionTheme !== undefined) {
-        if (typeof previousDirectionTheme === 'string') {
-          const classNamesArr = normalizeClassNames(previousDirectionTheme);
-          previousDirectionTheme = theme[previousDirection] = classNamesArr;
-        }
+      if (previousDirection !== null) {
+        let previousDirectionTheme = theme[previousDirection];
+        // Remove the old theme classes if they exist
+        if (previousDirectionTheme !== undefined) {
+          if (typeof previousDirectionTheme === 'string') {
+            const classNamesArr = normalizeClassNames(previousDirectionTheme);
+            previousDirectionTheme = theme[previousDirection] = classNamesArr;
+          }
 
-        // @ts-ignore: intentional
-        classList.remove(...previousDirectionTheme);
+          // @ts-ignore: intentional
+          classList.remove(...previousDirectionTheme);
+        }
       }
 
       if (
@@ -419,7 +421,6 @@ function reconcileBlockDirection(
 
     activeTextDirection = direction;
     dom.__lexicalDirTextContent = subTreeDirectionedTextContent;
-    dom.__lexicalDir = direction;
   }
 }
 
@@ -436,7 +437,8 @@ function $reconcileChildrenWithDirection(
   reconcileBlockDirection(nextElement, dom);
   reconcileTextFormat(nextElement);
   reconcileTextStyle(nextElement);
-  subTreeDirectionedTextContent = previousSubTreeDirectionTextContent;
+  subTreeDirectionedTextContent =
+    previousSubTreeDirectionTextContent + subTreeDirectionedTextContent;
 }
 
 function createChildrenArray(

--- a/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
@@ -49,5 +49,52 @@ describe('LexicalReconciler', () => {
       });
       expect(para3Dir).toEqual('rtl');
     });
+
+    test('Should set direction to "ltr" when content is added to a node after being marked dirty as an empty node', async () => {
+      const {editor} = testEnv;
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.append(
+            $createParagraphNode().append($createTextNode('Hello')),
+            $createParagraphNode().append(),
+          );
+        },
+        {discrete: true},
+      );
+
+      // Trigger another update, marking the paragraphs as dirty.
+      editor.update(
+        () => {
+          $getRoot()
+            .getChildren()
+            .forEach((child) => {
+              child.markDirty();
+            });
+        },
+        {discrete: true},
+      );
+
+      expect(testEnv.innerHTML).toEqual(
+        '<p dir="ltr"><span data-lexical-text="true">Hello</span></p>' +
+          '<p><br></p>',
+      );
+
+      // Add content to the second paragraph.
+      editor.update(
+        () => {
+          $getRoot()
+            .getChildAtIndex<ParagraphNode>(1)!
+            .append($createTextNode('World'));
+        },
+        {discrete: true},
+      );
+
+      expect(testEnv.innerHTML).toEqual(
+        '<p dir="ltr"><span data-lexical-text="true">Hello</span></p>' +
+          '<p dir="ltr"><span data-lexical-text="true">World</span></p>',
+      );
+    });
   });
 });


### PR DESCRIPTION
## Issue

Depending on the order of operations and what nodes are marked dirty, LexicalReconciler behaves differently: sometimes you end up with `dir="rtl/ltr"` (`p`, `a`) all the way up the DOM and sometimes it's just on child nodes of the tree (just `a`). For example in "Auto Links" tests, [Does not create redundant auto-link](https://github.com/facebook/lexical/blob/v0.32.1/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs#L225) has the direction set on `p` but [Handles multiple autolinks in a row](https://github.com/facebook/lexical/blob/v0.32.1/packages/lexical-playground/__tests__/e2e/AutoLinks.spec.mjs#L300) does not.

In some cases, eg "ListItemNode RTL behavior" tests, `dir` ends up on the root `contenteditable` node. Looking at [list items handle mixed LTR and RTL content](https://github.com/facebook/lexical/blob/v0.32.1/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts#L1451), the root and `ul` are `rtl` but the first `li` is `ltr`. This seems to be a last-write-wins situation: in the playground, if you have a table with RTL text in the first cell, then table becomes RTL; if you then add LTR text in another cell, the table gets switched back to LTR.

The TL;DR is that you end up with different behaviour based on whether the reconciler uses `subTreeDirectionedTextContent` or falls back to `activeEditorDirection`.

## Proposed Fix

Currently, `__lexicalTextContent` is attached to each DOM node up the tree. This is built up in [$createChildren](https://github.com/facebook/lexical/blob/v0.32.1/packages/lexical/src/LexicalReconciler.ts#L290) and [$reconcileNode](https://github.com/facebook/lexical/blob/v0.32.1/packages/lexical/src/LexicalReconciler.ts#L226). I.e. for the root node, `__lexicalTextContent` is the concatenated content of all children.

The same is not done for `__lexicalDirTextContent` - the subtree text is not appended in [$createChildrenWithDirection](https://github.com/facebook/lexical/blob/v0.32.1/packages/lexical/src/LexicalReconciler.ts#L259) nor [$reconcileChildrenWithDirection](https://github.com/facebook/lexical/blob/v0.32.1/packages/lexical/src/LexicalReconciler.ts#L439). This PR changes the behaviour to do the same as `__lexicalTextContent`, i.e. propagate up.

By always propagating the directioned text content up, the last-write-wins behaviour is removed, and instead the result is that a given node's direction will be the set based on the first directioned text of its descendants.

A side effect of this change is that `hasEmptyDirectionedText` will no longer be true in most cases, so `dir="ltr"` is going to be set on almost all DOM nodes - [this check](https://github.com/facebook/lexical/blob/v0.32.1/packages/lexical/src/LexicalReconciler.ts#L392) will no longer evaluate to true.

Wanted to get input on this change before I go and update all the test cases, as this will impact almost every file.