### PR TITLE
[lexical] Bug Fix: Implement missing deserialization for flat $config NodeState

### DIFF
--- a/packages/lexical/src/LexicalNode.ts
+++ b/packages/lexical/src/LexicalNode.ts
@@ -1147,7 +1147,7 @@ export class LexicalNode {
   updateFromJSON(
     serializedNode: LexicalUpdateJSON<SerializedLexicalNode>,
   ): this {
-    return $updateStateFromJSON(this, serializedNode[NODE_STATE_KEY]);
+    return $updateStateFromJSON(this, serializedNode);
   }
 
   /**

--- a/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
@@ -236,6 +236,32 @@ describe('LexicalNode state', () => {
         });
       });
 
+      test('flat config serialization round-trip', () => {
+        const {editor} = testEnv;
+        editor.update(() => {
+          const flatJSON: LexicalExportJSON<StateNode> = {
+            [NODE_STATE_KEY]: {boolState: true},
+            numberState: 2,
+            type: 'state',
+            version: 1,
+          };
+          const nestedJSON: LexicalExportJSON<StateNode> = {
+            [NODE_STATE_KEY]: {boolState: true, numberState: 2},
+            type: 'state',
+            version: 1,
+          };
+          const bothJSON: LexicalExportJSON<StateNode> = {
+            [NODE_STATE_KEY]: {boolState: true, numberState: 3},
+            numberState: 2,
+            type: 'state',
+            version: 1,
+          };
+          for (const doc of [flatJSON, nestedJSON, bothJSON]) {
+            expect(StateNode.importJSON(doc).exportJSON()).toEqual(flatJSON);
+          }
+        });
+      });
+
       test('default value should not be exported', async () => {
         const {editor} = testEnv;
         editor.update(() => {


### PR DESCRIPTION
## Description

The initial implementation of `$config` flat NodeState configuration was missing import support for flat keys, this implements that support. Previously, if you configured a NodeState key as flat, it would not be deserialized by `updateFromJSON`. Per the documentation and expectations, it should automatically be deserialized.

Closes #7682

## Test plan

New unit test coverage