### PR TITLE
[lexical-react] Feature: TypeaheadMenuPlugin: Add an option to not reposition the menu.

### DIFF
--- a/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
+++ b/packages/lexical-react/src/LexicalTypeaheadMenuPlugin.tsx
@@ -211,6 +211,7 @@ export type TypeaheadMenuPluginProps<TOption extends MenuOption> = {
   parent?: HTMLElement;
   preselectFirstItem?: boolean;
   ignoreEntityBoundary?: boolean;
+  positionMenu?: boolean;
 };
 
 export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
@@ -226,11 +227,12 @@ export function LexicalTypeaheadMenuPlugin<TOption extends MenuOption>({
   parent,
   preselectFirstItem = true,
   ignoreEntityBoundary = false,
+  positionMenu = true,
 }: TypeaheadMenuPluginProps<TOption>): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [resolution, setResolution] = useState<MenuResolution | null>(null);
   const anchorElementRef = useMenuAnchorRef(
-    resolution,
+    positionMenu ? resolution : null,
     setResolution,
     anchorClassName,
     parent,


### PR DESCRIPTION
By default, the TypeaheadMenuPlugin positions the menu below the trigger character. Sometimes it is useful to chose a different, possibly fixed positioning e.g. above or below the input. LexicalMenu supports this by allowing to pass null as `resolution` to `useMenuAnchorRef`. This change adds an option to make this accessible when using TypeaheadMenuPlugin. The default behavior does not change.

<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

Closes #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*