### PR TITLE
Chore: Fix npm warnings

### DIFF
--- a/packages/lexical-clipboard/package.json
+++ b/packages/lexical-clipboard/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-clipboard"
   },
   "module": "LexicalClipboard.mjs",

--- a/packages/lexical-code-shiki/package.json
+++ b/packages/lexical-code-shiki/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-code-shiki"
   },
   "devDependencies": {

--- a/packages/lexical-code/package.json
+++ b/packages/lexical-code/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-code"
   },
   "devDependencies": {

--- a/packages/lexical-devtools-core/package.json
+++ b/packages/lexical-devtools-core/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-devtools-core"
   },
   "module": "LexicalDevtoolsCore.mjs",

--- a/packages/lexical-dragon/package.json
+++ b/packages/lexical-dragon/package.json
@@ -14,7 +14,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-dragon"
   },
   "module": "LexicalDragon.mjs",

--- a/packages/lexical-file/package.json
+++ b/packages/lexical-file/package.json
@@ -15,7 +15,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-file"
   },
   "module": "LexicalFile.mjs",

--- a/packages/lexical-hashtag/package.json
+++ b/packages/lexical-hashtag/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-hashtag"
   },
   "module": "LexicalHashtag.mjs",

--- a/packages/lexical-headless/package.json
+++ b/packages/lexical-headless/package.json
@@ -11,7 +11,7 @@
   "version": "0.39.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-headless"
   },
   "sideEffects": false,

--- a/packages/lexical-history/package.json
+++ b/packages/lexical-history/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-history"
   },
   "module": "LexicalHistory.mjs",

--- a/packages/lexical-html/package.json
+++ b/packages/lexical-html/package.json
@@ -13,7 +13,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-html"
   },
   "dependencies": {

--- a/packages/lexical-link/package.json
+++ b/packages/lexical-link/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-link"
   },
   "module": "LexicalLink.mjs",

--- a/packages/lexical-list/package.json
+++ b/packages/lexical-list/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-list"
   },
   "module": "LexicalList.mjs",

--- a/packages/lexical-mark/package.json
+++ b/packages/lexical-mark/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-mark"
   },
   "module": "LexicalMark.mjs",

--- a/packages/lexical-markdown/package.json
+++ b/packages/lexical-markdown/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-markdown"
   },
   "module": "LexicalMarkdown.mjs",

--- a/packages/lexical-offset/package.json
+++ b/packages/lexical-offset/package.json
@@ -13,7 +13,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-offset"
   },
   "module": "LexicalOffset.mjs",

--- a/packages/lexical-overflow/package.json
+++ b/packages/lexical-overflow/package.json
@@ -13,7 +13,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-overflow"
   },
   "module": "LexicalOverflow.mjs",

--- a/packages/lexical-plain-text/package.json
+++ b/packages/lexical-plain-text/package.json
@@ -12,7 +12,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-plain-text"
   },
   "module": "LexicalPlainText.mjs",

--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -36,7 +36,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-react"
   },
   "exports": {

--- a/packages/lexical-rich-text/package.json
+++ b/packages/lexical-rich-text/package.json
@@ -12,7 +12,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-rich-text"
   },
   "module": "LexicalRichText.mjs",

--- a/packages/lexical-selection/package.json
+++ b/packages/lexical-selection/package.json
@@ -14,7 +14,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-selection"
   },
   "module": "LexicalSelection.mjs",

--- a/packages/lexical-table/package.json
+++ b/packages/lexical-table/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-table"
   },
   "module": "LexicalTable.mjs",

--- a/packages/lexical-text/package.json
+++ b/packages/lexical-text/package.json
@@ -14,7 +14,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-text"
   },
   "module": "LexicalText.mjs",

--- a/packages/lexical-utils/package.json
+++ b/packages/lexical-utils/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-utils"
   },
   "module": "LexicalUtils.mjs",

--- a/packages/lexical-yjs/package.json
+++ b/packages/lexical-yjs/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical-yjs"
   },
   "module": "LexicalYjs.mjs",

--- a/packages/lexical/package.json
+++ b/packages/lexical/package.json
@@ -14,7 +14,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/lexical"
   },
   "module": "Lexical.mjs",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/lexical",
+    "url": "git+https://github.com/facebook/lexical.git",
     "directory": "packages/shared"
   },
   "sideEffects": false


### PR DESCRIPTION
# Description

Publishing to npm generates warnings for several packages due to repository urls not being normalized

```
for pkg in packages/*/; do (cd $pkg && npm pkg fix); done
```

## Before

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository.url" was normalized to "git+https://github.com/facebook/lexical.git"
```