### PR TITLE
[lexical-website] Bug Fix: Replace broken algolia search with @easyops-cn/docusaurus-search-local

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -177,6 +177,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.3.0.tgz",
+      "integrity": "sha512-KqPVLdVNfoJzX5BKNGM9bsW8saHeyax8kmPFXul5gejrSPN3qss7PgsFH5mMem7oR8tvjvNkia97ljEYPYCN8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/@algolia/autocomplete-core": {
       "version": "1.17.9",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.9.tgz",
@@ -223,99 +238,99 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.25.0.tgz",
-      "integrity": "sha512-1pfQulNUYNf1Tk/svbfjfkLBS36zsuph6m+B6gDkPEivFmso/XnRgwDvjAx80WNtiHnmeNjIXdF7Gos8+OLHqQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.37.0.tgz",
+      "integrity": "sha512-Dp2Zq+x9qQFnuiQhVe91EeaaPxWBhzwQ6QnznZQnH9C1/ei3dvtmAFfFeaTxM6FzfJXDLvVnaQagTYFTQz3R5g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.25.0.tgz",
-      "integrity": "sha512-AFbG6VDJX/o2vDd9hqncj1B6B4Tulk61mY0pzTtzKClyTDlNP0xaUiEKhl6E7KO9I/x0FJF5tDCm0Hn6v5x18A==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.37.0.tgz",
+      "integrity": "sha512-wyXODDOluKogTuZxRII6mtqhAq4+qUR3zIUJEKTiHLe8HMZFxfUEI4NO2qSu04noXZHbv/sRVdQQqzKh12SZuQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.25.0.tgz",
-      "integrity": "sha512-il1zS/+Rc6la6RaCdSZ2YbJnkQC6W1wiBO8+SH+DE6CPMWBU6iDVzH0sCKSAtMWl9WBxoN6MhNjGBnCv9Yy2bA==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.37.0.tgz",
+      "integrity": "sha512-GylIFlPvLy9OMgFG8JkonIagv3zF+Dx3H401Uo2KpmfMVBBJiGfAb9oYfXtplpRMZnZPxF5FnkWaI/NpVJMC+g==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.25.0.tgz",
-      "integrity": "sha512-blbjrUH1siZNfyCGeq0iLQu00w3a4fBXm0WRIM0V8alcAPo7rWjLbMJMrfBtzL9X5ic6wgxVpDADXduGtdrnkw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.37.0.tgz",
+      "integrity": "sha512-T63afO2O69XHKw2+F7mfRoIbmXWGzgpZxgOFAdP3fR4laid7pWBt20P4eJ+Zn23wXS5kC9P2K7Bo3+rVjqnYiw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.25.0.tgz",
-      "integrity": "sha512-aywoEuu1NxChBcHZ1pWaat0Plw7A8jDMwjgRJ00Mcl7wGlwuPt5dJ/LTNcg3McsEUbs2MBNmw0ignXBw9Tbgow==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.37.0.tgz",
+      "integrity": "sha512-1zOIXM98O9zD8bYDCJiUJRC/qNUydGHK/zRK+WbLXrW1SqLFRXECsKZa5KoG166+o5q5upk96qguOtE8FTXDWQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.25.0.tgz",
-      "integrity": "sha512-a/W2z6XWKjKjIW1QQQV8PTTj1TXtaKx79uR3NGBdBdGvVdt24KzGAaN7sCr5oP8DW4D3cJt44wp2OY/fZcPAVA==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.37.0.tgz",
+      "integrity": "sha512-31Nr2xOLBCYVal+OMZn1rp1H4lPs1914Tfr3a34wU/nsWJ+TB3vWjfkUUuuYhWoWBEArwuRzt3YNLn0F/KRVkg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.25.0.tgz",
-      "integrity": "sha512-9rUYcMIBOrCtYiLX49djyzxqdK9Dya/6Z/8sebPn94BekT+KLOpaZCuc6s0Fpfq7nx5J6YY5LIVFQrtioK9u0g==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.37.0.tgz",
+      "integrity": "sha512-DAFVUvEg+u7jUs6BZiVz9zdaUebYULPiQ4LM2R4n8Nujzyj7BZzGr2DCd85ip4p/cx7nAZWKM8pLcGtkTRTdsg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -328,81 +343,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.25.0.tgz",
-      "integrity": "sha512-jJeH/Hk+k17Vkokf02lkfYE4A+EJX+UgnMhTLR/Mb+d1ya5WhE+po8p5a/Nxb6lo9OLCRl6w3Hmk1TX1e9gVbQ==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.37.0.tgz",
+      "integrity": "sha512-pkCepBRRdcdd7dTLbFddnu886NyyxmhgqiRcHHaDunvX03Ij4WzvouWrQq7B7iYBjkMQrLS8wQqSP0REfA4W8g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.25.0.tgz",
-      "integrity": "sha512-Ls3i1AehJ0C6xaHe7kK9vPmzImOn5zBg7Kzj8tRYIcmCWVyuuFwCIsbuIIz/qzUf1FPSWmw0TZrGeTumk2fqXg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.37.0.tgz",
+      "integrity": "sha512-fNw7pVdyZAAQQCJf1cc/ih4fwrRdQSgKwgor4gchsI/Q/ss9inmC6bl/69jvoRSzgZS9BX4elwHKdo0EfTli3w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.25.0.tgz",
-      "integrity": "sha512-79sMdHpiRLXVxSjgw7Pt4R1aNUHxFLHiaTDnN2MQjHwJ1+o3wSseb55T9VXU4kqy3m7TUme3pyRhLk5ip/S4Mw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.37.0.tgz",
+      "integrity": "sha512-U+FL5gzN2ldx3TYfQO5OAta2TBuIdabEdFwD5UVfWPsZE5nvOKkc/6BBqP54Z/adW/34c5ZrvvZhlhNTZujJXQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.25.0.tgz",
-      "integrity": "sha512-JLaF23p1SOPBmfEqozUAgKHQrGl3z/Z5RHbggBu6s07QqXXcazEsub5VLonCxGVqTv6a61AAPr8J1G5HgGGjEw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.37.0.tgz",
+      "integrity": "sha512-Ao8GZo8WgWFABrU7iq+JAftXV0t+UcOtCDL4mzHHZ+rQeTTf1TZssr4d0vIuoqkVNnKt9iyZ7T4lQff4ydcTrw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0"
+        "@algolia/client-common": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.25.0.tgz",
-      "integrity": "sha512-rtzXwqzFi1edkOF6sXxq+HhmRKDy7tz84u0o5t1fXwz0cwx+cjpmxu/6OQKTdOJFS92JUYHsG51Iunie7xbqfQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.37.0.tgz",
+      "integrity": "sha512-H7OJOXrFg5dLcGJ22uxx8eiFId0aB9b0UBhoOi4SMSuDBe6vjJJ/LeZyY25zPaSvkXNBN3vAM+ad6M0h6ha3AA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0"
+        "@algolia/client-common": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.25.0.tgz",
-      "integrity": "sha512-ZO0UKvDyEFvyeJQX0gmZDQEvhLZ2X10K+ps6hViMo1HgE2V8em00SwNsQ+7E/52a+YiBkVWX61pJJJE44juDMQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.37.0.tgz",
+      "integrity": "sha512-npZ9aeag4SGTx677eqPL3rkSPlQrnzx/8wNrl1P7GpWq9w/eTmRbOq+wKrJ2r78idlY0MMgmY/mld2tq6dc44g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0"
+        "@algolia/client-common": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -455,9 +470,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.3.tgz",
-      "integrity": "sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -567,15 +582,15 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.3.tgz",
-      "integrity": "sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.3",
-        "@babel/types": "^7.27.3",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
@@ -635,17 +650,17 @@
       "license": "ISC"
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
+      "integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-member-expression-to-functions": "^7.27.1",
         "@babel/helper-optimise-call-expression": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
+        "@babel/traverse": "^7.28.3",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -691,19 +706,51 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
-      "integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+      "integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.22.6",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "debug": "^4.1.1",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "debug": "^4.4.1",
         "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2"
+        "resolve": "^1.22.10"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
@@ -845,14 +892,14 @@
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
-      "integrity": "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
+      "integrity": "sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.3",
+        "@babel/types": "^7.28.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -888,12 +935,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.3.tgz",
-      "integrity": "sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -966,13 +1013,13 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz",
-      "integrity": "sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz",
+      "integrity": "sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/traverse": "^7.28.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1259,14 +1306,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz",
-      "integrity": "sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
+      "integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-remap-async-to-generator": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/traverse": "^7.28.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1308,9 +1355,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.3.tgz",
-      "integrity": "sha512-+F8CnfhuLhwUACIJMLWnjz6zvzYM2r0yeIHKlbgfw7ml8rOMJsXNXV/hyRcb3nb493gRs4WvYpQAndWj/qQmkQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.4.tgz",
+      "integrity": "sha512-1yxmvN0MJHOhPVmAsmoW5liWwoILobu/d/ShymZmj867bAdxGbehIrew1DuLpw2Ukv+qDSSPQdYW1dLNE7t11A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1339,12 +1386,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
-      "integrity": "sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
+      "integrity": "sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.28.3",
         "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
@@ -1355,17 +1402,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.1.tgz",
-      "integrity": "sha512-7iLhfFAubmpeJe/Wo2TVuDrykh/zlWXLzPNdL0Jqn/Xu8R3QQ8h9ff8FQoISZOsw74/HFqFI7NX63HN7QFIHKA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.4.tgz",
+      "integrity": "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-globals": "^7.28.0",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "globals": "^11.1.0"
+        "@babel/traverse": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1391,12 +1438,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.3.tgz",
-      "integrity": "sha512-s4Jrok82JpiaIprtY2nHsYmrThKvvwgHwjgd7UMiYhZaN0asdXNLr0y+NjTfkA7SyQE5i2Fb7eawUOZmLvyqOA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz",
+      "integrity": "sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1459,6 +1507,22 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
+      "integrity": "sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.28.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1734,15 +1798,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.3.tgz",
-      "integrity": "sha512-7ZZtznF9g4l2JCImCo5LNKFHB5eXnN39lLtLY5Tg+VkR0jwOt7TBciMckuiQIOIW7L5tkQOCh3bVGYeXgMx52Q==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.4.tgz",
+      "integrity": "sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.27.3",
-        "@babel/plugin-transform-parameters": "^7.27.1"
+        "@babel/plugin-transform-destructuring": "^7.28.0",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/traverse": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1799,9 +1864,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz",
-      "integrity": "sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1972,9 +2037,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.1.tgz",
-      "integrity": "sha512-B19lbbL7PMrKr52BNPjCqg1IyNUIjTcxKj8uX9zHO+PmWN93s19NDr/f69mIkEp2x9nmDJ08a7lgHaTTzvW7mw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.4.tgz",
+      "integrity": "sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -2018,16 +2083,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.3.tgz",
-      "integrity": "sha512-bA9ZL5PW90YwNgGfjg6U+7Qh/k3zCEQJ06BFgAGRp/yMjw9hP9UGbGPtx3KSOkHGljEPCCxaE+PH4fUR2h1sDw==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz",
+      "integrity": "sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1",
-        "babel-plugin-polyfill-corejs2": "^0.4.10",
-        "babel-plugin-polyfill-corejs3": "^0.11.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.1",
+        "babel-plugin-polyfill-corejs2": "^0.4.14",
+        "babel-plugin-polyfill-corejs3": "^0.13.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.5",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -2205,12 +2270,12 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.27.2.tgz",
-      "integrity": "sha512-Ma4zSuYSlGNRlCLO+EAzLnCmJK2vdstgv+n7aUP+/IKZrOfWHOJVdSJtuub8RzHTj3ahD37k5OKJWvzf16TQyQ==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.3.tgz",
+      "integrity": "sha512-ROiDcM+GbYVPYBOeCR6uBXKkQpBExLl8k9HO1ygXEyds39j+vCCsjmj7S8GOniZQlEs81QlkdJZe76IpLSiqpg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/compat-data": "^7.28.0",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-validator-option": "^7.27.1",
@@ -2218,25 +2283,26 @@
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.3",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
         "@babel/plugin-syntax-import-assertions": "^7.27.1",
         "@babel/plugin-syntax-import-attributes": "^7.27.1",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-async-generator-functions": "^7.27.1",
+        "@babel/plugin-transform-async-generator-functions": "^7.28.0",
         "@babel/plugin-transform-async-to-generator": "^7.27.1",
         "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-        "@babel/plugin-transform-block-scoping": "^7.27.1",
+        "@babel/plugin-transform-block-scoping": "^7.28.0",
         "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-class-static-block": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.27.1",
+        "@babel/plugin-transform-class-static-block": "^7.28.3",
+        "@babel/plugin-transform-classes": "^7.28.3",
         "@babel/plugin-transform-computed-properties": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.28.0",
         "@babel/plugin-transform-dotall-regex": "^7.27.1",
         "@babel/plugin-transform-duplicate-keys": "^7.27.1",
         "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
         "@babel/plugin-transform-dynamic-import": "^7.27.1",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.27.1",
         "@babel/plugin-transform-export-namespace-from": "^7.27.1",
         "@babel/plugin-transform-for-of": "^7.27.1",
@@ -2253,15 +2319,15 @@
         "@babel/plugin-transform-new-target": "^7.27.1",
         "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
         "@babel/plugin-transform-numeric-separator": "^7.27.1",
-        "@babel/plugin-transform-object-rest-spread": "^7.27.2",
+        "@babel/plugin-transform-object-rest-spread": "^7.28.0",
         "@babel/plugin-transform-object-super": "^7.27.1",
         "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
         "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "@babel/plugin-transform-parameters": "^7.27.1",
+        "@babel/plugin-transform-parameters": "^7.27.7",
         "@babel/plugin-transform-private-methods": "^7.27.1",
         "@babel/plugin-transform-private-property-in-object": "^7.27.1",
         "@babel/plugin-transform-property-literals": "^7.27.1",
-        "@babel/plugin-transform-regenerator": "^7.27.1",
+        "@babel/plugin-transform-regenerator": "^7.28.3",
         "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
         "@babel/plugin-transform-reserved-words": "^7.27.1",
         "@babel/plugin-transform-shorthand-properties": "^7.27.1",
@@ -2274,10 +2340,10 @@
         "@babel/plugin-transform-unicode-regex": "^7.27.1",
         "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "babel-plugin-polyfill-corejs2": "^0.4.10",
-        "babel-plugin-polyfill-corejs3": "^0.11.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.1",
-        "core-js-compat": "^3.40.0",
+        "babel-plugin-polyfill-corejs2": "^0.4.14",
+        "babel-plugin-polyfill-corejs3": "^0.13.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.5",
+        "core-js-compat": "^3.43.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -2378,12 +2444,12 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.27.3.tgz",
-      "integrity": "sha512-ZYcgrwb+dkWNcDlsTe4fH1CMdqMDSJ5lWFd1by8Si2pI54XcQjte/+ViIPqAk7EAWisaUxvQ89grv+bNX2x8zg==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz",
+      "integrity": "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==",
       "license": "MIT",
       "dependencies": {
-        "core-js-pure": "^3.30.2"
+        "core-js-pure": "^3.43.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2404,27 +2470,27 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.3.tgz",
-      "integrity": "sha512-lId/IfN/Ye1CIu8xG7oKBHXd2iNb2aW1ilPszzGcJug6M8RCKfVNcYhpI5+bMvFYjK7lXIM0R+a+6r8xhHp2FQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.3",
-        "@babel/parser": "^7.27.3",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
-      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -3705,9 +3771,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
-      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "funding": [
         {
           "type": "github",
@@ -3747,9 +3813,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
-      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "funding": [
         {
           "type": "github",
@@ -3762,7 +3828,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/color-helpers": "^5.1.0",
         "@csstools/css-calc": "^2.1.4"
       },
       "engines": {
@@ -3837,10 +3903,39 @@
         "@csstools/css-tokenizer": "^3.0.4"
       }
     },
+    "node_modules/@csstools/postcss-alpha-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-alpha-function/-/postcss-alpha-function-1.0.0.tgz",
+      "integrity": "sha512-r2L8KNg5Wriq5n8IUQcjzy2Rh37J5YjzP9iOyHZL5fxdWYHB08vqykHQa4wAzN/tXwDuCHnhQDGCtxfS76xn7g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
+        "@csstools/utilities": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
     "node_modules/@csstools/postcss-cascade-layers": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-5.0.1.tgz",
-      "integrity": "sha512-XOfhI7GShVcKiKwmPAnWSqd2tBR0uxt+runAxttbSp/LY2U16yAVPmAf7e9q4JJ0d+xMNmpwNDLBXnmRCl3HMQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-5.0.2.tgz",
+      "integrity": "sha512-nWBE08nhO8uWl6kSAeCx4im7QfVko3zLrtgWZY4/bP87zrSPpSyN/3W3TDqz1jJuH+kbKOHXg5rJnK+ZVYcFFg==",
       "funding": [
         {
           "type": "github",
@@ -3877,9 +3972,9 @@
       }
     },
     "node_modules/@csstools/postcss-color-function": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-4.0.10.tgz",
-      "integrity": "sha512-4dY0NBu7NVIpzxZRgh/Q/0GPSz/jLSw0i/u3LTUor0BkQcz/fNhN10mSWBDsL0p9nDb0Ky1PD6/dcGbhACuFTQ==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-4.0.11.tgz",
+      "integrity": "sha512-AtH22zLHTLm64HLdpv5EedT/zmYTm1MtdQbQhRZXxEB6iYtS6SrS1jLX3TcmUWMFzpumK/OVylCm3HcLms4slw==",
       "funding": [
         {
           "type": "github",
@@ -3892,10 +3987,39 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
+        "@csstools/utilities": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-color-function-display-p3-linear": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function-display-p3-linear/-/postcss-color-function-display-p3-linear-1.0.0.tgz",
+      "integrity": "sha512-7q+OuUqfowRrP84m/Jl0wv3pfCQyUTCW5MxDIux+/yty5IkUUHOTigCjrC0Fjy3OT0ncGLudHbfLWmP7E1arNA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -3906,9 +4030,9 @@
       }
     },
     "node_modules/@csstools/postcss-color-mix-function": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-3.0.10.tgz",
-      "integrity": "sha512-P0lIbQW9I4ShE7uBgZRib/lMTf9XMjJkFl/d6w4EMNHu2qvQ6zljJGEcBkw/NsBtq/6q3WrmgxSS8kHtPMkK4Q==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-3.0.11.tgz",
+      "integrity": "sha512-cQpXBelpTx0YhScZM5Ve0jDCA4RzwFc7oNafzZOGgCHt/GQVYiU8Vevz9QJcwy/W0Pyi/BneY+KMjz23lI9r+Q==",
       "funding": [
         {
           "type": "github",
@@ -3921,10 +4045,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -3935,9 +4059,9 @@
       }
     },
     "node_modules/@csstools/postcss-color-mix-variadic-function-arguments": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-variadic-function-arguments/-/postcss-color-mix-variadic-function-arguments-1.0.0.tgz",
-      "integrity": "sha512-Z5WhouTyD74dPFPrVE7KydgNS9VvnjB8qcdes9ARpCOItb4jTnm7cHp4FhxCRUoyhabD0WVv43wbkJ4p8hLAlQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-variadic-function-arguments/-/postcss-color-mix-variadic-function-arguments-1.0.1.tgz",
+      "integrity": "sha512-c7hyBtbF+jlHIcUGVdWY06bHICgguV9ypfcELU3eU3W/9fiz2dxM8PqxQk2ndXYTzLnwPvNNqu1yCmQ++N6Dcg==",
       "funding": [
         {
           "type": "github",
@@ -3950,10 +4074,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -3964,9 +4088,9 @@
       }
     },
     "node_modules/@csstools/postcss-content-alt-text": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-content-alt-text/-/postcss-content-alt-text-2.0.6.tgz",
-      "integrity": "sha512-eRjLbOjblXq+byyaedQRSrAejKGNAFued+LcbzT+LCL78fabxHkxYjBbxkroONxHHYu2qxhFK2dBStTLPG3jpQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-content-alt-text/-/postcss-content-alt-text-2.0.7.tgz",
+      "integrity": "sha512-cq/zWaEkpcg3RttJ5+GdNwk26NwxY5KgqgtNL777Fdd28AVGHxuBvqmK4Jq4oKhW1NX4M2LbgYAVVN0NZ+/XYQ==",
       "funding": [
         {
           "type": "github",
@@ -3981,7 +4105,7 @@
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -4045,9 +4169,9 @@
       }
     },
     "node_modules/@csstools/postcss-gamut-mapping": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-2.0.10.tgz",
-      "integrity": "sha512-QDGqhJlvFnDlaPAfCYPsnwVA6ze+8hhrwevYWlnUeSjkkZfBpcCO42SaUD8jiLlq7niouyLgvup5lh+f1qessg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-2.0.11.tgz",
+      "integrity": "sha512-fCpCUgZNE2piVJKC76zFsgVW1apF6dpYsqGyH8SIeCcM4pTEsRTWTLCaJIMKFEundsCKwY1rwfhtrio04RJ4Dw==",
       "funding": [
         {
           "type": "github",
@@ -4060,7 +4184,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4"
       },
@@ -4072,9 +4196,9 @@
       }
     },
     "node_modules/@csstools/postcss-gradients-interpolation-method": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-5.0.10.tgz",
-      "integrity": "sha512-HHPauB2k7Oits02tKFUeVFEU2ox/H3OQVrP3fSOKDxvloOikSal+3dzlyTZmYsb9FlY9p5EUpBtz0//XBmy+aw==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-5.0.11.tgz",
+      "integrity": "sha512-8M3mcNTL3cGIJXDnvrJ2oWEcKi3zyw7NeYheFKePUlBmLYm1gkw9Rr/BA7lFONrOPeQA3yeMPldrrws6lqHrug==",
       "funding": [
         {
           "type": "github",
@@ -4087,10 +4211,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -4101,9 +4225,9 @@
       }
     },
     "node_modules/@csstools/postcss-hwb-function": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-4.0.10.tgz",
-      "integrity": "sha512-nOKKfp14SWcdEQ++S9/4TgRKchooLZL0TUFdun3nI4KPwCjETmhjta1QT4ICQcGVWQTvrsgMM/aLB5We+kMHhQ==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-4.0.11.tgz",
+      "integrity": "sha512-9meZbsVWTZkWsSBazQips3cHUOT29a/UAwFz0AMEXukvpIGGDR9+GMl3nIckWO5sPImsadu4F5Zy+zjt8QgCdA==",
       "funding": [
         {
           "type": "github",
@@ -4116,10 +4240,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -4130,9 +4254,9 @@
       }
     },
     "node_modules/@csstools/postcss-ic-unit": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-4.0.2.tgz",
-      "integrity": "sha512-lrK2jjyZwh7DbxaNnIUjkeDmU8Y6KyzRBk91ZkI5h8nb1ykEfZrtIVArdIjX4DHMIBGpdHrgP0n4qXDr7OHaKA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-4.0.3.tgz",
+      "integrity": "sha512-RtYYm2qUIu9vAaHB0cC8rQGlOCQAUgEc2tMr7ewlGXYipBQKjoWmyVArqsk7SEr8N3tErq6P6UOJT3amaVof5Q==",
       "funding": [
         {
           "type": "github",
@@ -4145,7 +4269,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0",
         "postcss-value-parser": "^4.2.0"
       },
@@ -4179,9 +4303,9 @@
       }
     },
     "node_modules/@csstools/postcss-is-pseudo-class": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.1.tgz",
-      "integrity": "sha512-JLp3POui4S1auhDR0n8wHd/zTOWmMsmK3nQd3hhL6FhWPaox5W7j1se6zXOG/aP07wV2ww0lxbKYGwbBszOtfQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.3.tgz",
+      "integrity": "sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==",
       "funding": [
         {
           "type": "github",
@@ -4218,9 +4342,9 @@
       }
     },
     "node_modules/@csstools/postcss-light-dark-function": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-light-dark-function/-/postcss-light-dark-function-2.0.9.tgz",
-      "integrity": "sha512-1tCZH5bla0EAkFAI2r0H33CDnIBeLUaJh1p+hvvsylJ4svsv2wOmJjJn+OXwUZLXef37GYbRIVKX+X+g6m+3CQ==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-light-dark-function/-/postcss-light-dark-function-2.0.10.tgz",
+      "integrity": "sha512-g7Lwb294lSoNnyrwcqoooh9fTAp47rRNo+ILg7SLRSMU3K9ePIwRt566sNx+pehiCelv4E1ICaU1EwLQuyF2qw==",
       "funding": [
         {
           "type": "github",
@@ -4235,7 +4359,7 @@
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -4469,9 +4593,9 @@
       }
     },
     "node_modules/@csstools/postcss-oklab-function": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-4.0.10.tgz",
-      "integrity": "sha512-ZzZUTDd0fgNdhv8UUjGCtObPD8LYxMH+MJsW9xlZaWTV8Ppr4PtxlHYNMmF4vVWGl0T6f8tyWAKjoI6vePSgAg==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-4.0.11.tgz",
+      "integrity": "sha512-9f03ZGxZ2VmSCrM4SDXlAYP+Xpu4VFzemfQUQFL9OYxAbpvDy0FjDipZ0i8So1pgs8VIbQI0bNjFWgfdpGw8ig==",
       "funding": [
         {
           "type": "github",
@@ -4484,10 +4608,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -4498,9 +4622,9 @@
       }
     },
     "node_modules/@csstools/postcss-progressive-custom-properties": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.1.0.tgz",
-      "integrity": "sha512-YrkI9dx8U4R8Sz2EJaoeD9fI7s7kmeEBfmO+UURNeL6lQI7VxF6sBE+rSqdCBn4onwqmxFdBU3lTwyYb/lCmxA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.2.0.tgz",
+      "integrity": "sha512-fWCXRasX17N1NCPTCuwC3FJDV+Wc031f16cFuuMEfIsYJ1q5ABCa59W0C6VeMGqjNv6ldf37vvwXXAeaZjD9PA==",
       "funding": [
         {
           "type": "github",
@@ -4550,9 +4674,9 @@
       }
     },
     "node_modules/@csstools/postcss-relative-color-syntax": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-3.0.10.tgz",
-      "integrity": "sha512-8+0kQbQGg9yYG8hv0dtEpOMLwB9M+P7PhacgIzVzJpixxV4Eq9AUQtQw8adMmAJU1RBBmIlpmtmm3XTRd/T00g==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-3.0.11.tgz",
+      "integrity": "sha512-oQ5fZvkcBrWR+k6arHXk0F8FlkmD4IxM+rcGDLWrF2f31tWyEM3lSraeWAV0f7BGH6LIrqmyU3+Qo/1acfoJng==",
       "funding": [
         {
           "type": "github",
@@ -4565,10 +4689,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -4671,9 +4795,9 @@
       }
     },
     "node_modules/@csstools/postcss-text-decoration-shorthand": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-4.0.2.tgz",
-      "integrity": "sha512-8XvCRrFNseBSAGxeaVTaNijAu+FzUvjwFXtcrynmazGb/9WUdsPCpBX+mHEHShVRq47Gy4peYAoxYs8ltUnmzA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-4.0.3.tgz",
+      "integrity": "sha512-KSkGgZfx0kQjRIYnpsD7X2Om9BUXX/Kii77VBifQW9Ih929hK0KNjVngHDH0bFB9GmfWcR9vJYJJRvw/NQjkrA==",
       "funding": [
         {
           "type": "github",
@@ -4686,7 +4810,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/color-helpers": "^5.1.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -4746,9 +4870,9 @@
       }
     },
     "node_modules/@csstools/selector-resolve-nested": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.0.0.tgz",
-      "integrity": "sha512-ZoK24Yku6VJU1gS79a5PFmC8yn3wIapiKmPgun0hZgEI5AOqgH2kiPRsPz1qkGv4HL+wuDLH83yQyk6inMYrJQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz",
+      "integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==",
       "funding": [
         {
           "type": "github",
@@ -4913,9 +5037,9 @@
       }
     },
     "node_modules/@docusaurus/babel": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.8.0.tgz",
-      "integrity": "sha512-9EJwSgS6TgB8IzGk1L8XddJLhZod8fXT4ULYMx6SKqyCBqCFpVCEjR/hNXXhnmtVM2irDuzYoVLGWv7srG/VOA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.8.1.tgz",
+      "integrity": "sha512-3brkJrml8vUbn9aeoZUlJfsI/GqyFcDgQJwQkmBtclJgWDEQBKKeagZfOgx0WfUQhagL1sQLNW0iBdxnI863Uw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -4928,8 +5052,8 @@
         "@babel/runtime": "^7.25.9",
         "@babel/runtime-corejs3": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -4939,18 +5063,18 @@
       }
     },
     "node_modules/@docusaurus/babel/node_modules/@babel/runtime": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.3.tgz",
