### PR TITLE
[lexical] Bug Fix: allow same mutation listener fn to be registered to multiple nodes

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -244,7 +244,7 @@ export type Transform<T extends LexicalNode> = (node: T) => void;
 
 export type ErrorHandler = (error: Error) => void;
 
-export type MutationListeners = Map<MutationListener, Klass<LexicalNode>>;
+export type MutationListeners = Map<MutationListener, Set<Klass<LexicalNode>>>;
 
 export type MutatedNodes = Map<Klass<LexicalNode>, Map<NodeKey, NodeMutation>>;
 
@@ -948,7 +948,10 @@ export class LexicalEditor {
       this.getRegisteredNode(klass),
     ).klass;
     const mutations = this._listeners.mutation;
-    mutations.set(listener, klassToMutate);
+    if (!mutations.has(listener)) {
+      mutations.set(listener, new Set());
+    }
+    mutations.get(listener)!.add(klassToMutate);
     const skipInitialization = options && options.skipInitialization;
     if (
       !(skipInitialization === undefined
@@ -959,7 +962,11 @@ export class LexicalEditor {
     }
 
     return () => {
-      mutations.delete(listener);
+      const klassSet = mutations.get(listener)!;
+      klassSet.delete(klassToMutate);
+      if (klassSet.size === 0) {
+        mutations.delete(listener);
+      }
     };
   }
 

--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -948,10 +948,12 @@ export class LexicalEditor {
       this.getRegisteredNode(klass),
     ).klass;
     const mutations = this._listeners.mutation;
-    if (!mutations.has(listener)) {
-      mutations.set(listener, new Set());
+    let klassSet = mutations.get(listener);
+    if (klassSet === undefined) {
+      klassSet = new Set();
+      mutations.set(listener, klassSet);
     }
-    mutations.get(listener)!.add(klassToMutate);
+    klassSet.add(klassToMutate);
     const skipInitialization = options && options.skipInitialization;
     if (
       !(skipInitialization === undefined
@@ -962,7 +964,6 @@ export class LexicalEditor {
     }
 
     return () => {
-      const klassSet = mutations.get(listener)!;
       klassSet.delete(klassToMutate);
       if (klassSet.size === 0) {
         mutations.delete(listener);

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -731,14 +731,16 @@ function triggerMutationListeners(
   const listenersLength = listeners.length;
 
   for (let i = 0; i < listenersLength; i++) {
-    const [listener, klass] = listeners[i];
-    const mutatedNodesByType = mutatedNodes.get(klass);
-    if (mutatedNodesByType !== undefined) {
-      listener(mutatedNodesByType, {
-        dirtyLeaves,
-        prevEditorState,
-        updateTags,
-      });
+    const [listener, klassSet] = listeners[i];
+    for (const klass of klassSet) {
+      const mutatedNodesByType = mutatedNodes.get(klass);
+      if (mutatedNodesByType !== undefined) {
+        listener(mutatedNodesByType, {
+          dirtyLeaves,
+          prevEditorState,
+          updateTags,
+        });
+      }
     }
   }
 }

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2684,6 +2684,35 @@ describe('LexicalEditor tests', () => {
     expect(mutationListener).toHaveBeenCalledTimes(1);
   });
 
+  it('allows using the same listener for multiple node types', async () => {
+    init();
+
+    const listener = jest.fn();
+    editor.registerMutationListener(TextNode, listener);
+    editor.registerMutationListener(ParagraphNode, listener);
+
+    let paragraphKey: string;
+    let textNodeKey: string;
+
+    await editor.update(() => {
+      const root = $getRoot();
+      const paragraph = $createParagraphNode();
+      const textNode = $createTextNode('Hello world');
+      paragraphKey = paragraph.getKey();
+      textNodeKey = textNode.getKey();
+      root.append(paragraph);
+      paragraph.append(textNode);
+    });
+
+    expect(listener.mock.calls.length).toBe(2);
+    const [textNodeMutation, paragraphMutation] = listener.mock.calls;
+
+    expect(textNodeMutation[0].size).toBe(1);
+    expect(textNodeMutation[0].get(textNodeKey!)).toBe('created');
+    expect(paragraphMutation[0].size).toBe(1);
+    expect(paragraphMutation[0].get(paragraphKey!)).toBe('created');
+  });
+
   it('calls mutation listener with initial state', async () => {
     // TODO add tests for node replacement
     const mutationListenerA = jest.fn();


### PR DESCRIPTION
## Description

`registerMutationListener` currently maps from the listener function to the corresponding node class. If you then call `registerMutationListener` with a different class, it overwrites the first. This also means that the cleanup function from the first class could end up removing the listener for the second class.

`registerNodeTransform` on the other hand already allows you to register the same listener function to multiple classes. This change brings the same behaviour to `registerMutationListener`.

## Test plan

Added unit test, fails before change, passes after.