### PR TITLE
[lexical] Chore: Update flow-bin (to 0.290.0) and fix incompatible-variance issues

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -114,4 +114,4 @@ nonstrict-import
 unclear-type
 
 [version]
-^0.289.0
+^0.290.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-simple-import-sort": "^12.1.0",
         "eslint-plugin-sort-keys-fix": "^1.1.2",
-        "flow-bin": "^0.289.0",
+        "flow-bin": "^0.290.0",
         "flow-typed": "^4.1.1",
         "fs-extra": "^10.0.0",
         "glob": "^10.4.1",
@@ -24147,9 +24147,9 @@
       "dev": true
     },
     "node_modules/flow-bin": {
-      "version": "0.289.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.289.0.tgz",
-      "integrity": "sha512-xNmTDLq6TkHa3LvNWHF9lcnKmtBlxZstEWXo7p0KXRzrtHNAAWJGDFyidz7E0IEw95VxxjNZhgiTYGDOIAWPPw==",
+      "version": "0.290.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.290.0.tgz",
+      "integrity": "sha512-YvfxgT9I/FLY2WyZs9dAxvMk9LPtv6MC097rwqEWU2mUlPAmOmaJ8AJaRLUXtJ3DnF/nQDq4EbS4w3SiKZvwCQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -63031,9 +63031,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.289.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.289.0.tgz",
-      "integrity": "sha512-xNmTDLq6TkHa3LvNWHF9lcnKmtBlxZstEWXo7p0KXRzrtHNAAWJGDFyidz7E0IEw95VxxjNZhgiTYGDOIAWPPw==",
+      "version": "0.290.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.290.0.tgz",
+      "integrity": "sha512-YvfxgT9I/FLY2WyZs9dAxvMk9LPtv6MC097rwqEWU2mUlPAmOmaJ8AJaRLUXtJ3DnF/nQDq4EbS4w3SiKZvwCQ==",
       "dev": true
     },
     "flow-enums-runtime": {

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "eslint-plugin-sort-keys-fix": "^1.1.2",
-    "flow-bin": "^0.289.0",
+    "flow-bin": "^0.290.0",
     "flow-typed": "^4.1.1",
     "fs-extra": "^10.0.0",
     "glob": "^10.4.1",

--- a/packages/lexical/flow/Lexical.js.flow
+++ b/packages/lexical/flow/Lexical.js.flow
@@ -1633,13 +1633,13 @@ export type LexicalExtensionArgument<
 > =
   | LexicalExtension<Config, Name, Output, Init>
   | NormalizedLexicalExtensionArgument<Config, Name, Output, Init>;
-export type LexicalExtensionConfig<Extension: AnyLexicalExtension> =
+export type LexicalExtensionConfig<+Extension: AnyLexicalExtension> =
   $NonMaybeType<Extension[typeof configTypeSymbol]>;
 export interface LexicalExtensionDependency<
   +Dependency: AnyLexicalExtension,
 > {
-  config: LexicalExtensionConfig<Dependency>;
-  output: LexicalExtensionOutput<Dependency>;
+  +config: LexicalExtensionConfig<Dependency>;
+  +output: LexicalExtensionOutput<Dependency>;
 }
 export type LexicalExtensionInit<Extension: AnyLexicalExtension> =
   $NonMaybeType<Extension[typeof initTypeSymbol]>;
@@ -1656,7 +1656,7 @@ interface LexicalExtensionInternalOutput<Output> {
 export type LexicalExtensionName<Extension: AnyLexicalExtension> =
   Extension['name'];
 
-export type LexicalExtensionOutput<Extension: AnyLexicalExtension> =
+export type LexicalExtensionOutput<+Extension: AnyLexicalExtension> =
   $NonMaybeType<Extension[typeof outputTypeSymbol]>;
 declare export const peerDependencySymbol: symbol;
 export type NormalizedLexicalExtensionArgument<


### PR DESCRIPTION
(As annoying as this is... there's a new Flow release that introduced another sync breakage...)

Update flow-bin from v0.289.0 to v0.290.0, and fix the new `incompatible-variance` issues in `Lexical.js.flow`.
(Pls sanity check that the type parameter of `LexicalExtensionDependency` is intended to be covariant.)

## Test plan

`npm run flow`
`npm run ci-check`