### PR TITLE
[*] Chore: Replace jest with vitest for unit tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,7 +67,7 @@ module.exports = {
         'plugin:@typescript-eslint/recommended',
         'plugin:@lexical/all',
       ],
-      files: ['**/*.ts', '**/*.tsx'],
+      files: ['**/*.ts', '**/*.tsx', '**/*.mts'],
       parser: '@typescript-eslint/parser',
       parserOptions: {
         sourceType: 'module',

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,4 +1,4 @@
 module.exports = {
-  '*.(js|mjs|jsx|css|html|d.ts|ts|tsx|yml|mdx)': 'prettier --write',
-  '*.(js|mjs|jsx|ts|tsx)': ['eslint --fix'],
+  '*.(js|mjs|jsx|css|html|d.ts|ts|mts|tsx|yml|mdx)': 'prettier --write',
+  '*.(js|mjs|jsx|ts|mts|tsx)': ['eslint --fix'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,85 +8,17 @@
 
 'use strict';
 
-const tsconfig = require('./tsconfig.json');
-
 const common = {
   modulePathIgnorePatterns: ['/npm'],
 };
-
-// Use tsconfig's paths to configure jest's module name mapper
-const moduleNameMapper = {
-  ...Object.fromEntries(
-    Object.entries(tsconfig.compilerOptions.paths).map(
-      ([name, [firstPath]]) => [
-        `^${name}$`,
-        firstPath.replace(/^\./, '<rootDir>'),
-      ],
-    ),
-  ),
-  '^shared/invariant$': '<rootDir>/packages/shared/src/__mocks__/invariant.ts',
-  '^shared/warnOnlyOnce$':
-    '<rootDir>/packages/shared/src/__mocks__/warnOnlyOnce.ts',
-};
-
-// necessary transformations for shiki support
-const npm_modules_transformed = [
-  'shiki',
-  '@shikijs',
-  'hast-util-to-html',
-  'html-void-elements',
-  'property-information',
-  'zwitch',
-  'stringify-entities',
-  'character-entities-legacy',
-  'character-entities-html4',
-  'ccount',
-  'comma-separated-tokens',
-  'space-separated-tokens',
-  'hast-util-whitespace',
-];
 
 module.exports = {
   projects: [
     {
       ...common,
-      displayName: 'unit',
-      globals: {
-        // https://react.dev/blog/2022/03/08/react-18-upgrade-guide#configuring-your-testing-environment
-        IS_REACT_ACT_ENVIRONMENT: true,
-        __DEV__: true,
-      },
-      moduleNameMapper,
-      preset: 'ts-jest',
-      testEnvironment: 'jsdom',
-      testMatch: ['**/__tests__/unit/**/*.test{.ts,.tsx,.js,.jsx}'],
-      transform: {
-        '^.+\\.jsx?$': 'babel-jest',
-        '^.+\\.mjs$': 'babel-jest',
-        '^.+\\.tsx?$': [
-          'ts-jest',
-          {
-            tsconfig: 'tsconfig.test.json',
-          },
-        ],
-      },
-      transformIgnorePatterns: [
-        '/node_modules/(?!(' + npm_modules_transformed.join('|') + '))',
-      ],
-    },
-    {
-      ...common,
       displayName: 'integration',
       globalSetup: './scripts/__tests__/integration/setup.js',
       testMatch: ['**/scripts/__tests__/integration/**/*.test.js'],
-    },
-    {
-      ...common,
-      displayName: 'e2e',
-      testMatch: [
-        '**/__tests__/e2e/**/*.js',
-        '**/__tests__/regression/**/*.js',
-      ],
     },
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,9 @@
         "ts-node": "^10.9.1",
         "typedoc": "^0.25.12",
         "typescript": "^5.4.5",
-        "vite": "^5.2.11"
+        "vite": "^5.2.11",
+        "vite-tsconfig-paths": "^5.1.4",
+        "vitest": "^3.2.4"
       },
       "engines": {
         "npm": ">=8.2.3",
@@ -8092,9 +8094,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -11407,6 +11410,16 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
     "node_modules/@types/child-process-promise": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/@types/child-process-promise/-/child-process-promise-2.2.6.tgz",
@@ -11667,6 +11680,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "8.56.10",
@@ -12477,6 +12497,175 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.18",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/runner/node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.18",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -13313,6 +13502,16 @@
         "object-is": "^1.1.5",
         "object.assign": "^4.1.4",
         "util": "^0.12.5"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -14484,6 +14683,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -14549,6 +14765,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cheerio": {
@@ -16982,6 +17208,16 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -19757,6 +19993,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
@@ -21018,6 +21260,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -21278,6 +21530,24 @@
       "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/feed": {
@@ -22719,6 +22989,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glur": {
       "version": "1.1.2",
@@ -28190,6 +28467,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -32998,6 +33282,16 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -37903,6 +38197,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -38277,6 +38578,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -39215,18 +39523,75 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinypool": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
-      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/titleize": {
@@ -39549,6 +39914,27 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -40866,6 +41252,61 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vite-plugin-static-copy": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.0.tgz",
@@ -40911,6 +41352,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
+      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite/node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -40923,6 +41384,134 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.18",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vlq": {
@@ -41489,11 +42078,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/webpack/node_modules/es-module-lexer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.1.tgz",
-      "integrity": "sha512-JUFAyicQV9mXc3YRxPnDlrfBKpqt6hUYzz9/boprUJHs4e4KVr3XwOF70doO6gwXUor6EWZJAyWAfKki84t20Q=="
-    },
     "node_modules/webpack/node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -41802,6 +42386,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {
@@ -48670,9 +49271,9 @@
       }
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -50861,6 +51462,15 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "requires": {
+        "@types/deep-eql": "*"
+      }
+    },
     "@types/child-process-promise": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/@types/child-process-promise/-/child-process-promise-2.2.6.tgz",
@@ -51116,6 +51726,12 @@
       "requires": {
         "@types/ms": "*"
       }
+    },
+    "@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "@types/eslint": {
       "version": "8.56.10",
@@ -51800,6 +52416,132 @@
         "react-refresh": "^0.14.0"
       }
     },
+    "@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      }
+    },
+    "@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.30.18",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+          "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.5.5"
+          }
+        }
+      }
+    },
+    "@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "requires": {
+        "tinyrainbow": "^2.0.0"
+      }
+    },
+    "@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+          "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+          "dev": true
+        },
+        "pathe": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+          "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+          "dev": true
+        },
+        "strip-literal": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+          "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+          "dev": true,
+          "requires": {
+            "js-tokens": "^9.0.1"
+          }
+        }
+      }
+    },
+    "@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.30.18",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+          "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.5.5"
+          }
+        },
+        "pathe": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+          "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+          "dev": true
+        }
+      }
+    },
+    "@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "requires": {
+        "tinyspy": "^4.0.3"
+      }
+    },
+    "@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
@@ -52463,6 +53205,12 @@
         "object.assign": "^4.1.4",
         "util": "^0.12.5"
       }
+    },
+    "assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true
     },
     "ast-types-flow": {
       "version": "0.0.8",
@@ -53262,6 +54010,19 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
     },
+    "chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -53301,6 +54062,12 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true
     },
     "cheerio": {
@@ -54957,6 +55724,12 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
       "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true
     },
     "deep-extend": {
@@ -56825,6 +57598,11 @@
         "safe-array-concat": "^1.1.2"
       }
     },
+    "es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="
+    },
     "es-object-atoms": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
@@ -57710,6 +58488,12 @@
         "jest-util": "^29.7.0"
       }
     },
+    "expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true
+    },
     "express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -57901,6 +58685,12 @@
       "requires": {
         "pend": "~1.2.0"
       }
+    },
+    "fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true
     },
     "feed": {
       "version": "4.2.2",
@@ -58888,6 +59678,12 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "glur": {
       "version": "1.1.2",
@@ -62754,6 +63550,12 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
     "lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -65709,6 +66511,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true
     },
     "pend": {
@@ -68885,6 +69693,12 @@
         "object-inspect": "^1.13.1"
       }
     },
+    "siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -69179,6 +69993,12 @@
           "dev": true
         }
       }
+    },
+    "stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
     },
     "statuses": {
       "version": "2.0.1",
@@ -69872,15 +70692,51 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
     "tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
     },
+    "tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dev": true,
+      "requires": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+          "dev": true
+        }
+      }
+    },
     "tinypool": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
-      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="
+    },
+    "tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true
+    },
+    "tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "dev": true
     },
     "titleize": {
       "version": "3.0.0",
@@ -70087,6 +70943,12 @@
           "dev": true
         }
       }
+    },
+    "tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true
     },
     "tsconfig-paths": {
       "version": "3.15.0",
@@ -70996,6 +71858,42 @@
         }
       }
     },
+    "vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "requires": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+          "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "pathe": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+          "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+          "dev": true
+        }
+      }
+    },
     "vite-plugin-static-copy": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.0.tgz",
@@ -71024,6 +71922,86 @@
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
           "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+          "dev": true
+        }
+      }
+    },
+    "vite-tsconfig-paths": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
+      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      }
+    },
+    "vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+          "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "magic-string": {
+          "version": "0.30.18",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+          "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.5.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "pathe": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+          "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+          "dev": true
+        },
+        "picomatch": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
           "dev": true
         }
       }
@@ -71294,11 +72272,6 @@
           "version": "8.14.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
           "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="
