### PR TITLE
[lexical-history] Add Missing Argument for DispatchCommand in Undo/Redo Docs Example

### DIFF
--- a/packages/lexical-history/README.md
+++ b/packages/lexical-history/README.md
@@ -26,7 +26,7 @@ History package handles `UNDO_COMMAND`, `REDO_COMMAND` and `CLEAR_HISTORY_COMMAN
 import {UNDO_COMMAND, REDO_COMMAND} from 'lexical';
 
 <Toolbar>
-  <Button onClick={() => editor.dispatchCommand(UNDO_COMMAND)}>Undo</Button>
-  <Button onClick={() => editor.dispatchCommand(REDO_COMMAND)}>Redo</Button>
+  <Button onClick={() => editor.dispatchCommand(UNDO_COMMAND, undefined)}>Undo</Button>
+  <Button onClick={() => editor.dispatchCommand(REDO_COMMAND, undefined)}>Redo</Button>
 </Toolbar>;
 ```


### PR DESCRIPTION
## Context
This PR fixes a minor issue in the **Lexical History** undo/redo documentation example. The previous example was missing a required argument for `dispatchCommand`, which caused a TypeScript error

```ts
onClick={() => editor.dispatchCommand(UNDO_COMMAND)}
```
```text
Expected 2 arguments, but got 1.ts(2554)
LexicalEditor.d.ts(513, 79): An argument for 'payload' was not provided.
```

## Changes
The example has been updated to include the missing argument `payload` as `undefined`
```ts
onClick={() => editor.dispatchCommand(UNDO_COMMAND, undefined)}
```

## Checklist
- [x] Documentation updated to reflect the required argument  
- [x] Example code verified and works correctly in TypeScript  
- [x] No functional changes introduced 