### PR TITLE
[*] Chore: Port scripts unit tests to vitest and fix test include match pattern

### DIFF
--- a/scripts/__tests__/unit/build.test.ts
+++ b/scripts/__tests__/unit/build.test.ts
@@ -5,16 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-// @ts-check
-'use strict';
 
-const fs = require('fs-extra');
-const glob = require('glob');
-const path = require('node:path');
-const {packagesManager} = require('../../shared/packagesManager');
-const npmToWwwName = require('../../www/npmToWwwName');
+import * as fs from 'fs-extra';
+import * as glob from 'glob';
+import * as path from 'node:path';
+import {describe, expect, it, test} from 'vitest';
 
-const monorepoPackageJson = require('../../shared/readMonorepoPackageJson')();
+import {packagesManager} from '../../shared/packagesManager';
+import npmToWwwName from '../../www/npmToWwwName';
+
+const monorepoPackageJson = (
+  await import('../../shared/readMonorepoPackageJson')
+).default();
 
 const publicNpmNames = new Set(
   packagesManager.getPublicPackages().map((pkg) => pkg.getNpmName()),
@@ -28,7 +30,7 @@ describe('public package.json audits (`npm run update-packages` to fix most issu
       const sourceFiles = fs
         .readdirSync(pkg.resolve('src'))
         .filter((str) => /\.tsx?/.test(str))
-        .map((str) => str.replace(/\.tsx?$/, '', str))
+        .map((str) => str.replace(/\.tsx?$/, ''))
         .sort();
       const exportedModules = pkg.getExportedNpmModuleNames().sort();
       const {dependencies = {}, peerDependencies = {}} = packageJson;

--- a/scripts/__tests__/unit/stackblitz.test.ts
+++ b/scripts/__tests__/unit/stackblitz.test.ts
@@ -5,11 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-// @ts-check
-'use strict';
 
-const fs = require('fs-extra');
-const glob = require('glob');
+import * as fs from 'fs-extra';
+import * as glob from 'glob';
+import {describe, expect, it} from 'vitest';
 
 const STACKBLITZ_RE = /:\/\/stackblitz.com\/github\/([^?"']+)/g;
 

--- a/scripts/error-codes/__tests__/unit/ErrorMap.test.ts
+++ b/scripts/error-codes/__tests__/unit/ErrorMap.test.ts
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-// @ts-check
-'use strict';
 
-const ErrorMap = require('../../ErrorMap');
+import {describe, expect, test, vi} from 'vitest';
 
-/** @returns {Promise<void>} */
-function waitTick() {
+import ErrorMap from '../../ErrorMap';
+
+function waitTick(): Promise<void> {
   return new Promise((resolve) => queueMicrotask(resolve));
 }
 
@@ -21,13 +20,13 @@ describe('ErrorMap', () => {
     {
       initialMessages: ['known message', 'another known message'],
     },
-  ].forEach(({name, initialMessages}) => {
+  ].forEach(({initialMessages}) => {
     const initialMap = Object.fromEntries(
       initialMessages.map((message, i) => [`${i}`, message]),
     );
     describe(`with ${initialMessages.length} message(s)`, () => {
       test('does not insert unless extractCodes is true', async () => {
-        const flush = jest.fn();
+        const flush = vi.fn();
         const errorMap = new ErrorMap(initialMap, flush);
         expect(errorMap.getOrAddToErrorMap('unknown message', false)).toBe(
           undefined,
@@ -40,7 +39,7 @@ describe('ErrorMap', () => {
       });
       if (initialMessages.length > 0) {
         test('looks up existing messages', async () => {
-          const flush = jest.fn();
+          const flush = vi.fn();
           const errorMap = new ErrorMap(initialMap, flush);
           initialMessages.forEach((msg, i) => {
             expect(errorMap.getOrAddToErrorMap(msg, false)).toBe(i);
@@ -55,7 +54,7 @@ describe('ErrorMap', () => {
         });
       }
       test('inserts with extractCodes true', async () => {
-        const flush = jest.fn();
+        const flush = vi.fn();
         const errorMap = new ErrorMap(initialMap, flush);
         const msg = 'unknown message';
         const beforeSize = initialMessages.length;
@@ -77,7 +76,7 @@ describe('ErrorMap', () => {
         });
       });
       test('inserts two messages with extractCodes true', async () => {
-        const flush = jest.fn();
+        const flush = vi.fn();
         const errorMap = new ErrorMap(initialMap, flush);
         const msgs = ['unknown message', 'another unknown message'];
         msgs.forEach((msg, i) => {

--- a/scripts/www/__tests__/unit/transformFlowFileContents.test.ts
+++ b/scripts/www/__tests__/unit/transformFlowFileContents.test.ts
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-// @ts-check
-'use strict';
 
-const transformFlowFileContents = require('../../transformFlowFileContents');
+import {describe, expect, it} from 'vitest';
+
+import transformFlowFileContents from '../../transformFlowFileContents';
 
 const HEADER_BEFORE =
   `

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -45,16 +45,22 @@ export default defineConfig({
         ],
         test: {
           environment: 'jsdom',
-          include: [
-            'packages/*/src/__tests__/unit/**/*.test{.ts,.tsx,.js,.jsx}',
-          ],
+          include: ['packages/**/__tests__/unit/**/*.test{.ts,.tsx,.js,.jsx}'],
           name: 'unit',
+          setupFiles: ['./vitest.setup.mts'],
+          typecheck: {
+            tsconfig: './tsconfig.test.json',
+          },
+        },
+      },
+      {
+        extends: true,
+        test: {
+          environment: 'node',
+          include: ['scripts/**/__tests__/unit/**/*.test.ts'],
+          name: 'scripts-unit',
         },
       },
     ],
-    setupFiles: ['./vitest.setup.mts'],
-    typecheck: {
-      tsconfig: './tsconfig.test.json',
-    },
   },
 });


### PR DESCRIPTION
## Description

Some unit tests were not ported from jest to vitest, and others were at paths that didn't get matched by the configuration. This fixes both of those issues so that all unit tests are now running with vitest.

## Test plan

### Before

Some unit tests weren't running

### After

All unit tests are running