### PR TITLE
[*] Bug Fix: devInvariant should warn in prod even if not in codes.json

### DIFF
--- a/packages/shared/src/formatDevWarningMessage.ts
+++ b/packages/shared/src/formatDevWarningMessage.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// Do not require this module directly! Use normal `invariant` calls.
+
+export default function formatDevWarningMessage(message: string): void {
+  console.warn(message);
+}

--- a/packages/shared/src/formatProdWarningMessage.ts
+++ b/packages/shared/src/formatProdWarningMessage.ts
@@ -6,7 +6,7 @@
  *
  */
 
-export default function prodWarningMessage(
+export default function formatProdWarningMessage(
   code: string,
   ...args: string[]
 ): void {

--- a/scripts/error-codes/__tests__/unit/transform-error-messages.test.ts
+++ b/scripts/error-codes/__tests__/unit/transform-error-messages.test.ts
@@ -248,7 +248,7 @@ describe('transform-error-messages', () => {
           codeExpect: `
           /*FIXME (minify-errors-in-prod): Unminified error message in production build!*/
           if (!condition) {
-            formatDevErrorMessage(\`A new invariant\`);
+            formatDevWarningMessage(\`A new invariant\`);
           }
        `,
           messageMapBefore: KNOWN_MSG_MAP,

--- a/scripts/error-codes/transform-error-messages.js
+++ b/scripts/error-codes/transform-error-messages.js
@@ -55,11 +55,13 @@ const invariantExpressions = [
     dev: 'formatDevErrorMessage',
     name: 'invariant',
     prod: 'formatProdErrorMessage',
+    prodNoCode: 'formatDevErrorMessage',
   },
   {
     dev: 'formatDevErrorMessage',
     name: 'devInvariant',
     prod: 'formatProdWarningMessage',
+    prodNoCode: 'formatDevWarningMessage',
   },
 ];
 
@@ -79,7 +81,7 @@ module.exports = function (babel, opts) {
         const node = path.node;
         const {extractCodes, noMinify} =
           /** @type Partial<TransformErrorMessagesOptions> */ (file.opts);
-        for (const {name, dev, prod} of invariantExpressions) {
+        for (const {name, dev, prod, prodNoCode} of invariantExpressions) {
           if (path.get('callee').isIdentifier({name})) {
             // Turns this code:
             //
@@ -137,9 +139,11 @@ module.exports = function (babel, opts) {
               //   if (!condition) {
               //     formatDevErrorMessage(`A ${adj} message that contains ${noun}`);
               //   }
+              const moduleName =
+                prodErrorId === undefined && !noMinify ? prodNoCode : dev;
               const formatDevErrorMessageIdentifier =
-                helperModuleImports.addDefault(path, `shared/${dev}`, {
-                  nameHint: dev,
+                helperModuleImports.addDefault(path, `shared/${moduleName}`, {
+                  nameHint: moduleName,
                 });
               callExpression = t.callExpression(
                 formatDevErrorMessageIdentifier,


### PR DESCRIPTION
## Description

`devInvariant` would throw in prod when the error was not yet in codes.json, now it warns

Closes #7869

## Test plan

Unit test added for the transform update