### PR TITLE
[lexical-extension][lexical-*] Bug Fix: Defer node class references to potentially work around webpack issues

### DIFF
--- a/packages/lexical-code/src/CodeExtension.ts
+++ b/packages/lexical-code/src/CodeExtension.ts
@@ -15,5 +15,5 @@ import {CodeNode} from './CodeNode';
  */
 export const CodeExtension = defineExtension({
   name: '@lexical/code',
-  nodes: [CodeNode, CodeHighlightNode],
+  nodes: () => [CodeNode, CodeHighlightNode],
 });

--- a/packages/lexical-extension/src/HorizontalRuleExtension.ts
+++ b/packages/lexical-extension/src/HorizontalRuleExtension.ts
@@ -136,7 +136,7 @@ function $toggleNodeSelection(
 export const HorizontalRuleExtension = defineExtension({
   dependencies: [EditorStateExtension, NodeSelectionExtension],
   name: '@lexical/extension/HorizontalRule',
-  nodes: [HorizontalRuleNode],
+  nodes: () => [HorizontalRuleNode],
   register(editor, config, state) {
     const {watchNodeKey} = state.getDependency(NodeSelectionExtension).output;
     const nodeSelectionStore = signal({

--- a/packages/lexical-hashtag/src/LexicalHashtagExtension.ts
+++ b/packages/lexical-hashtag/src/LexicalHashtagExtension.ts
@@ -298,6 +298,6 @@ export interface HashtagConfig {
 export const HashtagExtension = defineExtension({
   config: defaultHashtagConfig,
   name: '@lexical/hashtag/Hashtag',
-  nodes: [HashtagNode],
+  nodes: () => [HashtagNode],
   register: registerLexicalHashtag,
 });

--- a/packages/lexical-link/src/LexicalLinkExtension.ts
+++ b/packages/lexical-link/src/LexicalLinkExtension.ts
@@ -148,7 +148,7 @@ export const LinkExtension = defineExtension({
     return merged;
   },
   name: '@lexical/link/Link',
-  nodes: [LinkNode],
+  nodes: () => [LinkNode],
   register(editor, config, state) {
     return registerLink(editor, state.getOutput());
   },

--- a/packages/lexical-list/src/index.ts
+++ b/packages/lexical-list/src/index.ts
@@ -300,7 +300,7 @@ export const ListExtension = defineExtension({
   },
   config: safeCast<ListConfig>({hasStrictIndent: false}),
   name: '@lexical/list/List',
-  nodes: [ListNode, ListItemNode],
+  nodes: () => [ListNode, ListItemNode],
   register(editor, config, state) {
     const stores = state.getOutput();
     return mergeRegister(

--- a/packages/lexical-mark/src/index.ts
+++ b/packages/lexical-mark/src/index.ts
@@ -162,7 +162,7 @@ export function $getMarkIDs(
  */
 export const MarkExtension = defineExtension({
   name: '@lexical/mark',
-  nodes: [MarkNode],
+  nodes: () => [MarkNode],
 });
 
 export {$createMarkNode, $isMarkNode, MarkNode, SerializedMarkNode};

--- a/packages/lexical-overflow/src/index.ts
+++ b/packages/lexical-overflow/src/index.ts
@@ -72,5 +72,5 @@ export function $isOverflowNode(
  */
 export const OverflowExtension = defineExtension({
   name: '@lexical/overflow',
-  nodes: [OverflowNode],
+  nodes: () => [OverflowNode],
 });

--- a/packages/lexical-rich-text/src/index.ts
+++ b/packages/lexical-rich-text/src/index.ts
@@ -1153,6 +1153,6 @@ export const RichTextExtension = defineExtension({
   conflictsWith: ['@lexical/plain-text'],
   dependencies: [DragonExtension],
   name: '@lexical/rich-text',
-  nodes: [HeadingNode, QuoteNode],
+  nodes: () => [HeadingNode, QuoteNode],
   register: registerRichText,
 });

--- a/packages/lexical-table/src/LexicalTableExtension.ts
+++ b/packages/lexical-table/src/LexicalTableExtension.ts
@@ -58,7 +58,7 @@ export const TableExtension = defineExtension({
     hasTabHandler: true,
   }),
   name: '@lexical/table/Table',
-  nodes: [TableNode, TableRowNode, TableCellNode],
+  nodes: () => [TableNode, TableRowNode, TableCellNode],
   register(editor, config, state) {
     const stores = state.getOutput();
     return mergeRegister(

--- a/packages/lexical-website/docs/extensions/defining-extensions.md
+++ b/packages/lexical-website/docs/extensions/defining-extensions.md
@@ -52,7 +52,7 @@ or `theme` (specify classes to be used for nodes provided by lexical).
 ```ts
 export const CodeExtension = defineExtension({
   name: '@lexical/code',
-  nodes: [CodeNode, CodeHighlightNode],
+  nodes: () => [CodeNode, CodeHighlightNode],
 });
 ```
 

--- a/packages/lexical-website/docs/extensions/migration.mdx
+++ b/packages/lexical-website/docs/extensions/migration.mdx
@@ -456,7 +456,7 @@ export function KeywordsPlugin(): JSX.Element | null {
 // We only need to add metadata so that you can easily use this extension!
 export const KeywordsExtension = defineExtension({
   name: '@lexical/example/LexicalKeywords',
-  nodes: [KeywordNode],
+  nodes: () => [KeywordNode],
   dependencies: [
     configExtension(ReactExtension, {decorators: [<KeywordsPlugin />]}),
   ],
@@ -557,7 +557,7 @@ function $convertToKeywordNode(textNode: TextNode) {
 // Oh wait, we don't even have a React dependency anymore!
 export const KeywordsExtension = defineExtension({
   name: "@lexical/example/LexicalKeywords",
-  nodes: [KeywordNode],
+  nodes: () => [KeywordNode],
   config: safeCast<KeywordsConfig>({ className: "keyword" }),
   register(editor) {
     return registerLexicalTextEntity(

--- a/packages/lexical-website/docs/extensions/react.md
+++ b/packages/lexical-website/docs/extensions/react.md
@@ -35,7 +35,7 @@ After:
 const appExtension = defineExtension({
   name: 'MyEditor',
   namespace: 'MyEditor',
-  nodes: [QuoteNode, HeadingNode],
+  nodes: () => [QuoteNode, HeadingNode],
   theme,
   $initialEditorState,
 });


### PR DESCRIPTION
## Description

Nobody has provided a reproduction for this issue but there was a report [on discord](https://discord.com/channels/953974421008293909/1433510393497522326) that there was an issue upgrading and using the LinkPlugin. One theory is that they are probably using webpack and it's not handling module imports correctly, and this might fix the issue. It shouldn't cause any problems for other scenarios.

Follow-up to #7930

## Test plan

All existing unit and e2e tests pass