### PR TITLE
[lexical-markdown] Bug Fix: Prevent nesting links creation

### DIFF
--- a/packages/lexical-markdown/src/MarkdownTransformers.ts
+++ b/packages/lexical-markdown/src/MarkdownTransformers.ts
@@ -35,6 +35,7 @@ import {
 import {
   $createLineBreakNode,
   $createTextNode,
+  $findMatchingParent,
   $getState,
   $setState,
   createState,
@@ -681,6 +682,9 @@ export const LINK: TextMatchTransformer = {
     /(?:\[([^[\]]*(?:\[[^[\]]*\][^[\]]*)*)\])(?:\((?:([^()\s]+)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?)\))$/,
   replace: (textNode, match) => {
     // https://spec.commonmark.org/0.31.2/#inline-link
+    if ($findMatchingParent(textNode, $isLinkNode)) {
+      return;
+    }
     const [, linkText, linkUrl, linkTitle] = match;
     const linkNode = $createLinkNode(linkUrl, {title: linkTitle});
     const openBracketAmount = linkText.split('[').length - 1;

--- a/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
+++ b/packages/lexical-markdown/src/__tests__/unit/LexicalMarkdown.test.ts
@@ -635,6 +635,10 @@ describe('Markdown', () => {
       md: '[a](https://a.example.com) [b](https://b.example.com)',
     },
     {
+      html: '<p><span style="white-space: pre-wrap;">[foo </span><a href="/uri"><span style="white-space: pre-wrap;">bar</span></a><span style="white-space: pre-wrap;">](/uri)</span></p>',
+      md: '[foo [bar](/uri)](/uri)',
+    },
+    {
       // Import only: <mark>...</mark> is exported as ==...== in markdown.
       // Use HIGHLIGHT_TEXT_MATCH_IMPORT as custom transformer even though it is included later to ensure it runs before LINK.
       customTransformers: [HIGHLIGHT_TEXT_MATCH_IMPORT],


### PR DESCRIPTION
## Description

Fix for behavior where it is possible to create nested links by typing markdown link text inside LinkNode

https://spec.commonmark.org/0.31.2/#example-518

## Test plan

### Before

https://github.com/user-attachments/assets/e5a7bb0e-963d-432b-8e3c-efbb5675eb9d

### After

https://github.com/user-attachments/assets/5a36f600-bf90-40be-b121-a54309142090

