### PR TITLE
[lexical-react] [lexical-playground] Bug Fix: Prevent typeahead menu from closing during IME composition (#7985)

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -262,6 +262,10 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
           return;
         }
 
+        if (editor.isComposing()) {
+          return;
+        }
+
         const editorWindow = editor._window || window;
         const range = editorWindow.document.createRange();
         const selection = $getSelection();


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

During IME composition (Korean, Japanese, Chinese), the browser creates a range selection causing selection.isCollapsed() to return false, incorrectly closing the typeahead menu.

Changes:

Add editor.isComposing() check with early return in updateListener<link to Repo facebook/lexical: packages/lexical/src/LexicalEditor.ts:806-808 />
Add E2E test for IME composition with typeahead menu
Affects MentionsPlugin, ComponentPickerPlugin, EmojiPickerPlugin.

Closes #7985 

## Test plan

### Before

https://github.com/user-attachments/assets/2b104be7-f036-4283-ae9c-68caae5f1464

### After

https://github.com/user-attachments/assets/26a7186f-bb81-4c72-8fb0-0c3db8bc337c