### PR TITLE
[lexical-react] Fix: update cursor positions on awareness update in collab v1

### DIFF
--- a/packages/lexical-react/src/shared/useYjsCollaboration.tsx
+++ b/packages/lexical-react/src/shared/useYjsCollaboration.tsx
@@ -170,6 +170,8 @@ export function useYjsCollaboration(
     onBootstrap,
   );
 
+  useAwareness(binding, provider);
+
   return useYjsCursors(binding, cursorsContainerRef);
 }
 
@@ -251,7 +253,6 @@ export function useYjsCollaborationV2__EXPERIMENTAL(
 
   useEffect(() => {
     const {root} = binding;
-    const {awareness} = provider;
 
     if (diffSnapshots) {
       renderSnapshot__EXPERIMENTAL(
@@ -300,15 +301,9 @@ export function useYjsCollaborationV2__EXPERIMENTAL(
       },
     );
 
-    const onAwarenessUpdate = () => {
-      syncCursorPositions(binding, provider);
-    };
-    awareness.on('update', onAwarenessUpdate);
-
     return () => {
       root.unobserveDeep(onYjsTreeChanges);
       removeListener();
-      awareness.off('update', onAwarenessUpdate);
     };
   }, [binding, provider, editor, diffSnapshots]);
 
@@ -321,6 +316,8 @@ export function useYjsCollaborationV2__EXPERIMENTAL(
     awarenessData,
     onBootstrap,
   );
+
+  useAwareness(binding, provider);
 
   return binding;
 }
@@ -421,6 +418,20 @@ function useProvider(
       COMMAND_PRIORITY_EDITOR,
     );
   }, [connect, disconnect, editor]);
+}
+
+function useAwareness(binding: Binding | BindingV2, provider: Provider) {
+  useEffect(() => {
+    const {awareness} = provider;
+    const onAwarenessUpdate = () => {
+      syncCursorPositions(binding, provider);
+    };
+    awareness.on('update', onAwarenessUpdate);
+
+    return () => {
+      awareness.off('update', onAwarenessUpdate);
+    };
+  }, [binding, provider]);
 }
 
 export function useYjsCursors(


### PR DESCRIPTION
## Description

During the [refactoring of useYjsCollaboration](https://github.com/facebook/lexical/pull/7616/files#diff-ce0529a71ea4ee85a9eaab0983dba0341b27b48bbdffbb220d20d365a198bcf3) done as part of the collab v2 implementation, I inadvertently dropped the `awareness.on('update',...)` call. This brings it back.

Closes #7959

## Test plan

https://github.com/user-attachments/assets/055a4f3e-d93e-4638-a3c9-e092710cf9ea
