### PR TITLE
[lexical-react] Bug Fix: Include react-error-boundary and @floating-ui/react in WWW bundle

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -114,10 +114,9 @@ const monorepoExternalsSet = new Set(Object.entries(wwwMappings).flat());
 const thirdPartyExternals = [
   'react',
   'react-dom',
-  'react-error-boundary',
-  '@floating-ui/react',
   'yjs',
   'y-websocket',
+  ...(isWWW ? [] : ['react-error-boundary', '@floating-ui/react']),
 ];
 const thirdPartyExternalsRegExp = new RegExp(
   `^(${thirdPartyExternals.join('|')})(\\/|$)`,
@@ -201,6 +200,12 @@ async function build(
         warning.message.endsWith(`Can't resolve original location of error.`)
       ) {
         // Ignored
+      } else if (
+        isWWW &&
+        warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
+        /"use client"/.test(warning.message)
+      ) {
+        // Ignored in WWW
       } else if (typeof warning.code === 'string') {
         console.error(warning);
         // This is a warning coming from Rollup itself.


### PR DESCRIPTION
## Description

react-error-boundary and @floating-ui/react are external in OSS but should be bundled in WWW. This bundles them in that environment, and ignores any "use client" warnings.

## Test plan

Can only be reproduced in the www build at Meta, but `npm run build-www` works without warning and you can confirm that it does not use an external import when inspecting the build artifacts (e.g.  `packages/lexical-react/dist/LexicalErrorBoundary.dev.js`)
