### PR TITLE
[*] Chore: Add a post-release action to update the examples

### DIFF
--- a/.github/workflows/call-post-release.yml
+++ b/.github/workflows/call-post-release.yml
@@ -1,0 +1,44 @@
+name: (call) Post-release branch with updated examples
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'git ref (main)'
+        required: true
+        type: string
+        default: main
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+        default: main
+jobs:
+  post-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - id: latest
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          owner: facebook
+          repo: lexical
+          excludes: draft
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - run: |
+          npm i
+          for x in examples/*/ scripts/__tests__/integration/fixtures/*/; do
+            pushd "$x" && npm i && npm run build && popd
+          done
+      - uses: stefanzweifel/git-auto-commit-action@v6
+        with:
+          commit_message: 'Update examples for ${{ steps.latest.outputs.release }}'
+          commit_user_name: 'Lexical GitHub Actions Bot'
+          branch: post-release-${{ steps.latest.outputs.release }}
+          push_options: '--force'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -10,3 +10,8 @@ jobs:
       channel: latest
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  post-release:
+    uses: ./.github/workflows/call-post-release.yml
+    needs: release
+    with:
+      ref: main

--- a/packages/lexical-website/docs/maintainers-guide.md
+++ b/packages/lexical-website/docs/maintainers-guide.md
@@ -287,6 +287,7 @@ from main in step 4).
 4. After PR is merged to main, publish to NPM with the Github Actions "Publish to NPM" workflow (`pre-release.yml`)
 5. Create a GitHub release from the tag created in step 1, manually editing the release notes
 6. Announce the release in #announcements on Discord
+7. Raise a PR against the post-release-* version branch (created by `call-post-release.yml` via `pre-release.yml`) to update the examples
 
 ## Release Protocol
 


### PR DESCRIPTION
## Description

Per #7743 the package-lock files are not updated for examples when a release is published. This is a bit tricky because we can't update them until after the release happens, so it needs to be in a separate PR.

This updated workflow will automatically create a branch after a release is published with updated package-lock files. Like with updating a version, creating the associated PR is a manual process (github won't run actions for an automated PR unless it is using a personal access token).

## Test plan

There isn't a lot we can do to test actions like this without releasing them. In order to run it we first need to merge it to the default branch (main). Once the file is in place on main we can iterate on it from a branch if any issues arise.

* Run it directly with workflow_dispatch to make sure it behaves as expected
* Make sure it still behaves as expected (when called with workflow_call via pre-release) the next time a release is published

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_dispatch
