### PR TITLE
[lexical] Fix: insert into existing paragraph node if selection is on parent element

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -33,6 +33,7 @@ import {
   $isElementNode,
   $isExtendableTextPointCaret,
   $isLineBreakNode,
+  $isParagraphNode,
   $isRootNode,
   $isSiblingCaret,
   $isTextNode,
@@ -275,15 +276,19 @@ function $transferStartingElementPointToTextPoint(
   const element = start.getNode();
   const placementNode = element.getChildAtIndex(start.offset);
   const textNode = $createTextNode();
-  const target = $isRootNode(element)
-    ? $createParagraphNode().append(textNode)
-    : textNode;
   textNode.setFormat(format);
   textNode.setStyle(style);
-  if (placementNode === null) {
-    element.append(target);
+  if ($isParagraphNode(placementNode)) {
+    placementNode.splice(0, 0, [textNode]);
   } else {
-    placementNode.insertBefore(target);
+    const target = $isRootNode(element)
+      ? $createParagraphNode().append(textNode)
+      : textNode;
+    if (placementNode === null) {
+      element.append(target);
+    } else {
+      placementNode.insertBefore(target);
+    }
   }
   // Transfer the element point to a text point.
   if (start.is(end)) {

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -363,6 +363,27 @@ describe('LexicalSelection tests', () => {
         });
       });
     });
+
+    describe('insertText()', () => {
+      test('inserts into existing paragraph node when selection is on parent of paragraph', () => {
+        const {editor} = testEnv;
+        editor.update(() => {
+          const root = $getRoot();
+          const paragraph = $createParagraphNode();
+          root.clear().append(paragraph);
+
+          const selection = $createRangeSelection();
+          selection.anchor.set('root', 0, 'element');
+          selection.focus.set('root', 0, 'element');
+          $setSelection(selection);
+
+          selection.insertText('text');
+          expect(root.getChildrenSize()).toBe(1);
+          expect(root.getTextContent()).toBe('text');
+        });
+      });
+    });
+
     describe('removeText', () => {
       describe('with a leading TextNode and a trailing token TextNode', () => {
         let leadingText: TextNode;


### PR DESCRIPTION
## Description

If the selection is on the root node with an offset that points to a paragraph node, inserting text at the selection creates a new paragraph rather than inserting text into the existing paragraph. Noticed in collab when focusing the editor with the keyboard (i.e. refresh page, click frame outside of editor, tab into the content-editable).

## Test plan

### Before

Focusing editors by keyboard then inserting text results in new paragraphs being added, despite the cursor being positioned at the start of the paragraphs.

https://github.com/user-attachments/assets/c9780977-d767-4aec-bf49-ffec026378ec

### After

Text is inserted into the existing paragraph.

https://github.com/user-attachments/assets/dd81001c-891e-42f3-bf88-9d80aaddbaff
