### PR TITLE
[lexical-playground] fix: close link popup when user clicks out of it

### DIFF
--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -222,8 +222,8 @@ function FloatingLinkEditor({
     }
     const handleBlur = (event: FocusEvent) => {
       if (
-        editorElement.contains(event.relatedTarget as Element) === false &&
-        isLink === true
+        !editorElement.contains(event.relatedTarget as Element) &&
+        isLink
       ) {
         setIsLink(false);
         setIsLinkEditMode(false);

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -215,6 +215,26 @@ function FloatingLinkEditor({
     }
   }, [isLinkEditMode, isLink]);
 
+  useEffect(() => {
+    const editorElement = editorRef.current;
+    if (editorElement === null) {
+      return;
+    }
+    const handleBlur = (event: FocusEvent) => {
+      if (
+        editorElement.contains(event.relatedTarget as Element) === false &&
+        isLink === true
+      ) {
+        setIsLink(false);
+        setIsLinkEditMode(false);
+      }
+    };
+    editorElement.addEventListener('focusout', handleBlur);
+    return () => {
+      editorElement.removeEventListener('focusout', handleBlur);
+    };
+  }, [editorRef, setIsLink, setIsLinkEditMode, isLink]);
+
   const monitorInputInteraction = (
     event: React.KeyboardEvent<HTMLInputElement>,
   ) => {

--- a/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -221,10 +221,7 @@ function FloatingLinkEditor({
       return;
     }
     const handleBlur = (event: FocusEvent) => {
-      if (
-        !editorElement.contains(event.relatedTarget as Element) &&
-        isLink
-      ) {
+      if (!editorElement.contains(event.relatedTarget as Element) && isLink) {
         setIsLink(false);
         setIsLinkEditMode(false);
       }


### PR DESCRIPTION
## Description
Added a event listener to the FloatingLinkEditor component to ensure the link popup closes when it loses focus. 

Closes #7665 

## Test plan

### Before

https://github.com/user-attachments/assets/9d4d6937-1e18-46aa-be7e-806d43482bf8

### After

https://github.com/user-attachments/assets/72634740-a8bd-4c55-97db-233e04548ca5


