### PR TITLE
[lexical-clipboard] Fix: copy correct selection when editor in different window/document

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -468,7 +468,7 @@ export async function copyToClipboard(
 
   const rootElement = editor.getRootElement();
   const editorWindow = editor._window || window;
-  const windowDocument = window.document;
+  const windowDocument = editorWindow.document;
   const domSelection = getDOMSelection(editorWindow);
   if (rootElement === null || domSelection === null) {
     return false;
@@ -489,7 +489,7 @@ export async function copyToClipboard(
         if (objectKlassEquals(secondEvent, ClipboardEvent)) {
           removeListener();
           if (clipboardEventTimeout !== null) {
-            window.clearTimeout(clipboardEventTimeout);
+            editorWindow.clearTimeout(clipboardEventTimeout);
             clipboardEventTimeout = null;
           }
           resolve($copyToClipboardEvent(editor, secondEvent, data));
@@ -501,7 +501,7 @@ export async function copyToClipboard(
     );
     // If the above hack execCommand hack works, this timeout code should never fire. Otherwise,
     // the listener will be quickly freed so that the user can reuse it again
-    clipboardEventTimeout = window.setTimeout(() => {
+    clipboardEventTimeout = editorWindow.setTimeout(() => {
       removeListener();
       clipboardEventTimeout = null;
       resolve(false);


### PR DESCRIPTION
## Description

When the editor is mounted in a different window, for example when using [react-new-window](https://www.npmjs.com/package/react-new-window), then `copyToClipboard` copies the selection from the main window.

## Test plan

Tried to get a repro working with unit tests but couldn't get selection working with JSDOM.

### Before

Copy using context menu gets the text from the parent window's selection:

https://github.com/user-attachments/assets/5eaeed0c-2910-4dd9-8315-c2aae9e4665f

### After

https://github.com/user-attachments/assets/d30c01e7-3b11-4c26-9995-82a9bf1b3cd1

