### PR TITLE
[scripts] Allow export-froms in Flow files to be transformed for www build

### DIFF
--- a/scripts/www/__tests__/unit/transformFlowFileContents.test.ts
+++ b/scripts/www/__tests__/unit/transformFlowFileContents.test.ts
@@ -51,6 +51,9 @@ import type {
   NodeKey,
   TextNode,
 } from 'lexical';
+export type {YEvent} from 'yjs';
+export type {AnyLexicalExtension, AnyLexicalExtensionArgument} from 'lexical';
+export {configExtension, defineExtension} from 'lexical';
 `.trim() + '\n';
 
 const IMPORTS_AFTER =
@@ -68,6 +71,9 @@ import type {
   NodeKey,
   TextNode,
 } from 'Lexical';
+export type {YEvent} from 'yjs';
+export type {AnyLexicalExtension, AnyLexicalExtensionArgument} from 'Lexical';
+export {configExtension, defineExtension} from 'Lexical';
 `.trim() + '\n';
 
 const EXTRA_BLOCK_COMMENT =

--- a/scripts/www/transformFlowFileContents.js
+++ b/scripts/www/transformFlowFileContents.js
@@ -61,6 +61,16 @@ module.exports = async function transformFlowFileContents(source) {
     await transform(
       wrapCode(source),
       (context) => ({
+        ExportNamedDeclaration(node) {
+          const exportSource = node.source;
+          if (!exportSource) {
+            return;
+          }
+          const value = wwwMappings[exportSource.value];
+          if (value) {
+            context.replaceNode(node.source, t.StringLiteral({value}));
+          }
+        },
         ImportDeclaration(node) {
           const value = wwwMappings[node.source.value];
           if (value) {


### PR DESCRIPTION
When building for www, we need to ensure module references in 'export from' statements (in addition to import statements) in Flow files are correctly rewritten (e.g. "lexical" should be rewritten as "Lexical").

## Test plan

`npm run test-unit transformFlowFileContents`