-      "integrity": "sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@docusaurus/babel/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -4962,30 +5086,30 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.8.0.tgz",
-      "integrity": "sha512-Rq4Z/MSeAHjVzBLirLeMcjLIAQy92pF1OI+2rmt18fSlMARfTGLWRE8Vb+ljQPTOSfJxwDYSzsK6i7XloD2rNA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.8.1.tgz",
+      "integrity": "sha512-/z4V0FRoQ0GuSLToNjOSGsk6m2lQUG4FRn8goOVoZSRsTrU8YR2aJacX5K3RG18EaX9b+52pN4m1sL3MQZVsQA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.8.0",
-        "@docusaurus/cssnano-preset": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
+        "@docusaurus/babel": "3.8.1",
+        "@docusaurus/cssnano-preset": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "babel-loader": "^9.2.1",
-        "clean-css": "^5.3.2",
+        "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
-        "css-loader": "^6.8.1",
+        "css-loader": "^6.11.0",
         "css-minimizer-webpack-plugin": "^5.0.1",
         "cssnano": "^6.1.2",
         "file-loader": "^6.2.0",
         "html-minifier-terser": "^7.2.0",
-        "mini-css-extract-plugin": "^2.9.1",
+        "mini-css-extract-plugin": "^2.9.2",
         "null-loader": "^4.0.1",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "postcss-preset-env": "^10.1.0",
+        "postcss": "^8.5.4",
+        "postcss-loader": "^7.3.4",
+        "postcss-preset-env": "^10.2.1",
         "terser-webpack-plugin": "^5.3.9",
         "tslib": "^2.6.0",
         "url-loader": "^4.1.1",
@@ -5005,18 +5129,18 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.8.0.tgz",
-      "integrity": "sha512-c7u6zFELmSGPEP9WSubhVDjgnpiHgDqMh1qVdCB7rTflh4Jx0msTYmMiO91Ez0KtHj4sIsDsASnjwfJ2IZp3Vw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.8.1.tgz",
+      "integrity": "sha512-ENB01IyQSqI2FLtOzqSI3qxG2B/jP4gQPahl2C3XReiLebcVh5B5cB9KYFvdoOqOWPyr5gXK4sjgTKv7peXCrA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.8.0",
-        "@docusaurus/bundler": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/mdx-loader": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/babel": "3.8.1",
+        "@docusaurus/bundler": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -5124,9 +5248,9 @@
       }
     },
     "node_modules/@docusaurus/core/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5159,13 +5283,13 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.8.0.tgz",
-      "integrity": "sha512-UJ4hAS2T0R4WNy+phwVff2Q0L5+RXW9cwlH6AEphHR5qw3m/yacfWcSK7ort2pMMbDn8uGrD38BTm4oLkuuNoQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.8.1.tgz",
+      "integrity": "sha512-G7WyR2N6SpyUotqhGznERBK+x84uyhfMQM2MmDLs88bw4Flom6TY46HzkRkSEzaP9j80MbTN8naiL1fR17WQug==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
+        "postcss": "^8.5.4",
         "postcss-sort-media-queries": "^5.2.0",
         "tslib": "^2.6.0"
       },
@@ -5174,13 +5298,13 @@
       }
     },
     "node_modules/@docusaurus/faster": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.8.0.tgz",
-      "integrity": "sha512-v9+8rT2gw/4zIRBwc4fIVhrTH/yFVDQgJgyYZjqr3fgojOypdQCOwkN6Z8dOwTei4/zo+b/zDPB4x1UvghJZRg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.8.1.tgz",
+      "integrity": "sha512-XYrj3qnTm+o2d5ih5drCq9s63GJoM8vZ26WbLG5FZhURsNxTSXgHJcx11Qo7nWPUStCQkuqk1HvItzscCUnd4A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.8.0",
-        "@rspack/core": "^1.3.10",
+        "@docusaurus/types": "3.8.1",
+        "@rspack/core": "^1.3.15",
         "@swc/core": "^1.7.39",
         "@swc/html": "^1.7.39",
         "browserslist": "^4.24.2",
@@ -5197,9 +5321,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.8.0.tgz",
-      "integrity": "sha512-7eEMaFIam5Q+v8XwGqF/n0ZoCld4hV4eCCgQkfcN9Mq5inoZa6PHHW9Wu6lmgzoK5Kx3keEeABcO2SxwraoPDQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.8.1.tgz",
+      "integrity": "sha512-2wjeGDhKcExEmjX8k1N/MRDiPKXGF2Pg+df/bDDPnnJWHXnVEZxXj80d6jcxp1Gpnksl0hF8t/ZQw9elqj2+ww==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -5280,14 +5404,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.0.tgz",
-      "integrity": "sha512-mDPSzssRnpjSdCGuv7z2EIAnPS1MHuZGTaRLwPn4oQwszu4afjWZ/60sfKjTnjBjI8Vl4OgJl2vMmfmiNDX4Ng==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
+      "integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -5319,9 +5443,9 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5333,12 +5457,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.8.0.tgz",
-      "integrity": "sha512-/uMb4Ipt5J/QnD13MpnoC/A4EYAe6DKNWqTWLlGrqsPJwJv73vSwkA25xnYunwfqWk0FlUQfGv/Swdh5eCCg7g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.8.1.tgz",
+      "integrity": "sha512-6xhvAJiXzsaq3JdosS7wbRt/PwEPWHr9eM4YNYqVlbgG1hSK3uQDXTVvQktasp3VO6BmfYWPozueLWuj4gB+vg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.8.0",
+        "@docusaurus/types": "3.8.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -5352,16 +5476,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.8.0.tgz",
-      "integrity": "sha512-J8f5qzAlO61BnG1I91+N5WH1b/lPWqn6ifTxf/Bluz9JVe1bhFNSl0yW03p+Ff3AFOINDy2ofX70al9nOnOLyw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.8.1.tgz",
+      "integrity": "sha512-F+86R7PBn6VNgy/Ux8w3ZRypJGJEzksbejQKlbTC8u6uhBUhfdXWkDp6qdOisIoW0buY5nLqucvZt1zNJzhJhA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -5390,19 +5514,19 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.8.0.tgz",
-      "integrity": "sha512-0SlOTd9R55WEr1GgIXu+hhTT0hzARYx3zIScA5IzpdekZQesI/hKEa5LPHBd415fLkWMjdD59TaW/3qQKpJ0Lg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.8.1.tgz",
+      "integrity": "sha512-vNTpMmlvNP9n3hGEcgPaXyvTljanAKIUkuG9URQ1DeuDup0OR7Ltvoc8yrmH+iMZJbcQGhUJF+WjHLwuk8HSdw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/mdx-loader": "3.8.0",
-        "@docusaurus/theme-common": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -5424,9 +5548,9 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5438,20 +5562,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.8.0.tgz",
-      "integrity": "sha512-fRDMFLbUN6eVRXcjP8s3Y7HpAt9pzPYh1F/7KKXOCxvJhjjCtbon4VJW0WndEPInVz4t8QUXn5QZkU2tGVCE2g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.8.1.tgz",
+      "integrity": "sha512-oByRkSZzeGNQByCMaX+kif5Nl2vmtj2IHQI2fWjCfCootsdKZDPFLonhIp5s3IGJO7PLUfe0POyw0Xh/RrGXJA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/mdx-loader": "3.8.0",
-        "@docusaurus/module-type-aliases": "3.8.0",
-        "@docusaurus/theme-common": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -5503,16 +5627,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.8.0.tgz",
-      "integrity": "sha512-39EDx2y1GA0Pxfion5tQZLNJxL4gq6susd1xzetVBjVIQtwpCdyloOfQBAgX0FylqQxfJrYqL0DIUuq7rd7uBw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.8.1.tgz",
+      "integrity": "sha512-a+V6MS2cIu37E/m7nDJn3dcxpvXb6TvgdNI22vJX8iUTp8eoMoPa0VArEbWvCxMY/xdC26WzNv4wZ6y0iIni/w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/mdx-loader": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -5526,9 +5650,9 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5540,14 +5664,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-css-cascade-layers": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.8.0.tgz",
-      "integrity": "sha512-/VBTNymPIxQB8oA3ZQ4GFFRYdH4ZxDRRBECxyjRyv486mfUPXfcdk+im4S5mKWa6EK2JzBz95IH/Wu0qQgJ5yQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.8.1.tgz",
+      "integrity": "sha512-VQ47xRxfNKjHS5ItzaVXpxeTm7/wJLFMOPo1BkmoMG4Cuz4nuI+Hs62+RMk1OqVog68Swz66xVPK8g9XTrBKRw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -5555,14 +5680,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.8.0.tgz",
-      "integrity": "sha512-teonJvJsDB9o2OnG6ifbhblg/PXzZvpUKHFgD8dOL1UJ58u0lk8o0ZOkvaYEBa9nDgqzoWrRk9w+e3qaG2mOhQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.8.1.tgz",
+      "integrity": "sha512-nT3lN7TV5bi5hKMB7FK8gCffFTBSsBsAfV84/v293qAmnHOyg1nr9okEw8AiwcO3bl9vije5nsUvP0aRl2lpaw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
@@ -5576,9 +5701,9 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5590,14 +5715,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.8.0.tgz",
-      "integrity": "sha512-aKKa7Q8+3xRSRESipNvlFgNp3FNPELKhuo48Cg/svQbGNwidSHbZT03JqbW4cBaQnyyVchO1ttk+kJ5VC9Gx0w==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.8.1.tgz",
+      "integrity": "sha512-Hrb/PurOJsmwHAsfMDH6oVpahkEGsx7F8CWMjyP/dw1qjqmdS9rcV1nYCGlM8nOtD3Wk/eaThzUB5TSZsGz+7Q==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -5609,14 +5734,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.8.0.tgz",
-      "integrity": "sha512-ugQYMGF4BjbAW/JIBtVcp+9eZEgT9HRdvdcDudl5rywNPBA0lct+lXMG3r17s02rrhInMpjMahN3Yc9Cb3H5/g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.8.1.tgz",
+      "integrity": "sha512-tKE8j1cEZCh8KZa4aa80zpSTxsC2/ZYqjx6AAfd8uA8VHZVw79+7OTEP2PoWi0uL5/1Is0LF5Vwxd+1fz5HlKg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -5629,14 +5754,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.8.0.tgz",
-      "integrity": "sha512-9juRWxbwZD3SV02Jd9QB6yeN7eu+7T4zB0bvJLcVQwi+am51wAxn2CwbdL0YCCX+9OfiXbADE8D8Q65Hbopu/w==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.8.1.tgz",
+      "integrity": "sha512-iqe3XKITBquZq+6UAXdb1vI0fPY5iIOitVjPQ581R1ZKpHr0qe+V6gVOrrcOHixPDD/BUKdYwkxFjpNiEN+vBw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -5648,17 +5773,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.0.tgz",
-      "integrity": "sha512-fGpOIyJvNiuAb90nSJ2Gfy/hUOaDu6826e5w5UxPmbpCIc7KlBHNAZ5g4L4ZuHhc4hdfq4mzVBsQSnne+8Ze1g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.1.tgz",
+      "integrity": "sha512-+9YV/7VLbGTq8qNkjiugIelmfUEVkTyLe6X8bWq7K5qPvGXAjno27QAfFq63mYfFFbJc7z+pudL63acprbqGzw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -5672,9 +5797,9 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5686,15 +5811,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-svgr": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.8.0.tgz",
-      "integrity": "sha512-kEDyry+4OMz6BWLG/lEqrNsL/w818bywK70N1gytViw4m9iAmoxCUT7Ri9Dgs7xUdzCHJ3OujolEmD88Wy44OA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.8.1.tgz",
+      "integrity": "sha512-rW0LWMDsdlsgowVwqiMb/7tANDodpy1wWPwCcamvhY7OECReN3feoFwLjd/U4tKjNY3encj0AJSTxJA+Fpe+Gw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
         "tslib": "^2.6.0",
@@ -5709,26 +5834,26 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.8.0.tgz",
-      "integrity": "sha512-qOu6tQDOWv+rpTlKu+eJATCJVGnABpRCPuqf7LbEaQ1mNY//N/P8cHQwkpAU+aweQfarcZ0XfwCqRHJfjeSV/g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.8.1.tgz",
+      "integrity": "sha512-yJSjYNHXD8POMGc2mKQuj3ApPrN+eG0rO1UPgSx7jySpYU+n4WjBikbrA2ue5ad9A7aouEtMWUoiSRXTH/g7KQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/plugin-content-blog": "3.8.0",
-        "@docusaurus/plugin-content-docs": "3.8.0",
-        "@docusaurus/plugin-content-pages": "3.8.0",
-        "@docusaurus/plugin-css-cascade-layers": "3.8.0",
-        "@docusaurus/plugin-debug": "3.8.0",
-        "@docusaurus/plugin-google-analytics": "3.8.0",
-        "@docusaurus/plugin-google-gtag": "3.8.0",
-        "@docusaurus/plugin-google-tag-manager": "3.8.0",
-        "@docusaurus/plugin-sitemap": "3.8.0",
-        "@docusaurus/plugin-svgr": "3.8.0",
-        "@docusaurus/theme-classic": "3.8.0",
-        "@docusaurus/theme-common": "3.8.0",
-        "@docusaurus/theme-search-algolia": "3.8.0",
-        "@docusaurus/types": "3.8.0"
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/plugin-content-blog": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/plugin-content-pages": "3.8.1",
+        "@docusaurus/plugin-css-cascade-layers": "3.8.1",
+        "@docusaurus/plugin-debug": "3.8.1",
+        "@docusaurus/plugin-google-analytics": "3.8.1",
+        "@docusaurus/plugin-google-gtag": "3.8.1",
+        "@docusaurus/plugin-google-tag-manager": "3.8.1",
+        "@docusaurus/plugin-sitemap": "3.8.1",
+        "@docusaurus/plugin-svgr": "3.8.1",
+        "@docusaurus/theme-classic": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-search-algolia": "3.8.1",
+        "@docusaurus/types": "3.8.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -5739,31 +5864,31 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.8.0.tgz",
-      "integrity": "sha512-nQWFiD5ZjoT76OaELt2n33P3WVuuCz8Dt5KFRP2fCBo2r9JCLsp2GJjZpnaG24LZ5/arRjv4VqWKgpK0/YLt7g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.8.1.tgz",
+      "integrity": "sha512-bqDUCNqXeYypMCsE1VcTXSI1QuO4KXfx8Cvl6rYfY0bhhqN6d2WZlRkyLg/p6pm+DzvanqHOyYlqdPyP0iz+iw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/mdx-loader": "3.8.0",
-        "@docusaurus/module-type-aliases": "3.8.0",
-        "@docusaurus/plugin-content-blog": "3.8.0",
-        "@docusaurus/plugin-content-docs": "3.8.0",
-        "@docusaurus/plugin-content-pages": "3.8.0",
-        "@docusaurus/theme-common": "3.8.0",
-        "@docusaurus/theme-translations": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/plugin-content-blog": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/plugin-content-pages": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-translations": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
         "infima": "0.2.0-alpha.45",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
-        "postcss": "^8.4.26",
+        "postcss": "^8.5.4",
         "prism-react-renderer": "^2.3.0",
         "prismjs": "^1.29.0",
         "react-router-dom": "^5.3.4",
@@ -5780,15 +5905,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.8.0.tgz",
-      "integrity": "sha512-YqV2vAWpXGLA+A3PMLrOMtqgTHJLDcT+1Caa6RF7N4/IWgrevy5diY8oIHFkXR/eybjcrFFjUPrHif8gSGs3Tw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.8.1.tgz",
+      "integrity": "sha512-UswMOyTnPEVRvN5Qzbo+l8k4xrd5fTFu2VPPfD6FcW/6qUtVLmJTQCktbAL3KJ0BVXGm5aJXz/ZrzqFuZERGPw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.8.0",
-        "@docusaurus/module-type-aliases": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -5808,16 +5933,16 @@
       }
     },
     "node_modules/@docusaurus/theme-mermaid": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.8.0.tgz",
-      "integrity": "sha512-ou0NJM37p4xrVuFaZp8qFe5Z/qBq9LuyRTP4KKRa0u2J3zC4f3saBJDgc56FyvvN1OsmU0189KGEPUjTr6hFxg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.8.1.tgz",
+      "integrity": "sha512-IWYqjyTPjkNnHsFFu9+4YkeXS7PD1xI3Bn2shOhBq+f95mgDfWInkpfBN4aYvx4fTT67Am6cPtohRdwh4Tidtg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/module-type-aliases": "3.8.0",
-        "@docusaurus/theme-common": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "mermaid": ">=11.6.0",
         "tslib": "^2.6.0"
       },
