### PR TITLE
[lexical-playground] Fix: Prevent inline KaTeX equations from breaking to new lines

### DIFF
--- a/packages/lexical-playground/src/ui/KatexRenderer.tsx
+++ b/packages/lexical-playground/src/ui/KatexRenderer.tsx
@@ -38,29 +38,27 @@ export default function KatexRenderer({
     }
   }, [equation, inline]);
 
-  return (
-    // We use an empty image tag either side to ensure Android doesn't try and compose from the
-    // inner text from Katex. There didn't seem to be any other way of making this work,
-    // without having a physical space.
-    <>
-      <img
+  const emptyImageTag = <img
         src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
         width="0"
         height="0"
         alt=""
-      />
+      />;
+
+  return (
+    // We use an empty image tag either side to ensure Android doesn't try and compose from the
+    // inner text from Katex. There didn't seem to be any other way of making this work,
+    // without having a physical space.
+    // This is only needed for block equations to avoid breaking inline flow.
+    <>
+     {!inline && emptyImageTag}
       <span
         role="button"
         tabIndex={-1}
         onDoubleClick={onDoubleClick}
         ref={katexElementRef}
       />
-      <img
-        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-        width="0"
-        height="0"
-        alt=""
-      />
+    {!inline && emptyImageTag}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- The KatexRenderer component uses empty image tags  around equations to prevent Android composition issues. However, this is only needed for block equations. Inline Katex equations should not be forced onto separate lines
- This PR fixe inline KaTeX equations being forced onto separate lines
- It conditionally renders empty image tags only for block equations (when `inline=false`)
- It preserves inline flow for inline equations while maintaining Android composition fix for block equations

## Changes
- Refactored `KatexRenderer.tsx` to only render empty image tags around block equations
- Retained comment clarifying the purpose of the empty image tags and added that we don't need them for the inline state.
- Extracted empty image tag to a reusable variable for cleaner code

## Effect of change.
### Before
- Inline equations appear on a separate line
<img width="514" height="427" alt="Screenshot 2025-09-30 at 12 25 53 AM" src="https://github.com/user-attachments/assets/8fdfb946-eafa-4f92-9d04-13330bced277" />

### After
- Inline equations correctly appear in line with our content in their text node.
<img width="579" height="335" alt="Screenshot 2025-09-30 at 12 24 18 AM" src="https://github.com/user-attachments/assets/5bc62e09-74cc-41b5-bb29-51d9cf761862" />

## Test Plan
- [x] Verified inline KaTeX equations render inline with surrounding text
- [x] Verified block KaTeX equations still render correctly on separate lines
- [x] Tested on Android devices to ensure composition issues don't regress
- [x] Tested equation editing functionality (double-click) works correctly

## Context
  1. The empty image tags were added to prevent Android from trying to compose text from the KaTeX rendered content
  2. For inline equations, this wouldn't be an issue because:
    - Inline equations are part of the text flow
    - Android's text composition would naturally handle them as part of the surrounding text
    - The KaTeX content is rendered as HTML/spans, not as separate text nodes that would interfere with composition
  3. For block equations, the composition issue could occur because:
    - They're displayed as separate blocks
    - Android might try to compose across the block boundaries
    - The empty image tags create "physical space" as mentioned in the comment to prevent this