### PR TITLE
[lexical] Security: Fix @isaacs/brace-expansion vulnerability (CVE-2026-25547)

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,8 @@
       "react-dom": "19.1.1",
       "@types/node": "20.19.17",
       "qs": ">=6.14.2",
-      "form-data": ">=4.0.4"
+      "form-data": ">=4.0.4",
+      "@isaacs/brace-expansion": ">=5.0.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   '@types/node': 20.19.17
   qs: '>=6.14.2'
   form-data: '>=4.0.4'
+  '@isaacs/brace-expansion': '>=5.0.1'
 
 importers:
 
@@ -3189,8 +3190,8 @@ packages:
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
 
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
@@ -16391,7 +16392,7 @@ snapshots:
 
   '@isaacs/balanced-match@4.0.1': {}
 
-  '@isaacs/brace-expansion@5.0.0':
+  '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
@@ -24453,7 +24454,7 @@ snapshots:
 
   minimatch@10.1.1:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@3.1.2:
     dependencies:


### PR DESCRIPTION
## Description

Resolves Dependabot alerts [#462](https://github.com/facebook/lexical/security/dependabot/462), [#463](https://github.com/facebook/lexical/security/dependabot/463), [#464](https://github.com/facebook/lexical/security/dependabot/464) for `@isaacs/brace-expansion@5.0.0` (Uncontrolled Resource Consumption, HIGH severity, [CVE-2026-25547](https://nvd.nist.gov/vuln/detail/CVE-2026-25547)).

### Changes
- Added pnpm override `"@isaacs/brace-expansion": ">=5.0.1"` in root `package.json` to force the patched version
- Regenerated root `pnpm-lock.yaml` (resolves to `@isaacs/brace-expansion@5.0.1`)
- Regenerated example lockfiles for `extension-vanilla-tailwind` and `extension-vanilla-react-plugin-host` which now resolve to the non-scoped `brace-expansion@5.0.3` (no longer affected)

## Test plan

### Before
- `@isaacs/brace-expansion@5.0.0` present in root lockfile and 2 example lockfiles
- 3 open Dependabot alerts for CVE-2026-25547

### After
- Root lockfile resolves to `@isaacs/brace-expansion@5.0.1`
- Example lockfiles resolve to `brace-expansion@5.0.3` (vulnerability eliminated)
- All unit tests pass (2581 passed, 1 skipped)