-        },
-        "es-module-lexer": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.1.tgz",
-          "integrity": "sha512-JUFAyicQV9mXc3YRxPnDlrfBKpqt6hUYzz9/boprUJHs4e4KVr3XwOF70doO6gwXUor6EWZJAyWAfKki84t20Q=="
         },
         "graceful-fs": {
           "version": "4.2.11",
@@ -71653,6 +72626,16 @@
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.2"
+      }
+    },
+    "why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "requires": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
       }
     },
     "wide-align": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "tsc-watch": "tsc -w",
     "collab": "cross-env HOST=localhost PORT=1234 npx y-websocket-server",
     "validation": "npx ts-node --cwdMode packages/lexical-playground/src/server/validation.ts",
-    "test-unit": "jest --selectProjects unit --testPathPattern",
-    "test-unit-watch": "npm run test-unit -- --watch --coverage=''",
+    "vitest": "vitest",
+    "test-unit": "vitest --no-watch",
+    "test-unit-watch": "vitest",
     "test-integration": "jest --selectProjects integration --testPathPattern",
     "test-e2e-chromium": "cross-env E2E_BROWSER=chromium playwright test --project=\"chromium\"",
     "test-e2e-firefox": "cross-env E2E_BROWSER=firefox playwright test --project=\"firefox\"",
@@ -87,7 +88,7 @@
     "debug-test-e2e-plain-legacy-chromium": "cross-env E2E_BROWSER=chromium E2E_EDITOR_MODE=plain-text E2E_EVENTS_MODE=legacy-events playwright test --debug --project=\"chromium\"",
     "debug-test-e2e-plain-legacy-firefox": "cross-env E2E_BROWSER=firefox E2E_EDITOR_MODE=plain-text E2E_EVENTS_MODE=legacy-events playwright test --debug --project=\"firefox\"",
     "debug-test-e2e-plain-legacy-webkit": "cross-env E2E_BROWSER=webkit E2E_EDITOR_MODE=plain-text E2E_EVENTS_MODE=legacy-events playwright test --debug --project=\"webkit\"",
-    "debug-test-unit": "node --inspect-brk node_modules/.bin/jest --runInBand --collectCoverage=false",
+    "debug-test-unit": "vitest --inspect-brk --no-file-parallelism",
     "lint": "eslint ./",
     "prettier": "prettier --list-different .",
     "ci-check": "npm-run-all --parallel tsc tsc-extension flow prettier lint",
@@ -189,7 +190,9 @@
     "ts-node": "^10.9.1",
     "typedoc": "^0.25.12",
     "typescript": "^5.4.5",
-    "vite": "^5.2.11"
+    "vite": "^5.2.11",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "yjs": "^13.5.42"

