### PR TITLE
[lexical-markdown] Bug Fix: Prevent Markdown links with empty string link text from being automatically removed

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -604,6 +604,7 @@ export const LINK: TextMatchTransformer = {
     }
     const linkTextNode = $createTextNode(parsedLinkText);
     linkTextNode.setFormat(textNode.getFormat());
+    linkTextNode.toggleUnmergeable();
     linkNode.append(linkTextNode);
     textNode.replace(linkNode);
 

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -693,6 +693,10 @@ describe('Markdown', () => {
       html: '<p><span style="white-space: pre-wrap;">[h</span><a href="https://lexical.dev"><span style="white-space: pre-wrap;">ello</span></a><a href="https://lexical.dev"><span style="white-space: pre-wrap;">world</span></a></p>',
       md: '[h[ello](https://lexical.dev)[world](https://lexical.dev)',
     },
+    {
+      html: '<p><a href="https://lexical.dev"><span style="white-space: pre-wrap;"></span></a></p>',
+      md: '[](https://lexical.dev)',
+    },
   ];
 
   for (const {


### PR DESCRIPTION
## Description

Currently any markdown link where the _link text_ is an empty string, e.g. `[](https://lexical.dev)`, will be automatically removed on transformation. According to the [CommonMark Spec](https://spec.commonmark.org/0.31.2/#example-487), it's a valid link.
With this pull request the removal of the link's text node is prevented by using the _Unmergeable_ flag.

Not sure what the desired behaviour is here. Admittedly, a link without a corresponding text isn't terribly useful unless handled by the UI layer in some way. 
An option would be to not parse it as a valid link as is currently done when the _link destination_ is empty string (`[some link title]()`), even despite being compliant with the [CommonMark Spec](https://spec.commonmark.org/0.31.2/#example-487).

## Test plan

### Before

https://github.com/user-attachments/assets/9c9d6943-cfe1-4bcd-9988-d0353b4aa01e

### After

https://github.com/user-attachments/assets/9c68ca12-9282-413b-9172-a308b8794fe1

