### PR TITLE
fix(hashtag-plugin): exclude emoji keycap (from hashtag regex match)

### DIFF
--- a/packages/lexical-react/src/LexicalHashtagPlugin.ts
+++ b/packages/lexical-react/src/LexicalHashtagPlugin.ts
@@ -229,7 +229,9 @@ function getHashtagRegexString(): string {
   const hashtagAlpha = '[' + alpha + ']';
   const hashtagAlphanumeric = '[' + alphanumeric + ']';
   const hashtagBoundary = '^|$|[^&/' + alphanumeric + ']';
-  const hashCharList = '[' + hashChars + ']';
+  // const hashCharList = '[' + hashChars + ']';
+   // Prevent matching emoji hashtag: '#️⃣' == '#\uFE0F\u20E3'
+  const hashCharList = '(?!' + '[' + hashChars + ']' + '\\uFE0F\\u20E3)' + '[' + hashChars + ']';
 
   // A hashtag contains characters, numbers and underscores,
   // but not all numbers.


### PR DESCRIPTION
- **Current behavior**: The hashtag regex matches emoji keycap `#️⃣` (`#\uFE0F\u20E3`), causing rendering issues and incorrect hashtag detection in Chrome and Safari.
- **Change introduced**: Added a negative lookahead in the `getHashtagRegexString()` function to exclude emoji keycap sequences from matching.

Closes #7678 

### Before

- Typing `#️⃣` in Chrome/Safari breaks rendering and incorrectly triggers the hashtag plugin.

### After

- Typing `#️⃣` no longer triggers hashtag parsing.
- Regular hashtags (e.g., `#test123`) still work as expected.