### PR TITLE
[lexical-playground]Bug Fix: Image links lose link state when dragged

### DIFF
--- a/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
@@ -8,8 +8,18 @@
 
 import type {JSX} from 'react';
 
+import {
+  $isAutoLinkNode,
+  $isLinkNode,
+  LinkNode,
+  TOGGLE_LINK_COMMAND,
+} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$wrapNodeInElement, mergeRegister} from '@lexical/utils';
+import {
+  $findMatchingParent,
+  $wrapNodeInElement,
+  mergeRegister,
+} from '@lexical/utils';
 import {
   $createParagraphNode,
   $createRangeSelection,
@@ -314,6 +324,11 @@ function $onDrop(event: DragEvent, editor: LexicalEditor): boolean {
   if (!data) {
     return false;
   }
+  const existingLink = $findMatchingParent(
+    node,
+    (parent): parent is LinkNode =>
+      !$isAutoLinkNode(parent) && $isLinkNode(parent),
+  );
   event.preventDefault();
   if (canDropImage(event)) {
     const range = getDragSelection(event);
@@ -324,6 +339,9 @@ function $onDrop(event: DragEvent, editor: LexicalEditor): boolean {
     }
     $setSelection(rangeSelection);
     editor.dispatchCommand(INSERT_IMAGE_COMMAND, data);
+    if (existingLink) {
+      editor.dispatchCommand(TOGGLE_LINK_COMMAND, existingLink.getURL());
+    }
   }
   return true;
 }


### PR DESCRIPTION
## Description
I guess this is kind of an edge case: When the image is wrapped within a Link Node, toggle the link upon drop

Closes #7692

## Test plan

### Before


https://github.com/user-attachments/assets/44abe44b-3ebf-4cfe-ae8c-d127623c13d0


### After

https://github.com/user-attachments/assets/b7913055-5454-4a3d-bb3a-711bd0477cd6
