### PR TITLE
[lexical-markdown][lexical-playground] Bug Fix: Keep indent when switching with markdown

### DIFF
--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -669,6 +669,22 @@ describe('Markdown', () => {
       html: '<p><span style="white-space: pre-wrap;">[h</span><a href="https://lexical.dev"><span style="white-space: pre-wrap;">ello</span></a><a href="https://lexical.dev"><span style="white-space: pre-wrap;">world</span></a></p>',
       md: '[h[ello](https://lexical.dev)[world](https://lexical.dev)',
     },
+    {
+      html: '<p style="padding-inline-start: 40px;"><span style="white-space: pre-wrap;">Hello Word</span></p>',
+      md: '\tHello Word',
+    },
+    {
+      html: '<p style="padding-inline-start: 80px;"><span style="white-space: pre-wrap;">Hello Word</span></p>',
+      md: '\t\tHello Word',
+    },
+    {
+      html: '<p><span style="white-space: pre-wrap;">Hello\t Word</span></p>',
+      md: 'Hello\t Word',
+    },
+    {
+      html: '<p style="padding-inline-start: 40px;"><i><em style="white-space: pre-wrap;">Hello</em></i><span style="white-space: pre-wrap;"> Word</span></p>',
+      md: '\t*Hello* Word',
+    },
   ];
 
   const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {

--- a/packages/lexical-markdown/src/index.ts
+++ b/packages/lexical-markdown/src/index.ts
@@ -27,6 +27,7 @@ import {
   CODE,
   HEADING,
   HIGHLIGHT,
+  INDENT,
   INLINE_CODE,
   ITALIC_STAR,
   ITALIC_UNDERSCORE,
@@ -65,7 +66,7 @@ const TEXT_FORMAT_TRANSFORMERS: Array<TextFormatTransformer> = [
   STRIKETHROUGH,
 ];
 
-const TEXT_MATCH_TRANSFORMERS: Array<TextMatchTransformer> = [LINK];
+const TEXT_MATCH_TRANSFORMERS: Array<TextMatchTransformer> = [INDENT, LINK];
 
 const TRANSFORMERS: Array<Transformer> = [
   ...ELEMENT_TRANSFORMERS,


### PR DESCRIPTION
## Description
Reported issue: #7820
To summarize, if you use indent button and then switch to markdown, indent will be lost.

I decided to fix this issue by adding a transformer by I think it could also be fixed by handling it directly in `createMarkdownExport` and `createMarkdownImport`

This transformer simply add '\t' when exporting to markdown and remove those '\t' and set indent when importing from markdown. This only happen if '\t' is found at the beginning of the string and if the parent is a paragraph to avoid applying it to lists.

Closes #7820