### PR TITLE
[lexical-markdown] Fix: Prevent markdown shortcut link transformer from being too greedy

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -678,8 +678,9 @@ export const LINK: TextMatchTransformer = {
   importRegExp:
     /(?:\[(.+?)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))/,
   regExp:
-    /(?:\[(.+?)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))$/,
+    /(?:\[([^[\]]*(?:\[[^[\]]*\][^[\]]*)*)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))$/,
   replace: (textNode, match) => {
+    // https://spec.commonmark.org/0.31.2/#inline-link
     const [, linkText, linkUrl, linkTitle] = match;
     const linkNode = $createLinkNode(linkUrl, {title: linkTitle});
     const openBracketAmount = linkText.split('[').length - 1;

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -630,6 +630,11 @@ describe('Markdown', () => {
       md: '[link](https://lexical.dev)[link2](https://lexical.dev)',
     },
     {
+      // Test that importRegExp is not too greedy when there are multiple link patterns
+      html: '<p><a href="https://a.example.com"><span style="white-space: pre-wrap;">a</span></a><span style="white-space: pre-wrap;"> </span><a href="https://b.example.com"><span style="white-space: pre-wrap;">b</span></a></p>',
+      md: '[a](https://a.example.com) [b](https://b.example.com)',
+    },
+    {
       // Import only: <mark>...</mark> is exported as ==...== in markdown.
       // Use HIGHLIGHT_TEXT_MATCH_IMPORT as custom transformer even though it is included later to ensure it runs before LINK.
       customTransformers: [HIGHLIGHT_TEXT_MATCH_IMPORT],

--- a/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/MarkdownTransformers.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import {CodeExtension} from '@lexical/code';
+import {buildEditorFromExtensions} from '@lexical/extension';
+import {$isLinkNode, LinkExtension} from '@lexical/link';
+import {ListExtension} from '@lexical/list';
+import {registerMarkdownShortcuts} from '@lexical/markdown';
+import {RichTextExtension} from '@lexical/rich-text';
+import {
+  $getRoot,
+  $getSelection,
+  $isParagraphNode,
+  $isRangeSelection,
+  defineExtension,
+  LexicalEditor,
+} from 'lexical';
+import {assert, describe, expect, test} from 'vitest';
+
+const MarkdownShortcutTestExtension = defineExtension({
+  dependencies: [
+    LinkExtension,
+    RichTextExtension,
+    ListExtension,
+    CodeExtension,
+  ],
+  name: 'MarkdownShortcutTest',
+  register: (editor_) => registerMarkdownShortcuts(editor_),
+});
+
+function typeMarkdown(editor: LexicalEditor, text: string) {
+  editor.update(() => {
+    const selection = $getSelection();
+    if (!($isRangeSelection(selection) && selection.isCollapsed())) {
+      $getRoot().selectEnd();
+    }
+  });
+  for (const char of text) {
+    editor.update(() => $getSelection()?.insertRawText(char), {discrete: true});
+  }
+  // Markdown shortcuts issues a cascading update that is not
+  // discrete, so force sync reconciliation with a read.
+  editor.read(() => {});
+}
+
+describe('LINK', () => {
+  test('text before a markdown link is preserved', () => {
+    const editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    typeMarkdown(editor, 'Start [test](url)');
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
+      const children = paragraph.getChildren();
+      expect(children.map((node) => node.getTextContent())).toEqual([
+        'Start ',
+        'test',
+      ]);
+      assert($isLinkNode(children[1]), 'Second child must be a LinkNode');
+    });
+  });
+
+  test('formatted text before a markdown link is preserved', () => {
+    const editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    typeMarkdown(editor, '**Bold** [Link](url)');
+
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
+      const children = paragraph.getChildren();
+
+      expect(children.map((node) => node.getTextContent())).toEqual([
+        'Bold',
+        ' ',
+        'Link',
+      ]);
+
+      const linkNode = children[2];
+      assert($isLinkNode(linkNode), 'Third child must be a LinkNode');
+      expect(linkNode.getTextContent()).toBe('Link');
+      expect(linkNode.getURL()).toBe('url');
+    });
+  });
+
+  test('LINK is not too greedy if there is a preceding match that was not processed', () => {
+    // https://github.com/facebook/lexical/issues/8129
+    const editor = buildEditorFromExtensions([MarkdownShortcutTestExtension]);
+    // Set up initial condition, since we are not typing a character at a time
+    // it's not handled by markdown shortcuts in this update
+    editor.update(
+      () => {
+        $getRoot()
+          .selectEnd()
+          .insertRawText(
+            `[a](https://a.example.com) [b](https://b.example.com`,
+          );
+      },
+      {discrete: true},
+    );
+    typeMarkdown(editor, ')');
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      assert($isParagraphNode(paragraph), 'Root child must be a paragraph');
+      const children = paragraph.getChildren();
+
+      expect(children.map((node) => node.getTextContent())).toEqual([
+        '[a](https://a.example.com) ',
+        'b',
+      ]);
+
+      const linkNode = children[1];
+      assert($isLinkNode(linkNode), 'Second child must be a LinkNode');
+      expect(linkNode.getTextContent()).toBe('b');
+      expect(linkNode.getURL()).toBe('https://b.example.com');
+    });
+  });
+});


### PR DESCRIPTION
## Description

The RegExp used for the link markdown transformer was too greedy and could match a preceding link with unbalanced brackets if two are processed on the same line.

Closes #8129
Closes #8130

## Test plan

New unit tests to confirm that import works as expected and that it now works correctly with shortcuts