@@ -5932,19 +6057,19 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.8.0.tgz",
-      "integrity": "sha512-GBZ5UOcPgiu6nUw153+0+PNWvFKweSnvKIL6Rp04H9olKb475jfKjAwCCtju5D2xs5qXHvCMvzWOg5o9f6DtuQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.8.1.tgz",
+      "integrity": "sha512-NBFH5rZVQRAQM087aYSRKQ9yGEK9eHd+xOxQjqNpxMiV85OhJDD4ZGz6YJIod26Fbooy54UWVdzNU0TFeUUUzQ==",
       "license": "MIT",
       "dependencies": {
         "@docsearch/react": "^3.9.0",
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/plugin-content-docs": "3.8.0",
-        "@docusaurus/theme-common": "3.8.0",
-        "@docusaurus/theme-translations": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-translations": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "algoliasearch": "^5.17.1",
         "algoliasearch-helper": "^3.22.6",
         "clsx": "^2.0.0",
@@ -5963,9 +6088,9 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5977,9 +6102,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.8.0.tgz",
-      "integrity": "sha512-1DTy/snHicgkCkryWq54fZvsAglTdjTx4qjOXgqnXJ+DIty1B+aPQrAVUu8LiM+6BiILfmNxYsxhKTj+BS3PZg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.8.1.tgz",
+      "integrity": "sha512-OTp6eebuMcf2rJt4bqnvuwmm3NVXfzfYejL+u/Y1qwKhZPrjPoKWfk1CbOP5xH5ZOPkiAsx4dHdQBRJszK3z2g==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -6004,9 +6129,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.8.0.tgz",
-      "integrity": "sha512-RDEClpwNxZq02c+JlaKLWoS13qwWhjcNsi2wG1UpzmEnuti/z1Wx4SGpqbUqRPNSd8QWWePR8Cb7DvG0VN/TtA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.8.1.tgz",
+      "integrity": "sha512-ZPdW5AB+pBjiVrcLuw3dOS6BFlrG0XkS2lDGsj8TizcnREQg3J8cjsgfDviszOk4CweNfwo1AEELJkYaMUuOPg==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -6048,14 +6173,14 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.8.0.tgz",
-      "integrity": "sha512-2wvtG28ALCN/A1WCSLxPASFBFzXCnP0YKCAFIPcvEb6imNu1wg7ni/Svcp71b3Z2FaOFFIv4Hq+j4gD7gA0yfQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.8.1.tgz",
+      "integrity": "sha512-P1ml0nvOmEFdmu0smSXOqTS1sxU5tqvnc0dA4MTKV39kye+bhQnjkIKEE18fNOvxjyB86k8esoCIFM3x4RykOQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "escape-string-regexp": "^4.0.0",
         "execa": "5.1.1",
         "file-loader": "^6.2.0",
@@ -6080,12 +6205,12 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.8.0.tgz",
-      "integrity": "sha512-3TGF+wVTGgQ3pAc9+5jVchES4uXUAhAt9pwv7uws4mVOxL4alvU3ue/EZ+R4XuGk94pDy7CNXjRXpPjlfZXQfw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.8.1.tgz",
+      "integrity": "sha512-zTZiDlvpvoJIrQEEd71c154DkcriBecm4z94OzEE9kz7ikS3J+iSlABhFXM45mZ0eN5pVqqr7cs60+ZlYLewtg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.8.0",
+        "@docusaurus/types": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -6093,14 +6218,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.8.0.tgz",
-      "integrity": "sha512-MrnEbkigr54HkdFeg8e4FKc4EF+E9dlVwsY3XQZsNkbv3MKZnbHQ5LsNJDIKDROFe8PBf5C4qCAg5TPBpsjrjg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.8.1.tgz",
+      "integrity": "sha512-gs5bXIccxzEbyVecvxg6upTwaUbfa0KMmTj7HhHzc016AGyxH2o73k1/aOD0IFrdCsfJNt37MqNI47s2MgRZMA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -6185,6 +6310,136 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@easyops-cn/autocomplete.js": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/autocomplete.js/-/autocomplete.js-0.38.1.tgz",
+      "integrity": "sha512-drg76jS6syilOUmVNkyo1c7ZEBPcPuK+aJA7AksM5ZIIbV57DMHCywiCr+uHyv8BE5jUTU98j/H7gVrkHrWW3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "immediate": "^3.2.3"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.52.1.tgz",
+      "integrity": "sha512-pwfANjTLOQyAPc2Iz93WbG4OQM5C4COCWARbLAs79FIpIS38gHq3PrbDIX8f7oDhGQp1u6f8fr3K3u3+yZXZTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/plugin-content-docs": "^2 || ^3",
+        "@docusaurus/theme-translations": "^2 || ^3",
+        "@docusaurus/utils": "^2 || ^3",
+        "@docusaurus/utils-common": "^2 || ^3",
+        "@docusaurus/utils-validation": "^2 || ^3",
+        "@easyops-cn/autocomplete.js": "^0.38.1",
+        "@node-rs/jieba": "^1.6.0",
+        "cheerio": "^1.0.0",
+        "clsx": "^2.1.1",
+        "comlink": "^4.4.2",
+        "debug": "^4.2.0",
+        "fs-extra": "^10.0.0",
+        "klaw-sync": "^6.0.0",
+        "lunr": "^2.3.9",
+        "lunr-languages": "^1.4.0",
+        "mark.js": "^8.11.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@docusaurus/theme-common": "^2 || ^3",
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || 17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -8124,16 +8379,13 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
@@ -8160,9 +8412,10 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -8377,56 +8630,68 @@
       }
     },
     "node_modules/@module-federation/error-codes": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.14.0.tgz",
-      "integrity": "sha512-GGk+EoeSACJikZZyShnLshtq9E2eCrDWbRiB4QAFXCX4oYmGgFfzXlx59vMNwqTKPJWxkEGnPYacJMcr2YYjag==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.18.0.tgz",
+      "integrity": "sha512-Woonm8ehyVIUPXChmbu80Zj6uJkC0dD9SJUZ/wOPtO8iiz/m+dkrOugAuKgoiR6qH4F+yorWila954tBz4uKsQ==",
       "license": "MIT"
     },
     "node_modules/@module-federation/runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.14.0.tgz",
-      "integrity": "sha512-kR3cyHw/Y64SEa7mh4CHXOEQYY32LKLK75kJOmBroLNLO7/W01hMNAvGBYTedS7hWpVuefPk1aFZioy3q2VLdQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.18.0.tgz",
+      "integrity": "sha512-+C4YtoSztM7nHwNyZl6dQKGUVJdsPrUdaf3HIKReg/GQbrt9uvOlUWo2NXMZ8vDAnf/QRrpSYAwXHmWDn9Obaw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.14.0",
-        "@module-federation/runtime-core": "0.14.0",
-        "@module-federation/sdk": "0.14.0"
+        "@module-federation/error-codes": "0.18.0",
+        "@module-federation/runtime-core": "0.18.0",
+        "@module-federation/sdk": "0.18.0"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.14.0.tgz",
-      "integrity": "sha512-fGE1Ro55zIFDp/CxQuRhKQ1pJvG7P0qvRm2N+4i8z++2bgDjcxnCKUqDJ8lLD+JfJQvUJf0tuSsJPgevzueD4g==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.18.0.tgz",
+      "integrity": "sha512-ZyYhrDyVAhUzriOsVfgL6vwd+5ebYm595Y13KeMf6TKDRoUHBMTLGQ8WM4TDj8JNsy7LigncK8C03fn97of0QQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.14.0",
-        "@module-federation/sdk": "0.14.0"
+        "@module-federation/error-codes": "0.18.0",
+        "@module-federation/sdk": "0.18.0"
       }
     },
     "node_modules/@module-federation/runtime-tools": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.14.0.tgz",
-      "integrity": "sha512-y/YN0c2DKsLETE+4EEbmYWjqF9G6ZwgZoDIPkaQ9p0pQu0V4YxzWfQagFFxR0RigYGuhJKmSU/rtNoHq+qF8jg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.18.0.tgz",
+      "integrity": "sha512-fSga9o4t1UfXNV/Kh6qFvRyZpPp3EHSPRISNeyT8ZoTpzDNiYzhtw0BPUSSD8m6C6XQh2s/11rI4g80UY+d+hA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.14.0",
-        "@module-federation/webpack-bundler-runtime": "0.14.0"
+        "@module-federation/runtime": "0.18.0",
+        "@module-federation/webpack-bundler-runtime": "0.18.0"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.14.0.tgz",
-      "integrity": "sha512-lg/OWRsh18hsyTCamOOhEX546vbDiA2O4OggTxxH2wTGr156N6DdELGQlYIKfRdU/0StgtQS81Goc0BgDZlx9A==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.18.0.tgz",
+      "integrity": "sha512-Lo/Feq73tO2unjmpRfyyoUkTVoejhItXOk/h5C+4cistnHbTV8XHrW/13fD5e1Iu60heVdAhhelJd6F898Ve9A==",
       "license": "MIT"
     },
     "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.14.0.tgz",
-      "integrity": "sha512-POWS6cKBicAAQ3DNY5X7XEUSfOfUsRaBNxbuwEfSGlrkTE9UcWheO06QP2ndHi8tHQuUKcIHi2navhPkJ+k5xg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.18.0.tgz",
+      "integrity": "sha512-TEvErbF+YQ+6IFimhUYKK3a5wapD90d90sLsNpcu2kB3QGT7t4nIluE25duXuZDVUKLz86tEPrza/oaaCWTpvQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.14.0",
-        "@module-federation/sdk": "0.14.0"
+        "@module-federation/runtime": "0.18.0",
+        "@module-federation/sdk": "0.18.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -8436,6 +8701,259 @@
       "dev": true,
       "dependencies": {
         "eslint-scope": "5.1.1"
+      }
+    },
+    "node_modules/@node-rs/jieba": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba/-/jieba-1.10.4.tgz",
+      "integrity": "sha512-GvDgi8MnBiyWd6tksojej8anIx18244NmIOc1ovEw8WKNUejcccLfyu8vj66LWSuoZuKILVtNsOy4jvg3aoxIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@node-rs/jieba-android-arm-eabi": "1.10.4",
+        "@node-rs/jieba-android-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-x64": "1.10.4",
+        "@node-rs/jieba-freebsd-x64": "1.10.4",
+        "@node-rs/jieba-linux-arm-gnueabihf": "1.10.4",
+        "@node-rs/jieba-linux-arm64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-arm64-musl": "1.10.4",
+        "@node-rs/jieba-linux-x64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-x64-musl": "1.10.4",
+        "@node-rs/jieba-wasm32-wasi": "1.10.4",
+        "@node-rs/jieba-win32-arm64-msvc": "1.10.4",
+        "@node-rs/jieba-win32-ia32-msvc": "1.10.4",
+        "@node-rs/jieba-win32-x64-msvc": "1.10.4"
+      }
+    },
+    "node_modules/@node-rs/jieba-android-arm-eabi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm-eabi/-/jieba-android-arm-eabi-1.10.4.tgz",
+      "integrity": "sha512-MhyvW5N3Fwcp385d0rxbCWH42kqDBatQTyP8XbnYbju2+0BO/eTeCCLYj7Agws4pwxn2LtdldXRSKavT7WdzNA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-android-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm64/-/jieba-android-arm64-1.10.4.tgz",
+      "integrity": "sha512-XyDwq5+rQ+Tk55A+FGi6PtJbzf974oqnpyCcCPzwU3QVXJCa2Rr4Lci+fx8oOpU4plT3GuD+chXMYLsXipMgJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-darwin-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-arm64/-/jieba-darwin-arm64-1.10.4.tgz",
+      "integrity": "sha512-G++RYEJ2jo0rxF9626KUy90wp06TRUjAsvY/BrIzEOX/ingQYV/HjwQzNPRR1P1o32a6/U8RGo7zEBhfdybL6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-darwin-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-x64/-/jieba-darwin-x64-1.10.4.tgz",
+      "integrity": "sha512-MmDNeOb2TXIZCPyWCi2upQnZpPjAxw5ZGEj6R8kNsPXVFALHIKMa6ZZ15LCOkSTsKXVC17j2t4h+hSuyYb6qfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-freebsd-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-freebsd-x64/-/jieba-freebsd-x64-1.10.4.tgz",
+      "integrity": "sha512-/x7aVQ8nqUWhpXU92RZqd333cq639i/olNpd9Z5hdlyyV5/B65LLy+Je2B2bfs62PVVm5QXRpeBcZqaHelp/bg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm-gnueabihf": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm-gnueabihf/-/jieba-linux-arm-gnueabihf-1.10.4.tgz",
+      "integrity": "sha512-crd2M35oJBRLkoESs0O6QO3BBbhpv+tqXuKsqhIG94B1d02RVxtRIvSDwO33QurxqSdvN9IeSnVpHbDGkuXm3g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-gnu/-/jieba-linux-arm64-gnu-1.10.4.tgz",
+      "integrity": "sha512-omIzNX1psUzPcsdnUhGU6oHeOaTCuCjUgOA/v/DGkvWC1jLcnfXe4vdYbtXMh4XOCuIgS1UCcvZEc8vQLXFbXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-musl/-/jieba-linux-arm64-musl-1.10.4.tgz",
+      "integrity": "sha512-Y/tiJ1+HeS5nnmLbZOE+66LbsPOHZ/PUckAYVeLlQfpygLEpLYdlh0aPpS5uiaWMjAXYZYdFkpZHhxDmSLpwpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-x64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-gnu/-/jieba-linux-x64-gnu-1.10.4.tgz",
+      "integrity": "sha512-WZO8ykRJpWGE9MHuZpy1lu3nJluPoeB+fIJJn5CWZ9YTVhNDWoCF4i/7nxz1ntulINYGQ8VVuCU9LD86Mek97g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-x64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-musl/-/jieba-linux-x64-musl-1.10.4.tgz",
+      "integrity": "sha512-uBBD4S1rGKcgCyAk6VCKatEVQb6EDD5I40v/DxODi5CuZVCANi9m5oee/MQbAoaX7RydA2f0OSCE9/tcwXEwUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-wasm32-wasi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-wasm32-wasi/-/jieba-wasm32-wasi-1.10.4.tgz",
+      "integrity": "sha512-Y2umiKHjuIJy0uulNDz9SDYHdfq5Hmy7jY5nORO99B4pySKkcrMjpeVrmWXJLIsEKLJwcCXHxz8tjwU5/uhz0A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-arm64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-arm64-msvc/-/jieba-win32-arm64-msvc-1.10.4.tgz",
+      "integrity": "sha512-nwMtViFm4hjqhz1it/juQnxpXgqlGltCuWJ02bw70YUDMDlbyTy3grCJPpQQpueeETcALUnTxda8pZuVrLRcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-ia32-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-ia32-msvc/-/jieba-win32-ia32-msvc-1.10.4.tgz",
+      "integrity": "sha512-DCAvLx7Z+W4z5oKS+7vUowAJr0uw9JBw8x1Y23Xs/xMA4Em+OOSiaF5/tCJqZUCJ8uC4QeImmgDFiBqGNwxlyA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-x64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-x64-msvc/-/jieba-win32-x64-msvc-1.10.4.tgz",
+      "integrity": "sha512-+sqemSfS1jjb+Tt7InNbNzrRh1Ua3vProVvC4BZRPg010/leCbGFFiQHpzcPRfpxAXZrzG5Y0YBTsPzN/I4yHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -10263,26 +10781,27 @@
       ]
     },
     "node_modules/@rspack/binding": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.3.12.tgz",
-      "integrity": "sha512-4Ic8lV0+LCBfTlH5aIOujIRWZOtgmG223zC4L3o8WY/+ESAgpdnK6lSSMfcYgRanYLAy3HOmFIp20jwskMpbAg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.5.2.tgz",
+      "integrity": "sha512-NKiBcsxmAzFDYRnK2ZHWbTtDFVT5/704eK4OfpgsDXPMkaMnBKijMKNgP5pbe18X4rUlz+8HnGm4+Xllo9EESw==",
       "license": "MIT",
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "1.3.12",
-        "@rspack/binding-darwin-x64": "1.3.12",
-        "@rspack/binding-linux-arm64-gnu": "1.3.12",
-        "@rspack/binding-linux-arm64-musl": "1.3.12",
-        "@rspack/binding-linux-x64-gnu": "1.3.12",
-        "@rspack/binding-linux-x64-musl": "1.3.12",
-        "@rspack/binding-win32-arm64-msvc": "1.3.12",
-        "@rspack/binding-win32-ia32-msvc": "1.3.12",
-        "@rspack/binding-win32-x64-msvc": "1.3.12"
+        "@rspack/binding-darwin-arm64": "1.5.2",
+        "@rspack/binding-darwin-x64": "1.5.2",
+        "@rspack/binding-linux-arm64-gnu": "1.5.2",
+        "@rspack/binding-linux-arm64-musl": "1.5.2",
+        "@rspack/binding-linux-x64-gnu": "1.5.2",
+        "@rspack/binding-linux-x64-musl": "1.5.2",
+        "@rspack/binding-wasm32-wasi": "1.5.2",
+        "@rspack/binding-win32-arm64-msvc": "1.5.2",
+        "@rspack/binding-win32-ia32-msvc": "1.5.2",
+        "@rspack/binding-win32-x64-msvc": "1.5.2"
       }
     },
     "node_modules/@rspack/binding-darwin-arm64": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.3.12.tgz",
-      "integrity": "sha512-8hKjVTBeWPqkMzFPNWIh72oU9O3vFy3e88wRjMPImDCXBiEYrKqGTTLd/J0SO+efdL3SBD1rX1IvdJpxCv6Yrw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-aO76T6VQvAFt1LJNRA5aPOJ+szeTLlzC5wubsnxgWWjG53goP+Te35kFjDIDe+9VhKE/XqRId6iNAymaEsN+Uw==",
       "cpu": [
         "arm64"
       ],
@@ -10293,9 +10812,9 @@
       ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.3.12.tgz",
-      "integrity": "sha512-Sj4m+mCUxL7oCpdu7OmWT7fpBM7hywk5CM9RDc3D7StaBZbvNtNftafCrTZzTYKuZrKmemTh5SFzT5Tz7tf6GA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-XNSmUOwdGs2PEdCKTFCC0/vu/7U9nMhAlbHJKlmdt0V4iPvFyaNWxkNdFqzLc05jlJOfgDdwbwRb91y9IcIIFQ==",
       "cpu": [
         "x64"
       ],
@@ -10306,9 +10825,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.3.12.tgz",
-      "integrity": "sha512-7MuOxf3/Mhv4mgFdLTvgnt/J+VouNR65DEhorth+RZm3LEWojgoFEphSAMAvpvAOpYSS68Sw4SqsOZi719ia2w==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.5.2.tgz",
+      "integrity": "sha512-rNxRfgC5khlrhyEP6y93+45uQ4TI7CdtWqh5PKsaR6lPepG1rH4L8VE+etejSdhzXH6wQ76Rw4wzb96Hx+5vuQ==",
       "cpu": [
         "arm64"
       ],
@@ -10319,9 +10838,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.3.12.tgz",
-      "integrity": "sha512-s6KKj20T9Z1bA8caIjU6EzJbwyDo1URNFgBAlafCT2UC6yX7flstDJJ38CxZacA9A2P24RuQK2/jPSZpWrTUFA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.5.2.tgz",
+      "integrity": "sha512-kTFX+KsGgArWC5q+jJWz0K/8rfVqZOn1ojv1xpCCcz/ogWRC/qhDGSOva6Wandh157BiR93Vfoe1gMvgjpLe5g==",
       "cpu": [
         "arm64"
       ],
@@ -10332,9 +10851,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.3.12.tgz",
-      "integrity": "sha512-0w/sRREYbRgHgWvs2uMEJSLfvzbZkPHUg6CMcYQGNVK6axYRot6jPyKetyFYA9pR5fB5rsXegpnFaZaVrRIK2g==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.5.2.tgz",
+      "integrity": "sha512-Lh/6WZGq30lDV6RteQQu7Phw0RH2Z1f4kGR+MsplJ6X4JpnziDow+9oxKdu6FvFHWxHByncpveVeInusQPmL7Q==",
       "cpu": [
         "x64"
       ],
@@ -10345,9 +10864,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.3.12.tgz",
-      "integrity": "sha512-jEdxkPymkRxbijDRsBGdhopcbGXiXDg59lXqIRkVklqbDmZ/O6DHm7gImmlx5q9FoWbz0gqJuOKBz4JqWxjWVA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.5.2.tgz",
+      "integrity": "sha512-CsLC/SIOIFs6CBmusSAF0FECB62+J36alMdwl7j6TgN6nX3UQQapnL1aVWuQaxU6un/1Vpim0V/EZbUYIdJQ4g==",
       "cpu": [
         "x64"
       ],
@@ -10357,10 +10876,35 @@
         "linux"
       ]
     },
+    "node_modules/@rspack/binding-wasm32-wasi": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.5.2.tgz",
+      "integrity": "sha512-cuVbGr1b4q0Z6AtEraI3becZraPMMgZtZPRaIsVLeDXCmxup/maSAR3T6UaGf4Q2SNcFfjw4neGz5UJxPK8uvA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.0.1"
+      }
+    },
+    "node_modules/@rspack/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.3.tgz",
+      "integrity": "sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.5",
+        "@emnapi/runtime": "^1.4.5",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.3.12.tgz",
-      "integrity": "sha512-ZRvUCb3TDLClAqcTsl/o9UdJf0B5CgzAxgdbnYJbldyuyMeTUB4jp20OfG55M3C2Nute2SNhu2bOOp9Se5Ongw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.5.2.tgz",
+      "integrity": "sha512-4vJQdzRTSuvmvL3vrOPuiA7f9v9frNc2RFWDxqg+GYt0YAjDStssp+lkVbRYyXnTYVJkARSuO6N+BOiI+kLdsQ==",
       "cpu": [
         "arm64"
       ],
@@ -10371,9 +10915,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.3.12.tgz",
-      "integrity": "sha512-1TKPjuXStPJr14f3ZHuv40Xc/87jUXx10pzVtrPnw+f3hckECHrbYU/fvbVzZyuXbsXtkXpYca6ygCDRJAoNeQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.5.2.tgz",
+      "integrity": "sha512-zPbu3lx/NrNxdjZzTIjwD0mILUOpfhuPdUdXIFiOAO8RiWSeQpYOvyI061s/+bNOmr4A+Z0uM0dEoOClfkhUFg==",
       "cpu": [
         "ia32"
       ],
@@ -10384,9 +10928,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.3.12.tgz",
-      "integrity": "sha512-lCR0JfnYKpV+a6r2A2FdxyUKUS4tajePgpPJN5uXDgMGwrDtRqvx+d0BHhwjFudQVJq9VVbRaL89s2MQ6u+xYw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.5.2.tgz",
+      "integrity": "sha512-duLNUTshX38xhC10/W9tpkPca7rOifP2begZjdb1ikw7C4AI0I7VnBnYt8qPSxGISoclmhOBxU/LuAhS8jMMlg==",
       "cpu": [
         "x64"
       ],
@@ -10397,18 +10941,17 @@
       ]
     },
     "node_modules/@rspack/core": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.3.12.tgz",
