### PR TITLE
[lexical] Chore: Improve error message when a node is registered from a foreign lexical module

### DIFF
--- a/packages/lexical/src/LexicalUtils.ts
+++ b/packages/lexical/src/LexicalUtils.ts
@@ -2019,6 +2019,29 @@ export function hasOwnExportDOM(klass: Klass<LexicalNode>) {
 
 /** @internal */
 function isAbstractNodeClass(klass: Klass<LexicalNode>): boolean {
+  if (!(klass === LexicalNode || klass.prototype instanceof LexicalNode)) {
+    let ownNodeType = '<unknown>';
+    let version = '<unknown>';
+    try {
+      ownNodeType = klass.getType();
+    } catch (_err) {
+      // ignore
+    }
+    try {
+      if (LexicalEditor.version) {
+        version = JSON.parse(LexicalEditor.version);
+      }
+    } catch (_err) {
+      // ignore
+    }
+    invariant(
+      false,
+      '%s (type %s) does not subclass LexicalNode from the lexical package used by this editor (version %s). All lexical and @lexical/* packages used by an editor must have identical versions. If you suspect the version does match, then the problem may be caused by multiple copies of the same lexical module (e.g. both esm and cjs, or included directly in multiple entrypoints).',
+      klass.name,
+      ownNodeType,
+      version,
+    );
+  }
   return (
     klass === DecoratorNode || klass === ElementNode || klass === LexicalNode
   );

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2155,6 +2155,18 @@ describe('LexicalEditor tests', () => {
     expect(textNodeMutation2[0].get(textNodeKeys[1])).toBe('destroyed');
     expect(textNodeMutation2[0].get(textNodeKeys[2])).toBe('destroyed');
   });
+  it('rejects creating an editor with invalid LexicalNode parent class', async () => {
+    class FakeLexicalNode {
+      static getType() {
+        return 'fake-node';
+      }
+    }
+    expect(() =>
+      createEditor({nodes: [FakeLexicalNode as Klass<LexicalNode>]}),
+    ).toThrowError(
+      /FakeLexicalNode (type fake-node) does not subclass LexicalNode from the lexical package used by this editor/,
+    );
+  });
   it('mutation listener on newly initialized editor', async () => {
     editor = createEditor();
     const textNodeMutations = vi.fn();

--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -2164,7 +2164,7 @@ describe('LexicalEditor tests', () => {
     expect(() =>
       createEditor({nodes: [FakeLexicalNode as Klass<LexicalNode>]}),
     ).toThrowError(
-      /FakeLexicalNode (type fake-node) does not subclass LexicalNode from the lexical package used by this editor/,
+      /FakeLexicalNode \(type fake-node\) does not subclass LexicalNode from the lexical package used by this editor/,
     );
   });
   it('mutation listener on newly initialized editor', async () => {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -44,6 +44,11 @@ export default defineConfig({
           lexicalTestMocks(),
         ],
         test: {
+          env: {
+            LEXICAL_VERSION: JSON.stringify(
+              `${process.env.npm_package_version}+git`,
+            ),
+          },
           environment: 'jsdom',
           include: ['packages/**/__tests__/unit/**/*.test{.ts,.tsx,.js,.jsx}'],
           name: 'unit',


### PR DESCRIPTION
## Description

People can get themselves into scenarios where multiple versions of lexical are on the same page. We have some detection for this already with editors, but it doesn't get caught when an editor is configured with nodes that subclass nodes from some other version of lexical. This adds an additional check and provides a detailed error message for that scenario.

Closes #7819

## Test plan

Unit test to verify that an error happens in this sort of case.

`FakeLexicalNode (type fake-node) does not subclass LexicalNode from the lexical package used by this editor (version 0.35.0+git). All lexical and @lexical/* packages used by an editor must have identical versions. If you suspect the version does match, then the problem may be caused by multiple copies of the same lexical module (e.g. both esm and cjs, or included directly in multiple entrypoints).`
