### PR TITLE
[lexical-playground] [lexical-list] add ability to change ordered list start number

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -48,7 +48,7 @@ header h1 {
 .editor-shell {
   margin: 20px auto;
   border-radius: 2px;
-  max-width: 1140px;
+  max-width: 1100px;
   color: #000;
   position: relative;
   line-height: 1.7;
@@ -1491,7 +1491,6 @@ button.action-button:disabled {
 
 .toolbar {
   display: flex;
-  justify-content: center;
   margin-bottom: 1px;
   background: #fff;
   padding: 4px;

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -15,7 +15,7 @@ import {
   getLanguageFriendlyName,
 } from '@lexical/code';
 import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
-import {$isListNode, ListNode, UPDATE_LIST_START_COMMAND} from '@lexical/list';
+import {$isListNode, ListNode} from '@lexical/list';
 import {INSERT_EMBED_COMMAND} from '@lexical/react/LexicalAutoEmbedPlugin';
 import {INSERT_HORIZONTAL_RULE_COMMAND} from '@lexical/react/LexicalHorizontalRuleNode';
 import {$isHeadingNode} from '@lexical/rich-text';
@@ -581,21 +581,10 @@ export default function ToolbarPlugin({
             : element.getListType();
 
           updateToolbarState('blockType', type);
-          if (type === 'number') {
-            const start = parentList
-              ? parentList.getStart()
-              : element.getStart();
-            updateToolbarState('listStartNumber', start);
-          } else {
-            updateToolbarState('listStartNumber', null);
-          }
         } else {
-          updateToolbarState('listStartNumber', null);
           $handleHeadingNode(element);
           $handleCodeNode(element);
         }
-      } else {
-        updateToolbarState('listStartNumber', null);
       }
 
       // Handle buttons
@@ -830,30 +819,6 @@ export default function ToolbarPlugin({
               rootType={toolbarState.rootType}
               editor={activeEditor}
             />
-            {toolbarState.blockType === 'number' &&
-              toolbarState.listStartNumber !== null && (
-                <input
-                  type="number"
-                  value={toolbarState.listStartNumber}
-                  disabled={!isEditable}
-                  onChange={(e) => {
-                    const newStart = parseInt(e.target.value, 10);
-                    if (
-                      !isNaN(newStart) &&
-                      newStart >= 0 &&
-                      selectedElementKey
-                    ) {
-                      activeEditor.dispatchCommand(UPDATE_LIST_START_COMMAND, {
-                        listNodeKey: selectedElementKey,
-                        newStart,
-                      });
-                    }
-                  }}
-                  className="toolbar-item list-start-input"
-                  aria-label="List start number"
-                  style={{marginLeft: '5px', marginRight: '5px', width: '50px'}}
-                />
-              )}
             <Divider />
           </>
         )}


### PR DESCRIPTION

## Description

This PR introduces a feature allowing users to modify the starting number of an existing ordered list directly through the toolbar in the playground. 

Closes #7621
 
## Test plan

- Create an ordered list.
- Select an item in the ordered list.
- You should see a new number input field appear in the toolbar, next to the block type dropdown, showing the current start number .
- Change the number in that input field (e.g., to 9).
- Verify that the list in the editor updates its numbering accordingly (e.g., starts from 9, 10, 11...).

### Before

Currently, Lexical allows starting an ordered list with an arbitrary number only by creating a new list with that specific starting number. There is no UI mechanism to change the start number of an *existing* ordered list.


### After

https://github.com/user-attachments/assets/f2f8165e-2bbb-4101-b15c-6caa217b7677


