### PR TITLE
[lexical-website] Documentation Update: Add editor context gotcha documentation for editorState.read()

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,27 @@ pending state, where node transforms and DOM reconciliation may not have run yet
 `editor.getEditorState().read()` will use the latest reconciled `EditorState` (after any node transforms,
 DOM reconciliation, etc. have already run), any pending `editor.update` mutations will not yet be visible.
 
+**⚠️ Editor Context Gotcha:** `editor.read()` provides editor context (allowing functions like `$getEditor()` to work),
+while `editor.getEditorState().read()` does **not** provide editor context by default. If you need editor context
+with `editorState.read()`, you must explicitly provide it:
+
+```js
+// ❌ This will throw "Unable to find an active editor"
+editor.getEditorState().read(() => {
+  const editor = $getEditor(); // Error!
+});
+
+// ✅ This works - editor context provided
+editor.getEditorState().read(() => {
+  const editor = $getEditor(); // Works!
+}, { editor });
+
+// ✅ This also works - editor.read() provides context automatically
+editor.read(() => {
+  const editor = $getEditor(); // Works!
+});
+```
+
 :::
 
 ### DOM Reconciler

--- a/packages/lexical-website/docs/concepts/editor-state.md
+++ b/packages/lexical-website/docs/concepts/editor-state.md
@@ -190,6 +190,30 @@ editor.registerUpdateListener(({editorState}) => {
 });
 ```
 
+:::warning Editor Context Limitation
+
+Note that `editorState.read()` does not provide editor context by default. Functions like `$getEditor()` 
+will fail unless you explicitly provide the editor:
+
+```js
+// ❌ This will throw an error
+editorState.read(() => {
+  const editor = $getEditor(); // Error: "Unable to find an active editor"
+});
+
+// ✅ Provide editor context explicitly  
+editorState.read(() => {
+  const editor = $getEditor(); // Works!
+}, { editor });
+
+// ✅ Or use editor.read() which provides context automatically
+editor.read(() => {
+  const editor = $getEditor(); // Works!
+});
+```
+
+:::
+
 ## When are Listeners, Transforms, and Commands called?
 
 There are several types of callbacks that can be registered with the editor that are related to

--- a/packages/lexical-website/docs/faq.md
+++ b/packages/lexical-website/docs/faq.md
@@ -156,3 +156,38 @@ also should call `event.preventDefault()` unless your command relies on the
 browser's native processing of that event.
 
 :::
+
+## Why does `$getEditor()` throw "Unable to find an active editor" in `editorState.read()`?
+
+This is a common gotcha! The issue is that `editor.getEditorState().read()` does not provide editor context by default, 
+while `editor.read()` does.
+
+**The Problem:**
+```js
+// ❌ This fails
+editor.getEditorState().read(() => {
+  const editor = $getEditor(); // Throws: "Unable to find an active editor"
+});
+```
+
+**Solutions:**
+
+1. **Use `editor.read()` instead** (recommended for most cases):
+```js
+// ✅ This works
+editor.read(() => {
+  const editor = $getEditor(); // Works!
+});
+```
+
+2. **Explicitly provide editor context**:
+```js
+// ✅ This also works
+editor.getEditorState().read(() => {
+  const editor = $getEditor(); // Works!
+}, {editor: editor});
+```
+
+**When to use which:**
+- Use `editor.read()` when you want the latest state including pending updates
+- Use `editor.getEditorState().read()` when you want to read from a specific historical state or when called from an update listener

--- a/packages/lexical-website/docs/intro.md
+++ b/packages/lexical-website/docs/intro.md
@@ -107,6 +107,31 @@ DOM reconciliation, etc. have already run), any pending `editor.update` mutation
 
 :::
 
+:::warning Editor Context Limitation
+
+`editor.read()` provides editor context (allowing functions like `$getEditor()` to work),
+while `editor.getEditorState().read()` does **not** provide editor context by default. If you need editor context
+with `editorState.read()`, you must explicitly provide it:
+
+```js
+// ❌ This will throw "Unable to find an active editor"
+editor.getEditorState().read(() => {
+  const editor = $getEditor(); // Error!
+});
+
+// ✅ This works - editor context provided
+editor.getEditorState().read(() => {
+  const editor = $getEditor(); // Works!
+}, { editor });
+
+// ✅ This also works - editor.read() provides context automatically
+editor.read(() => {
+  const editor = $getEditor(); // Works!
+});
+```
+
+:::
+
 ### DOM Reconciler
 
 Lexical has its own DOM reconciler that takes a set of Editor States (always the "current" and the "pending") and applies a "diff"


### PR DESCRIPTION
## Description

**Current behavior:** 
The documentation does not explain that `editor.getEditorState().read()` lacks editor context by default, causing functions like `$getEditor()` to throw "Unable to find an active editor" errors. This is a common gotcha that developers discover through trial and error.

**Changes being added:**
- Enhanced the existing tip sections in `intro.md` and `README.md` with clear warnings about editor context differences
- Added a dedicated FAQ entry explaining why `$getEditor()` fails in `editorState.read()` and how to fix it
- Added warning callout in `concepts/editor-state.md` right after the `editorState.read()` example
- Provided multiple solutions with clear ❌/✅ examples showing what works and what doesn't
- Added guidance on when to use `editor.read()` vs `editor.getEditorState().read()`

## Test plan

### Before

*Developers encountering this issue would:*
- Try `editor.getEditorState().read(() => $getEditor())` 
- Get cryptic "Unable to find an active editor" error
- Have to dig through tests or source code to understand the `{ editor }` option
- No clear guidance on when to use which read method

### After

*With the updated documentation:*
- Clear warnings in multiple locations where developers will see them
- Prominent ⚠️ gotcha sections with visual ❌/✅ indicators
- Dedicated FAQ entry for this specific error
- Multiple solution examples showing both the explicit editor option and using `editor.read()` instead
- Guidance on when to use each approach


https://github.com/user-attachments/assets/586cbf76-f82f-4e28-a705-31be0efd19e3

