### PR TITLE
[lexical] Bug fix: $dfsCaretIterator should be able to stop at its last descendant

### DIFF
--- a/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
+++ b/packages/lexical-utils/src/__tests__/unit/LexicalNodeHelpers.test.ts
@@ -269,6 +269,48 @@ describe('LexicalNodeHelpers tests', () => {
       });
     });
 
+    test('DFS with endNode as ElementNode should stop at the ElementNode, not include children', async () => {
+      const editor: LexicalEditor = testEnv.editor;
+      editor.update(() => {
+        const root = $getRoot();
+
+        // Create structure:
+        // root
+        //   ├── elementNode
+        //   │     ├── word1
+        //   │     └── word2
+        //   ├── elementNode2
+        //   │     └── word3
+        const elementNode1 = $createTestElementNode().append(
+          $createTextNode('word1'),
+          $createTextNode('word2'),
+        );
+        const elementNode2 = $createTestElementNode().append(
+          $createTextNode('word3'),
+        );
+
+        root.clear().append(elementNode1, elementNode2);
+        expect($dfs(undefined, elementNode2)).toEqual([
+          {depth: 0, node: $getRoot()},
+          {depth: 1, node: elementNode1},
+          {depth: 2, node: elementNode1.getFirstDescendant()},
+          {depth: 2, node: elementNode1.getLastDescendant()},
+          {depth: 1, node: elementNode2},
+        ]);
+
+        expect($dfs(elementNode1, elementNode2)).toEqual([
+          {depth: 1, node: elementNode1},
+          {depth: 2, node: elementNode1.getFirstDescendant()},
+          {depth: 2, node: elementNode1.getLastDescendant()},
+          {depth: 1, node: elementNode2},
+        ]);
+
+        expect($dfs(elementNode1, elementNode1)).toEqual([
+          {depth: 1, node: elementNode1},
+        ]);
+      });
+    });
+
     test('DFS triggers getLatest()', async () => {
       const editor: LexicalEditor = testEnv.editor;
       let rootKey: string;

--- a/packages/lexical-utils/src/index.ts
+++ b/packages/lexical-utils/src/index.ts
@@ -198,8 +198,10 @@ export interface DFSNode {
  * before backtracking and finding a new path. Consider solving a maze by hugging either wall, moving down a
  * branch until you hit a dead-end (leaf) and backtracking to find the nearest branching path and repeat.
  * It will then return all the nodes found in the search in an array of objects.
+ * Preorder traversal is used, meaning that nodes are listed in the order of when they are FIRST encountered.
  * @param startNode - The node to start the search (inclusive), if omitted, it will start at the root node.
- * @param endNode - The node to end the search (inclusive), if omitted, it will find all descendants of the startingNode.
+ * @param endNode - The node to end the search (inclusive), if omitted, it will find all descendants of the startingNode. If endNode
+ * is an ElementNode, it will stop before visiting any of its children.
  * @returns An array of objects of all the nodes found by the search, including their depth into the tree.
  * \\{depth: number, node: LexicalNode\\} It will always return at least 1 node (the start node).
  */
@@ -237,8 +239,10 @@ export function $reverseDfs(
 
 /**
  * $dfs iterator (left to right). Tree traversal is done on the fly as new values are requested with O(1) memory.
+ * Preorder traversal is used, meaning that nodes are iterated over in the order of when they are FIRST encountered.
  * @param startNode - The node to start the search (inclusive), if omitted, it will start at the root node.
  * @param endNode - The node to end the search (inclusive), if omitted, it will find all descendants of the startingNode.
+ * If endNode is an ElementNode, the iterator will end as soon as it reaches the endNode (no children will be visited).
  * @returns An iterator, each yielded value is a DFSNode. It will always return at least 1 node (the start node).
  */
 export function $dfsIterator(


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
When you have an element node and you want to iterate through all it's children, you might do something like:

```
$dfsIterator(elementNode, elementNode.getLastDescendant());
```

You would expect it to end at the last descendant inside of the elementNode. However, currently it will iterate through all the descendants, and then just continue right on through to the end of the entire editor's tree.

*Describe the changes in this pull request*
I checked the condition where endCaret is null even though the user did pass in an endNode. In this case, we should get the adjacent parent as the end caret.
Closes #<!-- issue number -->

## Test plan
Unit test included.

### Before
It would return all nodes to the end of the editor's tree


### After
It will properly stop at the node that is passed in as the endNode