-      "integrity": "sha512-mAPmV4LPPRgxpouUrGmAE4kpF1NEWJGyM5coebsjK/zaCMSjw3mkdxiU2b5cO44oIi0Ifv5iGkvwbdrZOvMyFA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-ifjHqLczC81d1xjXPXCzxTFKNOFsEzuuLN44cMnyzQ/GWi4B48fyX7JHndWE7Lxd54cW1O9Ik7AdBN3Gq891EA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime-tools": "0.14.0",
-        "@rspack/binding": "1.3.12",
-        "@rspack/lite-tapable": "1.0.1",
-        "caniuse-lite": "^1.0.30001718"
+        "@module-federation/runtime-tools": "0.18.0",
+        "@rspack/binding": "1.5.2",
+        "@rspack/lite-tapable": "1.0.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.12.0"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.1"
@@ -11396,6 +11939,16 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+      "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
@@ -13718,33 +14271,34 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.25.0.tgz",
-      "integrity": "sha512-n73BVorL4HIwKlfJKb4SEzAYkR3Buwfwbh+MYxg2mloFph2fFGV58E90QTzdbfzWrLn4HE5Czx/WTjI8fcHaMg==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.37.0.tgz",
+      "integrity": "sha512-y7gau/ZOQDqoInTQp0IwTOjkrHc4Aq4R8JgpmCleFwiLl+PbN2DMWoDUWZnrK8AhNJwT++dn28Bt4NZYNLAmuA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-abtesting": "5.25.0",
-        "@algolia/client-analytics": "5.25.0",
-        "@algolia/client-common": "5.25.0",
-        "@algolia/client-insights": "5.25.0",
-        "@algolia/client-personalization": "5.25.0",
-        "@algolia/client-query-suggestions": "5.25.0",
-        "@algolia/client-search": "5.25.0",
-        "@algolia/ingestion": "1.25.0",
-        "@algolia/monitoring": "1.25.0",
-        "@algolia/recommend": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/abtesting": "1.3.0",
+        "@algolia/client-abtesting": "5.37.0",
+        "@algolia/client-analytics": "5.37.0",
+        "@algolia/client-common": "5.37.0",
+        "@algolia/client-insights": "5.37.0",
+        "@algolia/client-personalization": "5.37.0",
+        "@algolia/client-query-suggestions": "5.37.0",
+        "@algolia/client-search": "5.37.0",
+        "@algolia/ingestion": "1.37.0",
+        "@algolia/monitoring": "1.37.0",
+        "@algolia/recommend": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.25.0.tgz",
-      "integrity": "sha512-vQoK43U6HXA9/euCqLjvyNdM4G2Fiu/VFp4ae0Gau9sZeIKBPvUPnXfLYAe65Bg7PFuw03coeu5K6lTPSXRObw==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.26.0.tgz",
+      "integrity": "sha512-Rv2x3GXleQ3ygwhkhJubhhYGsICmShLAiqtUuJTUkr9uOCOXyF2E71LVT4XDnVffbknv8XgScP4U0Oxtgm+hIw==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1"
@@ -14402,13 +14956,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
-      "integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+      "integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.4",
+        "@babel/compat-data": "^7.27.7",
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -14425,25 +14979,25 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
-      "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
+      "integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.3",
-        "core-js-compat": "^3.40.0"
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
+        "core-js-compat": "^3.43.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
-      "integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+      "integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.4"
+        "@babel/helper-define-polyfill-provider": "^0.6.5"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -14877,9 +15431,9 @@
       "integrity": "sha512-LSvVX5e21LRrXqVMhqtAwj5xPgDb+fXAIH80NsnCQ9xuZPs2xWsOREi24RKgZa1XOiQRbcmVrv87+ulOKsgjxw=="
     },
     "node_modules/browserslist": {
-      "version": "4.24.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+      "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
+      "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -14896,8 +15450,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001716",
-        "electron-to-chromium": "^1.5.149",
+        "caniuse-lite": "^1.0.30001737",
+        "electron-to-chromium": "^1.5.211",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -15214,9 +15768,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001741",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+      "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -15786,9 +16340,10 @@
       }
     },
     "node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -15893,6 +16448,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -16303,9 +16864,9 @@
       "license": "MIT"
     },
     "node_modules/copy-text-to-clipboard": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz",
-      "integrity": "sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.1.tgz",
+      "integrity": "sha512-3am6cw+WOicd0+HyzhC4kYS02wHJUiVQXmAADxfUARKsHBkWl1Vl3QQEiILlSs8YcPS/C0+y/urCNEYQk+byWA==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -16400,12 +16961,12 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.42.0.tgz",
-      "integrity": "sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==",
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.1.tgz",
+      "integrity": "sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.4"
+        "browserslist": "^4.25.3"
       },
       "funding": {
         "type": "opencollective",
@@ -16413,9 +16974,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.42.0.tgz",
-      "integrity": "sha512-007bM04u91fF4kMgwom2I5cQxAFIy8jVulgr9eozILl/SZE53QOqnW/+vviC+wQWLv+AunBG+8Q0TLoeSsSxRQ==",
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.1.tgz",
+      "integrity": "sha512-OHnWFKgTUshEU8MK+lOs1H8kC8GkTi9Z1tvNkxrCcw9wl3MJIO7q2ld77wjWn4/xuGrVu2X+nME1iIIPBSdyEQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -16706,9 +17267,9 @@
       }
     },
     "node_modules/css-has-pseudo": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-7.0.2.tgz",
-      "integrity": "sha512-nzol/h+E0bId46Kn2dQH5VElaknX2Sr0hFuB/1EomdC7j+OISt2ZzK7EHX9DZDY53WbIVAR7FYKSO2XnSf07MQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-7.0.3.tgz",
+      "integrity": "sha512-oG+vKuGyqe/xvEMoxAQrhi7uY16deJR3i7wwhBerVrGQKSqUC5GiOVxTpM9F9B9hw0J+eKeOWLH7E9gZ1Dr5rA==",
       "funding": [
         {
           "type": "github",
@@ -16891,9 +17452,9 @@
       }
     },
     "node_modules/cssdb": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.3.0.tgz",
-      "integrity": "sha512-c7bmItIg38DgGjSwDPZOYF/2o0QU/sSgkWOMyl8votOfgFuyiFKWPesmCGEsrGLxEA9uL540cp8LdaGEjUGsZQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.4.0.tgz",
+      "integrity": "sha512-lyATYGyvXwQ8h55WeQeEHXhI+47rl52pXSYkFK/ZrCbAJSgVIaPFjYc3RM8TpRHKk7W3wsAZImmLps+P5VyN9g==",
       "funding": [
         {
           "type": "opencollective",
@@ -20227,9 +20788,10 @@
       "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -20314,9 +20876,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.159",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.159.tgz",
-      "integrity": "sha512-CEvHptWAMV5p6GJ0Lq8aheyvVbfzVrv5mmidu1D3pidoVNkB3tTBsTMVtPJ+rzRK5oV229mCLz9Zj/hNvU8GBA==",
+      "version": "1.5.215",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.215.tgz",
+      "integrity": "sha512-TIvGp57UpeNetj/wV/xpFNpWGb0b/ROw372lHPx5Aafx02gjTBtWnEEcaSX3W2dLM3OSdGGyHX/cHl01JQsLaQ==",
       "license": "ISC"
     },
     "node_modules/elkjs": {
@@ -20389,6 +20951,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
     "node_modules/end-of-stream": {
@@ -20868,23 +21443,6 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -23530,14 +24088,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -25116,11 +25666,15 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -28004,6 +28558,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -29140,6 +29703,12 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "license": "MIT"
     },
     "node_modules/markdown-extensions": {
       "version": "2.0.0",
@@ -32177,9 +32746,9 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.2.tgz",
-      "integrity": "sha512-GJuACcS//jtq4kCtd5ii/M0SZf7OZRH+BxdqXZHaJfb8TJiVl+NgQRPwiYt2EuqeSkNydn/7vP+bcE27C5mb9w==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
+      "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
       "license": "MIT",
       "dependencies": {
         "schema-utils": "^4.0.0",
@@ -32471,15 +33040,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -33725,11 +34295,12 @@
       "license": "ISC"
     },
     "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -33746,6 +34317,30 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -34106,9 +34701,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "funding": [
         {
           "type": "opencollective",
@@ -34123,10 +34718,11 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -34202,9 +34798,9 @@
       }
     },
     "node_modules/postcss-color-functional-notation": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-7.0.10.tgz",
-      "integrity": "sha512-k9qX+aXHBiLTRrWoCJuUFI6F1iF6QJQUXNVWJVSbqZgj57jDhBlOvD8gNUGl35tgqDivbGLhZeW3Ongz4feuKA==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-7.0.11.tgz",
+      "integrity": "sha512-zfqoUSaHMko/k2PA9xnaydVTHqYv5vphq5Q2AHcG/dCdv/OkHYWcVWfVTBKZ526uzT8L7NghuvSw3C9PxlKnLg==",
       "funding": [
         {
           "type": "github",
@@ -34217,10 +34813,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -34345,9 +34941,9 @@
       }
     },
     "node_modules/postcss-custom-properties": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-14.0.5.tgz",
-      "integrity": "sha512-UWf/vhMapZatv+zOuqlfLmYXeOhhHLh8U8HAKGI2VJ00xLRYoAJh4xv8iX6FB6+TLXeDnm0DBLMi00E0hodbQw==",
+      "version": "14.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-14.0.6.tgz",
+      "integrity": "sha512-fTYSp3xuk4BUeVhxCSJdIPhDLpJfNakZKoiTDx7yRGCdlZrSJR7mWKVOBS4sBF+5poPQFMj2YdXx1VHItBGihQ==",
       "funding": [
         {
           "type": "github",
@@ -34516,9 +35112,9 @@
       }
     },
     "node_modules/postcss-double-position-gradients": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-6.0.2.tgz",
-      "integrity": "sha512-7qTqnL7nfLRyJK/AHSVrrXOuvDDzettC+wGoienURV8v2svNbu6zJC52ruZtHaO6mfcagFmuTGFdzRsJKB3k5Q==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-6.0.3.tgz",
+      "integrity": "sha512-Dl0Z9sdbMwrPslgOaGBZRGo3TASmmgTcqcUODr82MTYyJk6devXZM6MlQjpQKMJqlLJ6oL1w78U7IXFdPA5+ug==",
       "funding": [
         {
           "type": "github",
@@ -34531,7 +35127,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0",
         "postcss-value-parser": "^4.2.0"
       },
@@ -34712,9 +35308,9 @@
       }
     },
     "node_modules/postcss-lab-function": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-7.0.10.tgz",
-      "integrity": "sha512-tqs6TCEv9tC1Riq6fOzHuHcZyhg4k3gIAMB8GGY/zA1ssGdm6puHMVE7t75aOSoFg7UD2wyrFFhbldiCMyyFTQ==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-7.0.11.tgz",
+      "integrity": "sha512-BEA4jId8uQe1gyjZZ6Bunb6ZsH2izks+v25AxQJDBtigXCjTLmCPWECwQpLTtcxH589MVxhs/9TAmRC6lUEmXQ==",
       "funding": [
         {
           "type": "github",
@@ -34727,10 +35323,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -35088,9 +35684,9 @@
       }
     },
     "node_modules/postcss-nesting": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.1.tgz",
-      "integrity": "sha512-VbqqHkOBOt4Uu3G8Dm8n6lU5+9cJFxiuty9+4rcoyRPO9zZS1JIs6td49VIoix3qYqELHlJIn46Oih9SAKo+yQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.2.tgz",
+      "integrity": "sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==",
       "funding": [
         {
           "type": "github",
@@ -35103,7 +35699,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/selector-resolve-nested": "^3.0.0",
+        "@csstools/selector-resolve-nested": "^3.1.0",
         "@csstools/selector-specificity": "^5.0.0",
         "postcss-selector-parser": "^7.0.0"
       },
@@ -35358,9 +35954,9 @@
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.2.0.tgz",
-      "integrity": "sha512-cl13sPBbSqo1Q7Ryb19oT5NZO5IHFolRbIMdgDq4f9w1MHYiL6uZS7uSsjXJ1KzRIcX5BMjEeyxmAevVXENa3Q==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.3.1.tgz",
+      "integrity": "sha512-8ZOOWVwQ0iMpfEYkYo+U6W7fE2dJ/tP6dtEFwPJ66eB5JjnFupfYh+y6zo+vWDO72nGhKOVdxwhTjfzcSNRg4Q==",
       "funding": [
         {
           "type": "github",
@@ -35373,20 +35969,22 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/postcss-cascade-layers": "^5.0.1",
-        "@csstools/postcss-color-function": "^4.0.10",
-        "@csstools/postcss-color-mix-function": "^3.0.10",
-        "@csstools/postcss-color-mix-variadic-function-arguments": "^1.0.0",
-        "@csstools/postcss-content-alt-text": "^2.0.6",
+        "@csstools/postcss-alpha-function": "^1.0.0",
+        "@csstools/postcss-cascade-layers": "^5.0.2",
+        "@csstools/postcss-color-function": "^4.0.11",
+        "@csstools/postcss-color-function-display-p3-linear": "^1.0.0",
+        "@csstools/postcss-color-mix-function": "^3.0.11",
+        "@csstools/postcss-color-mix-variadic-function-arguments": "^1.0.1",
+        "@csstools/postcss-content-alt-text": "^2.0.7",
         "@csstools/postcss-exponential-functions": "^2.0.9",
         "@csstools/postcss-font-format-keywords": "^4.0.0",
-        "@csstools/postcss-gamut-mapping": "^2.0.10",
-        "@csstools/postcss-gradients-interpolation-method": "^5.0.10",
-        "@csstools/postcss-hwb-function": "^4.0.10",
-        "@csstools/postcss-ic-unit": "^4.0.2",
+        "@csstools/postcss-gamut-mapping": "^2.0.11",
+        "@csstools/postcss-gradients-interpolation-method": "^5.0.11",
+        "@csstools/postcss-hwb-function": "^4.0.11",
+        "@csstools/postcss-ic-unit": "^4.0.3",
         "@csstools/postcss-initial": "^2.0.1",
-        "@csstools/postcss-is-pseudo-class": "^5.0.1",
-        "@csstools/postcss-light-dark-function": "^2.0.9",
+        "@csstools/postcss-is-pseudo-class": "^5.0.3",
+        "@csstools/postcss-light-dark-function": "^2.0.10",
         "@csstools/postcss-logical-float-and-clear": "^3.0.0",
         "@csstools/postcss-logical-overflow": "^2.0.0",
         "@csstools/postcss-logical-overscroll-behavior": "^2.0.0",
@@ -35396,40 +35994,40 @@
         "@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.5",
         "@csstools/postcss-nested-calc": "^4.0.0",
         "@csstools/postcss-normalize-display-values": "^4.0.0",
-        "@csstools/postcss-oklab-function": "^4.0.10",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-oklab-function": "^4.0.11",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/postcss-random-function": "^2.0.1",
-        "@csstools/postcss-relative-color-syntax": "^3.0.10",
+        "@csstools/postcss-relative-color-syntax": "^3.0.11",
         "@csstools/postcss-scope-pseudo-class": "^4.0.1",
         "@csstools/postcss-sign-functions": "^1.1.4",
         "@csstools/postcss-stepped-value-functions": "^4.0.9",
-        "@csstools/postcss-text-decoration-shorthand": "^4.0.2",
+        "@csstools/postcss-text-decoration-shorthand": "^4.0.3",
         "@csstools/postcss-trigonometric-functions": "^4.0.9",
         "@csstools/postcss-unset-value": "^4.0.0",
         "autoprefixer": "^10.4.21",
-        "browserslist": "^4.24.5",
+        "browserslist": "^4.25.1",
         "css-blank-pseudo": "^7.0.1",
-        "css-has-pseudo": "^7.0.2",
+        "css-has-pseudo": "^7.0.3",
         "css-prefers-color-scheme": "^10.0.0",
-        "cssdb": "^8.3.0",
+        "cssdb": "^8.4.0",
         "postcss-attribute-case-insensitive": "^7.0.1",
         "postcss-clamp": "^4.1.0",
-        "postcss-color-functional-notation": "^7.0.10",
+        "postcss-color-functional-notation": "^7.0.11",
         "postcss-color-hex-alpha": "^10.0.0",
         "postcss-color-rebeccapurple": "^10.0.0",
         "postcss-custom-media": "^11.0.6",
-        "postcss-custom-properties": "^14.0.5",
+        "postcss-custom-properties": "^14.0.6",
         "postcss-custom-selectors": "^8.0.5",
         "postcss-dir-pseudo-class": "^9.0.1",
-        "postcss-double-position-gradients": "^6.0.2",
+        "postcss-double-position-gradients": "^6.0.3",
         "postcss-focus-visible": "^10.0.1",
         "postcss-focus-within": "^9.0.1",
         "postcss-font-variant": "^5.0.0",
         "postcss-gap-properties": "^6.0.0",
         "postcss-image-set-function": "^7.0.0",
-        "postcss-lab-function": "^7.0.10",
+        "postcss-lab-function": "^7.0.11",
         "postcss-logical": "^8.1.0",
-        "postcss-nesting": "^13.0.1",
+        "postcss-nesting": "^13.0.2",
         "postcss-opacity-percentage": "^3.0.0",
         "postcss-overflow-shorthand": "^6.0.0",
         "postcss-page-break": "^3.0.4",
@@ -36664,9 +37262,9 @@
       "dev": true
     },
     "node_modules/react-json-view-lite": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.4.1.tgz",
-      "integrity": "sha512-fwFYknRIBxjbFm0kBDrzgBy1xa5tDg2LyXXBepC5f1b+MY3BUClMCsvanMPn089JbV1Eg3nZcrp0VCuH43aXnA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.5.0.tgz",
+      "integrity": "sha512-tk7o7QG9oYyELWHL8xiMQ8x4WzjCzbWNyig3uexmkLb54r8jO0yH3WCWx8UZS0c49eSA4QUmG5caiRJ8fAn58g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -37755,16 +38353,20 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -39006,9 +39608,10 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -40883,6 +41486,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.15.0.tgz",
+      "integrity": "sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unescape": {
@@ -42871,7 +43483,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "dev": true,
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
@@ -42883,7 +43494,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       }
@@ -44547,12 +45157,12 @@
       "name": "@lexical/website",
       "version": "0.35.0",
       "dependencies": {
-        "@docusaurus/core": "^3.8.0",
-        "@docusaurus/faster": "^3.8.0",
-        "@docusaurus/plugin-client-redirects": "^3.8.0",
-        "@docusaurus/preset-classic": "^3.8.0",
-        "@docusaurus/theme-mermaid": "^3.8.0",
-        "@docusaurus/theme-search-algolia": "^3.8.0",
+        "@docusaurus/core": "^3.8.1",
+        "@docusaurus/faster": "^3.8.1",
+        "@docusaurus/plugin-client-redirects": "^3.8.1",
+        "@docusaurus/preset-classic": "^3.8.1",
+        "@docusaurus/theme-mermaid": "^3.8.1",
+        "@easyops-cn/docusaurus-search-local": "^0.52.1",
         "@mdx-js/react": "^3.0.1",
         "@radix-ui/react-tabs": "^1.0.4",
         "@vercel/analytics": "^1.0.1",
@@ -44764,6 +45374,17 @@
         }
       }
     },
+    "@algolia/abtesting": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.3.0.tgz",
+      "integrity": "sha512-KqPVLdVNfoJzX5BKNGM9bsW8saHeyax8kmPFXul5gejrSPN3qss7PgsFH5mMem7oR8tvjvNkia97ljEYPYCN8Q==",
+      "requires": {
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
+      }
+    },
     "@algolia/autocomplete-core": {
       "version": "1.17.9",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.9.tgz",
@@ -44795,74 +45416,74 @@
       "integrity": "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ=="
     },
     "@algolia/client-abtesting": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.25.0.tgz",
-      "integrity": "sha512-1pfQulNUYNf1Tk/svbfjfkLBS36zsuph6m+B6gDkPEivFmso/XnRgwDvjAx80WNtiHnmeNjIXdF7Gos8+OLHqQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.37.0.tgz",
+      "integrity": "sha512-Dp2Zq+x9qQFnuiQhVe91EeaaPxWBhzwQ6QnznZQnH9C1/ei3dvtmAFfFeaTxM6FzfJXDLvVnaQagTYFTQz3R5g==",
       "requires": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       }
     },
     "@algolia/client-analytics": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.25.0.tgz",
-      "integrity": "sha512-AFbG6VDJX/o2vDd9hqncj1B6B4Tulk61mY0pzTtzKClyTDlNP0xaUiEKhl6E7KO9I/x0FJF5tDCm0Hn6v5x18A==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.37.0.tgz",
+      "integrity": "sha512-wyXODDOluKogTuZxRII6mtqhAq4+qUR3zIUJEKTiHLe8HMZFxfUEI4NO2qSu04noXZHbv/sRVdQQqzKh12SZuQ==",
       "requires": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       }
     },
     "@algolia/client-common": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.25.0.tgz",
-      "integrity": "sha512-il1zS/+Rc6la6RaCdSZ2YbJnkQC6W1wiBO8+SH+DE6CPMWBU6iDVzH0sCKSAtMWl9WBxoN6MhNjGBnCv9Yy2bA=="
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.37.0.tgz",
+      "integrity": "sha512-GylIFlPvLy9OMgFG8JkonIagv3zF+Dx3H401Uo2KpmfMVBBJiGfAb9oYfXtplpRMZnZPxF5FnkWaI/NpVJMC+g=="
     },
     "@algolia/client-insights": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.25.0.tgz",
-      "integrity": "sha512-blbjrUH1siZNfyCGeq0iLQu00w3a4fBXm0WRIM0V8alcAPo7rWjLbMJMrfBtzL9X5ic6wgxVpDADXduGtdrnkw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.37.0.tgz",
+      "integrity": "sha512-T63afO2O69XHKw2+F7mfRoIbmXWGzgpZxgOFAdP3fR4laid7pWBt20P4eJ+Zn23wXS5kC9P2K7Bo3+rVjqnYiw==",
       "requires": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       }
     },
     "@algolia/client-personalization": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.25.0.tgz",
-      "integrity": "sha512-aywoEuu1NxChBcHZ1pWaat0Plw7A8jDMwjgRJ00Mcl7wGlwuPt5dJ/LTNcg3McsEUbs2MBNmw0ignXBw9Tbgow==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.37.0.tgz",
+      "integrity": "sha512-1zOIXM98O9zD8bYDCJiUJRC/qNUydGHK/zRK+WbLXrW1SqLFRXECsKZa5KoG166+o5q5upk96qguOtE8FTXDWQ==",
       "requires": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       }
     },
     "@algolia/client-query-suggestions": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.25.0.tgz",
-      "integrity": "sha512-a/W2z6XWKjKjIW1QQQV8PTTj1TXtaKx79uR3NGBdBdGvVdt24KzGAaN7sCr5oP8DW4D3cJt44wp2OY/fZcPAVA==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.37.0.tgz",
+      "integrity": "sha512-31Nr2xOLBCYVal+OMZn1rp1H4lPs1914Tfr3a34wU/nsWJ+TB3vWjfkUUuuYhWoWBEArwuRzt3YNLn0F/KRVkg==",
       "requires": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       }
     },
     "@algolia/client-search": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.25.0.tgz",
-      "integrity": "sha512-9rUYcMIBOrCtYiLX49djyzxqdK9Dya/6Z/8sebPn94BekT+KLOpaZCuc6s0Fpfq7nx5J6YY5LIVFQrtioK9u0g==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.37.0.tgz",
+      "integrity": "sha512-DAFVUvEg+u7jUs6BZiVz9zdaUebYULPiQ4LM2R4n8Nujzyj7BZzGr2DCd85ip4p/cx7nAZWKM8pLcGtkTRTdsg==",
       "requires": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       }
     },
     "@algolia/events": {
@@ -44871,60 +45492,60 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "@algolia/ingestion": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.25.0.tgz",
-      "integrity": "sha512-jJeH/Hk+k17Vkokf02lkfYE4A+EJX+UgnMhTLR/Mb+d1ya5WhE+po8p5a/Nxb6lo9OLCRl6w3Hmk1TX1e9gVbQ==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.37.0.tgz",
+      "integrity": "sha512-pkCepBRRdcdd7dTLbFddnu886NyyxmhgqiRcHHaDunvX03Ij4WzvouWrQq7B7iYBjkMQrLS8wQqSP0REfA4W8g==",
       "requires": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       }
     },
     "@algolia/monitoring": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.25.0.tgz",
-      "integrity": "sha512-Ls3i1AehJ0C6xaHe7kK9vPmzImOn5zBg7Kzj8tRYIcmCWVyuuFwCIsbuIIz/qzUf1FPSWmw0TZrGeTumk2fqXg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.37.0.tgz",
+      "integrity": "sha512-fNw7pVdyZAAQQCJf1cc/ih4fwrRdQSgKwgor4gchsI/Q/ss9inmC6bl/69jvoRSzgZS9BX4elwHKdo0EfTli3w==",
       "requires": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       }
     },
     "@algolia/recommend": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.25.0.tgz",
-      "integrity": "sha512-79sMdHpiRLXVxSjgw7Pt4R1aNUHxFLHiaTDnN2MQjHwJ1+o3wSseb55T9VXU4kqy3m7TUme3pyRhLk5ip/S4Mw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.37.0.tgz",
+      "integrity": "sha512-U+FL5gzN2ldx3TYfQO5OAta2TBuIdabEdFwD5UVfWPsZE5nvOKkc/6BBqP54Z/adW/34c5ZrvvZhlhNTZujJXQ==",
       "requires": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.25.0.tgz",
