### PR TITLE
[security] Fix: Override minimatch@3 to 3.1.3 to resolve CVE-2022-3517

### DIFF
--- a/examples/extension-sveltekit-ssr-hydration/package.json
+++ b/examples/extension-sveltekit-ssr-hydration/package.json
@@ -54,6 +54,11 @@
     "vitest": "^3.2.3",
     "vitest-browser-svelte": "^0.1.0"
   },
+  "pnpm": {
+    "overrides": {
+      "minimatch@3": "3.1.3"
+    }
+  },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.52.0",
     "@rollup/rollup-darwin-arm64": "4.52.0",

--- a/examples/extension-sveltekit-ssr-hydration/pnpm-lock.yaml
+++ b/examples/extension-sveltekit-ssr-hydration/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  minimatch@3: 3.1.3
+
 importers:
 
   .:
@@ -1334,8 +1337,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.3:
+    resolution: {integrity: sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -1922,7 +1925,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 3.1.2
+      minimatch: 3.1.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1943,7 +1946,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -2684,7 +2687,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -2899,7 +2902,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  minimatch@3.1.2:
+  minimatch@3.1.3:
     dependencies:
       brace-expansion: 1.1.12
 

--- a/examples/extension-vanilla-react-plugin-host/package.json
+++ b/examples/extension-vanilla-react-plugin-host/package.json
@@ -31,6 +31,11 @@
     "vite": "^7.1.4",
     "vite-tsconfig-paths": "^5.1.4"
   },
+  "pnpm": {
+    "overrides": {
+      "minimatch@3": "3.1.3"
+    }
+  },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.52.0",
     "@rollup/rollup-darwin-arm64": "4.52.0",

--- a/examples/extension-vanilla-react-plugin-host/pnpm-lock.yaml
+++ b/examples/extension-vanilla-react-plugin-host/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  minimatch@3: 3.1.3
+
 importers:
 
   .:
@@ -874,8 +877,8 @@ packages:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.3:
+    resolution: {integrity: sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1668,7 +1671,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -1786,7 +1789,7 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
-  minimatch@3.1.2:
+  minimatch@3.1.3:
     dependencies:
       brace-expansion: 1.1.12
 

--- a/examples/extension-vanilla-tailwind/package.json
+++ b/examples/extension-vanilla-tailwind/package.json
@@ -30,6 +30,11 @@
     "vite": "^7.1.4",
     "vite-tsconfig-paths": "^5.1.4"
   },
+  "pnpm": {
+    "overrides": {
+      "minimatch@3": "3.1.3"
+    }
+  },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.52.0",
     "@rollup/rollup-darwin-arm64": "4.52.0",

--- a/examples/extension-vanilla-tailwind/pnpm-lock.yaml
+++ b/examples/extension-vanilla-tailwind/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  minimatch@3: 3.1.3
+
 importers:
 
   .:
@@ -795,8 +798,8 @@ packages:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.3:
+    resolution: {integrity: sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1432,7 +1435,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -1544,7 +1547,7 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
-  minimatch@3.1.2:
+  minimatch@3.1.3:
     dependencies:
       brace-expansion: 1.1.12
 

--- a/package.json
+++ b/package.json
@@ -217,7 +217,8 @@
       "@shikijs/types": "3.20.0",
       "react": "19.1.1",
       "react-dom": "19.1.1",
-      "@types/node": "20.19.17"
+      "@types/node": "20.19.17",
+      "minimatch@3": "3.1.3"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   react: 19.1.1
   react-dom: 19.1.1
   '@types/node': 20.19.17
+  minimatch@3: 3.1.3
 
 importers:
 
@@ -9729,8 +9730,8 @@ packages:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.3:
+    resolution: {integrity: sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==}
 
   minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
@@ -16350,7 +16351,7 @@ snapshots:
       ignore: 5.3.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -16455,7 +16456,7 @@ snapshots:
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
       debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 3.1.2
+      minimatch: 3.1.3
     transitivePeerDependencies:
       - supports-color
 
@@ -20530,7 +20531,7 @@ snapshots:
       hogan.js: 3.0.2
       lunr: 2.3.9
       lunr-languages: 1.14.0
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       object-assign: 4.1.1
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
@@ -20992,7 +20993,7 @@ snapshots:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.0
@@ -21032,7 +21033,7 @@ snapshots:
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       object.entries: 1.1.8
       object.fromentries: 2.0.8
 
@@ -21058,7 +21059,7 @@ snapshots:
       eslint: 8.57.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       object.entries: 1.1.8
       object.fromentries: 2.0.8
       object.hasown: 1.1.4
@@ -21134,7 +21135,7 @@ snapshots:
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       natural-compare: 1.4.0
       optionator: 0.9.4
       strip-ansi: 6.0.1
@@ -21673,7 +21674,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -24548,7 +24549,7 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
-  minimatch@3.1.2:
+  minimatch@3.1.3:
     dependencies:
       brace-expansion: 1.1.11
 
@@ -24599,7 +24600,7 @@ snapshots:
       '@types/minimatch': 3.0.5
       array-differ: 4.0.0
       array-union: 3.0.1
-      minimatch: 3.1.2
+      minimatch: 3.1.3
 
   multimath@2.0.0:
     dependencies:
@@ -24710,7 +24711,7 @@ snapshots:
       chalk: 2.4.2
       cross-spawn: 6.0.6
       memorystream: 0.3.1
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       pidtree: 0.3.1
       read-pkg: 3.0.0
       shell-quote: 1.8.3
@@ -26499,7 +26500,7 @@ snapshots:
       bytes: 3.0.0
       content-disposition: 0.5.2
       mime-types: 2.1.18
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       path-is-inside: 1.0.2
       path-to-regexp: 3.3.0
       range-parser: 1.2.0
@@ -27058,7 +27059,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 3.1.2
+      minimatch: 3.1.3
 
   text-table@0.2.0: {}
 


### PR DESCRIPTION
Summary                                                                                                                                                  
                                                            
  - Adds pnpm.overrides to pin minimatch@3 to 3.1.3 in the root package.json and three example package.json files that maintain their own lock files       
                                                                                                                                                           
  Why overrides?

  minimatch < 3.1.3 has a HIGH severity ReDoS vulnerability (CVE-2022-3517) via the braceExpand function. The vulnerable version 3.1.2 is pulled in as a transitive dependency by several packages:

  - eslint@8.57.0
  - eslint-plugin-import@2.29.1
  - eslint-plugin-jsx-a11y@6.8.0
  - eslint-plugin-react@7.34.1
  - docusaurus-lunr-search@2.4.2 (via docusaurus-plugin-internaldocs-fb)
  - @eslint/eslintrc@2.1.4, @humanwhocodes/config-array@0.11.14 (transitive from eslint)

  None of these packages have released a version that drops minimatch@^3.1.2. Even the latest releases of all three eslint plugins still depend on it. The override "minimatch@3": "3.1.3" targets only the 3.x resolution, bumping 3.1.2 to the backward-compatible patch 3.1.3. It does not affect minimatch@5.1.6, @9.0.5, or @10.1.1 used by other packages.

  Test plan
  - pnpm run build passes
  - pnpm run test-unit passes (2581/2581 tests)
  - pnpm install --lockfile-only to regenerate lock files (blocked by npm registry outage for @atlaskit packages — unrelated to this change)

