### PR TITLE
[lexical-playground] Bug Fix: include font sizes in pt as well in parseAllowedFontSize

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
@@ -55,34 +55,26 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
-                  a
-                </span>
+                <span style="font-size: 11pt" data-lexical-text="true">a</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
-                  b
-                </span>
+                <span style="font-size: 11pt" data-lexical-text="true">b</span>
               </p>
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
-                  b
-                </span>
+                <span style="font-size: 11pt" data-lexical-text="true">b</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
-                  c
-                </span>
+                <span style="font-size: 11pt" data-lexical-text="true">c</span>
               </p>
             </td>
           </tr>
@@ -91,27 +83,21 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
-                  d
-                </span>
+                <span style="font-size: 11pt" data-lexical-text="true">d</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
-                  e
-                </span>
+                <span style="font-size: 11pt" data-lexical-text="true">e</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
-                  f
-                </span>
+                <span style="font-size: 11pt" data-lexical-text="true">f</span>
               </p>
             </td>
           </tr>
@@ -145,7 +131,7 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
+                <span style="font-size: 11pt" data-lexical-text="true">
                   short
                 </span>
               </p>
@@ -154,7 +140,7 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
+                <span style="font-size: 11pt" data-lexical-text="true">
                   wide
                 </span>
               </p>
@@ -163,7 +149,7 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
+                <span style="font-size: 11pt" data-lexical-text="true">
                   default
                 </span>
               </p>
@@ -174,27 +160,21 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
-                  a
-                </span>
+                <span style="font-size: 11pt" data-lexical-text="true">a</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
-                  b
-                </span>
+                <span style="font-size: 11pt" data-lexical-text="true">b</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 14.6667px" data-lexical-text="true">
-                  c
-                </span>
+                <span style="font-size: 11pt" data-lexical-text="true">c</span>
               </p>
             </td>
           </tr>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
@@ -55,26 +55,34 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">a</span>
+                <span style="font-size: 14.6667px" data-lexical-text="true">
+                  a
+                </span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">b</span>
+                <span style="font-size: 14.6667px" data-lexical-text="true">
+                  b
+                </span>
               </p>
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">b</span>
+                <span style="font-size: 14.6667px" data-lexical-text="true">
+                  b
+                </span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">c</span>
+                <span style="font-size: 14.6667px" data-lexical-text="true">
+                  c
+                </span>
               </p>
             </td>
           </tr>
@@ -83,21 +91,27 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">d</span>
+                <span style="font-size: 14.6667px" data-lexical-text="true">
+                  d
+                </span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">e</span>
+                <span style="font-size: 14.6667px" data-lexical-text="true">
+                  e
+                </span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">f</span>
+                <span style="font-size: 14.6667px" data-lexical-text="true">
+                  f
+                </span>
               </p>
             </td>
           </tr>
@@ -131,7 +145,7 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">
+                <span style="font-size: 14.6667px" data-lexical-text="true">
                   short
                 </span>
               </p>
@@ -140,7 +154,7 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">
+                <span style="font-size: 14.6667px" data-lexical-text="true">
                   wide
                 </span>
               </p>
@@ -149,7 +163,7 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">
+                <span style="font-size: 14.6667px" data-lexical-text="true">
                   default
                 </span>
               </p>
@@ -160,21 +174,27 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">a</span>
+                <span style="font-size: 14.6667px" data-lexical-text="true">
+                  a
+                </span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">b</span>
+                <span style="font-size: 14.6667px" data-lexical-text="true">
+                  b
+                </span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span style="font-size: 11pt" data-lexical-text="true">c</span>
+                <span style="font-size: 14.6667px" data-lexical-text="true">
+                  c
+                </span>
               </p>
             </td>
           </tr>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TablesHTMLCopyAndPaste.spec.mjs
@@ -55,26 +55,26 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">a</span>
+                <span style="font-size: 11pt" data-lexical-text="true">a</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">b</span>
+                <span style="font-size: 11pt" data-lexical-text="true">b</span>
               </p>
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">b</span>
+                <span style="font-size: 11pt" data-lexical-text="true">b</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">c</span>
+                <span style="font-size: 11pt" data-lexical-text="true">c</span>
               </p>
             </td>
           </tr>