-      "integrity": "sha512-JLaF23p1SOPBmfEqozUAgKHQrGl3z/Z5RHbggBu6s07QqXXcazEsub5VLonCxGVqTv6a61AAPr8J1G5HgGGjEw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.37.0.tgz",
+      "integrity": "sha512-Ao8GZo8WgWFABrU7iq+JAftXV0t+UcOtCDL4mzHHZ+rQeTTf1TZssr4d0vIuoqkVNnKt9iyZ7T4lQff4ydcTrw==",
       "requires": {
-        "@algolia/client-common": "5.25.0"
+        "@algolia/client-common": "5.37.0"
       }
     },
     "@algolia/requester-fetch": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.25.0.tgz",
-      "integrity": "sha512-rtzXwqzFi1edkOF6sXxq+HhmRKDy7tz84u0o5t1fXwz0cwx+cjpmxu/6OQKTdOJFS92JUYHsG51Iunie7xbqfQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.37.0.tgz",
+      "integrity": "sha512-H7OJOXrFg5dLcGJ22uxx8eiFId0aB9b0UBhoOi4SMSuDBe6vjJJ/LeZyY25zPaSvkXNBN3vAM+ad6M0h6ha3AA==",
       "requires": {
-        "@algolia/client-common": "5.25.0"
+        "@algolia/client-common": "5.37.0"
       }
     },
     "@algolia/requester-node-http": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.25.0.tgz",
-      "integrity": "sha512-ZO0UKvDyEFvyeJQX0gmZDQEvhLZ2X10K+ps6hViMo1HgE2V8em00SwNsQ+7E/52a+YiBkVWX61pJJJE44juDMQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.37.0.tgz",
+      "integrity": "sha512-npZ9aeag4SGTx677eqPL3rkSPlQrnzx/8wNrl1P7GpWq9w/eTmRbOq+wKrJ2r78idlY0MMgmY/mld2tq6dc44g==",
       "requires": {
-        "@algolia/client-common": "5.25.0"
+        "@algolia/client-common": "5.37.0"
       }
     },
     "@alloc/quick-lru": {
@@ -44958,9 +45579,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.3.tgz",
-      "integrity": "sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw=="
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw=="
     },
     "@babel/core": {
       "version": "7.26.0",
@@ -45040,14 +45661,14 @@
       }
     },
     "@babel/generator": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.3.tgz",
-      "integrity": "sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
       "requires": {
-        "@babel/parser": "^7.27.3",
-        "@babel/types": "^7.27.3",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       }
     },
@@ -45092,16 +45713,16 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
+      "integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-member-expression-to-functions": "^7.27.1",
         "@babel/helper-optimise-call-expression": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
+        "@babel/traverse": "^7.28.3",
         "semver": "^6.3.1"
       },
       "dependencies": {
@@ -45130,16 +45751,36 @@
       }
     },
     "@babel/helper-define-polyfill-provider": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
-      "integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+      "integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
       "requires": {
-        "@babel/helper-compilation-targets": "^7.22.6",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "debug": "^4.1.1",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "debug": "^4.4.1",
         "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2"
+        "resolve": "^1.22.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+          "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
       }
+    },
+    "@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="
     },
     "@babel/helper-member-expression-to-functions": {
       "version": "7.27.1",
@@ -45227,13 +45868,13 @@
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="
     },
     "@babel/helper-wrap-function": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
-      "integrity": "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
+      "integrity": "sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==",
       "requires": {
-        "@babel/template": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.3",
+        "@babel/types": "^7.28.2"
       }
     },
     "@babel/helpers": {
@@ -45258,11 +45899,11 @@
       }
     },
     "@babel/parser": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.3.tgz",
-      "integrity": "sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "requires": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.28.4"
       }
     },
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
@@ -45301,12 +45942,12 @@
       }
     },
     "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz",
-      "integrity": "sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz",
+      "integrity": "sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/traverse": "^7.28.3"
       }
     },
     "@babel/plugin-proposal-private-property-in-object": {
@@ -45489,13 +46130,13 @@
       }
     },
     "@babel/plugin-transform-async-generator-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz",
-      "integrity": "sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
+      "integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-remap-async-to-generator": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/traverse": "^7.28.0"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
@@ -45517,9 +46158,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.3.tgz",
-      "integrity": "sha512-+F8CnfhuLhwUACIJMLWnjz6zvzYM2r0yeIHKlbgfw7ml8rOMJsXNXV/hyRcb3nb493gRs4WvYpQAndWj/qQmkQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.4.tgz",
+      "integrity": "sha512-1yxmvN0MJHOhPVmAsmoW5liWwoILobu/d/ShymZmj867bAdxGbehIrew1DuLpw2Ukv+qDSSPQdYW1dLNE7t11A==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.27.1"
       }
@@ -45534,25 +46175,25 @@
       }
     },
     "@babel/plugin-transform-class-static-block": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
-      "integrity": "sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
+      "integrity": "sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.28.3",
         "@babel/helper-plugin-utils": "^7.27.1"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.1.tgz",
-      "integrity": "sha512-7iLhfFAubmpeJe/Wo2TVuDrykh/zlWXLzPNdL0Jqn/Xu8R3QQ8h9ff8FQoISZOsw74/HFqFI7NX63HN7QFIHKA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.4.tgz",
+      "integrity": "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-globals": "^7.28.0",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "globals": "^11.1.0"
+        "@babel/traverse": "^7.28.4"
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -45565,11 +46206,12 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.3.tgz",
-      "integrity": "sha512-s4Jrok82JpiaIprtY2nHsYmrThKvvwgHwjgd7UMiYhZaN0asdXNLr0y+NjTfkA7SyQE5i2Fb7eawUOZmLvyqOA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz",
+      "integrity": "sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -45604,6 +46246,15 @@
       "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.27.1"
+      }
+    },
+    "@babel/plugin-transform-explicit-resource-management": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
+      "integrity": "sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.28.0"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
@@ -45755,14 +46406,15 @@
       }
     },
     "@babel/plugin-transform-object-rest-spread": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.3.tgz",
-      "integrity": "sha512-7ZZtznF9g4l2JCImCo5LNKFHB5eXnN39lLtLY5Tg+VkR0jwOt7TBciMckuiQIOIW7L5tkQOCh3bVGYeXgMx52Q==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.4.tgz",
+      "integrity": "sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==",
       "requires": {
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.27.3",
-        "@babel/plugin-transform-parameters": "^7.27.1"
+        "@babel/plugin-transform-destructuring": "^7.28.0",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/traverse": "^7.28.4"
       }
     },
     "@babel/plugin-transform-object-super": {
@@ -45792,9 +46444,9 @@
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz",
-      "integrity": "sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.27.1"
       }
@@ -45890,9 +46542,9 @@
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.1.tgz",
-      "integrity": "sha512-B19lbbL7PMrKr52BNPjCqg1IyNUIjTcxKj8uX9zHO+PmWN93s19NDr/f69mIkEp2x9nmDJ08a7lgHaTTzvW7mw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.4.tgz",
+      "integrity": "sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.27.1"
       }
@@ -45915,15 +46567,15 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.3.tgz",
-      "integrity": "sha512-bA9ZL5PW90YwNgGfjg6U+7Qh/k3zCEQJ06BFgAGRp/yMjw9hP9UGbGPtx3KSOkHGljEPCCxaE+PH4fUR2h1sDw==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz",
+      "integrity": "sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==",
       "requires": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1",
-        "babel-plugin-polyfill-corejs2": "^0.4.10",
-        "babel-plugin-polyfill-corejs3": "^0.11.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.1",
+        "babel-plugin-polyfill-corejs2": "^0.4.14",
+        "babel-plugin-polyfill-corejs3": "^0.13.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.5",
         "semver": "^6.3.1"
       },
       "dependencies": {
@@ -46023,11 +46675,11 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.27.2.tgz",
-      "integrity": "sha512-Ma4zSuYSlGNRlCLO+EAzLnCmJK2vdstgv+n7aUP+/IKZrOfWHOJVdSJtuub8RzHTj3ahD37k5OKJWvzf16TQyQ==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.3.tgz",
+      "integrity": "sha512-ROiDcM+GbYVPYBOeCR6uBXKkQpBExLl8k9HO1ygXEyds39j+vCCsjmj7S8GOniZQlEs81QlkdJZe76IpLSiqpg==",
       "requires": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/compat-data": "^7.28.0",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-validator-option": "^7.27.1",
@@ -46035,25 +46687,26 @@
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.3",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
         "@babel/plugin-syntax-import-assertions": "^7.27.1",
         "@babel/plugin-syntax-import-attributes": "^7.27.1",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-async-generator-functions": "^7.27.1",
+        "@babel/plugin-transform-async-generator-functions": "^7.28.0",
         "@babel/plugin-transform-async-to-generator": "^7.27.1",
         "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-        "@babel/plugin-transform-block-scoping": "^7.27.1",
+        "@babel/plugin-transform-block-scoping": "^7.28.0",
         "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-class-static-block": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.27.1",
+        "@babel/plugin-transform-class-static-block": "^7.28.3",
+        "@babel/plugin-transform-classes": "^7.28.3",
         "@babel/plugin-transform-computed-properties": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.28.0",
         "@babel/plugin-transform-dotall-regex": "^7.27.1",
         "@babel/plugin-transform-duplicate-keys": "^7.27.1",
         "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
         "@babel/plugin-transform-dynamic-import": "^7.27.1",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.27.1",
         "@babel/plugin-transform-export-namespace-from": "^7.27.1",
         "@babel/plugin-transform-for-of": "^7.27.1",
@@ -46070,15 +46723,15 @@
         "@babel/plugin-transform-new-target": "^7.27.1",
         "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
         "@babel/plugin-transform-numeric-separator": "^7.27.1",
-        "@babel/plugin-transform-object-rest-spread": "^7.27.2",
+        "@babel/plugin-transform-object-rest-spread": "^7.28.0",
         "@babel/plugin-transform-object-super": "^7.27.1",
         "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
         "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "@babel/plugin-transform-parameters": "^7.27.1",
+        "@babel/plugin-transform-parameters": "^7.27.7",
         "@babel/plugin-transform-private-methods": "^7.27.1",
         "@babel/plugin-transform-private-property-in-object": "^7.27.1",
         "@babel/plugin-transform-property-literals": "^7.27.1",
-        "@babel/plugin-transform-regenerator": "^7.27.1",
+        "@babel/plugin-transform-regenerator": "^7.28.3",
         "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
         "@babel/plugin-transform-reserved-words": "^7.27.1",
         "@babel/plugin-transform-shorthand-properties": "^7.27.1",
@@ -46091,10 +46744,10 @@
         "@babel/plugin-transform-unicode-regex": "^7.27.1",
         "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "babel-plugin-polyfill-corejs2": "^0.4.10",
-        "babel-plugin-polyfill-corejs3": "^0.11.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.1",
-        "core-js-compat": "^3.40.0",
+        "babel-plugin-polyfill-corejs2": "^0.4.14",
+        "babel-plugin-polyfill-corejs3": "^0.13.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.5",
+        "core-js-compat": "^3.43.0",
         "semver": "^6.3.1"
       },
       "dependencies": {
@@ -46160,11 +46813,11 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.27.3.tgz",
-      "integrity": "sha512-ZYcgrwb+dkWNcDlsTe4fH1CMdqMDSJ5lWFd1by8Si2pI54XcQjte/+ViIPqAk7EAWisaUxvQ89grv+bNX2x8zg==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz",
+      "integrity": "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==",
       "requires": {
-        "core-js-pure": "^3.30.2"
+        "core-js-pure": "^3.43.0"
       }
     },
     "@babel/template": {
@@ -46178,23 +46831,23 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.3.tgz",
-      "integrity": "sha512-lId/IfN/Ye1CIu8xG7oKBHXd2iNb2aW1ilPszzGcJug6M8RCKfVNcYhpI5+bMvFYjK7lXIM0R+a+6r8xhHp2FQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
       "requires": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.3",
-        "@babel/parser": "^7.27.3",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
       }
     },
     "@babel/types": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
-      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "requires": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1"
@@ -47156,9 +47809,9 @@
       "integrity": "sha512-p1ko5eHgV+MgXFVa4STPKpvPxr6ReS8oS2jzTukjR74i5zJNyWO1ZM1m8YKBXnzDKWfBN1ztLYlHxbVemDD88A=="
     },
     "@csstools/color-helpers": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
-      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="
     },
     "@csstools/css-calc": {
       "version": "2.1.4",
@@ -47166,11 +47819,11 @@
       "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="
     },
     "@csstools/css-color-parser": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
-      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "requires": {
-        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/color-helpers": "^5.1.0",
         "@csstools/css-calc": "^2.1.4"
       }
     },
@@ -47189,10 +47842,22 @@
       "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
       "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ=="
     },
+    "@csstools/postcss-alpha-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-alpha-function/-/postcss-alpha-function-1.0.0.tgz",
+      "integrity": "sha512-r2L8KNg5Wriq5n8IUQcjzy2Rh37J5YjzP9iOyHZL5fxdWYHB08vqykHQa4wAzN/tXwDuCHnhQDGCtxfS76xn7g==",
+      "requires": {
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
+        "@csstools/utilities": "^2.0.0"
+      }
+    },
     "@csstools/postcss-cascade-layers": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-5.0.1.tgz",
-      "integrity": "sha512-XOfhI7GShVcKiKwmPAnWSqd2tBR0uxt+runAxttbSp/LY2U16yAVPmAf7e9q4JJ0d+xMNmpwNDLBXnmRCl3HMQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-5.0.2.tgz",
+      "integrity": "sha512-nWBE08nhO8uWl6kSAeCx4im7QfVko3zLrtgWZY4/bP87zrSPpSyN/3W3TDqz1jJuH+kbKOHXg5rJnK+ZVYcFFg==",
       "requires": {
         "@csstools/selector-specificity": "^5.0.0",
         "postcss-selector-parser": "^7.0.0"
@@ -47210,49 +47875,61 @@
       }
     },
     "@csstools/postcss-color-function": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-4.0.10.tgz",
-      "integrity": "sha512-4dY0NBu7NVIpzxZRgh/Q/0GPSz/jLSw0i/u3LTUor0BkQcz/fNhN10mSWBDsL0p9nDb0Ky1PD6/dcGbhACuFTQ==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-4.0.11.tgz",
+      "integrity": "sha512-AtH22zLHTLm64HLdpv5EedT/zmYTm1MtdQbQhRZXxEB6iYtS6SrS1jLX3TcmUWMFzpumK/OVylCm3HcLms4slw==",
       "requires": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
+        "@csstools/utilities": "^2.0.0"
+      }
+    },
+    "@csstools/postcss-color-function-display-p3-linear": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function-display-p3-linear/-/postcss-color-function-display-p3-linear-1.0.0.tgz",
+      "integrity": "sha512-7q+OuUqfowRrP84m/Jl0wv3pfCQyUTCW5MxDIux+/yty5IkUUHOTigCjrC0Fjy3OT0ncGLudHbfLWmP7E1arNA==",
+      "requires": {
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       }
     },
     "@csstools/postcss-color-mix-function": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-3.0.10.tgz",
-      "integrity": "sha512-P0lIbQW9I4ShE7uBgZRib/lMTf9XMjJkFl/d6w4EMNHu2qvQ6zljJGEcBkw/NsBtq/6q3WrmgxSS8kHtPMkK4Q==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-3.0.11.tgz",
+      "integrity": "sha512-cQpXBelpTx0YhScZM5Ve0jDCA4RzwFc7oNafzZOGgCHt/GQVYiU8Vevz9QJcwy/W0Pyi/BneY+KMjz23lI9r+Q==",
       "requires": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       }
     },
     "@csstools/postcss-color-mix-variadic-function-arguments": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-variadic-function-arguments/-/postcss-color-mix-variadic-function-arguments-1.0.0.tgz",
-      "integrity": "sha512-Z5WhouTyD74dPFPrVE7KydgNS9VvnjB8qcdes9ARpCOItb4jTnm7cHp4FhxCRUoyhabD0WVv43wbkJ4p8hLAlQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-variadic-function-arguments/-/postcss-color-mix-variadic-function-arguments-1.0.1.tgz",
+      "integrity": "sha512-c7hyBtbF+jlHIcUGVdWY06bHICgguV9ypfcELU3eU3W/9fiz2dxM8PqxQk2ndXYTzLnwPvNNqu1yCmQ++N6Dcg==",
       "requires": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       }
     },
     "@csstools/postcss-content-alt-text": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-content-alt-text/-/postcss-content-alt-text-2.0.6.tgz",
-      "integrity": "sha512-eRjLbOjblXq+byyaedQRSrAejKGNAFued+LcbzT+LCL78fabxHkxYjBbxkroONxHHYu2qxhFK2dBStTLPG3jpQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-content-alt-text/-/postcss-content-alt-text-2.0.7.tgz",
+      "integrity": "sha512-cq/zWaEkpcg3RttJ5+GdNwk26NwxY5KgqgtNL777Fdd28AVGHxuBvqmK4Jq4oKhW1NX4M2LbgYAVVN0NZ+/XYQ==",
       "requires": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       }
     },
@@ -47276,45 +47953,45 @@
       }
     },
     "@csstools/postcss-gamut-mapping": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-2.0.10.tgz",
-      "integrity": "sha512-QDGqhJlvFnDlaPAfCYPsnwVA6ze+8hhrwevYWlnUeSjkkZfBpcCO42SaUD8jiLlq7niouyLgvup5lh+f1qessg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-2.0.11.tgz",
+      "integrity": "sha512-fCpCUgZNE2piVJKC76zFsgVW1apF6dpYsqGyH8SIeCcM4pTEsRTWTLCaJIMKFEundsCKwY1rwfhtrio04RJ4Dw==",
       "requires": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "@csstools/postcss-gradients-interpolation-method": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-5.0.10.tgz",
-      "integrity": "sha512-HHPauB2k7Oits02tKFUeVFEU2ox/H3OQVrP3fSOKDxvloOikSal+3dzlyTZmYsb9FlY9p5EUpBtz0//XBmy+aw==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-5.0.11.tgz",
+      "integrity": "sha512-8M3mcNTL3cGIJXDnvrJ2oWEcKi3zyw7NeYheFKePUlBmLYm1gkw9Rr/BA7lFONrOPeQA3yeMPldrrws6lqHrug==",
       "requires": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       }
     },
     "@csstools/postcss-hwb-function": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-4.0.10.tgz",
-      "integrity": "sha512-nOKKfp14SWcdEQ++S9/4TgRKchooLZL0TUFdun3nI4KPwCjETmhjta1QT4ICQcGVWQTvrsgMM/aLB5We+kMHhQ==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-4.0.11.tgz",
+      "integrity": "sha512-9meZbsVWTZkWsSBazQips3cHUOT29a/UAwFz0AMEXukvpIGGDR9+GMl3nIckWO5sPImsadu4F5Zy+zjt8QgCdA==",
       "requires": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       }
     },
     "@csstools/postcss-ic-unit": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-4.0.2.tgz",
-      "integrity": "sha512-lrK2jjyZwh7DbxaNnIUjkeDmU8Y6KyzRBk91ZkI5h8nb1ykEfZrtIVArdIjX4DHMIBGpdHrgP0n4qXDr7OHaKA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-4.0.3.tgz",
+      "integrity": "sha512-RtYYm2qUIu9vAaHB0cC8rQGlOCQAUgEc2tMr7ewlGXYipBQKjoWmyVArqsk7SEr8N3tErq6P6UOJT3amaVof5Q==",
       "requires": {
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0",
         "postcss-value-parser": "^4.2.0"
       }
@@ -47325,9 +48002,9 @@
       "integrity": "sha512-L1wLVMSAZ4wovznquK0xmC7QSctzO4D0Is590bxpGqhqjboLXYA16dWZpfwImkdOgACdQ9PqXsuRroW6qPlEsg=="
     },
     "@csstools/postcss-is-pseudo-class": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.1.tgz",
-      "integrity": "sha512-JLp3POui4S1auhDR0n8wHd/zTOWmMsmK3nQd3hhL6FhWPaox5W7j1se6zXOG/aP07wV2ww0lxbKYGwbBszOtfQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.3.tgz",
+      "integrity": "sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==",
       "requires": {
         "@csstools/selector-specificity": "^5.0.0",
         "postcss-selector-parser": "^7.0.0"
@@ -47345,13 +48022,13 @@
       }
     },
     "@csstools/postcss-light-dark-function": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-light-dark-function/-/postcss-light-dark-function-2.0.9.tgz",
-      "integrity": "sha512-1tCZH5bla0EAkFAI2r0H33CDnIBeLUaJh1p+hvvsylJ4svsv2wOmJjJn+OXwUZLXef37GYbRIVKX+X+g6m+3CQ==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-light-dark-function/-/postcss-light-dark-function-2.0.10.tgz",
+      "integrity": "sha512-g7Lwb294lSoNnyrwcqoooh9fTAp47rRNo+ILg7SLRSMU3K9ePIwRt566sNx+pehiCelv4E1ICaU1EwLQuyF2qw==",
       "requires": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       }
     },
@@ -47426,21 +48103,21 @@
       }
     },
     "@csstools/postcss-oklab-function": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-4.0.10.tgz",
-      "integrity": "sha512-ZzZUTDd0fgNdhv8UUjGCtObPD8LYxMH+MJsW9xlZaWTV8Ppr4PtxlHYNMmF4vVWGl0T6f8tyWAKjoI6vePSgAg==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-4.0.11.tgz",
+      "integrity": "sha512-9f03ZGxZ2VmSCrM4SDXlAYP+Xpu4VFzemfQUQFL9OYxAbpvDy0FjDipZ0i8So1pgs8VIbQI0bNjFWgfdpGw8ig==",
       "requires": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       }
     },
     "@csstools/postcss-progressive-custom-properties": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.1.0.tgz",
-      "integrity": "sha512-YrkI9dx8U4R8Sz2EJaoeD9fI7s7kmeEBfmO+UURNeL6lQI7VxF6sBE+rSqdCBn4onwqmxFdBU3lTwyYb/lCmxA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.2.0.tgz",
+      "integrity": "sha512-fWCXRasX17N1NCPTCuwC3FJDV+Wc031f16cFuuMEfIsYJ1q5ABCa59W0C6VeMGqjNv6ldf37vvwXXAeaZjD9PA==",
       "requires": {
         "postcss-value-parser": "^4.2.0"
       }
@@ -47456,14 +48133,14 @@
       }
     },
     "@csstools/postcss-relative-color-syntax": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-3.0.10.tgz",
-      "integrity": "sha512-8+0kQbQGg9yYG8hv0dtEpOMLwB9M+P7PhacgIzVzJpixxV4Eq9AUQtQw8adMmAJU1RBBmIlpmtmm3XTRd/T00g==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-3.0.11.tgz",
+      "integrity": "sha512-oQ5fZvkcBrWR+k6arHXk0F8FlkmD4IxM+rcGDLWrF2f31tWyEM3lSraeWAV0f7BGH6LIrqmyU3+Qo/1acfoJng==",
       "requires": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       }
     },
@@ -47507,11 +48184,11 @@
       }
     },
     "@csstools/postcss-text-decoration-shorthand": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-4.0.2.tgz",
