### PR TITLE
[lexical-react] Bug Fix: Add getServerSnapshot for RSC compatibility

### DIFF
--- a/packages/lexical-react/src/shared/useReactDecorators.tsx
+++ b/packages/lexical-react/src/shared/useReactDecorators.tsx
@@ -27,7 +27,7 @@ export function useReactDecorators(
       ] as const,
     [editor],
   );
-  const decorators = useSyncExternalStore(subscribe, getSnapshot);
+  const decorators = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   // Return decorators defined as React Portals
   return useMemo(() => {


### PR DESCRIPTION
## Description

- **Current behavior:** When using Lexical in a React Server Components (RSC) environment (e.g., Next.js App Router), a console warning appears: `useSyncExternalStore missing getServerSnapshot, which is required for server-rendered content`. This is caused by the `useSyncExternalStore` hook in `useReactDecorators.tsx` being called without the required third argument.

- **Changes in this PR:** This PR passes the existing `getSnapshot` function as the third argument (`getServerSnapshot`) to the `useSyncExternalStore` hook. This satisfies the hook's API for server rendering, resolves the warning, and ensures correct hydration in RSC environments.

Closes #7934

## Test plan

The test plan follows the reproduction steps outlined in the issue.

1.  Set up a project using React Server Components (e.g., Next.js with the App Router).
2.  Install and render a Lexical editor.
3.  Run the development server and observe the browser's developer console.

### Before

The following warning is visible in the console, and there may be hydration mismatch errors.

`useSyncExternalStore missing getServerSnapshot, which is required for server-rendered content`

### After

The `useSyncExternalStore` warning is no longer present in the console, and the editor component hydrates correctly without errors.