### PR TITLE
[lexical] Bug Fix: LexicalNode.getType() fallback to $config protocol

### DIFF
--- a/packages/lexical/src/LexicalEditor.ts
+++ b/packages/lexical/src/LexicalEditor.ts
@@ -566,7 +566,11 @@ export function createEditor(editorConfig?: CreateEditorArgs): LexicalEditor {
         if (
           name !== 'RootNode' &&
           nodeType !== 'root' &&
-          nodeType !== 'artificial'
+          nodeType !== 'artificial' &&
+          // This is mostly for the unit test suite which
+          // uses LexicalNode in an otherwise incorrect way
+          // by mocking its static getType
+          klass !== LexicalNode
         ) {
           const proto = klass.prototype;
           (['getType', 'clone'] as const).forEach((method) => {

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -61,6 +61,7 @@ import {
   $setSelection,
   errorOnInsertTextNodeOnRoot,
   getRegisteredNode,
+  getStaticNodeConfig,
   internalMarkNodeAsDirty,
   removeFromParent,
 } from './LexicalUtils';
@@ -407,11 +408,13 @@ export class LexicalNode {
    *
    */
   static getType(): string {
+    const {ownNodeType} = getStaticNodeConfig(this);
     invariant(
-      false,
+      ownNodeType !== undefined,
       'LexicalNode: Node %s does not implement .getType().',
       this.name,
     );
+    return ownNodeType;
   }
 
   /**


### PR DESCRIPTION
## Description

Follow-up to #7258

The `$config` protocol initially assumed that no code was calling `Node.getType()` before the Node was used in an editor, but there is a use case with plug-ins. This changes the stub implementation of `LexicalNode.getType()` to support the `$config` protocol directly.

## Test plan

### Before

Calling `Node.getType()` on a node using the `$config` protocol will throw if it has not first been registered with an editor

### After

Calling `Node.getType()` is safe at all times