### PR TITLE
[lexical] Bug Fix: call $validatePoint on resolvedFocusPoint

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -2494,7 +2494,7 @@ function $internalResolveSelectionPoints(
   }
   if (__DEV__) {
     $validatePoint(editor, 'anchor', resolvedAnchorPoint);
-    $validatePoint(editor, 'focus', resolvedAnchorPoint);
+    $validatePoint(editor, 'focus', resolvedFocusPoint);
   }
   if (
     resolvedAnchorPoint.type === 'element' &&


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description

Looks like the original author want to call `$validatePoint` on `resolvedAnchorPoint` AND `resolvedFocusPoint`, but accidentally call it only on `resolvedAnchorPoint` twice. 
