### PR TITLE
[lexical-react] Fix: Use explicit key attr in NodeContextMenuPlugin

### DIFF
--- a/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalNodeContextMenuPlugin.tsx
@@ -287,6 +287,7 @@ const NodeContextMenuPlugin = forwardRef<
                         },
                         tabIndex: activeIndex === index ? 0 : -1,
                       })}
+                      key={item.key}
                     />
                   );
                 } else if (item.type === 'separator') {
@@ -299,6 +300,7 @@ const NodeContextMenuPlugin = forwardRef<
                         },
                         tabIndex: activeIndex === index ? 0 : -1,
                       })}
+                      key={item.key}
                     />
                   );
                 }


### PR DESCRIPTION
## Description

Explicitly specify the key attribute in the implementation of NodeContextMenuPlugin instead of relying on a spread. This seems to cause a problem with the way next.js handles jsx. I was expecting it to show up when using React 19 but it didn't seem to complain in the draft #7802 (before I added the commit for this fix).

Closes #7801

## Test plan

I think this requires next.js to reproduce so it's hard in our current test environment