### PR TITLE
[lexical-website] Documentation Update: Add missing getDocFromMap fn to docs

### DIFF
--- a/packages/lexical-website/docs/collaboration/react.md
+++ b/packages/lexical-website/docs/collaboration/react.md
@@ -40,6 +40,8 @@ $ HOST=localhost PORT=1234 YPERSISTENCE=./yjs-wss-db npx y-websocket
 **Get basic collaborative Lexical setup:**
 
 ```tsx
+import { useCallback } from 'react';
+
 import {$getRoot, $createParagraphNode, $createTextNode} from 'lexical';
 import {LexicalCollaboration} from '@lexical/react/LexicalCollaborationContext';
 import {LexicalComposer} from '@lexical/react/LexicalComposer';
@@ -65,6 +67,19 @@ function Editor() {
     theme: {},
   };
 
+  const getDocFromMap = (id: string, yjsDocMap: Map<string, Y.Doc>): Y.Doc => {
+    let doc = yjsDocMap.get(id);
+  
+    if (doc === undefined) {
+      doc = new Y.Doc();
+      yjsDocMap.set(id, doc);
+    } else {
+      doc.load();
+    }
+
+    return doc;
+  }
+
   const providerFactory = useCallback(
     (id: string, yjsDocMap: Map<string, Y.Doc>) => {
       const doc = getDocFromMap(id, yjsDocMap);
@@ -88,7 +103,7 @@ function Editor() {
           providerFactory={providerFactory}
         />
       </LexicalComposer>
-    <LexicalCollaboration>
+    </LexicalCollaboration>
   );
 }
 ```


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
In the React collaboration docs, the existing provider factory function calls `getDocFromMap()` (see new line 85) and it is missing in the `Editor` component.  This pull request adds the missing `getDocFromMap()` function, a missing import, and closing `</>`.

Closes #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*