### PR TITLE
[lexical-examples]  Bug Fix: missing dependency @lexical/utils at examples/react-rich-collab

### DIFF
--- a/examples/react-rich-collab/package-lock.json
+++ b/examples/react-rich-collab/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@lexical/react-rich-collab-example",
-  "version": "0.29.0",
+  "version": "0.33.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-rich-collab-example",
-      "version": "0.29.0",
+      "version": "0.33.1",
       "dependencies": {
-        "@lexical/react": "0.29.0",
-        "@lexical/yjs": "0.29.0",
-        "lexical": "0.29.0",
+        "@lexical/react": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "@lexical/yjs": "0.33.1",
+        "lexical": "0.33.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "y-webrtc": "^10.3.0",
@@ -746,6 +747,59 @@
         "node": ">=12"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
+      "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.15",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.15.tgz",
+      "integrity": "sha512-0LGxhBi3BB1DwuSNQAmuaSuertFzNAerlMdPbotjTVnvPtdOs7CkrHLaev5NIXemhzDXNC0tFzuseut7cWA5mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.5",
+        "@floating-ui/utils": "^0.2.10",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.5.tgz",
+      "integrity": "sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -795,41 +849,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
-      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.33.1.tgz",
+      "integrity": "sha512-Qd3/Cm3TW2DFQv58kMtLi86u5YOgpBdf+o7ySbXz55C613SLACsYQBB3X5Vu5hTx/t/ugYOpII4HkiatW6d9zA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.29.0",
-        "@lexical/list": "0.29.0",
-        "@lexical/selection": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/html": "0.33.1",
+        "@lexical/list": "0.33.1",
+        "@lexical/selection": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
-      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.33.1.tgz",
+      "integrity": "sha512-E0Y/+1znkqVpP52Y6blXGAduoZek9SSehJN+vbH+4iQKyFwTA7JB+jd5C5/K0ik55du9X7SN/oTynByg7lbcAA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
-      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.33.1.tgz",
+      "integrity": "sha512-3yHu5diNtjwhoe2q/x9as6n6rIfA+QO2CfaVjFRkam8rkAW6zUzQT1D0fQdE8nOfWvXBgY1mH/ZLP4dDXBdG5Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.29.0",
-        "@lexical/link": "0.29.0",
-        "@lexical/mark": "0.29.0",
-        "@lexical/table": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/html": "0.33.1",
+        "@lexical/link": "0.33.1",
+        "@lexical/mark": "0.33.1",
+        "@lexical/table": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -837,143 +891,144 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
-      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.33.1.tgz",
+      "integrity": "sha512-UQ6DLkcDAr83wA1vz3sUgtcpYcMifC4sF0MieZAoMzFrna6Ekqj7OJ7g8Lo7m7AeuT4NETRVDsjIEDdrQMKLLA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.29.0"
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
-      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.33.1.tgz",
+      "integrity": "sha512-M3IsDe4cifggMBZgYAVT7hCLWcwQ3dIcUPdr9Xc6wDQQQdEqOQYB0PO//9bSYUVq+BNiiTgysc+TtlM7PiJfiw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
-      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.33.1.tgz",
+      "integrity": "sha512-Bk0h3D6cFkJ7w3HKvqQua7n6Xfz7nR7L3gLDBH9L0nsS4MM9+LteSEZPUe0kj4VuEjnxufYstTc9HA2aNLKxnQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
-      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.33.1.tgz",
+      "integrity": "sha512-t14vu4eKa6BWz1N7/rwXgXif1k4dj73dRvllWJgfXum+a36vn1aySNYOlOfqWXF7k1b3uJmoqsWK7n/1ASnimw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/selection": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
-      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.33.1.tgz",
+      "integrity": "sha512-JCTu7Fft2J2kgfqJiWnGei+UMIXVKiZKaXzuHCuGQTFu92DeCyd02azBaFazZHEkSqCIFZ0DqVV2SpIJmd0Ygw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
-      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.33.1.tgz",
+      "integrity": "sha512-PXp56dWADSThc9WhwWV4vXhUc3sdtCqsfPD3UQNGUZ9rsAY1479rqYLtfYgEmYPc8JWXikQCAKEejahCJIm8OQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/selection": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
-      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.33.1.tgz",
+      "integrity": "sha512-tGdOf1e694lnm/HyWUKEkEWjDyfhCBFG7u8iRKNpsYTpB3M1FsJUXbphE2bb8MyWfhHbaNxnklupSSaSPzO88A==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
-      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.33.1.tgz",
+      "integrity": "sha512-p5zwWNF70pELRx60wxE8YOFVNiNDkw7gjKoYqkED23q5hj4mcqco9fQf6qeeZChjxLKjfyT6F1PpWgxmlBlxBw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.29.0",
-        "@lexical/link": "0.29.0",
-        "@lexical/list": "0.29.0",
-        "@lexical/rich-text": "0.29.0",
-        "@lexical/text": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/code": "0.33.1",
+        "@lexical/link": "0.33.1",
+        "@lexical/list": "0.33.1",
+        "@lexical/rich-text": "0.33.1",
+        "@lexical/text": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
-      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.33.1.tgz",
+      "integrity": "sha512-3YIlUs43QdKSBLEfOkuciE2tn9loxVmkSs/HgaIiLYl0Edf1W00FP4ItSmYU4De5GopXsHq6+Y3ry4pU/ciUiQ==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.29.0"
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
-      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.33.1.tgz",
+      "integrity": "sha512-3BDq1lOw567FeCk4rN2ellKwoXTM9zGkGuKnSGlXS1JmtGGGSvT+uTANX3KOOfqTNSrOkrwoM+3hlFv7p6VpiQ==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.29.0"
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
-      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.33.1.tgz",
+      "integrity": "sha512-2HxdhAx6bwF8y5A9P0q3YHsYbhUo4XXm+GyKJO87an8JClL2W+GYLTSDbfNWTh4TtH95eG+UYLOjNEgyU6tsWA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.29.0",
-        "@lexical/selection": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/clipboard": "0.33.1",
+        "@lexical/selection": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
-      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.33.1.tgz",
+      "integrity": "sha512-ylnUmom5h8PY+Z14uDmKLQEoikTPN77GRM0NRCIdtbWmOQqOq/5BhuCzMZE1WvpL5C6n3GtK6IFnsMcsKmVOcw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/devtools-core": "0.29.0",
-        "@lexical/dragon": "0.29.0",
-        "@lexical/hashtag": "0.29.0",
-        "@lexical/history": "0.29.0",
-        "@lexical/link": "0.29.0",
-        "@lexical/list": "0.29.0",
-        "@lexical/mark": "0.29.0",
-        "@lexical/markdown": "0.29.0",
-        "@lexical/overflow": "0.29.0",
-        "@lexical/plain-text": "0.29.0",
-        "@lexical/rich-text": "0.29.0",
-        "@lexical/table": "0.29.0",
-        "@lexical/text": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "@lexical/yjs": "0.29.0",
-        "lexical": "0.29.0",
+        "@floating-ui/react": "^0.27.8",
+        "@lexical/devtools-core": "0.33.1",
+        "@lexical/dragon": "0.33.1",
+        "@lexical/hashtag": "0.33.1",
+        "@lexical/history": "0.33.1",
+        "@lexical/link": "0.33.1",
+        "@lexical/list": "0.33.1",
+        "@lexical/mark": "0.33.1",
+        "@lexical/markdown": "0.33.1",
+        "@lexical/overflow": "0.33.1",
+        "@lexical/plain-text": "0.33.1",
+        "@lexical/rich-text": "0.33.1",
+        "@lexical/table": "0.33.1",
+        "@lexical/text": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "@lexical/yjs": "0.33.1",
+        "lexical": "0.33.1",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -982,67 +1037,67 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
-      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.33.1.tgz",
+      "integrity": "sha512-ZBIsj4LwmamRBCGjJiPSLj7N/XkUDv/pnYn5Rp0BL42WpOiQLvOoGLrZxgUJZEmRPQnx42ZgLKVgrWHsyjuoAA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.29.0",
-        "@lexical/selection": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/clipboard": "0.33.1",
+        "@lexical/selection": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
-      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.33.1.tgz",
+      "integrity": "sha512-KXPkdCDdVfIUXmkwePu9DAd3kLjL0aAqL5G9CMCFsj7RG9lLvvKk7kpivrAIbRbcsDzO44QwsFPisZHbX4ioXA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.29.0"
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
-      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.33.1.tgz",
+      "integrity": "sha512-pzB11i1Y6fzmy0IPUKJyCdhVBgXaNOxJUxrQJWdKNYCh1eMwwMEQvj+8inItd/11aUkjcdHjwDTht8gL2UHKiQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/clipboard": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
-      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.33.1.tgz",
+      "integrity": "sha512-CnyU3q3RytXXWVSvC5StOKISzFAPGK9MuesNDDGyZk7yDK+J98gV6df4RBKfqwcokFMThpkUlvMeKe1+S2y25A==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.29.0"
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
-      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.33.1.tgz",
+      "integrity": "sha512-eKysPjzEE9zD+2af3WRX5U3XbeNk0z4uv1nXGH3RG15uJ4Huzjht82hzsQpCFUobKmzYlQaQs5y2IYKE2puipQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.29.0",
-        "@lexical/selection": "0.29.0",
-        "@lexical/table": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/list": "0.33.1",
+        "@lexical/selection": "0.33.1",
+        "@lexical/table": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
-      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.33.1.tgz",
+      "integrity": "sha512-Zx1rabMm/Zjk7n7YQMIQLUN+tqzcg1xqcgNpEHSfK1GA8QMPXCPvXWFT3ZDC4tfZOSy/YIqpVUyWZAomFqRa+g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.29.0",
-        "@lexical/selection": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/offset": "0.33.1",
+        "@lexical/selection": "0.33.1",
+        "lexical": "0.33.1"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -2069,9 +2124,9 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
-      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.33.1.tgz",
+      "integrity": "sha512-+kiCS/GshQmCs/meMb8MQT4AMvw3S3Ef0lSCv2Xi6Itvs59OD+NjQWNfYkDteIbKtVE/w0Yiqh56VyGwIb8UcA==",
       "license": "MIT"
     },
     "node_modules/lib0": {
@@ -2554,6 +2609,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -3355,6 +3416,46 @@
       "dev": true,
       "optional": true
     },
