### PR TITLE
[lexical-playground] Fix: Increase toolbar z-index to prevent content overlap

### DIFF
--- a/packages/lexical-playground/src/index.css
+++ b/packages/lexical-playground/src/index.css
@@ -1442,7 +1442,7 @@ button.action-button:disabled {
   height: 36px;
   position: sticky;
   top: 0;
-  z-index: 2;
+  z-index: 20;
   overflow-y: hidden; /* disable vertical scroll*/
 }
 


### PR DESCRIPTION
Summary
This PR fixes a visual regression where the comment highlight overlay (yellow background) would render on top of the sticky toolbar when scrolling.

The Issue
The .toolbar class had a z-index of 2. The sticky note container and other overlay elements have higher stacking contexts (e.g., 9), causing them to bleed through the toolbar during scroll.

The Fix

- Increased .toolbar z-index from 2 to 20.
- This ensures the toolbar sits above content layers (text, highlights, sticky notes) but remains below application-level overlays (modals, dropdowns, etc.).

Test Plan

- Verified locally in Playground.
- Added long text, highlighted a section, opened the comment panel, and scrolled.
- Confirmed highlight now correctly scrolls under the toolbar.