### PR TITLE
[lexical-react] Bug Fix: handle DraggableBlockPlugin in scrollable editors 

### DIFF
--- a/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
+++ b/packages/lexical-react/src/LexicalDraggableBlockPlugin.tsx
@@ -203,7 +203,8 @@ function setMenuPosition(
   const top =
     targetRect.top +
     (targetCalculateHeight - floatingElemRect.height) / 2 -
-    anchorElementRect.top;
+    anchorElementRect.top +
+    anchorElem.scrollTop;
 
   const left = SPACE;
 
@@ -244,7 +245,8 @@ function setTargetLine(
     lineTop -= marginTop / 2;
   }
 
-  const top = lineTop - anchorTop - TARGET_LINE_HALF_HEIGHT;
+  const top =
+    lineTop - anchorTop - TARGET_LINE_HALF_HEIGHT + anchorElem.scrollTop;
   const left = TEXT_BOX_HORIZONTAL_PADDING - SPACE;
 
   targetLineElem.style.transform = `translate(${left}px, ${top}px)`;


### PR DESCRIPTION
## Description
The draggable block plugin did not render its handle in the correct place in scrollable editors.

## Test plan

### Before

https://github.com/user-attachments/assets/93493688-19d9-4756-b29a-87cfdfed3da3

### After

https://github.com/user-attachments/assets/11f4eacb-58c2-4f95-8dff-0e174ab71441
