### PR TITLE
[lexical-selection] Bug Fix: Correct backward inversion for RTL

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -1066,7 +1066,12 @@ test.describe.parallel('Selection', () => {
     );
   });
 
-  test('Select previous with RTL (DecoratorNode) #7685', async ({page}) => {
+  test('Select previous with RTL (DecoratorNode) #7685', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
     await page.keyboard.type('קצת מלל');
     await insertHorizontalRule(page);
     await page.keyboard.type('עוד');
@@ -1092,7 +1097,12 @@ test.describe.parallel('Selection', () => {
     );
   });
 
-  test('Select next with RTL (DecoratorNode) #7685', async ({page}) => {
+  test('Select next with RTL (DecoratorNode) #7685', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
     await page.keyboard.type('קצת מלל');
     await insertHorizontalRule(page);
     await page.keyboard.type('עוד');

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -1066,6 +1066,59 @@ test.describe.parallel('Selection', () => {
     );
   });
 
+  test('Select previous with RTL (DecoratorNode) #7685', async ({page}) => {
+    await page.keyboard.type('קצת מלל');
+    await insertHorizontalRule(page);
+    await page.keyboard.type('עוד');
+    await moveRight(page, 4);
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__rtl"
+          dir="rtl">
+          <span data-lexical-text="true">קצת מלל</span>
+        </p>
+        <hr
+          class="PlaygroundEditorTheme__hr PlaygroundEditorTheme__hrSelected"
+          contenteditable="false"
+          data-lexical-decorator="true" />
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__rtl"
+          dir="rtl">
+          <span data-lexical-text="true">עוד</span>
+        </p>
+      `,
+    );
+  });
+
+  test('Select next with RTL (DecoratorNode) #7685', async ({page}) => {
+    await page.keyboard.type('קצת מלל');
+    await insertHorizontalRule(page);
+    await page.keyboard.type('עוד');
+    await moveToEditorBeginning(page);
+    await moveLeft(page, 8);
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__rtl"
+          dir="rtl">
+          <span data-lexical-text="true">קצת מלל</span>
+        </p>
+        <hr
+          class="PlaygroundEditorTheme__hr PlaygroundEditorTheme__hrSelected"
+          contenteditable="false"
+          data-lexical-decorator="true" />
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__rtl"
+          dir="rtl">
+          <span data-lexical-text="true">עוד</span>
+        </p>
+      `,
+    );
+  });
+
   test('Can delete table node present at the end #5543', async ({
     page,
     isPlainText,

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -460,7 +460,12 @@ export function $shouldOverrideDefaultCharacterSelection(
   const isVertical = $isEditorVerticalOrientation(selection);
 
   // In vertical writing mode, we adjust the direction for correct caret movement
-  const adjustedIsBackward = isVertical ? !isBackward : isBackward;
+  let adjustedIsBackward = isVertical ? !isBackward : isBackward;
+
+  // In right-to-left writing mode, we invert the direction for correct caret movement
+  if ($isParentElementRTL(selection)) {
+    adjustedIsBackward = !adjustedIsBackward;
+  }
 
   const focusCaret = $caretFromPoint(
     selection.focus,


### PR DESCRIPTION
## Description
This updates the `$shouldOverrideDefaultCharacterSelection` to the correct "backward" value when inside an RTL element.

Closes #7685.

## Test plan

### Before

https://github.com/user-attachments/assets/7143b0f1-ec1d-4e3e-b5da-ca2e453a1c4e

### After

https://github.com/user-attachments/assets/90ba1799-9ab7-4329-95bb-a33cbe874cf3