+    "@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "requires": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "@floating-ui/dom": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
+      "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
+      "requires": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "@floating-ui/react": {
+      "version": "0.27.15",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.15.tgz",
+      "integrity": "sha512-0LGxhBi3BB1DwuSNQAmuaSuertFzNAerlMdPbotjTVnvPtdOs7CkrHLaev5NIXemhzDXNC0tFzuseut7cWA5mw==",
+      "requires": {
+        "@floating-ui/react-dom": "^2.1.5",
+        "@floating-ui/utils": "^0.2.10",
+        "tabbable": "^6.0.0"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.5.tgz",
+      "integrity": "sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==",
+      "requires": {
+        "@floating-ui/dom": "^1.7.3"
+      }
+    },
+    "@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -3395,225 +3496,226 @@
       }
     },
     "@lexical/clipboard": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.29.0.tgz",
-      "integrity": "sha512-llxZosYCwH13p2GfPfhAinukdvAZYxWuwf5md107X80hsE8TQJj25unjqTwRKQ+w/wD+hpmBMziU8+K/WTitWQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.33.1.tgz",
+      "integrity": "sha512-Qd3/Cm3TW2DFQv58kMtLi86u5YOgpBdf+o7ySbXz55C613SLACsYQBB3X5Vu5hTx/t/ugYOpII4HkiatW6d9zA==",
       "requires": {
-        "@lexical/html": "0.29.0",
-        "@lexical/list": "0.29.0",
-        "@lexical/selection": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/html": "0.33.1",
+        "@lexical/list": "0.33.1",
+        "@lexical/selection": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/code": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.29.0.tgz",
-      "integrity": "sha512-yKGzoKpyIO39Xf7OKLPpoCE5V8mTDCM3l3CDHZR3X1gM/VZQzf4jAiO3b06y9YkQ2fM8kqwchYu87wGvs8/iIQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.33.1.tgz",
+      "integrity": "sha512-E0Y/+1znkqVpP52Y6blXGAduoZek9SSehJN+vbH+4iQKyFwTA7JB+jd5C5/K0ik55du9X7SN/oTynByg7lbcAA==",
       "requires": {
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1",
         "prismjs": "^1.30.0"
       }
     },
     "@lexical/devtools-core": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.29.0.tgz",
