### PR TITLE
[lexical-react] Chore: make ref types mutable

### DIFF
--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -264,8 +264,8 @@ function hideTargetLine(targetLineElem: HTMLElement | null) {
 function useDraggableBlockMenu(
   editor: LexicalEditor,
   anchorElem: HTMLElement,
-  menuRef: React.RefObject<HTMLElement>,
-  targetLineRef: React.RefObject<HTMLElement>,
+  menuRef: React.RefObject<HTMLElement | null>,
+  targetLineRef: React.RefObject<HTMLElement | null>,
   isEditable: boolean,
   menuComponent: ReactNode,
   targetLineComponent: ReactNode,
@@ -457,8 +457,8 @@ export function DraggableBlockPlugin_EXPERIMENTAL({
   onElementChanged,
 }: {
   anchorElem?: HTMLElement;
-  menuRef: React.RefObject<HTMLElement>;
-  targetLineRef: React.RefObject<HTMLElement>;
+  menuRef: React.RefObject<HTMLElement | null>;
+  targetLineRef: React.RefObject<HTMLElement | null>;
   menuComponent: ReactNode;
   targetLineComponent: ReactNode;
   isOnMenu: (element: HTMLElement) => boolean;


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

Fixes a typescript error when using Lexical with React 19 - as refs are [all now mutable](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-argument). 

```
const menuRef = useRef<HTMLDivElement>(null);

...

<DraggableBlockPlugin_EXPERIMENTAL
        menuRef={menuRef}
```


```
Type 'RefObject<HTMLDivElement | null>' is not assignable to type 'RefObject<HTMLElement>'.
  Type 'HTMLDivElement | null' is not assignable to type 'HTMLElement'.
    Type 'null' is not assignable to type 'HTMLElement'.ts(2322)
```

This matches the [flow types](https://github.com/facebook/lexical/blob/main/packages/lexical-react/flow/LexicalDraggableBlockPlugin.js.flow#L14-L15).
 

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*