### PR TITLE
[lexical-react] Bug Fix: Prevent out-of-bounds selection in LexicalMenu when options shrink

### DIFF
--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -377,12 +377,12 @@ export function LexicalMenu<TOption extends MenuOption>({
             const newSelectedIndex =
               selectedIndex === null
                 ? 0
-                : selectedIndex !== options.length - 1
+                : selectedIndex < options.length - 1
                   ? selectedIndex + 1
                   : 0;
             updateSelectedIndex(newSelectedIndex);
             const option = options[newSelectedIndex];
-            if (option.ref != null && option.ref.current) {
+            if (option && option.ref != null && option.ref.current) {
               editor.dispatchCommand(
                 SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND,
                 {
@@ -411,7 +411,7 @@ export function LexicalMenu<TOption extends MenuOption>({
                   : options.length - 1;
             updateSelectedIndex(newSelectedIndex);
             const option = options[newSelectedIndex];
-            if (option.ref != null && option.ref.current) {
+            if (option && option.ref != null && option.ref.current) {
               scrollIntoViewIfNeeded(option.ref.current);
             }
             event.preventDefault();


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
When the typeahead menu’s options list shrinks (e.g., user types quickly and the suggestions refresh) before selectedIndex is reset, the code may try to read option.ref from an out-of-range index, causing a runtime error and breaking keyboard navigation. The affected logic lives in `packages/lexical-react/src/shared/LexicalMenu.ts`

**What this PR changes**

- Clamp selectedIndex whenever options change so it always stays within [0, options.length - 1]. If options is empty, clear the selection.
- Add a defensive guard before accessing a selected option (avoid reading ref from undefined).

Closes #7897 <!-- issue number -->

## Test plan

### Before

https://github.com/user-attachments/assets/997b3279-1fca-4a42-871d-64ca80378747

*Insert relevant screenshots/recordings/automated-tests*


### After

https://github.com/user-attachments/assets/d8fd9d4d-907b-4920-a444-e7f85e0a3508

*Insert relevant screenshots/recordings/automated-tests*