### PR TITLE
[lexical-react] Bug Fix: LexicalMenu position menu immediately regression

### DIFF
--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -513,9 +513,10 @@ export function useMenuAnchorRef(
   shouldIncludePageYOffset__EXPERIMENTAL: boolean = true,
 ): MutableRefObject<HTMLElement | null> {
   const [editor] = useLexicalComposerContext();
-  const anchorElementRef = useRef<HTMLElement | null>(
-    CAN_USE_DOM ? document.createElement('div') : null,
-  );
+  const initialAnchorElement = CAN_USE_DOM
+    ? document.createElement('div')
+    : null;
+  const anchorElementRef = useRef<HTMLElement | null>(initialAnchorElement);
   const positionMenu = useCallback(() => {
     if (anchorElementRef.current === null || parent === undefined) {
       return;
@@ -569,7 +570,6 @@ export function useMenuAnchorRef(
         parent.append(containerDiv);
       }
       containerDiv.setAttribute('id', 'typeahead-menu');
-      anchorElementRef.current = containerDiv;
       rootElement.setAttribute('aria-controls', 'typeahead-menu');
     }
   }, [
@@ -589,7 +589,7 @@ export function useMenuAnchorRef(
       if (rootElement !== null) {
         rootElement.removeAttribute('aria-controls');
       }
-
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       const containerDiv = anchorElementRef.current;
       if (containerDiv !== null && containerDiv.isConnected) {
         containerDiv.remove();
@@ -617,11 +617,13 @@ export function useMenuAnchorRef(
   );
 
   // Append the context for the menu immediately
-  const containerDiv = anchorElementRef.current;
-  if (containerDiv != null) {
-    setContainerDivAttributes(containerDiv, className);
+  if (
+    initialAnchorElement != null &&
+    initialAnchorElement === anchorElementRef.current
+  ) {
+    setContainerDivAttributes(initialAnchorElement, className);
     if (parent != null) {
-      parent.append(containerDiv);
+      parent.append(initialAnchorElement);
     }
   }
 


### PR DESCRIPTION
## Description

The LexicalMenu change in #7181 caused a regression where extra DIVs were left in the DOM, sometimes taking up space and preventing interaction with the elements below.

Closes #7668

## Test plan

First follow #7668 repro steps

### Before

```
> [...new Set([...document.querySelectorAll('div[aria-label="Typeahead menu"]')].map((el) => el.style.cssText))]
(2) ['display: block; position: absolute;', 'display: block; position: absolute; left: 216px; height: 17.5px; width: 21.0938px; top: 166.273px;']
```

### After

```
> [...new Set([...document.querySelectorAll('div[aria-label="Typeahead menu"]')].map((el) => el.style.cssText))]
['display: block; position: absolute;']
```