### PR TITLE
[lexical-website] Documentation Update: Add @y/websocket-server package dependency

### DIFF
--- a/packages/lexical-website/docs/collaboration/react.md
+++ b/packages/lexical-website/docs/collaboration/react.md
@@ -20,7 +20,7 @@ This guide is based on [examples/react-rich](https://github.com/facebook/lexical
 
 **Install minimal set of the required dependencies:**
 ```bash
-$ npm i -S @lexical/react @lexical/yjs lexical react react-dom y-websocket yjs
+$ npm i -S @lexical/react @lexical/yjs lexical react react-dom y-websocket @y/websocket-server yjs
 ```
 
 :::note


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
On April 2, 2025, the backend websocket server code from y-websocket was refactored to a new package called [@y/websocket-server](https://github.com/yjs/y-websocket-server/).

"The fastest way to get started is to run the [@y/websocket-server](https://github.com/yjs/y-websocket-server/) backend. This package was previously included in y-websocket and now lives in a forkable repository."

See https://github.com/yjs/y-websocket/commit/c802cc9d0e267cdceabecc48a979b60c66524465

Without installing this additional package, user sees the following error when trying to run `HOST=localhost PORT=1234 YPERSISTENCE=./yjs-wss-db npx y-websocket`: `npm error could not determine executable to run`

Closes #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*