### PR TITLE
Fix $convertLayoutContainerElement always returning null

### DIFF
--- a/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
+++ b/packages/lexical-playground/src/nodes/LayoutContainerNode.ts
@@ -31,10 +31,7 @@ export type SerializedLayoutContainerNode = Spread<
 function $convertLayoutContainerElement(
   domNode: HTMLElement,
 ): DOMConversionOutput | null {
-  const styleAttributes = window.getComputedStyle(domNode);
-  const templateColumns = styleAttributes.getPropertyValue(
-    'grid-template-columns',
-  );
+  const templateColumns = domNode.style.gridTemplateColumns;
   if (templateColumns) {
     const node = $createLayoutContainerNode(templateColumns);
     return {node};


### PR DESCRIPTION
Fixes #6813

## Summary

The `$convertLayoutContainerElement` function in `LayoutContainerNode.ts` always returned `null` when importing HTML because it used `window.getComputedStyle()` to read `grid-template-columns`. Since the DOM nodes being imported are not mounted in the document, `getComputedStyle()` returns empty values for all properties.

## Fix

Changed from `window.getComputedStyle(domNode).getPropertyValue('grid-template-columns')` to reading `domNode.style.gridTemplateColumns` directly. This works because `exportDOM()` already sets `gridTemplateColumns` as an inline style on the exported element, so the value is available on the `style` property without needing computed styles.

## Test plan

- Export a 2-column layout as HTML
- Re-import the exported HTML — layout columns should now be preserved correctly
- Verified that `exportDOM()` sets inline `gridTemplateColumns`, confirming `domNode.style` will have the value

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>