### PR TITLE
[lexical] Bug Fix: update block cursor if selection has changed

### DIFF
--- a/packages/lexical/src/LexicalUpdates.ts
+++ b/packages/lexical/src/LexicalUpdates.ts
@@ -623,7 +623,10 @@ export function $commitPendingUpdates(
     editor._editable &&
     // domSelection will be null in headless
     domSelection !== null &&
-    (needsUpdate || pendingSelection === null || pendingSelection.dirty) &&
+    (needsUpdate ||
+      pendingSelection === null ||
+      pendingSelection.dirty ||
+      !pendingSelection.is(currentSelection)) &&
     rootElement !== null &&
     !tags.has(SKIP_DOM_SELECTION_TAG)
   ) {


### PR DESCRIPTION
In some cases, the selection is [created based on the DOM selection](https://github.com/facebook/lexical/blob/9f6c7b3697ce994e76ed9cafb718e5b927172427/packages/lexical/src/LexicalUpdates.ts#L945) (`$internalCreateSelection` → `$internalCreateRangeSelection` → `$internalResolveSelectionPoints`), and it doesn't match the editor state. This selection isn't marked as dirty (since it's already in sync with the DOM). The issue is that it skips the block cursor update, causing the editor to keep the fake cursor in the wrong position.

You can reproduce this issue in the playground using a collapsible block that contains a YouTube node. After selecting the YouTube node, moving the selection with the down arrow key creates a block cursor initially but fails to reset it back to a regular caret.

Another potential fix location:  
When creating the DOM-based selection, we could compare it to the existing one and mark it as dirty if it differs. However, since this happens in `$beginUpdate`, and with batched updates it might run multiple times per commit, running the comparison during the commit phase might be slightly better.

## Test plan

### Before

Changed hidden caret-color from transparent to red for a demo purpose (block cursor remains visible, real caret is still red):


https://github.com/user-attachments/assets/79f20f8a-a379-4424-a7bd-4db1675bdd8a



### After

Now red caret turns back to black, and block cursor disappears:


https://github.com/user-attachments/assets/c89fc7f0-8eef-4151-bfe4-07f4fa2add4b


