### PR TITLE
fix(LexicalMenu): guard against undefined option when list shrinks

### DIFF
--- a/packages/lexical-react/src/shared/LexicalMenu.ts
+++ b/packages/lexical-react/src/shared/LexicalMenu.ts
@@ -350,6 +350,13 @@ export function LexicalMenu<TOption extends MenuOption>({
     }
   }, [options, selectedIndex, updateSelectedIndex, preselectFirstItem]);
 
+  // Clamp highlighted index if options list shrinks
+  useEffect(() => {
+    if (selectedIndex != null && options && selectedIndex >= options.length) {
+      updateSelectedIndex(options.length ? options.length - 1 : -1);
+    }
+  }, [options.length, selectedIndex, updateSelectedIndex]);
+
   useEffect(() => {
     return mergeRegister(
       editor.registerCommand(
@@ -380,9 +387,18 @@ export function LexicalMenu<TOption extends MenuOption>({
                 : selectedIndex !== options.length - 1
                   ? selectedIndex + 1
                   : 0;
+
             updateSelectedIndex(newSelectedIndex);
+
             const option = options[newSelectedIndex];
-            if (option.ref != null && option.ref.current) {
+            if (!option) {
+              updateSelectedIndex(-1);
+              event.preventDefault();
+              event.stopImmediatePropagation();
+              return true;
+            }
+
+            if (option.ref && option.ref.current) {
               editor.dispatchCommand(
                 SCROLL_TYPEAHEAD_OPTION_INTO_VIEW_COMMAND,
                 {
@@ -409,9 +425,18 @@ export function LexicalMenu<TOption extends MenuOption>({
                 : selectedIndex !== 0
                   ? selectedIndex - 1
                   : options.length - 1;
+
             updateSelectedIndex(newSelectedIndex);
+
             const option = options[newSelectedIndex];
-            if (option.ref != null && option.ref.current) {
+            if (!option) {
+              updateSelectedIndex(-1);
+              event.preventDefault();
+              event.stopImmediatePropagation();
+              return true;
+            }
+
+            if (option.ref && option.ref.current) {
               scrollIntoViewIfNeeded(option.ref.current);
             }
             event.preventDefault();


### PR DESCRIPTION
## Title 
[lexical-react] Bug Fix: guard against undefined option when list shrinks

### PR Types:
Bug Fix 

## Description

- **Current behavior**:  
  When navigating the typeahead menu with ArrowDown/ArrowUp, if the list shrinks (e.g. type `@p`, move down to last option, then continue typing `@poo`), `options[newSelectedIndex]` can become `undefined`.  
  This causes a crash: 
- **Behavior after fix**:  
Added a guard for missing option before accessing `.ref`, and safely reset the highlighted index when the list shrinks.  
This prevents crashes and ensures stable keyboard navigation in the typeahead menu.

Closes #7897 

---

## Test plan

### Before

Steps:
1. Open Playground  
2. Type `@p` to open mention list  
3. Use ArrowDown to select the last item  
4. Continue typing quickly (`poo`) so that the list shrinks  
5. Press ArrowDown  

❌ Crash occurs in console:  

### After

Steps:
1. Open Playground  
2. Type `@p` to open mention list  
3. Use ArrowDown to select the last item  
4. Continue typing quickly (`poo`) so that the list shrinks  
5. Press ArrowDown  

✅ No crash, console stays clean, and list resets correctly.

Screenshot:  

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bb61f240-166e-4ca4-a714-dfbba777b715" />



