### PR TITLE
[lexical-clipboard] Inherit style when typing after pasting rich text

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -228,6 +228,53 @@ export function $insertGeneratedNodes(
     })
   ) {
     selection.insertNodes(nodes);
+
+    if ($isRangeSelection(selection) && selection.isCollapsed()) {
+      const anchor = selection.anchor;
+      let nodeToInspect: LexicalNode | null = null;
+
+      if (anchor.type === 'text') {
+        const potentialNode = anchor.getNode();
+        if ($isTextNode(potentialNode)) {
+          nodeToInspect = potentialNode;
+        }
+      } else if (anchor.type === 'element') {
+        const elementNode = anchor.getNode();
+        if (anchor.offset > 0 && $isElementNode(elementNode)) {
+          const nodeBefore = elementNode.getChildAtIndex(anchor.offset - 1);
+          if (nodeBefore && $isTextNode(nodeBefore)) {
+            nodeToInspect = nodeBefore;
+          } else if (
+            nodeBefore &&
+            $isElementNode(nodeBefore) &&
+            nodeBefore.isInline()
+          ) {
+            let potentialTextChild = nodeBefore.getLastDescendant();
+            while (
+              potentialTextChild &&
+              !$isTextNode(potentialTextChild) &&
+              potentialTextChild.getPreviousSibling()
+            ) {
+              potentialTextChild = potentialTextChild.getPreviousSibling();
+            }
+            if (potentialTextChild && $isTextNode(potentialTextChild)) {
+              nodeToInspect = potentialTextChild;
+            }
+          }
+        }
+      }
+
+      if (nodeToInspect && $isTextNode(nodeToInspect)) {
+        const newFormat = nodeToInspect.getFormat();
+        const newStyle = nodeToInspect.getStyle();
+
+        if (selection.format !== newFormat || selection.style !== newStyle) {
+          selection.format = newFormat;
+          selection.style = newStyle;
+          selection.dirty = true;
+        }
+      }
+    }
   }
   return;
 }

--- a/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
+++ b/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
@@ -92,6 +92,12 @@ describe('HTMLCopyAndPaste tests', () => {
           name: 'github checklist',
           pastedHTML: `<meta charset='utf-8'><p dir="auto" style="box-sizing: border-box; margin-top: 0px !important; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">checklist</p><ul class="contains-task-list" style="box-sizing: border-box; padding: 0px; margin-top: 0px; margin-bottom: 0px !important; position: relative; color: rgb(31, 35, 40); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; padding: 2px 15px 2px 42px; margin-right: -15px; margin-left: -15px; line-height: 1.5; border: 0px;"><span class="handle" style="box-sizing: border-box; display: block; float: left; width: 20px; padding: 2px 0px 0px 2px; margin-left: -43px; opacity: 0;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" checked="" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span></span>done</li><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; padding: 2px 15px 2px 42px; margin-right: -15px; margin-left: -15px; line-height: 1.5; border: 0px;"><span class="handle" style="box-sizing: border-box; display: block; float: left; width: 20px; padding: 2px 0px 0px 2px; margin-left: -43px; opacity: 0;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span></span>todo</li></ul>`,
         },
+        {
+          expectedHTML: `<p dir="ltr"><strong class="editor-text-bold" data-lexical-text="true">hello world</strong></p>`,
+          name: 'pasting inheritance',
+          pastedHTML: `<strong>hello</strong>`,
+          plainTextInsert: ' world',
+        },
       ];
 
       HTML_COPY_PASTING_TESTS.forEach((testCase, i) => {
@@ -107,6 +113,16 @@ describe('HTMLCopyAndPaste tests', () => {
               'isRangeSelection(selection)',
             );
             $insertDataTransferForRichText(dataTransfer, selection, editor);
+            if (testCase.plainTextInsert) {
+              editor.update(() => {
+                const newSelection = $getSelection();
+                invariant(
+                  $isRangeSelection(newSelection),
+                  'isRangeSelection(newSelection) for plainTextInsert',
+                );
+                newSelection.insertText(testCase.plainTextInsert);
+              });
+            }
           });
           expect(testEnv.innerHTML).toBe(testCase.expectedHTML);
         });

--- a/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
+++ b/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
@@ -114,14 +114,12 @@ describe('HTMLCopyAndPaste tests', () => {
             );
             $insertDataTransferForRichText(dataTransfer, selection, editor);
             if (testCase.plainTextInsert) {
-              editor.update(() => {
-                const newSelection = $getSelection();
-                invariant(
-                  $isRangeSelection(newSelection),
-                  'isRangeSelection(newSelection) for plainTextInsert',
-                );
-                newSelection.insertText(testCase.plainTextInsert);
-              });
+              const newSelection = $getSelection();
+              invariant(
+                $isRangeSelection(newSelection),
+                'isRangeSelection(newSelection) for plainTextInsert',
+              );
+              newSelection.insertText(testCase.plainTextInsert);
             }
           });
           expect(testEnv.innerHTML).toBe(testCase.expectedHTML);


### PR DESCRIPTION
## Description

When pasting rich text content, the editor selection's active format and style are now updated to match the style of the last character of the pasted content.

This ensures that continuing to type after a paste operation will correctly inherit the formatting (e.g., bold, italics, background-color, font-size) from the pasted material.

Closes #7490 

## Test plan

### Before

https://github.com/user-attachments/assets/826cfda6-7994-49dd-8d82-0d9f658a0ffa

/automated-tests*

### After

https://github.com/user-attachments/assets/2d9f4731-90de-4ad3-99fd-73189779ff29
