### PR TITLE
[lexical-extension][docs] Chore: Add @experimental to extension functions

### DIFF
--- a/packages/lexical-extension/src/config.ts
+++ b/packages/lexical-extension/src/config.ts
@@ -11,6 +11,15 @@ export interface KnownTypesAndNodes {
   types: Set<string>;
   nodes: Set<KlassConstructor<typeof LexicalNode>>;
 }
+/**
+ * @experimental
+ * Get the sets of nodes and types registered in the
+ * {@link InitialEditorConfig}. This is to be used when an extension
+ * needs to register optional behavior if some node or type is present.
+ *
+ * @param config The InitialEditorConfig (accessible from an extension's init)
+ * @returns The known types and nodes as Sets
+ */
 export function getKnownTypesAndNodes(config: InitialEditorConfig) {
   const types: KnownTypesAndNodes['types'] = new Set();
   const nodes: KnownTypesAndNodes['nodes'] = new Set();

--- a/packages/lexical-extension/src/getExtensionDependencyFromEditor.ts
+++ b/packages/lexical-extension/src/getExtensionDependencyFromEditor.ts
@@ -16,6 +16,7 @@ import invariant from 'shared/invariant';
 import {LexicalBuilder} from './LexicalBuilder';
 
 /**
+ * @experimental
  * Get the finalized config and output of an Extension that was used to build the editor.
  *
  * This is useful in the implementation of a LexicalNode or in other

--- a/packages/lexical-extension/src/getPeerDependencyFromEditor.ts
+++ b/packages/lexical-extension/src/getPeerDependencyFromEditor.ts
@@ -16,6 +16,7 @@ import invariant from 'shared/invariant';
 import {LexicalBuilder} from './LexicalBuilder';
 
 /**
+ * @experimental
  * Get the finalized config and output of an Extension that was used to build the
  * editor by name.
  *

--- a/packages/lexical-extension/src/namedSignals.ts
+++ b/packages/lexical-extension/src/namedSignals.ts
@@ -14,6 +14,19 @@ export type NamedSignalsOutput<Defaults> = {
   [K in keyof Defaults]: Signal<Defaults[K]>;
 };
 
+/**
+ * @experimental
+ * Return an object with the same shape as `defaults` with a {@link Signal}
+ * for each value. If specified, the second `opts` argument is a partial
+ * of overrides to the defaults and will be used as the initial value.
+ *
+ * Typically used to make a reactive version of some subset of the
+ * configuration of an extension, so it can be reconfigured at runtime.
+ *
+ * @param defaults The object with default values
+ * @param opts Overrides to those default values
+ * @returns An object with signals initialized with the default values
+ */
 export function namedSignals<Defaults>(
   defaults: Defaults,
   opts: NamedSignalsOptions<Defaults> = {},

--- a/packages/lexical-extension/src/watchedSignal.ts
+++ b/packages/lexical-extension/src/watchedSignal.ts
@@ -8,6 +8,7 @@
 import {type Signal, signal} from './signals';
 
 /**
+ * @experimental
  * Create a Signal that will subscribe to a value from an external store when watched, similar to
  * React's [useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore).
  *

--- a/packages/lexical/src/extension-core/defineExtension.ts
+++ b/packages/lexical/src/extension-core/defineExtension.ts
@@ -16,6 +16,7 @@ import type {
 } from './types';
 
 /**
+ * @experimental
  * Define a LexicalExtension from the given object literal. TypeScript will
  * infer Config and Name in most cases, but you may want to use
  * {@link safeCast} for config if there are default fields or varying types.
@@ -63,6 +64,7 @@ export function defineExtension<
 }
 
 /**
+ * @experimental
  * Override a partial of the configuration of an Extension, to be used
  * in the dependencies array of another extension, or as
  * an argument to {@link buildEditorFromExtensions}.
@@ -100,6 +102,7 @@ export function configExtension<
 }
 
 /**
+ * @experimental
  * Used to declare a peer dependency of an extension in a type-safe way,
  * requires the type parameter. The most common use case for peer dependencies
  * is to avoid a direct import dependency, so you would want to use a


### PR DESCRIPTION
## Description

Add the `@experimental` tag to the jsdocs for extension functions to make it clear that these APIs are subject to change