### PR TITLE
[Lexical]Refactor: Change UnionToIntersection flow type

### DIFF
--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -1351,7 +1351,7 @@ export type StateValueConfig<V> = {
 
 export type UnionToIntersection<T> = (
   // $FlowFixMe[unclear-type]
-  T extends any ? (x: T) => any : empty
+  T extends mixed ? (x: T) => mixed : empty
   // $FlowFixMe[unclear-type]
 ) extends (x: infer R) => any
   ? R


### PR DESCRIPTION

## Description
The 'any' type in `UnionToIntersection` caused a flow error at meta internally.

In Flow, `mixed` is the preferred top type (similar to TypeScript's `unknown`), while `any` is less type-safe.

The `any` in `(x: infer R) => any` is kept unchanged because it's only used for the return type of the function type pattern, and we're only interested in extracting the parameter type `R`.

## Test plan

existing tests