### PR TITLE
[lexical-yjs] Fix: skip elements that were added and removed between snapshots

### DIFF
--- a/packages/lexical-yjs/src/SyncV2.ts
+++ b/packages/lexical-yjs/src/SyncV2.ts
@@ -140,10 +140,14 @@ export const $createOrUpdateNodeFromYElement = (
     if (snapshot === undefined || prevSnapshot === undefined) {
       el.toArray().forEach($createChildren);
     } else {
-      typeListToArraySnapshot(
-        el,
-        new Snapshot(prevSnapshot.ds, snapshot.sv),
-      ).forEach($createChildren);
+      typeListToArraySnapshot(el, new Snapshot(prevSnapshot.ds, snapshot.sv))
+        .filter(
+          (childType) =>
+            !childType._item.deleted ||
+            isItemVisible(childType._item, snapshot) ||
+            isItemVisible(childType._item, prevSnapshot),
+        )
+        .forEach($createChildren);
     }
 
     $spliceChildren(node, children);


### PR DESCRIPTION
## Description

`renderSnapshot` was including elements that were added and removed between the two snapshots. These should be filtered out. This is the same logic as [y-prosemirror](https://github.com/yjs/y-prosemirror/blob/ef35266/src/plugins/sync-plugin.js#L557-L574).

## Test plan

Unit test fails before the change, passes after.