### PR TITLE
[lexical] Chore: Update flow-bin (to 0.289.0) and LexicalLink Flow types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -114,4 +114,4 @@ nonstrict-import
 unclear-type
 
 [version]
-^0.280.0
+^0.289.0

--- a/flow-typed/environments/dom.js
+++ b/flow-typed/environments/dom.js
@@ -1,5 +1,5 @@
-// flow-typed signature: 2872ddd56ba4b4bfefacac38ebdc6087
-// flow-typed version: 3e51657e95/dom/flow_>=v0.261.x
+// flow-typed signature: c126209a0e678d121655f21a36219841
+// flow-typed version: f998bd7c46/dom/flow_>=v0.261.x
 
 /* Files */
 
@@ -154,34 +154,41 @@ type StorageEventTypes = 'storage';
 type SecurityPolicyViolationEventTypes = 'securitypolicyviolation';
 type USBConnectionEventTypes = 'connect' | 'disconnect';
 type ToggleEventTypes = 'beforetoggle' | 'toggle';
-type EventListenerOptionsOrUseCapture = boolean | {
-       capture?: boolean,
-       once?: boolean,
-       passive?: boolean,
-       signal?: AbortSignal,
-       ...
-};
+
+type AddEventListenerOptionsOrUseCapture =
+  | boolean
+  | $ReadOnly<{
+      capture?: boolean,
+      once?: boolean,
+      passive?: boolean,
+      signal?: AbortSignal,
+    }>;
+type EventListenerOptionsOrUseCapture =
+  | boolean
+  | $ReadOnly<{
+      capture?: boolean,
+    }>;
 
 declare class EventTarget {
-  addEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: FocusEventTypes, listener: FocusEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: InputEventTypes, listener: InputEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: TouchEventTypes, listener: TouchEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: WheelEventTypes, listener: WheelEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: AbortProgressEventTypes, listener: AbortProgressEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: ProgressEventTypes, listener: ProgressEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: DragEventTypes, listener: DragEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: PointerEventTypes, listener: PointerEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: AnimationEventTypes, listener: AnimationEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: ClipboardEventTypes, listener: ClipboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: TransitionEventTypes, listener: TransitionEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: MessageEventTypes, listener: MessageEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: BeforeUnloadEventTypes, listener: BeforeUnloadEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: StorageEventTypes, listener: StorageEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: SecurityPolicyViolationEventTypes, listener: SecurityPolicyViolationEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: USBConnectionEventTypes, listener: USBConnectionEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
-  addEventListener(type: string, listener: EventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: FocusEventTypes, listener: FocusEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: InputEventTypes, listener: InputEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: TouchEventTypes, listener: TouchEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: WheelEventTypes, listener: WheelEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: AbortProgressEventTypes, listener: AbortProgressEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: ProgressEventTypes, listener: ProgressEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: DragEventTypes, listener: DragEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: PointerEventTypes, listener: PointerEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: AnimationEventTypes, listener: AnimationEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: ClipboardEventTypes, listener: ClipboardEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: TransitionEventTypes, listener: TransitionEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: MessageEventTypes, listener: MessageEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: BeforeUnloadEventTypes, listener: BeforeUnloadEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: StorageEventTypes, listener: StorageEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: SecurityPolicyViolationEventTypes, listener: SecurityPolicyViolationEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: USBConnectionEventTypes, listener: USBConnectionEventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
+  addEventListener(type: string, listener: EventListener, optionsOrUseCapture?: AddEventListenerOptionsOrUseCapture): void;
 
   removeEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: FocusEventTypes, listener: FocusEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
@@ -824,6 +831,28 @@ declare class SecurityPolicyViolationEvent extends Event {
   +lineNumber: number;
   +columnNumber: number;
 };
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Scheduler
+declare class TaskSignal extends AbortSignal {
+  +priority: number;
+}
+
+type SchedulerPostTaskOptions = {
+  priority?: "user-blocking" | "user-visible" | "background",
+  signal?: TaskSignal | AbortSignal,
+  delay?: number,
+};
+
+declare class Scheduler {
+  postTask<T>(
+    callback: () => T,
+    options?: SchedulerPostTaskOptions,
+  ): Promise<T>;
+  yield(): Promise<void>;
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone
+declare function structuredClone<T>(value: T, options?: {| transfer: any[] |}): T;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/USBConnectionEvent
 declare class USBConnectionEvent extends Event {

--- a/libdefs/yjs.js
+++ b/libdefs/yjs.js
@@ -65,7 +65,6 @@ declare module 'yjs' {
     unobserveDeep(fn: Function): void;
   }
 
-  // $FlowFixMe: needs fixing
   declare type YMapEventKeyChanges = any;
 
   declare type Operation = {
@@ -644,8 +643,7 @@ declare module 'yjs' {
   };
 
   declare type StackItem = {
-    // $FlowFixMe: perhaps add generic typing instead of mixed
-    meta: Map<mixed, mixed>,
+    meta: Map,
     type: 'undo' | 'redo',
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-simple-import-sort": "^12.1.0",
         "eslint-plugin-sort-keys-fix": "^1.1.2",
-        "flow-bin": "^0.280.0",
+        "flow-bin": "^0.289.0",
         "flow-typed": "^4.1.1",
         "fs-extra": "^10.0.0",
         "glob": "^10.4.1",
@@ -24147,9 +24147,9 @@
       "dev": true
     },
     "node_modules/flow-bin": {
-      "version": "0.280.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.280.0.tgz",
-      "integrity": "sha512-7WHDjleRd6KDggSYovdrNSz1xMM9HKSI3ajHF3xMmWaETxx3SHnl60cclW6mPm3z+0FUVQSr7XFLiGSW3Zkq7Q==",
+      "version": "0.289.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.289.0.tgz",
+      "integrity": "sha512-xNmTDLq6TkHa3LvNWHF9lcnKmtBlxZstEWXo7p0KXRzrtHNAAWJGDFyidz7E0IEw95VxxjNZhgiTYGDOIAWPPw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -63031,9 +63031,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.280.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.280.0.tgz",
-      "integrity": "sha512-7WHDjleRd6KDggSYovdrNSz1xMM9HKSI3ajHF3xMmWaETxx3SHnl60cclW6mPm3z+0FUVQSr7XFLiGSW3Zkq7Q==",
+      "version": "0.289.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.289.0.tgz",
+      "integrity": "sha512-xNmTDLq6TkHa3LvNWHF9lcnKmtBlxZstEWXo7p0KXRzrtHNAAWJGDFyidz7E0IEw95VxxjNZhgiTYGDOIAWPPw==",
       "dev": true
     },
     "flow-enums-runtime": {

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "eslint-plugin-sort-keys-fix": "^1.1.2",
-    "flow-bin": "^0.280.0",
+    "flow-bin": "^0.289.0",
     "flow-typed": "^4.1.1",
     "fs-extra": "^10.0.0",
     "glob": "^10.4.1",

--- a/packages/lexical-link/flow/LexicalLink.js.flow
+++ b/packages/lexical-link/flow/LexicalLink.js.flow
@@ -106,7 +106,7 @@ export type ClickableLinkConfig = {
   disabled: boolean;
 }
 
-type AddEventListenerOptions = Exclude<EventListenerOptionsOrUseCapture, boolean>;
+type AddEventListenerOptions = Exclude<AddEventListenerOptionsOrUseCapture, boolean>;
 
 declare export function registerClickableLink(
   editor: LexicalEditor,


### PR DESCRIPTION
Update `flow-bin` from v0.280.0 to v0.289.0.

To unblock the internal sync, I'm also updating Flow `dom` types for event listener options (by manually modifying our checked-in `dom.js` file) + the usage in `LexicalLink`.

## Test plan

`npm run flow`
`npm run ci-check`