### PR TITLE
[lexical-markdown] Bug Fix: Fix incorrect format tag placement at link boundaries

### DIFF
--- a/packages/lexical-markdown/src/MarkdownExport.ts
+++ b/packages/lexical-markdown/src/MarkdownExport.ts
@@ -293,47 +293,11 @@ function exportTextFormat(
   return closingTagsBefore + output;
 }
 
-// Get next or previous text sibling a text node, including cases
-// when it's a child of inline element (e.g. link)
 function getTextSibling(node: TextNode, backward: boolean): TextNode | null {
-  let sibling = backward ? node.getPreviousSibling() : node.getNextSibling();
+  const sibling = backward ? node.getPreviousSibling() : node.getNextSibling();
 
-  if (!sibling) {
-    const parent = node.getParentOrThrow();
-
-    if (parent.isInline()) {
-      sibling = backward
-        ? parent.getPreviousSibling()
-        : parent.getNextSibling();
-    }
-  }
-
-  while (sibling) {
-    if ($isElementNode(sibling)) {
-      if (!sibling.isInline()) {
-        break;
-      }
-
-      const descendant = backward
-        ? sibling.getLastDescendant()
-        : sibling.getFirstDescendant();
-
-      if ($isTextNode(descendant)) {
-        return descendant;
-      } else {
-        sibling = backward
-          ? sibling.getPreviousSibling()
-          : sibling.getNextSibling();
-      }
-    }
-
-    if ($isTextNode(sibling)) {
-      return sibling;
-    }
-
-    if (!$isElementNode(sibling)) {
-      return null;
-    }
+  if ($isTextNode(sibling)) {
+    return sibling;
   }
 
   return null;

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -604,25 +604,25 @@ describe('Markdown', () => {
       html: '<p><span style="white-space: pre-wrap;">Text </span><b><strong style="white-space: pre-wrap;">boldstart </strong></b><a href="https://lexical.dev"><b><strong style="white-space: pre-wrap;">text</strong></b></a><b><strong style="white-space: pre-wrap;"> boldend</strong></b><span style="white-space: pre-wrap;"> text</span></p>',
       md: 'Text **boldstart [text](https://lexical.dev) boldend** text',
       mdAfterExport:
-        'Text **boldstart&#32;[text](https://lexical.dev)&#32;boldend** text',
+        'Text **boldstart&#32;**[**text**](https://lexical.dev)**&#32;boldend** text',
     },
     {
       html: '<p><span style="white-space: pre-wrap;">Text </span><b><strong style="white-space: pre-wrap;">boldstart </strong></b><a href="https://lexical.dev"><b><code spellcheck="false" style="white-space: pre-wrap;"><strong>text</strong></code></b></a><b><strong style="white-space: pre-wrap;"> boldend</strong></b><span style="white-space: pre-wrap;"> text</span></p>',
       md: 'Text **boldstart [`text`](https://lexical.dev) boldend** text',
       mdAfterExport:
-        'Text **boldstart&#32;[`text`](https://lexical.dev)&#32;boldend** text',
+        'Text **boldstart&#32;**[**`text`**](https://lexical.dev)**&#32;boldend** text',
     },
     {
       html: '<p><span style="white-space: pre-wrap;">It </span><s><i><b><strong style="white-space: pre-wrap;">works </strong></b></i></s><a href="https://lexical.io"><s><i><b><strong style="white-space: pre-wrap;">with links</strong></b></i></s></a><span style="white-space: pre-wrap;"> too</span></p>',
       md: 'It ~~___works [with links](https://lexical.io)___~~ too',
       mdAfterExport:
-        'It ***~~works&#32;[with links](https://lexical.io)~~*** too',
+        'It ***~~works&#32;~~***[***~~with links~~***](https://lexical.io) too',
     },
     {
       html: '<p><span style="white-space: pre-wrap;">It </span><s><i><b><strong style="white-space: pre-wrap;">works </strong></b></i></s><a href="https://lexical.io"><s><i><b><strong style="white-space: pre-wrap;">with links</strong></b></i></s></a><s><i><b><strong style="white-space: pre-wrap;"> too</strong></b></i></s><span style="white-space: pre-wrap;">!</span></p>',
       md: 'It ~~___works [with links](https://lexical.io) too___~~!',
       mdAfterExport:
-        'It ***~~works&#32;[with links](https://lexical.io)&#32;too~~***!',
+        'It ***~~works&#32;~~***[***~~with links~~***](https://lexical.io)***~~&#32;too~~***!',
     },
     {
       html: '<p><a href="https://lexical.dev"><span style="white-space: pre-wrap;">link</span></a><a href="https://lexical.dev"><span style="white-space: pre-wrap;">link2</span></a></p>',
@@ -705,6 +705,16 @@ describe('Markdown', () => {
     {
       html: '<p><span style="white-space: pre-wrap;">[](https://lexical.dev)</span></p>',
       md: '[](https://lexical.dev)',
+    },
+    {
+      html: '<p><a href="https://lexical.dev"><b><strong style="white-space: pre-wrap;">link</strong></b></a><b><strong style="white-space: pre-wrap;"> text</strong></b></p>',
+      md: '[**link**](https://lexical.dev)** text**',
+      mdAfterExport: '[**link**](https://lexical.dev)**&#32;text**',
+    },
+    {
+      html: '<p><b><strong style="white-space: pre-wrap;">text </strong></b><a href="https://lexical.dev"><b><strong style="white-space: pre-wrap;">link</strong></b></a></p>',
+      md: '**text [link](https://lexical.dev)**',
+      mdAfterExport: '**text&#32;**[**link**](https://lexical.dev)',
     },
   ];
 


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->

Current Behavior: 
There is an issue where markdown format tags (e.g. bold, italic) are incorrectly placed when a format starts or ends at a link boundary. This happens because the formatter attempts to minimize the number of tags by looking across inline element siblings, leading to the following bugs:

Format starting inside a link: When a format is applied to text within a link, the formatter fails to close the tag inside the link because it expects the format to continue into the parent's next sibling. This results in the tag opening inside the link but closing outside of it (Refer to #7817).

Format ending inside a link: Since formatting is applied only to the text node within the link and not the link element itself, the closing tag is often omitted or misplaced (Refer to #7503).

Changes in this PR: 
I have simplified the getTextSibling() function to ensure correct tag placement.

Previously, the logic attempted to traverse siblings of inline elements (like links) to minimize the total number of markdown tags. While this aimed for "cleaner" markdown, it resulted in syntactically incorrect tag at boundaries.

This PR prioritizes structural correctness over tag minimization. By ensuring tags are closed and opened correctly relative to the link boundaries:

Markdown integrity is preserved even if it requires slightly more tags.

I have verified this fix against the reported issue and existing tests. All relevant tests, including those involving links, have passed.

PR Closes #7503, Closes #7811 , Closes #7817 

## Test plan

### Before

https://github.com/user-attachments/assets/12ac834a-4eb0-483f-bba2-ed8c66306170

### After

https://github.com/user-attachments/assets/bb9c980c-090a-458d-b8b9-9ffa76432ba2