-      "integrity": "sha512-8XvCRrFNseBSAGxeaVTaNijAu+FzUvjwFXtcrynmazGb/9WUdsPCpBX+mHEHShVRq47Gy4peYAoxYs8ltUnmzA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-4.0.3.tgz",
+      "integrity": "sha512-KSkGgZfx0kQjRIYnpsD7X2Om9BUXX/Kii77VBifQW9Ih929hK0KNjVngHDH0bFB9GmfWcR9vJYJJRvw/NQjkrA==",
       "requires": {
-        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/color-helpers": "^5.1.0",
         "postcss-value-parser": "^4.2.0"
       }
     },
@@ -47531,9 +48208,9 @@
       "integrity": "sha512-cBz3tOCI5Fw6NIFEwU3RiwK6mn3nKegjpJuzCndoGq3BZPkUjnsq7uQmIeMNeMbMk7YD2MfKcgCpZwX5jyXqCA=="
     },
     "@csstools/selector-resolve-nested": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.0.0.tgz",
-      "integrity": "sha512-ZoK24Yku6VJU1gS79a5PFmC8yn3wIapiKmPgun0hZgEI5AOqgH2kiPRsPz1qkGv4HL+wuDLH83yQyk6inMYrJQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz",
+      "integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g=="
     },
     "@csstools/selector-specificity": {
       "version": "5.0.0",
@@ -47607,9 +48284,9 @@
       }
     },
     "@docusaurus/babel": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.8.0.tgz",
-      "integrity": "sha512-9EJwSgS6TgB8IzGk1L8XddJLhZod8fXT4ULYMx6SKqyCBqCFpVCEjR/hNXXhnmtVM2irDuzYoVLGWv7srG/VOA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.8.1.tgz",
+      "integrity": "sha512-3brkJrml8vUbn9aeoZUlJfsI/GqyFcDgQJwQkmBtclJgWDEQBKKeagZfOgx0WfUQhagL1sQLNW0iBdxnI863Uw==",
       "requires": {
         "@babel/core": "^7.25.9",
         "@babel/generator": "^7.25.9",
@@ -47621,22 +48298,22 @@
         "@babel/runtime": "^7.25.9",
         "@babel/runtime-corejs3": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.27.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.3.tgz",
-          "integrity": "sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw=="
+          "version": "7.28.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+          "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="
         },
         "fs-extra": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-          "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+          "version": "11.3.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+          "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -47646,29 +48323,29 @@
       }
     },
     "@docusaurus/bundler": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.8.0.tgz",
-      "integrity": "sha512-Rq4Z/MSeAHjVzBLirLeMcjLIAQy92pF1OI+2rmt18fSlMARfTGLWRE8Vb+ljQPTOSfJxwDYSzsK6i7XloD2rNA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.8.1.tgz",
+      "integrity": "sha512-/z4V0FRoQ0GuSLToNjOSGsk6m2lQUG4FRn8goOVoZSRsTrU8YR2aJacX5K3RG18EaX9b+52pN4m1sL3MQZVsQA==",
       "requires": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.8.0",
-        "@docusaurus/cssnano-preset": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
+        "@docusaurus/babel": "3.8.1",
+        "@docusaurus/cssnano-preset": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "babel-loader": "^9.2.1",
-        "clean-css": "^5.3.2",
+        "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
-        "css-loader": "^6.8.1",
+        "css-loader": "^6.11.0",
         "css-minimizer-webpack-plugin": "^5.0.1",
         "cssnano": "^6.1.2",
         "file-loader": "^6.2.0",
         "html-minifier-terser": "^7.2.0",
-        "mini-css-extract-plugin": "^2.9.1",
+        "mini-css-extract-plugin": "^2.9.2",
         "null-loader": "^4.0.1",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "postcss-preset-env": "^10.1.0",
+        "postcss": "^8.5.4",
+        "postcss-loader": "^7.3.4",
+        "postcss-preset-env": "^10.2.1",
         "terser-webpack-plugin": "^5.3.9",
         "tslib": "^2.6.0",
         "url-loader": "^4.1.1",
@@ -47677,17 +48354,17 @@
       }
     },
     "@docusaurus/core": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.8.0.tgz",
-      "integrity": "sha512-c7u6zFELmSGPEP9WSubhVDjgnpiHgDqMh1qVdCB7rTflh4Jx0msTYmMiO91Ez0KtHj4sIsDsASnjwfJ2IZp3Vw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.8.1.tgz",
+      "integrity": "sha512-ENB01IyQSqI2FLtOzqSI3qxG2B/jP4gQPahl2C3XReiLebcVh5B5cB9KYFvdoOqOWPyr5gXK4sjgTKv7peXCrA==",
       "requires": {
-        "@docusaurus/babel": "3.8.0",
-        "@docusaurus/bundler": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/mdx-loader": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/babel": "3.8.1",
+        "@docusaurus/bundler": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -47761,9 +48438,9 @@
           "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
         },
         "fs-extra": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-          "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+          "version": "11.3.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+          "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -47786,23 +48463,23 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.8.0.tgz",
-      "integrity": "sha512-UJ4hAS2T0R4WNy+phwVff2Q0L5+RXW9cwlH6AEphHR5qw3m/yacfWcSK7ort2pMMbDn8uGrD38BTm4oLkuuNoQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.8.1.tgz",
+      "integrity": "sha512-G7WyR2N6SpyUotqhGznERBK+x84uyhfMQM2MmDLs88bw4Flom6TY46HzkRkSEzaP9j80MbTN8naiL1fR17WQug==",
       "requires": {
         "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
+        "postcss": "^8.5.4",
         "postcss-sort-media-queries": "^5.2.0",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/faster": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.8.0.tgz",
-      "integrity": "sha512-v9+8rT2gw/4zIRBwc4fIVhrTH/yFVDQgJgyYZjqr3fgojOypdQCOwkN6Z8dOwTei4/zo+b/zDPB4x1UvghJZRg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.8.1.tgz",
+      "integrity": "sha512-XYrj3qnTm+o2d5ih5drCq9s63GJoM8vZ26WbLG5FZhURsNxTSXgHJcx11Qo7nWPUStCQkuqk1HvItzscCUnd4A==",
       "requires": {
-        "@docusaurus/types": "3.8.0",
-        "@rspack/core": "^1.3.10",
+        "@docusaurus/types": "3.8.1",
+        "@rspack/core": "^1.3.15",
         "@swc/core": "^1.7.39",
         "@swc/html": "^1.7.39",
         "browserslist": "^4.24.2",
@@ -47813,9 +48490,9 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.8.0.tgz",
-      "integrity": "sha512-7eEMaFIam5Q+v8XwGqF/n0ZoCld4hV4eCCgQkfcN9Mq5inoZa6PHHW9Wu6lmgzoK5Kx3keEeABcO2SxwraoPDQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.8.1.tgz",
+      "integrity": "sha512-2wjeGDhKcExEmjX8k1N/MRDiPKXGF2Pg+df/bDDPnnJWHXnVEZxXj80d6jcxp1Gpnksl0hF8t/ZQw9elqj2+ww==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -47867,13 +48544,13 @@
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.0.tgz",
-      "integrity": "sha512-mDPSzssRnpjSdCGuv7z2EIAnPS1MHuZGTaRLwPn4oQwszu4afjWZ/60sfKjTnjBjI8Vl4OgJl2vMmfmiNDX4Ng==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
+      "integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
       "requires": {
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -47898,9 +48575,9 @@
       },
       "dependencies": {
         "fs-extra": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-          "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+          "version": "11.3.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+          "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -47910,11 +48587,11 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.8.0.tgz",
-      "integrity": "sha512-/uMb4Ipt5J/QnD13MpnoC/A4EYAe6DKNWqTWLlGrqsPJwJv73vSwkA25xnYunwfqWk0FlUQfGv/Swdh5eCCg7g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.8.1.tgz",
+      "integrity": "sha512-6xhvAJiXzsaq3JdosS7wbRt/PwEPWHr9eM4YNYqVlbgG1hSK3uQDXTVvQktasp3VO6BmfYWPozueLWuj4gB+vg==",
       "requires": {
-        "@docusaurus/types": "3.8.0",
+        "@docusaurus/types": "3.8.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -47924,15 +48601,15 @@
       }
     },
     "@docusaurus/plugin-client-redirects": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.8.0.tgz",
-      "integrity": "sha512-J8f5qzAlO61BnG1I91+N5WH1b/lPWqn6ifTxf/Bluz9JVe1bhFNSl0yW03p+Ff3AFOINDy2ofX70al9nOnOLyw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.8.1.tgz",
+      "integrity": "sha512-F+86R7PBn6VNgy/Ux8w3ZRypJGJEzksbejQKlbTC8u6uhBUhfdXWkDp6qdOisIoW0buY5nLqucvZt1zNJzhJhA==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -47952,18 +48629,18 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.8.0.tgz",
-      "integrity": "sha512-0SlOTd9R55WEr1GgIXu+hhTT0hzARYx3zIScA5IzpdekZQesI/hKEa5LPHBd415fLkWMjdD59TaW/3qQKpJ0Lg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.8.1.tgz",
+      "integrity": "sha512-vNTpMmlvNP9n3hGEcgPaXyvTljanAKIUkuG9URQ1DeuDup0OR7Ltvoc8yrmH+iMZJbcQGhUJF+WjHLwuk8HSdw==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/mdx-loader": "3.8.0",
-        "@docusaurus/theme-common": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -47977,9 +48654,9 @@
       },
       "dependencies": {
         "fs-extra": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-          "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+          "version": "11.3.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+          "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -47989,19 +48666,19 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.8.0.tgz",
-      "integrity": "sha512-fRDMFLbUN6eVRXcjP8s3Y7HpAt9pzPYh1F/7KKXOCxvJhjjCtbon4VJW0WndEPInVz4t8QUXn5QZkU2tGVCE2g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.8.1.tgz",
+      "integrity": "sha512-oByRkSZzeGNQByCMaX+kif5Nl2vmtj2IHQI2fWjCfCootsdKZDPFLonhIp5s3IGJO7PLUfe0POyw0Xh/RrGXJA==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/mdx-loader": "3.8.0",
-        "@docusaurus/module-type-aliases": "3.8.0",
-        "@docusaurus/theme-common": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -48039,24 +48716,24 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.8.0.tgz",
-      "integrity": "sha512-39EDx2y1GA0Pxfion5tQZLNJxL4gq6susd1xzetVBjVIQtwpCdyloOfQBAgX0FylqQxfJrYqL0DIUuq7rd7uBw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.8.1.tgz",
+      "integrity": "sha512-a+V6MS2cIu37E/m7nDJn3dcxpvXb6TvgdNI22vJX8iUTp8eoMoPa0VArEbWvCxMY/xdC26WzNv4wZ6y0iIni/w==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/mdx-loader": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-          "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+          "version": "11.3.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+          "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -48066,33 +48743,34 @@
       }
     },
     "@docusaurus/plugin-css-cascade-layers": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.8.0.tgz",
-      "integrity": "sha512-/VBTNymPIxQB8oA3ZQ4GFFRYdH4ZxDRRBECxyjRyv486mfUPXfcdk+im4S5mKWa6EK2JzBz95IH/Wu0qQgJ5yQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.8.1.tgz",
+      "integrity": "sha512-VQ47xRxfNKjHS5ItzaVXpxeTm7/wJLFMOPo1BkmoMG4Cuz4nuI+Hs62+RMk1OqVog68Swz66xVPK8g9XTrBKRw==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.8.0.tgz",
-      "integrity": "sha512-teonJvJsDB9o2OnG6ifbhblg/PXzZvpUKHFgD8dOL1UJ58u0lk8o0ZOkvaYEBa9nDgqzoWrRk9w+e3qaG2mOhQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.8.1.tgz",
+      "integrity": "sha512-nT3lN7TV5bi5hKMB7FK8gCffFTBSsBsAfV84/v293qAmnHOyg1nr9okEw8AiwcO3bl9vije5nsUvP0aRl2lpaw==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-          "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+          "version": "11.3.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+          "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -48102,59 +48780,59 @@
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.8.0.tgz",
-      "integrity": "sha512-aKKa7Q8+3xRSRESipNvlFgNp3FNPELKhuo48Cg/svQbGNwidSHbZT03JqbW4cBaQnyyVchO1ttk+kJ5VC9Gx0w==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.8.1.tgz",
+      "integrity": "sha512-Hrb/PurOJsmwHAsfMDH6oVpahkEGsx7F8CWMjyP/dw1qjqmdS9rcV1nYCGlM8nOtD3Wk/eaThzUB5TSZsGz+7Q==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.8.0.tgz",
-      "integrity": "sha512-ugQYMGF4BjbAW/JIBtVcp+9eZEgT9HRdvdcDudl5rywNPBA0lct+lXMG3r17s02rrhInMpjMahN3Yc9Cb3H5/g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.8.1.tgz",
+      "integrity": "sha512-tKE8j1cEZCh8KZa4aa80zpSTxsC2/ZYqjx6AAfd8uA8VHZVw79+7OTEP2PoWi0uL5/1Is0LF5Vwxd+1fz5HlKg==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-google-tag-manager": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.8.0.tgz",
-      "integrity": "sha512-9juRWxbwZD3SV02Jd9QB6yeN7eu+7T4zB0bvJLcVQwi+am51wAxn2CwbdL0YCCX+9OfiXbADE8D8Q65Hbopu/w==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.8.1.tgz",
+      "integrity": "sha512-iqe3XKITBquZq+6UAXdb1vI0fPY5iIOitVjPQ581R1ZKpHr0qe+V6gVOrrcOHixPDD/BUKdYwkxFjpNiEN+vBw==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.0.tgz",
-      "integrity": "sha512-fGpOIyJvNiuAb90nSJ2Gfy/hUOaDu6826e5w5UxPmbpCIc7KlBHNAZ5g4L4ZuHhc4hdfq4mzVBsQSnne+8Ze1g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.1.tgz",
+      "integrity": "sha512-+9YV/7VLbGTq8qNkjiugIelmfUEVkTyLe6X8bWq7K5qPvGXAjno27QAfFq63mYfFFbJc7z+pudL63acprbqGzw==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-          "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+          "version": "11.3.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+          "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -48164,14 +48842,14 @@
       }
     },
     "@docusaurus/plugin-svgr": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.8.0.tgz",
-      "integrity": "sha512-kEDyry+4OMz6BWLG/lEqrNsL/w818bywK70N1gytViw4m9iAmoxCUT7Ri9Dgs7xUdzCHJ3OujolEmD88Wy44OA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.8.1.tgz",
+      "integrity": "sha512-rW0LWMDsdlsgowVwqiMb/7tANDodpy1wWPwCcamvhY7OECReN3feoFwLjd/U4tKjNY3encj0AJSTxJA+Fpe+Gw==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
         "tslib": "^2.6.0",
@@ -48179,52 +48857,52 @@
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.8.0.tgz",
-      "integrity": "sha512-qOu6tQDOWv+rpTlKu+eJATCJVGnABpRCPuqf7LbEaQ1mNY//N/P8cHQwkpAU+aweQfarcZ0XfwCqRHJfjeSV/g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.8.1.tgz",
+      "integrity": "sha512-yJSjYNHXD8POMGc2mKQuj3ApPrN+eG0rO1UPgSx7jySpYU+n4WjBikbrA2ue5ad9A7aouEtMWUoiSRXTH/g7KQ==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/plugin-content-blog": "3.8.0",
-        "@docusaurus/plugin-content-docs": "3.8.0",
-        "@docusaurus/plugin-content-pages": "3.8.0",
-        "@docusaurus/plugin-css-cascade-layers": "3.8.0",
-        "@docusaurus/plugin-debug": "3.8.0",
-        "@docusaurus/plugin-google-analytics": "3.8.0",
-        "@docusaurus/plugin-google-gtag": "3.8.0",
-        "@docusaurus/plugin-google-tag-manager": "3.8.0",
-        "@docusaurus/plugin-sitemap": "3.8.0",
-        "@docusaurus/plugin-svgr": "3.8.0",
-        "@docusaurus/theme-classic": "3.8.0",
-        "@docusaurus/theme-common": "3.8.0",
-        "@docusaurus/theme-search-algolia": "3.8.0",
-        "@docusaurus/types": "3.8.0"
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/plugin-content-blog": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/plugin-content-pages": "3.8.1",
+        "@docusaurus/plugin-css-cascade-layers": "3.8.1",
+        "@docusaurus/plugin-debug": "3.8.1",
+        "@docusaurus/plugin-google-analytics": "3.8.1",
+        "@docusaurus/plugin-google-gtag": "3.8.1",
+        "@docusaurus/plugin-google-tag-manager": "3.8.1",
+        "@docusaurus/plugin-sitemap": "3.8.1",
+        "@docusaurus/plugin-svgr": "3.8.1",
+        "@docusaurus/theme-classic": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-search-algolia": "3.8.1",
+        "@docusaurus/types": "3.8.1"
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.8.0.tgz",
-      "integrity": "sha512-nQWFiD5ZjoT76OaELt2n33P3WVuuCz8Dt5KFRP2fCBo2r9JCLsp2GJjZpnaG24LZ5/arRjv4VqWKgpK0/YLt7g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.8.1.tgz",
+      "integrity": "sha512-bqDUCNqXeYypMCsE1VcTXSI1QuO4KXfx8Cvl6rYfY0bhhqN6d2WZlRkyLg/p6pm+DzvanqHOyYlqdPyP0iz+iw==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/mdx-loader": "3.8.0",
-        "@docusaurus/module-type-aliases": "3.8.0",
-        "@docusaurus/plugin-content-blog": "3.8.0",
-        "@docusaurus/plugin-content-docs": "3.8.0",
-        "@docusaurus/plugin-content-pages": "3.8.0",
-        "@docusaurus/theme-common": "3.8.0",
-        "@docusaurus/theme-translations": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/plugin-content-blog": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/plugin-content-pages": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-translations": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
         "infima": "0.2.0-alpha.45",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
-        "postcss": "^8.4.26",
+        "postcss": "^8.5.4",
         "prism-react-renderer": "^2.3.0",
         "prismjs": "^1.29.0",
         "react-router-dom": "^5.3.4",
@@ -48234,14 +48912,14 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.8.0.tgz",
-      "integrity": "sha512-YqV2vAWpXGLA+A3PMLrOMtqgTHJLDcT+1Caa6RF7N4/IWgrevy5diY8oIHFkXR/eybjcrFFjUPrHif8gSGs3Tw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.8.1.tgz",
+      "integrity": "sha512-UswMOyTnPEVRvN5Qzbo+l8k4xrd5fTFu2VPPfD6FcW/6qUtVLmJTQCktbAL3KJ0BVXGm5aJXz/ZrzqFuZERGPw==",
       "requires": {
-        "@docusaurus/mdx-loader": "3.8.0",
-        "@docusaurus/module-type-aliases": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -48253,15 +48931,15 @@
       }
     },
     "@docusaurus/theme-mermaid": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.8.0.tgz",
-      "integrity": "sha512-ou0NJM37p4xrVuFaZp8qFe5Z/qBq9LuyRTP4KKRa0u2J3zC4f3saBJDgc56FyvvN1OsmU0189KGEPUjTr6hFxg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.8.1.tgz",
+      "integrity": "sha512-IWYqjyTPjkNnHsFFu9+4YkeXS7PD1xI3Bn2shOhBq+f95mgDfWInkpfBN4aYvx4fTT67Am6cPtohRdwh4Tidtg==",
       "requires": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/module-type-aliases": "3.8.0",
-        "@docusaurus/theme-common": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "mermaid": ">=11.6.0",
         "tslib": "^2.6.0"
       },
@@ -48349,18 +49027,18 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.8.0.tgz",
-      "integrity": "sha512-GBZ5UOcPgiu6nUw153+0+PNWvFKweSnvKIL6Rp04H9olKb475jfKjAwCCtju5D2xs5qXHvCMvzWOg5o9f6DtuQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.8.1.tgz",
+      "integrity": "sha512-NBFH5rZVQRAQM087aYSRKQ9yGEK9eHd+xOxQjqNpxMiV85OhJDD4ZGz6YJIod26Fbooy54UWVdzNU0TFeUUUzQ==",
       "requires": {
         "@docsearch/react": "^3.9.0",
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/plugin-content-docs": "3.8.0",
-        "@docusaurus/theme-common": "3.8.0",
-        "@docusaurus/theme-translations": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-translations": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "algoliasearch": "^5.17.1",
         "algoliasearch-helper": "^3.22.6",
         "clsx": "^2.0.0",
@@ -48372,9 +49050,9 @@
       },
       "dependencies": {
         "fs-extra": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-          "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+          "version": "11.3.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+          "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -48384,9 +49062,9 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.8.0.tgz",
-      "integrity": "sha512-1DTy/snHicgkCkryWq54fZvsAglTdjTx4qjOXgqnXJ+DIty1B+aPQrAVUu8LiM+6BiILfmNxYsxhKTj+BS3PZg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.8.1.tgz",
+      "integrity": "sha512-OTp6eebuMcf2rJt4bqnvuwmm3NVXfzfYejL+u/Y1qwKhZPrjPoKWfk1CbOP5xH5ZOPkiAsx4dHdQBRJszK3z2g==",
       "requires": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -48405,9 +49083,9 @@
       }
     },
     "@docusaurus/types": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.8.0.tgz",
-      "integrity": "sha512-RDEClpwNxZq02c+JlaKLWoS13qwWhjcNsi2wG1UpzmEnuti/z1Wx4SGpqbUqRPNSd8QWWePR8Cb7DvG0VN/TtA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.8.1.tgz",
+      "integrity": "sha512-ZPdW5AB+pBjiVrcLuw3dOS6BFlrG0XkS2lDGsj8TizcnREQg3J8cjsgfDviszOk4CweNfwo1AEELJkYaMUuOPg==",
       "requires": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
