### PR TITLE
[lexical-rich-text] Bug fix: up/down arrows for node selection

### DIFF
--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -781,6 +781,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
           // back to being a range selection.
           const nodes = selection.getNodes();
           if (nodes.length > 0) {
+            event.preventDefault();
             nodes[0].selectPrevious();
             return true;
           }
@@ -810,6 +811,7 @@ export function registerRichText(editor: LexicalEditor): () => void {
           // back to being a range selection.
           const nodes = selection.getNodes();
           if (nodes.length > 0) {
+            event.preventDefault();
             nodes[0].selectNext(0, 0);
             return true;
           }


### PR DESCRIPTION
## Description
For whatever reason we didn’t have preventDefault for the up/down arrows for node selection. As a result, the caret jumps two lines when exiting a decorator.

## Test plan
Insert decorator (easier to spot with block level decorator, like Youtube node)

### Before

https://github.com/user-attachments/assets/8039713e-cd18-4826-a71c-62fa14b77082



### After

https://github.com/user-attachments/assets/a212fa85-b553-4067-ad56-7497c35739b6
