### PR TITLE
[lexical-clipboard] Bug Fix: Update Lexical Clipboard with Empty Selection

### DIFF
--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -588,7 +588,11 @@ export function setLexicalClipboardDataTransfer(
   clipboardData: DataTransfer,
   data: LexicalClipboardData,
 ) {
-  clipboardData.clearData();
+  for (const [k] of clipboardDataFunctions) {
+    if (data[k] === undefined) {
+      clipboardData.setData(k, '');
+    }
+  }
   for (const k in data) {
     const v = data[k as keyof LexicalClipboardData];
     if (v !== undefined) {

--- a/packages/lexical-clipboard/src/clipboard.ts
+++ b/packages/lexical-clipboard/src/clipboard.ts
@@ -588,6 +588,7 @@ export function setLexicalClipboardDataTransfer(
   clipboardData: DataTransfer,
   data: LexicalClipboardData,
 ) {
+  clipboardData.clearData();
   for (const k in data) {
     const v = data[k as keyof LexicalClipboardData];
     if (v !== undefined) {


### PR DESCRIPTION
## Description
`$copyToClipboardEvent` updates a `ClipboardEvent` based on the current selection - however returning null for an absent or empty selection will prevent the Lexical content from getting cleared for an empty selection. This means the 'text/plain' and 'text/html' contents will update to empty strings, but the 'application/x-lexical-editor' will still have whatever stale value was present previously.

An alternative fix to the one committed already is to delete the content when null, rather than skipping, i.e.
```
const v = $editorFn(editor, selection);
if (v !== null) {
  clipboardData[mimeType] = v;
} else {
  delete clipboardData[mimeType]
}
```
This would preserve the `null` return for `$getLexicalContent`, though it doesn't look like anything in the repo depends on it.

## Test plan

No affected tests - though I could probably add one if desired.