### PR TITLE
[lexical] Bug Fix: Fix Bugs with `RangeSelection#extract`

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1534,7 +1534,7 @@ export class RangeSelection implements BaseSelection {
         selectedNodes.pop();
       } else if (endOffset !== lastNodeTextLength) {
         [lastNode] = lastNode.splitText(endOffset);
-        selectedNodes[lastIndex] = lastNode;
+        selectedNodes[selectedNodes.length - 1] = lastNode;
       }
     }
     return selectedNodes;

--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1523,6 +1523,7 @@ export class RangeSelection implements BaseSelection {
         selectedNodes.shift();
       } else if (startOffset !== 0) {
         [, firstNode] = firstNode.splitText(startOffset);
+        this._cachedNodes = selectedNodes;
         selectedNodes[0] = firstNode;
       }
     }
@@ -1534,6 +1535,7 @@ export class RangeSelection implements BaseSelection {
         selectedNodes.pop();
       } else if (endOffset !== lastNodeTextLength) {
         [lastNode] = lastNode.splitText(endOffset);
+        this._cachedNodes = selectedNodes;
         selectedNodes[selectedNodes.length - 1] = lastNode;
       }
     }


### PR DESCRIPTION
## Description
Fix two bugs:

- Using stale `lastIndex` - this is no longer accurate if `selectedNodes.shift()` happens above.
- `selectedNodes` is a view into `_cachedNodes` underneath (so changes are reflected) - except during `splitText`, `_cachedNodes` is reset to `null`, so later changes will not be reflected.

See commits for deeper explanation of each bug.

## Test plan

No affected tests - though I could probably add one if desired.