### PR TITLE
[lexical-react] feat: Context Menu icons

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -465,6 +465,12 @@ i.horizontal-rule {
   -webkit-mask-size: contain;
 }
 
+i {
+  width: 20px;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
 i.image {
   background-image: url(images/icons/file-image.svg);
 }
@@ -590,6 +596,10 @@ i.gif {
 
 i.copy {
   background-image: url(images/icons/copy.svg);
+}
+
+i.paste {
+  background-image: url(images/icons/clipboard.svg);
 }
 
 i.success {

--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -465,12 +465,6 @@ i.horizontal-rule {
   -webkit-mask-size: contain;
 }
 
-i {
-  width: 20px;
-  background-repeat: no-repeat;
-  background-size: contain;
-}
-
 i.image {
   background-image: url(images/icons/file-image.svg);
 }

--- a/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
@@ -47,12 +47,14 @@ export default function ContextMenuPlugin(): JSX.Element {
           editor.dispatchCommand(CUT_COMMAND, null);
         },
         disabled: false,
+        icon: <i className="icon page-break" />,
       }),
       new NodeContextMenuOption(`Copy`, {
         $onSelect: () => {
           editor.dispatchCommand(COPY_COMMAND, null);
         },
         disabled: false,
+        icon: <i className="icon copy" />,
       }),
       new NodeContextMenuOption(`Paste`, {
         $onSelect: () => {
@@ -84,6 +86,7 @@ export default function ContextMenuPlugin(): JSX.Element {
           });
         },
         disabled: false,
+        icon: <i className="icon paste" />,
       }),
       new NodeContextMenuOption(`Paste as Plain Text`, {
         $onSelect: () => {
@@ -109,6 +112,7 @@ export default function ContextMenuPlugin(): JSX.Element {
           });
         },
         disabled: false,
+        icon: <i className="icon" />,
       }),
       new NodeContextMenuSeparator(),
       new NodeContextMenuOption(`Delete Node`, {
@@ -131,6 +135,7 @@ export default function ContextMenuPlugin(): JSX.Element {
           }
         },
         disabled: false,
+        icon: <i className="icon clear" />,
       }),
     ];
   }, [editor]);

--- a/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ContextMenuPlugin/index.tsx
@@ -38,6 +38,7 @@ export default function ContextMenuPlugin(): JSX.Element {
         },
         $showOn: (node: LexicalNode) => $isLinkNode(node.getParent()),
         disabled: false,
+        icon: <i className="PlaygroundEditorTheme__contextMenuItemIcon" />,
       }),
       new NodeContextMenuSeparator({
         $showOn: (node: LexicalNode) => $isLinkNode(node.getParent()),
@@ -47,14 +48,16 @@ export default function ContextMenuPlugin(): JSX.Element {
           editor.dispatchCommand(CUT_COMMAND, null);
         },
         disabled: false,
-        icon: <i className="icon page-break" />,
+        icon: (
+          <i className="PlaygroundEditorTheme__contextMenuItemIcon page-break" />
+        ),
       }),
       new NodeContextMenuOption(`Copy`, {
         $onSelect: () => {
           editor.dispatchCommand(COPY_COMMAND, null);
         },
         disabled: false,
-        icon: <i className="icon copy" />,
+        icon: <i className="PlaygroundEditorTheme__contextMenuItemIcon copy" />,
       }),
       new NodeContextMenuOption(`Paste`, {
         $onSelect: () => {
@@ -86,7 +89,9 @@ export default function ContextMenuPlugin(): JSX.Element {
           });
         },
         disabled: false,
-        icon: <i className="icon paste" />,
+        icon: (
+          <i className="PlaygroundEditorTheme__contextMenuItemIcon paste" />
+        ),
       }),
       new NodeContextMenuOption(`Paste as Plain Text`, {
         $onSelect: () => {
@@ -112,7 +117,7 @@ export default function ContextMenuPlugin(): JSX.Element {
           });
         },
         disabled: false,
-        icon: <i className="icon" />,
+        icon: <i className="PlaygroundEditorTheme__contextMenuItemIcon" />,
       }),
       new NodeContextMenuSeparator(),
       new NodeContextMenuOption(`Delete Node`, {
@@ -135,7 +140,9 @@ export default function ContextMenuPlugin(): JSX.Element {
           }
         },
         disabled: false,
-        icon: <i className="icon clear" />,
+        icon: (
+          <i className="PlaygroundEditorTheme__contextMenuItemIcon clear" />
+        ),
       }),
     ];
   }, [editor]);

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -646,7 +646,7 @@
 }
 .PlaygroundEditorTheme__contextMenuItem {
   display: flex;
-  justify-content: space-between;
+  justify-content: left;
   width: 100%;
   background-color: #fff;
   color: #050505;

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -656,6 +656,7 @@
   text-align: left;
   line-height: 20px;
   padding: 8px;
+  padding-right: 14px;
   outline: 0;
   cursor: pointer;
 }
