### PR TITLE
[lexical-table] Bug Fix: ensure colWidths has length equal to number of columns

### DIFF
--- a/packages/lexical-table/src/LexicalTablePluginHelpers.ts
+++ b/packages/lexical-table/src/LexicalTablePluginHelpers.ts
@@ -141,6 +141,22 @@ function $tableTransform(node: TableNode) {
       rowNode.append(newCell);
     }
   }
+  const colWidths = node.getColWidths();
+  const columnCount = node.getColumnCount();
+  if (colWidths && colWidths.length !== columnCount) {
+    let newColWidths: number[] | undefined = undefined;
+    if (columnCount < colWidths.length) {
+      newColWidths = colWidths.slice(0, columnCount);
+    } else if (colWidths.length > 0) {
+      // Repeat the last column width.
+      const fillWidth = colWidths[colWidths.length - 1];
+      newColWidths = [
+        ...colWidths,
+        ...Array(columnCount - colWidths.length).fill(fillWidth),
+      ];
+    }
+    node.setColWidths(newColWidths);
+  }
 }
 
 function $tableClickCommand(event: MouseEvent): boolean {

--- a/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
+++ b/packages/lexical-table/src/__tests__/unit/LexicalTableExtension.test.ts
@@ -256,4 +256,72 @@ describe('TableExtension', () => {
       });
     });
   });
+
+  describe('colWidths', () => {
+    it('removes colWidths if it is an empty array', () => {
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear().selectStart();
+          editor.dispatchCommand(INSERT_TABLE_COMMAND, {
+            columns: '2',
+            rows: '2',
+          });
+          const table = root.getFirstChildOrThrow<TableNode>();
+          table.setColWidths([]);
+        },
+        {discrete: true},
+      );
+
+      editor.getEditorState().read(() => {
+        const root = $getRoot();
+        const table = root.getFirstChildOrThrow<TableNode>();
+        expect(table.getColWidths()).toBe(undefined);
+      });
+    });
+
+    it('uses the last column width if the column count is greater than the number of column widths', () => {
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear().selectStart();
+          editor.dispatchCommand(INSERT_TABLE_COMMAND, {
+            columns: '3',
+            rows: '2',
+          });
+          const table = root.getFirstChildOrThrow<TableNode>();
+          table.setColWidths([10, 20]);
+        },
+        {discrete: true},
+      );
+
+      editor.getEditorState().read(() => {
+        const root = $getRoot();
+        const table = root.getFirstChildOrThrow<TableNode>();
+        expect(table.getColWidths()).toEqual([10, 20, 20]);
+      });
+    });
+
+    it('shortens the colWidths if the column count is less than the number of column widths', () => {
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear().selectStart();
+          editor.dispatchCommand(INSERT_TABLE_COMMAND, {
+            columns: '2',
+            rows: '2',
+          });
+          const table = root.getFirstChildOrThrow<TableNode>();
+          table.setColWidths([10, 20, 30]);
+        },
+        {discrete: true},
+      );
+
+      editor.getEditorState().read(() => {
+        const root = $getRoot();
+        const table = root.getFirstChildOrThrow<TableNode>();
+        expect(table.getColWidths()).toEqual([10, 20]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description

When pasting a table from Excel, the pasted table has a single `col` element:

```html
...
<table border=0 cellpadding=0 cellspacing=0 width=261 style='border-collapse:
 collapse;width:195pt'>
<!--StartFragment-->
 <col width=87 span=3 style='width:65pt'>
 <tr height=21 style='height:16.0pt'>
  <td height=21 align=right width=87 style='height:16.0pt;width:65pt'>12</td>
  <td width=87 style='width:65pt'>a</td>
  <td width=87 style='width:65pt'></td>
 </tr>
...
 ```

With the above HTML, the DOM import logic would set `colWidths = [87]`. This was then breaking a plugin we have which assumed that `colWidths` would have the same length as the number of columns. We could address this in our plugin but it felt more robust to have the core table plugin ensure that `colWidths` and the number of columns stay in sync.