### PR TITLE
[lexical-headless] Chore: Update to happy-dom v20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25463,9 +25463,9 @@
       "license": "MIT"
     },
     "node_modules/happy-dom": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-18.0.1.tgz",
-      "integrity": "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.0.tgz",
+      "integrity": "sha512-GkWnwIFxVGCf2raNrxImLo397RdGhLapj5cT3R2PT7FwL62Ze1DROhzmYW7+J3p9105DYMVenEejEbnq5wA37w==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.0.0",
@@ -46444,7 +46444,7 @@
       "version": "0.36.2",
       "license": "MIT",
       "dependencies": {
-        "happy-dom": "^18.0.1",
+        "happy-dom": "^20.0.0",
         "lexical": "0.36.2"
       }
     },
@@ -52677,7 +52677,7 @@
     "@lexical/headless": {
       "version": "file:packages/lexical-headless",
       "requires": {
-        "happy-dom": "^18.0.1",
+        "happy-dom": "^20.0.0",
         "lexical": "0.36.2"
       }
     },
@@ -63906,9 +63906,9 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
     },
     "happy-dom": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-18.0.1.tgz",
-      "integrity": "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.0.tgz",
+      "integrity": "sha512-GkWnwIFxVGCf2raNrxImLo397RdGhLapj5cT3R2PT7FwL62Ze1DROhzmYW7+J3p9105DYMVenEejEbnq5wA37w==",
       "requires": {
         "@types/node": "^20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",

--- a/packages/lexical-headless/package.json
+++ b/packages/lexical-headless/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "happy-dom": "^18.0.1",
+    "happy-dom": "^20.0.0",
     "lexical": "0.36.2"
   }
 }


### PR DESCRIPTION
## Description

happy-dom has a CVE that is fixed by updating to v20. https://github.com/advisories/GHSA-37j7-fg3j-429f

The usage of happy-dom in withDOM and in the examples of withDOM in the sveltekit SSR example are not affected by this CVE. The intended use is primarily to use the document and DOMParser APIs which are not susceptible to loading JavaScript code.