### PR TITLE
[lexical-website] Chore: Update supported browsers list to Safari 15+, Chrome 86+, Firefox 115+

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@
 - **Collaborative Editing** - Real-time collaboration via [Yjs](https://github.com/yjs/yjs) integration
 - **Serialization** - Import/export from JSON, Markdown, and HTML
 - **Rich Content** - Support for tables, lists, code blocks, images, and custom nodes
-- **Cross-browser** - Firefox 52+, Chrome 49+, Safari 11+, Edge 79+
+- **Cross-browser** - Firefox 115+, Safari 15+, Chrome 86+ (see [Supported Browsers](https://lexical.dev/docs/getting-started/supported-browsers))
+
 - **Type Safe** - Written in TypeScript with comprehensive type definitions
 
 ## Quick Start

--- a/packages/lexical-website/docs/getting-started/supported-browsers.md
+++ b/packages/lexical-website/docs/getting-started/supported-browsers.md
@@ -6,10 +6,6 @@ sidebar_position: 4
 
 > Note: Lexical does not support Internet Explorer or legacy versions of Edge.
 
-- Firefox 52+
-- Chrome 49+
-- Edge 79+ (when Edge switched to Chromium)
-- Safari 11+
-- iOS 11+ (Safari)
-- iPad OS 13+ (Safari)
-- Android Chrome 72+
+- Firefox 115+
+- Chrome 86+ (and other browsers based on Chrome 86+ such as Android Chrome 86+, Edge 86+ and Opera 72+)
+- Safari 15+ (iOS 15+, iPad OS 15+)


### PR DESCRIPTION
Update the supported browsers list to match current expectations (at least as of Oct 2025)