-      "integrity": "sha512-uUq0m9ql/7mthp7Ho1vnG7Id6imQ5kD5mxUhX2lmgHretS+yAHGsGsGiPIVHdPWeVmUb2n4IVDJ+cJbUsUjQJw==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.33.1.tgz",
+      "integrity": "sha512-3yHu5diNtjwhoe2q/x9as6n6rIfA+QO2CfaVjFRkam8rkAW6zUzQT1D0fQdE8nOfWvXBgY1mH/ZLP4dDXBdG5Q==",
       "requires": {
-        "@lexical/html": "0.29.0",
-        "@lexical/link": "0.29.0",
-        "@lexical/mark": "0.29.0",
-        "@lexical/table": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/html": "0.33.1",
+        "@lexical/link": "0.33.1",
+        "@lexical/mark": "0.33.1",
+        "@lexical/table": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/dragon": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.29.0.tgz",
-      "integrity": "sha512-Zaky2jd/Pp1blAZqPeGNdyhxnVL4lwVjbWPxhfS1gbW4Q5CBQ3aD3B0T4ljiKfmRNJm004LJ9q7KjhlRbREvZA==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.33.1.tgz",
+      "integrity": "sha512-UQ6DLkcDAr83wA1vz3sUgtcpYcMifC4sF0MieZAoMzFrna6Ekqj7OJ7g8Lo7m7AeuT4NETRVDsjIEDdrQMKLLA==",
       "requires": {
-        "lexical": "0.29.0"
+        "lexical": "0.33.1"
       }
     },
     "@lexical/hashtag": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.29.0.tgz",
