### PR TITLE
[lexical-website][docs] Documentation Update: Fix typo 

### DIFF
--- a/packages/lexical-website/docs/concepts/node-state.md
+++ b/packages/lexical-website/docs/concepts/node-state.md
@@ -89,7 +89,7 @@ NodeState value from the given node, or the default if that key was never
 set on the node.
 
 ```ts
-const question = $getValue(pollNode, questionState);
+const question = $getState(pollNode, questionState);
 ```
 
 See also
@@ -104,7 +104,7 @@ an update listener or mutation listener).
 NodeState value on the given node.
 
 ```ts
-const question = $setValue(
+const question = $setState(
   pollNode,
   questionState,
   'Are you planning to use NodeState?',


### PR DESCRIPTION
Fixed small type in Concept Docs: NodeState

The $getState and $setState functions were incorrectly named $getValue and $setValue inside of their example snippet.