@@ -83,21 +83,21 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">d</span>
+                <span style="font-size: 11pt" data-lexical-text="true">d</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">e</span>
+                <span style="font-size: 11pt" data-lexical-text="true">e</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">f</span>
+                <span style="font-size: 11pt" data-lexical-text="true">f</span>
               </p>
             </td>
           </tr>
@@ -131,21 +131,27 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">short</span>
+                <span style="font-size: 11pt" data-lexical-text="true">
+                  short
+                </span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">wide</span>
+                <span style="font-size: 11pt" data-lexical-text="true">
+                  wide
+                </span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">default</span>
+                <span style="font-size: 11pt" data-lexical-text="true">
+                  default
+                </span>
               </p>
             </td>
           </tr>
@@ -154,21 +160,21 @@ test.describe('HTML Tables CopyAndPaste', () => {
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">a</span>
+                <span style="font-size: 11pt" data-lexical-text="true">a</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">b</span>
+                <span style="font-size: 11pt" data-lexical-text="true">b</span>
               </p>
             </td>
             <td class="PlaygroundEditorTheme__tableCell">
               <p
                 class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
                 dir="ltr">
-                <span data-lexical-text="true">c</span>
+                <span style="font-size: 11pt" data-lexical-text="true">c</span>
               </p>
             </td>
           </tr>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TextFormatHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TextFormatHTMLCopyAndPaste.spec.mjs
@@ -32,7 +32,7 @@ test.describe('HTML CopyAndPaste', () => {
           dir="ltr">
           <strong
             class="PlaygroundEditorTheme__textBold"
-            style="font-size: 14.6667px"
+            style="font-size: 11pt"
             data-lexical-text="true">
             Bold
           </strong>
@@ -42,7 +42,7 @@ test.describe('HTML CopyAndPaste', () => {
           dir="ltr">
           <em
             class="PlaygroundEditorTheme__textItalic"
-            style="font-size: 14.6667px"
+            style="font-size: 11pt"
             data-lexical-text="true">
             Italic
           </em>
@@ -52,7 +52,7 @@ test.describe('HTML CopyAndPaste', () => {
           dir="ltr">
           <span
             class="PlaygroundEditorTheme__textUnderline"
-            style="font-size: 14.6667px"
+            style="font-size: 11pt"
             data-lexical-text="true">
             underline
           </span>
@@ -63,7 +63,7 @@ test.describe('HTML CopyAndPaste', () => {
           <strong
             class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic
            PlaygroundEditorTheme__textUnderline"
-            style="font-size: 14.6667px"
+            style="font-size: 11pt"
             data-lexical-text="true">
             Bold Italic Underline
           </strong>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TextFormatHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TextFormatHTMLCopyAndPaste.spec.mjs
@@ -32,6 +32,7 @@ test.describe('HTML CopyAndPaste', () => {
           dir="ltr">
           <strong
             class="PlaygroundEditorTheme__textBold"
+            style="font-size: 11pt"
             data-lexical-text="true">
             Bold
           </strong>
@@ -41,6 +42,7 @@ test.describe('HTML CopyAndPaste', () => {
           dir="ltr">
           <em
             class="PlaygroundEditorTheme__textItalic"
+            style="font-size: 11pt"
             data-lexical-text="true">
             Italic
           </em>
@@ -50,6 +52,7 @@ test.describe('HTML CopyAndPaste', () => {
           dir="ltr">
           <span
             class="PlaygroundEditorTheme__textUnderline"
+            style="font-size: 11pt"
             data-lexical-text="true">
             underline
           </span>
@@ -60,6 +63,7 @@ test.describe('HTML CopyAndPaste', () => {
           <strong
             class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic
            PlaygroundEditorTheme__textUnderline"
+            style="font-size: 11pt"
             data-lexical-text="true">
             Bold Italic Underline
           </strong>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TextFormatHTMLCopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/html/TextFormatHTMLCopyAndPaste.spec.mjs
@@ -32,7 +32,7 @@ test.describe('HTML CopyAndPaste', () => {
           dir="ltr">
           <strong
             class="PlaygroundEditorTheme__textBold"
-            style="font-size: 11pt"
+            style="font-size: 14.6667px"
             data-lexical-text="true">
             Bold
           </strong>
@@ -42,7 +42,7 @@ test.describe('HTML CopyAndPaste', () => {
           dir="ltr">
           <em
             class="PlaygroundEditorTheme__textItalic"
-            style="font-size: 11pt"
+            style="font-size: 14.6667px"
             data-lexical-text="true">
             Italic
           </em>
@@ -52,7 +52,7 @@ test.describe('HTML CopyAndPaste', () => {
           dir="ltr">
           <span
             class="PlaygroundEditorTheme__textUnderline"
-            style="font-size: 11pt"
+            style="font-size: 14.6667px"
             data-lexical-text="true">
             underline
           </span>
@@ -63,7 +63,7 @@ test.describe('HTML CopyAndPaste', () => {
           <strong
             class="PlaygroundEditorTheme__textBold PlaygroundEditorTheme__textItalic
            PlaygroundEditorTheme__textUnderline"
-            style="font-size: 11pt"
+            style="font-size: 14.6667px"
             data-lexical-text="true">
             Bold Italic Underline
           </strong>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/CopyAndPaste.spec.mjs
@@ -962,4 +962,34 @@ test.describe('CopyAndPaste', () => {
       `,
     );
   });
+
+  test('Process font-size from content copied from Google Docs/MS Word', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+
+    const clipboard = {
+      'text/html': `<meta charset='utf-8'><meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-1e6b36e2-7fff-9788-e6e2-d502cc6babbf"><p dir="ltr" style="line-height:1.56;margin-top:10pt;margin-bottom:0pt;"><span style="font-size:24pt;font-family:Lato,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Random text at </span><span style="font-size:36pt;font-family:Lato,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">36 pt</span></p></b>`,
+    };
+
+    await withExclusiveClipboardAccess(async () => {
+      await pasteFromClipboard(page, clipboard);
+
+      await assertHTML(
+        page,
+        html`
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span style="font-size: 24pt" data-lexical-text="true">
+              Random text at
+            </span>
+            <span style="font-size: 36pt" data-lexical-text="true">36 pt</span>
+          </p>
+        `,
+      );
+    });
+  });
 });

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/CopyAndPaste.spec.mjs
@@ -983,10 +983,10 @@ test.describe('CopyAndPaste', () => {
           <p
             class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
             dir="ltr">
-            <span style="font-size: 32px" data-lexical-text="true">
+            <span style="font-size: 24pt" data-lexical-text="true">
               Random text at
             </span>
-            <span style="font-size: 48px" data-lexical-text="true">36 pt</span>
+            <span style="font-size: 36pt" data-lexical-text="true">36 pt</span>
           </p>
         `,
       );
@@ -1020,7 +1020,7 @@ test.describe('CopyAndPaste', () => {
           <p
             class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
             dir="ltr">
-            <span style="font-size: 48px;" data-lexical-text="true">
+            <span style="font-size: 36pt;" data-lexical-text="true">
               Text in 36pt
             </span>
           </p>

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/CopyAndPaste.spec.mjs
@@ -992,4 +992,40 @@ test.describe('CopyAndPaste', () => {
       );
     });
   });
+
+  test('test font-size in pt and px both are processed correctly', async ({
+    page,
+    isPlainText,
+  }) => {
+    test.skip(isPlainText);
+    await focusEditor(page);
+
+    const clipboard = {
+      'text/html': `<meta charset='utf-8'><meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-2d2ed25f-7fff-2f5a-2422-f7e624a743db"><p dir="ltr" style="line-height:1.56;margin-top:10pt;margin-bottom:0pt;"><span style="font-size:24px;font-family:Lato,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Text in 24px</span></p><p dir="ltr" style="line-height:1.56;margin-top:10pt;margin-bottom:0pt;"><span style="font-size:36pt;font-family:Lato,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Text in 36pt</span></p></b>`,
+    };
+
+    await withExclusiveClipboardAccess(async () => {
+      await pasteFromClipboard(page, clipboard);
+
+      await assertHTML(
+        page,
+        html`
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span style="font-size: 24px;" data-lexical-text="true">
+              Text in 24px
+            </span>
+          </p>
+          <p
+            class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+            dir="ltr">
+            <span style="font-size: 36pt;" data-lexical-text="true">
+              Text in 36pt
+            </span>
+          </p>
+        `,
+      );
+    });
+  });
 });

--- a/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/CopyAndPaste.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/CopyAndPaste/lexical/CopyAndPaste.spec.mjs
@@ -983,10 +983,10 @@ test.describe('CopyAndPaste', () => {
           <p
             class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
             dir="ltr">
-            <span style="font-size: 24pt" data-lexical-text="true">
+            <span style="font-size: 32px" data-lexical-text="true">
               Random text at
             </span>
-            <span style="font-size: 36pt" data-lexical-text="true">36 pt</span>
+            <span style="font-size: 48px" data-lexical-text="true">36 pt</span>
           </p>
         `,
       );
@@ -1020,7 +1020,7 @@ test.describe('CopyAndPaste', () => {
           <p
             class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
             dir="ltr">
-            <span style="font-size: 36pt;" data-lexical-text="true">
+            <span style="font-size: 48px;" data-lexical-text="true">
               Text in 36pt
             </span>
           </p>

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -23,13 +23,21 @@ import {
 } from './utils';
 
 export function parseAllowedFontSize(input: string): string {
-  const match = input.match(/^(\d+(?:\.\d+)?)px$/);
-  if (match) {
-    const n = Number(match[1]);
-    if (n >= MIN_ALLOWED_FONT_SIZE && n <= MAX_ALLOWED_FONT_SIZE) {
-      return input;
-    }
+  const pxMatch = input.match(/^(\d+(?:\.\d+)?)px$/);
+  const ptMatch = input.match(/^(\d+(?:\.\d+)?)pt$/);
+
+  let pxValue: number = pxMatch ? Number(pxMatch[1]) : undefined;
+
+  if (ptMatch) {
+    pxValue = Number(ptMatch[1]) * (4 / 3);
+  } else {
+    return '';
   }
+
+  if (pxValue >= MIN_ALLOWED_FONT_SIZE && pxValue <= MAX_ALLOWED_FONT_SIZE) {
+    return input;
+  }
+
   return '';
 }
 

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -26,7 +26,7 @@ export function parseAllowedFontSize(input: string): string {
   const pxMatch = input.match(/^(\d+(?:\.\d+)?)px$/);
   const ptMatch = input.match(/^(\d+(?:\.\d+)?)pt$/);
 
-  let pxValue: number = pxMatch ? Number(pxMatch[1]) : undefined;
+  let pxValue: number | undefined = pxMatch ? Number(pxMatch[1]) : undefined;
 
   if (ptMatch) {
     pxValue = Number(ptMatch[1]) * (4 / 3);

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -30,7 +30,7 @@ export function parseAllowedFontSize(input: string): string {
   const pxValue =
     Number(pxOrptMatch[1]) * (pxOrptMatch[2] === 'pt' ? 4 / 3 : 1);
   if (pxValue >= MIN_ALLOWED_FONT_SIZE && pxValue <= MAX_ALLOWED_FONT_SIZE) {
-    return input;
+    return pxValue + 'px';
   }
 
   return '';

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -30,11 +30,13 @@ export function parseAllowedFontSize(input: string): string {
 
   if (ptMatch) {
     pxValue = Number(ptMatch[1]) * (4 / 3);
-  } else {
-    return '';
   }
 
-  if (pxValue >= MIN_ALLOWED_FONT_SIZE && pxValue <= MAX_ALLOWED_FONT_SIZE) {
+  if (
+    pxValue &&
+    pxValue >= MIN_ALLOWED_FONT_SIZE &&
+    pxValue <= MAX_ALLOWED_FONT_SIZE
+  ) {
     return input;
   }
 

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -23,20 +23,13 @@ import {
 } from './utils';
 
 export function parseAllowedFontSize(input: string): string {
-  const pxMatch = input.match(/^(\d+(?:\.\d+)?)px$/);
-  const ptMatch = input.match(/^(\d+(?:\.\d+)?)pt$/);
-
-  let pxValue: number | undefined = pxMatch ? Number(pxMatch[1]) : undefined;
-
-  if (ptMatch) {
-    pxValue = Number(ptMatch[1]) * (4 / 3);
+  const pxOrptMatch = input.match(/^(\d+(?:\.\d+)?)(px|pt)$/);
+  if (!pxOrptMatch) {
+    return '';
   }
-
-  if (
-    pxValue &&
-    pxValue >= MIN_ALLOWED_FONT_SIZE &&
-    pxValue <= MAX_ALLOWED_FONT_SIZE
-  ) {
+  const pxValue =
+    Number(pxOrptMatch[1]) * (pxOrptMatch[2] === 'pt' ? 4 / 3 : 1);
+  if (pxValue >= MIN_ALLOWED_FONT_SIZE && pxValue <= MAX_ALLOWED_FONT_SIZE) {
     return input;
   }
 

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -22,30 +22,41 @@ import {
   UpdateFontSizeType,
 } from './utils';
 
-export function parseFontSizeForToolbar(input: string): string {
-  const pxOrptValue = parseAllowedFontSize(input);
-  if (!pxOrptValue) {return pxOrptValue;}
+function parseFontSize(input: string): [number, string] | null {
+  const match = input.match(/^(\d+(?:\.\d+)?)(px|pt)$/);
+  return match ? [Number(match[1]), match[2]] : null;
+}
 
-  if (pxOrptValue.includes('pt')) {
-    const pxValue = Math.round((Number(pxOrptValue.replace('pt', '')) * 4) / 3);
-    return `${pxValue}px`;
+function normalizeToPx(fontSize: number, unit: string): number {
+  return unit === 'pt' ? Math.round((fontSize * 4) / 3) : fontSize;
+}
+
+function isValidFontSize(fontSizePx: number): boolean {
+  return (
+    fontSizePx >= MIN_ALLOWED_FONT_SIZE && fontSizePx <= MAX_ALLOWED_FONT_SIZE
+  );
+}
+
+export function parseFontSizeForToolbar(input: string): string {
+  const parsed = parseFontSize(input);
+  if (!parsed) {
+    return '';
   }
 
-  return pxOrptValue;
+  const [fontSize, unit] = parsed;
+  const fontSizePx = normalizeToPx(fontSize, unit);
+  return `${fontSizePx}px`;
 }
 
 export function parseAllowedFontSize(input: string): string {
-  const pxOrptMatch = input.match(/^(\d+(?:\.\d+)?)(px|pt)$/);
-  if (!pxOrptMatch) {
+  const parsed = parseFontSize(input);
+  if (!parsed) {
     return '';
   }
-  const pxValue =
-    Number(pxOrptMatch[1]) * (pxOrptMatch[2] === 'pt' ? 4 / 3 : 1);
-  if (pxValue >= MIN_ALLOWED_FONT_SIZE && pxValue <= MAX_ALLOWED_FONT_SIZE) {
-    return input;
-  }
 
-  return '';
+  const [fontSize, unit] = parsed;
+  const fontSizePx = normalizeToPx(fontSize, unit);
+  return isValidFontSize(fontSizePx) ? input : '';
 }
 
 export default function FontSize({

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/fontSize.tsx
@@ -22,6 +22,18 @@ import {
   UpdateFontSizeType,
 } from './utils';
 
+export function parseFontSizeForToolbar(input: string): string {
+  const pxOrptValue = parseAllowedFontSize(input);
+  if (!pxOrptValue) {return pxOrptValue;}
+
+  if (pxOrptValue.includes('pt')) {
+    const pxValue = Math.round((Number(pxOrptValue.replace('pt', '')) * 4) / 3);
+    return `${pxValue}px`;
+  }
+
+  return pxOrptValue;
+}
+
 export function parseAllowedFontSize(input: string): string {
   const pxOrptMatch = input.match(/^(\d+(?:\.\d+)?)(px|pt)$/);
   if (!pxOrptMatch) {
@@ -30,7 +42,7 @@ export function parseAllowedFontSize(input: string): string {
   const pxValue =
     Number(pxOrptMatch[1]) * (pxOrptMatch[2] === 'pt' ? 4 / 3 : 1);
   if (pxValue >= MIN_ALLOWED_FONT_SIZE && pxValue <= MAX_ALLOWED_FONT_SIZE) {
-    return pxValue + 'px';
+    return input;
   }
 
   return '';

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -89,7 +89,7 @@ import {INSERT_PAGE_BREAK} from '../PageBreakPlugin';
 import {InsertPollDialog} from '../PollPlugin';
 import {SHORTCUTS} from '../ShortcutsPlugin/shortcuts';
 import {InsertTableDialog} from '../TablePlugin';
-import FontSize, {parseAllowedFontSize} from './fontSize';
+import FontSize, {parseFontSizeForToolbar} from './fontSize';
 import {
   clearFormatting,
   formatBulletList,
@@ -1000,7 +1000,7 @@ export default function ToolbarPlugin({
           />
           <Divider />
           <FontSize
-            selectionFontSize={parseAllowedFontSize(
+            selectionFontSize={parseFontSizeForToolbar(
               toolbarState.fontSize,
             ).slice(0, -2)}
             editor={activeEditor}

--- a/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ToolbarPlugin/index.tsx
@@ -89,7 +89,7 @@ import {INSERT_PAGE_BREAK} from '../PageBreakPlugin';
 import {InsertPollDialog} from '../PollPlugin';
 import {SHORTCUTS} from '../ShortcutsPlugin/shortcuts';
 import {InsertTableDialog} from '../TablePlugin';
-import FontSize from './fontSize';
+import FontSize, {parseAllowedFontSize} from './fontSize';
 import {
   clearFormatting,
   formatBulletList,
@@ -1000,7 +1000,9 @@ export default function ToolbarPlugin({
           />
           <Divider />
           <FontSize
-            selectionFontSize={toolbarState.fontSize.slice(0, -2)}
+            selectionFontSize={parseAllowedFontSize(
+              toolbarState.fontSize,
+            ).slice(0, -2)}
             editor={activeEditor}
             disabled={!isEditable}
           />

--- a/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
+++ b/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
@@ -98,6 +98,11 @@ describe('HTMLCopyAndPaste tests', () => {
           pastedHTML: `<strong>hello</strong>`,
           plainTextInsert: ' world',
         },
+        {
+          expectedHTML: `<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true" style="font-size: 24pt;">Random text at </span><span data-lexical-text="true" style="font-size: 36pt;">36 pt</span></p>`,
+          name: 'Pasting content with custom font-sizes',
+          pastedHTML: `<meta charset='utf-8'><meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-1e6b36e2-7fff-9788-e6e2-d502cc6babbf"><p dir="ltr" style="line-height:1.56;margin-top:10pt;margin-bottom:0pt;"><span style="font-size:24pt;font-family:Lato,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Random text at </span><span style="font-size:36pt;font-family:Lato,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">36 pt</span></p></b><br class="Apple-interchange-newline">`,
+        },
       ];
 
       HTML_COPY_PASTING_TESTS.forEach((testCase, i) => {

--- a/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
+++ b/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
@@ -98,11 +98,6 @@ describe('HTMLCopyAndPaste tests', () => {
           pastedHTML: `<strong>hello</strong>`,
           plainTextInsert: ' world',
         },
-        {
-          expectedHTML: `<p class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr" dir="ltr"><span data-lexical-text="true" style="font-size: 24pt;">Random text at </span><span data-lexical-text="true" style="font-size: 36pt;">36 pt</span></p>`,
-          name: 'Pasting content with custom font-sizes',
-          pastedHTML: `<meta charset='utf-8'><meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-1e6b36e2-7fff-9788-e6e2-d502cc6babbf"><p dir="ltr" style="line-height:1.56;margin-top:10pt;margin-bottom:0pt;"><span style="font-size:24pt;font-family:Lato,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Random text at </span><span style="font-size:36pt;font-family:Lato,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">36 pt</span></p></b><br class="Apple-interchange-newline">`,
-        },
       ];
 
       HTML_COPY_PASTING_TESTS.forEach((testCase, i) => {


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
*Describe the changes in this pull request*
Consider font sizes in pt as well along with px in `parseAllowedFontSize` as most of editors like Google docs and MS word export font-sizes in pt when copied content

Closes #7718
Closes #7726

## Test plan
tests added for custom font-size in HTMLCopyAndPaste.test.ts
### Before


https://github.com/user-attachments/assets/3d5ed1a4-5780-44b9-92a3-25a735b37728




### 


After

https://github.com/user-attachments/assets/65c2d61c-d1dc-4805-9460-e73b15542bb1