### PR TITLE
[lexical-react] Fix: ensure selection listeners cleaned up from original owner document

### DIFF
--- a/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
+++ b/packages/lexical/src/__tests__/unit/LexicalEditor.test.tsx
@@ -26,6 +26,7 @@ import {
   TableCellNode,
   TableRowNode,
 } from '@lexical/table';
+import {JSDOM} from 'jsdom';
 import {
   $createLineBreakNode,
   $createNodeSelection,
@@ -3192,20 +3193,45 @@ describe('LexicalEditor tests', () => {
     expect(ParagraphNode.importDOM).toHaveBeenCalledTimes(1);
   });
 
-  it('root element count is always positive', () => {
-    const newEditor1 = createTestEditor();
-    const newEditor2 = createTestEditor();
+  describe('setRootElement', () => {
+    it('root element count is always positive', () => {
+      const newEditor1 = createTestEditor();
+      const newEditor2 = createTestEditor();
 
-    const container1 = document.createElement('div');
-    const container2 = document.createElement('div');
+      const container1 = document.createElement('div');
+      const container2 = document.createElement('div');
 
-    newEditor1.setRootElement(container1);
-    newEditor1.setRootElement(null);
+      newEditor1.setRootElement(container1);
+      newEditor1.setRootElement(null);
 
-    newEditor1.setRootElement(container1);
-    newEditor2.setRootElement(container2);
-    newEditor1.setRootElement(null);
-    newEditor2.setRootElement(null);
+      newEditor1.setRootElement(container1);
+      newEditor2.setRootElement(container2);
+      newEditor1.setRootElement(null);
+      newEditor2.setRootElement(null);
+    });
+
+    it('should handle root element moving between documents', () => {
+      const origEditor = createTestEditor();
+      origEditor.setRootElement(container);
+
+      // Register and unregister editor in jsdom document, so that root element
+      // count is non-zero.
+      const jsdom = new JSDOM();
+      const jsdomDocument = jsdom.window.document;
+      const jsdomContainer = jsdomDocument.createElement('div');
+      const jsdomEditor = createTestEditor();
+      jsdomEditor.setRootElement(jsdomContainer);
+      jsdomEditor.setRootElement(null);
+
+      // Move container from original document to jsdom document
+      jsdomDocument.body.appendChild(container);
+
+      // Ensure that cleanup still works
+      origEditor.setRootElement(null);
+
+      // Move node back to the original document so afterEach works
+      document.body.appendChild(container);
+    });
   });
 
   describe('html config', () => {


### PR DESCRIPTION
## Description

When rendering into a different window using `createPortal`, eg with [react-new-window](https://www.npmjs.com/package/react-new-window), `ownerDocument` _initially_ refers to the document in which the element was created. Once React has mounted it into the portal however, it points to the portal's document.

This causes an issue with ref counting in `addRootElementEvents`/`removeRootElementEvents` as the counter is [incremented](https://github.com/facebook/lexical/blob/v0.35.0/packages/lexical/src/LexicalEvents.ts#L1322-L1332) for one document but [decremented](https://github.com/facebook/lexical/blob/v0.35.0/packages/lexical/src/LexicalEvents.ts#L1439-L1446) for the other, causing `invariant(newCount >= 0, 'Root element count less than 0')` to fail. It also means that the listeners are not added to the document in which the root element is mounted.

~~When `useCallback` refs are used, the ref is called before the element is in DOM: in the debugger, we observed that [`rootElement.isConnected`](https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected) is false. By switching to an effect, the code is only called after the element has been attached to the new document, i.e. `isConnected` is true and `ownerDocument` has the correct reference.~~

Rather than looking at `ownerDocument` again when removing listeners, we now instead track what the owner document was at registration time, and decrement the counter/remove listeners for that document.

## Test plan

~~Wasn't able to repro in unit tests, but we monkey-patched this change into Lexical in our application and confirmed it fixes the crash.~~

Added a unit test which fails pre-change.