### PR TITLE
Override workspace with actual version on npm/ bundle

### DIFF
--- a/scripts/npm/release.js
+++ b/scripts/npm/release.js
@@ -54,6 +54,8 @@ async function publish() {
           console.info(`Ignoring previously published error`);
           return null;
         }
+        console.error(`\nFailed to publish ${pkg.getNpmName()}:`);
+        console.error(err);
         return err;
       });
       console.info(`Done!`);


### PR DESCRIPTION
The `workplace:*` setting works wonders for the packages until we copy-paste the build into the separate folder `npm/` folder, at which point it can't resolve the version anymore, so befor the publish step we need to convert these into actual versions.

Also, added some additional errors logs because last nightlie is incorrectly passing.