### PR TITLE
[lexical-headless] Bug Fix: Fix types for @lexical/headless/dom and simplify npmToWwwName workaround

### DIFF
--- a/packages/lexical-headless/package.json
+++ b/packages/lexical-headless/package.json
@@ -18,20 +18,20 @@
   "exports": {
     "./dom": {
       "browser": {
-        "types": "./LexicalHeadlessDom.d.ts",
+        "types": "./dom.d.ts",
         "development": "./LexicalHeadlessDom.dev.browser.mjs",
         "production": "./LexicalHeadlessDom.prod.browser.mjs",
         "default": "./LexicalHeadlessDom.browser.mjs"
       },
       "import": {
-        "types": "./LexicalHeadlessDom.d.ts",
+        "types": "./dom.d.ts",
         "development": "./LexicalHeadlessDom.dev.mjs",
         "production": "./LexicalHeadlessDom.prod.mjs",
         "node": "./LexicalHeadlessDom.node.mjs",
         "default": "./LexicalHeadlessDom.mjs"
       },
       "require": {
-        "types": "./LexicalHeadlessDom.d.ts",
+        "types": "./dom.d.ts",
         "development": "./LexicalHeadlessDom.dev.js",
         "production": "./LexicalHeadlessDom.prod.js",
         "default": "./LexicalHeadlessDom.js"

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -177,10 +177,7 @@ function updatePublicPackage(pkg) {
           ? packageName
           : `${packageName}/${basename}`;
         const entryName = npmToWwwName(entryNameInput);
-        const typesName = isIndex
-          ? 'index'
-          : npmToWwwName(entryNameInput, true);
-        let entry = exportEntry(entryName, `${typesName}.d.ts`);
+        let entry = exportEntry(entryName, `${basename}.d.ts`);
         if (hasBrowser) {
           entry = withBrowser(entry);
         }

--- a/scripts/www/npmToWwwName.js
+++ b/scripts/www/npmToWwwName.js
@@ -18,15 +18,13 @@
  * @param {boolean} [forTypes] true to match the name that typescript will produce
  * @returns {string} the name of the package in www format
  */
-module.exports = function npmToWwwName(name, forTypes = false) {
+module.exports = function npmToWwwName(name) {
   let parts = name.replace(/^@/, '').split(/\//g);
 
   // Handle the @lexical/react/FlatNameSpace scenario
   if (name.startsWith('@lexical/react/')) {
     const lastPart = parts[parts.length - 1];
-    if (forTypes) {
-      parts = [lastPart];
-    } else if (lastPart.match(/^(use)?lexical/i)) {
+    if (lastPart.match(/^(use)?lexical/i)) {
       parts = [lastPart];
     } else if (lastPart.startsWith('use')) {
       parts = ['useLexical', lastPart.replace(/^use/, '')];


### PR DESCRIPTION
## Description

The hotfix in #7857 caused a regression in the package.json entry for @lexical/headless/dom. This fixes it and simplifies the workaround to what it should've been in the first place.

We don't have example coverage of this feature yet so it wasn't caught.

## Test plan

Add an example that uses this feature (after patch release) so a future regression would get caught by the integration tests