### PR TITLE
[lexical-table] Bug Fix: Handle accessing table selection following table deletion

### DIFF
--- a/packages/lexical-table/src/LexicalTableSelection.ts
+++ b/packages/lexical-table/src/LexicalTableSelection.ts
@@ -9,6 +9,7 @@
 import {$findMatchingParent} from '@lexical/utils';
 import {
   $createPoint,
+  $getNodeByKey,
   $getSelection,
   $isElementNode,
   $isParagraphNode,
@@ -134,13 +135,22 @@ export class TableSelection implements BaseSelection {
    * @returns true if the TableSelection is (probably) valid
    */
   isValid(): boolean {
-    return (
-      this.tableKey !== 'root' &&
-      this.anchor.key !== 'root' &&
-      this.anchor.type === 'element' &&
-      this.focus.key !== 'root' &&
-      this.focus.type === 'element'
-    );
+    if (
+      this.tableKey === 'root' ||
+      this.anchor.key === 'root' ||
+      this.anchor.type !== 'element' ||
+      this.focus.key === 'root' ||
+      this.focus.type !== 'element'
+    ) {
+      return false;
+    }
+
+    // Check if the referenced nodes still exist in the editor
+    const tableNode = $getNodeByKey(this.tableKey);
+    const anchorNode = $getNodeByKey(this.anchor.key);
+    const focusNode = $getNodeByKey(this.focus.key);
+
+    return tableNode !== null && anchorNode !== null && focusNode !== null;
   }
 
   /**

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableSelection.test.tsx
@@ -13,6 +13,7 @@ import {
   $createTableNode,
   $createTableRowNode,
   $createTableSelectionFrom,
+  $deleteTableRowAtSelection,
   $isTableSelection,
   TableMapType,
   TableNode,
@@ -85,6 +86,49 @@ describe('table selection', () => {
           },
           {discrete: true},
         );
+      });
+    });
+
+    describe('regression #7140', () => {
+      test('selection points to missing nodes after deleting table rows', () => {
+        testEnv.editor.update(() => {
+          const root = $getRoot();
+          root.clear();
+          const paragraph = $createParagraphNode().append(
+            $createTextNode('Before table'),
+          );
+          root.append(paragraph);
+          root.append(tableNode);
+
+          const newTableMap = $computeTableMapSkipCellCheck(
+            tableNode,
+            null,
+            null,
+          )[0];
+          const newTableSelection = $createTableSelectionFrom(
+            tableNode,
+            newTableMap.at(0)!.at(0)!.cell,
+            newTableMap.at(-1)!.at(-1)!.cell,
+          );
+          $setSelection(newTableSelection);
+        });
+
+        // Delete table rows
+        testEnv.editor.update(() => {
+          const selection = $getSelection();
+          expect($isTableSelection(selection)).toBe(true);
+          $deleteTableRowAtSelection();
+        });
+
+        // Try to access the selection after deletion
+        testEnv.editor.update(() => {
+          const selection = $getSelection();
+          if (selection && $isTableSelection(selection)) {
+            expect(selection.isValid()).toBe(false);
+            const nodes = selection.getNodes();
+            expect(nodes).toEqual([]);
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
## Description

If you have a table selection, delete the table, then access that selection immediately afterwards (eg `selection.getNode()`), and error is thrown ("node not found"). This can occur via an update listener as shown in #7140 

It is also common in collab scenarios where one client has a table selection and another client deletes the selected rows.

I have reproduced the error in a unit test, and fixed it by adding extra checks in `getNodes` to detect the invalid selection.

fixes #7140

## Test plan

Added unit text reproducing the error `Error: Point.getNode: node not found`

Test passes with code fix