### PR TITLE
Fix trigger reconcilation on nested read

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -840,7 +840,7 @@ function triggerDeferredUpdateCallbacks(
   }
 }
 
-function processNestedUpdates(
+function $processNestedUpdates(
   editor: LexicalEditor,
   initialSkipTransforms?: boolean,
 ): boolean {
@@ -854,6 +854,7 @@ function processNestedUpdates(
     const queuedUpdate = queuedUpdates.shift();
     if (queuedUpdate) {
       const [nextUpdateFn, options] = queuedUpdate;
+      const pendingEditorState = editor._pendingEditorState;
 
       let onUpdate;
 
@@ -864,7 +865,6 @@ function processNestedUpdates(
           skipTransforms = true;
         }
         if (options.discrete) {
-          const pendingEditorState = editor._pendingEditorState;
           invariant(
             pendingEditorState !== null,
             'Unexpected empty pending editor state on discrete nested update',
@@ -879,7 +879,11 @@ function processNestedUpdates(
         addTags(editor, options.tag);
       }
 
-      nextUpdateFn();
+      if (pendingEditorState == null) {
+        $beginUpdate(editor, nextUpdateFn, options);
+      } else {
+        nextUpdateFn();
+      }
     }
   }
 
@@ -947,7 +951,7 @@ function $beginUpdate(
 
     const startingCompositionKey = editor._compositionKey;
     updateFn();
-    skipTransforms = processNestedUpdates(editor, skipTransforms);
+    skipTransforms = $processNestedUpdates(editor, skipTransforms);
     applySelectionTransforms(pendingEditorState, editor);
 
     if (editor._dirtyType !== NO_DIRTY_NODES) {
@@ -957,7 +961,7 @@ function $beginUpdate(
         $applyAllTransforms(pendingEditorState, editor);
       }
 
-      processNestedUpdates(editor);
+      $processNestedUpdates(editor);
       $garbageCollectDetachedNodes(
         currentEditorState,
         pendingEditorState,

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2892,6 +2892,25 @@ describe('LexicalEditor tests', () => {
     expect(onUpdate).toHaveBeenCalledTimes(1);
   });
 
+  it('can read in a nested update', async () => {
+    init();
+    await editor.update(() => {
+      $getRoot().append($createParagraphNode().append($createTextNode('foo')));
+      editor.read(() => {});
+      expect(editor.getRootElement()?.innerHTML).toBe(
+        '<p dir="ltr"><span data-lexical-text="true">foo</span></p>',
+      );
+      editor.update(() => {
+        $getRoot().append(
+          $createParagraphNode().append($createTextNode('bar')),
+        );
+      });
+    });
+    expect(editor.getRootElement()?.innerHTML).toBe(
+      '<p dir="ltr"><span data-lexical-text="true">foo</span></p><p dir="ltr"><span data-lexical-text="true">bar</span></p>',
+    );
+  });
+
   it('does not include linebreak into inline elements', async () => {
     init();
 


### PR DESCRIPTION
**Problem:**

A combination of nested updates + reads can cause a missed reconcilation, consequently leading to further errors such as https://lexical.dev/docs/error?code=75&v=6 or mutating (should've been frozen) nodes.

For example:
1. `dispatchCommand(KEY_DOWN)`
2. (dispatch command triggers an update by command design)
3. User triggers a function such as submit message that contains a combination of `editor.read` and `editor.update`
4. `editor.read` flushes by design
5. `editor.update` has no `pendingEditorState` as it has been flushed. Hence, reconcilation never happens.

**Solution**

We can either recreate the EditorState or ignore the flush sync behavior on read. Because we already support `flushSync` flag in nested updates this PR does the first. 

**Note for self**

We can't just reuse the discrete functionality within update as in 

```
read<T>(callbackFn: () => T): T {
    const pendingEditorState = this._pendingEditorState;
    if (pendingEditorState !== null) {
      this.update(() => {}, {discrete: true});
    }
    return this.getEditorState().read(callbackFn, {editor: this});
  }
```

This will trigger a (parent) update and dismiss the concept of queued updates.
