### PR TITLE
[lexical-react] Bug Fix: prevent race condition in CollaborationPlugin during rapid mount/unmount cycles

### DIFF
--- a/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
@@ -84,6 +84,7 @@ export function CollaborationPlugin({
   }, [collabContext, editor]);
 
   const [provider, setProvider] = useState<Provider>();
+  const [doc, setDoc] = useState<Doc>();
 
   useEffect(() => {
     if (isProviderInitialized.current) {
@@ -94,13 +95,13 @@ export function CollaborationPlugin({
 
     const newProvider = providerFactory(id, yjsDocMap);
     setProvider(newProvider);
+    setDoc(yjsDocMap.get(id));
 
     return () => {
       newProvider.disconnect();
     };
   }, [id, providerFactory, yjsDocMap]);
 
-  const [doc, setDoc] = useState(yjsDocMap.get(id));
   const [binding, setBinding] = useState<Binding>();
 
   useEffect(() => {


### PR DESCRIPTION
## Description
This fix resolves a race condition by ensuring the Yjs document reference is captured after the provider is initialized, rather than during the component's render function.

**Before:** The doc state was initialized with `yjsDocMap.get(id)` during the new component's render phase, which could capture a stale document reference because the old component instance's cleanup may not have executed yet.

**After:** The doc state is now set within the provider useEffect, ensuring it always references the fresh document that corresponds to the newly created provider. By doing this we guarantee that:

- The new component's render function doesn't prematurely capture a stale document
- The provider factory has completed and stored the current document in the map
- Any previous component cleanup has had a chance to finish
- The binding will be created with the correct, up-to-date document reference

This prevents the race condition where the new component's render function would capture a document reference before the old component's cleanup could run `docMap.delete(id)`, ensuring the binding's observer is always attached to the active Yjs document that's receiving server updates.

Closes #7722 