### PR TITLE
[WIP][lexical] Feature: GenMap - A generational copy-on-write NodeMap implementation

### DIFF
--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -8,7 +8,6 @@
 
 import {
   $caretFromPoint,
-  $cloneWithProperties,
   $createParagraphNode,
   $getAdjacentChildCaret,
   $getCaretInDirection,
@@ -32,6 +31,7 @@ import {
   $setState,
   $splitAtPointCaretNext,
   type CaretDirection,
+  cloneEditorState,
   type EditorState,
   ElementNode,
   type Klass,
@@ -535,15 +535,15 @@ export function $restoreEditorState(
   editorState: EditorState,
 ): void {
   const FULL_RECONCILE = 2;
-  const nodeMap = new Map();
   const activeEditorState = editor._pendingEditorState;
 
-  for (const [key, node] of editorState._nodeMap) {
-    nodeMap.set(key, $cloneWithProperties(node));
-  }
-
   if (activeEditorState) {
-    activeEditorState._nodeMap = nodeMap;
+    activeEditorState._nodeMap = cloneEditorState(editorState)._nodeMap;
+    editor._cloneNotNeeded.clear();
+    editor._dirtyLeaves = new Set();
+    editor._dirtyElements.clear();
+  } else {
+    editor._editorState = editorState;
   }
 
   editor._dirtyType = FULL_RECONCILE;

--- a/packages/lexical/src/LexicalEditorState.ts
+++ b/packages/lexical/src/LexicalEditorState.ts
@@ -7,13 +7,19 @@
  */
 
 import type {LexicalEditor} from './LexicalEditor';
-import type {LexicalNode, NodeMap, SerializedLexicalNode} from './LexicalNode';
+import type {
+  LexicalNode,
+  NodeKey,
+  NodeMap,
+  SerializedLexicalNode,
+} from './LexicalNode';
 import type {BaseSelection} from './LexicalSelection';
 import type {SerializedElementNode} from './nodes/LexicalElementNode';
 import type {SerializedRootNode} from './nodes/LexicalRootNode';
 
 import invariant from 'shared/invariant';
 
+import {GenMap} from './LexicalGenMap';
 import {readEditorState} from './LexicalUpdates';
 import {$getRoot} from './LexicalUtils';
 import {$isElementNode} from './nodes/LexicalElementNode';
@@ -45,12 +51,15 @@ export function editorStateHasDirtySelection(
   return false;
 }
 
+/** @internal */
 export function cloneEditorState(current: EditorState): EditorState {
-  return new EditorState(new Map(current._nodeMap));
+  return new EditorState(new GenMap(current._nodeMap));
 }
 
 export function createEmptyEditorState(): EditorState {
-  return new EditorState(new Map([['root', $createRootNode()]]));
+  return new EditorState(
+    new GenMap<NodeKey, LexicalNode>().set('root', $createRootNode()),
+  );
 }
 
 function exportNodeToJSON<SerializedNode extends SerializedLexicalNode>(

--- a/packages/lexical/src/LexicalGenMap.ts
+++ b/packages/lexical/src/LexicalGenMap.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import invariant from 'shared/invariant';
+
+const TOMBSTONE = null;
+
+/**
+ * A Copy-on-write Map scheme suitable for NodeMap usage. Before it is
+ * written to it merely points to the previous GenMap. On first write it will
+ * either do a compaction (create a new "_old" generation) or create a copy of
+ * the "_nursery" from prev.
+ *
+ * This is an optimization as `new Map(oldMap)` must allocate some
+ * constant factor of `oldMap.size` even if very few values are changing from
+ * one state to the next.
+ */
+export class GenMap<K, V> {
+  /**
+   * The previous GenMap, this will be set only until first write. This GenMap
+   * should already be "frozen" (e.g. from a readonly EditorState).
+   * This invariant is not checked.
+   */
+  _prev: undefined | Omit<GenMap<K, V>, 'set' | 'delete' | 'clear'>;
+  /**
+   * A snapshot of the NodeMap when the last compaction occurred.
+   */
+  _old: undefined | ReadonlyMap<K, V>;
+  /**
+   * This Map represents any changes from `_old`, deletions that are present
+   * in `_old` are marked with `TOMBSTONE`.
+   */
+  _nursery: undefined | Map<K, typeof TOMBSTONE | V>;
+  /**
+   * The current size of the Map, accounting for the various optimizations
+   * used here.
+   */
+  _size: number;
+  constructor(prev?: GenMap<K, V>) {
+    this._prev = (prev ? prev._prev : prev) || prev;
+    invariant(
+      this._prev === undefined || this._prev._prev === undefined,
+      'GenMap ancestry chain greater than one',
+    );
+    this._old = undefined;
+    this._nursery = undefined;
+    this._size = prev ? prev.size : 0;
+  }
+  get size() {
+    return this._size;
+  }
+  has(key: K): boolean {
+    return this.get(key) !== undefined;
+  }
+  get(key: K): undefined | V {
+    if (this._prev) {
+      return this._prev.get(key);
+    }
+    if (this._nursery) {
+      const v = this._nursery.get(key);
+      if (v !== undefined) {
+        return v === TOMBSTONE ? undefined : v;
+      }
+    }
+    return this._old ? this._old.get(key) : undefined;
+  }
+  _getNursery() {
+    const prev = this._prev;
+    if (prev) {
+      this._prev = undefined;
+      const oldSize = prev._old ? prev._old.size : 0;
+      // Run a compaction when the nursery is greater than half the size of the snapshot
+      if (prev._nursery && prev._nursery.size * 2 > oldSize) {
+        const compact = new Map(prev._old);
+        for (const [k, v] of prev._nursery) {
+          if (v !== TOMBSTONE) {
+            compact.set(k, v);
+          }
+        }
+        this._old = compact;
+      } else {
+        this._old = prev._old;
+        this._nursery = new Map(prev._nursery);
+      }
+    }
+    if (!this._nursery) {
+      this._nursery = new Map();
+    }
+    return this._nursery;
+  }
+  set(key: K, value: V): this {
+    if (!this.has(key)) {
+      this._size++;
+    }
+    this._getNursery().set(key, value);
+    return this;
+  }
+  delete(key: K): boolean {
+    const deleted = this.has(key);
+    if (deleted) {
+      this._size--;
+      const nursery = this._getNursery();
+      if (this._old && this._old.has(key)) {
+        nursery.set(key, TOMBSTONE);
+      } else {
+        nursery.delete(key);
+      }
+    }
+    return deleted;
+  }
+  clear(): void {
+    this._old = undefined;
+    this._nursery = undefined;
+    this._prev = undefined;
+    this._size = 0;
+  }
+  *keys(): IterableIterator<K> {
+    for (const [k, _v] of this.entries()) {
+      yield k;
+    }
+  }
+  *values(): IterableIterator<V> {
+    for (const [_k, v] of this.entries()) {
+      yield v;
+    }
+  }
+  *entries(): IterableIterator<[K, V]> {
+    if (this._prev) {
+      yield* this._prev.entries();
+    }
+    const nursery = this._nursery;
+    const old = this._old;
+    // seen is used so we can provide the same ordered Map semantics from
+    // the naive Map based NodeMap
+    const seen = new Set<K>();
+    if (old) {
+      for (const pair of old) {
+        const k = pair[0];
+        const v = nursery ? nursery.get(k) : undefined;
+        if (v !== undefined) {
+          seen.add(k);
+          if (v === TOMBSTONE) {
+            continue;
+          }
+          pair[1] = v;
+        }
+        yield pair;
+      }
+    }
+    if (nursery) {
+      for (const pair of nursery) {
+        if (!seen.has(pair[0]) && pair[1] !== TOMBSTONE) {
+          yield pair as [K, V];
+        }
+      }
+    }
+  }
+  [Symbol.iterator](): IterableIterator<[K, V]> {
+    return this.entries();
+  }
+}

--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -30,6 +30,7 @@ import {
   NODE_STATE_KEY,
 } from '.';
 import {PROTOTYPE_CONFIG_METHOD} from './LexicalConstants';
+import {GenMap} from './LexicalGenMap';
 import {
   $updateStateFromJSON,
   type NodeState,
@@ -66,7 +67,7 @@ import {
   removeFromParent,
 } from './LexicalUtils';
 
-export type NodeMap = Map<NodeKey, LexicalNode>;
+export type NodeMap = GenMap<NodeKey, LexicalNode>;
 
 /**
  * The base type for all serialized nodes

--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -419,7 +419,7 @@ export function parseEditorState(
   editor._dirtyElements = new Map();
   editor._dirtyLeaves = new Set();
   editor._cloneNotNeeded = new Set();
-  editor._dirtyType = 0;
+  editor._dirtyType = NO_DIRTY_NODES;
   activeEditorState = editorState;
   isReadOnlyMode = false;
   activeEditor = editor;

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -578,7 +578,7 @@ export function markNodesWithTypesAsDirty(
   // We only need to mark nodes dirty if they were in the previous state.
   // If they aren't, then they are by definition dirty already.
   const cachedMap = getCachedTypeToNodeMap(editor.getEditorState());
-  const dirtyNodeMaps: NodeMap[] = [];
+  const dirtyNodeMaps: Map<NodeKey, LexicalNode>[] = [];
   for (const type of types) {
     const nodeMap = cachedMap.get(type);
     if (nodeMap) {
@@ -1886,7 +1886,7 @@ export function $getEditor(): LexicalEditor {
 }
 
 /** @internal */
-export type TypeToNodeMap = Map<string, NodeMap>;
+export type TypeToNodeMap = Map<string, Map<NodeKey, LexicalNode>>;
 /**
  * @internal
  * Compute a cached Map of node type to nodes for a frozen EditorState

--- a/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
@@ -11,22 +11,21 @@ import {
   $createTextNode,
   $getEditor,
   $getRoot,
+  $isRootNode,
   ParagraphNode,
+  type RootNode,
   TextNode,
 } from 'lexical';
 
-import {EditorState} from '../../LexicalEditorState';
-import {$createRootNode, RootNode} from '../../nodes/LexicalRootNode';
+import {createEmptyEditorState} from '../../LexicalEditorState';
 import {initializeUnitTest} from '../utils';
 
 describe('LexicalEditorState tests', () => {
   initializeUnitTest((testEnv) => {
-    test('constructor', async () => {
-      const root = $createRootNode();
-      const nodeMap = new Map([['root', root]]);
-
-      const editorState = new EditorState(nodeMap);
-      expect(editorState._nodeMap).toBe(nodeMap);
+    test('createEmptyEditorState', async () => {
+      const editorState = createEmptyEditorState();
+      expect(editorState._nodeMap.size).toBe(1);
+      expect($isRootNode(editorState._nodeMap.get('root'))).toBe(true);
       expect(editorState._selection).toBe(null);
     });
 
@@ -134,30 +133,28 @@ describe('LexicalEditorState tests', () => {
         $getRoot().getFirstChild()!.remove();
       });
 
-      expect(editor.getEditorState()._nodeMap).toEqual(
-        new Map([
-          [
-            'root',
-            {
-              __cachedText: '',
-              __dir: null,
-              __first: null,
-              __format: 0,
-              __indent: 0,
-              __key: 'root',
-              __last: null,
-              __next: null,
-              __parent: null,
-              __prev: null,
-              __size: 0,
-              __style: '',
-              __textFormat: 0,
-              __textStyle: '',
-              __type: 'root',
-            },
-          ],
-        ]),
-      );
+      expect([...editor.getEditorState()._nodeMap]).toEqual([
+        [
+          'root',
+          {
+            __cachedText: '',
+            __dir: null,
+            __first: null,
+            __format: 0,
+            __indent: 0,
+            __key: 'root',
+            __last: null,
+            __next: null,
+            __parent: null,
+            __prev: null,
+            __size: 0,
+            __style: '',
+            __textFormat: 0,
+            __textStyle: '',
+            __type: 'root',
+          },
+        ],
+      ]);
     });
   });
 });

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -168,6 +168,7 @@ export type {
   EditorStateReadOptions,
   SerializedEditorState,
 } from './LexicalEditorState';
+export {cloneEditorState} from './LexicalEditorState';
 export type {EventHandler} from './LexicalEvents';
 export type {
   BaseStaticNodeConfig,


### PR DESCRIPTION
## Description

Replace the naïve Map implementation of NodeMap with a version optimized for structural sharing.

GenMap has two "modes":

* Readonly Proxy - when `_prev` is set to some previous GenMap it proxies all read operations to that object. This is used to avoid any unnecessary work when there are no changes to state.
* Mutable - On first mutation it sets `_prev` to undefined and directly performs read and write operations

In Mutable mode there are two Maps:

* `_old` - A read-only snapshot of some previous state (equivalent to an old Map based NodeMap), generated by the last collection
* `_nursery` - The mutable working set of nodes (or tombstones) that have changed from `_old`. Tombstones are used to mark deletions of nodes that are still present in `_old` but will be removed at the next collection

When transitioning to Mutable mode one of two things will happen:

* A collection - this generates the next `_old` by creating a Map from every entry from `_prev`

```ts
this._old = new Map(prev.entries());
this._nursery = new Map();
```

* A copy - the `_old` from `_prev` is referenced (no copy) and `_nursery` from `_prev` is copied 

```ts
this._old = prev._old;
this._nursery = new Map(prev._nursery);
```

This is an optimization because the cost of copying a Map is linear in both memory and time. In large documents, most nodes are not updated on each update cycle, so we are only paying the cost to copy the smaller nursery. Occasionally we pay the full cost to do a collection, but this is amortized since we don't do it often.

Related:
* #6728
* https://emergence-engineering.com/blog/lexical-prosemirror-comparison
* [discord discussion](https://discord.com/channels/953974421008293909/964928369793843230/1303854088596881510)

## Test plan

All existing suites pass

## TODO

- [ ] Benchmarks
- [ ] More specific tests