### PR TITLE
[lexical] Chore: Change TabNode.setTextContent invariant to devInvariant

### DIFF
--- a/packages/lexical/src/nodes/LexicalTabNode.ts
+++ b/packages/lexical/src/nodes/LexicalTabNode.ts
@@ -8,8 +8,8 @@
 
 import type {DOMConversionMap, NodeKey} from '../LexicalNode';
 
-import invariant from 'shared/invariant';
 import devInvariant from 'shared/devInvariant';
+import invariant from 'shared/invariant';
 
 import {IS_UNMERGEABLE} from '../LexicalConstants';
 import {EditorConfig} from '../LexicalEditor';


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

Currently, if the `setTextContent` method on `TabNode` is called with text that is not `"\t"` or `""`, it throws an error even in production. We had an issue where because we were using an older version of Lexical, some users' documents got into a state where their `TabNode`s had non-tab text content which got synced to the Y.Doc. And then when we upgraded to 0.32.1, where the invariant was added, those users' document weren't syncing correctly because the Yjs hook would recreate the TabNode and try to set the non-tab text content which then throws an error.

This PR changes the invariant to a devInvariant so that it only errors in development and only warns in production.