### PR TITLE
[lexical-utils] fix: Backward selection was not being retained

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/SelectionAlwaysOnDisplay.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/SelectionAlwaysOnDisplay.spec.mjs
@@ -6,7 +6,7 @@
  *
  */
 
-import {selectAll} from '../keyboardShortcuts/index.mjs';
+import {selectAll, selectCharacters} from '../keyboardShortcuts/index.mjs';
 import {
   evaluate,
   expect,
@@ -27,6 +27,53 @@ test.describe('SelectionAlwaysOnDisplay', () => {
     await page.keyboard.type('Lexical');
     await selectAll(page);
     await locate(page, 'body').click();
+    const {distance, widthDifference, heightDifference} = await evaluate(
+      page,
+      () => {
+        function compareNodeAlignment(node1, node2, tolerance = 0) {
+          const rect1 = node1.getBoundingClientRect();
+          const rect2 = node2.getBoundingClientRect();
+          const distance_ = Math.sqrt(
+            Math.pow(rect1.left - rect2.left, 2) +
+              Math.pow(rect1.top - rect2.top, 2),
+          );
+          const widthDifference_ = Math.abs(rect1.width - rect2.width);
+          const heightDifference_ = Math.abs(rect1.height - rect2.height);
+          return {
+            distance: distance_,
+            widthDifference: widthDifference_,
+            heightDifference: heightDifference_,
+          };
+        }
+        const editorSpan = document.querySelector(
+          '[contenteditable="true"] span',
+        );
+        const fakeSelection = document.querySelector(
+          '[style*="background: highlight"]',
+        );
+        return compareNodeAlignment(editorSpan, fakeSelection, 5);
+      },
+    );
+    await expect(distance).toBeLessThanOrEqual(5);
+    await expect(widthDifference).toBeLessThanOrEqual(5);
+    await expect(heightDifference).toBeLessThanOrEqual(5);
+  });
+
+  test(`retain selection works with reverse selection`, async ({
+    page,
+    isPlainText,
+    browserName,
+  }) => {
+    test.skip(isPlainText); // Fixed in #6873
+    await focusEditor(page);
+    await page.keyboard.type('Lexical');
+
+    // Position cursor at the end, then create a reverse selection by selecting all text to the left
+    await selectCharacters(page, 'left', 'Lexical'.length);
+
+    // Click outside to lose focus
+    await locate(page, 'body').click();
+
     const {distance, widthDifference, heightDifference} = await evaluate(
       page,
       () => {

--- a/packages/lexical-utils/src/markSelection.ts
+++ b/packages/lexical-utils/src/markSelection.ts
@@ -47,7 +47,12 @@ function rangeFromPoints(
 ): Range {
   const editorDocument = editor._window ? editor._window.document : document;
   const range = editorDocument.createRange();
-  if (focusNode.isBefore(anchorNode)) {
+
+  const isBackwardSelection =
+    focusNode.isBefore(anchorNode) ||
+    (focusNode === anchorNode && focus.offset < anchor.offset);
+
+  if (isBackwardSelection) {
     range.setStart(...rangeTargetFromPoint(focus, focusNode, focusDOM));
     range.setEnd(...rangeTargetFromPoint(anchor, anchorNode, anchorDOM));
   } else {

--- a/packages/lexical-utils/src/markSelection.ts
+++ b/packages/lexical-utils/src/markSelection.ts
@@ -15,12 +15,18 @@ import {
   getDOMTextNode,
   type LexicalEditor,
   Point,
+  type RangeSelection,
   TextNode,
 } from 'lexical';
 
 import mergeRegister from './mergeRegister';
 import positionNodeOnRange from './positionNodeOnRange';
 import px from './px';
+
+function $getOrderedSelectionPoints(selection: RangeSelection): [Point, Point] {
+  const points = selection.getStartEndPoints()!;
+  return selection.isBackward() ? [points[1], points[0]] : points;
+}
 
 function rangeTargetFromPoint(
   point: Point,
@@ -38,27 +44,17 @@ function rangeTargetFromPoint(
 
 function rangeFromPoints(
   editor: LexicalEditor,
-  anchor: Point,
-  anchorNode: ElementNode | TextNode,
-  anchorDOM: HTMLElement,
-  focus: Point,
-  focusNode: ElementNode | TextNode,
-  focusDOM: HTMLElement,
+  start: Point,
+  startNode: ElementNode | TextNode,
+  startDOM: HTMLElement,
+  end: Point,
+  endNode: ElementNode | TextNode,
+  endDOM: HTMLElement,
 ): Range {
   const editorDocument = editor._window ? editor._window.document : document;
   const range = editorDocument.createRange();
-
-  const isBackwardSelection =
-    focusNode.isBefore(anchorNode) ||
-    (focusNode === anchorNode && focus.offset < anchor.offset);
-
-  if (isBackwardSelection) {
-    range.setStart(...rangeTargetFromPoint(focus, focusNode, focusDOM));
-    range.setEnd(...rangeTargetFromPoint(anchor, anchorNode, anchorDOM));
-  } else {
-    range.setStart(...rangeTargetFromPoint(anchor, anchorNode, anchorDOM));
-    range.setEnd(...rangeTargetFromPoint(focus, focusNode, focusDOM));
-  }
+  range.setStart(...rangeTargetFromPoint(start, startNode, startDOM));
+  range.setEnd(...rangeTargetFromPoint(end, endNode, endDOM));
   return range;
 }
 /**
@@ -93,38 +89,38 @@ export default function markSelection(
         removeRangeListener = () => {};
         return;
       }
-      const {anchor, focus} = selection;
-      const currentAnchorNode = anchor.getNode();
-      const currentAnchorNodeKey = currentAnchorNode.getKey();
-      const currentAnchorOffset = anchor.offset;
-      const currentFocusNode = focus.getNode();
-      const currentFocusNodeKey = currentFocusNode.getKey();
-      const currentFocusOffset = focus.offset;
-      const currentAnchorNodeDOM = editor.getElementByKey(currentAnchorNodeKey);
-      const currentFocusNodeDOM = editor.getElementByKey(currentFocusNodeKey);
-      const differentAnchorDOM =
+      const [start, end] = $getOrderedSelectionPoints(selection);
+      const currentStartNode = start.getNode() as TextNode | ElementNode;
+      const currentStartNodeKey = currentStartNode.getKey();
+      const currentStartOffset = start.offset;
+      const currentEndNode = end.getNode() as TextNode | ElementNode;
+      const currentEndNodeKey = currentEndNode.getKey();
+      const currentEndOffset = end.offset;
+      const currentStartNodeDOM = editor.getElementByKey(currentStartNodeKey);
+      const currentEndNodeDOM = editor.getElementByKey(currentEndNodeKey);
+      const differentStartDOM =
         previousAnchorNode === null ||
-        currentAnchorNodeDOM !== previousAnchorNodeDOM ||
-        currentAnchorOffset !== previousAnchorOffset ||
-        currentAnchorNodeKey !== previousAnchorNode.getKey();
-      const differentFocusDOM =
+        currentStartNodeDOM !== previousAnchorNodeDOM ||
+        currentStartOffset !== previousAnchorOffset ||
+        currentStartNodeKey !== previousAnchorNode.getKey();
+      const differentEndDOM =
         previousFocusNode === null ||
-        currentFocusNodeDOM !== previousFocusNodeDOM ||
-        currentFocusOffset !== previousFocusOffset ||
-        currentFocusNodeKey !== previousFocusNode.getKey();
+        currentEndNodeDOM !== previousFocusNodeDOM ||
+        currentEndOffset !== previousFocusOffset ||
+        currentEndNodeKey !== previousFocusNode.getKey();
       if (
-        (differentAnchorDOM || differentFocusDOM) &&
-        currentAnchorNodeDOM !== null &&
-        currentFocusNodeDOM !== null
+        (differentStartDOM || differentEndDOM) &&
+        currentStartNodeDOM !== null &&
+        currentEndNodeDOM !== null
       ) {
         const range = rangeFromPoints(
           editor,
-          anchor,
-          currentAnchorNode,
-          currentAnchorNodeDOM,
-          focus,
-          currentFocusNode,
-          currentFocusNodeDOM,
+          start,
+          currentStartNode,
+          currentStartNodeDOM,
+          end,
+          currentEndNode,
+          currentEndNodeDOM,
         );
         removeRangeListener();
         removeRangeListener = positionNodeOnRange(editor, range, (domNodes) => {
@@ -153,12 +149,12 @@ export default function markSelection(
           }
         });
       }
-      previousAnchorNode = currentAnchorNode;
-      previousAnchorNodeDOM = currentAnchorNodeDOM;
-      previousAnchorOffset = currentAnchorOffset;
-      previousFocusNode = currentFocusNode;
-      previousFocusNodeDOM = currentFocusNodeDOM;
-      previousFocusOffset = currentFocusOffset;
+      previousAnchorNode = currentStartNode;
+      previousAnchorNodeDOM = currentStartNodeDOM;
+      previousAnchorOffset = currentStartOffset;
+      previousFocusNode = currentEndNode;
+      previousFocusNodeDOM = currentEndNodeDOM;
+      previousFocusOffset = currentEndOffset;
     });
   }
   compute(editor.getEditorState());


### PR DESCRIPTION
## Description

**Problem**
The selectionAlwaysOnDisplay utility wasn't working correctly for right-to-left text selections (when users drag from right to left). The visual selection mark would not appear properly when the editor lost focus after making a right-to-left selection.


**Root Cause**
The issue was in the rangeFromPoints function in markSelection.ts. The function was only checking focusNode.isBefore(anchorNode) to determine selection direction, which works for selections across different DOM nodes but fails for selections within the same text node.

For same-node selections:
Left-to-right: anchor.offset < focus.offset (e.g., 5 → 10)
Right-to-left: anchor.offset > focus.offset (e.g., 10 → 5)
The original logic didn't account for this offset-based direction detection.

**Solution**
Enhanced the selection direction detection logic to handle both cases:

Closes https://github.com/facebook/lexical/issues/7736

### Before

https://github.com/user-attachments/assets/7bc54d5f-ea84-4a7d-ac53-fc72fbad84c6


### After


https://github.com/user-attachments/assets/9c82f76c-3cc5-4678-80c9-028bc17dd0b5