@@ -48438,13 +49116,13 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.8.0.tgz",
-      "integrity": "sha512-2wvtG28ALCN/A1WCSLxPASFBFzXCnP0YKCAFIPcvEb6imNu1wg7ni/Svcp71b3Z2FaOFFIv4Hq+j4gD7gA0yfQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.8.1.tgz",
+      "integrity": "sha512-P1ml0nvOmEFdmu0smSXOqTS1sxU5tqvnc0dA4MTKV39kye+bhQnjkIKEE18fNOvxjyB86k8esoCIFM3x4RykOQ==",
       "requires": {
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "escape-string-regexp": "^4.0.0",
         "execa": "5.1.1",
         "file-loader": "^6.2.0",
@@ -48496,22 +49174,22 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.8.0.tgz",
-      "integrity": "sha512-3TGF+wVTGgQ3pAc9+5jVchES4uXUAhAt9pwv7uws4mVOxL4alvU3ue/EZ+R4XuGk94pDy7CNXjRXpPjlfZXQfw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.8.1.tgz",
+      "integrity": "sha512-zTZiDlvpvoJIrQEEd71c154DkcriBecm4z94OzEE9kz7ikS3J+iSlABhFXM45mZ0eN5pVqqr7cs60+ZlYLewtg==",
       "requires": {
-        "@docusaurus/types": "3.8.0",
+        "@docusaurus/types": "3.8.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.8.0.tgz",
-      "integrity": "sha512-MrnEbkigr54HkdFeg8e4FKc4EF+E9dlVwsY3XQZsNkbv3MKZnbHQ5LsNJDIKDROFe8PBf5C4qCAg5TPBpsjrjg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.8.1.tgz",
+      "integrity": "sha512-gs5bXIccxzEbyVecvxg6upTwaUbfa0KMmTj7HhHzc016AGyxH2o73k1/aOD0IFrdCsfJNt37MqNI47s2MgRZMA==",
       "requires": {
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -48542,6 +49220,103 @@
             "argparse": "^2.0.1"
           }
         }
+      }
+    },
+    "@easyops-cn/autocomplete.js": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/autocomplete.js/-/autocomplete.js-0.38.1.tgz",
+      "integrity": "sha512-drg76jS6syilOUmVNkyo1c7ZEBPcPuK+aJA7AksM5ZIIbV57DMHCywiCr+uHyv8BE5jUTU98j/H7gVrkHrWW3Q==",
+      "requires": {
+        "cssesc": "^3.0.0",
+        "immediate": "^3.2.3"
+      }
+    },
+    "@easyops-cn/docusaurus-search-local": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.52.1.tgz",
+      "integrity": "sha512-pwfANjTLOQyAPc2Iz93WbG4OQM5C4COCWARbLAs79FIpIS38gHq3PrbDIX8f7oDhGQp1u6f8fr3K3u3+yZXZTA==",
+      "requires": {
+        "@docusaurus/plugin-content-docs": "^2 || ^3",
+        "@docusaurus/theme-translations": "^2 || ^3",
+        "@docusaurus/utils": "^2 || ^3",
+        "@docusaurus/utils-common": "^2 || ^3",
+        "@docusaurus/utils-validation": "^2 || ^3",
+        "@easyops-cn/autocomplete.js": "^0.38.1",
+        "@node-rs/jieba": "^1.6.0",
+        "cheerio": "^1.0.0",
+        "clsx": "^2.1.1",
+        "comlink": "^4.4.2",
+        "debug": "^4.2.0",
+        "fs-extra": "^10.0.0",
+        "klaw-sync": "^6.0.0",
+        "lunr": "^2.3.9",
+        "lunr-languages": "^1.4.0",
+        "mark.js": "^8.11.1",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "cheerio": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+          "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+          "requires": {
+            "cheerio-select": "^2.1.0",
+            "dom-serializer": "^2.0.0",
+            "domhandler": "^5.0.3",
+            "domutils": "^3.2.2",
+            "encoding-sniffer": "^0.2.1",
+            "htmlparser2": "^10.0.0",
+            "parse5": "^7.3.0",
+            "parse5-htmlparser2-tree-adapter": "^7.1.0",
+            "parse5-parser-stream": "^7.1.2",
+            "undici": "^7.12.0",
+            "whatwg-mimetype": "^4.0.0"
+          }
+        },
+        "entities": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+          "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
+        },
+        "htmlparser2": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+          "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3",
+            "domutils": "^3.2.1",
+            "entities": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@emnapi/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "optional": true,
+      "requires": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
       }
     },
     "@emotion/babel-plugin": {
@@ -49904,12 +50679,11 @@
       }
     },
     "@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "requires": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -49933,9 +50707,9 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -50222,12 +50996,12 @@
     "@lexical/website": {
       "version": "file:packages/lexical-website",
       "requires": {
-        "@docusaurus/core": "^3.8.0",
-        "@docusaurus/faster": "^3.8.0",
-        "@docusaurus/plugin-client-redirects": "^3.8.0",
-        "@docusaurus/preset-classic": "^3.8.0",
-        "@docusaurus/theme-mermaid": "^3.8.0",
-        "@docusaurus/theme-search-algolia": "^3.8.0",
+        "@docusaurus/core": "^3.8.1",
+        "@docusaurus/faster": "^3.8.1",
+        "@docusaurus/plugin-client-redirects": "^3.8.1",
+        "@docusaurus/preset-classic": "^3.8.1",
+        "@docusaurus/theme-mermaid": "^3.8.1",
+        "@easyops-cn/docusaurus-search-local": "^0.52.1",
         "@mdx-js/react": "^3.0.1",
         "@radix-ui/react-tabs": "^1.0.4",
         "@vercel/analytics": "^1.0.1",
@@ -50395,50 +51169,61 @@
       }
     },
     "@module-federation/error-codes": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.14.0.tgz",
-      "integrity": "sha512-GGk+EoeSACJikZZyShnLshtq9E2eCrDWbRiB4QAFXCX4oYmGgFfzXlx59vMNwqTKPJWxkEGnPYacJMcr2YYjag=="
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.18.0.tgz",
+      "integrity": "sha512-Woonm8ehyVIUPXChmbu80Zj6uJkC0dD9SJUZ/wOPtO8iiz/m+dkrOugAuKgoiR6qH4F+yorWila954tBz4uKsQ=="
     },
     "@module-federation/runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.14.0.tgz",
-      "integrity": "sha512-kR3cyHw/Y64SEa7mh4CHXOEQYY32LKLK75kJOmBroLNLO7/W01hMNAvGBYTedS7hWpVuefPk1aFZioy3q2VLdQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.18.0.tgz",
+      "integrity": "sha512-+C4YtoSztM7nHwNyZl6dQKGUVJdsPrUdaf3HIKReg/GQbrt9uvOlUWo2NXMZ8vDAnf/QRrpSYAwXHmWDn9Obaw==",
       "requires": {
-        "@module-federation/error-codes": "0.14.0",
-        "@module-federation/runtime-core": "0.14.0",
-        "@module-federation/sdk": "0.14.0"
+        "@module-federation/error-codes": "0.18.0",
+        "@module-federation/runtime-core": "0.18.0",
+        "@module-federation/sdk": "0.18.0"
       }
     },
     "@module-federation/runtime-core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.14.0.tgz",
-      "integrity": "sha512-fGE1Ro55zIFDp/CxQuRhKQ1pJvG7P0qvRm2N+4i8z++2bgDjcxnCKUqDJ8lLD+JfJQvUJf0tuSsJPgevzueD4g==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.18.0.tgz",
+      "integrity": "sha512-ZyYhrDyVAhUzriOsVfgL6vwd+5ebYm595Y13KeMf6TKDRoUHBMTLGQ8WM4TDj8JNsy7LigncK8C03fn97of0QQ==",
       "requires": {
-        "@module-federation/error-codes": "0.14.0",
-        "@module-federation/sdk": "0.14.0"
+        "@module-federation/error-codes": "0.18.0",
+        "@module-federation/sdk": "0.18.0"
       }
     },
     "@module-federation/runtime-tools": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.14.0.tgz",
-      "integrity": "sha512-y/YN0c2DKsLETE+4EEbmYWjqF9G6ZwgZoDIPkaQ9p0pQu0V4YxzWfQagFFxR0RigYGuhJKmSU/rtNoHq+qF8jg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.18.0.tgz",
+      "integrity": "sha512-fSga9o4t1UfXNV/Kh6qFvRyZpPp3EHSPRISNeyT8ZoTpzDNiYzhtw0BPUSSD8m6C6XQh2s/11rI4g80UY+d+hA==",
       "requires": {
-        "@module-federation/runtime": "0.14.0",
-        "@module-federation/webpack-bundler-runtime": "0.14.0"
+        "@module-federation/runtime": "0.18.0",
+        "@module-federation/webpack-bundler-runtime": "0.18.0"
       }
     },
     "@module-federation/sdk": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.14.0.tgz",
-      "integrity": "sha512-lg/OWRsh18hsyTCamOOhEX546vbDiA2O4OggTxxH2wTGr156N6DdELGQlYIKfRdU/0StgtQS81Goc0BgDZlx9A=="
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.18.0.tgz",
+      "integrity": "sha512-Lo/Feq73tO2unjmpRfyyoUkTVoejhItXOk/h5C+4cistnHbTV8XHrW/13fD5e1Iu60heVdAhhelJd6F898Ve9A=="
     },
     "@module-federation/webpack-bundler-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.14.0.tgz",
-      "integrity": "sha512-POWS6cKBicAAQ3DNY5X7XEUSfOfUsRaBNxbuwEfSGlrkTE9UcWheO06QP2ndHi8tHQuUKcIHi2navhPkJ+k5xg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.18.0.tgz",
+      "integrity": "sha512-TEvErbF+YQ+6IFimhUYKK3a5wapD90d90sLsNpcu2kB3QGT7t4nIluE25duXuZDVUKLz86tEPrza/oaaCWTpvQ==",
       "requires": {
-        "@module-federation/runtime": "0.14.0",
-        "@module-federation/sdk": "0.14.0"
+        "@module-federation/runtime": "0.18.0",
+        "@module-federation/sdk": "0.18.0"
+      }
+    },
+    "@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "optional": true,
+      "requires": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
       }
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -50449,6 +51234,114 @@
       "requires": {
         "eslint-scope": "5.1.1"
       }
+    },
+    "@node-rs/jieba": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba/-/jieba-1.10.4.tgz",
+      "integrity": "sha512-GvDgi8MnBiyWd6tksojej8anIx18244NmIOc1ovEw8WKNUejcccLfyu8vj66LWSuoZuKILVtNsOy4jvg3aoxIw==",
+      "requires": {
+        "@node-rs/jieba-android-arm-eabi": "1.10.4",
+        "@node-rs/jieba-android-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-x64": "1.10.4",
+        "@node-rs/jieba-freebsd-x64": "1.10.4",
+        "@node-rs/jieba-linux-arm-gnueabihf": "1.10.4",
+        "@node-rs/jieba-linux-arm64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-arm64-musl": "1.10.4",
+        "@node-rs/jieba-linux-x64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-x64-musl": "1.10.4",
+        "@node-rs/jieba-wasm32-wasi": "1.10.4",
+        "@node-rs/jieba-win32-arm64-msvc": "1.10.4",
+        "@node-rs/jieba-win32-ia32-msvc": "1.10.4",
+        "@node-rs/jieba-win32-x64-msvc": "1.10.4"
+      }
+    },
+    "@node-rs/jieba-android-arm-eabi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm-eabi/-/jieba-android-arm-eabi-1.10.4.tgz",
+      "integrity": "sha512-MhyvW5N3Fwcp385d0rxbCWH42kqDBatQTyP8XbnYbju2+0BO/eTeCCLYj7Agws4pwxn2LtdldXRSKavT7WdzNA==",
+      "optional": true
+    },
+    "@node-rs/jieba-android-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm64/-/jieba-android-arm64-1.10.4.tgz",
+      "integrity": "sha512-XyDwq5+rQ+Tk55A+FGi6PtJbzf974oqnpyCcCPzwU3QVXJCa2Rr4Lci+fx8oOpU4plT3GuD+chXMYLsXipMgJA==",
+      "optional": true
+    },
+    "@node-rs/jieba-darwin-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-arm64/-/jieba-darwin-arm64-1.10.4.tgz",
+      "integrity": "sha512-G++RYEJ2jo0rxF9626KUy90wp06TRUjAsvY/BrIzEOX/ingQYV/HjwQzNPRR1P1o32a6/U8RGo7zEBhfdybL6w==",
+      "optional": true
+    },
+    "@node-rs/jieba-darwin-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-x64/-/jieba-darwin-x64-1.10.4.tgz",
+      "integrity": "sha512-MmDNeOb2TXIZCPyWCi2upQnZpPjAxw5ZGEj6R8kNsPXVFALHIKMa6ZZ15LCOkSTsKXVC17j2t4h+hSuyYb6qfQ==",
+      "optional": true
+    },
+    "@node-rs/jieba-freebsd-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-freebsd-x64/-/jieba-freebsd-x64-1.10.4.tgz",
+      "integrity": "sha512-/x7aVQ8nqUWhpXU92RZqd333cq639i/olNpd9Z5hdlyyV5/B65LLy+Je2B2bfs62PVVm5QXRpeBcZqaHelp/bg==",
+      "optional": true
+    },
+    "@node-rs/jieba-linux-arm-gnueabihf": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm-gnueabihf/-/jieba-linux-arm-gnueabihf-1.10.4.tgz",
+      "integrity": "sha512-crd2M35oJBRLkoESs0O6QO3BBbhpv+tqXuKsqhIG94B1d02RVxtRIvSDwO33QurxqSdvN9IeSnVpHbDGkuXm3g==",
+      "optional": true
+    },
+    "@node-rs/jieba-linux-arm64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-gnu/-/jieba-linux-arm64-gnu-1.10.4.tgz",
+      "integrity": "sha512-omIzNX1psUzPcsdnUhGU6oHeOaTCuCjUgOA/v/DGkvWC1jLcnfXe4vdYbtXMh4XOCuIgS1UCcvZEc8vQLXFbXQ==",
+      "optional": true
+    },
+    "@node-rs/jieba-linux-arm64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-musl/-/jieba-linux-arm64-musl-1.10.4.tgz",
+      "integrity": "sha512-Y/tiJ1+HeS5nnmLbZOE+66LbsPOHZ/PUckAYVeLlQfpygLEpLYdlh0aPpS5uiaWMjAXYZYdFkpZHhxDmSLpwpw==",
+      "optional": true
+    },
+    "@node-rs/jieba-linux-x64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-gnu/-/jieba-linux-x64-gnu-1.10.4.tgz",
+      "integrity": "sha512-WZO8ykRJpWGE9MHuZpy1lu3nJluPoeB+fIJJn5CWZ9YTVhNDWoCF4i/7nxz1ntulINYGQ8VVuCU9LD86Mek97g==",
+      "optional": true
+    },
+    "@node-rs/jieba-linux-x64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-musl/-/jieba-linux-x64-musl-1.10.4.tgz",
+      "integrity": "sha512-uBBD4S1rGKcgCyAk6VCKatEVQb6EDD5I40v/DxODi5CuZVCANi9m5oee/MQbAoaX7RydA2f0OSCE9/tcwXEwUg==",
+      "optional": true
+    },
+    "@node-rs/jieba-wasm32-wasi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-wasm32-wasi/-/jieba-wasm32-wasi-1.10.4.tgz",
+      "integrity": "sha512-Y2umiKHjuIJy0uulNDz9SDYHdfq5Hmy7jY5nORO99B4pySKkcrMjpeVrmWXJLIsEKLJwcCXHxz8tjwU5/uhz0A==",
+      "optional": true,
+      "requires": {
+        "@napi-rs/wasm-runtime": "^0.2.3"
+      }
+    },
+    "@node-rs/jieba-win32-arm64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-arm64-msvc/-/jieba-win32-arm64-msvc-1.10.4.tgz",
+      "integrity": "sha512-nwMtViFm4hjqhz1it/juQnxpXgqlGltCuWJ02bw70YUDMDlbyTy3grCJPpQQpueeETcALUnTxda8pZuVrLRcBA==",
+      "optional": true
+    },
+    "@node-rs/jieba-win32-ia32-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-ia32-msvc/-/jieba-win32-ia32-msvc-1.10.4.tgz",
+      "integrity": "sha512-DCAvLx7Z+W4z5oKS+7vUowAJr0uw9JBw8x1Y23Xs/xMA4Em+OOSiaF5/tCJqZUCJ8uC4QeImmgDFiBqGNwxlyA==",
+      "optional": true
+    },
+    "@node-rs/jieba-win32-x64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-x64-msvc/-/jieba-win32-x64-msvc-1.10.4.tgz",
+      "integrity": "sha512-+sqemSfS1jjb+Tt7InNbNzrRh1Ua3vProVvC4BZRPg010/leCbGFFiQHpzcPRfpxAXZrzG5Y0YBTsPzN/I4yHQ==",
+      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -51429,84 +52322,106 @@
       "optional": true
     },
     "@rspack/binding": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.3.12.tgz",
-      "integrity": "sha512-4Ic8lV0+LCBfTlH5aIOujIRWZOtgmG223zC4L3o8WY/+ESAgpdnK6lSSMfcYgRanYLAy3HOmFIp20jwskMpbAg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.5.2.tgz",
+      "integrity": "sha512-NKiBcsxmAzFDYRnK2ZHWbTtDFVT5/704eK4OfpgsDXPMkaMnBKijMKNgP5pbe18X4rUlz+8HnGm4+Xllo9EESw==",
       "requires": {
-        "@rspack/binding-darwin-arm64": "1.3.12",
-        "@rspack/binding-darwin-x64": "1.3.12",
-        "@rspack/binding-linux-arm64-gnu": "1.3.12",
-        "@rspack/binding-linux-arm64-musl": "1.3.12",
-        "@rspack/binding-linux-x64-gnu": "1.3.12",
-        "@rspack/binding-linux-x64-musl": "1.3.12",
-        "@rspack/binding-win32-arm64-msvc": "1.3.12",
-        "@rspack/binding-win32-ia32-msvc": "1.3.12",
-        "@rspack/binding-win32-x64-msvc": "1.3.12"
+        "@rspack/binding-darwin-arm64": "1.5.2",
+        "@rspack/binding-darwin-x64": "1.5.2",
+        "@rspack/binding-linux-arm64-gnu": "1.5.2",
+        "@rspack/binding-linux-arm64-musl": "1.5.2",
+        "@rspack/binding-linux-x64-gnu": "1.5.2",
+        "@rspack/binding-linux-x64-musl": "1.5.2",
+        "@rspack/binding-wasm32-wasi": "1.5.2",
+        "@rspack/binding-win32-arm64-msvc": "1.5.2",
+        "@rspack/binding-win32-ia32-msvc": "1.5.2",
+        "@rspack/binding-win32-x64-msvc": "1.5.2"
       }
     },
     "@rspack/binding-darwin-arm64": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.3.12.tgz",
-      "integrity": "sha512-8hKjVTBeWPqkMzFPNWIh72oU9O3vFy3e88wRjMPImDCXBiEYrKqGTTLd/J0SO+efdL3SBD1rX1IvdJpxCv6Yrw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-aO76T6VQvAFt1LJNRA5aPOJ+szeTLlzC5wubsnxgWWjG53goP+Te35kFjDIDe+9VhKE/XqRId6iNAymaEsN+Uw==",
       "optional": true
     },
     "@rspack/binding-darwin-x64": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.3.12.tgz",
-      "integrity": "sha512-Sj4m+mCUxL7oCpdu7OmWT7fpBM7hywk5CM9RDc3D7StaBZbvNtNftafCrTZzTYKuZrKmemTh5SFzT5Tz7tf6GA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-XNSmUOwdGs2PEdCKTFCC0/vu/7U9nMhAlbHJKlmdt0V4iPvFyaNWxkNdFqzLc05jlJOfgDdwbwRb91y9IcIIFQ==",
       "optional": true
     },
     "@rspack/binding-linux-arm64-gnu": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.3.12.tgz",
-      "integrity": "sha512-7MuOxf3/Mhv4mgFdLTvgnt/J+VouNR65DEhorth+RZm3LEWojgoFEphSAMAvpvAOpYSS68Sw4SqsOZi719ia2w==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.5.2.tgz",
+      "integrity": "sha512-rNxRfgC5khlrhyEP6y93+45uQ4TI7CdtWqh5PKsaR6lPepG1rH4L8VE+etejSdhzXH6wQ76Rw4wzb96Hx+5vuQ==",
       "optional": true
     },
     "@rspack/binding-linux-arm64-musl": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.3.12.tgz",
-      "integrity": "sha512-s6KKj20T9Z1bA8caIjU6EzJbwyDo1URNFgBAlafCT2UC6yX7flstDJJ38CxZacA9A2P24RuQK2/jPSZpWrTUFA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.5.2.tgz",
+      "integrity": "sha512-kTFX+KsGgArWC5q+jJWz0K/8rfVqZOn1ojv1xpCCcz/ogWRC/qhDGSOva6Wandh157BiR93Vfoe1gMvgjpLe5g==",
       "optional": true
     },
     "@rspack/binding-linux-x64-gnu": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.3.12.tgz",
-      "integrity": "sha512-0w/sRREYbRgHgWvs2uMEJSLfvzbZkPHUg6CMcYQGNVK6axYRot6jPyKetyFYA9pR5fB5rsXegpnFaZaVrRIK2g==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.5.2.tgz",
+      "integrity": "sha512-Lh/6WZGq30lDV6RteQQu7Phw0RH2Z1f4kGR+MsplJ6X4JpnziDow+9oxKdu6FvFHWxHByncpveVeInusQPmL7Q==",
       "optional": true
     },
     "@rspack/binding-linux-x64-musl": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.3.12.tgz",
-      "integrity": "sha512-jEdxkPymkRxbijDRsBGdhopcbGXiXDg59lXqIRkVklqbDmZ/O6DHm7gImmlx5q9FoWbz0gqJuOKBz4JqWxjWVA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.5.2.tgz",
+      "integrity": "sha512-CsLC/SIOIFs6CBmusSAF0FECB62+J36alMdwl7j6TgN6nX3UQQapnL1aVWuQaxU6un/1Vpim0V/EZbUYIdJQ4g==",
       "optional": true
     },
+    "@rspack/binding-wasm32-wasi": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.5.2.tgz",
+      "integrity": "sha512-cuVbGr1b4q0Z6AtEraI3becZraPMMgZtZPRaIsVLeDXCmxup/maSAR3T6UaGf4Q2SNcFfjw4neGz5UJxPK8uvA==",
+      "optional": true,
+      "requires": {
+        "@napi-rs/wasm-runtime": "^1.0.1"
+      },
+      "dependencies": {
+        "@napi-rs/wasm-runtime": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.3.tgz",
+          "integrity": "sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q==",
+          "optional": true,
+          "requires": {
+            "@emnapi/core": "^1.4.5",
+            "@emnapi/runtime": "^1.4.5",
+            "@tybys/wasm-util": "^0.10.0"
+          }
+        }
+      }
+    },
     "@rspack/binding-win32-arm64-msvc": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.3.12.tgz",
-      "integrity": "sha512-ZRvUCb3TDLClAqcTsl/o9UdJf0B5CgzAxgdbnYJbldyuyMeTUB4jp20OfG55M3C2Nute2SNhu2bOOp9Se5Ongw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.5.2.tgz",
+      "integrity": "sha512-4vJQdzRTSuvmvL3vrOPuiA7f9v9frNc2RFWDxqg+GYt0YAjDStssp+lkVbRYyXnTYVJkARSuO6N+BOiI+kLdsQ==",
       "optional": true
     },
     "@rspack/binding-win32-ia32-msvc": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.3.12.tgz",
-      "integrity": "sha512-1TKPjuXStPJr14f3ZHuv40Xc/87jUXx10pzVtrPnw+f3hckECHrbYU/fvbVzZyuXbsXtkXpYca6ygCDRJAoNeQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.5.2.tgz",
+      "integrity": "sha512-zPbu3lx/NrNxdjZzTIjwD0mILUOpfhuPdUdXIFiOAO8RiWSeQpYOvyI061s/+bNOmr4A+Z0uM0dEoOClfkhUFg==",
       "optional": true
     },
     "@rspack/binding-win32-x64-msvc": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.3.12.tgz",
-      "integrity": "sha512-lCR0JfnYKpV+a6r2A2FdxyUKUS4tajePgpPJN5uXDgMGwrDtRqvx+d0BHhwjFudQVJq9VVbRaL89s2MQ6u+xYw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.5.2.tgz",
+      "integrity": "sha512-duLNUTshX38xhC10/W9tpkPca7rOifP2begZjdb1ikw7C4AI0I7VnBnYt8qPSxGISoclmhOBxU/LuAhS8jMMlg==",
       "optional": true
     },
     "@rspack/core": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.3.12.tgz",
-      "integrity": "sha512-mAPmV4LPPRgxpouUrGmAE4kpF1NEWJGyM5coebsjK/zaCMSjw3mkdxiU2b5cO44oIi0Ifv5iGkvwbdrZOvMyFA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-ifjHqLczC81d1xjXPXCzxTFKNOFsEzuuLN44cMnyzQ/GWi4B48fyX7JHndWE7Lxd54cW1O9Ik7AdBN3Gq891EA==",
       "requires": {
-        "@module-federation/runtime-tools": "0.14.0",
-        "@rspack/binding": "1.3.12",
-        "@rspack/lite-tapable": "1.0.1",
-        "caniuse-lite": "^1.0.30001718"
+        "@module-federation/runtime-tools": "0.18.0",
+        "@rspack/binding": "1.5.2",
+        "@rspack/lite-tapable": "1.0.1"
       }
     },
     "@rspack/lite-tapable": {
@@ -52042,6 +52957,15 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
+    },
+    "@tybys/wasm-util": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+      "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "@types/acorn": {
       "version": "4.0.6",
