### PR TITLE
[lexical-markdown] Bug Fix: Prevent Markdown links with empty string link text from being automatically removed

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -589,9 +589,9 @@ export const LINK: TextMatchTransformer = {
     return linkContent;
   },
   importRegExp:
-    /(?:\[(.*?)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))/,
+    /(?:\[(.+?)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))/,
   regExp:
-    /(?:\[(.*?)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))$/,
+    /(?:\[(.+?)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))$/,
   replace: (textNode, match) => {
     const [, linkText, linkUrl, linkTitle] = match;
     const linkNode = $createLinkNode(linkUrl, {title: linkTitle});

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -693,6 +693,10 @@ describe('Markdown', () => {
       html: '<p><span style="white-space: pre-wrap;">[h</span><a href="https://lexical.dev"><span style="white-space: pre-wrap;">ello</span></a><a href="https://lexical.dev"><span style="white-space: pre-wrap;">world</span></a></p>',
       md: '[h[ello](https://lexical.dev)[world](https://lexical.dev)',
     },
+    {
+      html: '<p><span style="white-space: pre-wrap;">[](https://lexical.dev)</span></p>',
+      md: '[](https://lexical.dev)',
+    },
   ];
 
   for (const {


### PR DESCRIPTION
## Description
Currently any markdown link where the link text is an empty string, e.g. `[](https://lexical.dev)`, will be automatically removed. 
With this pull request, the link persists allowing for further editing.

## Test plan

### Before

https://github.com/user-attachments/assets/27df2e96-2791-4f9b-bdc7-cb367f4d72da

### After

https://github.com/user-attachments/assets/be82307c-3c72-423b-a60f-b44c287bf82c