### PR TITLE
[lexical-code][lexical][lexical-playground][lexical-list][lexical-rich-text] Feature: adjust text selection by node position before applying block-level formats

### DIFF
--- a/packages/lexical-code/src/CodeHighlighter.ts
+++ b/packages/lexical-code/src/CodeHighlighter.ts
@@ -34,6 +34,7 @@ import {
   $isTabNode,
   $isTextNode,
   $normalizeCaret,
+  $normalizeSelectionByPosition__EXPERIMENTAL as $normalizeSelectionByPosition,
   $setSelectionFromCaretRange,
   COMMAND_PRIORITY_LOW,
   INDENT_CONTENT_COMMAND,
@@ -646,7 +647,7 @@ function $handleTab(shiftKey: boolean): null | LexicalCommand<void> {
 }
 
 function $handleMultilineIndent(type: LexicalCommand<void>): boolean {
-  const selection = $getSelection();
+  const selection = $normalizeSelectionByPosition();
   if (!$isRangeSelection(selection) || !$isSelectionInCode(selection)) {
     return false;
   }

--- a/packages/lexical-list/src/formatList.ts
+++ b/packages/lexical-list/src/formatList.ts
@@ -16,6 +16,7 @@ import {
   $isRangeSelection,
   $isRootOrShadowRoot,
   $normalizeCaret,
+  $normalizeSelectionByPosition__EXPERIMENTAL as $normalizeSelectionByPosition,
   $setPointFromCaret,
   ElementNode,
   LexicalNode,
@@ -63,7 +64,7 @@ function $isSelectingEmptyListItem(
  * @param listType - The type of list, "number" | "bullet" | "check".
  */
 export function $insertList(listType: ListType): void {
-  const selection = $getSelection();
+  const selection = $normalizeSelectionByPosition();
 
   if (selection !== null) {
     let nodes = selection.getNodes();

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
@@ -27,6 +27,7 @@ import {
   $getSelection,
   $isRangeSelection,
   $isTextNode,
+  $normalizeSelectionByPosition__EXPERIMENTAL as $normalizeSelectionByPosition,
   LexicalEditor,
 } from 'lexical';
 
@@ -157,7 +158,7 @@ export const updateFontSize = (
 
 export const formatParagraph = (editor: LexicalEditor) => {
   editor.update(() => {
-    const selection = $getSelection();
+    const selection = $normalizeSelectionByPosition();
     $setBlocksType(selection, () => $createParagraphNode());
   });
 };
@@ -169,7 +170,7 @@ export const formatHeading = (
 ) => {
   if (blockType !== headingSize) {
     editor.update(() => {
-      const selection = $getSelection();
+      const selection = $normalizeSelectionByPosition();
       $setBlocksType(selection, () => $createHeadingNode(headingSize));
     });
   }
@@ -205,7 +206,7 @@ export const formatNumberedList = (
 export const formatQuote = (editor: LexicalEditor, blockType: string) => {
   if (blockType !== 'quote') {
     editor.update(() => {
-      const selection = $getSelection();
+      const selection = $normalizeSelectionByPosition();
       $setBlocksType(selection, () => $createQuoteNode());
     });
   }
@@ -214,7 +215,7 @@ export const formatQuote = (editor: LexicalEditor, blockType: string) => {
 export const formatCode = (editor: LexicalEditor, blockType: string) => {
   if (blockType !== 'code') {
     editor.update(() => {
-      let selection = $getSelection();
+      let selection = $normalizeSelectionByPosition();
       if (!selection) {
         return;
       }

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -59,6 +59,7 @@ import {
   $isRootNode,
   $isTextNode,
   $normalizeSelection__EXPERIMENTAL,
+  $normalizeSelectionByPosition__EXPERIMENTAL as $normalizeSelectionByPosition,
   $selectAll,
   $setSelection,
   CLICK_COMMAND,
@@ -696,7 +697,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
     editor.registerCommand<ElementFormatType>(
       FORMAT_ELEMENT_COMMAND,
       (format) => {
-        const selection = $getSelection();
+        const selection = $normalizeSelectionByPosition();
         if (!$isRangeSelection(selection) && !$isNodeSelection(selection)) {
           return false;
         }

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2701,6 +2701,95 @@ function $validatePoint(
   }
 }
 
+function $traverseNodes(
+  callback: (
+    node: LexicalNode,
+    absoluteOffset: number,
+  ) => {found: boolean; newOffset: number},
+) {
+  const root = $getRoot();
+  let absoluteOffset = 0;
+
+  const traverse = (node: LexicalNode): boolean => {
+    const result = callback(node, absoluteOffset);
+
+    if (result.found) {
+      absoluteOffset = result.newOffset;
+      return true; // Found - stop traversal
+    }
+
+    if ($isTextNode(node)) {
+      absoluteOffset += node.getTextContent().length;
+    } else if ($isElementNode(node)) {
+      return node.getChildren().some((child) => traverse(child));
+    }
+
+    return false;
+  };
+
+  root.getChildren().some((child) => traverse(child));
+  return absoluteOffset;
+}
+
+function $calculateSelectionPositions() {
+  const selection = $getSelection();
+
+  if (!$isRangeSelection(selection)) {
+    return {from: 0, to: 0};
+  }
+
+  const anchorPos = $calculateAbsolutePosition(selection.anchor);
+  const focusPos = $calculateAbsolutePosition(selection.focus);
+
+  return {
+    from: Math.min(anchorPos, focusPos),
+    to: Math.max(anchorPos, focusPos),
+  };
+}
+
+function $calculateAbsolutePosition(target: PointType | LexicalNode): number {
+  const targetKey =
+    target instanceof Object && 'key' in target ? target.key : target.getKey();
+  const targetOffset =
+    target instanceof Object && 'offset' in target ? target.offset : 0;
+
+  return $traverseNodes((node, currentOffset) => {
+    if (node.getKey() === targetKey) {
+      return {
+        found: true,
+        newOffset: currentOffset + targetOffset,
+      };
+    }
+    return {found: false, newOffset: currentOffset};
+  });
+}
+
+export function $normalizeSelectionByPosition(): null | BaseSelection {
+  const selection = getActiveEditorState()._selection;
+
+  if ($isRangeSelection(selection)) {
+    const {to} = $calculateSelectionPositions();
+    const allNodes = selection.getNodes();
+
+    // Filter nodes to make sure the all nodes are within the selected range
+    const filteredNodes = allNodes.filter((node) => {
+      const nodeStart = $calculateAbsolutePosition(node);
+      return nodeStart < to - 1 && $isTextNode(node);
+    });
+
+    if (filteredNodes.length > 0) {
+      const firstNode = filteredNodes[0];
+      const lastNode = filteredNodes[filteredNodes.length - 1];
+      const lastNodeEndOffset = lastNode.getTextContent().length;
+
+      selection.anchor.set(firstNode.getKey(), 0, 'text');
+      selection.focus.set(lastNode.getKey(), lastNodeEndOffset, 'text');
+    }
+  }
+
+  return selection;
+}
+
 export function $getSelection(): null | BaseSelection {
   const editorState = getActiveEditorState();
   return editorState._selection;

--- a/packages/lexical/src/index.ts
+++ b/packages/lexical/src/index.ts
@@ -228,6 +228,7 @@ export {
   $isBlockElementNode,
   $isNodeSelection,
   $isRangeSelection,
+  $normalizeSelectionByPosition as $normalizeSelectionByPosition__EXPERIMENTAL,
 } from './LexicalSelection';
 export {$parseSerializedNode, isCurrentlyReadOnlyMode} from './LexicalUpdates';
 export {


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
### Current Behavior

When you triple-click to select an entire line in the editor, the start of the next line is sometimes unintentionally included in the selection. This happens due to the browser’s default selection behavior and is not visibly noticeable to the user. However, it becomes apparent when applying block-level formats — since these styles affect the entire line, the formatting gets applied to both the intended line and part of the next one. This issue is most common in Chromium-based browsers.
How This PR Fixes It.
https://github.com/user-attachments/assets/2b59e59c-155b-4f79-8896-d7e88ce9cb12

### How this PR addresses this
This PR addresses the issue by normalizing the selection before applying block-level formats. It calculates the absolute numeric position of the selection’s end, then filters out any nodes whose start position is greater than or equal to that endpoint. This ensures that only the intended line receives the formatting.
https://github.com/user-attachments/assets/832a1350-622b-4418-be18-29fbceb67455