### PR TITLE
[lexical] Bug Fix: copy NodeState when splitting text nodes

### DIFF
--- a/packages/lexical/src/nodes/LexicalTextNode.ts
+++ b/packages/lexical/src/nodes/LexicalTextNode.ts
@@ -983,6 +983,7 @@ export class TextNode extends LexicalNode {
     const format = self.getFormat();
     const style = self.getStyle();
     const detail = self.__detail;
+    const state = self.__state;
     let hasReplacedSelf = false;
 
     // Prepare to handle selection
@@ -1007,6 +1008,7 @@ export class TextNode extends LexicalNode {
       writableNode.__format = format;
       writableNode.__style = style;
       writableNode.__detail = detail;
+      writableNode.__state = state;
       hasReplacedSelf = true;
     } else {
       // For the first part, update the existing node
@@ -1024,6 +1026,7 @@ export class TextNode extends LexicalNode {
       sibling.__format = format;
       sibling.__style = style;
       sibling.__detail = detail;
+      sibling.__state = state;
       const siblingKey = sibling.__key;
       const nextTextSize = textSize + partSize;
       if (compositionKey === key) {

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -12,8 +12,11 @@ import {
   $getNodeByKey,
   $getRoot,
   $getSelection,
+  $getState,
   $isNodeSelection,
   $isRangeSelection,
+  $setState,
+  createState,
   ElementNode,
   LexicalEditor,
   ParagraphNode,
@@ -629,6 +632,40 @@ describe('LexicalTextNode tests', () => {
           'o',
           'o',
         ]);
+      });
+    });
+
+    test('copies state to all nodes', async () => {
+      await update(() => {
+        const textNode = $createTextNode('hello world');
+        const state = createState('state', {
+          parse: (v) => v,
+          unparse: (v) => v,
+        });
+        $setState(textNode, state, 'foo');
+        const splits = textNode.splitText(3, 5);
+        expect(
+          splits
+            .map((split) => $getState(split, state))
+            .every((v) => v === 'foo'),
+        ).toEqual(true);
+      });
+    });
+
+    test('copies state to all nodes (segmented)', async () => {
+      await update(() => {
+        const textNode = $createTestSegmentedNode('hello world');
+        const state = createState('state', {
+          parse: (v) => v,
+          unparse: (v) => v,
+        });
+        $setState(textNode, state, 'foo');
+        const splits = textNode.splitText(3, 5);
+        expect(
+          splits
+            .map((split) => $getState(split, state))
+            .every((v) => v === 'foo'),
+        ).toEqual(true);
       });
     });
   });


### PR DESCRIPTION
## Description
Fixes node state not being copied to the new sibling nodes when splitting text nodes.

## Test plan
Unit test created for this behaviour (and segmented text nodes)

### Before

Formatting the middle of a TextNode with state applied to it would drop the styling from the split parts.

https://github.com/user-attachments/assets/ad9a01ee-603e-42f3-85f9-38dddf4720ee


### After

(Difficult to re-record the above situation, but the test should demonstrate the desired outcome)