### PR TITLE
[lexical-playground] Bug Fix: Show draggable block target line when dragging images

### DIFF
--- a/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/ImagesPlugin/index.tsx
@@ -312,7 +312,7 @@ function $onDragover(event: DragEvent): boolean {
   if (!canDropImage(event)) {
     event.preventDefault();
   }
-  return true;
+  return false;
 }
 
 function $onDrop(event: DragEvent, editor: LexicalEditor): boolean {


### PR DESCRIPTION
Updates the dragover event handler to correctly prevent default behavior, resolving an issue where the image drag and drop target line was not consistently displayed.

## Description
**Current behavior**: When dragging an image in the editor, the `$onDragover` function in ImagesPlugin returns true, which stops the `DRAGOVER_COMMAND` event propagation. This prevents `DraggableBlockPlugin` from displaying the `draggable-block-target-line` indicator. 
**Changes in this PR**: Changed `$onDragover` to return false instead of true, allowing the event to propagate to `DraggableBlockPlugin` so it can display the target line during image drag operations.

## Test plan
### Before
1. Insert an image into the editor
2. Click on the image to select it
3. Drag the image → No target line indicator shown

https://github.com/user-attachments/assets/dae33a14-3559-4399-b3be-2eb75f66a187

### After
1. Insert an image into the editor
2. Click on the image to select it
3. Drag the image → Blue target line indicator is displayed

https://github.com/user-attachments/assets/f78f9801-2fda-4e90-a9a7-0dfb18782074