### PR TITLE
[lexical-react] Chore: make __shouldBootstrapUnsafe prop optional

### DIFF
--- a/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
+++ b/packages/lexical-react/src/LexicalCollaborationPlugin.tsx
@@ -201,7 +201,7 @@ type CollaborationPluginV2Props = {
   id: string;
   doc: Doc;
   provider: Provider;
-  __shouldBootstrapUnsafe: boolean;
+  __shouldBootstrapUnsafe?: boolean;
   username?: string;
   cursorColor?: string;
   cursorsContainerRef?: CursorsContainerRef;


### PR DESCRIPTION
As it says on the tin.