### PR TITLE
fix(Image):Image Links loose link state when dragged

### DIFF
--- a/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
@@ -8,11 +8,13 @@
 
 import type {JSX} from 'react';
 
+import {$createLinkNode, LinkNode} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$wrapNodeInElement, mergeRegister} from '@lexical/utils';
 import {
   $createParagraphNode,
   $createRangeSelection,
+  $getNodeByKey,
   $getSelection,
   $insertNodes,
   $isNodeSelection,
@@ -272,6 +274,7 @@ function $onDragStart(event: DragEvent): boolean {
   if (!dataTransfer) {
     return false;
   }
+
   dataTransfer.setData('text/plain', '_');
   dataTransfer.setDragImage(img, 0, 0);
   dataTransfer.setData(
@@ -306,25 +309,67 @@ function $onDragover(event: DragEvent): boolean {
 }
 
 function $onDrop(event: DragEvent, editor: LexicalEditor): boolean {
+  // Get the currently selected image node
   const node = $getImageNodeInSelection();
   if (!node) {
-    return false;
+    return false; // No image node selected, exit early
   }
+
+  // Get the parent node's key
+  const parent_key = String(node.__parent);
+  let link = '';
+  if (node) {
+    // Check if the parent node is a link
+    const nodelink = $getNodeByKey(parent_key);
+    if (nodelink?.__type === 'link') {
+      // Cast to LinkNode to safely access the URL
+      const linkNode = nodelink as LinkNode;
+      link = linkNode.__url || ''; // Extract the URL or default to empty string
+    }
+  }
+
+  // Retrieve image data from the drag event
   const data = getDragImageData(event);
   if (!data) {
-    return false;
+    return false; // No valid image data, exit early
   }
+
+  // Prevent default browser drop behavior
   event.preventDefault();
+
+  // Check if the image can be dropped at the current location
   if (canDropImage(event)) {
+    // Get the drop range from the event
     const range = getDragSelection(event);
+
+    // Remove the original image node
     node.remove();
+
+    // Create a new range selection for the drop position
     const rangeSelection = $createRangeSelection();
     if (range !== null && range !== undefined) {
+      // Apply the drop range to the selection
       rangeSelection.applyDOMRange(range);
     }
+
+    // Set the editor's selection to the new range
     $setSelection(rangeSelection);
-    editor.dispatchCommand(INSERT_IMAGE_COMMAND, data);
+
+    if (link) {
+      // If a link exists, wrap the image in a link node
+      editor.update(() => {
+        const linkNode = $createLinkNode(link); // Create a new link node
+        const imageNode = $createImageNode(data); // Create a new image node
+        linkNode.append(imageNode); // Set image as child of link node
+        $insertNodes([linkNode]); // Insert the link node (with image) into the editor
+      });
+    } else {
+      // If no link, insert the image directly
+      editor.dispatchCommand(INSERT_IMAGE_COMMAND, data);
+    }
   }
+
+  // Indicate that the drop event was handled
   return true;
 }
 

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/utils.ts
@@ -24,6 +24,7 @@ import {$isTableSelection} from '@lexical/table';
 import {$getNearestBlockElementAncestorOrThrow} from '@lexical/utils';
 import {
   $createParagraphNode,
+  $createTextNode,
   $getSelection,
   $isRangeSelection,
   $isTextNode,
@@ -214,7 +215,7 @@ export const formatQuote = (editor: LexicalEditor, blockType: string) => {
 export const formatCode = (editor: LexicalEditor, blockType: string) => {
   if (blockType !== 'code') {
     editor.update(() => {
-      let selection = $getSelection();
+      const selection = $getSelection();
       if (!selection) {
         return;
       }
@@ -223,11 +224,14 @@ export const formatCode = (editor: LexicalEditor, blockType: string) => {
       } else {
         const textContent = selection.getTextContent();
         const codeNode = $createCodeNode();
-        selection.insertNodes([codeNode]);
-        selection = $getSelection();
-        if ($isRangeSelection(selection)) {
-          selection.insertRawText(textContent);
-        }
+        const anchorNode = selection.anchor.getNode();
+
+        // Insert code node just below the selected node (as its sibling)
+        anchorNode.insertAfter(codeNode);
+        // Insert the selected text into the code node
+        codeNode.append($createTextNode(textContent));
+        // Remove the selected content
+        selection.removeText();
       }
     });
   }


### PR DESCRIPTION
I guess this is kind of an edge case: When the image is wrapped within a Link Node,  add a parent link node to the image and then update the editor.

Closes https://github.com/facebook/lexical/issues/7692