### PR TITLE
[*] Bug Fix: Update examples and fix package.json for v0.36.0 (will need a patch release)

### DIFF
--- a/examples/extension-react-table/README.md
+++ b/examples/extension-react-table/README.md
@@ -5,6 +5,4 @@ Here we have simplest Lexical Table Plugin setup in rich text configuration (`@l
 **Run it locally:** `npm i && npm run dev`
 
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/~/github.com/facebook/lexical/pull/7706?file=examples/extension-react-table/src/main.ts&configPath=examples/extension-react-table)
-
-TODO #7706: update stackblitz url after merge
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/facebook/lexical/tree/main/examples/extension-react-table?file=src%2Fmain.tsx)

--- a/examples/extension-react-table/package-lock.json
+++ b/examples/extension-react-table/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "@lexical/extension-react-table-example",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/extension-react-table-example",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
-        "@lexical/react": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/react": "0.36.0",
+        "@lexical/tailwind": "0.36.0",
+        "lexical": "0.36.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -434,41 +436,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-clipboard-0.35.0.tgz",
-      "integrity": "sha512-5PL30CVsLLbyRK8kUn2WXxC6HwIMDgKie6ky/OhkjYx0ORFLCczu3rhXEHgjR4pvKEKYivK/pWmNueXBFl29Ow==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.36.0.tgz",
+      "integrity": "sha512-pmQLuVBf3bzfnl+e6PqwjwX+FAtlZG+cWwVdBxw3zOs4Eec6ZCPbWtXwZ4a0O+PtjL4Eqron5qvB2TAtL0qtXA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-code-0.35.0.tgz",
-      "integrity": "sha512-39HDeZgpM/Ov4raEIIg1kNwcz3LYi6BxRiUqX4IJWNHjBzsHK31B3lZuEf46Zvd9bkiLbE2ZfSNHZWdvnMfrlA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.36.0.tgz",
+      "integrity": "sha512-hgS3KH7hvnVL6ywcv7oDr0xAIaBKDIJzCW7cXOf1GoB6yFdaalMggIKbSdCiAkOPlfbix/bfsJFwPn7nm6n6dw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-devtools-core-0.35.0.tgz",
-      "integrity": "sha512-CDu2Q/sYIVTU6l6MmClcXlqBLA7ecDIQ/iHueW4Jt5YOcGXAzLMGO3kDNydw+qQ6XmWJ1TdtDnzEh8ANDy/XpA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.36.0.tgz",
+      "integrity": "sha512-sX59vW5/csiWfJQos8SV0ctzgFYY1Juj87qQoaJK0rwP2EEc1pwWLyqBPZdqukwwQuPswzs1ml5xEDnnNJNycQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -476,162 +478,162 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-dragon-0.35.0.tgz",
-      "integrity": "sha512-VIJxpZ7ny6jdJAxKwH1R3JCrGjnVu9H/6DRt/Bpofo9UnG/udzQ4+U10OvcvtwTVU9TEPOo5UypXZ+purMq8Gg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.36.0.tgz",
+      "integrity": "sha512-I1R8HORGyiyzAUDi9Y0tUuCH1gUsupyuFiC3NkVdrC6gR03qnwPRS5c3W5nsIRUwcLRFFb3yHS7/zPuFkC5A/g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/extension": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-extension-0.35.0.tgz",
-      "integrity": "sha512-1ZTutbgEOwn1sqaS5/q2wPAnU61TPNv3jf4Y71aPUwtYh3BlMNiCKbfcHN+xtrzN1xoKHtceLIBPpwoWu+hUtQ==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.36.0.tgz",
+      "integrity": "sha512-ccmygnsJIQ/u1fLat8ULwR+FW4mB3HKp5ZlzJahDRjWfoM71XgHhaEZtbf9L/HZMNMst87POZyPl8te9pVXgCQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
+        "@lexical/utils": "0.36.0",
         "@preact/signals-core": "^1.11.0",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-hashtag-0.35.0.tgz",
-      "integrity": "sha512-2qcW99qgJzqTBz+Co/mP5jHaqamXtuYgxJ5Wqhe2utatevvpyGAHhvluSMvxfYZ3uO/IiqV/VjEZto7z737A8g==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.36.0.tgz",
+      "integrity": "sha512-w1TyQy4MFQIyMyBl+6afyxYrz5haX+dHl6Q/VgjxjlTQWpb+ftmx7aWwlCdJdP91kUISx7R+Ti47pOKYAN/rLQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-history-0.35.0.tgz",
-      "integrity": "sha512-SBDOzWqlN8axfi3tb/1wNW0ZsBOT8HKhhCggytR6qZucieNmMpnF7TYBnfrW/C/6L8PocrrPoEW1QSDJPsmPOw==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.36.0.tgz",
+      "integrity": "sha512-bY2AukJ59l7Yp+va8xS3fNmHmZNI72m2sDqtKw7HAl8BdvPw5Tu3XabqMOVBApM9kz5t0oO0RXWzJcL1suZP+Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-html-0.35.0.tgz",
-      "integrity": "sha512-rXGFE5S5rKsg3tVnr1s4iEgOfCApNXGpIFI3T2jGEShaCZ5HLaBY9NVBXnE9Nb49e9bkDkpZ8FZd1qokCbQXbw==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.36.0.tgz",
+      "integrity": "sha512-3vHn91r2fTek4UHsJyZ2ePjfh90McErsXuyJX/hU+q+KnzQRXKyZi8PkX1qNZfannfnUwq93TV4/qp/QQ2CEzg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-link-0.35.0.tgz",
-      "integrity": "sha512-xcxIJ9dBuRzdw+N5zEHC5VtQRLrNbcZ4H0xaBKTed2flUgEaPk4VVnWgzxpMIAQH/I7EuyJu5/KPTPNm9Dcdxg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.36.0.tgz",
+      "integrity": "sha512-WG9UgPsVbbCsfNckXXp9OnnhEq3T9UAzpYHEOqwUdtXGTUDREHx2owcE1FDtG5KSbdg6QLP7Bc533v1oW77WVg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-list-0.35.0.tgz",
-      "integrity": "sha512-+UUOXF275+zPn4mrx/zakiDZ13d2p8mdJfUmhPB8+LtMfCHVJH8gZmmIAAUHdIi5x1uxe7f9cyNoV8zMN+RuLA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.36.0.tgz",
+      "integrity": "sha512-0gcXRLmNPfS5FdGRUS0xpHPvuLp7HaCXnd4lZ8SpaFsjsE9fjju8iOGmUmHfy/KthLQk5zKG9DHU0DAGNyrikg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-mark-0.35.0.tgz",
-      "integrity": "sha512-Cg2evr/EyND1gD++2fzn0FDICWXEACMQ8xJlp/2MR3Uyhx3777U38N2z237abWn1BQew+i62VAFQDz7h0+UpQg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.36.0.tgz",
+      "integrity": "sha512-HerD1La/3zxmZ0EE8XejMJLyKiVKnNMFk1p/mDqhHCrF9IKhiNqj6J51Brovnbsm36hkeD697H4f3fGn8o1kUA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-markdown-0.35.0.tgz",
-      "integrity": "sha512-qqA8yZs4wLKIuj8C+xBujJcNVuEGMppI/7hhpHlcNBS/no9CiGbS+C1of54NCYKMU6dh8ceZHKCvl+uYbqxxJg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.36.0.tgz",
+      "integrity": "sha512-YKBg7ZayWfGI+raDkt7idKO0vnn431sCMR3GB1op5BRDLEnLKN3r8YpIt04hUtFlu8nqOvyZAJkypIPE5n1cwQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/code": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-offset-0.35.0.tgz",
-      "integrity": "sha512-O0AWoVpdbHNC2Dv8QA1INrGi4dentVj91sX38zfdasutMfs/EKiX1HB+omiy9UaVCkz/YvSdTGYzXIlWb97cZQ==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.36.0.tgz",
+      "integrity": "sha512-/aRMavorGJ4HM+s6OJUCtrSV6n0MZ+0mU1Ljt2EqK+MuzDniDEhnfI/T8c5Zr0mEQB5ggfwLxcYgK2z82IZNGA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-overflow-0.35.0.tgz",
-      "integrity": "sha512-0NgtAK0uCeuwuf5yLXGa5wiIvOpAORTUKl25aZEKw+oKcl8QMdHQ+5EVPcPzwjW+wI9BaoS2hqUqA1d5KVQaEA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.36.0.tgz",
+      "integrity": "sha512-lNfG/EMUdnFJx+KtPQGH3ww5QEmW/s13P6AF3iBm3c7NCpETzswORn8F01OrlMPYB3tjD5vSjXdCgVg3AyYwlw==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-plain-text-0.35.0.tgz",
-      "integrity": "sha512-N5PPMGbjITovLlhez337HL2+E0co9jzQ0NK2NELCnHHwc5S6XG77mVU+NoYVD35wZxVJNAtffVTrq4WE/OHeww==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.36.0.tgz",
+      "integrity": "sha512-gHFhWLx+CgbdImo1IZojvsbST53ZBI2JyhviZOZKv/j85IQIGGJZvgha64TCJkxn6EL3/mPFKtOvuRynil53Ww==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-react-0.35.0.tgz",
-      "integrity": "sha512-io6miDW6XryN7ptU3qq6+JsCxrc473AgHkaC1M3wJ4U5DJqSfxQVo8ekFkMjBbSlLf6j1Dyy9UEFDL44NvvgVA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.36.0.tgz",
+      "integrity": "sha512-SQbRTaThgPQd0ggJrb9xmKuzruokNlqBAdGj6rcV6y2m6SzZg+03Qbl9zfPyLY2JssxObLH4gV1qKj/LA2Pv+w==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
-        "@lexical/devtools-core": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/hashtag": "0.35.0",
-        "@lexical/history": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/markdown": "0.35.0",
-        "@lexical/overflow": "0.35.0",
-        "@lexical/plain-text": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "@lexical/yjs": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/devtools-core": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/hashtag": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/markdown": "0.36.0",
+        "@lexical/overflow": "0.36.0",
+        "@lexical/plain-text": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "@lexical/yjs": "0.36.0",
+        "lexical": "0.36.0",
         "react-error-boundary": "^6.0.0"
       },
       "peerDependencies": {
@@ -640,69 +642,79 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-rich-text-0.35.0.tgz",
-      "integrity": "sha512-g34Xd0sItq4XuKK9MhxZFnCXkXgkOgCuwD7zg7rmV74o5fl9EJNjXn2gso2JhG92B32Go2Vd0hKgt7/zFTnTuA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.36.0.tgz",
+      "integrity": "sha512-rHy2bc4i0Dl5nJDHPgrQSq523o4DrxUfn+i7V6maF1YqUmayjnhjZ5yQhtPiKKIuGsHtM90XWWBXmSq1x0v45w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-selection-0.35.0.tgz",
-      "integrity": "sha512-Qd5/jPk3fcaC3Gd4RFeRgHPnT1zMYluszywdT0RJ6uJqE/tzu6uNAZjIKcmeOKlYsvyEdzExUYNdwD4cqDawAA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.36.0.tgz",
+      "integrity": "sha512-vR/uWqmj3M/FMDgILLT5HFcQpeenqwwbJnWEfERSytWWJOE16EEEBESg8n9OistvujCEmrWSpo64GWGIEEd13g==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-table-0.35.0.tgz",
-      "integrity": "sha512-RlEQE+10X0NEKroUTxnZ25kyC1gBUIGXOSGJSNw3KyON4EFU/r+ChXb8xsvFhr+ad+pg/0D9yZi07orMQwxhNw==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.36.0.tgz",
+      "integrity": "sha512-/fveRVQxHx9UcL6wXFHI4q2LO2ouigLT/l4Qa5RcT6dXU8ht1shvI/2YB8pOMKx8SV4uu4kiEeupdYAWVd3mZQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
+      }
+    },
+    "node_modules/@lexical/tailwind": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/tailwind/-/tailwind-0.36.0.tgz",
+      "integrity": "sha512-PwR8sUqbPl1kOnyfmukrA4au/Bj90WiSCdrnGSlItqPWgbib6WMKjCsADvGd73sKibf0U6MrKmTD5qJcEamt2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-text-0.35.0.tgz",
-      "integrity": "sha512-uaMh46BkysV8hK8wQwp5g/ByZW+2hPDt8ahAErxtf8NuzQem1FHG/f5RTchmFqqUDVHO3qLNTv4AehEGmXv8MA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.36.0.tgz",
+      "integrity": "sha512-Lqu8py5mfCYc41g2HRMWXSAer2fycenU0SyjOBD2mYArZ4LCfJeawej4yYLW3tYSx3eck0aOUp6PazTQjB/1vQ==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-utils-0.35.0.tgz",
-      "integrity": "sha512-bWuwCPyyiJwsP8KZ3pCWqydY49CUET9snp4g8GdFIvqlwqMV/Lp/JFNq9FmuDYjx1MY9EVBFNodnwG2+OEnHmw==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.36.0.tgz",
+      "integrity": "sha512-qKaeIpoN9lIR5LnDxgmNsPkVSrJ7K3u64PluxI6KWNpSpVDz11voQLX/+vXBeEEmj1UKVzqL1P/EChsYDl9qcg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-yjs-0.35.0.tgz",
-      "integrity": "sha512-PoiqTdt6fhPk9h3AodGBX2MGY3q9Ywtf2ZEq8QNfYua25Ce4ShmJG0+OXa5vJbve68KmXIWi3L1csm7NTdgfDQ==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.36.0.tgz",
+      "integrity": "sha512-KLvpP+60Dou6c3xjDwYjo1b/m3d+v7d1kTE1N9FfrjJS6qVPoWBrV7/k4mB1J3+1+2ZGguKXtk/aRHCJf21Ofg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/offset": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1090,9 +1102,9 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-0.35.0.tgz",
-      "integrity": "sha512-ojiJw9X6rdEMopjN92DtIofJAJy8xEFW9J4yA5lH1/zW2PXDo7lIucsipT11ueIYII3gRJnfyYp5GFE3Iy1Ahg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.36.0.tgz",
+      "integrity": "sha512-exAJfRimJCbUSGMerG03hfsfCI4+35VDllvOTI7KvbNa6uq2K8Ec9zF1ELOR7P1SqR9PXrzzMn7xRTBOaac5XA==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {

--- a/examples/extension-react-table/package.json
+++ b/examples/extension-react-table/package.json
@@ -9,14 +9,10 @@
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
-  "lexicalUnreleasedDependencies": {
-    "@lexical/extension": "0.35.0",
-    "@lexical/react": "0.35.0",
-    "@lexical/tailwind": "0.35.0",
-    "lexical": "0.35.0"
-  },
   "dependencies": {
+    "@lexical/extension": "0.36.0",
     "@lexical/react": "0.36.0",
+    "@lexical/tailwind": "0.36.0",
     "lexical": "0.36.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/extension-react-table/tsconfig.json
+++ b/examples/extension-react-table/tsconfig.json
@@ -16,12 +16,10 @@
 
     /* Linting */
     "strict": true,
-    // "noUnusedLocals": true,
-    // "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  /* TODO #7706 this depends on unreleased packages so we build from monorepo */
-  "extends": ["../../tsconfig.json"],
-  "include": ["src", "../../libdefs"],
+  "include": ["src"],
   "references": [{"path": "./tsconfig.node.json"}]
 }

--- a/examples/extension-vanilla-react-plugin-host/README.md
+++ b/examples/extension-vanilla-react-plugin-host/README.md
@@ -4,6 +4,4 @@ Demonstrates using Lexical Extension to build a very basic checklist editor with
 
 **Run it locally:** `npm i && npm run dev`
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/~/github.com/facebook/lexical/pull/7706?file=examples/extension-vanilla-tailwind/src/main.ts&configPath=examples/extension-vanilla-tailwind)
-
-TODO #7706: update stackblitz url after merge
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/facebook/lexical/tree/main/examples/extension-vanilla-tailwind?file=src%2Fmain.ts)

--- a/examples/extension-vanilla-react-plugin-host/package-lock.json
+++ b/examples/extension-vanilla-react-plugin-host/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "@lexical/extension-vanilla-react-plugin-host",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/extension-vanilla-react-plugin-host",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
-        "@lexical/history": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/react": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/react": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/tailwind": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.13",
@@ -142,35 +144,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.36.0.tgz",
+      "integrity": "sha512-pmQLuVBf3bzfnl+e6PqwjwX+FAtlZG+cWwVdBxw3zOs4Eec6ZCPbWtXwZ4a0O+PtjL4Eqron5qvB2TAtL0qtXA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.36.0.tgz",
+      "integrity": "sha512-hgS3KH7hvnVL6ywcv7oDr0xAIaBKDIJzCW7cXOf1GoB6yFdaalMggIKbSdCiAkOPlfbix/bfsJFwPn7nm6n6dw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.36.0.tgz",
+      "integrity": "sha512-sX59vW5/csiWfJQos8SV0ctzgFYY1Juj87qQoaJK0rwP2EEc1pwWLyqBPZdqukwwQuPswzs1ml5xEDnnNJNycQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -178,136 +186,162 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.36.0.tgz",
+      "integrity": "sha512-I1R8HORGyiyzAUDi9Y0tUuCH1gUsupyuFiC3NkVdrC6gR03qnwPRS5c3W5nsIRUwcLRFFb3yHS7/zPuFkC5A/g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/extension": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.36.0.tgz",
+      "integrity": "sha512-ccmygnsJIQ/u1fLat8ULwR+FW4mB3HKp5ZlzJahDRjWfoM71XgHhaEZtbf9L/HZMNMst87POZyPl8te9pVXgCQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
+        "@lexical/utils": "0.36.0",
         "@preact/signals-core": "^1.11.0",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.36.0.tgz",
+      "integrity": "sha512-w1TyQy4MFQIyMyBl+6afyxYrz5haX+dHl6Q/VgjxjlTQWpb+ftmx7aWwlCdJdP91kUISx7R+Ti47pOKYAN/rLQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.36.0.tgz",
+      "integrity": "sha512-bY2AukJ59l7Yp+va8xS3fNmHmZNI72m2sDqtKw7HAl8BdvPw5Tu3XabqMOVBApM9kz5t0oO0RXWzJcL1suZP+Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.36.0.tgz",
+      "integrity": "sha512-3vHn91r2fTek4UHsJyZ2ePjfh90McErsXuyJX/hU+q+KnzQRXKyZi8PkX1qNZfannfnUwq93TV4/qp/QQ2CEzg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.36.0.tgz",
+      "integrity": "sha512-WG9UgPsVbbCsfNckXXp9OnnhEq3T9UAzpYHEOqwUdtXGTUDREHx2owcE1FDtG5KSbdg6QLP7Bc533v1oW77WVg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.36.0.tgz",
+      "integrity": "sha512-0gcXRLmNPfS5FdGRUS0xpHPvuLp7HaCXnd4lZ8SpaFsjsE9fjju8iOGmUmHfy/KthLQk5zKG9DHU0DAGNyrikg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.36.0.tgz",
+      "integrity": "sha512-HerD1La/3zxmZ0EE8XejMJLyKiVKnNMFk1p/mDqhHCrF9IKhiNqj6J51Brovnbsm36hkeD697H4f3fGn8o1kUA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.36.0.tgz",
+      "integrity": "sha512-YKBg7ZayWfGI+raDkt7idKO0vnn431sCMR3GB1op5BRDLEnLKN3r8YpIt04hUtFlu8nqOvyZAJkypIPE5n1cwQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/code": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.36.0.tgz",
+      "integrity": "sha512-/aRMavorGJ4HM+s6OJUCtrSV6n0MZ+0mU1Ljt2EqK+MuzDniDEhnfI/T8c5Zr0mEQB5ggfwLxcYgK2z82IZNGA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.36.0.tgz",
+      "integrity": "sha512-lNfG/EMUdnFJx+KtPQGH3ww5QEmW/s13P6AF3iBm3c7NCpETzswORn8F01OrlMPYB3tjD5vSjXdCgVg3AyYwlw==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.36.0.tgz",
+      "integrity": "sha512-gHFhWLx+CgbdImo1IZojvsbST53ZBI2JyhviZOZKv/j85IQIGGJZvgha64TCJkxn6EL3/mPFKtOvuRynil53Ww==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.36.0.tgz",
+      "integrity": "sha512-SQbRTaThgPQd0ggJrb9xmKuzruokNlqBAdGj6rcV6y2m6SzZg+03Qbl9zfPyLY2JssxObLH4gV1qKj/LA2Pv+w==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
-        "@lexical/devtools-core": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/hashtag": "0.35.0",
-        "@lexical/history": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/markdown": "0.35.0",
-        "@lexical/overflow": "0.35.0",
-        "@lexical/plain-text": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "@lexical/yjs": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/devtools-core": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/hashtag": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/markdown": "0.36.0",
+        "@lexical/overflow": "0.36.0",
+        "@lexical/plain-text": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "@lexical/yjs": "0.36.0",
+        "lexical": "0.36.0",
         "react-error-boundary": "^6.0.0"
       },
       "peerDependencies": {
@@ -316,57 +350,79 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.36.0.tgz",
+      "integrity": "sha512-rHy2bc4i0Dl5nJDHPgrQSq523o4DrxUfn+i7V6maF1YqUmayjnhjZ5yQhtPiKKIuGsHtM90XWWBXmSq1x0v45w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.36.0.tgz",
+      "integrity": "sha512-vR/uWqmj3M/FMDgILLT5HFcQpeenqwwbJnWEfERSytWWJOE16EEEBESg8n9OistvujCEmrWSpo64GWGIEEd13g==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.36.0.tgz",
+      "integrity": "sha512-/fveRVQxHx9UcL6wXFHI4q2LO2ouigLT/l4Qa5RcT6dXU8ht1shvI/2YB8pOMKx8SV4uu4kiEeupdYAWVd3mZQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
+      }
+    },
+    "node_modules/@lexical/tailwind": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/tailwind/-/tailwind-0.36.0.tgz",
+      "integrity": "sha512-PwR8sUqbPl1kOnyfmukrA4au/Bj90WiSCdrnGSlItqPWgbib6WMKjCsADvGd73sKibf0U6MrKmTD5qJcEamt2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.36.0.tgz",
+      "integrity": "sha512-Lqu8py5mfCYc41g2HRMWXSAer2fycenU0SyjOBD2mYArZ4LCfJeawej4yYLW3tYSx3eck0aOUp6PazTQjB/1vQ==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.36.0.tgz",
+      "integrity": "sha512-qKaeIpoN9lIR5LnDxgmNsPkVSrJ7K3u64PluxI6KWNpSpVDz11voQLX/+vXBeEEmj1UKVzqL1P/EChsYDl9qcg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.36.0.tgz",
+      "integrity": "sha512-KLvpP+60Dou6c3xjDwYjo1b/m3d+v7d1kTE1N9FfrjJS6qVPoWBrV7/k4mB1J3+1+2ZGguKXtk/aRHCJf21Ofg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/offset": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -901,7 +957,9 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.36.0.tgz",
+      "integrity": "sha512-exAJfRimJCbUSGMerG03hfsfCI4+35VDllvOTI7KvbNa6uq2K8Ec9zF1ELOR7P1SqR9PXrzzMn7xRTBOaac5XA==",
       "license": "MIT"
     },
     "node_modules/lightningcss": {
@@ -1121,6 +1179,8 @@
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/examples/extension-vanilla-react-plugin-host/package.json
+++ b/examples/extension-vanilla-react-plugin-host/package.json
@@ -12,15 +12,13 @@
   "stackblitz": {
     "startCommand": "npm i && npm run monorepo:dev"
   },
-  "lexicalUnreleasedDependencies": {
-    "@lexical/extension": "0.35.0",
-    "@lexical/tailwind": "0.35.0"
-  },
   "dependencies": {
+    "@lexical/extension": "0.36.0",
     "@lexical/history": "0.36.0",
     "@lexical/list": "0.36.0",
     "@lexical/react": "0.36.0",
     "@lexical/rich-text": "0.36.0",
+    "@lexical/tailwind": "0.36.0",
     "@lexical/utils": "0.36.0",
     "lexical": "0.36.0"
   },

--- a/examples/extension-vanilla-react-plugin-host/src/styles.css
+++ b/examples/extension-vanilla-react-plugin-host/src/styles.css
@@ -7,10 +7,4 @@
  */
 
 @import 'tailwindcss';
-/*
-TODO #7706: update @source after npm release of v0.36.0
-
-In a normal project this would probably look like:
-@source "../node_modules/lexical-tailwind"
-*/
-@source "../../../packages/lexical-tailwind/src/index.ts";
+@source "../node_modules/lexical-tailwind";

--- a/examples/extension-vanilla-react-plugin-host/tsconfig.json
+++ b/examples/extension-vanilla-react-plugin-host/tsconfig.json
@@ -16,11 +16,9 @@
 
     /* Linting */
     "strict": true,
-    // "noUnusedLocals": true,
-    // "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  /* TODO #7706 this depends on unreleased packages so we build from monorepo */
-  "extends": ["../../tsconfig.json"],
-  "include": ["src", "../../libdefs"]
+  "include": ["src"]
 }

--- a/examples/extension-vanilla-tailwind/README.md
+++ b/examples/extension-vanilla-tailwind/README.md
@@ -4,6 +4,4 @@ Demonstrates using Lexical Extension to build a very basic checklist editor with
 
 **Run it locally:** `npm i && npm run dev`
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/~/github.com/facebook/lexical/pull/7706?file=examples/extension-vanilla-tailwind/src/main.ts&configPath=examples/extension-vanilla-tailwind)
-
-TODO #7706: update stackblitz url after merge
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/facebook/lexical/tree/main/examples/extension-vanilla-tailwind?file=src%2Fmain.ts)

--- a/examples/extension-vanilla-tailwind/package-lock.json
+++ b/examples/extension-vanilla-tailwind/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "@lexical/extension-vanilla-example",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/extension-vanilla-example",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
-        "@lexical/history": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/tailwind": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.13",
@@ -91,97 +93,127 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.36.0.tgz",
+      "integrity": "sha512-pmQLuVBf3bzfnl+e6PqwjwX+FAtlZG+cWwVdBxw3zOs4Eec6ZCPbWtXwZ4a0O+PtjL4Eqron5qvB2TAtL0qtXA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.36.0.tgz",
+      "integrity": "sha512-I1R8HORGyiyzAUDi9Y0tUuCH1gUsupyuFiC3NkVdrC6gR03qnwPRS5c3W5nsIRUwcLRFFb3yHS7/zPuFkC5A/g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/extension": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.36.0.tgz",
+      "integrity": "sha512-ccmygnsJIQ/u1fLat8ULwR+FW4mB3HKp5ZlzJahDRjWfoM71XgHhaEZtbf9L/HZMNMst87POZyPl8te9pVXgCQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
+        "@lexical/utils": "0.36.0",
         "@preact/signals-core": "^1.11.0",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.36.0.tgz",
+      "integrity": "sha512-bY2AukJ59l7Yp+va8xS3fNmHmZNI72m2sDqtKw7HAl8BdvPw5Tu3XabqMOVBApM9kz5t0oO0RXWzJcL1suZP+Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.36.0.tgz",
+      "integrity": "sha512-3vHn91r2fTek4UHsJyZ2ePjfh90McErsXuyJX/hU+q+KnzQRXKyZi8PkX1qNZfannfnUwq93TV4/qp/QQ2CEzg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.36.0.tgz",
+      "integrity": "sha512-0gcXRLmNPfS5FdGRUS0xpHPvuLp7HaCXnd4lZ8SpaFsjsE9fjju8iOGmUmHfy/KthLQk5zKG9DHU0DAGNyrikg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.36.0.tgz",
+      "integrity": "sha512-rHy2bc4i0Dl5nJDHPgrQSq523o4DrxUfn+i7V6maF1YqUmayjnhjZ5yQhtPiKKIuGsHtM90XWWBXmSq1x0v45w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.36.0.tgz",
+      "integrity": "sha512-vR/uWqmj3M/FMDgILLT5HFcQpeenqwwbJnWEfERSytWWJOE16EEEBESg8n9OistvujCEmrWSpo64GWGIEEd13g==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.36.0.tgz",
+      "integrity": "sha512-/fveRVQxHx9UcL6wXFHI4q2LO2ouigLT/l4Qa5RcT6dXU8ht1shvI/2YB8pOMKx8SV4uu4kiEeupdYAWVd3mZQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
+      }
+    },
+    "node_modules/@lexical/tailwind": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/tailwind/-/tailwind-0.36.0.tgz",
+      "integrity": "sha512-PwR8sUqbPl1kOnyfmukrA4au/Bj90WiSCdrnGSlItqPWgbib6WMKjCsADvGd73sKibf0U6MrKmTD5qJcEamt2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.36.0.tgz",
+      "integrity": "sha512-qKaeIpoN9lIR5LnDxgmNsPkVSrJ7K3u64PluxI6KWNpSpVDz11voQLX/+vXBeEEmj1UKVzqL1P/EChsYDl9qcg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -713,7 +745,9 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.36.0.tgz",
+      "integrity": "sha512-exAJfRimJCbUSGMerG03hfsfCI4+35VDllvOTI7KvbNa6uq2K8Ec9zF1ELOR7P1SqR9PXrzzMn7xRTBOaac5XA==",
       "license": "MIT"
     },
     "node_modules/lightningcss": {

--- a/examples/extension-vanilla-tailwind/package.json
+++ b/examples/extension-vanilla-tailwind/package.json
@@ -12,14 +12,12 @@
   "stackblitz": {
     "startCommand": "npm i && npm run monorepo:dev"
   },
-  "lexicalUnreleasedDependencies": {
-    "@lexical/extension": "0.35.0",
-    "@lexical/tailwind": "0.35.0"
-  },
   "dependencies": {
+    "@lexical/extension": "0.36.0",
     "@lexical/history": "0.36.0",
     "@lexical/list": "0.36.0",
     "@lexical/rich-text": "0.36.0",
+    "@lexical/tailwind": "0.36.0",
     "@lexical/utils": "0.36.0",
     "lexical": "0.36.0"
   },

--- a/examples/extension-vanilla-tailwind/src/styles.css
+++ b/examples/extension-vanilla-tailwind/src/styles.css
@@ -7,10 +7,4 @@
  */
 
 @import 'tailwindcss';
-/*
-TODO #7706: update @source after npm release of v0.36.0
-
-In a normal project this would probably look like:
-@source "../node_modules/lexical-tailwind"
-*/
-@source "../../../packages/lexical-tailwind/src/index.ts";
+@source "../node_modules/lexical-tailwind";

--- a/examples/extension-vanilla-tailwind/tsconfig.json
+++ b/examples/extension-vanilla-tailwind/tsconfig.json
@@ -15,11 +15,9 @@
 
     /* Linting */
     "strict": true,
-    // "noUnusedLocals": true,
-    // "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  /* TODO #7706 this depends on unreleased packages so we build from monorepo */
-  "extends": ["../../tsconfig.json"],
-  "include": ["src", "../../libdefs"]
+  "include": ["src"]
 }

--- a/examples/node-replacement/package-lock.json
+++ b/examples/node-replacement/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@lexical/node-replacement-example",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/node-replacement-example",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
-        "@lexical/react": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/react": "0.36.0",
+        "lexical": "0.36.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -372,35 +372,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.36.0.tgz",
+      "integrity": "sha512-pmQLuVBf3bzfnl+e6PqwjwX+FAtlZG+cWwVdBxw3zOs4Eec6ZCPbWtXwZ4a0O+PtjL4Eqron5qvB2TAtL0qtXA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.36.0.tgz",
+      "integrity": "sha512-hgS3KH7hvnVL6ywcv7oDr0xAIaBKDIJzCW7cXOf1GoB6yFdaalMggIKbSdCiAkOPlfbix/bfsJFwPn7nm6n6dw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.36.0.tgz",
+      "integrity": "sha512-sX59vW5/csiWfJQos8SV0ctzgFYY1Juj87qQoaJK0rwP2EEc1pwWLyqBPZdqukwwQuPswzs1ml5xEDnnNJNycQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -408,136 +414,162 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.36.0.tgz",
+      "integrity": "sha512-I1R8HORGyiyzAUDi9Y0tUuCH1gUsupyuFiC3NkVdrC6gR03qnwPRS5c3W5nsIRUwcLRFFb3yHS7/zPuFkC5A/g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/extension": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.36.0.tgz",
+      "integrity": "sha512-ccmygnsJIQ/u1fLat8ULwR+FW4mB3HKp5ZlzJahDRjWfoM71XgHhaEZtbf9L/HZMNMst87POZyPl8te9pVXgCQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
+        "@lexical/utils": "0.36.0",
         "@preact/signals-core": "^1.11.0",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.36.0.tgz",
+      "integrity": "sha512-w1TyQy4MFQIyMyBl+6afyxYrz5haX+dHl6Q/VgjxjlTQWpb+ftmx7aWwlCdJdP91kUISx7R+Ti47pOKYAN/rLQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.36.0.tgz",
+      "integrity": "sha512-bY2AukJ59l7Yp+va8xS3fNmHmZNI72m2sDqtKw7HAl8BdvPw5Tu3XabqMOVBApM9kz5t0oO0RXWzJcL1suZP+Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.36.0.tgz",
+      "integrity": "sha512-3vHn91r2fTek4UHsJyZ2ePjfh90McErsXuyJX/hU+q+KnzQRXKyZi8PkX1qNZfannfnUwq93TV4/qp/QQ2CEzg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.36.0.tgz",
+      "integrity": "sha512-WG9UgPsVbbCsfNckXXp9OnnhEq3T9UAzpYHEOqwUdtXGTUDREHx2owcE1FDtG5KSbdg6QLP7Bc533v1oW77WVg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.36.0.tgz",
+      "integrity": "sha512-0gcXRLmNPfS5FdGRUS0xpHPvuLp7HaCXnd4lZ8SpaFsjsE9fjju8iOGmUmHfy/KthLQk5zKG9DHU0DAGNyrikg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.36.0.tgz",
+      "integrity": "sha512-HerD1La/3zxmZ0EE8XejMJLyKiVKnNMFk1p/mDqhHCrF9IKhiNqj6J51Brovnbsm36hkeD697H4f3fGn8o1kUA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.36.0.tgz",
+      "integrity": "sha512-YKBg7ZayWfGI+raDkt7idKO0vnn431sCMR3GB1op5BRDLEnLKN3r8YpIt04hUtFlu8nqOvyZAJkypIPE5n1cwQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/code": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.36.0.tgz",
+      "integrity": "sha512-/aRMavorGJ4HM+s6OJUCtrSV6n0MZ+0mU1Ljt2EqK+MuzDniDEhnfI/T8c5Zr0mEQB5ggfwLxcYgK2z82IZNGA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.36.0.tgz",
+      "integrity": "sha512-lNfG/EMUdnFJx+KtPQGH3ww5QEmW/s13P6AF3iBm3c7NCpETzswORn8F01OrlMPYB3tjD5vSjXdCgVg3AyYwlw==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.36.0.tgz",
+      "integrity": "sha512-gHFhWLx+CgbdImo1IZojvsbST53ZBI2JyhviZOZKv/j85IQIGGJZvgha64TCJkxn6EL3/mPFKtOvuRynil53Ww==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.36.0.tgz",
+      "integrity": "sha512-SQbRTaThgPQd0ggJrb9xmKuzruokNlqBAdGj6rcV6y2m6SzZg+03Qbl9zfPyLY2JssxObLH4gV1qKj/LA2Pv+w==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
-        "@lexical/devtools-core": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/hashtag": "0.35.0",
-        "@lexical/history": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/markdown": "0.35.0",
-        "@lexical/overflow": "0.35.0",
-        "@lexical/plain-text": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "@lexical/yjs": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/devtools-core": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/hashtag": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/markdown": "0.36.0",
+        "@lexical/overflow": "0.36.0",
+        "@lexical/plain-text": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "@lexical/yjs": "0.36.0",
+        "lexical": "0.36.0",
         "react-error-boundary": "^6.0.0"
       },
       "peerDependencies": {
@@ -546,57 +578,69 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.36.0.tgz",
+      "integrity": "sha512-rHy2bc4i0Dl5nJDHPgrQSq523o4DrxUfn+i7V6maF1YqUmayjnhjZ5yQhtPiKKIuGsHtM90XWWBXmSq1x0v45w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.36.0.tgz",
+      "integrity": "sha512-vR/uWqmj3M/FMDgILLT5HFcQpeenqwwbJnWEfERSytWWJOE16EEEBESg8n9OistvujCEmrWSpo64GWGIEEd13g==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.36.0.tgz",
+      "integrity": "sha512-/fveRVQxHx9UcL6wXFHI4q2LO2ouigLT/l4Qa5RcT6dXU8ht1shvI/2YB8pOMKx8SV4uu4kiEeupdYAWVd3mZQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.36.0.tgz",
+      "integrity": "sha512-Lqu8py5mfCYc41g2HRMWXSAer2fycenU0SyjOBD2mYArZ4LCfJeawej4yYLW3tYSx3eck0aOUp6PazTQjB/1vQ==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.36.0.tgz",
+      "integrity": "sha512-qKaeIpoN9lIR5LnDxgmNsPkVSrJ7K3u64PluxI6KWNpSpVDz11voQLX/+vXBeEEmj1UKVzqL1P/EChsYDl9qcg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.36.0.tgz",
+      "integrity": "sha512-KLvpP+60Dou6c3xjDwYjo1b/m3d+v7d1kTE1N9FfrjJS6qVPoWBrV7/k4mB1J3+1+2ZGguKXtk/aRHCJf21Ofg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/offset": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -604,6 +648,8 @@
     },
     "node_modules/@preact/signals-core": {
       "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
+      "integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -929,7 +975,9 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.36.0.tgz",
+      "integrity": "sha512-exAJfRimJCbUSGMerG03hfsfCI4+35VDllvOTI7KvbNa6uq2K8Ec9zF1ELOR7P1SqR9PXrzzMn7xRTBOaac5XA==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -1020,6 +1068,8 @@
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/examples/node-state-style/package-lock.json
+++ b/examples/node-state-style/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "@lexical/node-state-style-example",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/node-state-style-example",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
         "@ark-ui/react": "^5.6.0",
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/html": "0.35.0",
-        "@lexical/react": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/html": "0.36.0",
+        "@lexical/react": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
         "@shikijs/langs": "^3.3.0",
         "@shikijs/themes": "^3.3.0",
         "inline-style-parser": "^0.2.4",
-        "lexical": "0.35.0",
+        "lexical": "0.36.0",
         "lucide-react": "^0.503.0",
         "prettier": "^3.5.3",
         "react": "^19.1.0",
@@ -468,35 +468,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.36.0.tgz",
+      "integrity": "sha512-pmQLuVBf3bzfnl+e6PqwjwX+FAtlZG+cWwVdBxw3zOs4Eec6ZCPbWtXwZ4a0O+PtjL4Eqron5qvB2TAtL0qtXA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.36.0.tgz",
+      "integrity": "sha512-hgS3KH7hvnVL6ywcv7oDr0xAIaBKDIJzCW7cXOf1GoB6yFdaalMggIKbSdCiAkOPlfbix/bfsJFwPn7nm6n6dw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.36.0.tgz",
+      "integrity": "sha512-sX59vW5/csiWfJQos8SV0ctzgFYY1Juj87qQoaJK0rwP2EEc1pwWLyqBPZdqukwwQuPswzs1ml5xEDnnNJNycQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -504,136 +510,162 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.36.0.tgz",
+      "integrity": "sha512-I1R8HORGyiyzAUDi9Y0tUuCH1gUsupyuFiC3NkVdrC6gR03qnwPRS5c3W5nsIRUwcLRFFb3yHS7/zPuFkC5A/g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/extension": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.36.0.tgz",
+      "integrity": "sha512-ccmygnsJIQ/u1fLat8ULwR+FW4mB3HKp5ZlzJahDRjWfoM71XgHhaEZtbf9L/HZMNMst87POZyPl8te9pVXgCQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
+        "@lexical/utils": "0.36.0",
         "@preact/signals-core": "^1.11.0",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.36.0.tgz",
+      "integrity": "sha512-w1TyQy4MFQIyMyBl+6afyxYrz5haX+dHl6Q/VgjxjlTQWpb+ftmx7aWwlCdJdP91kUISx7R+Ti47pOKYAN/rLQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.36.0.tgz",
+      "integrity": "sha512-bY2AukJ59l7Yp+va8xS3fNmHmZNI72m2sDqtKw7HAl8BdvPw5Tu3XabqMOVBApM9kz5t0oO0RXWzJcL1suZP+Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.36.0.tgz",
+      "integrity": "sha512-3vHn91r2fTek4UHsJyZ2ePjfh90McErsXuyJX/hU+q+KnzQRXKyZi8PkX1qNZfannfnUwq93TV4/qp/QQ2CEzg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.36.0.tgz",
+      "integrity": "sha512-WG9UgPsVbbCsfNckXXp9OnnhEq3T9UAzpYHEOqwUdtXGTUDREHx2owcE1FDtG5KSbdg6QLP7Bc533v1oW77WVg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.36.0.tgz",
+      "integrity": "sha512-0gcXRLmNPfS5FdGRUS0xpHPvuLp7HaCXnd4lZ8SpaFsjsE9fjju8iOGmUmHfy/KthLQk5zKG9DHU0DAGNyrikg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.36.0.tgz",
+      "integrity": "sha512-HerD1La/3zxmZ0EE8XejMJLyKiVKnNMFk1p/mDqhHCrF9IKhiNqj6J51Brovnbsm36hkeD697H4f3fGn8o1kUA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.36.0.tgz",
+      "integrity": "sha512-YKBg7ZayWfGI+raDkt7idKO0vnn431sCMR3GB1op5BRDLEnLKN3r8YpIt04hUtFlu8nqOvyZAJkypIPE5n1cwQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/code": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.36.0.tgz",
+      "integrity": "sha512-/aRMavorGJ4HM+s6OJUCtrSV6n0MZ+0mU1Ljt2EqK+MuzDniDEhnfI/T8c5Zr0mEQB5ggfwLxcYgK2z82IZNGA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.36.0.tgz",
+      "integrity": "sha512-lNfG/EMUdnFJx+KtPQGH3ww5QEmW/s13P6AF3iBm3c7NCpETzswORn8F01OrlMPYB3tjD5vSjXdCgVg3AyYwlw==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.36.0.tgz",
+      "integrity": "sha512-gHFhWLx+CgbdImo1IZojvsbST53ZBI2JyhviZOZKv/j85IQIGGJZvgha64TCJkxn6EL3/mPFKtOvuRynil53Ww==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.36.0.tgz",
+      "integrity": "sha512-SQbRTaThgPQd0ggJrb9xmKuzruokNlqBAdGj6rcV6y2m6SzZg+03Qbl9zfPyLY2JssxObLH4gV1qKj/LA2Pv+w==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
-        "@lexical/devtools-core": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/hashtag": "0.35.0",
-        "@lexical/history": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/markdown": "0.35.0",
-        "@lexical/overflow": "0.35.0",
-        "@lexical/plain-text": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "@lexical/yjs": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/devtools-core": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/hashtag": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/markdown": "0.36.0",
+        "@lexical/overflow": "0.36.0",
+        "@lexical/plain-text": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "@lexical/yjs": "0.36.0",
+        "lexical": "0.36.0",
         "react-error-boundary": "^6.0.0"
       },
       "peerDependencies": {
@@ -642,57 +674,69 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.36.0.tgz",
+      "integrity": "sha512-rHy2bc4i0Dl5nJDHPgrQSq523o4DrxUfn+i7V6maF1YqUmayjnhjZ5yQhtPiKKIuGsHtM90XWWBXmSq1x0v45w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.36.0.tgz",
+      "integrity": "sha512-vR/uWqmj3M/FMDgILLT5HFcQpeenqwwbJnWEfERSytWWJOE16EEEBESg8n9OistvujCEmrWSpo64GWGIEEd13g==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.36.0.tgz",
+      "integrity": "sha512-/fveRVQxHx9UcL6wXFHI4q2LO2ouigLT/l4Qa5RcT6dXU8ht1shvI/2YB8pOMKx8SV4uu4kiEeupdYAWVd3mZQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.36.0.tgz",
+      "integrity": "sha512-Lqu8py5mfCYc41g2HRMWXSAer2fycenU0SyjOBD2mYArZ4LCfJeawej4yYLW3tYSx3eck0aOUp6PazTQjB/1vQ==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.36.0.tgz",
+      "integrity": "sha512-qKaeIpoN9lIR5LnDxgmNsPkVSrJ7K3u64PluxI6KWNpSpVDz11voQLX/+vXBeEEmj1UKVzqL1P/EChsYDl9qcg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.36.0.tgz",
+      "integrity": "sha512-KLvpP+60Dou6c3xjDwYjo1b/m3d+v7d1kTE1N9FfrjJS6qVPoWBrV7/k4mB1J3+1+2ZGguKXtk/aRHCJf21Ofg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/offset": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -700,6 +744,8 @@
     },
     "node_modules/@preact/signals-core": {
       "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
+      "integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1905,7 +1951,9 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.36.0.tgz",
+      "integrity": "sha512-exAJfRimJCbUSGMerG03hfsfCI4+35VDllvOTI7KvbNa6uq2K8Ec9zF1ELOR7P1SqR9PXrzzMn7xRTBOaac5XA==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -2131,6 +2179,8 @@
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/examples/react-plain-text/package-lock.json
+++ b/examples/react-plain-text/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@lexical/react-plain-text-example",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-plain-text-example",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
-        "@lexical/react": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/react": "0.36.0",
+        "lexical": "0.36.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -372,35 +372,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.36.0.tgz",
+      "integrity": "sha512-pmQLuVBf3bzfnl+e6PqwjwX+FAtlZG+cWwVdBxw3zOs4Eec6ZCPbWtXwZ4a0O+PtjL4Eqron5qvB2TAtL0qtXA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.36.0.tgz",
+      "integrity": "sha512-hgS3KH7hvnVL6ywcv7oDr0xAIaBKDIJzCW7cXOf1GoB6yFdaalMggIKbSdCiAkOPlfbix/bfsJFwPn7nm6n6dw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.36.0.tgz",
+      "integrity": "sha512-sX59vW5/csiWfJQos8SV0ctzgFYY1Juj87qQoaJK0rwP2EEc1pwWLyqBPZdqukwwQuPswzs1ml5xEDnnNJNycQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -408,136 +414,162 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.36.0.tgz",
+      "integrity": "sha512-I1R8HORGyiyzAUDi9Y0tUuCH1gUsupyuFiC3NkVdrC6gR03qnwPRS5c3W5nsIRUwcLRFFb3yHS7/zPuFkC5A/g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/extension": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.36.0.tgz",
+      "integrity": "sha512-ccmygnsJIQ/u1fLat8ULwR+FW4mB3HKp5ZlzJahDRjWfoM71XgHhaEZtbf9L/HZMNMst87POZyPl8te9pVXgCQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
+        "@lexical/utils": "0.36.0",
         "@preact/signals-core": "^1.11.0",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.36.0.tgz",
+      "integrity": "sha512-w1TyQy4MFQIyMyBl+6afyxYrz5haX+dHl6Q/VgjxjlTQWpb+ftmx7aWwlCdJdP91kUISx7R+Ti47pOKYAN/rLQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.36.0.tgz",
+      "integrity": "sha512-bY2AukJ59l7Yp+va8xS3fNmHmZNI72m2sDqtKw7HAl8BdvPw5Tu3XabqMOVBApM9kz5t0oO0RXWzJcL1suZP+Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.36.0.tgz",
+      "integrity": "sha512-3vHn91r2fTek4UHsJyZ2ePjfh90McErsXuyJX/hU+q+KnzQRXKyZi8PkX1qNZfannfnUwq93TV4/qp/QQ2CEzg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.36.0.tgz",
+      "integrity": "sha512-WG9UgPsVbbCsfNckXXp9OnnhEq3T9UAzpYHEOqwUdtXGTUDREHx2owcE1FDtG5KSbdg6QLP7Bc533v1oW77WVg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.36.0.tgz",
+      "integrity": "sha512-0gcXRLmNPfS5FdGRUS0xpHPvuLp7HaCXnd4lZ8SpaFsjsE9fjju8iOGmUmHfy/KthLQk5zKG9DHU0DAGNyrikg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.36.0.tgz",
+      "integrity": "sha512-HerD1La/3zxmZ0EE8XejMJLyKiVKnNMFk1p/mDqhHCrF9IKhiNqj6J51Brovnbsm36hkeD697H4f3fGn8o1kUA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.36.0.tgz",
+      "integrity": "sha512-YKBg7ZayWfGI+raDkt7idKO0vnn431sCMR3GB1op5BRDLEnLKN3r8YpIt04hUtFlu8nqOvyZAJkypIPE5n1cwQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/code": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.36.0.tgz",
+      "integrity": "sha512-/aRMavorGJ4HM+s6OJUCtrSV6n0MZ+0mU1Ljt2EqK+MuzDniDEhnfI/T8c5Zr0mEQB5ggfwLxcYgK2z82IZNGA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.36.0.tgz",
+      "integrity": "sha512-lNfG/EMUdnFJx+KtPQGH3ww5QEmW/s13P6AF3iBm3c7NCpETzswORn8F01OrlMPYB3tjD5vSjXdCgVg3AyYwlw==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.36.0.tgz",
+      "integrity": "sha512-gHFhWLx+CgbdImo1IZojvsbST53ZBI2JyhviZOZKv/j85IQIGGJZvgha64TCJkxn6EL3/mPFKtOvuRynil53Ww==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.36.0.tgz",
+      "integrity": "sha512-SQbRTaThgPQd0ggJrb9xmKuzruokNlqBAdGj6rcV6y2m6SzZg+03Qbl9zfPyLY2JssxObLH4gV1qKj/LA2Pv+w==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
-        "@lexical/devtools-core": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/hashtag": "0.35.0",
-        "@lexical/history": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/markdown": "0.35.0",
-        "@lexical/overflow": "0.35.0",
-        "@lexical/plain-text": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "@lexical/yjs": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/devtools-core": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/hashtag": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/markdown": "0.36.0",
+        "@lexical/overflow": "0.36.0",
+        "@lexical/plain-text": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "@lexical/yjs": "0.36.0",
+        "lexical": "0.36.0",
         "react-error-boundary": "^6.0.0"
       },
       "peerDependencies": {
@@ -546,57 +578,69 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.36.0.tgz",
+      "integrity": "sha512-rHy2bc4i0Dl5nJDHPgrQSq523o4DrxUfn+i7V6maF1YqUmayjnhjZ5yQhtPiKKIuGsHtM90XWWBXmSq1x0v45w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.36.0.tgz",
+      "integrity": "sha512-vR/uWqmj3M/FMDgILLT5HFcQpeenqwwbJnWEfERSytWWJOE16EEEBESg8n9OistvujCEmrWSpo64GWGIEEd13g==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.36.0.tgz",
+      "integrity": "sha512-/fveRVQxHx9UcL6wXFHI4q2LO2ouigLT/l4Qa5RcT6dXU8ht1shvI/2YB8pOMKx8SV4uu4kiEeupdYAWVd3mZQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.36.0.tgz",
+      "integrity": "sha512-Lqu8py5mfCYc41g2HRMWXSAer2fycenU0SyjOBD2mYArZ4LCfJeawej4yYLW3tYSx3eck0aOUp6PazTQjB/1vQ==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.36.0.tgz",
+      "integrity": "sha512-qKaeIpoN9lIR5LnDxgmNsPkVSrJ7K3u64PluxI6KWNpSpVDz11voQLX/+vXBeEEmj1UKVzqL1P/EChsYDl9qcg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.36.0.tgz",
+      "integrity": "sha512-KLvpP+60Dou6c3xjDwYjo1b/m3d+v7d1kTE1N9FfrjJS6qVPoWBrV7/k4mB1J3+1+2ZGguKXtk/aRHCJf21Ofg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/offset": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -604,6 +648,8 @@
     },
     "node_modules/@preact/signals-core": {
       "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
+      "integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -929,7 +975,9 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.36.0.tgz",
+      "integrity": "sha512-exAJfRimJCbUSGMerG03hfsfCI4+35VDllvOTI7KvbNa6uq2K8Ec9zF1ELOR7P1SqR9PXrzzMn7xRTBOaac5XA==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -1020,6 +1068,8 @@
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/examples/react-rich-collab/package-lock.json
+++ b/examples/react-rich-collab/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@lexical/react-rich-collab-example",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-rich-collab-example",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
-        "@lexical/react": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "@lexical/yjs": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/react": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "@lexical/yjs": "0.36.0",
+        "lexical": "0.36.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "y-webrtc": "^10.3.0",
@@ -440,41 +440,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-clipboard-0.35.0.tgz",
-      "integrity": "sha512-5PL30CVsLLbyRK8kUn2WXxC6HwIMDgKie6ky/OhkjYx0ORFLCczu3rhXEHgjR4pvKEKYivK/pWmNueXBFl29Ow==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.36.0.tgz",
+      "integrity": "sha512-pmQLuVBf3bzfnl+e6PqwjwX+FAtlZG+cWwVdBxw3zOs4Eec6ZCPbWtXwZ4a0O+PtjL4Eqron5qvB2TAtL0qtXA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-code-0.35.0.tgz",
-      "integrity": "sha512-39HDeZgpM/Ov4raEIIg1kNwcz3LYi6BxRiUqX4IJWNHjBzsHK31B3lZuEf46Zvd9bkiLbE2ZfSNHZWdvnMfrlA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.36.0.tgz",
+      "integrity": "sha512-hgS3KH7hvnVL6ywcv7oDr0xAIaBKDIJzCW7cXOf1GoB6yFdaalMggIKbSdCiAkOPlfbix/bfsJFwPn7nm6n6dw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-devtools-core-0.35.0.tgz",
-      "integrity": "sha512-CDu2Q/sYIVTU6l6MmClcXlqBLA7ecDIQ/iHueW4Jt5YOcGXAzLMGO3kDNydw+qQ6XmWJ1TdtDnzEh8ANDy/XpA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.36.0.tgz",
+      "integrity": "sha512-sX59vW5/csiWfJQos8SV0ctzgFYY1Juj87qQoaJK0rwP2EEc1pwWLyqBPZdqukwwQuPswzs1ml5xEDnnNJNycQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -482,162 +482,162 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-dragon-0.35.0.tgz",
-      "integrity": "sha512-VIJxpZ7ny6jdJAxKwH1R3JCrGjnVu9H/6DRt/Bpofo9UnG/udzQ4+U10OvcvtwTVU9TEPOo5UypXZ+purMq8Gg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.36.0.tgz",
+      "integrity": "sha512-I1R8HORGyiyzAUDi9Y0tUuCH1gUsupyuFiC3NkVdrC6gR03qnwPRS5c3W5nsIRUwcLRFFb3yHS7/zPuFkC5A/g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/extension": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-extension-0.35.0.tgz",
-      "integrity": "sha512-1ZTutbgEOwn1sqaS5/q2wPAnU61TPNv3jf4Y71aPUwtYh3BlMNiCKbfcHN+xtrzN1xoKHtceLIBPpwoWu+hUtQ==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.36.0.tgz",
+      "integrity": "sha512-ccmygnsJIQ/u1fLat8ULwR+FW4mB3HKp5ZlzJahDRjWfoM71XgHhaEZtbf9L/HZMNMst87POZyPl8te9pVXgCQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
+        "@lexical/utils": "0.36.0",
         "@preact/signals-core": "^1.11.0",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-hashtag-0.35.0.tgz",
-      "integrity": "sha512-2qcW99qgJzqTBz+Co/mP5jHaqamXtuYgxJ5Wqhe2utatevvpyGAHhvluSMvxfYZ3uO/IiqV/VjEZto7z737A8g==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.36.0.tgz",
+      "integrity": "sha512-w1TyQy4MFQIyMyBl+6afyxYrz5haX+dHl6Q/VgjxjlTQWpb+ftmx7aWwlCdJdP91kUISx7R+Ti47pOKYAN/rLQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-history-0.35.0.tgz",
-      "integrity": "sha512-SBDOzWqlN8axfi3tb/1wNW0ZsBOT8HKhhCggytR6qZucieNmMpnF7TYBnfrW/C/6L8PocrrPoEW1QSDJPsmPOw==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.36.0.tgz",
+      "integrity": "sha512-bY2AukJ59l7Yp+va8xS3fNmHmZNI72m2sDqtKw7HAl8BdvPw5Tu3XabqMOVBApM9kz5t0oO0RXWzJcL1suZP+Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-html-0.35.0.tgz",
-      "integrity": "sha512-rXGFE5S5rKsg3tVnr1s4iEgOfCApNXGpIFI3T2jGEShaCZ5HLaBY9NVBXnE9Nb49e9bkDkpZ8FZd1qokCbQXbw==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.36.0.tgz",
+      "integrity": "sha512-3vHn91r2fTek4UHsJyZ2ePjfh90McErsXuyJX/hU+q+KnzQRXKyZi8PkX1qNZfannfnUwq93TV4/qp/QQ2CEzg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-link-0.35.0.tgz",
-      "integrity": "sha512-xcxIJ9dBuRzdw+N5zEHC5VtQRLrNbcZ4H0xaBKTed2flUgEaPk4VVnWgzxpMIAQH/I7EuyJu5/KPTPNm9Dcdxg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.36.0.tgz",
+      "integrity": "sha512-WG9UgPsVbbCsfNckXXp9OnnhEq3T9UAzpYHEOqwUdtXGTUDREHx2owcE1FDtG5KSbdg6QLP7Bc533v1oW77WVg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-list-0.35.0.tgz",
-      "integrity": "sha512-+UUOXF275+zPn4mrx/zakiDZ13d2p8mdJfUmhPB8+LtMfCHVJH8gZmmIAAUHdIi5x1uxe7f9cyNoV8zMN+RuLA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.36.0.tgz",
+      "integrity": "sha512-0gcXRLmNPfS5FdGRUS0xpHPvuLp7HaCXnd4lZ8SpaFsjsE9fjju8iOGmUmHfy/KthLQk5zKG9DHU0DAGNyrikg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-mark-0.35.0.tgz",
-      "integrity": "sha512-Cg2evr/EyND1gD++2fzn0FDICWXEACMQ8xJlp/2MR3Uyhx3777U38N2z237abWn1BQew+i62VAFQDz7h0+UpQg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.36.0.tgz",
+      "integrity": "sha512-HerD1La/3zxmZ0EE8XejMJLyKiVKnNMFk1p/mDqhHCrF9IKhiNqj6J51Brovnbsm36hkeD697H4f3fGn8o1kUA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-markdown-0.35.0.tgz",
-      "integrity": "sha512-qqA8yZs4wLKIuj8C+xBujJcNVuEGMppI/7hhpHlcNBS/no9CiGbS+C1of54NCYKMU6dh8ceZHKCvl+uYbqxxJg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.36.0.tgz",
+      "integrity": "sha512-YKBg7ZayWfGI+raDkt7idKO0vnn431sCMR3GB1op5BRDLEnLKN3r8YpIt04hUtFlu8nqOvyZAJkypIPE5n1cwQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/code": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-offset-0.35.0.tgz",
-      "integrity": "sha512-O0AWoVpdbHNC2Dv8QA1INrGi4dentVj91sX38zfdasutMfs/EKiX1HB+omiy9UaVCkz/YvSdTGYzXIlWb97cZQ==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.36.0.tgz",
+      "integrity": "sha512-/aRMavorGJ4HM+s6OJUCtrSV6n0MZ+0mU1Ljt2EqK+MuzDniDEhnfI/T8c5Zr0mEQB5ggfwLxcYgK2z82IZNGA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-overflow-0.35.0.tgz",
-      "integrity": "sha512-0NgtAK0uCeuwuf5yLXGa5wiIvOpAORTUKl25aZEKw+oKcl8QMdHQ+5EVPcPzwjW+wI9BaoS2hqUqA1d5KVQaEA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.36.0.tgz",
+      "integrity": "sha512-lNfG/EMUdnFJx+KtPQGH3ww5QEmW/s13P6AF3iBm3c7NCpETzswORn8F01OrlMPYB3tjD5vSjXdCgVg3AyYwlw==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-plain-text-0.35.0.tgz",
-      "integrity": "sha512-N5PPMGbjITovLlhez337HL2+E0co9jzQ0NK2NELCnHHwc5S6XG77mVU+NoYVD35wZxVJNAtffVTrq4WE/OHeww==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.36.0.tgz",
+      "integrity": "sha512-gHFhWLx+CgbdImo1IZojvsbST53ZBI2JyhviZOZKv/j85IQIGGJZvgha64TCJkxn6EL3/mPFKtOvuRynil53Ww==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-react-0.35.0.tgz",
-      "integrity": "sha512-io6miDW6XryN7ptU3qq6+JsCxrc473AgHkaC1M3wJ4U5DJqSfxQVo8ekFkMjBbSlLf6j1Dyy9UEFDL44NvvgVA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.36.0.tgz",
+      "integrity": "sha512-SQbRTaThgPQd0ggJrb9xmKuzruokNlqBAdGj6rcV6y2m6SzZg+03Qbl9zfPyLY2JssxObLH4gV1qKj/LA2Pv+w==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
-        "@lexical/devtools-core": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/hashtag": "0.35.0",
-        "@lexical/history": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/markdown": "0.35.0",
-        "@lexical/overflow": "0.35.0",
-        "@lexical/plain-text": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "@lexical/yjs": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/devtools-core": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/hashtag": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/markdown": "0.36.0",
+        "@lexical/overflow": "0.36.0",
+        "@lexical/plain-text": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "@lexical/yjs": "0.36.0",
+        "lexical": "0.36.0",
         "react-error-boundary": "^6.0.0"
       },
       "peerDependencies": {
@@ -646,69 +646,69 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-rich-text-0.35.0.tgz",
-      "integrity": "sha512-g34Xd0sItq4XuKK9MhxZFnCXkXgkOgCuwD7zg7rmV74o5fl9EJNjXn2gso2JhG92B32Go2Vd0hKgt7/zFTnTuA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.36.0.tgz",
+      "integrity": "sha512-rHy2bc4i0Dl5nJDHPgrQSq523o4DrxUfn+i7V6maF1YqUmayjnhjZ5yQhtPiKKIuGsHtM90XWWBXmSq1x0v45w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-selection-0.35.0.tgz",
-      "integrity": "sha512-Qd5/jPk3fcaC3Gd4RFeRgHPnT1zMYluszywdT0RJ6uJqE/tzu6uNAZjIKcmeOKlYsvyEdzExUYNdwD4cqDawAA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.36.0.tgz",
+      "integrity": "sha512-vR/uWqmj3M/FMDgILLT5HFcQpeenqwwbJnWEfERSytWWJOE16EEEBESg8n9OistvujCEmrWSpo64GWGIEEd13g==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-table-0.35.0.tgz",
-      "integrity": "sha512-RlEQE+10X0NEKroUTxnZ25kyC1gBUIGXOSGJSNw3KyON4EFU/r+ChXb8xsvFhr+ad+pg/0D9yZi07orMQwxhNw==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.36.0.tgz",
+      "integrity": "sha512-/fveRVQxHx9UcL6wXFHI4q2LO2ouigLT/l4Qa5RcT6dXU8ht1shvI/2YB8pOMKx8SV4uu4kiEeupdYAWVd3mZQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-text-0.35.0.tgz",
-      "integrity": "sha512-uaMh46BkysV8hK8wQwp5g/ByZW+2hPDt8ahAErxtf8NuzQem1FHG/f5RTchmFqqUDVHO3qLNTv4AehEGmXv8MA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.36.0.tgz",
+      "integrity": "sha512-Lqu8py5mfCYc41g2HRMWXSAer2fycenU0SyjOBD2mYArZ4LCfJeawej4yYLW3tYSx3eck0aOUp6PazTQjB/1vQ==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-utils-0.35.0.tgz",
-      "integrity": "sha512-bWuwCPyyiJwsP8KZ3pCWqydY49CUET9snp4g8GdFIvqlwqMV/Lp/JFNq9FmuDYjx1MY9EVBFNodnwG2+OEnHmw==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.36.0.tgz",
+      "integrity": "sha512-qKaeIpoN9lIR5LnDxgmNsPkVSrJ7K3u64PluxI6KWNpSpVDz11voQLX/+vXBeEEmj1UKVzqL1P/EChsYDl9qcg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-yjs-0.35.0.tgz",
-      "integrity": "sha512-PoiqTdt6fhPk9h3AodGBX2MGY3q9Ywtf2ZEq8QNfYua25Ce4ShmJG0+OXa5vJbve68KmXIWi3L1csm7NTdgfDQ==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.36.0.tgz",
+      "integrity": "sha512-KLvpP+60Dou6c3xjDwYjo1b/m3d+v7d1kTE1N9FfrjJS6qVPoWBrV7/k4mB1J3+1+2ZGguKXtk/aRHCJf21Ofg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/offset": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -1368,9 +1368,9 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.35.0",
-      "resolved": "file:../../npm/lexical-0.35.0.tgz",
-      "integrity": "sha512-ojiJw9X6rdEMopjN92DtIofJAJy8xEFW9J4yA5lH1/zW2PXDo7lIucsipT11ueIYII3gRJnfyYp5GFE3Iy1Ahg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.36.0.tgz",
+      "integrity": "sha512-exAJfRimJCbUSGMerG03hfsfCI4+35VDllvOTI7KvbNa6uq2K8Ec9zF1ELOR7P1SqR9PXrzzMn7xRTBOaac5XA==",
       "license": "MIT"
     },
     "node_modules/lib0": {

--- a/examples/react-rich-collab/package.json
+++ b/examples/react-rich-collab/package.json
@@ -13,10 +13,6 @@
     "server:ws": "cross-env HOST=localhost PORT=1234 YPERSISTENCE=./yjs-wss-db npx y-websocket",
     "server:webrtc": "cross-env HOST=localhost PORT=1235 npx y-webrtc"
   },
-  "lexicalUnreleasedDependencies": {
-    "@lexical/react": "0.35.0",
-    "@lexical/yjs": "0.35.0"
-  },
   "dependencies": {
     "@lexical/react": "0.36.0",
     "@lexical/utils": "0.36.0",

--- a/examples/react-rich-collab/tsconfig.json
+++ b/examples/react-rich-collab/tsconfig.json
@@ -16,12 +16,10 @@
 
     /* Linting */
     "strict": true,
-    // "noUnusedLocals": true,
-    // "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  /* TODO #7706 this depends on unreleased packages so we build from monorepo */
-  "extends": ["../../tsconfig.json"],
-  "include": ["src", "../../libdefs"],
+  "include": ["src"],
   "references": [{"path": "./tsconfig.node.json"}]
 }

--- a/examples/react-rich/package-lock.json
+++ b/examples/react-rich/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@lexical/react-rich-example",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-rich-example",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
-        "@lexical/react": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/react": "0.36.0",
+        "lexical": "0.36.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -372,35 +372,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.36.0.tgz",
+      "integrity": "sha512-pmQLuVBf3bzfnl+e6PqwjwX+FAtlZG+cWwVdBxw3zOs4Eec6ZCPbWtXwZ4a0O+PtjL4Eqron5qvB2TAtL0qtXA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.36.0.tgz",
+      "integrity": "sha512-hgS3KH7hvnVL6ywcv7oDr0xAIaBKDIJzCW7cXOf1GoB6yFdaalMggIKbSdCiAkOPlfbix/bfsJFwPn7nm6n6dw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.36.0.tgz",
+      "integrity": "sha512-sX59vW5/csiWfJQos8SV0ctzgFYY1Juj87qQoaJK0rwP2EEc1pwWLyqBPZdqukwwQuPswzs1ml5xEDnnNJNycQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -408,136 +414,162 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.36.0.tgz",
+      "integrity": "sha512-I1R8HORGyiyzAUDi9Y0tUuCH1gUsupyuFiC3NkVdrC6gR03qnwPRS5c3W5nsIRUwcLRFFb3yHS7/zPuFkC5A/g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/extension": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.36.0.tgz",
+      "integrity": "sha512-ccmygnsJIQ/u1fLat8ULwR+FW4mB3HKp5ZlzJahDRjWfoM71XgHhaEZtbf9L/HZMNMst87POZyPl8te9pVXgCQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
+        "@lexical/utils": "0.36.0",
         "@preact/signals-core": "^1.11.0",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.36.0.tgz",
+      "integrity": "sha512-w1TyQy4MFQIyMyBl+6afyxYrz5haX+dHl6Q/VgjxjlTQWpb+ftmx7aWwlCdJdP91kUISx7R+Ti47pOKYAN/rLQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.36.0.tgz",
+      "integrity": "sha512-bY2AukJ59l7Yp+va8xS3fNmHmZNI72m2sDqtKw7HAl8BdvPw5Tu3XabqMOVBApM9kz5t0oO0RXWzJcL1suZP+Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.36.0.tgz",
+      "integrity": "sha512-3vHn91r2fTek4UHsJyZ2ePjfh90McErsXuyJX/hU+q+KnzQRXKyZi8PkX1qNZfannfnUwq93TV4/qp/QQ2CEzg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.36.0.tgz",
+      "integrity": "sha512-WG9UgPsVbbCsfNckXXp9OnnhEq3T9UAzpYHEOqwUdtXGTUDREHx2owcE1FDtG5KSbdg6QLP7Bc533v1oW77WVg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.36.0.tgz",
+      "integrity": "sha512-0gcXRLmNPfS5FdGRUS0xpHPvuLp7HaCXnd4lZ8SpaFsjsE9fjju8iOGmUmHfy/KthLQk5zKG9DHU0DAGNyrikg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.36.0.tgz",
+      "integrity": "sha512-HerD1La/3zxmZ0EE8XejMJLyKiVKnNMFk1p/mDqhHCrF9IKhiNqj6J51Brovnbsm36hkeD697H4f3fGn8o1kUA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.36.0.tgz",
+      "integrity": "sha512-YKBg7ZayWfGI+raDkt7idKO0vnn431sCMR3GB1op5BRDLEnLKN3r8YpIt04hUtFlu8nqOvyZAJkypIPE5n1cwQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/code": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.36.0.tgz",
+      "integrity": "sha512-/aRMavorGJ4HM+s6OJUCtrSV6n0MZ+0mU1Ljt2EqK+MuzDniDEhnfI/T8c5Zr0mEQB5ggfwLxcYgK2z82IZNGA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.36.0.tgz",
+      "integrity": "sha512-lNfG/EMUdnFJx+KtPQGH3ww5QEmW/s13P6AF3iBm3c7NCpETzswORn8F01OrlMPYB3tjD5vSjXdCgVg3AyYwlw==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.36.0.tgz",
+      "integrity": "sha512-gHFhWLx+CgbdImo1IZojvsbST53ZBI2JyhviZOZKv/j85IQIGGJZvgha64TCJkxn6EL3/mPFKtOvuRynil53Ww==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.36.0.tgz",
+      "integrity": "sha512-SQbRTaThgPQd0ggJrb9xmKuzruokNlqBAdGj6rcV6y2m6SzZg+03Qbl9zfPyLY2JssxObLH4gV1qKj/LA2Pv+w==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
-        "@lexical/devtools-core": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/hashtag": "0.35.0",
-        "@lexical/history": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/markdown": "0.35.0",
-        "@lexical/overflow": "0.35.0",
-        "@lexical/plain-text": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "@lexical/yjs": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/devtools-core": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/hashtag": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/markdown": "0.36.0",
+        "@lexical/overflow": "0.36.0",
+        "@lexical/plain-text": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "@lexical/yjs": "0.36.0",
+        "lexical": "0.36.0",
         "react-error-boundary": "^6.0.0"
       },
       "peerDependencies": {
@@ -546,57 +578,69 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.36.0.tgz",
+      "integrity": "sha512-rHy2bc4i0Dl5nJDHPgrQSq523o4DrxUfn+i7V6maF1YqUmayjnhjZ5yQhtPiKKIuGsHtM90XWWBXmSq1x0v45w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.36.0.tgz",
+      "integrity": "sha512-vR/uWqmj3M/FMDgILLT5HFcQpeenqwwbJnWEfERSytWWJOE16EEEBESg8n9OistvujCEmrWSpo64GWGIEEd13g==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.36.0.tgz",
+      "integrity": "sha512-/fveRVQxHx9UcL6wXFHI4q2LO2ouigLT/l4Qa5RcT6dXU8ht1shvI/2YB8pOMKx8SV4uu4kiEeupdYAWVd3mZQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.36.0.tgz",
+      "integrity": "sha512-Lqu8py5mfCYc41g2HRMWXSAer2fycenU0SyjOBD2mYArZ4LCfJeawej4yYLW3tYSx3eck0aOUp6PazTQjB/1vQ==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.36.0.tgz",
+      "integrity": "sha512-qKaeIpoN9lIR5LnDxgmNsPkVSrJ7K3u64PluxI6KWNpSpVDz11voQLX/+vXBeEEmj1UKVzqL1P/EChsYDl9qcg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.36.0.tgz",
+      "integrity": "sha512-KLvpP+60Dou6c3xjDwYjo1b/m3d+v7d1kTE1N9FfrjJS6qVPoWBrV7/k4mB1J3+1+2ZGguKXtk/aRHCJf21Ofg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/offset": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -604,6 +648,8 @@
     },
     "node_modules/@preact/signals-core": {
       "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
+      "integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -929,7 +975,9 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.36.0.tgz",
+      "integrity": "sha512-exAJfRimJCbUSGMerG03hfsfCI4+35VDllvOTI7KvbNa6uq2K8Ec9zF1ELOR7P1SqR9PXrzzMn7xRTBOaac5XA==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -1020,6 +1068,8 @@
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/examples/react-table/package-lock.json
+++ b/examples/react-table/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@lexical/react-table-example",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/react-table-example",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
-        "@lexical/react": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/react": "0.36.0",
+        "lexical": "0.36.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -372,35 +372,41 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.36.0.tgz",
+      "integrity": "sha512-pmQLuVBf3bzfnl+e6PqwjwX+FAtlZG+cWwVdBxw3zOs4Eec6ZCPbWtXwZ4a0O+PtjL4Eqron5qvB2TAtL0qtXA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.36.0.tgz",
+      "integrity": "sha512-hgS3KH7hvnVL6ywcv7oDr0xAIaBKDIJzCW7cXOf1GoB6yFdaalMggIKbSdCiAkOPlfbix/bfsJFwPn7nm6n6dw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.36.0.tgz",
+      "integrity": "sha512-sX59vW5/csiWfJQos8SV0ctzgFYY1Juj87qQoaJK0rwP2EEc1pwWLyqBPZdqukwwQuPswzs1ml5xEDnnNJNycQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -408,136 +414,162 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.36.0.tgz",
+      "integrity": "sha512-I1R8HORGyiyzAUDi9Y0tUuCH1gUsupyuFiC3NkVdrC6gR03qnwPRS5c3W5nsIRUwcLRFFb3yHS7/zPuFkC5A/g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/extension": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.36.0.tgz",
+      "integrity": "sha512-ccmygnsJIQ/u1fLat8ULwR+FW4mB3HKp5ZlzJahDRjWfoM71XgHhaEZtbf9L/HZMNMst87POZyPl8te9pVXgCQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
+        "@lexical/utils": "0.36.0",
         "@preact/signals-core": "^1.11.0",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.36.0.tgz",
+      "integrity": "sha512-w1TyQy4MFQIyMyBl+6afyxYrz5haX+dHl6Q/VgjxjlTQWpb+ftmx7aWwlCdJdP91kUISx7R+Ti47pOKYAN/rLQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.36.0.tgz",
+      "integrity": "sha512-bY2AukJ59l7Yp+va8xS3fNmHmZNI72m2sDqtKw7HAl8BdvPw5Tu3XabqMOVBApM9kz5t0oO0RXWzJcL1suZP+Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.36.0.tgz",
+      "integrity": "sha512-3vHn91r2fTek4UHsJyZ2ePjfh90McErsXuyJX/hU+q+KnzQRXKyZi8PkX1qNZfannfnUwq93TV4/qp/QQ2CEzg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.36.0.tgz",
+      "integrity": "sha512-WG9UgPsVbbCsfNckXXp9OnnhEq3T9UAzpYHEOqwUdtXGTUDREHx2owcE1FDtG5KSbdg6QLP7Bc533v1oW77WVg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.36.0.tgz",
+      "integrity": "sha512-0gcXRLmNPfS5FdGRUS0xpHPvuLp7HaCXnd4lZ8SpaFsjsE9fjju8iOGmUmHfy/KthLQk5zKG9DHU0DAGNyrikg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.36.0.tgz",
+      "integrity": "sha512-HerD1La/3zxmZ0EE8XejMJLyKiVKnNMFk1p/mDqhHCrF9IKhiNqj6J51Brovnbsm36hkeD697H4f3fGn8o1kUA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.36.0.tgz",
+      "integrity": "sha512-YKBg7ZayWfGI+raDkt7idKO0vnn431sCMR3GB1op5BRDLEnLKN3r8YpIt04hUtFlu8nqOvyZAJkypIPE5n1cwQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/code": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.36.0.tgz",
+      "integrity": "sha512-/aRMavorGJ4HM+s6OJUCtrSV6n0MZ+0mU1Ljt2EqK+MuzDniDEhnfI/T8c5Zr0mEQB5ggfwLxcYgK2z82IZNGA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.36.0.tgz",
+      "integrity": "sha512-lNfG/EMUdnFJx+KtPQGH3ww5QEmW/s13P6AF3iBm3c7NCpETzswORn8F01OrlMPYB3tjD5vSjXdCgVg3AyYwlw==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.36.0.tgz",
+      "integrity": "sha512-gHFhWLx+CgbdImo1IZojvsbST53ZBI2JyhviZOZKv/j85IQIGGJZvgha64TCJkxn6EL3/mPFKtOvuRynil53Ww==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.36.0.tgz",
+      "integrity": "sha512-SQbRTaThgPQd0ggJrb9xmKuzruokNlqBAdGj6rcV6y2m6SzZg+03Qbl9zfPyLY2JssxObLH4gV1qKj/LA2Pv+w==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
-        "@lexical/devtools-core": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/hashtag": "0.35.0",
-        "@lexical/history": "0.35.0",
-        "@lexical/link": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/mark": "0.35.0",
-        "@lexical/markdown": "0.35.0",
-        "@lexical/overflow": "0.35.0",
-        "@lexical/plain-text": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "@lexical/text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "@lexical/yjs": "0.35.0",
-        "lexical": "0.35.0",
+        "@lexical/devtools-core": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/hashtag": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/link": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/mark": "0.36.0",
+        "@lexical/markdown": "0.36.0",
+        "@lexical/overflow": "0.36.0",
+        "@lexical/plain-text": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "@lexical/text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "@lexical/yjs": "0.36.0",
+        "lexical": "0.36.0",
         "react-error-boundary": "^6.0.0"
       },
       "peerDependencies": {
@@ -546,57 +578,69 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.36.0.tgz",
+      "integrity": "sha512-rHy2bc4i0Dl5nJDHPgrQSq523o4DrxUfn+i7V6maF1YqUmayjnhjZ5yQhtPiKKIuGsHtM90XWWBXmSq1x0v45w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.36.0.tgz",
+      "integrity": "sha512-vR/uWqmj3M/FMDgILLT5HFcQpeenqwwbJnWEfERSytWWJOE16EEEBESg8n9OistvujCEmrWSpo64GWGIEEd13g==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.36.0.tgz",
+      "integrity": "sha512-/fveRVQxHx9UcL6wXFHI4q2LO2ouigLT/l4Qa5RcT6dXU8ht1shvI/2YB8pOMKx8SV4uu4kiEeupdYAWVd3mZQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.36.0.tgz",
+      "integrity": "sha512-Lqu8py5mfCYc41g2HRMWXSAer2fycenU0SyjOBD2mYArZ4LCfJeawej4yYLW3tYSx3eck0aOUp6PazTQjB/1vQ==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.36.0.tgz",
+      "integrity": "sha512-qKaeIpoN9lIR5LnDxgmNsPkVSrJ7K3u64PluxI6KWNpSpVDz11voQLX/+vXBeEEmj1UKVzqL1P/EChsYDl9qcg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.36.0.tgz",
+      "integrity": "sha512-KLvpP+60Dou6c3xjDwYjo1b/m3d+v7d1kTE1N9FfrjJS6qVPoWBrV7/k4mB1J3+1+2ZGguKXtk/aRHCJf21Ofg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/offset": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "lexical": "0.36.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -604,6 +648,8 @@
     },
     "node_modules/@preact/signals-core": {
       "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
+      "integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -929,7 +975,9 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.36.0.tgz",
+      "integrity": "sha512-exAJfRimJCbUSGMerG03hfsfCI4+35VDllvOTI7KvbNa6uq2K8Ec9zF1ELOR7P1SqR9PXrzzMn7xRTBOaac5XA==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -1020,6 +1068,8 @@
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/examples/vanilla-js-iframe/package-lock.json
+++ b/examples/vanilla-js-iframe/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@lexical/vanilla-js-iframe-example",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/vanilla-js-iframe-example",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
-        "@lexical/dragon": "0.35.0",
-        "@lexical/history": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/dragon": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       },
       "devDependencies": {
         "cross-env": "^7.0.3",
@@ -36,101 +36,123 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.36.0.tgz",
+      "integrity": "sha512-pmQLuVBf3bzfnl+e6PqwjwX+FAtlZG+cWwVdBxw3zOs4Eec6ZCPbWtXwZ4a0O+PtjL4Eqron5qvB2TAtL0qtXA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.36.0.tgz",
+      "integrity": "sha512-I1R8HORGyiyzAUDi9Y0tUuCH1gUsupyuFiC3NkVdrC6gR03qnwPRS5c3W5nsIRUwcLRFFb3yHS7/zPuFkC5A/g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/extension": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.36.0.tgz",
+      "integrity": "sha512-ccmygnsJIQ/u1fLat8ULwR+FW4mB3HKp5ZlzJahDRjWfoM71XgHhaEZtbf9L/HZMNMst87POZyPl8te9pVXgCQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
+        "@lexical/utils": "0.36.0",
         "@preact/signals-core": "^1.11.0",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.36.0.tgz",
+      "integrity": "sha512-bY2AukJ59l7Yp+va8xS3fNmHmZNI72m2sDqtKw7HAl8BdvPw5Tu3XabqMOVBApM9kz5t0oO0RXWzJcL1suZP+Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.36.0.tgz",
+      "integrity": "sha512-3vHn91r2fTek4UHsJyZ2ePjfh90McErsXuyJX/hU+q+KnzQRXKyZi8PkX1qNZfannfnUwq93TV4/qp/QQ2CEzg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.36.0.tgz",
+      "integrity": "sha512-0gcXRLmNPfS5FdGRUS0xpHPvuLp7HaCXnd4lZ8SpaFsjsE9fjju8iOGmUmHfy/KthLQk5zKG9DHU0DAGNyrikg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.36.0.tgz",
+      "integrity": "sha512-rHy2bc4i0Dl5nJDHPgrQSq523o4DrxUfn+i7V6maF1YqUmayjnhjZ5yQhtPiKKIuGsHtM90XWWBXmSq1x0v45w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.36.0.tgz",
+      "integrity": "sha512-vR/uWqmj3M/FMDgILLT5HFcQpeenqwwbJnWEfERSytWWJOE16EEEBESg8n9OistvujCEmrWSpo64GWGIEEd13g==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.36.0.tgz",
+      "integrity": "sha512-/fveRVQxHx9UcL6wXFHI4q2LO2ouigLT/l4Qa5RcT6dXU8ht1shvI/2YB8pOMKx8SV4uu4kiEeupdYAWVd3mZQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.36.0.tgz",
+      "integrity": "sha512-qKaeIpoN9lIR5LnDxgmNsPkVSrJ7K3u64PluxI6KWNpSpVDz11voQLX/+vXBeEEmj1UKVzqL1P/EChsYDl9qcg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@preact/signals-core": {
       "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
+      "integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -246,7 +268,9 @@
       "license": "ISC"
     },
     "node_modules/lexical": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.36.0.tgz",
+      "integrity": "sha512-exAJfRimJCbUSGMerG03hfsfCI4+35VDllvOTI7KvbNa6uq2K8Ec9zF1ELOR7P1SqR9PXrzzMn7xRTBOaac5XA==",
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/examples/vanilla-js-plugin/package-lock.json
+++ b/examples/vanilla-js-plugin/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@lexical/vanilla-js-plugin-example",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/vanilla-js-plugin-example",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
-        "@lexical/dragon": "0.35.0",
-        "@lexical/history": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/utils": "0.35.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/utils": "0.36.0",
         "emoji-datasource-facebook": "15.1.2",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       },
       "devDependencies": {
         "cross-env": "^7.0.3",
@@ -37,101 +37,123 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.36.0.tgz",
+      "integrity": "sha512-pmQLuVBf3bzfnl+e6PqwjwX+FAtlZG+cWwVdBxw3zOs4Eec6ZCPbWtXwZ4a0O+PtjL4Eqron5qvB2TAtL0qtXA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.36.0.tgz",
+      "integrity": "sha512-I1R8HORGyiyzAUDi9Y0tUuCH1gUsupyuFiC3NkVdrC6gR03qnwPRS5c3W5nsIRUwcLRFFb3yHS7/zPuFkC5A/g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/extension": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.36.0.tgz",
+      "integrity": "sha512-ccmygnsJIQ/u1fLat8ULwR+FW4mB3HKp5ZlzJahDRjWfoM71XgHhaEZtbf9L/HZMNMst87POZyPl8te9pVXgCQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
+        "@lexical/utils": "0.36.0",
         "@preact/signals-core": "^1.11.0",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.36.0.tgz",
+      "integrity": "sha512-bY2AukJ59l7Yp+va8xS3fNmHmZNI72m2sDqtKw7HAl8BdvPw5Tu3XabqMOVBApM9kz5t0oO0RXWzJcL1suZP+Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.36.0.tgz",
+      "integrity": "sha512-3vHn91r2fTek4UHsJyZ2ePjfh90McErsXuyJX/hU+q+KnzQRXKyZi8PkX1qNZfannfnUwq93TV4/qp/QQ2CEzg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.36.0.tgz",
+      "integrity": "sha512-0gcXRLmNPfS5FdGRUS0xpHPvuLp7HaCXnd4lZ8SpaFsjsE9fjju8iOGmUmHfy/KthLQk5zKG9DHU0DAGNyrikg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.36.0.tgz",
+      "integrity": "sha512-rHy2bc4i0Dl5nJDHPgrQSq523o4DrxUfn+i7V6maF1YqUmayjnhjZ5yQhtPiKKIuGsHtM90XWWBXmSq1x0v45w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.36.0.tgz",
+      "integrity": "sha512-vR/uWqmj3M/FMDgILLT5HFcQpeenqwwbJnWEfERSytWWJOE16EEEBESg8n9OistvujCEmrWSpo64GWGIEEd13g==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.36.0.tgz",
+      "integrity": "sha512-/fveRVQxHx9UcL6wXFHI4q2LO2ouigLT/l4Qa5RcT6dXU8ht1shvI/2YB8pOMKx8SV4uu4kiEeupdYAWVd3mZQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.36.0.tgz",
+      "integrity": "sha512-qKaeIpoN9lIR5LnDxgmNsPkVSrJ7K3u64PluxI6KWNpSpVDz11voQLX/+vXBeEEmj1UKVzqL1P/EChsYDl9qcg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@preact/signals-core": {
       "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
+      "integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -251,7 +273,9 @@
       "license": "ISC"
     },
     "node_modules/lexical": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.36.0.tgz",
+      "integrity": "sha512-exAJfRimJCbUSGMerG03hfsfCI4+35VDllvOTI7KvbNa6uq2K8Ec9zF1ELOR7P1SqR9PXrzzMn7xRTBOaac5XA==",
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/examples/vanilla-js/package-lock.json
+++ b/examples/vanilla-js/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@lexical/vanilla-js-example",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lexical/vanilla-js-example",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
-        "@lexical/dragon": "0.35.0",
-        "@lexical/history": "0.35.0",
-        "@lexical/rich-text": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/dragon": "0.36.0",
+        "@lexical/history": "0.36.0",
+        "@lexical/rich-text": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       },
       "devDependencies": {
         "cross-env": "^7.0.3",
@@ -36,101 +36,123 @@
       }
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.36.0.tgz",
+      "integrity": "sha512-pmQLuVBf3bzfnl+e6PqwjwX+FAtlZG+cWwVdBxw3zOs4Eec6ZCPbWtXwZ4a0O+PtjL4Eqron5qvB2TAtL0qtXA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.35.0",
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/html": "0.36.0",
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.36.0.tgz",
+      "integrity": "sha512-I1R8HORGyiyzAUDi9Y0tUuCH1gUsupyuFiC3NkVdrC6gR03qnwPRS5c3W5nsIRUwcLRFFb3yHS7/zPuFkC5A/g==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/extension": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.36.0.tgz",
+      "integrity": "sha512-ccmygnsJIQ/u1fLat8ULwR+FW4mB3HKp5ZlzJahDRjWfoM71XgHhaEZtbf9L/HZMNMst87POZyPl8te9pVXgCQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.35.0",
+        "@lexical/utils": "0.36.0",
         "@preact/signals-core": "^1.11.0",
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.36.0.tgz",
+      "integrity": "sha512-bY2AukJ59l7Yp+va8xS3fNmHmZNI72m2sDqtKw7HAl8BdvPw5Tu3XabqMOVBApM9kz5t0oO0RXWzJcL1suZP+Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.36.0.tgz",
+      "integrity": "sha512-3vHn91r2fTek4UHsJyZ2ePjfh90McErsXuyJX/hU+q+KnzQRXKyZi8PkX1qNZfannfnUwq93TV4/qp/QQ2CEzg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.36.0.tgz",
+      "integrity": "sha512-0gcXRLmNPfS5FdGRUS0xpHPvuLp7HaCXnd4lZ8SpaFsjsE9fjju8iOGmUmHfy/KthLQk5zKG9DHU0DAGNyrikg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/extension": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.36.0.tgz",
+      "integrity": "sha512-rHy2bc4i0Dl5nJDHPgrQSq523o4DrxUfn+i7V6maF1YqUmayjnhjZ5yQhtPiKKIuGsHtM90XWWBXmSq1x0v45w==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/dragon": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/dragon": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.36.0.tgz",
+      "integrity": "sha512-vR/uWqmj3M/FMDgILLT5HFcQpeenqwwbJnWEfERSytWWJOE16EEEBESg8n9OistvujCEmrWSpo64GWGIEEd13g==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.35.0"
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.36.0.tgz",
+      "integrity": "sha512-/fveRVQxHx9UcL6wXFHI4q2LO2ouigLT/l4Qa5RcT6dXU8ht1shvI/2YB8pOMKx8SV4uu4kiEeupdYAWVd3mZQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.35.0",
-        "@lexical/extension": "0.35.0",
-        "@lexical/utils": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/clipboard": "0.36.0",
+        "@lexical/extension": "0.36.0",
+        "@lexical/utils": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.36.0.tgz",
+      "integrity": "sha512-qKaeIpoN9lIR5LnDxgmNsPkVSrJ7K3u64PluxI6KWNpSpVDz11voQLX/+vXBeEEmj1UKVzqL1P/EChsYDl9qcg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.35.0",
-        "@lexical/selection": "0.35.0",
-        "@lexical/table": "0.35.0",
-        "lexical": "0.35.0"
+        "@lexical/list": "0.36.0",
+        "@lexical/selection": "0.36.0",
+        "@lexical/table": "0.36.0",
+        "lexical": "0.36.0"
       }
     },
     "node_modules/@preact/signals-core": {
       "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
+      "integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -246,7 +268,9 @@
       "license": "ISC"
     },
     "node_modules/lexical": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.36.0.tgz",
+      "integrity": "sha512-exAJfRimJCbUSGMerG03hfsfCI4+35VDllvOTI7KvbNa6uq2K8Ec9zF1ELOR7P1SqR9PXrzzMn7xRTBOaac5XA==",
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -42,14 +42,14 @@
   "exports": {
     "./ExtensionComponent": {
       "import": {
-        "types": "./LexicalExtensionComponent.d.ts",
+        "types": "./ExtensionComponent.d.ts",
         "development": "./LexicalExtensionComponent.dev.mjs",
         "production": "./LexicalExtensionComponent.prod.mjs",
         "node": "./LexicalExtensionComponent.node.mjs",
         "default": "./LexicalExtensionComponent.mjs"
       },
       "require": {
-        "types": "./LexicalExtensionComponent.d.ts",
+        "types": "./ExtensionComponent.d.ts",
         "development": "./LexicalExtensionComponent.dev.js",
         "production": "./LexicalExtensionComponent.prod.js",
         "default": "./LexicalExtensionComponent.js"
@@ -57,14 +57,14 @@
     },
     "./ExtensionComponent.js": {
       "import": {
-        "types": "./LexicalExtensionComponent.d.ts",
+        "types": "./ExtensionComponent.d.ts",
         "development": "./LexicalExtensionComponent.dev.mjs",
         "production": "./LexicalExtensionComponent.prod.mjs",
         "node": "./LexicalExtensionComponent.node.mjs",
         "default": "./LexicalExtensionComponent.mjs"
       },
       "require": {
-        "types": "./LexicalExtensionComponent.d.ts",
+        "types": "./ExtensionComponent.d.ts",
         "development": "./LexicalExtensionComponent.dev.js",
         "production": "./LexicalExtensionComponent.prod.js",
         "default": "./LexicalExtensionComponent.js"
@@ -1242,14 +1242,14 @@
     },
     "./ReactExtension": {
       "import": {
-        "types": "./LexicalReactExtension.d.ts",
+        "types": "./ReactExtension.d.ts",
         "development": "./LexicalReactExtension.dev.mjs",
         "production": "./LexicalReactExtension.prod.mjs",
         "node": "./LexicalReactExtension.node.mjs",
         "default": "./LexicalReactExtension.mjs"
       },
       "require": {
-        "types": "./LexicalReactExtension.d.ts",
+        "types": "./ReactExtension.d.ts",
         "development": "./LexicalReactExtension.dev.js",
         "production": "./LexicalReactExtension.prod.js",
         "default": "./LexicalReactExtension.js"
@@ -1257,14 +1257,14 @@
     },
     "./ReactExtension.js": {
       "import": {
-        "types": "./LexicalReactExtension.d.ts",
+        "types": "./ReactExtension.d.ts",
         "development": "./LexicalReactExtension.dev.mjs",
         "production": "./LexicalReactExtension.prod.mjs",
         "node": "./LexicalReactExtension.node.mjs",
         "default": "./LexicalReactExtension.mjs"
       },
       "require": {
-        "types": "./LexicalReactExtension.d.ts",
+        "types": "./ReactExtension.d.ts",
         "development": "./LexicalReactExtension.dev.js",
         "production": "./LexicalReactExtension.prod.js",
         "default": "./LexicalReactExtension.js"
@@ -1272,14 +1272,14 @@
     },
     "./ReactPluginHostExtension": {
       "import": {
-        "types": "./LexicalReactPluginHostExtension.d.ts",
+        "types": "./ReactPluginHostExtension.d.ts",
         "development": "./LexicalReactPluginHostExtension.dev.mjs",
         "production": "./LexicalReactPluginHostExtension.prod.mjs",
         "node": "./LexicalReactPluginHostExtension.node.mjs",
         "default": "./LexicalReactPluginHostExtension.mjs"
       },
       "require": {
-        "types": "./LexicalReactPluginHostExtension.d.ts",
+        "types": "./ReactPluginHostExtension.d.ts",
         "development": "./LexicalReactPluginHostExtension.dev.js",
         "production": "./LexicalReactPluginHostExtension.prod.js",
         "default": "./LexicalReactPluginHostExtension.js"
@@ -1287,14 +1287,14 @@
     },
     "./ReactPluginHostExtension.js": {
       "import": {
-        "types": "./LexicalReactPluginHostExtension.d.ts",
+        "types": "./ReactPluginHostExtension.d.ts",
         "development": "./LexicalReactPluginHostExtension.dev.mjs",
         "production": "./LexicalReactPluginHostExtension.prod.mjs",
         "node": "./LexicalReactPluginHostExtension.node.mjs",
         "default": "./LexicalReactPluginHostExtension.mjs"
       },
       "require": {
-        "types": "./LexicalReactPluginHostExtension.d.ts",
+        "types": "./ReactPluginHostExtension.d.ts",
         "development": "./LexicalReactPluginHostExtension.dev.js",
         "production": "./LexicalReactPluginHostExtension.prod.js",
         "default": "./LexicalReactPluginHostExtension.js"
@@ -1302,14 +1302,14 @@
     },
     "./ReactProviderExtension": {
       "import": {
-        "types": "./LexicalReactProviderExtension.d.ts",
+        "types": "./ReactProviderExtension.d.ts",
         "development": "./LexicalReactProviderExtension.dev.mjs",
         "production": "./LexicalReactProviderExtension.prod.mjs",
         "node": "./LexicalReactProviderExtension.node.mjs",
         "default": "./LexicalReactProviderExtension.mjs"
       },
       "require": {
-        "types": "./LexicalReactProviderExtension.d.ts",
+        "types": "./ReactProviderExtension.d.ts",
         "development": "./LexicalReactProviderExtension.dev.js",
         "production": "./LexicalReactProviderExtension.prod.js",
         "default": "./LexicalReactProviderExtension.js"
@@ -1317,14 +1317,14 @@
     },
     "./ReactProviderExtension.js": {
       "import": {
-        "types": "./LexicalReactProviderExtension.d.ts",
+        "types": "./ReactProviderExtension.d.ts",
         "development": "./LexicalReactProviderExtension.dev.mjs",
         "production": "./LexicalReactProviderExtension.prod.mjs",
         "node": "./LexicalReactProviderExtension.node.mjs",
         "default": "./LexicalReactProviderExtension.mjs"
       },
       "require": {
-        "types": "./LexicalReactProviderExtension.d.ts",
+        "types": "./ReactProviderExtension.d.ts",
         "development": "./LexicalReactProviderExtension.dev.js",
         "production": "./LexicalReactProviderExtension.prod.js",
         "default": "./LexicalReactProviderExtension.js"
@@ -1332,14 +1332,14 @@
     },
     "./TreeViewExtension": {
       "import": {
-        "types": "./LexicalTreeViewExtension.d.ts",
+        "types": "./TreeViewExtension.d.ts",
         "development": "./LexicalTreeViewExtension.dev.mjs",
         "production": "./LexicalTreeViewExtension.prod.mjs",
         "node": "./LexicalTreeViewExtension.node.mjs",
         "default": "./LexicalTreeViewExtension.mjs"
       },
       "require": {
-        "types": "./LexicalTreeViewExtension.d.ts",
+        "types": "./TreeViewExtension.d.ts",
         "development": "./LexicalTreeViewExtension.dev.js",
         "production": "./LexicalTreeViewExtension.prod.js",
         "default": "./LexicalTreeViewExtension.js"
@@ -1347,14 +1347,14 @@
     },
     "./TreeViewExtension.js": {
       "import": {
-        "types": "./LexicalTreeViewExtension.d.ts",
+        "types": "./TreeViewExtension.d.ts",
         "development": "./LexicalTreeViewExtension.dev.mjs",
         "production": "./LexicalTreeViewExtension.prod.mjs",
         "node": "./LexicalTreeViewExtension.node.mjs",
         "default": "./LexicalTreeViewExtension.mjs"
       },
       "require": {
-        "types": "./LexicalTreeViewExtension.d.ts",
+        "types": "./TreeViewExtension.d.ts",
         "development": "./LexicalTreeViewExtension.dev.js",
         "production": "./LexicalTreeViewExtension.prod.js",
         "default": "./LexicalTreeViewExtension.js"
@@ -1362,14 +1362,14 @@
     },
     "./useExtensionComponent": {
       "import": {
-        "types": "./useLexicalExtensionComponent.d.ts",
+        "types": "./useExtensionComponent.d.ts",
         "development": "./useLexicalExtensionComponent.dev.mjs",
         "production": "./useLexicalExtensionComponent.prod.mjs",
         "node": "./useLexicalExtensionComponent.node.mjs",
         "default": "./useLexicalExtensionComponent.mjs"
       },
       "require": {
-        "types": "./useLexicalExtensionComponent.d.ts",
+        "types": "./useExtensionComponent.d.ts",
         "development": "./useLexicalExtensionComponent.dev.js",
         "production": "./useLexicalExtensionComponent.prod.js",
         "default": "./useLexicalExtensionComponent.js"
@@ -1377,14 +1377,14 @@
     },
     "./useExtensionComponent.js": {
       "import": {
-        "types": "./useLexicalExtensionComponent.d.ts",
+        "types": "./useExtensionComponent.d.ts",
         "development": "./useLexicalExtensionComponent.dev.mjs",
         "production": "./useLexicalExtensionComponent.prod.mjs",
         "node": "./useLexicalExtensionComponent.node.mjs",
         "default": "./useLexicalExtensionComponent.mjs"
       },
       "require": {
-        "types": "./useLexicalExtensionComponent.d.ts",
+        "types": "./useExtensionComponent.d.ts",
         "development": "./useLexicalExtensionComponent.dev.js",
         "production": "./useLexicalExtensionComponent.prod.js",
         "default": "./useLexicalExtensionComponent.js"

--- a/packages/lexical-website/docs/extensions/faq.mdx
+++ b/packages/lexical-website/docs/extensions/faq.mdx
@@ -35,9 +35,7 @@ implementation to when it is used.
 
 See the extension-vanilla-tailwind example for a demonstration for
 how this can be done.
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/~/github.com/facebook/lexical/pull/7706?file=examples/extension-vanilla-tailwind/src/main.ts&configPath=examples/extension-vanilla-tailwind)
-
-TODO #7706: update stackblitz url after merge
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/facebook/lexical/tree/main/examples/extension-vanilla-tailwind?file=src%2Fmain.ts)
 
 :::note
 

--- a/packages/lexical-website/docs/extensions/react.md
+++ b/packages/lexical-website/docs/extensions/react.md
@@ -210,9 +210,6 @@ While this does mean your application will include the React runtime, you
 don't have to use JSX or have any other React infrastructure in your app.
 
 See
-[extension-vanilla-react-plugin-host](https://github.com/etrepum/lexical/blob/extension/examples/extension-vanilla-react-plugin-host/src/main.ts)
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/~/github.com/facebook/lexical/pull/7706?file=examples/extension-vanilla-react-plugin-host/src/main.ts&configPath=examples/extension-vanilla-react-plugin-host)
+[extension-vanilla-react-plugin-host](https://github.com/facebook/lexical/blob/main/examples/extension-vanilla-react-plugin-host/src/main.ts)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/facebook/lexical/tree/main/examples/?file=src%2Fmain.ts)
 for usage of this extension and its API
-
-TODO #7706: update github url after merge
-TODO #7706: update stackblitz url after merge

--- a/scripts/update-examples.mjs
+++ b/scripts/update-examples.mjs
@@ -32,7 +32,7 @@ async function main() {
     // assume that npm run update-packages has already updated the version and lexical deps
     const json = pkg.packageJson;
     const {lexicalUnreleasedDependencies = {}} = json;
-    let hasUnreleasedDependency = !!json.lexicalUnreleasedDependencies;
+    let hasUnreleasedDependency = false;
     for (const [k, v] of Object.entries(lexicalUnreleasedDependencies)) {
       if (semverGt(version, v)) {
         delete lexicalUnreleasedDependencies[k];

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -173,10 +173,14 @@ function updatePublicPackage(pkg) {
         );
         const packageName = pkg.getNpmName();
         const isIndex = basename === 'index';
-        let entry = exportEntry(
-          npmToWwwName(isIndex ? packageName : `${packageName}/${basename}`),
-          isIndex ? 'index.d.ts' : undefined,
-        );
+        const entryNameInput = isIndex
+          ? packageName
+          : `${packageName}/${basename}`;
+        const entryName = npmToWwwName(entryNameInput);
+        const typesName = isIndex
+          ? 'index'
+          : npmToWwwName(entryNameInput, true);
+        let entry = exportEntry(entryName, `${typesName}.d.ts`);
         if (hasBrowser) {
           entry = withBrowser(entry);
         }

--- a/scripts/www/npmToWwwName.js
+++ b/scripts/www/npmToWwwName.js
@@ -15,15 +15,18 @@
  * '@lexical/react/useLexicalEditor' -> 'useLexicalEditor'
  *
  * @param {string} name the npm or directory name of a package
+ * @param {boolean} [forTypes] true to match the name that typescript will produce
  * @returns {string} the name of the package in www format
  */
-module.exports = function npmToWwwName(name) {
+module.exports = function npmToWwwName(name, forTypes = false) {
   let parts = name.replace(/^@/, '').split(/\//g);
 
   // Handle the @lexical/react/FlatNameSpace scenario
   if (name.startsWith('@lexical/react/')) {
     const lastPart = parts[parts.length - 1];
-    if (lastPart.match(/^(use)?lexical/i)) {
+    if (forTypes) {
+      parts = [lastPart];
+    } else if (lastPart.match(/^(use)?lexical/i)) {
       parts = [lastPart];
     } else if (lastPart.startsWith('use')) {
       parts = ['useLexical', lastPart.replace(/^use/, '')];


### PR DESCRIPTION
## Description

The meta prefixing in the entrypoint renaming didn't carry over to the typescript .d.ts output so it needs an additional change to make the package.json files usable for renamed entrypoints.

Also includes the normal example updates so that everything matches the current version, plus the doc fixes

Closes #7863 
Closes #7849
Closes #7848
