### PR TITLE
[lexical] Bug Fix: Clamp DOM selection offsets to valid lexical TextNode offsets in $internalResolveSelectionPoint

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Composition.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Composition.spec.mjs
@@ -1297,6 +1297,8 @@ test.describe('Composition', () => {
       // await page.keyboard.imeSetComposition('すｓｈ', 0, 4);
       await client.send('Input.imeSetComposition', {
         selectionStart: 0,
+        // The fourth character in the DOM is a zero-width space
+        // which is not represented in the lexical document (or this string)
         selectionEnd: 4,
         text: 'すｓｈ',
       });

--- a/packages/lexical-playground/__tests__/e2e/Mutations.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Mutations.spec.mjs
@@ -120,13 +120,8 @@ test.describe('Mutations', () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const textNode = rootElement.querySelector('span').firstChild;
       textNode.nodeValue = 'Hi!';
-      const domSelection = window.getSelection();
-      const range = document.createRange();
-      const uiElement = document.querySelector('i.mic');
-      range.setStart(uiElement, 0);
-      range.setEnd(uiElement, 0);
-      domSelection.removeAllRanges();
-      domSelection.addRange(range);
+      // Select something else on the page that will not modify the lexical selection
+      document.querySelector('input').focus();
     });
 
     await assertHTML(

--- a/packages/lexical-playground/__tests__/e2e/Mutations.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Mutations.spec.mjs
@@ -160,7 +160,6 @@ test.describe('Mutations', () => {
       focusOffset: 3,
       focusPath: [0, 0, 0],
     });
-    await page.pause();
   });
   test(`Can restore the DOM to the editor state state`, async ({page}) => {
     await focusEditor(page);

--- a/packages/lexical-playground/__tests__/e2e/Mutations.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Mutations.spec.mjs
@@ -120,8 +120,13 @@ test.describe('Mutations', () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const textNode = rootElement.querySelector('span').firstChild;
       textNode.nodeValue = 'Hi!';
-      // Select something else on the page that will not modify the lexical selection
-      document.querySelector('input').focus();
+      const domSelection = window.getSelection();
+      const range = document.createRange();
+      const uiElement = document.querySelector('i.lock');
+      range.setStart(uiElement, 0);
+      range.setEnd(uiElement, 0);
+      domSelection.removeAllRanges();
+      domSelection.addRange(range);
     });
 
     await assertHTML(

--- a/packages/lexical-playground/__tests__/e2e/Mutations.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Mutations.spec.mjs
@@ -6,6 +6,8 @@
  *
  */
 
+import {expect} from '@playwright/test';
+
 import {
   assertHTML,
   assertSelection,
@@ -13,6 +15,7 @@ import {
   focusEditor,
   html,
   initialize,
+  sleep,
   test,
 } from '../utils/index.mjs';
 
@@ -49,6 +52,116 @@ async function validateContent(page) {
 
 test.describe('Mutations', () => {
   test.beforeEach(({isCollab, page}) => initialize({isCollab, page}));
+  test(`Text mutation observers also manage the selection`, async ({page}) => {
+    await focusEditor(page);
+    await page.keyboard.type('Hello world.');
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello world.</span>
+        </p>
+      `,
+    );
+    await assertSelection(page, {
+      anchorOffset: 12,
+      anchorPath: [0, 0, 0],
+      focusOffset: 12,
+      focusPath: [0, 0, 0],
+    });
+    // We need to wait at least 100msec (TEXT_MUTATION_VARIANCE) after typing,
+    // otherwise the mutation will be applied to the DOM but not synchronized
+    // with the lexical state (see shouldFlushTextMutations in flushMutations).
+    // TODO: It might be worth tracking ignored mutations with a timeout to reconcile this edge case
+    await sleep(100);
+    await evaluate(page, () => {
+      const rootElement = document.querySelector('div[contenteditable="true"]');
+      const textNode = rootElement.querySelector('span').firstChild;
+      textNode.nodeValue = 'Hello.';
+      const domSelection = window.getSelection();
+      const range = document.createRange();
+      range.setStart(textNode, textNode.nodeValue.length);
+      range.setEnd(textNode, textNode.nodeValue.length);
+      domSelection.removeAllRanges();
+      domSelection.addRange(range);
+    });
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hello.</span>
+        </p>
+      `,
+    );
+    let editorStateJSON = await evaluate(page, () => {
+      const rootElement = document.querySelector('div[contenteditable="true"]');
+      return rootElement.__lexicalEditor.getEditorState().toJSON();
+    });
+    expect(editorStateJSON).toMatchObject({
+      root: {
+        children: [
+          {children: [{text: 'Hello.', type: 'text'}], type: 'paragraph'},
+        ],
+        type: 'root',
+      },
+    });
+    await assertSelection(page, {
+      anchorOffset: 6,
+      anchorPath: [0, 0, 0],
+      focusOffset: 6,
+      focusPath: [0, 0, 0],
+    });
+
+    await evaluate(page, () => {
+      const rootElement = document.querySelector('div[contenteditable="true"]');
+      const textNode = rootElement.querySelector('span').firstChild;
+      textNode.nodeValue = 'Hi!';
+      const domSelection = window.getSelection();
+      const range = document.createRange();
+      const uiElement = document.querySelector('i.mic');
+      range.setStart(uiElement, 0);
+      range.setEnd(uiElement, 0);
+      domSelection.removeAllRanges();
+      domSelection.addRange(range);
+    });
+
+    await assertHTML(
+      page,
+      html`
+        <p
+          class="PlaygroundEditorTheme__paragraph PlaygroundEditorTheme__ltr"
+          dir="ltr">
+          <span data-lexical-text="true">Hi!</span>
+        </p>
+      `,
+    );
+    editorStateJSON = await evaluate(page, () => {
+      const rootElement = document.querySelector('div[contenteditable="true"]');
+      return rootElement.__lexicalEditor.getEditorState().toJSON();
+    });
+    expect(editorStateJSON).toMatchObject({
+      root: {
+        children: [
+          {children: [{text: 'Hi!', type: 'text'}], type: 'paragraph'},
+        ],
+        type: 'root',
+      },
+    });
+    // This does "steal" the focus which might be unexpected? The key here
+    // is that the lexical selection is modified accordingly (offset clamp)
+    // even though the DOM selection was elsewhere at the time of mutation
+    await assertSelection(page, {
+      anchorOffset: 3,
+      anchorPath: [0, 0, 0],
+      focusOffset: 3,
+      focusPath: [0, 0, 0],
+    });
+    await page.pause();
+  });
   test(`Can restore the DOM to the editor state state`, async ({page}) => {
     await focusEditor(page);
     await page.keyboard.type(
@@ -58,7 +171,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Remove the paragraph
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const paragraph = rootElement.firstChild;
 
@@ -67,7 +180,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Remove the paragraph content
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const paragraph = rootElement.firstChild;
 
@@ -76,7 +189,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Remove the first text
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const firstTextNode = rootElement.firstChild.firstChild;
 
@@ -85,7 +198,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Remove the first text contents
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const firstTextNode = rootElement.firstChild.firstChild;
 
@@ -94,7 +207,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Remove the second text
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const secondTextNode = rootElement.firstChild.firstChild.nextSibling;
 
@@ -103,7 +216,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Remove the third text
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const thirdTextNode =
         rootElement.firstChild.firstChild.nextSibling.nextSibling;
@@ -113,7 +226,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Remove the forth text
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const forthTextNode =
         rootElement.firstChild.firstChild.nextSibling.nextSibling.nextSibling;
@@ -123,7 +236,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Move last to first
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const paragraph = rootElement.firstChild;
       const firstTextNode = paragraph.firstChild;
@@ -135,7 +248,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Reverse sort all the children
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const paragraph = rootElement.firstChild;
       const firstTextNode = paragraph.firstChild;
@@ -151,7 +264,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Adding additional nodes to root
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const span = document.createElement('span');
       const span2 = document.createElement('span');
@@ -163,7 +276,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Adding additional nodes to paragraph
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const paragraph = rootElement.firstChild;
       const firstTextNode = paragraph.firstChild;
@@ -177,7 +290,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Adding additional nodes to text nodes
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const paragraph = rootElement.firstChild;
       const firstTextNode = paragraph.firstChild;
@@ -189,7 +302,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Replace text nodes on text nodes #1
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const paragraph = rootElement.firstChild;
       const firstTextNode = paragraph.firstChild;
@@ -199,7 +312,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Replace text nodes on line break #2
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const paragraph = rootElement.firstChild;
       const firstTextNode = paragraph.firstChild;
@@ -209,7 +322,7 @@ test.describe('Mutations', () => {
     await validateContent(page);
 
     // Update text content, this should work :)
-    await await evaluate(page, () => {
+    await evaluate(page, () => {
       const rootElement = document.querySelector('div[contenteditable="true"]');
       const paragraph = rootElement.firstChild;
       const firstTextNode = paragraph.firstChild;

--- a/packages/lexical/src/LexicalMutations.ts
+++ b/packages/lexical/src/LexicalMutations.ts
@@ -180,6 +180,9 @@ function flushMutations(
           // Text mutations are deferred and passed to mutation listeners to be
           // processed outside of the Lexical engine.
           if (
+            // TODO there is an edge case here if a mutation happens too quickly
+            //      after text input, it may never be handled since we do not
+            //      track the ignored mutations in any way
             shouldFlushTextMutations &&
             $isTextNode(targetNode) &&
             isDOMTextNode(targetDOM) &&

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -27,6 +27,7 @@ import {
   $getCaretRangeInDirection,
   $getChildCaret,
   $getSiblingCaret,
+  $getTextNodeOffset,
   $isChildCaret,
   $isDecoratorNode,
   $isElementNode,
@@ -80,7 +81,6 @@ import {
   getDOMSelection,
   getDOMTextNode,
   getElementByKeyOrThrow,
-  getTextNodeOffset,
   getWindow,
   INTERNAL_$isBlock,
   isHTMLElement,
@@ -2272,7 +2272,10 @@ function $internalResolveSelectionPoint(
     resolvedNode = $getNodeFromDOM(childDOM);
 
     if ($isTextNode(resolvedNode)) {
-      resolvedOffset = getTextNodeOffset(resolvedNode, moveSelectionToEnd);
+      resolvedOffset = $getTextNodeOffset(
+        resolvedNode,
+        moveSelectionToEnd ? 'next' : 'previous',
+      );
     } else {
       let resolvedElement = $getNodeFromDOM(dom);
       // Ensure resolvedElement is actually a element.
@@ -2324,7 +2327,10 @@ function $internalResolveSelectionPoint(
         if ($isTextNode(child)) {
           resolvedNode = child;
           resolvedElement = null;
-          resolvedOffset = getTextNodeOffset(child, moveSelectionToEnd);
+          resolvedOffset = $getTextNodeOffset(
+            child,
+            moveSelectionToEnd ? 'next' : 'previous',
+          );
         } else if (
           child !== resolvedElement &&
           moveSelectionToEnd &&
@@ -2362,7 +2368,11 @@ function $internalResolveSelectionPoint(
   if (!$isTextNode(resolvedNode)) {
     return null;
   }
-  return $createPoint(resolvedNode.__key, resolvedOffset, 'text');
+  return $createPoint(
+    resolvedNode.__key,
+    $getTextNodeOffset(resolvedNode, resolvedOffset, 'clamp'),
+    'text',
+  );
 }
 
 function resolveSelectionPointOnBoundary(
@@ -2493,8 +2503,8 @@ function $internalResolveSelectionPoints(
     return null;
   }
   if (__DEV__) {
-    $validatePoint(editor, 'anchor', resolvedAnchorPoint);
-    $validatePoint(editor, 'focus', resolvedAnchorPoint);
+    $validatePoint('anchor', resolvedAnchorPoint);
+    $validatePoint('focus', resolvedFocusPoint);
   }
   if (
     resolvedAnchorPoint.type === 'element' &&
@@ -2666,11 +2676,7 @@ export function $internalCreateRangeSelection(
   );
 }
 
-function $validatePoint(
-  editor: LexicalEditor,
-  name: 'anchor' | 'focus',
-  point: PointType,
-): void {
+function $validatePoint(name: 'anchor' | 'focus', point: PointType): void {
   const node = $getNodeByKey(point.key);
   invariant(
     node !== undefined,

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -656,13 +656,6 @@ export function $getNodeFromDOM(dom: Node): null | LexicalNode {
   return $getNodeByKey(nodeKey);
 }
 
-export function getTextNodeOffset(
-  node: TextNode,
-  moveSelectionToEnd: boolean,
-): number {
-  return moveSelectionToEnd ? node.getTextContentSize() : 0;
-}
-
 function getNodeKeyFromDOMTree(
   // Note that node here refers to a DOM Node, not an Lexical Node
   dom: Node,

--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -36,6 +36,7 @@ import {
   $createTextNode,
   $getPreviousSelection,
   $getSelection,
+  $getTextNodeOffset,
   $isDecoratorNode,
   $isElementNode,
   $isLineBreakNode,
@@ -817,7 +818,7 @@ export function $updateTextNodeFromDOMContent(
         anchorOffset === null ||
         focusOffset === null
       ) {
-        node.setTextContent(normalizedTextContent);
+        $setTextContentWithSelection(node, normalizedTextContent, selection);
         return;
       }
       selection.setTextNodeRange(node, anchorOffset, node, focusOffset);
@@ -828,7 +829,24 @@ export function $updateTextNodeFromDOMContent(
         node.replace(replacement);
         node = replacement;
       }
-      node.setTextContent(normalizedTextContent);
+      $setTextContentWithSelection(node, normalizedTextContent, selection);
+    }
+  }
+}
+
+function $setTextContentWithSelection(
+  node: TextNode,
+  textContent: string,
+  selection: BaseSelection | null,
+) {
+  node.setTextContent(textContent);
+  if ($isRangeSelection(selection)) {
+    const key = node.getKey();
+    for (const k of ['anchor', 'focus'] as const) {
+      const pt = selection[k];
+      if (pt.type === 'text' && pt.key === key) {
+        pt.offset = $getTextNodeOffset(node, pt.offset, 'clamp');
+      }
     }
   }
 }

--- a/packages/lexical/src/caret/LexicalCaret.ts
+++ b/packages/lexical/src/caret/LexicalCaret.ts
@@ -896,18 +896,20 @@ export function $getTextPointCaret(
  *
  * @param origin a TextNode
  * @param offset An absolute offset into the TextNode string, or a direction for which end to use as the offset
+ * @param mode If 'error' (the default) out of bounds offsets will be an error in dev. Otherwise it will clamp to a valid offset.
  * @returns An absolute offset into the TextNode string
  */
 export function $getTextNodeOffset(
   origin: TextNode,
   offset: number | CaretDirection,
+  mode: 'error' | 'clamp' = 'error',
 ): number {
   const size = origin.getTextContentSize();
   let numericOffset =
     offset === 'next' ? size : offset === 'previous' ? 0 : offset;
   if (numericOffset < 0 || numericOffset > size) {
     devInvariant(
-      false,
+      mode === 'clamp',
       '$getTextNodeOffset: invalid offset %s for size %s at key %s',
       String(offset),
       String(size),


### PR DESCRIPTION
## Description

In some scenarios when IME input is happening, the browser's Text node will have a selection or content that is not represented in the lexical TextNode (a trailing zero-width-space). This changes the `$internalResolveSelectionPoint` implementation such that it will only resolve valid offsets by clamping to the size of the TextNode.

There were also scenarios where the MutationObserver handles text mutations without updating the lexical selection, so a similar fix was applied to `flushMutations`

Closes #7715 (superseded by this PR)
Closes #7639

## Test plan

e2e tests pass, added new e2e test to exercise flushMutations edge cases