### PR TITLE
[lexical-headless] Bug Fix: Replace happy-dom with jsdom in www and map react-dom/client

### DIFF
--- a/packages/lexical-headless/src/dom.ts
+++ b/packages/lexical-headless/src/dom.ts
@@ -6,7 +6,18 @@
  *
  */
 
-import {Window as HappyDOMWindow} from 'happy-dom';
+import * as HappyDOM from 'happy-dom';
+
+function createWindow(): Window & typeof globalThis {
+  if ('Window' in HappyDOM) {
+    // @ts-expect-error -- DOMWindow is not exactly Window
+    return new HappyDOM.Window();
+  } else {
+    const jsdom = HappyDOM as typeof import('jsdom');
+    // @ts-expect-error -- this is jsdom in www
+    return new jsdom.JSDOM().window;
+  }
+}
 
 /**
  * Call the given synchronous function with a window object,
@@ -28,8 +39,7 @@ export function withDOM<T>(f: (window: Window) => T): T {
   }
   const prevMutationObserver = globalThis.MutationObserver;
   const prevDocument = globalThis.document;
-  // @ts-expect-error -- DOMWindow is not exactly Window
-  const newWindow: Window & typeof globalThis = new HappyDOMWindow();
+  const newWindow = createWindow();
   globalThis.window = newWindow;
   globalThis.document = newWindow.document;
   globalThis.MutationObserver = newWindow.MutationObserver;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -69,6 +69,7 @@ const wwwMappings = {
       `shikijs-themes-${name}`,
     ]),
   ),
+  'happy-dom': 'jsdom',
   'prismjs/components/prism-c': 'prism-c',
   'prismjs/components/prism-clike': 'prism-clike',
   'prismjs/components/prism-core': 'prismjs',
@@ -86,6 +87,7 @@ const wwwMappings = {
   'prismjs/components/prism-swift': 'prism-swift',
   'prismjs/components/prism-typescript': 'prism-typescript',
   'react-dom': 'ReactDOM',
+  'react-dom/client': 'ReactDOM',
   // The react entrypoint in fb includes the jsx runtime
   'react/jsx-runtime': 'react',
 };
@@ -117,6 +119,7 @@ const thirdPartyExternals = [
   'yjs',
   'y-websocket',
   'happy-dom',
+  'jsdom',
   ...(isWWW ? [] : ['react-error-boundary', '@floating-ui/react']),
 ];
 const thirdPartyExternalsRegExp = new RegExp(


### PR DESCRIPTION
## Description

Use jsdom instead of happy-dom in the www environment, also update mapping for react-dom/client

There's still probably some work to do before `@lexical/headless/dom` can be used in www because it probably needs something like a fork module since those imports are not using the package.json export conditions.