### PR TITLE
[lexical-website] Chore: Add a website build step to Github Actions in CI

### DIFF
--- a/.github/workflows/call-core-tests.yml
+++ b/.github/workflows/call-core-tests.yml
@@ -27,6 +27,7 @@ jobs:
       - run: pnpm run ci-check
       - run: pnpm run build
       - run: pnpm run build-www
+      - run: pnpm run --filter @lexical/website build
 
   unit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Add a redundant build of `@lexical/website` to Github Actions in CI so that people can observe errors that would normally only be seen with access to Vercel logs (or locally)

## Test plan

### Before

Did not build `@lexical/website` with Github Actions in CI

### After

Builds `@lexical/website` with Github Actions in CI

Example: https://github.com/facebook/lexical/actions/runs/22041512112/job/63683123523?pr=8146
```
Run pnpm run --filter @lexical/website build
…
[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.
```