### PR TITLE
[lexical-playground] Chore: Fix AutocompleteNode importDOM warning

### DIFF
--- a/packages/lexical-playground/src/nodes/AutocompleteNode.tsx
+++ b/packages/lexical-playground/src/nodes/AutocompleteNode.tsx
@@ -45,6 +45,11 @@ export class AutocompleteNode extends TextNode {
     return 'autocomplete';
   }
 
+  static importDOM() {
+    // Never import from DOM
+    return null;
+  }
+
   static importJSON(
     serializedNode: SerializedAutocompleteNode,
   ): AutocompleteNode {


### PR DESCRIPTION
## Description

Since #7659 fixed the code that generates importDOM warnings we now have a new warning for AutocompleteNode's lack of importDOM in the playground. This fixes that warning.

## Test plan

### Before

> AutocompleteNode should implement "importDOM" if using a custom "exportDOM" method to ensure HTML serialization (important for copy & paste) works as expected

### After

No warning