### PR TITLE
[lexical-headless] Bug Fix: Custom www entrypoint for @lexical/headless/dom

### DIFF
--- a/packages/lexical-headless/src/dom.ts
+++ b/packages/lexical-headless/src/dom.ts
@@ -6,17 +6,11 @@
  *
  */
 
-import * as HappyDOM from 'happy-dom';
+import {Window as HappyDOMWindow} from 'happy-dom';
 
 function createWindow(): Window & typeof globalThis {
-  if ('Window' in HappyDOM) {
-    // @ts-expect-error -- DOMWindow is not exactly Window
-    return new HappyDOM.Window();
-  } else {
-    const jsdom = HappyDOM as typeof import('jsdom');
-    // @ts-expect-error -- this is jsdom in www
-    return new jsdom.JSDOM().window;
-  }
+  // @ts-expect-error -- DOMWindow is not exactly Window
+  return new HappyDOMWindow();
 }
 
 /**

--- a/packages/lexical-headless/src/dom.www.cjs
+++ b/packages/lexical-headless/src/dom.www.cjs
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';
+
+if (typeof window === 'undefined') {
+  exports.withDOM = function withDOM(f) {
+    const ctx = global;
+    const prevWindow = ctx.window;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- handle recursive case
+    if (prevWindow) {
+      return f(ctx.window);
+    }
+    const prevMutationObserver = ctx.MutationObserver;
+    const prevDocument = ctx.document;
+    const newWindow = new (require(':server-only-hack:jsdom').JSDOM)();
+    ctx.window = newWindow;
+    ctx.document = newWindow.document;
+    ctx.MutationObserver = newWindow.MutationObserver;
+    try {
+      return f(newWindow);
+    } finally {
+      ctx.MutationObserver = prevMutationObserver;
+      ctx.document = prevDocument;
+      ctx.window = prevWindow;
+      newWindow.close();
+    }
+  };
+} else {
+  exports.withDOM = function withDOM(f) {
+    return f(window);
+  };
+}

--- a/scripts/lint-flow-types.js
+++ b/scripts/lint-flow-types.js
@@ -131,7 +131,7 @@ function lintFlowTypesForPackage(
   /** @type {tsMorph.Project} */ project,
   /** @type {PackageMetadata} */ pkg,
 ) {
-  const def = pkg.getPackageBuildDefinition();
+  const def = pkg.getPackageBuildDefinition({consolidateBrowserSource: true});
   if (def.packageName === 'lexical-eslint-plugin') {
     return false;
   }

--- a/scripts/shared/PackageMetadata.js
+++ b/scripts/shared/PackageMetadata.js
@@ -16,6 +16,7 @@ const npmToWwwName = require('../www/npmToWwwName');
  * @typedef {Object} ModuleBuildDefinition
  * @property {string} outputFileName
  * @property {string} sourceFileName
+ * @property {undefined | string} [browserSourceFileName]
  */
 
 /**
@@ -192,16 +193,17 @@ class PackageMetadata {
   /**
    * @returns {PackageBuildDefinition}
    */
-  getPackageBuildDefinition() {
+  getPackageBuildDefinition(opts = {consolidateBrowserSource: false}) {
     const npmName = this.getNpmName();
     return {
       modules: this.getExportedNpmModuleEntries().flatMap(
         ({name, sourceFileName, browserSourceFileName}) => [
           {
+            browserSourceFileName,
             outputFileName: npmToWwwName(name),
             sourceFileName,
           },
-          ...(browserSourceFileName
+          ...(browserSourceFileName && !opts.consolidateBrowserSource
             ? [
                 {
                   outputFileName: `${npmToWwwName(name)}.browser`,


### PR DESCRIPTION
## Description

Hard to know if this works being on the outside of haste but this gives the capability to add a special combined `.www.cjs` entrypoint instaed of the dual `.ts` + `.browser.ts` files. It's up to the www dev to come up with these special cases, but I don't think we'll really need more of them than here?

## Test plan

### Before

Produced code that would require jsdom unconditionally even if not used (e.g. in the browser) when the LexicalHeadlessDom module was loaded.

### After

Produces code that requires jsdom conditionally by doing an unholy combination of a specially written entrypoint plus a hack to effectively un-hoist the require.