-      "integrity": "sha512-fa7s0Yi2RKz/GvgT5XU9fborx6VPU3VtvvEPaIXgyd6zXZRiOhD9rGypwB3oj4fMK1ndx2dX0m7SwhMJo48D8w==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.33.1.tgz",
+      "integrity": "sha512-M3IsDe4cifggMBZgYAVT7hCLWcwQ3dIcUPdr9Xc6wDQQQdEqOQYB0PO//9bSYUVq+BNiiTgysc+TtlM7PiJfiw==",
       "requires": {
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/history": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.29.0.tgz",
-      "integrity": "sha512-OrCwZycp/yaq63mw511NutkwAB+W6WSchG1xTxlLh6nbc8jnbvKhCf4CGbnrvlhD7hTuzxJ8FI9/2M/2zv/mNQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.33.1.tgz",
+      "integrity": "sha512-Bk0h3D6cFkJ7w3HKvqQua7n6Xfz7nR7L3gLDBH9L0nsS4MM9+LteSEZPUe0kj4VuEjnxufYstTc9HA2aNLKxnQ==",
       "requires": {
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/html": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.29.0.tgz",
-      "integrity": "sha512-+jV6ijppOpxpUGeXkGssXJbsAmFALfeLrgbM0xuZbxZ7RgYZ+5Atn00WjSno7+JV5EOuRkYmCNtS1tiHtXMY1g==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.33.1.tgz",
+      "integrity": "sha512-t14vu4eKa6BWz1N7/rwXgXif1k4dj73dRvllWJgfXum+a36vn1aySNYOlOfqWXF7k1b3uJmoqsWK7n/1ASnimw==",
       "requires": {
-        "@lexical/selection": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/selection": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/link": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.29.0.tgz",
-      "integrity": "sha512-wGbKRF0x/6ZQHuCfr8m8qD1J0R1kFmWINBG2A1hUXPDf7UY5qm/nS2oKNDGpjiDMGwkVZ7n7WfzeBGO+KRe/Lg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.33.1.tgz",
+      "integrity": "sha512-JCTu7Fft2J2kgfqJiWnGei+UMIXVKiZKaXzuHCuGQTFu92DeCyd02azBaFazZHEkSqCIFZ0DqVV2SpIJmd0Ygw==",
       "requires": {
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/list": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.29.0.tgz",
-      "integrity": "sha512-sWiof+i2ff8rL7KxJ3dxHLwyJfX423e1EVLmAdQEOPhyZJiNbeLTSNhNGsZ8FjFoBwvTTEDwuQZm3iT3hliKOg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.33.1.tgz",
+      "integrity": "sha512-PXp56dWADSThc9WhwWV4vXhUc3sdtCqsfPD3UQNGUZ9rsAY1479rqYLtfYgEmYPc8JWXikQCAKEejahCJIm8OQ==",
       "requires": {
-        "@lexical/selection": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/selection": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/mark": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.29.0.tgz",
-      "integrity": "sha512-UB3x6pyUdpZHRqF4tiajLnC1+Umvt7x8Rkkdi29aNNvzIWniVwGkBOlmvFus7x+4dOV1D1fydwiP4m38nGgLDw==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.33.1.tgz",
+      "integrity": "sha512-tGdOf1e694lnm/HyWUKEkEWjDyfhCBFG7u8iRKNpsYTpB3M1FsJUXbphE2bb8MyWfhHbaNxnklupSSaSPzO88A==",
       "requires": {
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/markdown": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.29.0.tgz",
-      "integrity": "sha512-4Od8WoDoviv9DxJZVgrIORTIAzyoGOpztbGbIBXguGmwvy7NnHQDh9fZYIYRrdI1Awp1VVGdJ3ku/7KTgSOoRw==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.33.1.tgz",
+      "integrity": "sha512-p5zwWNF70pELRx60wxE8YOFVNiNDkw7gjKoYqkED23q5hj4mcqco9fQf6qeeZChjxLKjfyT6F1PpWgxmlBlxBw==",
       "requires": {
-        "@lexical/code": "0.29.0",
-        "@lexical/link": "0.29.0",
-        "@lexical/list": "0.29.0",
-        "@lexical/rich-text": "0.29.0",
-        "@lexical/text": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/code": "0.33.1",
+        "@lexical/link": "0.33.1",
+        "@lexical/list": "0.33.1",
+        "@lexical/rich-text": "0.33.1",
+        "@lexical/text": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/offset": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.29.0.tgz",
-      "integrity": "sha512-VyD2Ff3rBJpo++Fxvi3MNYmDELa+9nA0EgXqGRNb3MvRehRjHbaDbymtLMMHIwvbkF5lnra+ubStcTRQmoQxXw==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.33.1.tgz",
+      "integrity": "sha512-3YIlUs43QdKSBLEfOkuciE2tn9loxVmkSs/HgaIiLYl0Edf1W00FP4ItSmYU4De5GopXsHq6+Y3ry4pU/ciUiQ==",
       "requires": {
-        "lexical": "0.29.0"
+        "lexical": "0.33.1"
       }
     },
     "@lexical/overflow": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.29.0.tgz",
-      "integrity": "sha512-IzH3M652Ej2gB2sK65N3yTgyiQAa3I3tqKbSnBRiXu/+isxHoCy/qRr9/kL63uy7zhGvgV+EYsoffQCawIFt8Q==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.33.1.tgz",
+      "integrity": "sha512-3BDq1lOw567FeCk4rN2ellKwoXTM9zGkGuKnSGlXS1JmtGGGSvT+uTANX3KOOfqTNSrOkrwoM+3hlFv7p6VpiQ==",
       "requires": {
-        "lexical": "0.29.0"
+        "lexical": "0.33.1"
       }
     },
     "@lexical/plain-text": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.29.0.tgz",
-      "integrity": "sha512-F5C3meDb2HmO0NmKJBVRkjmX9PNln6O1jXU/APJuSFBdvfcIWSY58ncHR4zy2M5LF1Q5PQMWyIay9p+SqOtY5A==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.33.1.tgz",
+      "integrity": "sha512-2HxdhAx6bwF8y5A9P0q3YHsYbhUo4XXm+GyKJO87an8JClL2W+GYLTSDbfNWTh4TtH95eG+UYLOjNEgyU6tsWA==",
       "requires": {
-        "@lexical/clipboard": "0.29.0",
-        "@lexical/selection": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/clipboard": "0.33.1",
+        "@lexical/selection": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/react": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.29.0.tgz",
-      "integrity": "sha512-YMlnljW/jxmwSzsRv5UPatfOoMZXqxFmRIEltTUIQfrOFdqn+ssUtCpjE6xRD1oxD6KpSIekakzLs+y/8+7CuQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.33.1.tgz",
+      "integrity": "sha512-ylnUmom5h8PY+Z14uDmKLQEoikTPN77GRM0NRCIdtbWmOQqOq/5BhuCzMZE1WvpL5C6n3GtK6IFnsMcsKmVOcw==",
       "requires": {
-        "@lexical/devtools-core": "0.29.0",
-        "@lexical/dragon": "0.29.0",
-        "@lexical/hashtag": "0.29.0",
-        "@lexical/history": "0.29.0",
-        "@lexical/link": "0.29.0",
-        "@lexical/list": "0.29.0",
-        "@lexical/mark": "0.29.0",
-        "@lexical/markdown": "0.29.0",
-        "@lexical/overflow": "0.29.0",
-        "@lexical/plain-text": "0.29.0",
-        "@lexical/rich-text": "0.29.0",
-        "@lexical/table": "0.29.0",
-        "@lexical/text": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "@lexical/yjs": "0.29.0",
-        "lexical": "0.29.0",
+        "@floating-ui/react": "^0.27.8",
+        "@lexical/devtools-core": "0.33.1",
+        "@lexical/dragon": "0.33.1",
+        "@lexical/hashtag": "0.33.1",
+        "@lexical/history": "0.33.1",
+        "@lexical/link": "0.33.1",
+        "@lexical/list": "0.33.1",
+        "@lexical/mark": "0.33.1",
+        "@lexical/markdown": "0.33.1",
+        "@lexical/overflow": "0.33.1",
+        "@lexical/plain-text": "0.33.1",
+        "@lexical/rich-text": "0.33.1",
+        "@lexical/table": "0.33.1",
+        "@lexical/text": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "@lexical/yjs": "0.33.1",
+        "lexical": "0.33.1",
         "react-error-boundary": "^3.1.4"
       }
     },
     "@lexical/rich-text": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.29.0.tgz",
-      "integrity": "sha512-fSKgXGxJUOWo7dwSTUYFVBNNk4pPN8norsZfdmKM1kGDS1/GKuVzlzHLKZ7rQb8RLD5a43p4ifEL+28P+q0Qqg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.33.1.tgz",
+      "integrity": "sha512-ZBIsj4LwmamRBCGjJiPSLj7N/XkUDv/pnYn5Rp0BL42WpOiQLvOoGLrZxgUJZEmRPQnx42ZgLKVgrWHsyjuoAA==",
       "requires": {
-        "@lexical/clipboard": "0.29.0",
-        "@lexical/selection": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/clipboard": "0.33.1",
+        "@lexical/selection": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/selection": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.29.0.tgz",
-      "integrity": "sha512-lX9CRrXgKte65cozTHFXwUJ2fvZD92OEtos+YU+U40GJjf3NdheGeKDxDfOpF4AXrYRSszY7E0CzmIvuEs0p4A==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.33.1.tgz",
+      "integrity": "sha512-KXPkdCDdVfIUXmkwePu9DAd3kLjL0aAqL5G9CMCFsj7RG9lLvvKk7kpivrAIbRbcsDzO44QwsFPisZHbX4ioXA==",
       "requires": {
-        "lexical": "0.29.0"
+        "lexical": "0.33.1"
       }
     },
     "@lexical/table": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.29.0.tgz",
-      "integrity": "sha512-Jdj32kBDeJh/0dGaZB14JggnEIS956/cN7grnLr7cmhhVzDicvLMBENSXQVEJAQVcSIU4G9EvxC7GJZ9VgqDnA==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.33.1.tgz",
+      "integrity": "sha512-pzB11i1Y6fzmy0IPUKJyCdhVBgXaNOxJUxrQJWdKNYCh1eMwwMEQvj+8inItd/11aUkjcdHjwDTht8gL2UHKiQ==",
       "requires": {
-        "@lexical/clipboard": "0.29.0",
-        "@lexical/utils": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/clipboard": "0.33.1",
+        "@lexical/utils": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/text": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.29.0.tgz",
-      "integrity": "sha512-QnNGr6ickTLk76o3PdxJjPwt//dpuh8idVfR73WdCIoAwkhiEPUxxTZERoMsudXj6O/lJ+/HhI61wVjLckYr3A==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.33.1.tgz",
+      "integrity": "sha512-CnyU3q3RytXXWVSvC5StOKISzFAPGK9MuesNDDGyZk7yDK+J98gV6df4RBKfqwcokFMThpkUlvMeKe1+S2y25A==",
       "requires": {
-        "lexical": "0.29.0"
+        "lexical": "0.33.1"
       }
     },
     "@lexical/utils": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.29.0.tgz",
-      "integrity": "sha512-y2hhWQDjcXdplsAaQMuZx6ht9u1I4BV5NynA+WKoQ3h8vKxzeDnpCxVOK/zxU1R5dhM/nilnFu7uhvrSeEn+TQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.33.1.tgz",
+      "integrity": "sha512-eKysPjzEE9zD+2af3WRX5U3XbeNk0z4uv1nXGH3RG15uJ4Huzjht82hzsQpCFUobKmzYlQaQs5y2IYKE2puipQ==",
       "requires": {
-        "@lexical/list": "0.29.0",
-        "@lexical/selection": "0.29.0",
-        "@lexical/table": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/list": "0.33.1",
+        "@lexical/selection": "0.33.1",
+        "@lexical/table": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@lexical/yjs": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.29.0.tgz",
-      "integrity": "sha512-6IXWWlGkVJEzWP/+LcuKYJ9jmcFp8k7TT/jmz4V5gBD9Ut3swOGsIA/sQCtB9y7jad10csaDVmFdFzGNWKVH9A==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.33.1.tgz",
+      "integrity": "sha512-Zx1rabMm/Zjk7n7YQMIQLUN+tqzcg1xqcgNpEHSfK1GA8QMPXCPvXWFT3ZDC4tfZOSy/YIqpVUyWZAomFqRa+g==",
       "requires": {
-        "@lexical/offset": "0.29.0",
-        "@lexical/selection": "0.29.0",
-        "lexical": "0.29.0"
+        "@lexical/offset": "0.33.1",
+        "@lexical/selection": "0.33.1",
+        "lexical": "0.33.1"
       }
     },
     "@rollup/rollup-android-arm-eabi": {
@@ -4310,9 +4412,9 @@
       }
     },
     "lexical": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.29.0.tgz",
-      "integrity": "sha512-eoBHUEn0LmExKeK6x2cFKU0FPaMk2Bc5HgiCzTiv5ymKtwWw7LeKcxaNPmLxRRdQpcWV1IMKjayAbw7Lt/Gu7w=="
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.33.1.tgz",
+      "integrity": "sha512-+kiCS/GshQmCs/meMb8MQT4AMvw3S3Ef0lSCv2Xi6Itvs59OD+NjQWNfYkDteIbKtVE/w0Yiqh56VyGwIb8UcA=="
     },
     "lib0": {
       "version": "0.2.93",
@@ -4629,6 +4731,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/examples/react-rich-collab/package.json
+++ b/examples/react-rich-collab/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@lexical/react": "0.33.1",
     "@lexical/yjs": "0.33.1",
+    "@lexical/utils": "0.33.1",
     "lexical": "0.33.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Description

### Expected vs Actual
- `npm i && npm run dev` run out of the box
- however below error is thrown


```
11:55:27 PM [vite] Internal server error: Failed to resolve import "@lexical/utils" from "src/plugins/ToolbarPlugin.tsx". Does the file exist?
```

### Root Cause & Changes
- `package-lock.json` is outdated, adding `@lexical/utils` in `package.json` and `npm i`  resolves the issue 
- seems other packages also has outdated `package-lock.json`. Shall we bump all of them & run `npm i` at build process everytime?

## Test plan

### After

- tested `npm i && npm run dev` able to start 
