### PR TITLE
[lexical-react] Bug Fix: Add 'yjs' as optional peer dependency for Yarn PnP compatibility

### DIFF
--- a/packages/lexical-react/package.json
+++ b/packages/lexical-react/package.json
@@ -32,7 +32,13 @@
   },
   "peerDependencies": {
     "react": ">=17.x",
-    "react-dom": ">=17.x"
+    "react-dom": ">=17.x",
+    "yjs": ">=13.5.22"
+  },
+  "peerDependenciesMeta": {
+    "yjs": {
+      "optional": true
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
 ## Description

**Current problem:**
- `@lexical/react` includes `@lexical/yjs` as a dependency
- `@lexical/yjs` requires `yjs` as a peer dependency
- However, `yjs` is not declared in `@lexical/react`
- In strict dependency management environments like Yarn PnP, this causes a resolution error for `yjs`

**Changes:**
- Added `yjs` as an optional peer dependency in `@lexical/react`
- Users who don't use collaboration features are not affected

## Test plan

### Before

Yarn PnP environment fails to resolve `yjs`:

![error screenshot]

**Workaround required in `.yarnrc.yml`:**
```yaml
packageExtensions:
  '@lexical/react@*':
    peerDependencies:
      'yjs': '*'
```

This workaround confirms that adding yjs as a peer dependency resolves the issue.

### After

Works without the workaround.
