### PR TITLE
[lexical-code] Bug fix: Add editor key in highlighted nodes cache

### DIFF
--- a/packages/lexical-code/src/CodeHighlighterPrism.ts
+++ b/packages/lexical-code/src/CodeHighlighterPrism.ts
@@ -149,6 +149,7 @@ function codeNodeTransform(
   tokenizer: Tokenizer,
 ) {
   const nodeKey = node.getKey();
+  const cacheKey = editor.getKey() + '/' + nodeKey;
 
   // When new code block inserted it might not have language selected
   if (node.getLanguage() === undefined) {
@@ -168,11 +169,11 @@ function codeNodeTransform(
     return;
   }
 
-  if (nodesCurrentlyHighlighting.has(nodeKey)) {
+  if (nodesCurrentlyHighlighting.has(cacheKey)) {
     return;
   }
 
-  nodesCurrentlyHighlighting.add(nodeKey);
+  nodesCurrentlyHighlighting.add(cacheKey);
 
   // Using nested update call to pass `skipTransforms` since we don't want
   // each individual CodeHighlightNode to be transformed again as it's already
@@ -211,7 +212,7 @@ function codeNodeTransform(
     },
     {
       onUpdate: () => {
-        nodesCurrentlyHighlighting.delete(nodeKey);
+        nodesCurrentlyHighlighting.delete(cacheKey);
       },
       skipTransforms: true,
     },


### PR DESCRIPTION
Prepend editor keys when adding node keys into the `nodesCurrentlyHighlighting` cache in `CodeHighlighterPrism.ts`, so that code highlighting does not get skipped for some editors when multiple editors on the page are initialized with the same content.

## Test plan

Run existing tests:
`npm run test-unit LexicalCodeNode`