### PR TITLE
[lexical] Bug Fix: Correct exit direction from decorator nodes in RTL

### DIFF
--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -36,6 +36,7 @@ import {
   html,
   initialize,
   insertCollapsible,
+  insertDateTime,
   insertHorizontalRule,
   insertImageCaption,
   insertSampleImage,
@@ -1056,6 +1057,32 @@ test.describe.parallel('Selection', () => {
         </p>
       `,
     );
+  });
+
+  test('Move left from DecoratorNode in RTL #7771', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await page.keyboard.type('קצת');
+    await insertDateTime(page);
+    await moveToEditorBeginning(page);
+    await moveLeft(page, 4);
+    // TODO: assert selection is at end of paragraph
+  });
+
+  test('Move right from DecoratorNode in RTL #7771', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await page.keyboard.type('קצת');
+    await insertDateTime(page);
+    await moveToEditorBeginning(page);
+    await moveRight(page, 2);
+    // TODO: assert selection is right before the datetime
   });
 
   test('Can delete table node present at the end #5543', async ({

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -1145,8 +1145,10 @@ test.describe.parallel('Selection', () => {
     page,
     isPlainText,
     isCollab,
+    browserName,
   }) => {
     test.skip(isPlainText || isCollab);
+    test.skip(browserName === 'firefox');
     await page.keyboard.type('קצת');
     await insertDateTime(page);
     await moveLeft(page);

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -1124,6 +1124,32 @@ test.describe.parallel('Selection', () => {
     await assertSelection(page, expectedSelection);
   });
 
+  test('Move right from last node in RTL #7775', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await page.keyboard.type('קצת');
+    await insertDateTime(page);
+    await moveRight(page);
+
+    // TODO: verify selection
+  });
+
+  test('Move left from last node in RTL #7775', async ({
+    page,
+    isPlainText,
+    isCollab,
+  }) => {
+    test.skip(isPlainText || isCollab);
+    await page.keyboard.type('קצת');
+    await insertDateTime(page);
+    await moveLeft(page);
+
+    // TODO: verify selection
+  });
+
   test('Can delete table node present at the end #5543', async ({
     page,
     isPlainText,

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -1134,7 +1134,11 @@ test.describe.parallel('Selection', () => {
     await insertDateTime(page);
     await moveRight(page);
 
-    // TODO: verify selection
+    const selected = await evaluate(page, () => {
+      const datetimePillElement = document.querySelector('.dateTimePill');
+      return datetimePillElement.classList.contains('selected');
+    });
+    expect(selected).toBe(true);
   });
 
   test('Move left from last node in RTL #7775', async ({
@@ -1147,7 +1151,17 @@ test.describe.parallel('Selection', () => {
     await insertDateTime(page);
     await moveLeft(page);
 
-    // TODO: verify selection
+    const expectedSelection = createHumanReadableSelection(
+      'at end of paragraph',
+      {
+        anchorOffset: {desc: 'third segment', value: 2},
+        anchorPath: [{desc: 'first paragraph', value: 0}],
+        focusOffset: {desc: 'third segment', value: 2},
+        focusPath: [{desc: 'first paragraph', value: 0}],
+      },
+    );
+
+    await assertSelection(page, expectedSelection);
   });
 
   test('Can delete table node present at the end #5543', async ({

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -1067,16 +1067,25 @@ test.describe.parallel('Selection', () => {
     test.skip(isPlainText || isCollab);
     await page.keyboard.type('קצת');
     await insertDateTime(page);
+    await page.keyboard.type('קצת');
     await moveToEditorBeginning(page);
     await moveLeft(page, 5);
 
     const expectedSelection = createHumanReadableSelection(
-      'the full text of the last cell in the table',
+      'just after the datetime',
       {
-        anchorOffset: {desc: 'after datetime', value: 2},
-        anchorPath: [{desc: 'first paragraph', value: 0}],
-        focusOffset: {desc: 'after datetime', value: 2},
-        focusPath: [{desc: 'first paragraph', value: 0}],
+        anchorOffset: {desc: 'start of the span', value: 0},
+        anchorPath: [
+          {desc: 'first paragraph', value: 0},
+          {desc: 'third span', value: 2},
+          {desc: 'beginning of text', value: 0},
+        ],
+        focusOffset: {desc: 'start of the span', value: 0},
+        focusPath: [
+          {desc: 'first paragraph', value: 0},
+          {desc: 'third span', value: 2},
+          {desc: 'beginning of text', value: 0},
+        ],
       },
     );
 
@@ -1091,9 +1100,28 @@ test.describe.parallel('Selection', () => {
     test.skip(isPlainText || isCollab);
     await page.keyboard.type('קצת');
     await insertDateTime(page);
-    await moveToEditorBeginning(page);
-    await moveRight(page, 2);
-    // TODO: assert selection is right before the datetime
+    await page.keyboard.type('קצת');
+    await moveRight(page, 5);
+
+    const expectedSelection = createHumanReadableSelection(
+      'just before the datetime',
+      {
+        anchorOffset: {desc: 'before datetime', value: 3},
+        anchorPath: [
+          {desc: 'first paragraph', value: 0},
+          {desc: 'first span', value: 0},
+          {desc: 'beginning of text', value: 0},
+        ],
+        focusOffset: {desc: 'before datetime', value: 3},
+        focusPath: [
+          {desc: 'first paragraph', value: 0},
+          {desc: 'first span', value: 0},
+          {desc: 'beginning of text', value: 0},
+        ],
+      },
+    );
+
+    await assertSelection(page, expectedSelection);
   });
 
   test('Can delete table node present at the end #5543', async ({

--- a/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
+++ b/packages/lexical-playground/__tests__/e2e/Selection.spec.mjs
@@ -1068,8 +1068,19 @@ test.describe.parallel('Selection', () => {
     await page.keyboard.type('קצת');
     await insertDateTime(page);
     await moveToEditorBeginning(page);
-    await moveLeft(page, 4);
-    // TODO: assert selection is at end of paragraph
+    await moveLeft(page, 5);
+
+    const expectedSelection = createHumanReadableSelection(
+      'the full text of the last cell in the table',
+      {
+        anchorOffset: {desc: 'after datetime', value: 2},
+        anchorPath: [{desc: 'first paragraph', value: 0}],
+        focusOffset: {desc: 'after datetime', value: 2},
+        focusPath: [{desc: 'first paragraph', value: 0}],
+      },
+    );
+
+    await assertSelection(page, expectedSelection);
   });
 
   test('Move right from DecoratorNode in RTL #7771', async ({

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -750,6 +750,7 @@ export async function insertHorizontalRule(page) {
 
 export async function insertDateTime(page) {
   await selectFromInsertDropdown(page, '.calendar');
+  await sleep(500);
 }
 
 export async function insertImageCaption(page, caption) {

--- a/packages/lexical-playground/__tests__/utils/index.mjs
+++ b/packages/lexical-playground/__tests__/utils/index.mjs
@@ -748,6 +748,10 @@ export async function insertHorizontalRule(page) {
   await selectFromInsertDropdown(page, '.horizontal-rule');
 }
 
+export async function insertDateTime(page) {
+  await selectFromInsertDropdown(page, '.calendar');
+}
+
 export async function insertImageCaption(page, caption) {
   await click(page, '.editor-image img');
   await click(page, '.image-caption-button');

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -31,6 +31,7 @@ import {
   copyToClipboard,
 } from '@lexical/clipboard';
 import {
+  $isParentRTL,
   $moveCharacter,
   $shouldOverrideDefaultCharacterSelection,
 } from '@lexical/selection';
@@ -841,7 +842,11 @@ export function registerRichText(editor: LexicalEditor): () => void {
           const nodes = selection.getNodes();
           if (nodes.length > 0) {
             event.preventDefault();
-            nodes[0].selectPrevious();
+            if ($isParentRTL(nodes[0])) {
+              nodes[0].selectNext(0, 0);
+            } else {
+              nodes[0].selectPrevious();
+            }
             return true;
           }
         }
@@ -868,7 +873,11 @@ export function registerRichText(editor: LexicalEditor): () => void {
           const nodes = selection.getNodes();
           if (nodes.length > 0) {
             event.preventDefault();
-            nodes[0].selectNext(0, 0);
+            if ($isParentRTL(nodes[0])) {
+              nodes[0].selectPrevious();
+            } else {
+              nodes[0].selectNext(0, 0);
+            }
             return true;
           }
         }

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -28,6 +28,8 @@ export {
   $wrapNodes,
 } from './range-selection';
 export {
+  $getComputedStyleForParent,
+  $isParentRTL,
   createDOMRange,
   createRectsFromDOMRange,
   getCSSFromStyleObject,

--- a/packages/lexical-selection/src/index.ts
+++ b/packages/lexical-selection/src/index.ts
@@ -28,6 +28,7 @@ export {
   $wrapNodes,
 } from './range-selection';
 export {
+  $getComputedStyleForElement,
   $getComputedStyleForParent,
   $isParentRTL,
   createDOMRange,

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -21,7 +21,6 @@ import {
   $caretFromPoint,
   $createRangeSelection,
   $extendCaretToRange,
-  $getEditor,
   $getPreviousSelection,
   $getSelection,
   $hasAncestor,
@@ -31,7 +30,6 @@ import {
   $isExtendableTextPointCaret,
   $isLeafNode,
   $isRangeSelection,
-  $isRootNode,
   $isRootOrShadowRoot,
   $isTextNode,
   $setSelection,
@@ -39,7 +37,7 @@ import {
 } from 'lexical';
 import invariant from 'shared/invariant';
 
-import {getStyleObjectFromCSS} from './utils';
+import {$getComputedStyleForParent, getStyleObjectFromCSS} from './utils';
 
 export function $copyBlockFormatIndent(
   srcNode: ElementNode,
@@ -432,23 +430,16 @@ function $isEditorVerticalOrientation(selection: RangeSelection): boolean {
   return computedStyle !== null && computedStyle.writingMode === 'vertical-rl';
 }
 
+/**
+ * Gets the computed DOM styles of the parent of the selection's anchor node.
+ * @param selection - The selection to check the styles for.
+ * @returns the computed styles of the node or null if there is no DOM element or no default view for the document.
+ */
 function $getComputedStyle(
   selection: RangeSelection,
 ): CSSStyleDeclaration | null {
   const anchorNode = selection.anchor.getNode();
-  const parent = $isRootNode(anchorNode)
-    ? anchorNode
-    : anchorNode.getParentOrThrow();
-  const editor = $getEditor();
-  const domElement = editor.getElementByKey(parent.getKey());
-  if (domElement === null) {
-    return null;
-  }
-  const view = domElement.ownerDocument.defaultView;
-  if (view === null) {
-    return null;
-  }
-  return view.getComputedStyle(domElement);
+  return $getComputedStyleForParent(anchorNode);
 }
 
 /**

--- a/packages/lexical-selection/src/range-selection.ts
+++ b/packages/lexical-selection/src/range-selection.ts
@@ -37,7 +37,11 @@ import {
 } from 'lexical';
 import invariant from 'shared/invariant';
 
-import {$getComputedStyleForParent, getStyleObjectFromCSS} from './utils';
+import {
+  $getComputedStyleForElement,
+  $getComputedStyleForParent,
+  getStyleObjectFromCSS,
+} from './utils';
 
 export function $copyBlockFormatIndent(
   srcNode: ElementNode,
@@ -439,6 +443,9 @@ function $getComputedStyle(
   selection: RangeSelection,
 ): CSSStyleDeclaration | null {
   const anchorNode = selection.anchor.getNode();
+  if ($isElementNode(anchorNode)) {
+    return $getComputedStyleForElement(anchorNode);
+  }
   return $getComputedStyleForParent(anchorNode);
 }
 

--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -7,7 +7,7 @@
  */
 import type {LexicalEditor, LexicalNode} from 'lexical';
 
-import {$isTextNode} from 'lexical';
+import {$getEditor, $isRootNode, $isTextNode} from 'lexical';
 
 import {CSS_TO_STYLES} from './constants';
 
@@ -228,4 +228,35 @@ export function getCSSFromStyleObject(styles: Record<string, string>): string {
   }
 
   return css;
+}
+
+/**
+ * Gets the computed DOM styles of the parent of the node.
+ * @param node - The node to check its parent's styles for.
+ * @returns the computed styles of the node or null if there is no DOM element or no default view for the document.
+ */
+export function $getComputedStyleForParent(
+  node: LexicalNode,
+): CSSStyleDeclaration | null {
+  const parent = $isRootNode(node) ? node : node.getParentOrThrow();
+  const editor = $getEditor();
+  const domElement = editor.getElementByKey(parent.getKey());
+  if (domElement === null) {
+    return null;
+  }
+  const view = domElement.ownerDocument.defaultView;
+  if (view === null) {
+    return null;
+  }
+  return view.getComputedStyle(domElement);
+}
+
+/**
+ * Determines whether a node's parent is RTL.
+ * @param node - The node to check whether it is RTL.
+ * @returns whether the node is RTL.
+ */
+export function $isParentRTL(node: LexicalNode): boolean {
+  const styles = $getComputedStyleForParent(node);
+  return styles !== null && styles.direction === 'rtl';
 }

--- a/packages/lexical-selection/src/utils.ts
+++ b/packages/lexical-selection/src/utils.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import type {LexicalEditor, LexicalNode} from 'lexical';
+import type {ElementNode, LexicalEditor, LexicalNode} from 'lexical';
 
 import {$getEditor, $isRootNode, $isTextNode} from 'lexical';
 
@@ -231,16 +231,15 @@ export function getCSSFromStyleObject(styles: Record<string, string>): string {
 }
 
 /**
- * Gets the computed DOM styles of the parent of the node.
- * @param node - The node to check its parent's styles for.
- * @returns the computed styles of the node or null if there is no DOM element or no default view for the document.
+ * Gets the computed DOM styles of the element.
+ * @param node - The node to check the styles for.
+ * @returns the computed styles of the element or null if there is no DOM element or no default view for the document.
  */
-export function $getComputedStyleForParent(
-  node: LexicalNode,
+export function $getComputedStyleForElement(
+  element: ElementNode,
 ): CSSStyleDeclaration | null {
-  const parent = $isRootNode(node) ? node : node.getParentOrThrow();
   const editor = $getEditor();
-  const domElement = editor.getElementByKey(parent.getKey());
+  const domElement = editor.getElementByKey(element.getKey());
   if (domElement === null) {
     return null;
   }
@@ -249,6 +248,18 @@ export function $getComputedStyleForParent(
     return null;
   }
   return view.getComputedStyle(domElement);
+}
+
+/**
+ * Gets the computed DOM styles of the parent of the node.
+ * @param node - The node to check its parent's styles for.
+ * @returns the computed styles of the node or null if there is no DOM element or no default view for the document.
+ */
+export function $getComputedStyleForParent(
+  node: LexicalNode,
+): CSSStyleDeclaration | null {
+  const parent = $isRootNode(node) ? node : node.getParentOrThrow();
+  return $getComputedStyleForElement(parent);
 }
 
 /**


### PR DESCRIPTION
## Description
This updates the right/left key arrow handlers to correct whether the previous/next node should be selected, for RTL scenarios.

Closes #7771.
Closes #7775.

## Test plan

Added a test for this.

### Before

https://github.com/user-attachments/assets/015b166a-9dc2-46b1-a599-c8f1cff2c33e


### After

https://github.com/user-attachments/assets/543d3d0a-468d-40b8-bc54-f0af870c74e9


