### PR TITLE
Nightlies fix frozen lockfile

### DIFF
--- a/scripts/npm/postversion.js
+++ b/scripts/npm/postversion.js
@@ -44,7 +44,7 @@ async function main() {
     // Update all package.json versions in the monorepo
     `pnpm run update-version`,
     // Update pnpm-lock.yaml
-    `pnpm install`,
+    `pnpm install --no-frozen-lockfile`,
     // Fix up all package.json files
     `pnpm run update-packages`,
     // Extract error codes and update changelog, but only in production


### PR DESCRIPTION
Fixing another error

>  ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with <ROOT>/packages/lexical-clipboard/package.json
> Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"