@@ -673,7 +674,7 @@
 }
 .PlaygroundEditorTheme__contextMenuItemIcon {
   width: 20px;
-  margin-right: 10px;
+  margin-right: 8px;
   background-repeat: no-repeat;
   background-size: contain;
 }

--- a/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
+++ b/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css
@@ -671,3 +671,9 @@
   color: #aaa;
   cursor: not-allowed;
 }
+.PlaygroundEditorTheme__contextMenuItemIcon {
+  width: 20px;
+  margin-right: 10px;
+  background-repeat: no-repeat;
+  background-size: contain;
+}

--- a/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
@@ -107,7 +107,7 @@ const ContextMenuItem = forwardRef<
       role="menuitem"
       disabled={disabled}>
       {icon}
-      <span style={{marginLeft: 10}}>{label}</span>
+      {label}
     </button>
   );
 });

--- a/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
@@ -43,6 +43,7 @@ class MenuOption {
 class NodeContextMenuOption extends MenuOption {
   type: string;
   title: string;
+  icon: JSX.Element | null;
   disabled: boolean;
   $onSelect: () => void;
   $showOn?: (node: LexicalNode) => boolean;
@@ -51,6 +52,7 @@ class NodeContextMenuOption extends MenuOption {
     title: string,
     options: {
       disabled?: boolean;
+      icon?: JSX.Element;
       $onSelect: () => void;
       $showOn?: (node: LexicalNode) => boolean;
     },
@@ -59,6 +61,7 @@ class NodeContextMenuOption extends MenuOption {
     this.type = 'item';
     this.title = title;
     this.disabled = options.disabled ?? false;
+    this.icon = options.icon ?? null;
     this.$onSelect = options.$onSelect;
     if (options.$showOn) {
       this.$showOn = options.$showOn;
@@ -93,8 +96,9 @@ const ContextMenuItem = forwardRef<
   React.ButtonHTMLAttributes<HTMLButtonElement> & {
     label?: string;
     disabled?: boolean;
+    icon?: JSX.Element | null;
   }
->(({className, label, disabled, ...props}, ref) => {
+>(({className, label, disabled, icon, ...props}, ref) => {
   return (
     <button
       {...props}
@@ -102,7 +106,8 @@ const ContextMenuItem = forwardRef<
       ref={ref}
       role="menuitem"
       disabled={disabled}>
-      {label}
+      {icon}
+      <span style={{marginLeft: 10}}>{label}</span>
     </button>
   );
 });
@@ -226,6 +231,7 @@ const NodeContextMenuPlugin = forwardRef<
           return {
             className: itemClassName,
             disabled: (option as NodeContextMenuOption).disabled,
+            icon: (option as NodeContextMenuOption).icon,
             key: option.key,
             label: (option as NodeContextMenuOption).title,
             onClick: () =>


### PR DESCRIPTION
Add support for icons in the new floatingUI-based context menu (LexicalNodeContextMenu).

<img width="330" height="343" alt="image" src="https://github.com/user-attachments/assets/b73e74cd-121e-4980-9f12-ad3de7ecfe71" />
