### PR TITLE
[lexical-yjs][lexical-playground] Breaking change: remove clientID from collab context

### DIFF
--- a/packages/lexical-playground/src/nodes/PollComponent.tsx
+++ b/packages/lexical-playground/src/nodes/PollComponent.tsx
@@ -24,7 +24,6 @@ import {
   COMMAND_PRIORITY_LOW,
   NodeKey,
 } from 'lexical';
-import * as React from 'react';
 import {useEffect, useMemo, useRef, useState} from 'react';
 
 import Button from '../ui/Button';
@@ -53,10 +52,10 @@ function PollOptionComponent({
     onSelect?: () => void,
   ) => void;
 }): JSX.Element {
-  const {clientID} = useCollaborationContext();
+  const {name: username} = useCollaborationContext();
   const checkboxRef = useRef(null);
   const votesArray = option.votes;
-  const checkedIndex = votesArray.indexOf(clientID);
+  const checkedIndex = votesArray.indexOf(username);
   const checked = checkedIndex !== -1;
   const votes = votesArray.length;
   const text = option.text;
@@ -74,7 +73,7 @@ function PollOptionComponent({
           type="checkbox"
           onChange={(e) => {
             withPollNode((node) => {
-              node.toggleVote(option, clientID);
+              node.toggleVote(option, username);
             });
           }}
           checked={checked}

--- a/packages/lexical-playground/src/nodes/PollNode.tsx
+++ b/packages/lexical-playground/src/nodes/PollNode.tsx
@@ -29,7 +29,7 @@ export type Options = ReadonlyArray<Option>;
 export type Option = Readonly<{
   text: string;
   uid: string;
-  votes: Array<number>;
+  votes: Array<string>;
 }>;
 
 const PollComponent = React.lazy(() => import('./PollComponent'));
@@ -52,7 +52,7 @@ export function createPollOption(text = ''): Option {
 function cloneOption(
   option: Option,
   text: string,
-  votes?: Array<number>,
+  votes?: Array<string>,
 ): Option {
   return {
     text,
@@ -90,7 +90,7 @@ function parseOptions(json: unknown): Options {
         typeof row.text === 'string' &&
         typeof row.uid === 'string' &&
         Array.isArray(row.votes) &&
-        row.votes.every((v: unknown) => typeof v === 'number')
+        row.votes.every((v: unknown) => typeof v === 'string')
       ) {
         options.push(row);
       }
@@ -167,7 +167,7 @@ export class PollNode extends DecoratorNode<JSX.Element> {
     });
   }
 
-  toggleVote(option: Option, clientID: number): this {
+  toggleVote(option: Option, username: string): this {
     return this.setOptions((prevOptions) => {
       const index = prevOptions.indexOf(option);
       if (index === -1) {
@@ -175,9 +175,9 @@ export class PollNode extends DecoratorNode<JSX.Element> {
       }
       const votes = option.votes;
       const votesClone = Array.from(votes);
-      const voteIndex = votes.indexOf(clientID);
+      const voteIndex = votes.indexOf(username);
       if (voteIndex === -1) {
-        votesClone.push(clientID);
+        votesClone.push(username);
       } else {
         votesClone.splice(voteIndex, 1);
       }

--- a/packages/lexical-react/src/LexicalCollaborationContext.ts
+++ b/packages/lexical-react/src/LexicalCollaborationContext.ts
@@ -11,7 +11,6 @@ import type {Doc} from 'yjs';
 import {createContext, useContext} from 'react';
 
 export type CollaborationContextType = {
-  clientID: number;
   color: string;
   isCollabActive: boolean;
   name: string;
@@ -39,7 +38,6 @@ const entries = [
 
 const randomEntry = entries[Math.floor(Math.random() * entries.length)];
 export const CollaborationContext = createContext<CollaborationContextType>({
-  clientID: 0,
   color: randomEntry[1],
   isCollabActive: false,
   name: randomEntry[0],

--- a/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
@@ -201,8 +201,6 @@ function YjsCollaborationCursors({
     syncCursorPositionsFn,
   );
 
-  collabContext.clientID = binding.clientID;
-
   useYjsHistory(editor, binding);
   useYjsFocusTracking(editor, provider, name, color, awarenessData);
 


### PR DESCRIPTION
## Description

Removes `clientID` from collaboration context. This ID was unreliable as it could be updated by nested collab editors. Consumers should retrieve the client ID by looking up the correct document in the context's `yjsDocMap`, or switch to using a different ID.

Also updated `PollComponent` to use name rather than client ID, so two clients with the same name will update each other's vote, which arguably is more correct.