### PR TITLE
[lexical-website] Documentation Update: change setText to setTextContent

### DIFF
--- a/packages/lexical-website/docs/concepts/nodes.mdx
+++ b/packages/lexical-website/docs/concepts/nodes.mdx
@@ -548,7 +548,11 @@ export class ColoredNode extends TextNode {
 export function $createColoredNode(text: string, color: string): ColoredNode {
   // Since our constructor has 0 arguments, we set all of its properties
   // after construction.
-  return $setState($create(ColoredNode).setTextContent(text), colorState, color);
+  return $setState(
+    $create(ColoredNode).setTextContent(text),
+    colorState,
+    color,
+  );
 }
 // highlight-end
 


### PR DESCRIPTION
### Description
- Fixed a small typo: changed `setText` to `setTextContent` because `setText` doesn't exist