### PR TITLE
[lexical] Bug Fix: format removed on multi selection after replace

### DIFF
--- a/packages/lexical/src/LexicalSelection.ts
+++ b/packages/lexical/src/LexicalSelection.ts
@@ -1133,10 +1133,15 @@ export class RangeSelection implements BaseSelection {
         );
         if (firstNode.getTextContent() === '') {
           firstNode.remove();
-        } else if (firstNode.isComposing() && this.anchor.type === 'text') {
-          // When composing, we need to adjust the anchor offset so that
-          // we correctly replace that right range.
-          this.anchor.offset -= text.length;
+        } else if (this.anchor.type === 'text') {
+          if (firstNode.isComposing()) {
+            // When composing, we need to adjust the anchor offset so that
+            // we correctly replace that right range.
+            this.anchor.offset -= text.length;
+          } else {
+            this.format = firstNode.getFormat();
+            this.style = firstNode.getStyle();
+          }
         }
       } else if (startOffset === firstNodeTextLength) {
         firstNode.select();

--- a/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
+++ b/packages/lexical/src/__tests__/unit/LexicalSelection.test.ts
@@ -1651,3 +1651,27 @@ describe('Regression #3181', () => {
     });
   });
 });
+
+describe('Regression #8067', () => {
+  initializeUnitTest((testEnv) => {
+    test('Formatting issue when replacing text with format', () => {
+      testEnv.editor.update(
+        () => {
+          const root = $getRoot();
+          const paragraph = $createParagraphNode();
+          const firstNode = $createTextNode('hello');
+          firstNode.toggleFormat('bold');
+          const lastNode = $createTextNode(' world!');
+          paragraph.append(firstNode, lastNode);
+          root.clear().append(paragraph);
+          const selection = $selectAll();
+          selection.insertText('hello');
+          const children = paragraph.getChildren()[0] as TextNode;
+          expect(children.getTextContent()).toBe('hello');
+          expect(children.hasFormat('bold')).toBe(true);
+        },
+        {discrete: true},
+      );
+    });
+  });
+});


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
Current behavior:
When a user applies formatting to first node and selects it with other nodes to replace the text, only the first inserted character retains the formatting. because insertText uses spliceText to insert the first character, it causes the selection's format state to reset. As a result, characters typed after the first one don't inherit the original formatting.

Changes in this PR:
Preserve formatting when text is spliced across multiple nodes. the selection's format don't reset after splicing, so user inputs retain the original formatting.

Closes #8067 

## Test plan

### Before

https://github.com/user-attachments/assets/99d7a23a-e9e0-4a0b-8b11-efc1d1bba026

### After

https://github.com/user-attachments/assets/15a48847-ec77-455b-a6ac-c07dd5286622