### PR TITLE
[lexical-react] Bug Fix: Add visibility margin to `isTriggerVisibleInNearestScrollContainer` to prevent popover from wrongfully closing

### DIFF
--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -194,7 +194,12 @@ function isTriggerVisibleInNearestScrollContainer(
 ): boolean {
   const tRect = targetElement.getBoundingClientRect();
   const cRect = containerElement.getBoundingClientRect();
-  return tRect.top > cRect.top && tRect.top < cRect.bottom;
+
+  const VISIBILITY_MARGIN_PX = 6;
+  return (
+    tRect.top >= cRect.top - VISIBILITY_MARGIN_PX &&
+    tRect.top <= cRect.bottom + VISIBILITY_MARGIN_PX
+  );
 }
 
 // Reposition the menu on scroll, window resize, and element resize.


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
Whenever the editors total height is so small that the LexicalMenu's popover is outside the bounds of it's parent element, the `isTriggerVisibleInNearestScrollContainer` results in `false` whenever the `useEffect` inside `useDynamicPositioning` is run. This happens on scrolling and also navigating all the way to the bottom via the arrow keys.

This PR proposes the addition of a margin to the visibility check in order for the popover trigger to still be considered "visible" even if it's slightly out of bounds.

Closes #7837

## Test plan

### Before

https://github.com/user-attachments/assets/98c5efe0-783c-44e7-886a-2362ea27e9bd

### After

https://github.com/user-attachments/assets/48f8ffff-ad33-44e2-ae4f-23e3be36b911