### PR TITLE
[lexical-yjs] Bug fix: don't rewrite unchanged non-primitive property/state values to yjs in collab v2

### DIFF
--- a/packages/lexical-react/src/__tests__/unit/utils.tsx
+++ b/packages/lexical-react/src/__tests__/unit/utils.tsx
@@ -288,7 +288,7 @@ export class Client implements Provider {
   }
 }
 
-class TestConnection {
+export class TestConnection {
   _clients = new Map<string, Client>();
 
   constructor(readonly _useCollabV2: boolean) {}

--- a/packages/lexical-yjs/src/SyncV2.ts
+++ b/packages/lexical-yjs/src/SyncV2.ts
@@ -382,12 +382,14 @@ const $createTypeFromTextOrElementNode = (
     ? $createTypeFromTextNodes(node, meta)
     : createTypeFromElementNode(node, meta);
 
-const isObject = (val: unknown): val is Record<string, unknown> =>
+const isObject = (
+  val: unknown,
+): val is Record<string | number | symbol, unknown> =>
   typeof val === 'object' && val != null;
 
 const equalAttrs = (
-  pattrs: Record<string, unknown>,
-  yattrs: Record<string, unknown> | null,
+  pattrs: Record<string | number | symbol, unknown>,
+  yattrs: Record<string | number | symbol, unknown> | null,
 ) => {
   const keys = Object.keys(pattrs).filter((key) => pattrs[key] !== null);
   if (yattrs == null) {
@@ -705,7 +707,13 @@ export const $updateYFragment = (
     };
     for (const key in lexicalAttrs) {
       if (lexicalAttrs[key] != null) {
-        if (yDomAttrs[key] !== lexicalAttrs[key] && key !== 'ychange') {
+        const isEqual =
+          yDomAttrs[key] === lexicalAttrs[key] ||
+          // deep equality check so we don't sync properties/state with object values every update
+          (isObject(yDomAttrs[key]) &&
+            isObject(lexicalAttrs[key]) &&
+            equalAttrs(yDomAttrs[key], lexicalAttrs[key]));
+        if (!isEqual && key !== 'ychange') {
           // TODO(collab-v2): typing for XmlElement generic
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           yDomFragment.setAttribute(key, lexicalAttrs[key] as any);


### PR DESCRIPTION
## Description

When syncing properties/state to Yjs in collab v2, I was doing a shallow equality check on the values in Yjs and Lexical. The former however was coming from `yDomFragment.getAttributes()` which may not have been reference-equal. This meant that any non-primitive values for properties or state could end up being re-written to Yjs whenever the node was dirty.

This is particularly a problem when GC is disabled on the ydoc as you end up building up a lot of cruft.

The fix is to do a deep equality check, which is what the code was already doing for [`equalYTypePNode`](https://github.com/facebook/lexical/blob/v0.38.1/packages/lexical-yjs/src/SyncV2.ts#L479-L482), as `equalAttrs` is recursive.

## Test plan

Added unit test fails before, passes after the change.