@@ -53887,29 +54811,30 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "algoliasearch": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.25.0.tgz",
-      "integrity": "sha512-n73BVorL4HIwKlfJKb4SEzAYkR3Buwfwbh+MYxg2mloFph2fFGV58E90QTzdbfzWrLn4HE5Czx/WTjI8fcHaMg==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.37.0.tgz",
+      "integrity": "sha512-y7gau/ZOQDqoInTQp0IwTOjkrHc4Aq4R8JgpmCleFwiLl+PbN2DMWoDUWZnrK8AhNJwT++dn28Bt4NZYNLAmuA==",
       "requires": {
-        "@algolia/client-abtesting": "5.25.0",
-        "@algolia/client-analytics": "5.25.0",
-        "@algolia/client-common": "5.25.0",
-        "@algolia/client-insights": "5.25.0",
-        "@algolia/client-personalization": "5.25.0",
-        "@algolia/client-query-suggestions": "5.25.0",
-        "@algolia/client-search": "5.25.0",
-        "@algolia/ingestion": "1.25.0",
-        "@algolia/monitoring": "1.25.0",
-        "@algolia/recommend": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/abtesting": "1.3.0",
+        "@algolia/client-abtesting": "5.37.0",
+        "@algolia/client-analytics": "5.37.0",
+        "@algolia/client-common": "5.37.0",
+        "@algolia/client-insights": "5.37.0",
+        "@algolia/client-personalization": "5.37.0",
+        "@algolia/client-query-suggestions": "5.37.0",
+        "@algolia/client-search": "5.37.0",
+        "@algolia/ingestion": "1.37.0",
+        "@algolia/monitoring": "1.37.0",
+        "@algolia/recommend": "5.37.0",
+        "@algolia/requester-browser-xhr": "5.37.0",
+        "@algolia/requester-fetch": "5.37.0",
+        "@algolia/requester-node-http": "5.37.0"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.25.0.tgz",
-      "integrity": "sha512-vQoK43U6HXA9/euCqLjvyNdM4G2Fiu/VFp4ae0Gau9sZeIKBPvUPnXfLYAe65Bg7PFuw03coeu5K6lTPSXRObw==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.26.0.tgz",
+      "integrity": "sha512-Rv2x3GXleQ3ygwhkhJubhhYGsICmShLAiqtUuJTUkr9uOCOXyF2E71LVT4XDnVffbknv8XgScP4U0Oxtgm+hIw==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -54389,12 +55314,12 @@
       }
     },
     "babel-plugin-polyfill-corejs2": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
-      "integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+      "integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
       "requires": {
-        "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.4",
+        "@babel/compat-data": "^7.27.7",
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
         "semver": "^6.3.1"
       },
       "dependencies": {
@@ -54406,20 +55331,20 @@
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
-      "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
+      "integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.6.3",
-        "core-js-compat": "^3.40.0"
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
+        "core-js-compat": "^3.43.0"
       }
     },
     "babel-plugin-polyfill-regenerator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
-      "integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+      "integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.6.4"
+        "@babel/helper-define-polyfill-provider": "^0.6.5"
       }
     },
     "babel-preset-current-node-syntax": {
@@ -54708,12 +55633,12 @@
       "integrity": "sha512-LSvVX5e21LRrXqVMhqtAwj5xPgDb+fXAIH80NsnCQ9xuZPs2xWsOREi24RKgZa1XOiQRbcmVrv87+ulOKsgjxw=="
     },
     "browserslist": {
-      "version": "4.24.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+      "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
+      "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
       "requires": {
-        "caniuse-lite": "^1.0.30001716",
-        "electron-to-chromium": "^1.5.149",
+        "caniuse-lite": "^1.0.30001737",
+        "electron-to-chromium": "^1.5.211",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       }
@@ -54939,9 +55864,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw=="
+      "version": "1.0.30001741",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+      "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw=="
     },
     "canvas-roundrect-polyfill": {
       "version": "0.0.1",
@@ -55340,9 +56265,9 @@
       }
     },
     "clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
     },
     "co": {
       "version": "4.6.0",
@@ -55420,6 +56345,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g=="
     },
     "comma-separated-tokens": {
       "version": "2.0.3",
@@ -55721,9 +56651,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "copy-text-to-clipboard": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz",
-      "integrity": "sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.1.tgz",
+      "integrity": "sha512-3am6cw+WOicd0+HyzhC4kYS02wHJUiVQXmAADxfUARKsHBkWl1Vl3QQEiILlSs8YcPS/C0+y/urCNEYQk+byWA=="
     },
     "copy-to-clipboard": {
       "version": "3.3.3",
@@ -55779,17 +56709,17 @@
       "integrity": "sha512-BTvUrwxVBezj5SZ3f10ImnX2oRByMxql3EimVqMysepbC9EeMUOpLwdy6Eoili2x6E4kf+ZUB5k/+Jv55alPfA=="
     },
     "core-js-compat": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.42.0.tgz",
-      "integrity": "sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==",
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.1.tgz",
+      "integrity": "sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==",
       "requires": {
-        "browserslist": "^4.24.4"
+        "browserslist": "^4.25.3"
       }
     },
     "core-js-pure": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.42.0.tgz",
-      "integrity": "sha512-007bM04u91fF4kMgwom2I5cQxAFIy8jVulgr9eozILl/SZE53QOqnW/+vviC+wQWLv+AunBG+8Q0TLoeSsSxRQ=="
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.1.tgz",
+      "integrity": "sha512-OHnWFKgTUshEU8MK+lOs1H8kC8GkTi9Z1tvNkxrCcw9wl3MJIO7q2ld77wjWn4/xuGrVu2X+nME1iIIPBSdyEQ=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -55985,9 +56915,9 @@
       "integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow=="
     },
     "css-has-pseudo": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-7.0.2.tgz",
-      "integrity": "sha512-nzol/h+E0bId46Kn2dQH5VElaknX2Sr0hFuB/1EomdC7j+OISt2ZzK7EHX9DZDY53WbIVAR7FYKSO2XnSf07MQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-7.0.3.tgz",
+      "integrity": "sha512-oG+vKuGyqe/xvEMoxAQrhi7uY16deJR3i7wwhBerVrGQKSqUC5GiOVxTpM9F9B9hw0J+eKeOWLH7E9gZ1Dr5rA==",
       "requires": {
         "@csstools/selector-specificity": "^5.0.0",
         "postcss-selector-parser": "^7.0.0",
@@ -56070,9 +57000,9 @@
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
     },
     "cssdb": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.3.0.tgz",
-      "integrity": "sha512-c7bmItIg38DgGjSwDPZOYF/2o0QU/sSgkWOMyl8votOfgFuyiFKWPesmCGEsrGLxEA9uL540cp8LdaGEjUGsZQ=="
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.4.0.tgz",
+      "integrity": "sha512-lyATYGyvXwQ8h55WeQeEHXhI+47rl52pXSYkFK/ZrCbAJSgVIaPFjYc3RM8TpRHKk7W3wsAZImmLps+P5VyN9g=="
     },
     "cssesc": {
       "version": "3.0.0",
@@ -58289,9 +59219,9 @@
       "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
     },
     "domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "requires": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -58354,9 +59284,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-to-chromium": {
-      "version": "1.5.159",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.159.tgz",
-      "integrity": "sha512-CEvHptWAMV5p6GJ0Lq8aheyvVbfzVrv5mmidu1D3pidoVNkB3tTBsTMVtPJ+rzRK5oV229mCLz9Zj/hNvU8GBA=="
+      "version": "1.5.215",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.215.tgz",
+      "integrity": "sha512-TIvGp57UpeNetj/wV/xpFNpWGb0b/ROw372lHPx5Aafx02gjTBtWnEEcaSX3W2dLM3OSdGGyHX/cHl01JQsLaQ=="
     },
     "elkjs": {
       "version": "0.9.3",
@@ -58404,6 +59334,15 @@
         "inherits": "^2.0.3",
         "level-codec": "^9.0.0",
         "level-errors": "^2.0.0"
+      }
+    },
+    "encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "requires": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
       }
     },
     "end-of-stream": {
@@ -58928,17 +59867,6 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "resolve": {
-          "version": "1.22.8",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-          "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.13.0",
-            "path-parse": "^1.0.7",
-            "supports-preserve-symlinks-flag": "^1.0.0"
           }
         }
       }
@@ -60603,11 +61531,6 @@
         }
       }
     },
-    "globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
-    },
     "globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -61692,11 +62615,11 @@
       }
     },
     "is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "requires": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
       }
     },
     "is-data-view": {
@@ -63754,6 +64677,14 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -64578,6 +65509,11 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="
     },
     "markdown-extensions": {
       "version": "2.0.0",
@@ -66266,9 +67202,9 @@
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg=="
     },
     "mini-css-extract-plugin": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.2.tgz",
-      "integrity": "sha512-GJuACcS//jtq4kCtd5ii/M0SZf7OZRH+BxdqXZHaJfb8TJiVl+NgQRPwiYt2EuqeSkNydn/7vP+bcE27C5mb9w==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
+      "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
       "requires": {
         "schema-utils": "^4.0.0",
         "tapable": "^2.2.1"
@@ -66496,9 +67432,9 @@
       "integrity": "sha512-FRS2otuFcPPYDPYViNWQ42+1iZqbXydinkRHTHFxrF4a1CpBfmydR9zkI44WSXAXCyPrkcGtPk5CnpW6Y3lFKQ=="
     },
     "nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="
     },
     "napi-macros": {
       "version": "2.0.0",
@@ -67365,11 +68301,18 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "requires": {
-        "entities": "^4.4.0"
+        "entities": "^6.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+          "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
+        }
       }
     },
     "parse5-htmlparser2-tree-adapter": {
@@ -67378,6 +68321,14 @@
       "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
       "requires": {
         "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      }
+    },
+    "parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "requires": {
         "parse5": "^7.0.0"
       }
     },
@@ -67664,13 +68615,13 @@
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
     },
     "postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "requires": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       }
     },
     "postcss-attribute-case-insensitive": {
@@ -67710,14 +68661,14 @@
       }
     },
     "postcss-color-functional-notation": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-7.0.10.tgz",
-      "integrity": "sha512-k9qX+aXHBiLTRrWoCJuUFI6F1iF6QJQUXNVWJVSbqZgj57jDhBlOvD8gNUGl35tgqDivbGLhZeW3Ongz4feuKA==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-7.0.11.tgz",
+      "integrity": "sha512-zfqoUSaHMko/k2PA9xnaydVTHqYv5vphq5Q2AHcG/dCdv/OkHYWcVWfVTBKZ526uzT8L7NghuvSw3C9PxlKnLg==",
       "requires": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       }
     },
@@ -67771,9 +68722,9 @@
       }
     },
     "postcss-custom-properties": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-14.0.5.tgz",
-      "integrity": "sha512-UWf/vhMapZatv+zOuqlfLmYXeOhhHLh8U8HAKGI2VJ00xLRYoAJh4xv8iX6FB6+TLXeDnm0DBLMi00E0hodbQw==",
+      "version": "14.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-14.0.6.tgz",
+      "integrity": "sha512-fTYSp3xuk4BUeVhxCSJdIPhDLpJfNakZKoiTDx7yRGCdlZrSJR7mWKVOBS4sBF+5poPQFMj2YdXx1VHItBGihQ==",
       "requires": {
         "@csstools/cascade-layer-name-parser": "^2.0.5",
         "@csstools/css-parser-algorithms": "^3.0.5",
@@ -67852,11 +68803,11 @@
       }
     },
     "postcss-double-position-gradients": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-6.0.2.tgz",
-      "integrity": "sha512-7qTqnL7nfLRyJK/AHSVrrXOuvDDzettC+wGoienURV8v2svNbu6zJC52ruZtHaO6mfcagFmuTGFdzRsJKB3k5Q==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-6.0.3.tgz",
+      "integrity": "sha512-Dl0Z9sdbMwrPslgOaGBZRGo3TASmmgTcqcUODr82MTYyJk6devXZM6MlQjpQKMJqlLJ6oL1w78U7IXFdPA5+ug==",
       "requires": {
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0",
         "postcss-value-parser": "^4.2.0"
       }
@@ -67939,14 +68890,14 @@
       }
     },
     "postcss-lab-function": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-7.0.10.tgz",
-      "integrity": "sha512-tqs6TCEv9tC1Riq6fOzHuHcZyhg4k3gIAMB8GGY/zA1ssGdm6puHMVE7t75aOSoFg7UD2wyrFFhbldiCMyyFTQ==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-7.0.11.tgz",
+      "integrity": "sha512-BEA4jId8uQe1gyjZZ6Bunb6ZsH2izks+v25AxQJDBtigXCjTLmCPWECwQpLTtcxH589MVxhs/9TAmRC6lUEmXQ==",
       "requires": {
-        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/utilities": "^2.0.0"
       }
     },
@@ -68140,11 +69091,11 @@
       }
     },
     "postcss-nesting": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.1.tgz",
-      "integrity": "sha512-VbqqHkOBOt4Uu3G8Dm8n6lU5+9cJFxiuty9+4rcoyRPO9zZS1JIs6td49VIoix3qYqELHlJIn46Oih9SAKo+yQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.2.tgz",
+      "integrity": "sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==",
       "requires": {
-        "@csstools/selector-resolve-nested": "^3.0.0",
+        "@csstools/selector-resolve-nested": "^3.1.0",
         "@csstools/selector-specificity": "^5.0.0",
         "postcss-selector-parser": "^7.0.0"
       },
@@ -68266,24 +69217,26 @@
       }
     },
     "postcss-preset-env": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.2.0.tgz",
-      "integrity": "sha512-cl13sPBbSqo1Q7Ryb19oT5NZO5IHFolRbIMdgDq4f9w1MHYiL6uZS7uSsjXJ1KzRIcX5BMjEeyxmAevVXENa3Q==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.3.1.tgz",
+      "integrity": "sha512-8ZOOWVwQ0iMpfEYkYo+U6W7fE2dJ/tP6dtEFwPJ66eB5JjnFupfYh+y6zo+vWDO72nGhKOVdxwhTjfzcSNRg4Q==",
       "requires": {
-        "@csstools/postcss-cascade-layers": "^5.0.1",
-        "@csstools/postcss-color-function": "^4.0.10",
-        "@csstools/postcss-color-mix-function": "^3.0.10",
-        "@csstools/postcss-color-mix-variadic-function-arguments": "^1.0.0",
-        "@csstools/postcss-content-alt-text": "^2.0.6",
+        "@csstools/postcss-alpha-function": "^1.0.0",
+        "@csstools/postcss-cascade-layers": "^5.0.2",
+        "@csstools/postcss-color-function": "^4.0.11",
+        "@csstools/postcss-color-function-display-p3-linear": "^1.0.0",
+        "@csstools/postcss-color-mix-function": "^3.0.11",
+        "@csstools/postcss-color-mix-variadic-function-arguments": "^1.0.1",
+        "@csstools/postcss-content-alt-text": "^2.0.7",
         "@csstools/postcss-exponential-functions": "^2.0.9",
         "@csstools/postcss-font-format-keywords": "^4.0.0",
-        "@csstools/postcss-gamut-mapping": "^2.0.10",
-        "@csstools/postcss-gradients-interpolation-method": "^5.0.10",
-        "@csstools/postcss-hwb-function": "^4.0.10",
-        "@csstools/postcss-ic-unit": "^4.0.2",
+        "@csstools/postcss-gamut-mapping": "^2.0.11",
+        "@csstools/postcss-gradients-interpolation-method": "^5.0.11",
+        "@csstools/postcss-hwb-function": "^4.0.11",
+        "@csstools/postcss-ic-unit": "^4.0.3",
         "@csstools/postcss-initial": "^2.0.1",
-        "@csstools/postcss-is-pseudo-class": "^5.0.1",
-        "@csstools/postcss-light-dark-function": "^2.0.9",
+        "@csstools/postcss-is-pseudo-class": "^5.0.3",
+        "@csstools/postcss-light-dark-function": "^2.0.10",
         "@csstools/postcss-logical-float-and-clear": "^3.0.0",
         "@csstools/postcss-logical-overflow": "^2.0.0",
         "@csstools/postcss-logical-overscroll-behavior": "^2.0.0",
@@ -68293,40 +69246,40 @@
         "@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.5",
         "@csstools/postcss-nested-calc": "^4.0.0",
         "@csstools/postcss-normalize-display-values": "^4.0.0",
-        "@csstools/postcss-oklab-function": "^4.0.10",
-        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/postcss-oklab-function": "^4.0.11",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.0",
         "@csstools/postcss-random-function": "^2.0.1",
-        "@csstools/postcss-relative-color-syntax": "^3.0.10",
+        "@csstools/postcss-relative-color-syntax": "^3.0.11",
         "@csstools/postcss-scope-pseudo-class": "^4.0.1",
         "@csstools/postcss-sign-functions": "^1.1.4",
         "@csstools/postcss-stepped-value-functions": "^4.0.9",
-        "@csstools/postcss-text-decoration-shorthand": "^4.0.2",
+        "@csstools/postcss-text-decoration-shorthand": "^4.0.3",
         "@csstools/postcss-trigonometric-functions": "^4.0.9",
         "@csstools/postcss-unset-value": "^4.0.0",
         "autoprefixer": "^10.4.21",
-        "browserslist": "^4.24.5",
+        "browserslist": "^4.25.1",
         "css-blank-pseudo": "^7.0.1",
-        "css-has-pseudo": "^7.0.2",
+        "css-has-pseudo": "^7.0.3",
         "css-prefers-color-scheme": "^10.0.0",
-        "cssdb": "^8.3.0",
+        "cssdb": "^8.4.0",
         "postcss-attribute-case-insensitive": "^7.0.1",
         "postcss-clamp": "^4.1.0",
-        "postcss-color-functional-notation": "^7.0.10",
+        "postcss-color-functional-notation": "^7.0.11",
         "postcss-color-hex-alpha": "^10.0.0",
         "postcss-color-rebeccapurple": "^10.0.0",
         "postcss-custom-media": "^11.0.6",
-        "postcss-custom-properties": "^14.0.5",
+        "postcss-custom-properties": "^14.0.6",
         "postcss-custom-selectors": "^8.0.5",
         "postcss-dir-pseudo-class": "^9.0.1",
-        "postcss-double-position-gradients": "^6.0.2",
+        "postcss-double-position-gradients": "^6.0.3",
         "postcss-focus-visible": "^10.0.1",
         "postcss-focus-within": "^9.0.1",
         "postcss-font-variant": "^5.0.0",
         "postcss-gap-properties": "^6.0.0",
         "postcss-image-set-function": "^7.0.0",
-        "postcss-lab-function": "^7.0.10",
+        "postcss-lab-function": "^7.0.11",
         "postcss-logical": "^8.1.0",
-        "postcss-nesting": "^13.0.1",
+        "postcss-nesting": "^13.0.2",
         "postcss-opacity-percentage": "^3.0.0",
         "postcss-overflow-shorthand": "^6.0.0",
         "postcss-page-break": "^3.0.4",
@@ -69104,9 +70057,9 @@
       "dev": true
     },
     "react-json-view-lite": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.4.1.tgz",
-      "integrity": "sha512-fwFYknRIBxjbFm0kBDrzgBy1xa5tDg2LyXXBepC5f1b+MY3BUClMCsvanMPn089JbV1Eg3nZcrp0VCuH43aXnA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.5.0.tgz",
+      "integrity": "sha512-tk7o7QG9oYyELWHL8xiMQ8x4WzjCzbWNyig3uexmkLb54r8jO0yH3WCWx8UZS0c49eSA4QUmG5caiRJ8fAn58g=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -69880,11 +70833,11 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "requires": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -70816,9 +71769,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
     "source-map-support": {
       "version": "0.5.13",
@@ -72164,6 +73117,11 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "undici": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.15.0.tgz",
+      "integrity": "sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ=="
+    },
     "unescape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unescape/-/unescape-1.0.1.tgz",
@@ -73490,7 +74448,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "dev": true,
       "requires": {
         "iconv-lite": "0.6.3"
       }
@@ -73498,8 +74455,7 @@
     "whatwg-mimetype": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="
     },
     "whatwg-url": {
       "version": "14.0.0",

--- a/packages/lexical-website/docusaurus.config.js
+++ b/packages/lexical-website/docusaurus.config.js
@@ -343,14 +343,8 @@ const config = {
   tagline: 'An extensible text editor framework that does things differently',
 
   themeConfig:
-    /** @type {import('@docusaurus/preset-classic').ThemeConfig & import('@docusaurus/theme-search-algolia').ThemeConfig} */
+    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      algolia: {
-        apiKey: '00b99bc61a623e1abd819b1d655da918',
-        appId: 'YRGKJK6OMH',
-        contextualSearch: true,
-        indexName: 'lexical',
-      },
       docs: {
         sidebar: {
           autoCollapseCategories: true,
@@ -477,7 +471,20 @@ const config = {
       },
     }),
 
-  themes: ['@docusaurus/theme-mermaid'],
+  themes: [
+    '@docusaurus/theme-mermaid',
+    [
+      require.resolve('@easyops-cn/docusaurus-search-local'),
+      /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */
+      ({
+        // ... Your options.
+        // `hashed` is recommended as long-term-cache of index file is possible.
+        hashed: true,
+        indexBlog: false,
+        language: ['en'],
+      }),
+    ],
+  ],
 
   title: TITLE,
   url: 'https://lexical.dev',

--- a/packages/lexical-website/package.json
+++ b/packages/lexical-website/package.json
@@ -14,12 +14,12 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.8.0",
-    "@docusaurus/faster": "^3.8.0",
-    "@docusaurus/plugin-client-redirects": "^3.8.0",
-    "@docusaurus/preset-classic": "^3.8.0",
-    "@docusaurus/theme-mermaid": "^3.8.0",
-    "@docusaurus/theme-search-algolia": "^3.8.0",
+    "@docusaurus/core": "^3.8.1",
+    "@docusaurus/faster": "^3.8.1",
+    "@docusaurus/plugin-client-redirects": "^3.8.1",
+    "@docusaurus/preset-classic": "^3.8.1",
+    "@docusaurus/theme-mermaid": "^3.8.1",
+    "@easyops-cn/docusaurus-search-local": "^0.52.1",
     "@mdx-js/react": "^3.0.1",
     "@radix-ui/react-tabs": "^1.0.4",
     "@vercel/analytics": "^1.0.1",


### PR DESCRIPTION
## Description

The docusaurus algolia index for lexical.dev hasn't been updated in at least 6+ months, this replaces algolia with a local lunr index that doesn't depend on any third parties.

There are a few rough edges in the UI but it's very usable. Two things I noticed:
* Pressing cmd+k to search doesn't select the previous input text so it takes an extra cmd+a keystroke to clear before searching again
* It displays `See all {count} results` instead of an actual count

https://lexical-git-fork-etrepum-docusaurus-search-local-fbopensource.vercel.app/

Closes #7808

## Test plan

### Before

Search results would be incomplete and/or return broken links, e.g. search for any class or something like NodeState which has been introduced in the past few months

### After

Search results are always up to date