--- a/packages/lexical-code-shiki/src/FacadeShiki.ts
+++ b/packages/lexical-code-shiki/src/FacadeShiki.ts
@@ -63,7 +63,7 @@ export function loadCodeLanguage(
     if (languageInfo) {
       // in case we arrive here concurrently (not yet loaded language is loaded twice)
       // shiki's synchronous checks make sure to load it only once
-      shiki.loadLanguage(languageInfo.import()).then(() => {
+      return shiki.loadLanguage(languageInfo.import()).then(() => {
         // here we know that the language is loaded
         // make sure the code is highlighed with the correct language
         if (editor && codeNodeKey) {
@@ -94,7 +94,7 @@ export function isCodeThemeLoaded(theme: string) {
   return shiki.getLoadedThemes().includes(themeId);
 }
 
-export async function loadCodeTheme(
+export function loadCodeTheme(
   theme: string,
   editor?: LexicalEditor,
   codeNodeKey?: NodeKey,
@@ -102,7 +102,7 @@ export async function loadCodeTheme(
   if (!isCodeThemeLoaded(theme)) {
     const themeInfo = bundledThemesInfo.find((info) => info.id === theme);
     if (themeInfo) {
-      shiki.loadTheme(themeInfo.import()).then(() => {
+      return shiki.loadTheme(themeInfo.import()).then(() => {
         if (editor && codeNodeKey) {
           editor.update(() => {
             const codeNode = $getNodeByKey(codeNodeKey);

--- a/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
+++ b/packages/lexical-code-shiki/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
@@ -29,6 +29,7 @@ import {
   initializeUnitTest,
   tabKeyboardEvent,
 } from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 describe('LexicalCodeNode tests', () => {
   initializeUnitTest((testEnv) => {

--- a/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
+++ b/packages/lexical-code/src/__tests__/unit/LexicalCodeNode.test.ts
@@ -44,6 +44,7 @@ import {
   shiftTabKeyboardEvent,
   tabKeyboardEvent,
 } from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 const editorConfig = Object.freeze({
   namespace: '',

--- a/packages/lexical-code/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
+++ b/packages/lexical-code/src/__tests__/unit/LexicalCodeNodeTabs.test.ts
@@ -32,6 +32,7 @@ import {
   initializeUnitTest,
   tabKeyboardEvent,
 } from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 describe('LexicalCodeNode tests', () => {
   initializeUnitTest((testEnv) => {

--- a/packages/lexical-eslint-plugin/src/__tests__/unit/buildMatcher.test.ts
+++ b/packages/lexical-eslint-plugin/src/__tests__/unit/buildMatcher.test.ts
@@ -7,6 +7,7 @@
  */
 
 import {type Identifier} from 'estree';
+import {describe, expect, it} from 'vitest';
 
 import {buildMatcher} from '../../util/buildMatcher';
 

--- a/packages/lexical-eslint-plugin/src/__tests__/unit/rules-of-lexical.test.ts
+++ b/packages/lexical-eslint-plugin/src/__tests__/unit/rules-of-lexical.test.ts
@@ -10,6 +10,7 @@ import {RuleTester} from 'eslint';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as prettier from 'prettier';
+import {describe, expect, it} from 'vitest';
 
 import plugin from '../../LexicalEslintPlugin.js';
 import {type RulesOfLexicalOptions} from '../../rules/rules-of-lexical.js';

--- a/packages/lexical-hashtag/src/__tests__/unit/LexicalHashtagNode.test.ts
+++ b/packages/lexical-hashtag/src/__tests__/unit/LexicalHashtagNode.test.ts
@@ -8,6 +8,7 @@
 
 import {$createHashtagNode} from '@lexical/hashtag';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 describe('LexicalHashtagNode tests', () => {
   initializeUnitTest((testEnv) => {

--- a/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.ts
+++ b/packages/lexical-headless/src/__tests__/unit/LexicalHeadlessEditor.test.ts
@@ -29,6 +29,7 @@ import {
   CONTROLLED_TEXT_INSERTION_COMMAND,
   ParagraphNode,
 } from 'lexical';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {createHeadlessEditor} from '../..';
 import {isEmptyNavigator} from '../utils';
@@ -124,10 +125,10 @@ describe('LexicalHeadlessEditor', () => {
   });
 
   it('can register listeners', async () => {
-    const onUpdate = jest.fn();
-    const onCommand = jest.fn();
-    const onTransform = jest.fn();
-    const onTextContent = jest.fn();
+    const onUpdate = vi.fn();
+    const onCommand = vi.fn();
+    const onTransform = vi.fn();
+    const onTextContent = vi.fn();
 
     editor.registerUpdateListener(onUpdate);
     editor.registerCommand(

--- a/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
+++ b/packages/lexical-history/src/__tests__/unit/LexicalHistory.test.tsx
@@ -45,6 +45,7 @@ import {
 import {createTestEditor, TestComposer} from 'lexical/src/__tests__/utils';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 
 type SerializedCustomTextNode = Spread<
   {type: string; classes: string[]},
@@ -121,7 +122,7 @@ describe('LexicalHistory tests', () => {
     }
     container = null;
 
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   // Shared instance across tests

--- a/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
+++ b/packages/lexical-html/src/__tests__/unit/LexicalHtml.test.ts
@@ -20,6 +20,7 @@ import {
   ParagraphNode,
   RangeSelection,
 } from 'lexical';
+import {describe, expect, test} from 'vitest';
 
 describe('HTML', () => {
   type Input = Array<{

--- a/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalAutoLinkNode.test.ts
@@ -21,6 +21,7 @@ import {
   TextNode,
 } from 'lexical/src';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 const editorConfig = Object.freeze({
   namespace: '',

--- a/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
+++ b/packages/lexical-link/src/__tests__/unit/LexicalLinkNode.test.ts
@@ -30,6 +30,7 @@ import {
   SerializedParagraphNode,
 } from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, it, test} from 'vitest';
 
 const editorConfig = Object.freeze({
   namespace: '',

--- a/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListItemNode.test.ts
@@ -17,6 +17,7 @@ import {
   html,
   initializeUnitTest,
 } from 'lexical/src/__tests__/utils';
+import {beforeEach, describe, expect, it, test} from 'vitest';
 
 import {
   $createListItemNode,

--- a/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/LexicalListNode.test.ts
@@ -8,6 +8,7 @@
 import {$createLinkNode, $isLinkNode, LinkNode} from '@lexical/link';
 import {$getRoot, ParagraphNode, TextNode} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 import {
   $createListItemNode,

--- a/packages/lexical-list/src/__tests__/unit/formatList.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/formatList.test.ts
@@ -21,6 +21,7 @@ import {
   $selectAll,
 } from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 import {$insertList} from '../../formatList';
 import {$createListItemNode} from '../../LexicalListItemNode';

--- a/packages/lexical-list/src/__tests__/unit/registerListStrictIndentTransform.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/registerListStrictIndentTransform.test.ts
@@ -12,6 +12,7 @@ import {
   html,
   initializeUnitTest,
 } from 'lexical/src/__tests__/utils';
+import {beforeEach, describe, test} from 'vitest';
 
 import {registerListStrictIndentTransform} from '../../index';
 

--- a/packages/lexical-list/src/__tests__/unit/utils.test.ts
+++ b/packages/lexical-list/src/__tests__/unit/utils.test.ts
@@ -7,6 +7,7 @@
  */
 import {$createParagraphNode, $getRoot} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 import {$createListItemNode, $createListNode} from '../..';
 import {$getListDepth, $getTopListNode, $isLastItemInList} from '../../utils';

--- a/packages/lexical-list/src/__tests__/utils.ts
+++ b/packages/lexical-list/src/__tests__/utils.ts
@@ -7,6 +7,7 @@
  */
 import {expect} from '@playwright/test';
 import prettier from 'prettier';
+import {expect} from 'vitest';
 
 // This tag function is just used to trigger prettier auto-formatting.
 // (https://prettier.io/blog/2020/08/24/2.1.0.html#api)

--- a/packages/lexical-list/src/__tests__/utils.ts
+++ b/packages/lexical-list/src/__tests__/utils.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {expect} from '@playwright/test';
 import prettier from 'prettier';
 import {expect} from 'vitest';
 

--- a/packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts
+++ b/packages/lexical-mark/__tests__/unit/LexicalMarkNode.test.ts
@@ -21,6 +21,7 @@ import {
   $createTestInlineElementNode,
   initializeUnitTest,
 } from 'lexical/src/__tests__/utils';
+import {beforeEach, describe, expect, test} from 'vitest';
 
 describe('LexicalMarkNode tests', () => {
   initializeUnitTest((testEnv) => {

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -20,6 +20,7 @@ import {
   $insertNodes,
   $isRangeSelection,
 } from 'lexical';
+import {describe, expect, it} from 'vitest';
 
 import {
   $convertFromMarkdownString,

--- a/packages/lexical-playground/__tests__/unit/docSerialization.test.ts
+++ b/packages/lexical-playground/__tests__/unit/docSerialization.test.ts
@@ -23,6 +23,7 @@ import {
   $insertNodes,
 } from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, it} from 'vitest';
 
 import {docFromHash, docToHash} from '../../src/utils/docSerialization';
 

--- a/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/Collaboration.test.ts
@@ -14,6 +14,7 @@ import {
   TextNode,
   UNDO_COMMAND,
 } from 'lexical';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import * as Y from 'yjs';
 
 import {Client, createTestConnection, waitForReact} from './utils';

--- a/packages/lexical-react/src/__tests__/unit/CollaborationWithCollisions.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/CollaborationWithCollisions.test.ts
@@ -16,6 +16,7 @@ import {
   BaseSelection,
   LexicalNode,
 } from 'lexical';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
 import {
   connectClients,

--- a/packages/lexical-react/src/__tests__/unit/LexicalCollaborationPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalCollaborationPlugin.test.tsx
@@ -14,6 +14,7 @@ import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
 import * as React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
 import * as Y from 'yjs';
 
 describe(`LexicalCollaborationPlugin`, () => {
@@ -40,7 +41,7 @@ describe(`LexicalCollaborationPlugin`, () => {
   });
 
   test(`providerFactory called only once`, () => {
-    const providerFactory = jest.fn(
+    const providerFactory = vi.fn(
       (id: string, yjsDocMap: Map<string, Y.Doc>) => {
         const doc = new Y.Doc();
         yjsDocMap.set(id, doc);

--- a/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalComposer.test.tsx
@@ -17,6 +17,7 @@ import {
 import * as React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 describe('LexicalComposer tests', () => {
   let container: HTMLDivElement | null = null;
@@ -32,7 +33,7 @@ describe('LexicalComposer tests', () => {
     document.body.removeChild(container!);
     container = null;
 
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('LexicalComposerContext', async () => {

--- a/packages/lexical-react/src/__tests__/unit/LexicalContentEditableElement.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalContentEditableElement.test.tsx
@@ -11,6 +11,7 @@ import {axe, toHaveNoViolations} from 'jest-axe';
 import {createEditor, LexicalEditor} from 'lexical';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 describe('ContentEditableElement tests', () => {
   let container: HTMLDivElement | null = null;
@@ -187,7 +188,7 @@ describe('ContentEditableElement tests', () => {
 
   it('registers and cleans up root element properly', async () => {
     let rootElement: HTMLElement | null = null;
-    editor.setRootElement = jest.fn((element) => {
+    editor.setRootElement = vi.fn((element) => {
       rootElement = element;
     });
 

--- a/packages/lexical-react/src/__tests__/unit/LexicalNestedComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalNestedComposer.test.tsx
@@ -40,7 +40,15 @@ import * as React from 'react';
 import {useEffect} from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  MockInstance,
+  test,
+  vi,
+} from 'vitest';
 
 expect.extend(toHaveNoViolations);
 class ReactDecoratorNode extends DecoratorNode<React.ReactNode> {
@@ -91,7 +99,7 @@ function $createReactDecoratorNode() {
 describe('LexicalNestedComposer', () => {
   let container: HTMLDivElement | null = null;
   let reactRoot: Root;
-  let warn: jest.SpyInstance;
+  let warn: MockInstance;
 
   beforeEach(() => {
     warn = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/lexical-react/src/__tests__/unit/LexicalNestedComposer.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/LexicalNestedComposer.test.tsx
@@ -40,6 +40,7 @@ import * as React from 'react';
 import {useEffect} from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 
 expect.extend(toHaveNoViolations);
 class ReactDecoratorNode extends DecoratorNode<React.ReactNode> {
@@ -93,7 +94,7 @@ describe('LexicalNestedComposer', () => {
   let warn: jest.SpyInstance;
 
   beforeEach(() => {
-    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     container = document.createElement('div');
     reactRoot = createRoot(container);
     document.body.appendChild(container);
@@ -104,7 +105,7 @@ describe('LexicalNestedComposer', () => {
     container = null;
     warn.mockReset();
 
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   test('with inherited configuration and namespace', async () => {
@@ -803,7 +804,7 @@ describe('LexicalNestedComposer', () => {
     let editor: undefined | LexicalEditor;
     let nestedEditor: undefined | LexicalEditor;
     const DELEGATED_COMMAND = createCommand<unknown>('DELEGATED_COMMAND');
-    const $commandListener = jest.fn((_) => false);
+    const $commandListener = vi.fn((_) => false);
     function DelegateListenerPlugin() {
       const [currentEditor] = useLexicalComposerContext();
       useEffect(() => {
@@ -1036,8 +1037,8 @@ describe('LexicalNestedComposer', () => {
   test('static transform and $config.transform inheritance', async () => {
     let editor: undefined | LexicalEditor;
     let nestedEditor: undefined | LexicalEditor;
-    const $transform = jest.fn();
-    const transform = jest.fn();
+    const $transform = vi.fn();
+    const transform = vi.fn();
     class StaticTransformNode extends TextNode {
       static getType() {
         return 'static-transform';

--- a/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/PlainRichTextPlugin.test.tsx
@@ -30,6 +30,7 @@ import {
 import * as React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 const RICH_TEXT_NODES = [
   HeadingNode,
@@ -59,7 +60,7 @@ describe('LexicalNodeHelpers tests', () => {
     document.body.removeChild(container!);
     container = null;
 
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   for (const plugin of ['PlainTextPlugin', 'RichTextPlugin']) {

--- a/packages/lexical-react/src/__tests__/unit/React19.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/React19.test.tsx
@@ -9,6 +9,7 @@
 import * as React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
 
 const IS_REACT_19 = parseInt(React.version.split('.')[0], 10) >= 19;
 const OVERRIDE_REACT_VERSION = process.env.OVERRIDE_REACT_VERSION ?? '';
@@ -31,7 +32,7 @@ describe(`React expectations (${React.version}) OVERRIDE_REACT_VERSION=${OVERRID
   }
   const cacheExpect = IS_REACT_19 ? 'cached' : 'not cached';
   test(`StrictMode useMemo is ${cacheExpect}`, () => {
-    const memoFun = jest
+    const memoFun = vi
       .fn()
       .mockReturnValueOnce('cached')
       .mockReturnValue('not cached');

--- a/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalCharacterLimit.test.ts
@@ -24,6 +24,7 @@ import {
   ParagraphNode,
 } from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, it} from 'vitest';
 
 import {$mergePrevious} from '../../shared/useCharacterLimit';
 

--- a/packages/lexical-react/src/__tests__/unit/useLexicalIsTextContentEmpty.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/useLexicalIsTextContentEmpty.test.tsx
@@ -19,6 +19,7 @@ import * as React from 'react';
 import {createRef} from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 
 describe('useLexicalIsTextContentEmpty', () => {
   let container: HTMLDivElement | null = null;
@@ -34,7 +35,7 @@ describe('useLexicalIsTextContentEmpty', () => {
     document.body.removeChild(container!);
     container = null;
 
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   function useLexicalEditor(rootElementRef: React.RefObject<HTMLDivElement>) {

--- a/packages/lexical-react/src/__tests__/unit/useMenuAnchorRef.test.tsx
+++ b/packages/lexical-react/src/__tests__/unit/useMenuAnchorRef.test.tsx
@@ -10,28 +10,29 @@ import {createTestEditor} from 'lexical/src/__tests__/utils';
 import * as React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {useMenuAnchorRef} from '../../shared/LexicalMenu';
-
-jest.mock('@lexical/react/LexicalComposerContext', () => ({
-  useLexicalComposerContext: () => [createTestEditor()],
-}));
-
-jest.mock('shared/canUseDOM', () => ({
-  CAN_USE_DOM: false,
-}));
 
 describe('useMenuAnchorRef', () => {
   let container: HTMLDivElement | null = null;
   let reactRoot: Root;
 
   beforeEach(() => {
+    vi.mock('@lexical/react/LexicalComposerContext', () => ({
+      useLexicalComposerContext: () => [createTestEditor()],
+    }));
+
+    vi.mock('shared/canUseDOM', () => ({
+      CAN_USE_DOM: false,
+    }));
+
     container = document.createElement('div');
     reactRoot = createRoot(container);
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('should return null if CAN_USE_DOM is false', async () => {
@@ -39,7 +40,7 @@ describe('useMenuAnchorRef', () => {
 
     function App() {
       const resolution = null;
-      const setResolution = jest.fn();
+      const setResolution = vi.fn();
       const anchorClassName = 'some-class';
       const parent = undefined;
       const shouldIncludePageYOffset__EXPERIMENTAL = true;

--- a/packages/lexical-react/src/__tests__/unit/utils.tsx
+++ b/packages/lexical-react/src/__tests__/unit/utils.tsx
@@ -19,6 +19,7 @@ import * as React from 'react';
 import {Container} from 'react-dom';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {expect} from 'vitest';
 import * as Y from 'yjs';
 
 function Editor({

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalHeadingNode.test.ts
@@ -19,6 +19,7 @@ import {
   RangeSelection,
 } from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 const editorConfig = Object.freeze({
   namespace: '',

--- a/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
+++ b/packages/lexical-rich-text/src/__tests__/unit/LexicalQuoteNode.test.ts
@@ -9,6 +9,7 @@
 import {$createQuoteNode, QuoteNode} from '@lexical/rich-text';
 import {$createRangeSelection, $getRoot, ParagraphNode} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 const editorConfig = Object.freeze({
   namespace: '',

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelection.test.tsx
@@ -53,6 +53,7 @@ import {
 } from 'lexical/src/__tests__/utils';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, expect, it, test, vi} from 'vitest';
 
 import {
   $setAnchorPoint,
@@ -90,12 +91,6 @@ interface ExpectedSelection {
 }
 
 initializeClipboard();
-
-jest.mock('shared/environment', () => {
-  const originalModule = jest.requireActual('shared/environment');
-
-  return {...originalModule, IS_FIREFOX: true};
-});
 
 Range.prototype.getBoundingClientRect = function (): DOMRect {
   const rect = {
@@ -2493,7 +2488,7 @@ describe('LexicalSelection tests', () => {
           });
 
           const newStyle = {
-            color: jest.fn(
+            color: vi.fn(
               (current: string | null, target: LexicalNode | RangeSelection) =>
                 nextColor,
             ),

--- a/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
+++ b/packages/lexical-selection/src/__tests__/unit/LexicalSelectionHelpers.test.ts
@@ -42,6 +42,7 @@ import {
   invariant,
   TestDecoratorNode,
 } from 'lexical/src/__tests__/utils';
+import {afterEach, describe, expect, it, test, vi} from 'vitest';
 
 import {$setAnchorPoint, $setFocusPoint} from '../utils';
 
@@ -2576,7 +2577,7 @@ describe('extract', () => {
 
 describe('insertNodes', () => {
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('can insert element next to top level decorator node', async () => {
@@ -2584,7 +2585,7 @@ describe('insertNodes', () => {
     const element = document.createElement('div');
     editor.setRootElement(element);
 
-    jest.spyOn(TestDecoratorNode.prototype, 'isInline').mockReturnValue(false);
+    vi.spyOn(TestDecoratorNode.prototype, 'isInline').mockReturnValue(false);
 
     await editor.update(() => {
       $getRoot().append(

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableCellNode.test.ts
@@ -14,6 +14,7 @@ import {
   html,
   initializeUnitTest,
 } from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 const editorConfig = Object.freeze({
   namespace: '',

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableMobileSelection.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableMobileSelection.test.tsx
@@ -22,6 +22,7 @@ import {
   $isRangeSelection,
 } from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 // Polyfill PointerEvent for Jest environment
 interface PointerEventInit extends EventInit {

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -44,11 +44,11 @@ import {
 } from 'lexical/src/__tests__/utils';
 import {useState} from 'react';
 import {act} from 'shared/react-test-utils';
-import {beforeEach, describe, expect, test, vi} from 'vitest';
+import {beforeEach, describe, expect, type Mock, test, vi} from 'vitest';
 
 export class ClipboardDataMock {
-  getData: jest.Mock<string, [string]>;
-  setData: jest.Mock<void, [string, string]>;
+  getData: Mock<(type: string) => [string]>;
+  setData: Mock<() => [string, string]>;
 
   constructor() {
     this.getData = vi.fn();

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableNode.test.tsx
@@ -44,14 +44,15 @@ import {
 } from 'lexical/src/__tests__/utils';
 import {useState} from 'react';
 import {act} from 'shared/react-test-utils';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
 
 export class ClipboardDataMock {
   getData: jest.Mock<string, [string]>;
   setData: jest.Mock<void, [string, string]>;
 
   constructor() {
-    this.getData = jest.fn();
-    this.setData = jest.fn();
+    this.getData = vi.fn();
+    this.setData = vi.fn();
   }
 }
 

--- a/packages/lexical-table/src/__tests__/unit/LexicalTablePlugin.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTablePlugin.test.tsx
@@ -26,6 +26,7 @@ import {
   LexicalEditor,
   SELECTION_INSERT_CLIPBOARD_NODES_COMMAND,
 } from 'lexical';
+import {beforeEach, describe, expect, test} from 'vitest';
 
 describe('LexicalTablePlugin', () => {
   let editor: LexicalEditor;

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableRowNode.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableRowNode.test.ts
@@ -8,6 +8,7 @@
 
 import {$createTableRowNode} from '@lexical/table';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, test} from 'vitest';
 
 const editorConfig = Object.freeze({
   namespace: '',

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
@@ -26,6 +26,7 @@ import {
   $setSelection,
 } from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {beforeEach, describe, expect, test} from 'vitest';
 
 describe('table selection', () => {
   initializeUnitTest((testEnv) => {

--- a/packages/lexical-utils/src/__tests__/unit/LexicalElementHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalElementHelpers.test.ts
@@ -10,6 +10,7 @@ import {
   addClassNamesToElement,
   removeClassNamesFromElement,
 } from '@lexical/utils';
+import {describe, expect, test} from 'vitest';
 
 describe('LexicalElementHelpers tests', () => {
   describe('addClassNamesToElement() and removeClassNamesFromElement()', () => {

--- a/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalEventHelpers.test.tsx
@@ -26,11 +26,7 @@ import {LexicalEditor} from 'lexical';
 import {initializeClipboard, TestComposer} from 'lexical/src/__tests__/utils';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
-
-jest.mock('shared/environment', () => {
-  const originalModule = jest.requireActual('shared/environment');
-  return {...originalModule, IS_FIREFOX: true};
-});
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 
 Range.prototype.getBoundingClientRect = function (): DOMRect {
   const rect = {

--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -23,6 +23,7 @@ import {
   initializeUnitTest,
   invariant,
 } from 'lexical/src/__tests__/utils';
+import {beforeEach, describe, expect, test} from 'vitest';
 
 import {
   $dfs,

--- a/packages/lexical-utils/src/__tests__/unit/LexicalRootHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalRootHelpers.test.ts
@@ -13,6 +13,7 @@ import {
 } from '@lexical/text';
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, it} from 'vitest';
 
 describe('LexicalRootHelpers tests', () => {
   initializeUnitTest((testEnv) => {

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRoot.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsInsertNodeToNearestRoot.test.tsx
@@ -19,6 +19,7 @@ import {
   $createTestDecoratorNode,
   createTestEditor,
 } from 'lexical/src/__tests__/utils';
+import {beforeEach, describe, expect, it} from 'vitest';
 
 import {$insertNodeToNearestRoot} from '../..';
 

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsKlassEqual.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsKlassEqual.test.ts
@@ -8,6 +8,7 @@
 
 import {objectKlassEquals} from '@lexical/utils';
 import {initializeUnitTest} from 'lexical/src/__tests__/utils';
+import {describe, expect, it} from 'vitest';
 
 class MyEvent extends Event {}
 

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsKlassEqual.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsKlassEqual.test.ts
@@ -14,13 +14,8 @@ class MyEvent extends Event {}
 
 class MyEvent2 extends Event {}
 
-let MyEventShadow: typeof Event = MyEvent;
-
-{
-  // eslint-disable-next-line no-shadow
-  class MyEvent extends Event {}
-  MyEventShadow = MyEvent;
-}
+// eslint-disable-next-line no-shadow
+const MyEventShadow = (() => class MyEvent extends Event {})();
 
 describe('LexicalUtilsKlassEqual tests', () => {
   initializeUnitTest((testEnv) => {

--- a/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalUtilsSplitNode.test.tsx
@@ -11,6 +11,7 @@ import type {ElementNode, LexicalEditor} from 'lexical';
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
 import {$getRoot, $isElementNode} from 'lexical';
 import {createTestEditor} from 'lexical/src/__tests__/utils';
+import {beforeEach, describe, expect, it} from 'vitest';
 
 import {$splitNode} from '../../index';
 

--- a/packages/lexical-utils/src/__tests__/unit/descendantsMatching.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/descendantsMatching.test.tsx
@@ -16,6 +16,7 @@ import {
   ParagraphNode,
 } from 'lexical';
 import {createTestEditor} from 'lexical/src/__tests__/utils';
+import {beforeEach, describe, expect, it} from 'vitest';
 
 function assertClass<T extends LexicalNode>(v: unknown, klass: Klass<T>): T {
   if (v instanceof klass) {

--- a/packages/lexical-utils/src/__tests__/unit/iterators.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/iterators.test.tsx
@@ -10,6 +10,7 @@ import type {Klass, LexicalEditor, LexicalNode} from 'lexical';
 import {$firstToLastIterator, $lastToFirstIterator} from '@lexical/utils';
 import {$createParagraphNode, $createTextNode, TextNode} from 'lexical';
 import {createTestEditor} from 'lexical/src/__tests__/utils';
+import {beforeEach, describe, expect, it} from 'vitest';
 
 function assertClass<T extends LexicalNode>(v: unknown, klass: Klass<T>): T {
   if (v instanceof klass) {

--- a/packages/lexical-utils/src/__tests__/unit/mergeRegister.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/mergeRegister.test.ts
@@ -6,15 +6,16 @@
  *
  */
 import {mergeRegister} from '@lexical/utils';
+import {describe, expect, it, vi} from 'vitest';
 
 describe('mergeRegister', () => {
   it('calls all of the clean-up functions', () => {
-    const cleanup = jest.fn();
+    const cleanup = vi.fn();
     mergeRegister(cleanup, cleanup)();
     expect(cleanup).toHaveBeenCalledTimes(2);
   });
   it('calls the clean-up functions in reverse order', () => {
-    const cleanup = jest.fn();
+    const cleanup = vi.fn();
     mergeRegister(cleanup.bind(null, 1), cleanup.bind(null, 2))();
     expect(cleanup.mock.calls.map(([v]) => v)).toEqual([2, 1]);
   });

--- a/packages/lexical-utils/src/__tests__/unit/unwrapAndFilterDescendants.test.tsx
+++ b/packages/lexical-utils/src/__tests__/unit/unwrapAndFilterDescendants.test.tsx
@@ -17,6 +17,7 @@ import {
   ParagraphNode,
 } from 'lexical';
 import {createTestEditor} from 'lexical/src/__tests__/utils';
+import {beforeEach, describe, expect, it} from 'vitest';
 
 function assertClass<T extends LexicalNode>(v: unknown, klass: Klass<T>): T {
   if (v instanceof klass) {

--- a/packages/lexical/src/__tests__/unit/CodeBlock.test.ts
+++ b/packages/lexical/src/__tests__/unit/CodeBlock.test.ts
@@ -18,6 +18,7 @@ import {
   initializeUnitTest,
   invariant,
 } from 'lexical/src/__tests__/utils';
+import {beforeEach, describe, expect, test} from 'vitest';
 
 describe('CodeBlock tests', () => {
   initializeUnitTest(

--- a/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
+++ b/packages/lexical/src/__tests__/unit/HTMLCopyAndPaste.test.ts
@@ -19,6 +19,7 @@ import {
   initializeUnitTest,
   invariant,
 } from 'lexical/src/__tests__/utils';
+import {beforeEach, describe, expect, test} from 'vitest';
 
 describe('HTMLCopyAndPaste tests', () => {
   initializeUnitTest(

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -3155,7 +3155,7 @@ describe('LexicalEditor tests', () => {
 
     expect(onError).toBeCalledWith(updateError);
     expect(textListener).toBeCalledWith('Hello\n\nworld');
-    expect(updateListener.mock.lastCall[0].prevEditorState).toBe(editorState);
+    expect(updateListener.mock.lastCall?.[0].prevEditorState).toBe(editorState);
   });
 
   it('should call importDOM methods only once', async () => {

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -75,6 +75,7 @@ import {createPortal} from 'react-dom';
 import {createRoot, Root} from 'react-dom/client';
 import invariant from 'shared/invariant';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {emptyFunction} from '../../LexicalUtils';
 import {SerializedParagraphNode} from '../../nodes/LexicalParagraphNode';
@@ -177,7 +178,7 @@ describe('LexicalEditor tests', () => {
     // @ts-ignore
     container = null;
 
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   function useLexicalEditor(
@@ -189,7 +190,7 @@ describe('LexicalEditor tests', () => {
       () =>
         createTestEditor({
           nodes: nodes ?? [],
-          onError: onError || jest.fn(),
+          onError: onError || vi.fn(),
           theme: {
             tableAlignment: {
               center: 'editor-table-alignment-center',
@@ -359,7 +360,7 @@ describe('LexicalEditor tests', () => {
       });
       expect(editor.read(() => $getRoot().getTextContent())).toEqual('');
       expect(editor.read(() => $getEditor())).toBe(editor);
-      const onUpdate = jest.fn();
+      const onUpdate = vi.fn();
       editor.update(
         () => {
           const root = $getRoot();
@@ -415,7 +416,7 @@ describe('LexicalEditor tests', () => {
           node.replace($createTextNode('Transforms work!'));
         }
       });
-      const onUpdate = jest.fn();
+      const onUpdate = vi.fn();
       editor.update(
         () => {
           const root = $getRoot();
@@ -482,7 +483,7 @@ describe('LexicalEditor tests', () => {
     container.appendChild(rootElement);
 
     const initialEditor = createTestEditor({
-      onError: jest.fn(),
+      onError: vi.fn(),
     });
 
     initialEditor.update(() => {
@@ -511,7 +512,7 @@ describe('LexicalEditor tests', () => {
 
     editor = createTestEditor({
       editorState: initialEditorState,
-      onError: jest.fn(),
+      onError: vi.fn(),
     });
     editor.setRootElement(rootElement);
 
@@ -523,7 +524,7 @@ describe('LexicalEditor tests', () => {
 
   it('Should handle nested updates in the correct sequence', async () => {
     init();
-    const onUpdate = jest.fn();
+    const onUpdate = vi.fn();
 
     let log: Array<string> = [];
 
@@ -668,7 +669,7 @@ describe('LexicalEditor tests', () => {
 
   it('nested update after selection update triggers exactly 1 update', async () => {
     init();
-    const onUpdate = jest.fn();
+    const onUpdate = vi.fn();
     editor.registerUpdateListener(onUpdate);
     const prevEditorState = editor.getEditorState();
     editor.update(() => {
@@ -696,7 +697,7 @@ describe('LexicalEditor tests', () => {
   it('update does not call onUpdate callback when no dirty nodes', () => {
     init();
 
-    const fn = jest.fn();
+    const fn = vi.fn();
     editor.update(
       () => {
         //
@@ -716,7 +717,7 @@ describe('LexicalEditor tests', () => {
       root.append($createParagraphNode());
     });
 
-    const fn = jest.fn();
+    const fn = vi.fn();
 
     await editor.focus(fn);
 
@@ -910,7 +911,7 @@ describe('LexicalEditor tests', () => {
   it('text transform runs when node is removed', async () => {
     init();
 
-    const executeTransform = jest.fn();
+    const executeTransform = vi.fn();
     let hasBeenRemoved = false;
     const removeListener = editor.registerNodeTransform(TextNode, (node) => {
       if (hasBeenRemoved) {
@@ -976,8 +977,8 @@ describe('LexicalEditor tests', () => {
 
       textNode.getWritable();
 
-      executeParagraphNodeTransform = jest.fn();
-      executeTextNodeTransform = jest.fn();
+      executeParagraphNodeTransform = vi.fn();
+      executeTextNodeTransform = vi.fn();
     });
 
     expect(executeParagraphNodeTransform).toHaveBeenCalledTimes(0);
@@ -1161,7 +1162,7 @@ describe('LexicalEditor tests', () => {
   });
 
   it('Detects infinite recursivity on transforms', async () => {
-    const errorListener = jest.fn();
+    const errorListener = vi.fn();
     init(errorListener);
 
     const boldListener = editor.registerNodeTransform(TextNode, (node) => {
@@ -1217,7 +1218,7 @@ describe('LexicalEditor tests', () => {
   });
 
   it('Should be able to recover from an update error', async () => {
-    const errorListener = jest.fn();
+    const errorListener = vi.fn();
     init(errorListener);
     editor.update(() => {
       const root = $getRoot();
@@ -1254,8 +1255,8 @@ describe('LexicalEditor tests', () => {
   });
 
   it('Should be able to handle a change in root element', async () => {
-    const rootListener = jest.fn();
-    const updateListener = jest.fn();
+    const rootListener = vi.fn();
+    const updateListener = vi.fn();
 
     function TestBase({changeElement}: {changeElement: boolean}) {
       editor = useMemo(() => createTestEditor(), []);
@@ -1380,7 +1381,7 @@ describe('LexicalEditor tests', () => {
     });
 
     it('Should correctly render React component into Lexical node #1', async () => {
-      const listener = jest.fn();
+      const listener = vi.fn();
 
       function Test() {
         editor = useMemo(() => createTestEditor(), []);
@@ -1424,7 +1425,7 @@ describe('LexicalEditor tests', () => {
     });
 
     it('Should correctly render React component into Lexical node #2', async () => {
-      const listener = jest.fn();
+      const listener = vi.fn();
 
       function Test({divKey}: {divKey: number}): JSX.Element {
         function TestPlugin() {
@@ -1891,7 +1892,7 @@ describe('LexicalEditor tests', () => {
   it('can subscribe and unsubscribe from commands and the callback is fired', () => {
     init();
 
-    const commandListener = jest.fn();
+    const commandListener = vi.fn();
     const command = createCommand('TEST_COMMAND');
     const payload = 'testPayload';
     const removeCommandListener = editor.registerCommand(
@@ -1919,8 +1920,8 @@ describe('LexicalEditor tests', () => {
   it('removes the command from the command map when no listener are attached', () => {
     init();
 
-    const commandListener = jest.fn();
-    const commandListenerTwo = jest.fn();
+    const commandListener = vi.fn();
+    const commandListenerTwo = vi.fn();
     const command = createCommand('TEST_COMMAND');
     const removeCommandListener = editor.registerCommand(
       command,
@@ -1999,7 +2000,7 @@ describe('LexicalEditor tests', () => {
   it('textcontent listener', async () => {
     init();
 
-    const fn = jest.fn();
+    const fn = vi.fn();
     editor.update(() => {
       const root = $getRoot();
       const paragraph = $createParagraphNode();
@@ -2060,9 +2061,9 @@ describe('LexicalEditor tests', () => {
   it('mutation listener', async () => {
     init();
 
-    const paragraphNodeMutations = jest.fn();
-    const textNodeMutations = jest.fn();
-    const onUpdate = jest.fn();
+    const paragraphNodeMutations = vi.fn();
+    const textNodeMutations = vi.fn();
+    const onUpdate = vi.fn();
     editor.registerUpdateListener(onUpdate);
     editor.registerMutationListener(ParagraphNode, paragraphNodeMutations, {
       skipInitialization: false,
@@ -2156,7 +2157,7 @@ describe('LexicalEditor tests', () => {
   });
   it('mutation listener on newly initialized editor', async () => {
     editor = createEditor();
-    const textNodeMutations = jest.fn();
+    const textNodeMutations = vi.fn();
     editor.registerMutationListener(TextNode, textNodeMutations, {
       skipInitialization: false,
     });
@@ -2170,7 +2171,7 @@ describe('LexicalEditor tests', () => {
     });
 
     const initialEditorState = editor.getEditorState();
-    const textNodeMutations = jest.fn();
+    const textNodeMutations = vi.fn();
     editor.registerMutationListener(TextNode, textNodeMutations, {
       skipInitialization: false,
     });
@@ -2242,8 +2243,8 @@ describe('LexicalEditor tests', () => {
       reactRoot.render(<TestBase />);
     });
 
-    const textNodeMutations = jest.fn();
-    const textNodeMutationsB = jest.fn();
+    const textNodeMutations = vi.fn();
+    const textNodeMutationsB = vi.fn();
     editor.registerMutationListener(TextNode, textNodeMutations, {
       skipInitialization: false,
     });
@@ -2339,8 +2340,8 @@ describe('LexicalEditor tests', () => {
       reactRoot.render(<TestBase />);
     });
 
-    const textNodeMutations = jest.fn();
-    const textNodeMutationsB = jest.fn();
+    const textNodeMutations = vi.fn();
+    const textNodeMutationsB = vi.fn();
     editor.registerMutationListener(TestTextNode, textNodeMutations, {
       skipInitialization: false,
     });
@@ -2401,8 +2402,8 @@ describe('LexicalEditor tests', () => {
   it('mutation listeners does not trigger when other node types are mutated', async () => {
     init();
 
-    const paragraphNodeMutations = jest.fn();
-    const textNodeMutations = jest.fn();
+    const paragraphNodeMutations = vi.fn();
+    const textNodeMutations = vi.fn();
     editor.registerMutationListener(ParagraphNode, paragraphNodeMutations, {
       skipInitialization: false,
     });
@@ -2421,7 +2422,7 @@ describe('LexicalEditor tests', () => {
   it('mutation listeners with normalization', async () => {
     init();
 
-    const textNodeMutations = jest.fn();
+    const textNodeMutations = vi.fn();
     editor.registerMutationListener(TextNode, textNodeMutations, {
       skipInitialization: false,
     });
@@ -2467,8 +2468,8 @@ describe('LexicalEditor tests', () => {
   it('mutation "update" listener', async () => {
     init();
 
-    const paragraphNodeMutations = jest.fn();
-    const textNodeMutations = jest.fn();
+    const paragraphNodeMutations = vi.fn();
+    const textNodeMutations = vi.fn();
 
     editor.registerMutationListener(ParagraphNode, paragraphNodeMutations, {
       skipInitialization: false,
@@ -2531,8 +2532,8 @@ describe('LexicalEditor tests', () => {
     let tableCellKey: string;
     let tableRowKey: string;
 
-    const tableCellMutations = jest.fn();
-    const tableRowMutations = jest.fn();
+    const tableCellMutations = vi.fn();
+    const tableRowMutations = vi.fn();
 
     editor.registerMutationListener(TableCellNode, tableCellMutations, {
       skipInitialization: false,
@@ -2585,7 +2586,7 @@ describe('LexicalEditor tests', () => {
   it('editable listener', () => {
     init();
 
-    const editableFn = jest.fn();
+    const editableFn = vi.fn();
     editor.registerEditableListener(editableFn);
 
     expect(editor.isEditable()).toBe(true);
@@ -2600,12 +2601,12 @@ describe('LexicalEditor tests', () => {
   });
 
   it('does not add new listeners while triggering existing', async () => {
-    const updateListener = jest.fn();
-    const mutationListener = jest.fn();
-    const nodeTransformListener = jest.fn();
-    const textContentListener = jest.fn();
-    const editableListener = jest.fn();
-    const commandListener = jest.fn();
+    const updateListener = vi.fn();
+    const mutationListener = vi.fn();
+    const nodeTransformListener = vi.fn();
+    const textContentListener = vi.fn();
+    const editableListener = vi.fn();
+    const commandListener = vi.fn();
     const TEST_COMMAND = createCommand('TEST_COMMAND');
 
     init();
@@ -2689,7 +2690,7 @@ describe('LexicalEditor tests', () => {
   it('allows using the same listener for multiple node types', async () => {
     init();
 
-    const listener = jest.fn();
+    const listener = vi.fn();
     editor.registerMutationListener(TextNode, listener);
     editor.registerMutationListener(ParagraphNode, listener);
 
@@ -2717,9 +2718,9 @@ describe('LexicalEditor tests', () => {
 
   it('calls mutation listener with initial state', async () => {
     // TODO add tests for node replacement
-    const mutationListenerA = jest.fn();
-    const mutationListenerB = jest.fn();
-    const mutationListenerC = jest.fn();
+    const mutationListenerA = vi.fn();
+    const mutationListenerB = vi.fn();
+    const mutationListenerC = vi.fn();
     init();
 
     editor.registerMutationListener(TextNode, mutationListenerA, {
@@ -2785,7 +2786,7 @@ describe('LexicalEditor tests', () => {
 
   it('can use discrete for synchronous updates', () => {
     init();
-    const onUpdate = jest.fn();
+    const onUpdate = vi.fn();
     editor.registerUpdateListener(onUpdate);
     const prevEditorState = editor.getEditorState();
     editor.update(
@@ -2812,7 +2813,7 @@ describe('LexicalEditor tests', () => {
 
   it('can use discrete after a non-discrete update to flush the entire queue', () => {
     const headless = createTestHeadlessEditor();
-    const onUpdate = jest.fn();
+    const onUpdate = vi.fn();
     headless.registerUpdateListener(onUpdate);
     headless.update(() => {
       $getRoot().append(
@@ -2869,7 +2870,7 @@ describe('LexicalEditor tests', () => {
 
   it('can use discrete in a nested update to flush the entire queue', () => {
     init();
-    const onUpdate = jest.fn();
+    const onUpdate = vi.fn();
     editor.registerUpdateListener(onUpdate);
     editor.update(() => {
       $getRoot().append(
@@ -2943,7 +2944,7 @@ describe('LexicalEditor tests', () => {
 
   describe('node replacement', () => {
     it('should work correctly', async () => {
-      const onError = jest.fn();
+      const onError = vi.fn();
 
       const newEditor = createTestEditor({
         nodes: [
@@ -2980,7 +2981,7 @@ describe('LexicalEditor tests', () => {
     });
 
     it('should fail if node keys are re-used', async () => {
-      const onError = jest.fn();
+      const onError = vi.fn();
 
       const newEditor = createTestEditor({
         nodes: [
@@ -3018,8 +3019,8 @@ describe('LexicalEditor tests', () => {
     });
 
     it('node transform to the nodes specified by "replace" should not be applied to the nodes specified by "with" when "withKlass" is not specified', async () => {
-      const onError = jest.fn();
-      const mockWarning = jest
+      const onError = vi.fn();
+      const mockWarning = vi
         .spyOn(console, 'warn')
         .mockImplementationOnce(() => {});
       const newEditor = createTestEditor({
@@ -3046,7 +3047,7 @@ describe('LexicalEditor tests', () => {
 
       newEditor.setRootElement(container);
 
-      const mockTransform = jest.fn();
+      const mockTransform = vi.fn();
       const removeTransform = newEditor.registerNodeTransform(
         TextNode,
         mockTransform,
@@ -3071,7 +3072,7 @@ describe('LexicalEditor tests', () => {
     });
 
     it('node transform to the nodes specified by "replace" should be applied also to the nodes specified by "with" when "withKlass" is specified', async () => {
-      const onError = jest.fn();
+      const onError = vi.fn();
 
       const newEditor = createTestEditor({
         nodes: [
@@ -3094,7 +3095,7 @@ describe('LexicalEditor tests', () => {
 
       newEditor.setRootElement(container);
 
-      const mockTransform = jest.fn();
+      const mockTransform = vi.fn();
       const removeTransform = newEditor.registerNodeTransform(
         TextNode,
         mockTransform,
@@ -3120,9 +3121,9 @@ describe('LexicalEditor tests', () => {
   });
 
   it('recovers from reconciler failure and trigger proper prev editor state', async () => {
-    const updateListener = jest.fn();
-    const textListener = jest.fn();
-    const onError = jest.fn();
+    const updateListener = vi.fn();
+    const textListener = vi.fn();
+    const onError = vi.fn();
     const updateError = new Error('Failed updateDOM');
 
     init(onError);
@@ -3138,7 +3139,7 @@ describe('LexicalEditor tests', () => {
 
     // Cause reconciler error in update dom, so that it attempts to fallback by
     // resetting editor and rerendering whole content
-    jest.spyOn(ParagraphNode.prototype, 'updateDOM').mockImplementation(() => {
+    vi.spyOn(ParagraphNode.prototype, 'updateDOM').mockImplementation(() => {
       throw updateError;
     });
 
@@ -3158,7 +3159,7 @@ describe('LexicalEditor tests', () => {
   });
 
   it('should call importDOM methods only once', async () => {
-    jest.spyOn(ParagraphNode, 'importDOM');
+    vi.spyOn(ParagraphNode, 'importDOM');
 
     class CustomParagraphNode extends ParagraphNode {
       static getType() {
@@ -3197,7 +3198,7 @@ describe('LexicalEditor tests', () => {
 
   describe('html config', () => {
     it('should override export output function', async () => {
-      const onError = jest.fn();
+      const onError = vi.fn();
 
       const newEditor = createTestEditor({
         html: {
@@ -3244,7 +3245,7 @@ describe('LexicalEditor tests', () => {
     });
 
     it('should override import conversion function', async () => {
-      const onError = jest.fn();
+      const onError = vi.fn();
 
       const newEditor = createTestEditor({
         html: {
@@ -3285,7 +3286,7 @@ describe('LexicalEditor tests', () => {
 
   describe('selection', () => {
     it('updates the DOM selection', async () => {
-      const onError = jest.fn();
+      const onError = vi.fn();
       const newEditor = createTestEditor({
         onError: onError,
       });
@@ -3327,7 +3328,7 @@ describe('LexicalEditor tests', () => {
       expect(onError).not.toHaveBeenCalled();
     });
     it('does not update the Lexical->DOM selection with skip-dom-selection', async () => {
-      const onError = jest.fn();
+      const onError = vi.fn();
       const newEditor = createTestEditor({
         onError: onError,
       });

--- a/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalEditorState.test.ts
@@ -14,6 +14,7 @@ import {
   ParagraphNode,
   TextNode,
 } from 'lexical';
+import {describe, expect, test} from 'vitest';
 
 import {EditorState} from '../../LexicalEditorState';
 import {$createRootNode, RootNode} from '../../nodes/LexicalRootNode';

--- a/packages/lexical/src/__tests__/unit/LexicalListPlugin.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalListPlugin.test.tsx
@@ -32,6 +32,7 @@ import {
 } from 'lexical/src/__tests__/utils';
 import {createRoot, Root} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, test, vi} from 'vitest';
 
 import {
   INSERT_UNORDERED_LIST_COMMAND,
@@ -53,7 +54,7 @@ describe('@lexical/list tests', () => {
     // @ts-ignore
     container = null;
 
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   // Shared instance across tests

--- a/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNode.test.ts
@@ -27,6 +27,15 @@ import {
   SerializedTextNode,
   TextNode,
 } from 'lexical';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
 
 import {LexicalNode} from '../../LexicalNode';
 import {$createParagraphNode} from '../../nodes/LexicalParagraphNode';
@@ -88,10 +97,10 @@ class InlineDecoratorNode extends DecoratorNode<string> {
 
 describe('LexicalNode tests', () => {
   beforeAll(() => {
-    jest.spyOn(LexicalNode, 'getType').mockImplementation(() => 'node');
+    vi.spyOn(LexicalNode, 'getType').mockImplementation(() => 'node');
   });
   afterAll(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
   initializeUnitTest(
     (testEnv) => {
@@ -1174,9 +1183,9 @@ describe('LexicalNode tests', () => {
       test('LexicalNode.replace() within canBeEmpty: false', async () => {
         const {editor} = testEnv;
 
-        jest
-          .spyOn(TestInlineElementNode.prototype, 'canBeEmpty')
-          .mockReturnValue(false);
+        vi.spyOn(TestInlineElementNode.prototype, 'canBeEmpty').mockReturnValue(
+          false,
+        );
 
         await editor.update(() => {
           textNode = $createTextNode('Hello');

--- a/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalNodeState.test.ts
@@ -22,6 +22,7 @@ import {
   RootNode,
   StateValueOrUpdater,
 } from 'lexical';
+import {beforeEach, describe, expect, test} from 'vitest';
 
 import {nodeStatesAreEquivalent} from '../../LexicalNodeState';
 import {initializeUnitTest, invariant} from '../utils';

--- a/packages/lexical/src/__tests__/unit/LexicalNormalization.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalNormalization.test.tsx
@@ -12,6 +12,7 @@ import {
   $getRoot,
   RangeSelection,
 } from 'lexical';
+import {describe, expect, test} from 'vitest';
 
 import {$normalizeSelection} from '../../LexicalNormalization';
 import {

--- a/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalReconciler.test.ts
@@ -13,6 +13,7 @@ import {
   $getRoot,
   ParagraphNode,
 } from 'lexical';
+import {describe, expect, test} from 'vitest';
 
 import {$getReconciledDirection} from '../../LexicalReconciler';
 import {initializeUnitTest} from '../utils';

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -34,6 +34,7 @@ import {
   RangeSelection,
   TextNode,
 } from 'lexical';
+import {beforeEach, describe, expect, test} from 'vitest';
 
 import {SerializedElementNode} from '../..';
 import {

--- a/packages/lexical/src/__tests__/unit/LexicalSerialization.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSerialization.test.ts
@@ -12,6 +12,7 @@ import {$createListItemNode, $createListNode} from '@lexical/list';
 import {$createHeadingNode, $createQuoteNode} from '@lexical/rich-text';
 import {$createTableNodeWithDimensions} from '@lexical/table';
 import {$createParagraphNode, $createTextNode, $getRoot} from 'lexical';
+import {describe, expect, test} from 'vitest';
 
 import {initializeUnitTest} from '../utils';
 

--- a/packages/lexical/src/__tests__/unit/LexicalUpdateTags.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUpdateTags.test.ts
@@ -20,6 +20,7 @@ import {
   SKIP_DOM_SELECTION_TAG,
   SKIP_SCROLL_INTO_VIEW_TAG,
 } from 'lexical';
+import {describe, expect, test, vi} from 'vitest';
 
 import {initializeUnitTest} from '../utils';
 
@@ -103,7 +104,7 @@ describe('LexicalUpdateTags tests', () => {
       const {editor} = testEnv;
 
       // Test that skip-dom-selection prevents selection updates
-      const updateListener = jest.fn();
+      const updateListener = vi.fn();
       editor.registerUpdateListener(({tags}: {tags: Set<string>}) => {
         updateListener(Array.from(tags));
       });

--- a/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalUtils.test.ts
@@ -27,6 +27,7 @@ import {
   SerializedTextNode,
   TextNode,
 } from 'lexical';
+import {describe, expect, test, vi} from 'vitest';
 
 import {
   emptyFunction,
@@ -41,7 +42,7 @@ import {initializeUnitTest} from '../utils';
 describe('LexicalUtils tests', () => {
   initializeUnitTest((testEnv) => {
     test('scheduleMicroTask(): native', async () => {
-      jest.resetModules();
+      vi.resetModules();
 
       let flag = false;
 
@@ -57,9 +58,9 @@ describe('LexicalUtils tests', () => {
     });
 
     test('scheduleMicroTask(): promise', async () => {
-      jest.resetModules();
+      vi.resetModules();
       const nativeQueueMicrotask = window.queueMicrotask;
-      const fn = jest.fn();
+      const fn = vi.fn();
       try {
         // @ts-ignore
         window.queueMicrotask = undefined;
@@ -461,7 +462,7 @@ describe('$applyNodeReplacement', () => {
     );
   });
   test('validates replace node type change', () => {
-    const mockWarning = jest
+    const mockWarning = vi
       .spyOn(console, 'warn')
       .mockImplementationOnce(() => {});
     const editor = createEditor({

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -25,7 +25,6 @@ import {
 } from '@lexical/react/LexicalComposerContext';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
-import {expect} from '@playwright/test';
 import {
   $isRangeSelection,
   createEditor,
@@ -50,7 +49,7 @@ import * as React from 'react';
 import {createRef} from 'react';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
-import {afterEach, beforeEach, expect, vi} from 'vitest';
+import {afterEach, beforeEach, expect, type Mock, vi} from 'vitest';
 
 import {
   CreateEditorArgs,
@@ -532,8 +531,8 @@ export function invariant(cond?: boolean, message?: string): asserts cond {
 }
 
 export class ClipboardDataMock {
-  getData: jest.Mock<string, [string]>;
-  setData: jest.Mock<void, [string, string]>;
+  getData: Mock<(type: string) => [string]>;
+  setData: Mock<() => [string, string]>;
 
   constructor() {
     this.getData = vi.fn();

--- a/packages/lexical/src/__tests__/utils/index.tsx
+++ b/packages/lexical/src/__tests__/utils/index.tsx
@@ -50,6 +50,7 @@ import * as React from 'react';
 import {createRef} from 'react';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, expect, vi} from 'vitest';
 
 import {
   CreateEditorArgs,
@@ -535,8 +536,8 @@ export class ClipboardDataMock {
   setData: jest.Mock<void, [string, string]>;
 
   constructor() {
-    this.getData = jest.fn();
-    this.setData = jest.fn();
+    this.getData = vi.fn();
+    this.setData = vi.fn();
   }
 }
 

--- a/packages/lexical/src/caret/__tests__/unit/LexicalCaret.test.ts
+++ b/packages/lexical/src/caret/__tests__/unit/LexicalCaret.test.ts
@@ -52,6 +52,7 @@ import {
   SiblingCaret,
   TextNode,
 } from 'lexical';
+import {beforeEach, describe, expect, test} from 'vitest';
 
 import {
   $assertRangeSelection,

--- a/packages/lexical/src/caret/__tests__/unit/docs-traversals.test.ts
+++ b/packages/lexical/src/caret/__tests__/unit/docs-traversals.test.ts
@@ -24,6 +24,7 @@ import {
   SiblingCaret,
   TextNode,
 } from 'lexical';
+import {beforeEach, describe, expect, test} from 'vitest';
 
 import {initializeUnitTest} from '../../../__tests__/utils';
 
@@ -170,8 +171,7 @@ describe('traversals.md', () => {
                   // If there is a sibling, try and get a ChildCaret from it
                   (nextCaret && nextCaret.getChildCaret()) ||
                   // Return the sibling if there is one
-                  nextCaret ||
-                  // Return a SiblingCaret of the parent, if there is one
+                  nextCaret || // Return a SiblingCaret of the parent, if there is one
                   prevCaret.getParentCaret('root')
                 );
               }

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalElementNode.test.tsx
@@ -23,6 +23,7 @@ import * as React from 'react';
 import {createRef, useEffect} from 'react';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, expect, it, test} from 'vitest';
 
 import {
   $createTestElementNode,

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalGC.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalGC.test.tsx
@@ -13,6 +13,7 @@ import {
   $getRoot,
   $isElementNode,
 } from 'lexical';
+import {describe, expect, test} from 'vitest';
 
 import {
   $createTestElementNode,

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalLineBreakNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalLineBreakNode.test.ts
@@ -7,6 +7,7 @@
  */
 
 import {$createLineBreakNode, $isLineBreakNode} from 'lexical';
+import {describe, expect, test} from 'vitest';
 
 import {initializeUnitTest} from '../../../__tests__/utils';
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalParagraphNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalParagraphNode.test.ts
@@ -12,6 +12,7 @@ import {
   $isParagraphNode,
   ParagraphNode,
 } from 'lexical';
+import {describe, expect, test} from 'vitest';
 
 import {initializeUnitTest} from '../../../__tests__/utils';
 

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalRootNode.test.ts
@@ -17,6 +17,7 @@ import {
   RootNode,
   TextNode,
 } from 'lexical';
+import {beforeEach, describe, expect, test} from 'vitest';
 
 import {
   $createTestDecoratorNode,

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTabNode.test.tsx
@@ -33,6 +33,7 @@ import {
   $setSelectionFromCaretRange,
   KEY_TAB_COMMAND,
 } from 'lexical';
+import {beforeEach, describe, expect, test} from 'vitest';
 
 import {
   DataTransferMock,

--- a/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
+++ b/packages/lexical/src/nodes/__tests__/unit/LexicalTextNode.test.tsx
@@ -28,6 +28,7 @@ import * as React from 'react';
 import {createRef, useEffect, useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
 import * as ReactTestUtils from 'shared/react-test-utils';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 
 import {
   $createTestSegmentedNode,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {defineConfig, mergeConfig, Plugin} from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+function lexicalTestMocks(): Plugin {
+  return {
+    name: 'lexicalTestMocks',
+    config(config, _env) {
+      return mergeConfig(config, {
+        resolve: {
+          alias: {
+            'shared/invariant': 'packages/shared/src/__mocks__/invariant.ts',
+            'shared/devInvariant':
+              'packages/shared/src/__mocks__/devInvariant.ts',
+            'shared/warnOnlyOnce':
+              'packages/shared/src/__mocks__/warnOnlyOnce.ts',
+          },
+        },
+      });
+    },
+  };
+}
+
+export default defineConfig({
+  test: {
+    typecheck: {
+      tsconfig: './tsconfig.test.json',
+    },
+    setupFiles: ['./vitest.setup.mts'],
+    clearMocks: true,
+    projects: [
+      {
+        plugins: [
+          tsconfigPaths({projects: ['./tsconfig.test.json']}),
+          lexicalTestMocks(),
+        ],
+        extends: true,
+        define: {
+          // https://react.dev/blog/2022/03/08/react-18-upgrade-guide#configuring-your-testing-environment
+          IS_REACT_ACT_ENVIRONMENT: true,
+          __DEV__: true,
+        },
+        test: {
+          environment: 'jsdom',
+          include: [
+            'packages/*/src/__tests__/unit/**/*.test{.ts,.tsx,.js,.jsx}',
+          ],
+          name: 'unit',
+        },
+      },
+    ],
+  },
+});
+
+// module.exports = {
+//     {
+//       ...common,
+//       displayName: 'integration',
+//       globalSetup: './scripts/__tests__/integration/setup.js',
+//       testMatch: ['**/scripts/__tests__/integration/**/*.test.js'],
+//     },
+//     {
+//       ...common,
+//       displayName: 'e2e',
+//       testMatch: [
+//         '**/__tests__/e2e/**/*.js',
+//         '**/__tests__/regression/**/*.js',
+//       ],
+//     },
+//   ],
+// };

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,47 +6,43 @@
  *
  */
 
-import {defineConfig, mergeConfig, Plugin} from 'vitest/config';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import {defineConfig, mergeConfig, Plugin} from 'vitest/config';
 
 function lexicalTestMocks(): Plugin {
   return {
-    name: 'lexicalTestMocks',
     config(config, _env) {
       return mergeConfig(config, {
         resolve: {
           alias: {
-            'shared/invariant': 'packages/shared/src/__mocks__/invariant.ts',
             'shared/devInvariant':
               'packages/shared/src/__mocks__/devInvariant.ts',
+            'shared/invariant': 'packages/shared/src/__mocks__/invariant.ts',
             'shared/warnOnlyOnce':
               'packages/shared/src/__mocks__/warnOnlyOnce.ts',
           },
         },
       });
     },
+    name: 'lexicalTestMocks',
   };
 }
 
 export default defineConfig({
   test: {
-    typecheck: {
-      tsconfig: './tsconfig.test.json',
-    },
-    setupFiles: ['./vitest.setup.mts'],
     clearMocks: true,
     projects: [
       {
-        plugins: [
-          tsconfigPaths({projects: ['./tsconfig.test.json']}),
-          lexicalTestMocks(),
-        ],
-        extends: true,
         define: {
           // https://react.dev/blog/2022/03/08/react-18-upgrade-guide#configuring-your-testing-environment
           IS_REACT_ACT_ENVIRONMENT: true,
           __DEV__: true,
         },
+        extends: true,
+        plugins: [
+          tsconfigPaths({projects: ['./tsconfig.test.json']}),
+          lexicalTestMocks(),
+        ],
         test: {
           environment: 'jsdom',
           include: [
@@ -56,23 +52,9 @@ export default defineConfig({
         },
       },
     ],
+    setupFiles: ['./vitest.setup.mts'],
+    typecheck: {
+      tsconfig: './tsconfig.test.json',
+    },
   },
 });
-
-// module.exports = {
-//     {
-//       ...common,
-//       displayName: 'integration',
-//       globalSetup: './scripts/__tests__/integration/setup.js',
-//       testMatch: ['**/scripts/__tests__/integration/**/*.test.js'],
-//     },
-//     {
-//       ...common,
-//       displayName: 'e2e',
-//       testMatch: [
-//         '**/__tests__/e2e/**/*.js',
-//         '**/__tests__/regression/**/*.js',
-//       ],
-//     },
-//   ],
-// };

--- a/vitest.setup.mts
+++ b/vitest.setup.mts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { vi } from 'vitest';
+vi.mock('shared/invariant');
+vi.mock('shared/devInvariant');
+vi.mock('shared/warnOnlyOnce');

--- a/vitest.setup.mts
+++ b/vitest.setup.mts
@@ -7,6 +7,7 @@
  */
 
 import {vi} from 'vitest';
+
 vi.mock('shared/invariant');
 vi.mock('shared/devInvariant');
 vi.mock('shared/warnOnlyOnce');

--- a/vitest.setup.mts
+++ b/vitest.setup.mts
@@ -6,7 +6,7 @@
  *
  */
 
-import { vi } from 'vitest';
+import {vi} from 'vitest';
 vi.mock('shared/invariant');
 vi.mock('shared/devInvariant');
 vi.mock('shared/warnOnlyOnce');


### PR DESCRIPTION
## Description

The version of jest we are using is old and jest in general doesn't work very well with modern toolchains (esm and typescript in particular). Switching to vitest runs the tests twice as fast, requires less configuration, gives us future options for browser tests instead of jsdom (a faster option than playwright), etc.

I decided to do this because I ran into problems with jest and asynchronous module loading for shiki languages when trying to update docusaurus.

Note that the integration tests are still in commonjs and run with jest. It will probably stay this way until we migrate that build infrastructure over to mjs.

## Test plan

The whole thing is tests :)

## Before

Unit tests run in 1m 26s with jest

## After

Unit tests run in 38s with vitest (~2.25x faster)