### PR TITLE
[lexical] Bug Fix: Prevent layout thrashing when setting element indent for no indent case

### DIFF
--- a/packages/lexical/src/LexicalReconciler.ts
+++ b/packages/lexical/src/LexicalReconciler.ts
@@ -127,13 +127,18 @@ function setElementIndent(dom: HTMLElement, indent: number): void {
     }
   }
 
+  if (indent === 0) {
+    dom.style.setProperty('padding-inline-start', '');
+    return;
+  }
+
   const indentationBaseValue =
     getComputedStyle(dom).getPropertyValue('--lexical-indent-base-value') ||
     DEFAULT_INDENT_VALUE;
 
   dom.style.setProperty(
     'padding-inline-start',
-    indent === 0 ? '' : `calc(${indent} * ${indentationBaseValue})`,
+    `calc(${indent} * ${indentationBaseValue})`,
   );
 }
 


### PR DESCRIPTION
## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
When the editor is loaded, browser is forced to recalculate style because of `getComputedStyle` call in `setElementIndent`.

Previously, even when indent was 0, `getComputedStyle` was called but last style change was setting `padding-inline-start` to ''. With this change, I am avoiding calling `getComputedStyle` for the case where indent is 0 and returning early.

<img width="957" height="943" alt="image" src="https://github.com/user-attachments/assets/3fc7199d-3571-48d9-b705-3d616005235e" />

Layout thrash: https://web.dev/articles/avoid-large-complex-layouts-and-layout-thrashing

Closes # 

## Test plan

### Before

See "Recalculate style" caused by `setElementIndent` in the profiler
<img width="1722" height="1049" alt="Screenshot 2026-02-02 at 16 13 49" src="https://github.com/user-attachments/assets/edf3eeb3-2cc5-4684-894c-5f5163db736b" />

### After

"Recalculate style" is still there but caused by another function (`updateDOMSelection`)
<img width="1728" height="1045" alt="Screenshot 2026-02-02 at 16 13 13" src="https://github.com/user-attachments/assets/1bdbd022-b7e5-4a8c-9185-75f54628aa6d" />


Indentation works
https://github.com/user-attachments/assets/c41c07cc-2dfc-4337-8a8a-ca6689d089c7

### Profiler results
[indent_recalc.gz](https://github.com/user-attachments/files/25020827/indent_recalc.gz)
[without_indent_recalc.gz](https://github.com/user-attachments/files/25020828/without_indent_recalc.gz)
