### PR TITLE
[lexical-markdown] Bug Fix: Ensure First Match is Used in `importTextMatchTransformer`

### DIFF
--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -39,6 +39,14 @@ import {
   TRANSFORMERS,
 } from '../../MarkdownTransformers';
 
+const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {
+  ...LINK,
+  importRegExp: /\$([^$]+?)\$/,
+  replace: (textNode, match) => {
+    textNode.toggleFormat('highlight');
+  },
+};
+
 const SIMPLE_INLINE_JSX_MATCHER: TextMatchTransformer = {
   dependencies: [LinkNode],
   getEndIndex(node, match) {
@@ -604,6 +612,14 @@ describe('Markdown', () => {
       md: '[link](https://lexical.dev)[link2](https://lexical.dev)',
     },
     {
+      // Import only: <mark>...</mark> is exported as ==...== in markdown.
+      // Use HIGHLIGHT_TEXT_MATCH_IMPORT as custom transformer even though it is included later to ensure it runs before LINK.
+      customTransformers: [HIGHLIGHT_TEXT_MATCH_IMPORT],
+      html: '<p><span style="white-space: pre-wrap;">Multiple </span><a href="https://lexical.dev"><code spellcheck="false" style="white-space: pre-wrap;"><span>TextMatchTransformer</span></code><span style="white-space: pre-wrap;">s</span></a><s><mark style="white-space: pre-wrap;"><span>$ with formatting$</span></mark></s></p>',
+      md: 'Multiple [`TextMatchTransformer`s](https://lexical.dev)~~$ with formatting$~~',
+      skipExport: true,
+    },
+    {
       html: '<p><b><code spellcheck="false" style="white-space: pre-wrap;"><strong>Bold Code</strong></code></b></p>',
       md: '**`Bold Code`**',
     },
@@ -670,14 +686,6 @@ describe('Markdown', () => {
       md: '[h[ello](https://lexical.dev)[world](https://lexical.dev)',
     },
   ];
-
-  const HIGHLIGHT_TEXT_MATCH_IMPORT: TextMatchTransformer = {
-    ...LINK,
-    importRegExp: /\$([^$]+?)\$/,
-    replace: (textNode) => {
-      textNode.setFormat('highlight');
-    },
-  };
 
   for (const {
     html,

--- a/packages/lexical-markdown/src/importTextMatchTransformer.ts
+++ b/packages/lexical-markdown/src/importTextMatchTransformer.ts
@@ -47,7 +47,9 @@ export function findOutermostTextMatchTransformer(
     if (
       foundMatchStartIndex === undefined ||
       foundMatchEndIndex === undefined ||
-      (startIndex < foundMatchStartIndex && endIndex > foundMatchEndIndex)
+      // Wraps previous match or is strictly before it.
+      (startIndex < foundMatchStartIndex &&
+        (endIndex > foundMatchEndIndex || endIndex <= foundMatchStartIndex))
     ) {
       foundMatchStartIndex = startIndex;
       foundMatchEndIndex = endIndex;


### PR DESCRIPTION
## Description
Ensure we use the first match if there are multiple on a line (when "outermost" is ambiguous), rather than just the match from the first transformer that ran on the line.

This prevents cases where there is a `TextFormatTransformer` match in an earlier `TextMatchTransformer`. The `TextFormatTransformer` will segment the earlier `TextMatchTransformer` so that it is never parsed correct. See added test for an example that failed before this fix (the link would not be parsed and the raw link markdown was present in the final output).

## Test plan

### Before

Added test failed

### After

Added test passes